### PR TITLE
fix: reindex/index CLI commands now build embeddings + Claude Desktop guide improvements

### DIFF
--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -43,24 +43,45 @@ Edit your Claude Desktop configuration file:
 
     `~/.config/Claude/claude_desktop_config.json`
 
-```json
-{
-  "mcpServers": {
-    "my-vault": {
-      "command": "markdown-vault-mcp",
-      "args": ["serve"],
-      "env": {
-        "MARKDOWN_VAULT_MCP_SOURCE_DIR": "/path/to/your/ObsidianVault",
-        "MARKDOWN_VAULT_MCP_SERVER_NAME": "my-vault",
-        "MARKDOWN_VAULT_MCP_EXCLUDE": ".obsidian/**,.trash/**",
-        "MARKDOWN_VAULT_MCP_INDEX_PATH": "/path/to/store/index.db"
+=== "macOS / Linux"
+
+    ```json
+    {
+      "mcpServers": {
+        "my-vault": {
+          "command": "markdown-vault-mcp",
+          "args": ["serve"],
+          "env": {
+            "MARKDOWN_VAULT_MCP_SOURCE_DIR": "/path/to/your/ObsidianVault",
+            "MARKDOWN_VAULT_MCP_SERVER_NAME": "my-vault",
+            "MARKDOWN_VAULT_MCP_EXCLUDE": ".obsidian/**,.trash/**",
+            "MARKDOWN_VAULT_MCP_INDEX_PATH": "/path/to/store/index.db"
+          }
+        }
       }
     }
-  }
-}
-```
+    ```
 
-Replace `/path/to/your/ObsidianVault` with the actual path to your vault.
+=== "Windows"
+
+    ```json
+    {
+      "mcpServers": {
+        "my-vault": {
+          "command": "markdown-vault-mcp",
+          "args": ["serve"],
+          "env": {
+            "MARKDOWN_VAULT_MCP_SOURCE_DIR": "C:\\Users\\YourName\\Documents\\ObsidianVault",
+            "MARKDOWN_VAULT_MCP_SERVER_NAME": "my-vault",
+            "MARKDOWN_VAULT_MCP_EXCLUDE": ".obsidian/**,.trash/**",
+            "MARKDOWN_VAULT_MCP_INDEX_PATH": "C:\\Users\\YourName\\vault_index.db"
+          }
+        }
+      }
+    }
+    ```
+
+Replace the paths with the actual locations on your machine.
 
 !!! tip "Persist the index"
     Setting `MARKDOWN_VAULT_MCP_INDEX_PATH` stores the FTS5 index on disk. Without it, the index is built in memory on every startup. With it, only changed files are reindexed.
@@ -154,57 +175,117 @@ You should see a commit from `markdown-vault-mcp`. Delete the test note when don
 
 **Goal:** Enable embedding-based search alongside keyword search for better recall on conceptual queries.
 
