### PR TITLE
chore: add SYNC.md for cross-repo tracking with image-generation-mcp

### DIFF
--- a/SYNC.md
+++ b/SYNC.md
@@ -9,7 +9,7 @@ silent divergence.
 | Area | markdown-vault-mcp | image-generation-mcp | Notes |
 |------|-------------------|----------------------|-------|
 | **Auth: bearer** | `mcp_server.py:_build_bearer_auth()` | `mcp_server.py:_build_bearer_auth()` | Identical (env prefix differs) |
-| **Auth: remote** | `mcp_server.py:_build_remote_auth()` | `mcp_server.py:_build_remote_auth()` | MV has httpx ImportError guard; IG catches specific exceptions |
+| **Auth: remote** | `mcp_server.py:_build_remote_auth()` | `mcp_server.py:_build_remote_auth()` | MV guards missing httpx with ImportError; IG does bare import (crashes if absent) |
 | **Auth: oidc-proxy** | `mcp_server.py:_build_oidc_auth()` | `mcp_server.py:_build_oidc_auth()` | Identical (env prefix differs) |
 | **Auth: mode detect** | `mcp_server.py:_resolve_auth_mode()` | `mcp_server.py:_resolve_auth_mode()` | MV logs on explicit+auto-detect; IG logs only warning |
 | **Auth: multi-auth** | `mcp_server.py:create_server()` | `mcp_server.py:create_server()` | Both use `MultiAuth(…, required_scopes=[])` |


### PR DESCRIPTION
## Summary

- Adds `SYNC.md` documenting the shared code surface between `markdown-vault-mcp` and `image-generation-mcp`
- Includes shared file mapping table, known divergences, completed sync log (5 ports), and pending ports (4 items)
- Documentation-only — no code changes, no test changes

Closes #266

## Design Conformance

No design documents cover this area — this is operational documentation for cross-repo maintenance.

## Test plan

- [ ] Verify `SYNC.md` renders correctly on GitHub
- [ ] Verify all linked PRs/issues exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)