### PR TITLE
docs: add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # markdown-vault-mcp
 
-[![CI](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp)
-[![PyPI](https://img.shields.io/pypi/v/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/)
-[![Python](https://img.shields.io/pypi/pyversions/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/)
-[![License](https://img.shields.io/github/license/pvliesdonk/markdown-vault-mcp)](LICENSE)
-[![Docker](https://img.shields.io/badge/ghcr.io-markdown--vault--mcp-blue?logo=docker)](https://ghcr.io/pvliesdonk/markdown-vault-mcp)
+[![CI](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp) [![PyPI](https://img.shields.io/pypi/v/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![Python](https://img.shields.io/pypi/pyversions/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/markdown-vault-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/markdown-vault-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)
 
 A generic markdown collection [MCP](https://modelcontextprotocol.io/) server with FTS5 full-text search, semantic vector search, frontmatter-aware indexing, incremental reindexing, and non-markdown attachment support.
 


### PR DESCRIPTION
## Summary

- Add 6 badges to README header: CI, Codecov, PyPI version, Python versions, License, Docker
- All badges link to their respective dashboards/pages

## Design Conformance

No design documents apply — this is a cosmetic README change, not a functional code change. Conformance review not applicable.

## Test plan

- [x] Badge markdown syntax is correct (verified locally)
- [x] All badge URLs point to correct repo (`pvliesdonk/markdown-vault-mcp`)
- [x] License badge works now that `LICENSE` file exists (PR #91)

🤖 Generated with [Claude Code](https://claude.com/claude-code)