### PR TITLE
chore(ci): auto-update server.json version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,26 @@ jobs:
           git_committer_email: "actions@users.noreply.github.com"
           force: ${{ inputs.force }}
 
+      - name: Update server.json to released version
+        if: steps.release.outputs.released == 'true'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          jq --arg v "$VERSION" '
+            .version = $v |
+            .packages |= map(
+              if .registryType == "pypi" then .version = $v
+              elif .registryType == "oci" then .identifier = ("ghcr.io/pvliesdonk/markdown-vault-mcp:" + $v)
+              else . end
+            )
+          ' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git add server.json
+          git diff --cached --quiet || git commit -m "chore: update server.json to v${VERSION} [skip ci]"
+          git push
+
       - name: Build package
         if: steps.release.outputs.released == 'true'
         run: uv build


### PR DESCRIPTION
## Problem

`server.json` contains the package version in three places — the top-level `version` field, the PyPI package `version`, and the OCI image tag inside `identifier`. These were updated manually, meaning they drifted from `pyproject.toml` after every semantic-release bump. Issue #132 tracks this drift.

## Changes

- Added a new workflow step **"Update server.json to released version"** in `.github/workflows/release.yml`, inserted between the `Semantic Version Release` step and the `Build package` step.
- The step runs only when `steps.release.outputs.released == 'true'`.
- Uses `jq` to atomically rewrite all three version occurrences in a single pass, filtering by `registryType` (not array index) so the logic is robust to entry reordering:
  - `.version` — top-level version field
  - `.packages[] | select(.registryType == "pypi") | .version`
  - `.packages[] | select(.registryType == "oci") | .identifier` (reconstructed as `ghcr.io/pvliesdonk/markdown-vault-mcp:<version>`)
- Commits with `[skip ci]` to avoid triggering a recursive release run, then pushes to main.

The `server.json` commit lands on main **after** the release tag is created. This is acceptable: the MCP registry reads from the default branch (`main`), not from tags, so the updated version is visible to the registry immediately after the push.

## Not Included / Future PRs

- Automated testing of the `jq` transformation in CI (could be a follow-up if desired).

## Design Conformance

No design document changes required — this is a CI automation change with no impact on the library API or MCP tool surface.

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | Version in `server.json` stays in sync with `pyproject.toml` after release | Issue #132 | CONFORMANT | `jq` step updates all 3 occurrences using `steps.release.outputs.version` |
| 2 | Filter by `registryType`, not array index | Issue #132 | CONFORMANT | `if .registryType == "pypi"` / `elif .registryType == "oci"` in `jq` expression |
| 3 | No recursive CI trigger | Issue #132 | CONFORMANT | Commit message includes `[skip ci]` |

## Test Plan

- Merge this PR and trigger the Release workflow manually (`workflow_dispatch`) with `force: patch`.
- Verify the `server.json` commit appears on `main` after the tag with the correct version in all three fields.
- Alternatively, inspect the `jq` expression locally:
  ```bash
  VERSION=1.6.0 jq --arg v "$VERSION" '
    .version = $v |
    .packages |= map(
      if .registryType == "pypi" then .version = $v
      elif .registryType == "oci" then .identifier = ("ghcr.io/pvliesdonk/markdown-vault-mcp:" + $v)
      else . end
    )
  ' server.json
  ```

## Risk / Rollback

- The step uses `git diff --cached --quiet || git commit` — a no-op write is safe and produces no extraneous commit.
- `RELEASE_TOKEN` (already used by `python-semantic-release`) has write access, so the push succeeds without additional secrets.
- Rollback: remove the step from `release.yml` and update `server.json` manually post-release (prior workflow).

Closes #132