### PR TITLE
fix: suppress CodeQL token-storage false positive (issue #129)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+name: "CodeQL config"
+
+query-filters:
+  - exclude:
+      id: py/clear-text-storage-of-sensitive-information
+      paths:
+        - src/markdown_vault_mcp/git.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           languages: python
           queries: security-extended
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -102,6 +102,8 @@ class GitWriteStrategy:
         commit_email: str | None = None,
         git_lfs: bool = True,
     ) -> None:
+        # Token is retained for GIT_ASKPASS credential forwarding in subprocesses.
+        # This pattern is intentionally accepted and suppressed in CodeQL config.
         self._token = token
         self._push_delay_s = push_delay_s
         self._commit_name = commit_name or self.DEFAULT_COMMIT_NAME


### PR DESCRIPTION
## Summary
- configure CodeQL to use a repository config file
- exclude the clear-text storage query for src/markdown_vault_mcp/git.py
- add an inline comment explaining why token storage is intentional for askpass subprocess auth

## Why
Issue #129 identifies a CodeQL alert on self._token assignment. In this project that token is intentionally forwarded to git subprocesses via a temporary GIT_ASKPASS script, so this is an accepted false positive.

Closes #129