### PR TITLE
feat: CLI with serve, index, search, reindex commands

### DIFF
--- a/src/markdown_mcp/cli.py
+++ b/src/markdown_mcp/cli.py
@@ -231,7 +231,11 @@ def main() -> None:
     )
 
     handler = _COMMANDS[args.command]
-    handler(args)
+    try:
+        handler(args)
+    except ValueError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,6 +151,37 @@ class TestCmdIndex:
         captured = capsys.readouterr()
         assert "42 documents" in captured.out
         assert "128 chunks" in captured.out
+        mock_collection.build_index.assert_called_once_with(force=False)
+
+    @patch("markdown_mcp.cli._build_collection")
+    def test_index_force_propagates(
+        self,
+        mock_build: MagicMock,
+    ) -> None:
+        mock_collection = MagicMock()
+        mock_stats = MagicMock()
+        mock_stats.documents_indexed = 0
+        mock_stats.chunks_indexed = 0
+        mock_collection.build_index.return_value = mock_stats
+        mock_build.return_value = mock_collection
+
+        with patch("sys.argv", ["markdown-mcp", "index", "--force"]):
+            main()
+
+        mock_collection.build_index.assert_called_once_with(force=True)
+
+    @patch("markdown_mcp.cli._build_collection")
+    def test_valueerror_exits_with_message(
+        self,
+        mock_build: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        mock_build.side_effect = ValueError("MARKDOWN_MCP_SOURCE_DIR is required")
+
+        with patch("sys.argv", ["markdown-mcp", "index"]), pytest.raises(
+            SystemExit, match="1"
+        ):
+            main()
 
 
 class TestCmdSearch:


### PR DESCRIPTION
## Summary
- `cli.py` with argparse-based subcommands: serve, index, search, reindex
- `serve`: runs MCP server with configurable transport (stdio/sse)
- `search`: text or JSON output, folder/mode/limit options
- Entry point registered as `markdown-mcp` in pyproject.toml
- 16 unit tests covering parser, dispatch, and output

**Stack:** 3/5 — depends on #35

## Test plan
- [x] `uv run pytest tests/test_cli.py -v` — 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | `MARKDOWN_MCP_SOURCE_DIR` env var, required | Design §env-vars | CONFORMANT | config.py:151-156 |
| 2 | `MARKDOWN_MCP_READ_ONLY` env var, default true | Design §env-vars | CONFORMANT | config.py:160-161 |
| 3 | `MARKDOWN_MCP_INDEX_PATH` env var | Design §env-vars | CONFORMANT | config.py:164-165 |
| 4 | `MARKDOWN_MCP_EMBEDDINGS_PATH` env var | Design §env-vars | CONFORMANT | config.py:168-171 |
| 5 | `MARKDOWN_MCP_INDEXED_FIELDS` comma-separated | Design §env-vars | CONFORMANT | config.py:178-184 |
| 6 | `MARKDOWN_MCP_REQUIRED_FIELDS` comma-separated | Design §env-vars | CONFORMANT | config.py:186-190 |
| 7 | `MARKDOWN_MCP_EXCLUDE` comma-separated globs | Design §env-vars | CONFORMANT | config.py:192-196 |
| 8 | `MARKDOWN_MCP_GIT_TOKEN` env var | Design §env-vars | CONFORMANT | config.py:198-199 |
| 9 | `to_collection_kwargs()` returns valid kwargs | Design §config | CONFORMANT | config.py:89-111, test verified |
| 10 | FastMCP 2.5+ with lifespan hooks | Design §mcp-server | CONFORMANT | mcp_server.py:113-121 |
| 11 | Collection init in lifespan, teardown on shutdown | Design §mcp-server | CONFORMANT | mcp_server.py:40-82 |
| 12 | `search` tool with correct annotations | Design §tools | CONFORMANT | mcp_server.py:125-161 |
| 13 | `read` tool with correct annotations | Design §tools | CONFORMANT | mcp_server.py:163-186 |
| 14 | `list_documents` tool (spec says `list`) | Design §tools | PARTIAL | Named list_documents to avoid Python builtin collision |
| 15 | `write` tool gated by read_only | Design §tools | CONFORMANT | mcp_server.py:338-364 |
| 16 | `edit` tool gated by read_only | Design §tools | CONFORMANT | mcp_server.py:366-392 |
| 17 | `delete` tool destructiveHint=True | Design §tools | CONFORMANT | mcp_server.py:394-412 |
| 18 | `rename` tool gated by read_only | Design §tools | CONFORMANT | mcp_server.py:414-436 |
| 19 | `list_folders`, `list_tags`, `stats`, `embeddings_status` | Design §tools | CONFORMANT | mcp_server.py:216-284 |
| 20 | `reindex`, `build_embeddings` tools | Design §tools | CONFORMANT | mcp_server.py:288-326 |
| 21 | Conditional write tool registration | Design §tools | CONFORMANT | mcp_server.py:333-436 |
| 22 | `asyncio.to_thread()` for all tool handlers | Design §mcp-server | CONFORMANT | 13 usages verified |
| 23 | CLI: serve, index, search, reindex subcommands | Design §cli | CONFORMANT | cli.py:65-114 |
| 24 | CLI entry point `markdown-mcp` | Design §packaging | CONFORMANT | pyproject.toml:37 |
| 25 | Docker: python:3.12-slim, uv, non-root user | Design §docker | CONFORMANT | Dockerfile:1-28 |
| 26 | Docker publish + PyPI workflow | Design §ci | CONFORMANT | .github/workflows/publish.yml |
| 27 | Path traversal protection in read() | Security | CONFORMANT | collection.py:524-526 |
| 28 | `configure_logging()` module | Design §logging | MISSING | Inline basicConfig in cli.py; low severity |
| 29 | Explicit MCP error handling | Design §errors | PARTIAL | Relies on FastMCP built-in conversion; functional |
| 30 | MCP integration tests via FastMCP Client | Design §testing | CONFORMANT | test_mcp_server.py, 16 async tests |

Reviewed by @architect-reviewer — 26 CONFORMANT, 3 PARTIAL (acceptable deviations), 1 MISSING (low severity, deferred).

PARTIAL deviations accepted:
- **#14**: `list_documents` name avoids Python `list` builtin collision
- **#29**: FastMCP exception-to-error conversion is sufficient for Phase 2
- **#42** (not shown): `all` extra includes sentence-transformers (improvement over spec)

MISSING deferred:
- **#28**: `configure_logging()` — inline config in CLI is sufficient; design doc update planned