### PR TITLE
fix(ci): RPM glob separator + pin ext-apps SDK to v1.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Create versionless copies for stable download URLs
         run: |
           cp dist/markdown-vault-mcp_*.deb dist/markdown-vault-mcp_latest.deb
-          cp dist/markdown-vault-mcp_*.rpm dist/markdown-vault-mcp_latest.rpm
+          cp dist/markdown-vault-mcp-*.rpm dist/markdown-vault-mcp_latest.rpm
 
       - name: Upload packages to GitHub Release
         run: gh release upload ${{ needs.release.outputs.tag }} dist/*.deb dist/*.rpm --clobber

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -73,7 +73,7 @@ _SPA_SHELL_HTML = """\
 <script src="https://unpkg.com/vis-network@10.0.2/standalone/umd/vis-network.min.js"></script>
 <script src="https://unpkg.com/marked@17.0.5/marked.min.js"></script>
 <script src="https://unpkg.com/dompurify@3.3.3/dist/purify.min.js"></script>
-<script type="module" src="https://unpkg.com/@anthropic-ai/claude-mcp-ext-apps@latest/dist/index.js"></script>
+<script type="module" src="https://unpkg.com/@anthropic-ai/claude-mcp-ext-apps@1.3.1/dist/index.js"></script>
 <style>
   :root {
     --fallback-bg: #ffffff;
@@ -380,7 +380,7 @@ _SPA_SHELL_HTML = """\
 <div class="toast" id="toast"></div>
 
 <script type="module">
-import { createApp } from 'https://unpkg.com/@anthropic-ai/claude-mcp-ext-apps@latest/dist/index.js';
+import { createApp } from 'https://unpkg.com/@anthropic-ai/claude-mcp-ext-apps@1.3.1/dist/index.js';
 
 // ── Globals ──────────────────────────────────────────────────────────────
 const app = createApp();


### PR DESCRIPTION
## Summary

- Fix RPM versionless-copy glob in release workflow: `_*.rpm` → `-*.rpm` to match nfpm RPM naming convention. This caused v1.17.0 to ship without Linux package assets.
- Pin ext-apps SDK from `@latest` to `@1.3.1` at both CDN import sites. All other CDN deps are already pinned.

Fixes #288, fixes #289.

## Design Conformance

| # | Requirement | Source | Status | Evidence |
|---|---|---|---|---|
| 1 | RPM glob uses hyphen separator | #288 AC1 | CONFORMANT | `release.yml:280` |
| 2 | Versionless name consistent with .deb | #288 AC2 | CONFORMANT | `release.yml:280` |
| 3 | Both `@latest` → `@1.3.1` | #289 AC1 | CONFORMANT | `_server_apps.py:76,383` |
| 4 | CSP resourceDomains unchanged | #289 AC2 | CONFORMANT | `_server_apps.py:36,1196` |

Reviewed by @architect-reviewer — all requirements CONFORMANT.

## Test plan

- [ ] `grep -n '@latest' src/markdown_vault_mcp/_server_apps.py` returns 0 matches
- [ ] Existing MCP Apps foundation tests pass (48/48)
- [ ] Next release uploads both .deb and .rpm assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)