-**Prerequisites:** Step 1 complete. One of: FastEmbed installed (`pip install markdown-vault-mcp[embeddings]`), [Ollama](https://ollama.com) running locally, or an OpenAI API key (see [Embeddings guide](embeddings.md) for details).
+**Prerequisites:** Step 1 complete. Choose an embedding backend:
 
-This example uses Ollama — the easiest option for local, private embeddings.
+- **FastEmbed** (recommended for Windows and offline use) — local inference, no external service
+- **Ollama** (macOS/Linux) — local inference via [Ollama](https://ollama.com)
+- **OpenAI** — cloud-based, requires API key (see [Embeddings guide](embeddings.md))
 
-### Install and start Ollama
+### Install and configure
 
-```bash
-# Install Ollama (macOS)
-brew install ollama
+=== "FastEmbed (Windows / offline)"
 
-# Pull the embedding model
-ollama pull nomic-embed-text
+    Install the embeddings extra:
 
-# Ollama runs automatically after install; verify:
-curl http://localhost:11434/api/tags
-```
+    ```powershell
+    pip install "markdown-vault-mcp[embeddings]"
+    # or:
+    uv tool install "markdown-vault-mcp[embeddings]"
+    ```
 
-### Update the configuration
+    Update your `claude_desktop_config.json`:
 
-Add the highlighted lines:
-
-```json hl_lines="9-12"
-{
-  "mcpServers": {
-    "my-vault": {
-      "command": "markdown-vault-mcp",
-      "args": ["serve"],
-      "env": {
-        "MARKDOWN_VAULT_MCP_SOURCE_DIR": "/path/to/your/ObsidianVault",
-        "MARKDOWN_VAULT_MCP_SERVER_NAME": "my-vault",
-        "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH": "/path/to/store/embeddings",
-        "EMBEDDING_PROVIDER": "ollama",
-        "OLLAMA_HOST": "http://localhost:11434",
-        "MARKDOWN_VAULT_MCP_OLLAMA_MODEL": "nomic-embed-text",
-        "MARKDOWN_VAULT_MCP_EXCLUDE": ".obsidian/**,.trash/**",
-        "MARKDOWN_VAULT_MCP_INDEX_PATH": "/path/to/store/index.db"
+    ```json hl_lines="9-13"
+    {
+      "mcpServers": {
+        "my-vault": {
+          "command": "markdown-vault-mcp",
+          "args": ["serve"],
+          "env": {
+            "MARKDOWN_VAULT_MCP_SOURCE_DIR": "C:\\Users\\YourName\\Documents\\ObsidianVault",
+            "MARKDOWN_VAULT_MCP_SERVER_NAME": "my-vault",
+            "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH": "C:\\Users\\YourName\\vault_embeddings",
+            "EMBEDDING_PROVIDER": "fastembed",
+            "MARKDOWN_VAULT_MCP_FASTEMBED_MODEL": "BAAI/bge-small-en-v1.5",
+            "MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR": "C:\\Users\\YourName\\fastembed_cache",
+            "MARKDOWN_VAULT_MCP_INDEX_PATH": "C:\\Users\\YourName\\vault_index.db",
+            "MARKDOWN_VAULT_MCP_EXCLUDE": ".obsidian/**,.trash/**"
+          }
+        }
       }
     }
-  }
-}
-```
+    ```
 
-**What these do:**
+=== "Ollama (macOS / Linux)"
+
+    Install and start Ollama:
+
+    ```bash
+    brew install ollama        # macOS
+    ollama pull nomic-embed-text
+    ```
+
+    Update your config:
+
+    ```json hl_lines="9-12"
+    {
+      "mcpServers": {
+        "my-vault": {
+          "command": "markdown-vault-mcp",
+          "args": ["serve"],
+          "env": {
+            "MARKDOWN_VAULT_MCP_SOURCE_DIR": "/path/to/your/ObsidianVault",
+            "MARKDOWN_VAULT_MCP_SERVER_NAME": "my-vault",
+            "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH": "/path/to/store/embeddings",
+            "EMBEDDING_PROVIDER": "ollama",
+            "OLLAMA_HOST": "http://localhost:11434",
+            "MARKDOWN_VAULT_MCP_OLLAMA_MODEL": "nomic-embed-text",
+            "MARKDOWN_VAULT_MCP_EXCLUDE": ".obsidian/**,.trash/**",
+            "MARKDOWN_VAULT_MCP_INDEX_PATH": "/path/to/store/index.db"
+          }
+        }
+      }
+    }
+    ```
+
+**Key env vars:**
 
 - `EMBEDDINGS_PATH` — where to persist embedding vectors on disk (required to enable semantic search)
-- `EMBEDDING_PROVIDER=ollama` — use Ollama for embeddings (auto-detected if omitted, but explicit is clearer)
-- `OLLAMA_HOST` — Ollama server URL (default `http://localhost:11434`)
-- `OLLAMA_MODEL` — embedding model (default `nomic-embed-text`)
+- `EMBEDDING_PROVIDER` — `fastembed`, `ollama`, or `openai`
+- `FASTEMBED_MODEL` / `OLLAMA_MODEL` — which model to use
 
