### PR TITLE
chore: generate SBOM and attach to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Generate SBOM
         if: steps.release.outputs.released == 'true'
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d  # v0.23.1
         with:
           path: .
           format: cyclonedx-json
@@ -195,7 +195,7 @@ jobs:
           push-to-registry: true
 
       - name: Generate SBOM for Docker image
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d  # v0.23.1
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-push.outputs.digest }}
           format: cyclonedx-json


### PR DESCRIPTION
## Summary

- Add `anchore/sbom-action` (CycloneDX JSON via syft) to the `release` job — generates `sbom.cdx.json` and uploads it as a GitHub Release asset after `uv build`
- Add `anchore/sbom-action` + `actions/attest-sbom@v2` to the `publish-docker` job — generates SBOM from the pushed GHCR image and attaches it as an attestation alongside the existing build-provenance attestation

## Verification

- [ ] GitHub Release contains `sbom.cdx.json` asset
- [ ] `gh attestation verify --repo pvliesdonk/markdown-vault-mcp <image>` shows both provenance and SBOM attestations

## Design Conformance

No design documents cover CI/CD workflow configuration — conformance review not applicable.

Closes #92