### PR TITLE
fix: enable SQLite WAL journal mode for concurrent read/write

### DIFF
--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -129,6 +129,14 @@ def _open_connection(db_path: Path | str) -> sqlite3.Connection:
     # does not guarantee this survives across statement boundaries in all
     # SQLite versions).
     conn.execute("PRAGMA foreign_keys = ON")
+    # Enable WAL journal mode so readers do not block writers and vice-versa.
+    # This prevents "database is locked" errors when search/list operations
+    # overlap with index updates.  Falls back gracefully (e.g. on a read-only
+    # filesystem) so the server can still start.
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+    except sqlite3.Error as exc:
+        logger.warning("Could not enable WAL journal mode: %s", exc)
     conn.commit()
     return conn
 

--- a/tests/test_fts_index.py
+++ b/tests/test_fts_index.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+from pathlib import Path
 
 import pytest
 
@@ -566,3 +567,27 @@ class TestInMemoryMode:
         results = idx.search("memory")
         assert len(results) >= 1
         assert results[0].path == "mem.md"
+
+
+class TestWALJournalMode:
+    def test_wal_mode_enabled_on_disk(self, tmp_path: Path) -> None:
+        """WAL journal mode is active for on-disk databases."""
+        db_file = tmp_path / "test.db"
+        idx = FTSIndex(db_file)
+        row = idx._conn.execute("PRAGMA journal_mode").fetchone()
+        assert row[0] == "wal"
+        idx.close()
+
+    def test_wal_mode_enabled_in_memory(self) -> None:
+        """WAL journal mode is requested for in-memory databases.
+
+        In-memory databases report 'memory' as their journal mode
+        regardless of PRAGMA setting, so we just verify the index
+        initialises without error.
+        """
+        idx = FTSIndex(":memory:")
+        row = idx._conn.execute("PRAGMA journal_mode").fetchone()
+        # In-memory DBs always report 'memory'; the important thing is
+        # that the PRAGMA did not raise.
+        assert row[0] == "memory"
+        idx.close()


### PR DESCRIPTION
## Summary
- Adds `PRAGMA journal_mode = WAL` in `_open_connection()` right after the existing `foreign_keys` pragma
- WAL mode allows concurrent readers during writes, preventing "database is locked" errors when search/list operations overlap with index updates
- Wrapped in `try/except sqlite3.Error` with `logger.warning()` — server still starts on read-only filesystems
- Added tests verifying WAL mode is active for on-disk databases and in-memory databases initialize without error

## Acceptance Criteria
- [x] `PRAGMA journal_mode = WAL` executed on every new connection
- [x] WAL mode set before any reads or writes
- [x] If WAL fails, log WARNING and continue — do not crash
- [x] Tests for WAL mode verification

## Test plan
- [ ] Run `pytest tests/test_fts_index.py::TestWALJournalMode` 
- [ ] Run full test suite to ensure no regressions
- [ ] Verify on-disk database shows WAL mode via `PRAGMA journal_mode`

Fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)