### PR TITLE
fix: exclude hidden dirs and exclude_patterns from attachment listing

### DIFF
--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -676,7 +676,7 @@ class Collection:
             except ValueError:
                 continue
             rel_path = str(rel)
-            # Skip files inside hidden directories (dotfile components).
+            # Skip files where any path component (including the filename itself) starts with ".".
             if any(part.startswith(".") for part in rel.parts):
                 continue
             # Apply exclude_patterns — mirrors scan_directory behaviour.

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -2271,9 +2271,9 @@ class TestListAttachmentHiddenDirFiltering:
         vault = tmp_path / "vault"
         vault.mkdir()
         (vault / "doc.md").write_text("# Doc\n", encoding="utf-8")
-        # File in an excluded directory.
-        (vault / ".obsidian").mkdir()
-        (vault / ".obsidian" / "workspace.json").write_text("{}", encoding="utf-8")
+        # File in a non-hidden excluded directory (tests pure exclude_patterns path).
+        (vault / "archived").mkdir()
+        (vault / "archived" / "workspace.json").write_text("{}", encoding="utf-8")
         # File in another excluded directory.
         (vault / "trash").mkdir()
         (vault / "trash" / "old.pdf").write_bytes(b"PDF")
@@ -2284,7 +2284,7 @@ class TestListAttachmentHiddenDirFiltering:
         col = Collection(
             source_dir=vault,
             attachment_extensions=["pdf", "json"],
-            exclude_patterns=[".obsidian/**", "trash/**"],
+            exclude_patterns=["archived/**", "trash/**"],
         )
         col.build_index()
         results = col.list(include_attachments=True)
@@ -2292,5 +2292,4 @@ class TestListAttachmentHiddenDirFiltering:
         attachment_paths = {r.path for r in results if hasattr(r, "mime_type")}
         assert "assets/chart.pdf" in attachment_paths
         assert "trash/old.pdf" not in attachment_paths
-        # .obsidian is hidden dir so it's excluded by the hidden-dir rule too.
-        assert not any(".obsidian" in p for p in attachment_paths)
+        assert "archived/workspace.json" not in attachment_paths


### PR DESCRIPTION
## Summary

- Fixes `list_documents(include_attachments=True)` leaking files from hidden directories (`.git/`, `.markdown_vault_mcp/`) and directories matched by `MARKDOWN_VAULT_MCP_EXCLUDE`
- In `Collection.list()`, attachment rglob now skips any file where a path component starts with `.` (hidden dir), and applies `exclude_patterns` via `fnmatch` — mirroring `scan_directory` behaviour
- Adds 3 tests in `TestListAttachmentHiddenDirFiltering` covering hidden-dir exclusion, root dotfile exclusion, and exclude_patterns filtering

Closes #78

## Conformance

| Requirement | Status |
|---|---|
| `list_documents` does not return files from `.git/` | CONFORMANT |
| `list_documents` does not return `.markdown_vault_mcp/state.json` | CONFORMANT |
| Files excluded by `MARKDOWN_VAULT_MCP_EXCLUDE` absent from attachment listings | CONFORMANT |
| Tests verify all three cases | CONFORMANT |

## Test plan
- [ ] `uv run python -m pytest tests/test_collection.py::TestListAttachmentHiddenDirFiltering -v`
- [ ] Full test suite: `uv run python -m pytest tests/ -x -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)