### PR TITLE
fix(ci): improve diff-cover handling and add versionless package copies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
             OUTPUT=$(uv run diff-cover coverage.xml --compare-branch="origin/${BASE_REF}" --fail-under=80 2>&1) && RC=0 || RC=$?
             echo "$OUTPUT"
             TOTAL=$(echo "$OUTPUT" | grep -oP 'Total:\s+\K[\d.]+' || true)
-            if [ -z "$TOTAL" ] && [ "$RC" != "0" ]; then
+            if [ -z "$TOTAL" ] && [ "$RC" -ne 0 ]; then
               echo "state=error" >> "$GITHUB_OUTPUT"
               echo "description=diff-cover failed to compute patch coverage" >> "$GITHUB_OUTPUT"
             elif [ -z "$TOTAL" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,8 +276,8 @@ jobs:
 
       - name: Create versionless copies for stable download URLs
         run: |
-          cp dist/*.deb dist/markdown-vault-mcp_latest.deb
-          cp dist/*.rpm dist/markdown-vault-mcp_latest.rpm
+          cp dist/markdown-vault-mcp_*.deb dist/markdown-vault-mcp_latest.deb
+          cp dist/markdown-vault-mcp_*.rpm dist/markdown-vault-mcp_latest.rpm
 
       - name: Upload packages to GitHub Release
         run: gh release upload ${{ needs.release.outputs.tag }} dist/*.deb dist/*.rpm --clobber


### PR DESCRIPTION
## Summary

- **CI diff-cover**: Add explicit "no coverable lines" case (was `TOTAL="unknown"` fallthrough) and "error" case when diff-cover fails with no parseable output
- **CI diff-cover**: Pass status via env vars (`PATCH_STATE`, `PATCH_DESC`) instead of string interpolation — safer against shell injection
- **Release**: Add versionless `markdown-vault-mcp_latest.deb`/`.rpm` copies for stable download URLs

Closes #270

## Design Conformance

No design documents cover this area — CI/infrastructure only.

## Test plan

- [ ] CI runs successfully on this PR (no Python changes → "Coverage not affected")
- [ ] Verify diff-cover step logic handles all 4 cases: no Python files, no coverable lines, pass, fail
- [ ] Release workflow change is additive (copy step before upload) — no risk to existing flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)