### PR TITLE
refactor: extract _update_backlinks helper from Collection.rename() (#208)

### DIFF
--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -2297,7 +2297,7 @@ class Collection:
                 source_abs = self._validate_path(source_path)
                 if not source_abs.is_file():
                     logger.warning(
-                        "update_links: skipping %s — file not found",
+                        "_update_backlinks: skipping %s — file not found",
                         source_path,
                     )
                     continue
@@ -2326,13 +2326,13 @@ class Collection:
                 pending_callbacks.append((source_abs, content))
             except (OSError, UnicodeDecodeError, ValueError, sqlite3.Error) as exc:
                 logger.warning(
-                    "update_links: failed to update %s: %s",
+                    "_update_backlinks: failed to update %s: %s",
                     source_path,
                     exc,
                 )
             except Exception as exc:
                 logger.warning(
-                    "update_links: unexpected error updating %s: %s",
+                    "_update_backlinks: unexpected error updating %s: %s",
                     source_path,
                     exc,
                     exc_info=True,


### PR DESCRIPTION
## Summary

- New private method `_update_backlinks(self, old_path, new_path, backlinks) -> list[tuple[Path, str]]` encapsulates the ~60-line per-file link-rewrite loop previously inline in `rename()`
- Returns a list of `(abs_path, new_content)` tuples for successfully updated source files — callbacks are **not** fired inside the helper
- `Collection.rename()` calls `_update_backlinks()` inside `_write_lock`, then fires the returned callbacks **after** releasing the lock — matching the pattern used by every other mutating method in the class
- `updated_links = len(backlink_callbacks)` replaces the per-iteration counter
- All existing `test_links.py` tests pass without modification

## Design Conformance

No design documents cover internal helper decomposition — implementation is the spec.

Closes #208

## Stack

This is PR 3/4 in a stack:
1. `feat/207-broken-link-raw-target` — `raw_target` on `BrokenLinkInfo`
2. `feat/201-link-limit-sql` — SQL LIMIT for `get_backlinks`/`get_outlinks`
3. **This PR** — extract `_update_backlinks` helper
4. `feat/191-stats-link-counts` — stats link health metrics