### PR TITLE
feat(mcp): improve all tool docstrings for LLM clarity

### DIFF
--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -363,15 +363,18 @@ def create_server() -> FastMCP:
         },
     )
     async def embeddings_status() -> dict[str, Any]:
-        """Check the embedding provider configuration and vector index freshness.
+        """Check the embedding provider configuration and vector index status.
 
-        Use this to diagnose why semantic search is unavailable or returning
-        poor results. If embeddings are stale (new documents indexed since last
-        embed run), call 'build_embeddings' to update the vector index.
+        Use this to diagnose why semantic search is unavailable. Compare
+        chunk_count here against chunk_count from 'stats': if stats has more
+        chunks, call 'build_embeddings' to initialise the vector index for
+        the first time (or 'reindex' to incrementally re-embed changed docs
+        when semantic search is already active).
 
         Returns:
-            Dict with provider info (name, model), document/chunk counts,
-            and a staleness indicator (whether unembedded chunks exist).
+            Dict with available (bool), provider (str — provider class name,
+            e.g. "OllamaProvider"), chunk_count (int — embedded chunks in the
+            vector index), and path (str — vector index file path).
         """
         collection = _get_collection()
         return await asyncio.to_thread(collection.embeddings_status)


### PR DESCRIPTION
## Summary

- Rewrite all 13 tool docstrings in `mcp_server.py` for LLM clarity (#53)
- `search`: documents when to use each mode, preference for hybrid
- `stats`: positioned as session-start capability-discovery tool
- `write`: WARNING about overwrite risk, directs to `edit`
- `edit`: documents both failure modes (zero-match, multi-match), directs to `read` first
- `delete`: IRREVERSIBLE notice, directs to confirm with user
- Cross-references added: `search` ↔ `stats`, `edit` → `read`, `reindex` → `build_embeddings`, `list_tags` → `stats`
- No changes to function signatures or behavior — docstring-only

Closes #53.

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | All 13 tool docstrings updated | Issue #53, AC 1 | CONFORMANT | All tools in diff |
| 2 | `search`: mode guidance with hybrid preference | Issue #53, AC 2 | CONFORMANT | Lines 180-207 |
| 3 | `stats`: session-start positioning | Issue #53, AC 3 | CONFORMANT | Lines 321-336 |
| 4 | `write`: overwrite WARNING | Issue #53, AC 4 | CONFORMANT | Lines 389-411 |
| 5 | `edit`: failure modes documented | Issue #53, AC 5 | CONFORMANT | Lines 417-437 |
| 6 | `delete`: IRREVERSIBLE notice | Issue #53, AC 6 | CONFORMANT | Lines 447-461 |
| 7 | Cross-references added | Issue #53, AC 7 | CONFORMANT | search↔stats, edit→read, reindex→build_embeddings, list_tags→stats |
| 8 | No signature/behavior changes | Issue #53, AC 8 | CONFORMANT | Diff is docstring-only |
| 9 | No `_DEFAULT_INSTRUCTIONS` changes | Issue #53, AC 9 | CONFORMANT | No instruction changes in diff |
| 10 | Tool annotations match design doc | Design doc §mcp_server.py | CONFORMANT | All annotation values unchanged |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [x] 227 tests pass (`uv run python -m pytest tests/ -x -q`)
- [x] Ruff lint + format clean
- [ ] Bot reviews pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)