### PR TITLE
feat: Vault Browser — tree navigation with markdown preview (#276)

### DIFF
--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -913,6 +913,14 @@ app.onDisplayModeChanged((mode) => {
 
 // ── Vault Browser View ──────────────────────────────────────────────────
 (function() {
+  function escHtml(s) {
+    return String(s ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
   let currentPreviewPath = null;
   let currentPreviewData = null;
   let treeDataCache = {};
@@ -937,14 +945,14 @@ app.onDisplayModeChanged((mode) => {
     }
   }
 
-  function renderTree(data, parentEl, parentFolder) {
+  function renderTree(data, parentEl) {
     parentEl.innerHTML = '';
     // Folders
     for (const f of data.folders) {
       const name = f.includes('/') ? f.split('/').pop() : f;
       const folderDiv = document.createElement('div');
       folderDiv.className = 'tree-folder';
-      folderDiv.innerHTML = '<span class="arrow">\\u25B6</span> \\uD83D\\uDCC1 ' + name;
+      folderDiv.innerHTML = '<span class="arrow">\\u25B6</span> \\uD83D\\uDCC1 ' + escHtml(name);
       folderDiv.dataset.folder = f;
       parentEl.appendChild(folderDiv);
 
@@ -960,7 +968,7 @@ app.onDisplayModeChanged((mode) => {
           folderDiv.classList.add('expanded');
           if (childrenDiv.children.length === 0) {
             const subData = await loadFolder(f);
-            renderTree(subData, childrenDiv, f);
+            renderTree(subData, childrenDiv);
           }
         }
       });
@@ -980,7 +988,7 @@ app.onDisplayModeChanged((mode) => {
   async function loadRootTree() {
     treeDataCache = {};
     const data = await loadFolder(null);
-    renderTree(data, treeEl, null);
+    renderTree(data, treeEl);
   }
 
   async function loadPreview(path) {
@@ -997,7 +1005,7 @@ app.onDisplayModeChanged((mode) => {
       currentPreviewData = data;
 
       let html = '<div class="preview-header">';
-      html += '<h2>' + (data.title || path) + '</h2>';
+      html += '<h2>' + escHtml(data.title || path) + '</h2>';
       html += '<div class="preview-actions">';
       html += '<button class="action-btn" id="preview-send-btn" title="Send to Claude">\\uD83D\\uDCAC Send</button>';
       html += '<button class="action-btn" id="preview-ctx-btn" title="Show Context" style="background:var(--host-surface,var(--fallback-surface));color:var(--host-fg,var(--fallback-fg));border:1px solid var(--host-border,var(--fallback-border));">\\uD83D\\uDD0D Context</button>';
@@ -1010,7 +1018,7 @@ app.onDisplayModeChanged((mode) => {
         html += '<div class="preview-fm"><table class="fm-table">';
         for (const [k, v] of Object.entries(data.frontmatter)) {
           const val = typeof v === 'object' ? JSON.stringify(v) : String(v);
-          html += '<tr><td>' + k + '</td><td>' + val + '</td></tr>';
+          html += '<tr><td>' + escHtml(k) + '</td><td>' + escHtml(val) + '</td></tr>';
         }
         html += '</table></div>';
       }
@@ -1020,7 +1028,7 @@ app.onDisplayModeChanged((mode) => {
       if (typeof marked !== 'undefined' && data.content) {
         rendered = marked.parse(data.content);
       } else {
-        rendered = '<pre>' + (data.content || '') + '</pre>';
+        rendered = '<pre>' + escHtml(data.content || '') + '</pre>';
       }
       if (typeof DOMPurify !== 'undefined') {
         rendered = DOMPurify.sanitize(rendered);
@@ -1042,7 +1050,11 @@ app.onDisplayModeChanged((mode) => {
 
       window.updateContext('browser', path, data.title);
     } catch (err) {
-      previewEl.innerHTML = '<div class="placeholder">Error: ' + (err.message || err) + '</div>';
+      const errDiv = document.createElement('div');
+      errDiv.className = 'placeholder';
+      errDiv.textContent = 'Error: ' + (err.message || err);
+      previewEl.innerHTML = '';
+      previewEl.appendChild(errDiv);
     }
   }
 
@@ -1067,8 +1079,8 @@ app.onDisplayModeChanged((mode) => {
       for (const r of data) {
         const div = document.createElement('div');
         div.className = 'search-result';
-        div.innerHTML = '<div class="search-result-title">' + (r.title || r.path) + '</div>'
-          + '<div class="search-result-snippet">' + (r.snippet || '') + '</div>';
+        div.innerHTML = '<div class="search-result-title">' + escHtml(r.title || r.path) + '</div>'
+          + '<div class="search-result-snippet">' + escHtml(r.snippet || '') + '</div>';
         div.addEventListener('click', () => loadPreview(r.path));
         treeEl.appendChild(div);
       }

--- a/tests/test_mcp_apps_browser.py
+++ b/tests/test_mcp_apps_browser.py
@@ -200,11 +200,11 @@ class TestBrowserDataTools:
             )
             data = _parse_tool_data(result)
             assert isinstance(data, list)
-            if len(data) > 0:
-                assert "path" in data[0]
-                assert "title" in data[0]
-                assert "snippet" in data[0]
-                assert "score" in data[0]
+            assert len(data) > 0, "Expected at least one result for query 'simple'"
+            assert "path" in data[0]
+            assert "title" in data[0]
+            assert "snippet" in data[0]
+            assert "score" in data[0]
 
     async def test_vault_search_respects_limit(self) -> None:
         server = create_server()


### PR DESCRIPTION
## Summary

- `_vault_list` app-only tool: folder tree with notes and subfolders
- `_vault_read` app-only tool: note content, frontmatter, metadata
- `_vault_search` app-only tool: keyword search with snippets and scores
- Two-panel Browser view: expandable folder tree + markdown note preview
- marked.js + DOMPurify from unpkg CDN for safe markdown rendering
- Search bar with results overlay and clear button
- Disabled Edit button placeholder ("Coming soon")
- Host CSS variable theming, updateModelContext, Send to Claude

Closes #276

## Stack

1. `feat/273-mcp-apps-foundation` → PR #280
2. `feat/274-context-card` → PR #281
3. `feat/275-graph-explorer` → PR #282
4. **This PR** ← `feat/276-vault-browser` (base: #282)
5. `feat/277-cross-navigation` (base: this)

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 276-1 | marked.js + DOMPurify from unpkg | AC1 | CONFORMANT | Lines 73-74 |
| 276-2 | `_vault_list` with folders/notes | AC2 | CONFORMANT | `_server_apps.py:1473-1514` |
| 276-3 | `_vault_read` with content/metadata | AC3 | CONFORMANT | `_server_apps.py:1516-1549` |
| 276-4 | `_vault_search` with snippets/scores | AC4 | CONFORMANT | `_server_apps.py:1551-1590` |
| 276-5 | Two-panel layout | AC5 | CONFORMANT | Lines 362-374 |
| 276-6 | Expandable folders, click loads preview | AC6 | CONFORMANT | Lines 936-973 |
| 276-7 | Rendered markdown + DOMPurify, title as H1 | AC7 | CONFORMANT | Lines 996-1024 |
| 276-8 | Search bar with results and clear | AC8 | CONFORMANT | Lines 1046-1086 |
| 276-9 | updateModelContext on selection | AC9 | CONFORMANT | Line 1039 |
| 276-10 | Send to Claude with 4000 char truncation | AC10 | CONFORMANT | Line 1029 |
| 276-11 | Host CSS variables | AC11 | CONFORMANT | Lines 294-314 |
| 276-12 | Disabled Edit button placeholder | AC12 | CONFORMANT | Line 1001 |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [ ] 21 new tests in `tests/test_mcp_apps_browser.py`
- [ ] HTML tests (14): CDNs, layout, folder tree, search, preview, edit button
- [ ] Data tool tests (7): vault_list root/subfolder, vault_read, vault_search, kind field
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)