### PR TITLE
docs: add cross-repo sync rule to CLAUDE.md, update SYNC.md pending ports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,12 @@ Every issue, PR, and code change must consider documentation impact. Before clos
 
 When writing issues, include a "Documentation" section listing which docs need updating. When reviewing PRs, verify documentation is included — code without matching docs is incomplete.
 
+## Cross-Repo Sync
+
+This repo shares domain-independent infrastructure with [`pvliesdonk/image-generation-mcp`](https://github.com/pvliesdonk/image-generation-mcp). See [`SYNC.md`](SYNC.md) for the shared file mapping, known divergences, and port history.
+
+**Rule:** When fixing or improving shared infrastructure (auth, CI/CD, Docker entrypoint, release pipeline, packaging, CLI logging), create a corresponding issue in the other repo to port the change. Reference the source PR in the issue body. Domain-specific code (vault logic, image generation, tools, resources) does not need cross-posting.
+
 ## Key Design Decisions
 
 - Document identity: relative path with `.md` extension

--- a/SYNC.md
+++ b/SYNC.md
@@ -101,9 +101,7 @@ Completed ports, newest first.
 
 ## Pending Ports
 
-| Direction | What | Source | Priority | Notes |
-|-----------|------|--------|----------|-------|
-| MV → IG | Per-package server.json format | MV#243 | Medium | IG still uses legacy root-level format |
-| MV → IG | httpx ImportError guard in `_build_remote_auth()` | MV#268 | Low | Prevents crash when httpx not installed |
-| IG → MV | Versionless `_latest.deb`/`_latest.rpm` copies | IG release.yml | Low | Stable download URLs |
-| IG → MV | "No coverable lines" explicit diff-cover case | IG#102 ci.yml | Low | Cleaner than TOTAL="unknown" fallthrough |
+All known pending ports have been filed as issues:
+
+- **MV → IG**: [image-generation-mcp#110](https://github.com/pvliesdonk/image-generation-mcp/issues/110) — server.json, httpx guard, auth logging, CI diff-cover, release job deps
+- **IG → MV**: [markdown-vault-mcp#270](https://github.com/pvliesdonk/markdown-vault-mcp/issues/270) — diff-cover cleanup, versionless package copies


### PR DESCRIPTION
## Summary

- Adds "Cross-Repo Sync" section to `CLAUDE.md` referencing `SYNC.md` with rule to cross-post domain-independent infrastructure fixes to the other repo
- Updates `SYNC.md` pending ports table → issue links (image-generation-mcp#110, #270)

## Design Conformance

No design documents cover this area — operational documentation for cross-repo maintenance.

## Test plan

- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify SYNC.md issue links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)