### PR TITLE
fix: multi-auth rejects bearer tokens with 403 insufficient_scope

### DIFF
--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import Any
 
@@ -243,9 +244,7 @@ def create_server() -> FastMCP:
         # (e.g. ["openid"]) would otherwise propagate to the HTTP
         # middleware and reject bearer tokens that lack "openid".
         # Each verifier already enforces its own scope requirements.
-        auth = MultiAuth(
-            server=oidc_auth, verifiers=[bearer_auth], required_scopes=[]
-        )
+        auth = MultiAuth(server=oidc_auth, verifiers=[bearer_auth], required_scopes=[])
         auth_mode = "multi"
         logger.info("Multi-auth enabled: bearer token + OIDC (either accepted)")
     elif bearer_auth:
@@ -263,7 +262,7 @@ def create_server() -> FastMCP:
 
     try:
         pkg_ver = _pkg_version("markdown-vault-mcp")
-    except Exception:
+    except PackageNotFoundError:
         pkg_ver = "unknown"
 
     logger.info(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2320,3 +2320,21 @@ class TestAuthDebugLogging:
         assert "version=" in caplog.text
         assert "auth=none" in caplog.text
         assert "read-only" in caplog.text
+
+    def test_startup_version_fallback(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Version falls back to 'unknown' when package is not installed."""
+        from importlib.metadata import PackageNotFoundError
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+        monkeypatch.setattr(
+            "markdown_vault_mcp.mcp_server._pkg_version",
+            lambda _name: (_ for _ in ()).throw(PackageNotFoundError("test")),
+        )
+        with caplog.at_level(logging.INFO):
+            create_server()
+        assert "version=unknown" in caplog.text


### PR DESCRIPTION
## Summary

- Fix multi-auth mode rejecting bearer tokens with 403 `insufficient_scope` — `MultiAuth` inherited `required_scopes=["openid"]` from OIDCProxy, which FastMCP's `RequireAuthMiddleware` enforced on ALL tokens including bearer (which only has `["read", "write"]`)
- Add package version to startup log line for production diagnostics (`version=X.Y.Z`)
- Add regression test asserting `MultiAuth.required_scopes == []`

## Root Cause

`MultiAuth(server=oidc_auth, verifiers=[bearer_auth])` without explicit `required_scopes` inherits from `server.required_scopes` = `["openid"]`. FastMCP's HTTP layer (`fastmcp/server/http.py:339`) passes `auth.required_scopes` to `RequireAuthMiddleware`, which rejects any token missing `"openid"` scope **before** the request reaches MCP. Bearer tokens with `scopes=["read", "write"]` get a 403 every time.

## Fix

Pass `required_scopes=[]` to `MultiAuth`. Each verifier already enforces its own scope requirements — the middleware-level check is redundant and incorrectly applies OIDC-specific constraints to bearer tokens.

## Design Conformance

No design documents specify the `required_scopes` propagation behavior at this level of detail. The auth section of `docs/design.md` describes multi-auth as "either bearer or OIDC" — this fix restores that contract.

## Test plan

- [x] `test_multi_auth_required_scopes_empty` — asserts `MultiAuth.required_scopes == []` when both auth methods configured
- [x] `test_startup_summary_logged` — updated to check `version=` in startup log
- [x] 803 tests passing (802 existing + 1 new)

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)