-!!! note "First startup is slower"
-    The first startup with embeddings builds vectors for every document. Subsequent starts only process changed files.
+### Pre-build embeddings before first launch
+
+For large vaults, building embeddings on first startup can take several minutes — long enough for Claude Desktop to time out the connection. Pre-build from the command line instead:
+
+=== "macOS / Linux"
+
+    ```bash
+    export MARKDOWN_VAULT_MCP_SOURCE_DIR="/path/to/your/ObsidianVault"
+    export MARKDOWN_VAULT_MCP_INDEX_PATH="/path/to/store/index.db"
+    export MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH="/path/to/store/embeddings"
+    export EMBEDDING_PROVIDER="ollama"
+
+    markdown-vault-mcp reindex
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    $env:MARKDOWN_VAULT_MCP_SOURCE_DIR = "C:\Users\YourName\Documents\ObsidianVault"
+    $env:MARKDOWN_VAULT_MCP_INDEX_PATH = "C:\Users\YourName\vault_index.db"
+    $env:MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH = "C:\Users\YourName\vault_embeddings"
+    $env:EMBEDDING_PROVIDER = "fastembed"
+    $env:MARKDOWN_VAULT_MCP_FASTEMBED_MODEL = "BAAI/bge-small-en-v1.5"
+    $env:MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR = "C:\Users\YourName\fastembed_cache"
+
+    markdown-vault-mcp reindex
+    ```
+
+`reindex` builds (or updates) both the FTS index and the embedding vectors. Once complete, Claude Desktop will load the pre-built index on startup without needing to re-embed anything.
+
+!!! note "Subsequent startups are fast"
+    After the initial build, only new or changed files are reindexed. You can run `reindex` again any time to catch up if you edited files outside Claude.
 
 ### Restart and verify
 

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -250,9 +250,9 @@ You should see a commit from `markdown-vault-mcp`. Delete the test note when don
 
 **Key env vars:**
 
-- `EMBEDDINGS_PATH` — where to persist embedding vectors on disk (required to enable semantic search)
-- `EMBEDDING_PROVIDER` — `fastembed`, `ollama`, or `openai`
-- `FASTEMBED_MODEL` / `OLLAMA_MODEL` — which model to use
+- `MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH` — where to persist embedding vectors on disk (required to enable semantic search)
+- `EMBEDDING_PROVIDER` — `fastembed`, `ollama`, or `openai` (no prefix — intentional)
+- `MARKDOWN_VAULT_MCP_FASTEMBED_MODEL` / `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` — which model to use
 
 ### Pre-build embeddings before first launch
 

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -195,7 +195,8 @@ def _cmd_reindex(args: argparse.Namespace) -> None:
         f"{result.deleted} deleted, {result.unchanged} unchanged"
     )
     try:
-        n = collection.build_embeddings(force=True)
+        should_force = result.added > 0 or result.modified > 0 or result.deleted > 0
+        n = collection.build_embeddings(force=should_force)
         logger.info("Embedded %d chunks", n)
         print(f"Embedded {n} chunks")
     except ValueError:

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -144,6 +144,12 @@ def _cmd_index(args: argparse.Namespace) -> None:
         stats.chunks_indexed,
     )
     print(f"Indexed {stats.documents_indexed} documents, {stats.chunks_indexed} chunks")
+    try:
+        n = collection.build_embeddings(force=args.force)
+        logger.info("Embedded %d chunks", n)
+        print(f"Embedded {n} chunks")
+    except ValueError:
+        pass  # embeddings not configured
 
 
 def _cmd_search(args: argparse.Namespace) -> None:
