### PR TITLE
fix(ci): exclude local package from pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,10 @@ jobs:
         run: uv python install 3.12
 
       - name: Export dependency list (excluding local project)
-        run: uv export --all-extras --frozen --no-emit-project --no-hashes -o /tmp/requirements.txt
+        run: uv export --all-extras --frozen --no-emit-project --no-hashes -o ${{ runner.temp }}/requirements.txt
 
       - name: Run pip-audit
-        run: uvx pip-audit --strict --progress-spinner off --ignore-vuln CVE-2026-25990 -r /tmp/requirements.txt
+        run: uvx pip-audit --strict --progress-spinner off --ignore-vuln CVE-2026-25990 -r ${{ runner.temp }}/requirements.txt
 
   secrets:
     name: Secret Detection


### PR DESCRIPTION
## Summary

- Switches pip-audit from scanning the installed environment to auditing an exported requirements file
- Uses `uv export --no-emit-project` to exclude the local project, then `uvx pip-audit -r` to audit deps only
- Fixes race condition where pip-audit fails on release commits because the new version isn't on PyPI yet

**Root cause:** python-semantic-release pushes a version bump commit to `main` → CI triggers → pip-audit tries to look up the new version on PyPI → fails because `publish-pypi` hasn't completed yet. See [failed run](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/23059002708/job/66980222941).

**Why this approach:** `--skip-editable` (the obvious fix) still fails under `--strict` because pip-audit treats skipped editables as errors. Exporting the lockfile with `--no-emit-project` structurally excludes the local package regardless of install mode, while keeping `--strict` for all third-party deps.

Fixes #164

## Design Conformance

No design documents found — CI workflow configuration change only.

## Test plan

- [x] CI audit job passes on this PR
- [ ] Verify next release does not fail on pip-audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)