### PR TITLE
fix(ci): add Python 3.13 to test matrix and align with ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -76,7 +76,7 @@ jobs:
         run: uv run pytest --cov --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Topic :: Text Processing :: Markup :: Markdown",
 ]


### PR DESCRIPTION
## Summary

The repo ruleset requires `Test (Python 3.13)` and `codecov/patch` status checks, but CI only tested Python 3.10-3.12. This mismatch caused **all PRs to fail the merge gate**, which was masked by using `--admin` to bypass protection.

- Add Python 3.13 to test matrix
- Upload codecov on 3.13 run (was 3.12)
- Add 3.13 to pyproject.toml classifiers
- All 227 tests pass on 3.13 locally

## Design Conformance

No design documents found — CI configuration is not covered by `docs/design.md`.

## Remaining: CODECOV_TOKEN secret

The `codecov/patch` check requires a `CODECOV_TOKEN` secret in the repo settings. Please verify this is configured (Settings → Secrets → Actions → `CODECOV_TOKEN`).

## Test plan

- [ ] CI runs Test (Python 3.13) job successfully
- [ ] codecov/patch check appears after merge
- [ ] PR can be merged **without** `--admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)