@@ -188,6 +194,12 @@ def _cmd_reindex(args: argparse.Namespace) -> None:
         f"Reindex: {result.added} added, {result.modified} modified, "
         f"{result.deleted} deleted, {result.unchanged} unchanged"
     )
+    try:
+        n = collection.build_embeddings(force=True)
+        logger.info("Embedded %d chunks", n)
+        print(f"Embedded {n} chunks")
+    except ValueError:
+        pass  # embeddings not configured
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -466,6 +466,25 @@ class TestCmdIndex:
 
         mock_collection.build_embeddings.assert_called_once()
 
+    @patch("markdown_vault_mcp.cli._build_collection")
+    def test_index_force_propagates_to_embeddings(
+        self,
+        mock_build: MagicMock,
+    ) -> None:
+        """--force flag is passed through to build_embeddings."""
+        mock_collection = MagicMock()
+        mock_stats = MagicMock()
+        mock_stats.documents_indexed = 5
+        mock_stats.chunks_indexed = 20
+        mock_collection.build_index.return_value = mock_stats
+        mock_collection.build_embeddings.return_value = 20
+        mock_build.return_value = mock_collection
+
+        with patch("sys.argv", ["markdown-vault-mcp", "index", "--force"]):
+            main()
+
+        mock_collection.build_embeddings.assert_called_once_with(force=True)
+
 
 class TestCmdSearch:
     """Test the search subcommand."""
@@ -774,3 +793,45 @@ class TestCmdReindex:
             main()  # must not raise
 
         mock_collection.build_embeddings.assert_called_once()
