### PR TITLE
chore: complete server.json env vars, restore OCI, automate registry publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,8 +249,10 @@ jobs:
           fetch-depth: 1
 
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.5.0
         run: |
-          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/server.json
+++ b/server.json
@@ -241,6 +241,22 @@
           "default": "markdown-vault-mcp"
         },
         {
+          "name": "MARKDOWN_VAULT_MCP_STATE_PATH",
+          "description": "Directory for index and embeddings state files",
+          "format": "filepath",
+          "default": "/data/state"
+        },
+        {
+          "name": "MARKDOWN_VAULT_MCP_INDEX_PATH",
+          "description": "Path to the FTS5 SQLite index file",
+          "format": "filepath"
+        },
+        {
+          "name": "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
+          "description": "Path to the numpy embeddings file",
+          "format": "filepath"
+        },
+        {
           "name": "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
           "description": "Comma-separated frontmatter fields to index for search"
         },


### PR DESCRIPTION
## Summary

- Add all **36 env vars** to PyPI package entry with `format`, `default`, `choices`, `isSecret` fields per the [MCP Registry schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json)
- Add all **35 env vars** to OCI package entry (includes `PUID`/`PGID` Docker-specific vars, container default paths)
- Restore OCI package (was removed for initial publish — v1.13.2 Docker images now have the required `io.modelcontextprotocol.server.name` label)
- Add `publish-registry` job to `release.yml`: installs `mcp-publisher`, authenticates via `github-oidc` (no PAT needed), publishes after PyPI + Docker complete

Env vars organized by category: core, mode, storage, indexing, embeddings, git sync, attachments, templates, bearer auth, OIDC auth.

Closes #242

## Design Conformance

No design documents found — conformance review not applicable. This is metadata and CI workflow only.

## Test plan

- [x] `mcp-publisher validate` passes locally
- [ ] CI checks pass (no functional code changes)
- [ ] Next release auto-publishes to the MCP Registry (verified when `publish-registry` job runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)