### PR TITLE
fix: fail fast on SSH remotes when GIT_TOKEN is set (issue #136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Git integration supports:
 
 - **Periodic pull** (ff-only): keeps the server's working tree up to date with the remote. Works in read-only mode.
 - **Auto-commit + push on write**: commits each MCP write and pushes after an idle delay. Requires `MARKDOWN_VAULT_MCP_READ_ONLY=false`.
+- When `MARKDOWN_VAULT_MCP_GIT_TOKEN` is set, `origin` must use an HTTPS remote URL.
+  SSH remotes (for example `git@github.com:owner/repo.git`) are rejected at startup.
+  Fix with: `git -C /path/to/vault remote set-url origin https://github.com/owner/repo.git`
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/src/markdown_vault_mcp/__init__.py
+++ b/src/markdown_vault_mcp/__init__.py
@@ -4,6 +4,7 @@ from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.config import CollectionConfig, load_config
 from markdown_vault_mcp.exceptions import (
     ConcurrentModificationError,
+    ConfigurationError,
     DocumentExistsError,
     DocumentNotFoundError,
     EditConflictError,
@@ -40,6 +41,7 @@ __all__ = [
     "CollectionConfig",
     "CollectionStats",
     "ConcurrentModificationError",
+    "ConfigurationError",
     "DeleteResult",
     "DocumentExistsError",
     "DocumentNotFoundError",

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -154,6 +154,7 @@ class CollectionConfig:
                 commit_name=self.git_commit_name,
                 commit_email=self.git_commit_email,
                 git_lfs=self.git_lfs,
+                repo_path=self.source_dir,
             )
             kwargs["git_strategy"] = git_strategy
 

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -32,3 +32,7 @@ class ConcurrentModificationError(MarkdownMCPError):
             f"Concurrent modification on {path}: "
             f"expected etag {expected!r}, actual {actual!r}"
         )
+
+
+class ConfigurationError(MarkdownMCPError):
+    """Invalid or unsupported configuration at startup."""

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -21,6 +21,8 @@ from typing import TYPE_CHECKING, Literal
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+from markdown_vault_mcp.exceptions import ConfigurationError
+
 logger = logging.getLogger(__name__)
 
 
@@ -80,6 +82,10 @@ class GitWriteStrategy:
             lazy initialisation so LFS pointers are resolved before the
             first write is committed.  Requires ``git-lfs`` to be on
             ``PATH``; failures are logged at ERROR and never propagated.
+        repo_path: Optional repository path used for startup validation.
+            When set together with ``token``, startup raises
+            :class:`~markdown_vault_mcp.exceptions.ConfigurationError`
+            if ``origin`` uses SSH transport instead of HTTPS.
 
     Example::
 
@@ -101,6 +107,7 @@ class GitWriteStrategy:
         commit_name: str | None = None,
         commit_email: str | None = None,
         git_lfs: bool = True,
+        repo_path: Path | None = None,
     ) -> None:
         self._token = token
         self._push_delay_s = push_delay_s
@@ -122,6 +129,8 @@ class GitWriteStrategy:
             Callable[[], contextlib.AbstractContextManager[None]] | None
         ) = None
         self._on_pull: Callable[[], None] | None = None