+
+    @patch("markdown_vault_mcp.cli._build_collection")
+    def test_reindex_uses_force_false_when_no_changes(
+        self,
+        mock_build: MagicMock,
+    ) -> None:
+        """reindex skips force rebuild when FTS found no changes."""
+        mock_collection = MagicMock()
+        mock_result = MagicMock()
+        mock_result.added = 0
+        mock_result.modified = 0
+        mock_result.deleted = 0
+        mock_result.unchanged = 10
+        mock_collection.reindex.return_value = mock_result
+        mock_collection.build_embeddings.return_value = 0
+        mock_build.return_value = mock_collection
+
+        with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
+            main()
+
+        mock_collection.build_embeddings.assert_called_once_with(force=False)
+
+    @patch("markdown_vault_mcp.cli._build_collection")
+    def test_reindex_uses_force_true_when_changes_exist(
+        self,
+        mock_build: MagicMock,
+    ) -> None:
+        """reindex forces rebuild when FTS found added/modified/deleted files."""
+        mock_collection = MagicMock()
+        mock_result = MagicMock()
+        mock_result.added = 2
+        mock_result.modified = 1
+        mock_result.deleted = 0
+        mock_result.unchanged = 10
+        mock_collection.reindex.return_value = mock_result
+        mock_collection.build_embeddings.return_value = 30
+        mock_build.return_value = mock_collection
+
+        with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
+            main()
+
+        mock_collection.build_embeddings.assert_called_once_with(force=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -428,6 +428,44 @@ class TestCmdIndex:
 
         mock_collection.build_index.assert_called_once_with(force=True)
 
+    @patch("markdown_vault_mcp.cli._build_collection")
+    def test_index_builds_embeddings_when_configured(
+        self,
+        mock_build: MagicMock,
+    ) -> None:
+        """index command calls build_embeddings() after build_index() when configured."""
+        mock_collection = MagicMock()
+        mock_stats = MagicMock()
+        mock_stats.documents_indexed = 5
+        mock_stats.chunks_indexed = 20
+        mock_collection.build_index.return_value = mock_stats
+        mock_collection.build_embeddings.return_value = 20
+        mock_build.return_value = mock_collection
+
+        with patch("sys.argv", ["markdown-vault-mcp", "index"]):
+            main()
+
+        mock_collection.build_embeddings.assert_called_once_with(force=False)
+
+    @patch("markdown_vault_mcp.cli._build_collection")
+    def test_index_skips_embeddings_when_not_configured(
+        self,
+        mock_build: MagicMock,
+    ) -> None:
+        """index command does not fail when embeddings are not configured."""
+        mock_collection = MagicMock()
+        mock_stats = MagicMock()
+        mock_stats.documents_indexed = 5
+        mock_stats.chunks_indexed = 20
+        mock_collection.build_index.return_value = mock_stats
+        mock_collection.build_embeddings.side_effect = ValueError("not configured")
+        mock_build.return_value = mock_collection
+
+        with patch("sys.argv", ["markdown-vault-mcp", "index"]):
+            main()  # must not raise
+
+        mock_collection.build_embeddings.assert_called_once()
+
 
 class TestCmdSearch:
     """Test the search subcommand."""
@@ -694,3 +732,45 @@ class TestCmdReindex:
         assert "1 modified" in captured.out
         assert "2 deleted" in captured.out
         assert "10 unchanged" in captured.out
+
+    @patch("markdown_vault_mcp.cli._build_collection")
+    def test_reindex_builds_embeddings_when_configured(
+        self,
+        mock_build: MagicMock,
+    ) -> None:
+        """reindex command calls build_embeddings(force=True) when configured."""
+        mock_collection = MagicMock()
+        mock_result = MagicMock()
+        mock_result.added = 1
+        mock_result.modified = 0
+        mock_result.deleted = 0
+        mock_result.unchanged = 5
+        mock_collection.reindex.return_value = mock_result
+        mock_collection.build_embeddings.return_value = 10
+        mock_build.return_value = mock_collection
+
+        with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
+            main()
+
+        mock_collection.build_embeddings.assert_called_once_with(force=True)
+
+    @patch("markdown_vault_mcp.cli._build_collection")
+    def test_reindex_skips_embeddings_when_not_configured(
+        self,
+        mock_build: MagicMock,
+    ) -> None:
+        """reindex command does not fail when embeddings are not configured."""
+        mock_collection = MagicMock()
+        mock_result = MagicMock()
+        mock_result.added = 0
+        mock_result.modified = 0
+        mock_result.deleted = 0
+        mock_result.unchanged = 5
+        mock_collection.reindex.return_value = mock_result
+        mock_collection.build_embeddings.side_effect = ValueError("not configured")
+        mock_build.return_value = mock_collection
+
+        with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
+            main()  # must not raise
+
+        mock_collection.build_embeddings.assert_called_once()


### PR DESCRIPTION
Closes #305

## Summary

- **Bug fix**: `reindex` and `index` CLI commands only updated the FTS index, never building embedding vectors. Users running these to pre-build the index before connecting Claude Desktop got no semantic search, and the first `serve` startup could time out Claude Desktop while embedding a large vault.
- **Docs**: Claude Desktop guide updated with Windows/FastEmbed examples and a "pre-build embeddings" workflow.

## Code changes

- `_cmd_reindex`: calls `build_embeddings(force=True)` after `reindex()` — full rebuild to match updated FTS
- `_cmd_index`: calls `build_embeddings(force=args.force)` after `build_index()` — respects `--force` flag
- Both silently skip if embeddings are not configured (`ValueError` catch)
- 4 new CLI tests

## Docs changes (`docs/guides/claude-desktop.md`)

- Step 1 config example: add Windows tab with backslash paths
- Step 3: replace single Ollama example with FastEmbed (Windows) + Ollama (macOS/Linux) tabs
- New "Pre-build embeddings" section: explains the timeout issue and shows `markdown-vault-mcp reindex` as the solution, with PowerShell and bash variants

## Test plan

- [ ] `uv run python -m pytest tests/test_cli.py -x -q` — all CLI tests pass
- [ ] `markdown-vault-mcp reindex` with embeddings configured → prints "Embedded N chunks"
- [ ] `markdown-vault-mcp reindex` without embeddings configured → no error, no embedding output