### PR TITLE
fix: server.json registry validation and OCI tag mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             .version = $v |
             .packages |= map(
               if .registryType == "pypi" then .version = $v
-              elif .registryType == "oci" then .identifier = ("ghcr.io/pvliesdonk/markdown-vault-mcp:" + $v)
+              elif .registryType == "oci" then .identifier = ("ghcr.io/pvliesdonk/markdown-vault-mcp:v" + $v)
               else . end
             )
           ' server.json > server.json.tmp
@@ -194,6 +194,7 @@ jobs:
             org.opencontainers.image.title=markdown-vault-mcp
             org.opencontainers.image.description=Generic markdown vault MCP server with FTS5 + semantic search
             org.opencontainers.image.vendor=pvliesdonk
+            io.modelcontextprotocol.server.name=io.github.pvliesdonk/markdown-vault-mcp
 
       - name: Build and push Docker image
         id: build-push

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ htmlcov/
 *.npy
 *.npz
 site/
+.mcpregistry_*

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.pvliesdonk/markdown-vault-mcp",
   "title": "Markdown Vault MCP",
-  "description": "Generic markdown vault MCP server with FTS5 + semantic search, frontmatter-aware indexing, and incremental reindexing",
+  "description": "Markdown vault MCP server with FTS5 + semantic search and frontmatter indexing",
   "version": "1.13.1",
   "websiteUrl": "https://pvliesdonk.github.io/markdown-vault-mcp/",
   "repository": {
@@ -55,7 +55,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:1.13.1",
+      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v1.13.1",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{--port}/mcp"
@@ -64,7 +64,7 @@
         {
           "type": "named",
           "name": "--port",
-          "default": 8000,
+          "default": "8000",
           "description": "Port for the HTTP transport"
         }
       ],


### PR DESCRIPTION
## Summary

- Fix `packageArguments.default` type: `8000` (number) → `"8000"` (string) — Go unmarshalling requirement
- Shorten `description` from 119 to 78 chars (registry enforces ≤100)
- Add `v` prefix to OCI image tag in `server.json` and `release.yml` jq command — Docker tags are `v1.13.1`, not `1.13.1`
- Add `io.modelcontextprotocol.server.name` label to Docker metadata in release workflow
- Add `.mcpregistry_*` to `.gitignore`

All discovered during first `mcp-publisher publish` attempt. PyPI-only publish succeeded; OCI will work on next release (once Docker image has MCP label).

Closes #240

## Test plan

- [ ] `mcp-publisher validate` passes
- [ ] No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)