+        if repo_path is not None:
+            self.validate_startup(repo_path)
 
     def _git_env(self) -> dict[str, str] | None:
         """Build environment for git subprocess calls.
@@ -164,6 +173,46 @@ class GitWriteStrategy:
                 self._git_root_checked = True
         return self._git_root
 
+    def _check_remote_protocol(self, git_root: Path) -> None:
+        """Raise ConfigurationError if origin uses SSH while token auth is enabled."""
+        if not self._token:
+            return
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(git_root), "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            return
+        if result.returncode != 0:
+            # No remote configured; ignore here.
+            return
+
+        url = result.stdout.strip()
+        if not (url.startswith("git@") or url.startswith("ssh://")):
+            return
+
+        if url.startswith("ssh://git@"):
+            https_url = "https://" + url[len("ssh://git@") :]
+        elif url.startswith("ssh://"):
+            https_url = "https://" + url[len("ssh://") :]
+        else:
+            without_prefix = url[len("git@") :]
+            https_url = "https://" + without_prefix.replace(":", "/", 1)
+
+        raise ConfigurationError(
+            f"Remote URL {url!r} uses SSH transport, but GIT_TOKEN requires HTTPS.\n"
+            f"Run: git -C {git_root} remote set-url origin {https_url}"
+        )
+
+    def validate_startup(self, repo_path: Path) -> None:
+        """Validate startup git settings for token-authenticated workflows."""
+        git_root = self._ensure_git_root(repo_path)
+        if git_root is None:
+            return
+        self._check_remote_protocol(git_root)
+
     def _ensure_write_init(self) -> None:
         """One-time initialisation for the write path (identity/push/LFS)."""
         if self._write_init_done or self._git_root is None:
@@ -171,6 +220,7 @@ class GitWriteStrategy:
         with self._lock:
             if self._write_init_done or self._git_root is None:
                 return
+            self._check_remote_protocol(self._git_root)
             self._check_identity()
             self._push_if_unpushed()
             # LFS pull runs under the git lock to avoid overlapping git ops.

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1513,3 +1513,85 @@ class TestGitPullLoop:
         assert strategy._pull_thread.is_alive()
 
         strategy.stop()
+
+
+class TestCheckRemoteProtocol:
+    """Tests for SSH remote validation when token auth is enabled."""
+
+    @staticmethod
+    def _make_run(url: str):
+        from types import SimpleNamespace
+
+        def fake_run(cmd, **_kwargs):
+            if "get-url" in cmd:
+                return SimpleNamespace(returncode=0, stdout=url + "\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        return fake_run
+
+    def test_ssh_git_at_raises_with_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp.exceptions import ConfigurationError
+
+        strategy = GitWriteStrategy(token="ghp_secret")
+        strategy._git_root = tmp_path
+
+        monkeypatch.setattr(
+            "markdown_vault_mcp.git.subprocess.run",
+            self._make_run("git@github.com:owner/repo.git"),
+        )
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            strategy._check_remote_protocol(tmp_path)
+
+        msg = str(exc_info.value)
+        assert "SSH transport" in msg
+        assert "remote set-url origin https://github.com/owner/repo.git" in msg
+
+    def test_https_remote_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        strategy = GitWriteStrategy(token="ghp_secret")
+        strategy._git_root = tmp_path
+
+        monkeypatch.setattr(
+            "markdown_vault_mcp.git.subprocess.run",
+            self._make_run("https://github.com/owner/repo.git"),
+        )
+
+        strategy._check_remote_protocol(tmp_path)
+
+    def test_no_token_does_not_raise_for_ssh_remote(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        strategy = GitWriteStrategy(token=None)
+        strategy._git_root = tmp_path
+
+        monkeypatch.setattr(
+            "markdown_vault_mcp.git.subprocess.run",
+            self._make_run("git@github.com:owner/repo.git"),
+        )
+
+        strategy._check_remote_protocol(tmp_path)
+
+    def test_startup_validation_raises_in_constructor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp.exceptions import ConfigurationError
+
+        monkeypatch.setattr(
+            "markdown_vault_mcp.git._find_git_root",
+            lambda _repo_path: tmp_path,
+        )
+        monkeypatch.setattr(
+            "markdown_vault_mcp.git.subprocess.run",
+            self._make_run("ssh://git@github.com/owner/repo.git"),
+        )
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            GitWriteStrategy(token="ghp_secret", repo_path=tmp_path)
+
+        msg = str(exc_info.value)
+        assert "SSH transport" in msg
+        assert "https://github.com/owner/repo.git" in msg


### PR DESCRIPTION
## Summary
- add startup validation for git remote protocol in `GitWriteStrategy`
- raise `ConfigurationError` when `GIT_TOKEN` is set and `origin` is SSH (`git@...` or `ssh://`)
- include actionable `git remote set-url origin https://...` command in the error
- wire startup validation via config (`repo_path=self.source_dir`) so the server fails fast
- document HTTPS-remote requirement in README Git integration section
- add tests for SSH/HTTPS/token and constructor startup validation

## Why
Issue #136 requires an immediate, actionable startup failure instead of runtime `cannot run ssh` failures in containerized environments where SSH is unavailable.

Closes #136