### PR TITLE
docs: fill design spec gaps (issue #66)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -304,8 +304,8 @@ resolved path escapes `source_dir`, it returns `None` instead of raising.
 
 `Collection.close()` must be called on shutdown to release resources:
 
-1. Closes the SQLite database connection.
-2. Duck-types on `on_write`: if the callback has a `close()` method, calls it.
+1. Duck-types on `on_write`: if the callback has a `close()` method, calls it (e.g. `GitWriteStrategy.close()` flushes and pushes pending commits).
+2. Closes the SQLite database connection.
 
 This enables `GitWriteStrategy` to flush and push any pending commits before
 the process exits. The contract is:


### PR DESCRIPTION
## Summary

Closes #66

Updates `docs/design.md` to reflect the actual implementation, fixing gaps and inaccuracies identified after PR #80 merged.

**MUST ADD (4 items):**
- Thread Safety: `threading.Lock` held during write, callback fires outside lock
- Path Traversal Protection: `_validate_path()` using `.resolve()` + `is_relative_to()`
- `Collection.close()` lifecycle: init → writes → close, duck-typed on `on_write`
- `exclude_patterns` parameter added to `Collection.__init__` signature

**SHOULD ADD (4 items):**
- WriteCallback contract: per-operation path/content semantics (note renames pass content, attachment renames pass `""`)
- `NoteInfo.kind = "note"` default field (moved to end of dataclass for valid field ordering)
- Tool name `list_documents` (not `list`) with note explaining Python builtin conflict
- Dynamic instructions: content varies with `read_only` mode

**Dead spec removed (1 item):**
- `configure_logging()` reference removed (function was never implemented; CLI uses inline `basicConfig`)

**Inconsistencies fixed (3 items):**
- Error table: `read()` returns `None` for traversal/missing (not `ValueError`)
- Git credential security: GIT_ASKPASS pattern, 0o700 permissions, token redaction in logs, `finally` cleanup
- Deferred push mechanics: `threading.Timer`, `push_delay_s`, `flush()`, startup recovery

## Architect Conformance Review

| Requirement | Status |
|---|---|
| Thread safety spec | CONFORMANT |
| Path traversal protection | CONFORMANT |
| Collection.close() lifecycle | CONFORMANT |
| exclude_patterns in __init__ | CONFORMANT |
| WriteCallback contract | CONFORMANT (fixed in follow-up commit) |
| NoteInfo.kind field | CONFORMANT (field ordering fixed) |
| list_documents tool name | CONFORMANT |
| Dynamic instructions | CONFORMANT |
| configure_logging() removed | CONFORMANT |
| Error table: read() → None | CONFORMANT (ValueError claim corrected) |
| Git credential security | CONFORMANT |
| Deferred push mechanics | CONFORMANT |

## Test plan

- [ ] Verify all spec additions match the actual implementation in `collection.py`, `git.py`
- [ ] Verify NoteInfo dataclass field ordering in `types.py` matches spec (kind last)
- [ ] Verify `rename()` callback content matches spec (note→content, attachment→"")

🤖 Generated with [Claude Code](https://claude.com/claude-code)