### PR TITLE
docs: improve LLM-facing tool docstrings to fix observed misbehaviors (#214)

### DIFF
--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -1549,7 +1549,7 @@ def create_server() -> FastMCP:
             f"Step 2: Call `get_context` with path='{path}' — this returns "
             "backlinks, outlinks, and similar notes in one call. Also call "
             "`search` using the main topic terms to surface additional documents "
-            "not captured by the link graph.\n"
+            "not captured by direct links or overall document similarity.\n"
             "Step 3: Present a list of the most relevant related documents. "
             "For each, include: the document title, its path, and one sentence "
             "explaining the connection.\n"


### PR DESCRIPTION
Closes #214

## Summary

Fixes two observed LLM misbehaviors and addresses 14 additional gaps found in a full docstring audit.

**Observed bugs fixed:**
- LLM was calling `reindex` after `write`/`edit`/`delete`/`rename` — write tools update the index synchronously, `reindex` is only for external changes
- LLM was renaming notes without `update_links=True`, leaving stale links in other documents

**Changes (all in `src/markdown_vault_mcp/mcp_server.py`, docstring-only):**

| Change | What changed |
|---|---|
| Server instructions | Added global rule: "never call reindex after write/edit/delete/rename"; added `update_links=True` hint inline with `rename` |
| `reindex` | Rewrote opening: now says "Sync with files changed by an **external process**" + explicit DO NOT call after write tools |
| `write`, `edit`, `delete`, `rename` | Added "index updated immediately; do not call reindex afterward" to each |
| `rename` | Added decision rule before Args: "always pass `update_links=True` when renaming a .md note" |
| `stats` Returns | Added 4 missing fields: `attachment_extensions`, `link_count`, `broken_link_count` (with `get_broken_links` trigger), `orphan_count` (with `get_orphan_notes` trigger) |
| `embeddings_status` | Fixed wrong tool reference: `reindex` → `build_embeddings` for filling vector index gaps |
| `get_backlinks`, `get_outlinks` | Added `get_context` as preferred alternative for full-picture queries |
| `get_broken_links` | Added trigger: call when `stats.broken_link_count > 0` or after rename without `update_links=True` |
| `get_orphan_notes` | Added trigger: call when `stats.orphan_count > 0` |
| `get_context` | Added `similar_limit=0` trigger: use when `semantic_search_available=False` |
| `list_tags` | Added warning that passing an unindexed field silently returns empty list |
| `related` prompt | Uses `get_context` as primary source, `search` as supplement |
| `research` prompt | Uses `mode='hybrid'` with error-retry instead of `stats` pre-check |

## Design Conformance

No design documents cover MCP tool docstring content — the issue itself is the authoritative spec.

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | All 16 docstring/instruction changes applied | Issue #214, criterion 1 | CONFORMANT | 16 distinct change sites in diff |
| 2 | Server instructions: "never call 'reindex' after write, edit, delete, or rename" | Issue #214, criterion 2 | CONFORMANT | `mcp_server.py:277` |
| 3 | `reindex` opens with "Sync the search index with files changed on disk by an external process" | Issue #214, criterion 3 | CONFORMANT | `mcp_server.py:1071` |
| 4 | `rename` mentions `update_links=True` before Args section | Issue #214, criterion 4 | CONFORMANT | `mcp_server.py:1287–1289` |
| 5 | `stats` Returns lists all 9 fields including `link_count`, `broken_link_count`, `orphan_count` | Issue #214, criterion 5 | CONFORMANT | `mcp_server.py:718–726` |
| 6 | `embeddings_status` no longer references `reindex` for vector index gaps | Issue #214, criterion 6 | CONFORMANT | `mcp_server.py:744–749` |
| 7 | `get_backlinks` and `get_outlinks` reference `get_context` as preferred alternative | Issue #214, criterion 7 | CONFORMANT | `mcp_server.py:776`, `814` |
| 8 | `get_broken_links` references `stats.broken_link_count` triage + `rename`/`update_links` post-condition | Issue #214, criterion 8 | CONFORMANT | `mcp_server.py:850–852` |
| 9 | `get_orphan_notes` references `stats.orphan_count` triage check | Issue #214, criterion 9 | CONFORMANT | `mcp_server.py:1016–1017` |

Reviewed by @architect-reviewer — all 9 requirements CONFORMANT.