### PR TITLE
feat: add raw_target to BrokenLinkInfo and get_broken_links (#207)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -533,6 +533,37 @@ class ChangeSet:
 # --- Graph types ---
 
 @dataclass
+class BacklinkInfo:
+    """A document that links to a given path."""
+    source_path: str
+    source_title: str
+    link_text: str
+    link_type: Literal["markdown", "wikilink", "reference"]
+    fragment: str | None = None
+    raw_target: str = ""              # literal link string as written in the source file
+
+@dataclass
+class OutlinkInfo:
+    """A link from a document to another path."""
+    target_path: str
+    link_text: str
+    link_type: Literal["markdown", "wikilink", "reference"]
+    fragment: str | None = None
+    raw_target: str = ""              # literal link string as written in the source file
+    exists: bool = False              # True if target_path is indexed in the collection
+
+@dataclass
+class BrokenLinkInfo:
+    """A link whose target does not exist in the collection."""
+    source_path: str
+    source_title: str
+    target_path: str
+    link_text: str
+    link_type: Literal["markdown", "wikilink", "reference"]
+    fragment: str | None = None
+    raw_target: str = ""              # literal link string as written in the source file
+
+@dataclass
 class MostLinkedNote:
     """A document with its inbound backlink count, returned by get_most_linked()."""
     path: str

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -1462,6 +1462,7 @@ class Collection:
                 link_text=row["link_text"],
                 link_type=row["link_type"],
                 fragment=row["fragment"],
+                raw_target=row["raw_target"],
             )
             for row in rows
         ]

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -777,7 +777,8 @@ class FTSIndex:
 
         Returns:
             List of dicts with keys ``source_path``, ``source_title``,
-            ``target_path``, ``link_text``, ``link_type``, ``fragment``.
+            ``target_path``, ``link_text``, ``link_type``, ``fragment``,
+            ``raw_target``.
         """
         folder_clause = ""
         params: list[str] = []
@@ -792,7 +793,8 @@ class FTSIndex:
                    l.target_path,
                    l.link_text,
                    l.link_type,
-                   l.fragment
+                   l.fragment,
+                   l.raw_target
             FROM links l
             JOIN documents d ON d.id = l.source_id
             WHERE NOT EXISTS (

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -224,6 +224,7 @@ class BrokenLinkInfo:
     link_text: str
     link_type: Literal["markdown", "wikilink", "reference"]
     fragment: str | None = None
+    raw_target: str = ""
 
 
 @dataclass

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -631,6 +631,25 @@ class TestRawTargetInFTS:
         rows = idx.get_outlinks("src.md")
         assert rows[0]["raw_target"] == "tgt.md"
 
+    def test_raw_target_returned_by_get_broken_links(self) -> None:
+        """raw_target is included in get_broken_links results."""
+        idx = FTSIndex(":memory:")
+        note = make_note(
+            path="source.md",
+            links=[
+                LinkInfo(
+                    target_path="missing/page.md",
+                    link_text="Missing",
+                    link_type="markdown",
+                    raw_target="../missing/page.md",
+                )
+            ],
+        )
+        idx.upsert_note(note)
+        rows = idx.get_broken_links()
+        assert len(rows) == 1
+        assert rows[0]["raw_target"] == "../missing/page.md"
+
 
 # ---------------------------------------------------------------------------
 # Collection: get_backlinks and get_outlinks


### PR DESCRIPTION
## Summary

- `BrokenLinkInfo` gains `raw_target: str = ""` field, mirroring `BacklinkInfo` and `OutlinkInfo`
- `FTSIndex.get_broken_links()` SQL SELECT includes `l.raw_target`
- `Collection.get_broken_links()` passes `raw_target` through to `BrokenLinkInfo`
- `docs/design.md`: adds `BacklinkInfo`, `OutlinkInfo`, `BrokenLinkInfo` dataclass definitions (were referenced in method signatures but not defined)
- Test: `raw_target` is included in `get_broken_links` results

## Design Conformance

No design documents defined `BrokenLinkInfo` explicitly — only referenced in method signatures. The design doc is updated as part of this PR to add the full dataclass definitions.

Closes #207

## Stack

This is PR 1/4 in a stack:
1. **This PR** — `raw_target` on `BrokenLinkInfo`
2. `feat/201-link-limit-sql` — SQL LIMIT for `get_backlinks`/`get_outlinks`
3. `feat/208-update-backlinks-helper` — extract `_update_backlinks` helper
4. `feat/191-stats-link-counts` — stats link health metrics