### PR TITLE
feat: add logging standard with FastMCP middleware and PR acceptance gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,25 @@ src/markdown_vault_mcp/
 - Type hints everywhere
 - Tests: `pytest` with fixtures in `tests/fixtures/`
 
+## Hard PR Acceptance Gates
+
+Every PR must pass **all** of the following before merge. Do not open or push a PR until these are green locally:
+
+1. **CI passes** — `uv run pytest -x -q` all tests pass
+2. **Lint passes** — run in this exact order: `uv run ruff check --fix .` then `uv run ruff format .` then verify with `uv run ruff format --check .`. Always run format *after* check --fix because check --fix can leave files needing reformatting.
+3. **Type-check passes** — `uv run mypy src/` reports no errors
+4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
+5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
+
+## GitHub Review Types
+
+GitHub has two distinct review mechanisms — **both must be read and addressed**:
+
+- **Inline review comments** (`get_review_comments`): attached to specific lines of the diff. Appear in the "Files changed" tab. Use `get_review_comments` to fetch these.
+- **PR-level comments** (`get_comments`): posted on the Conversation tab, not tied to a line. Review summary posts, bot analysis, and blocking issues are often posted here. Use `get_comments` to fetch these.
+
+Always fetch both before declaring a review round complete.
+
 ## Reference
 
 This project is extracted from [`pvliesdonk/if-craft-corpus`](https://github.com/pvliesdonk/if-craft-corpus). See the design doc's Reference Code section for the mapping between source files.
@@ -61,6 +80,34 @@ Every issue, PR, and code change must consider documentation impact. Before clos
 This repo shares domain-independent infrastructure with [`pvliesdonk/image-generation-mcp`](https://github.com/pvliesdonk/image-generation-mcp). See [`SYNC.md`](SYNC.md) for the shared file mapping, known divergences, and port history.
 
 **Rule:** When fixing or improving shared infrastructure (auth, CI/CD, Docker entrypoint, release pipeline, packaging, CLI logging), create a corresponding issue in the other repo to port the change. Reference the source PR in the issue body. Domain-specific code (vault logic, image generation, tools, resources) does not need cross-posting.
+
+## Logging Standard
+
+### Framework
+- Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
+- No `print()` for operational output. No third-party logging libraries.
+- FastMCP middleware handles tool invocation, timing, and error logging automatically.
+- All logging goes through FastMCP's `configure_logging()` for uniform output. `FASTMCP_LOG_LEVEL` is the single log level control; the `-v` CLI flag sets it to `DEBUG`. `FASTMCP_ENABLE_RICH_LOGGING=false` switches to plain/JSON output.
+
+### Log Levels
+| Level | Use for |
+|-------|---------|
+| `DEBUG` | Detailed internals: cache hits, parameter values, config resolution |
+| `INFO` | Significant operations: service startup, configuration decisions (tool calls logged by middleware) |
+| `WARNING` | Degraded but continuing: API errors with fallback, missing optional config, unexpected data |
+| `ERROR` | Failures affecting the primary result. Use `logger.error(..., exc_info=True)` when traceback is needed |
+
+### Exception Handling
+- All exceptions must be caught and handled. No bare `except:`. Always specify the exception type.
+- Expected errors (HTTP 4xx, missing data): catch, log, return user-facing error string.
+- Optional enrichment failures: catch, log at `DEBUG` with `exc_info=True`, continue.
+- Primary result errors: catch, log at `WARNING` or `ERROR`, return error string.
+- `ErrorHandlingMiddleware` is a safety net. If it catches something, that's a bug to fix.
+
+### Message Format
+- Pseudo-structured: `logger.info("event_name key=%s", value)`
+- Event name as first token (snake_case), then key=value pairs via `%s` formatting.
+- Never use f-strings in log calls (defeats lazy evaluation).
 
 ## Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` pr
 | `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | `file:///data/state/events` | Event store backend for HTTP session persistence. `file:///path` (default) survives restarts; `memory://` for dev (lost on restart). |
 | `MARKDOWN_VAULT_MCP_APP_DOMAIN` | (auto) | Override the Claude app domain used for MCP Apps iframe sandboxing. Auto-computed from `BASE_URL` when not set. |
 | `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). App loggers default to `INFO`. `-v` overrides both to `DEBUG`. |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output. |
 
 ### Search and embeddings
 

--- a/SYNC.md
+++ b/SYNC.md
@@ -107,3 +107,5 @@ All known pending ports have been filed as issues:
 - **MV → IG**: [image-generation-mcp#110](https://github.com/pvliesdonk/image-generation-mcp/issues/110) — server.json, httpx guard, auth logging, CI diff-cover, release job deps
 - **MV → IG**: [image-generation-mcp#137](https://github.com/pvliesdonk/image-generation-mcp/issues/137) — persistent EventStore for HTTP session persistence (MV#278)
 - **IG → MV**: [markdown-vault-mcp#270](https://github.com/pvliesdonk/markdown-vault-mcp/issues/270) — diff-cover cleanup, versionless package copies
+- **MV → IG**: *(issue not yet filed)* — FastMCP middleware stack (ErrorHandling, Timing, Logging/Structured), `FASTMCP_LOG_LEVEL` env-sync on `-v`, `FASTMCP_ENABLE_RICH_LOGGING` toggle, CLAUDE.md PR gates + logging standard (MV#331, adapted from scholar-mcp#99)
+- **MV → scholar-mcp**: *(issue not yet filed)* — middleware stack wiring and `FASTMCP_ENABLE_RICH_LOGGING` toggle; scholar-mcp#99 established the logging standard but did not wire the middleware (MV#331)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | url | `file:///data/state/events` | Event store backend for HTTP session persistence. `file:///path` survives restarts; `memory://` for dev (lost on restart) |
 | `MARKDOWN_VAULT_MCP_APP_DOMAIN` | string | (auto) | Override the Claude app domain used for MCP Apps iframe sandboxing. Auto-computed from `BASE_URL` when not set |
 | `FASTMCP_LOG_LEVEL` | string | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `-v` CLI flag overrides both app and FastMCP loggers to `DEBUG` |
+| `FASTMCP_ENABLE_RICH_LOGGING` | bool | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output |
 
 ## Search and Embeddings
 

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -338,6 +338,7 @@ def main() -> None:
         root.addHandler(handler)
 
     if args.verbose:
+        os.environ["FASTMCP_LOG_LEVEL"] = "DEBUG"
         configure_logging("DEBUG")
         # httpx is noisy at DEBUG — keep it at WARNING.
         logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -24,6 +24,12 @@ if TYPE_CHECKING:
     from fastmcp.server.event_store import EventStore
 
 from fastmcp import FastMCP
+from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+from fastmcp.server.middleware.logging import (
+    LoggingMiddleware,
+    StructuredLoggingMiddleware,
+)
+from fastmcp.server.middleware.timing import TimingMiddleware
 
 from markdown_vault_mcp.config import _ENV_PREFIX, load_config
 
@@ -493,6 +499,20 @@ def create_server(transport: str = "stdio") -> FastMCP:
         lifespan=make_collection_lifespan(config),
         auth=auth,
     )
+
+    # --- Middleware stack ---
+    # Order matters: outermost runs first.
+    #  1. ErrorHandlingMiddleware — catches unhandled exceptions
+    #  2. TimingMiddleware — records tool invocation duration
+    #  3. LoggingMiddleware — rich or structured (JSON) output
+    include_traceback = logging.getLogger().isEnabledFor(logging.DEBUG)
+    mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=include_traceback))
+    mcp.add_middleware(TimingMiddleware())
+    rich_logging = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true").strip().lower()
+    if rich_logging in ("false", "0", "no"):
+        mcp.add_middleware(StructuredLoggingMiddleware())
+    else:
+        mcp.add_middleware(LoggingMiddleware())
 
     register_tools(mcp, transport=transport)
     register_resources(mcp)

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -505,6 +505,9 @@ def create_server(transport: str = "stdio") -> FastMCP:
     #  1. ErrorHandlingMiddleware — catches unhandled exceptions
     #  2. TimingMiddleware — records tool invocation duration
     #  3. LoggingMiddleware — rich or structured (JSON) output
+    # Capture root log level *now* — works correctly when create_server() is
+    # called after CLI verbose setup.  In library/test usage where logging is
+    # configured later, tracebacks default to off (safe for production).
     include_traceback = logging.getLogger().isEnabledFor(logging.DEBUG)
     mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=include_traceback))
     mcp.add_middleware(TimingMiddleware())

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -509,7 +509,7 @@ def create_server(transport: str = "stdio") -> FastMCP:
     # called after CLI verbose setup.  In library/test usage where logging is
     # configured later, tracebacks default to off (safe for production).
     include_traceback = logging.getLogger().isEnabledFor(logging.DEBUG)
-    mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=include_traceback))
+    mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=include_traceback, transform_errors=False))
     mcp.add_middleware(TimingMiddleware())
     rich_logging = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true").strip().lower()
     if rich_logging in ("false", "0", "no"):

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -509,7 +509,11 @@ def create_server(transport: str = "stdio") -> FastMCP:
     # called after CLI verbose setup.  In library/test usage where logging is
     # configured later, tracebacks default to off (safe for production).
     include_traceback = logging.getLogger().isEnabledFor(logging.DEBUG)
-    mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=include_traceback, transform_errors=False))
+    mcp.add_middleware(
+        ErrorHandlingMiddleware(
+            include_traceback=include_traceback, transform_errors=False
+        )
+    )
     mcp.add_middleware(TimingMiddleware())
     rich_logging = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true").strip().lower()
     if rich_logging in ("false", "0", "no"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,6 +187,45 @@ class TestMainDispatch:
         assert logging.getLogger("httpcore").level == logging.WARNING
 
     @patch("markdown_vault_mcp.cli._COMMANDS")
+    @patch("markdown_vault_mcp.cli.configure_logging")
+    def test_verbose_sets_fastmcp_log_level_env(
+        self, _mock_configure: MagicMock, mock_commands: MagicMock
+    ) -> None:
+        """``-v`` sets FASTMCP_LOG_LEVEL=DEBUG in the environment."""
+        import os
+
+        mock_handler = MagicMock()
+        mock_commands.__getitem__ = MagicMock(return_value=mock_handler)
+        old = os.environ.pop("FASTMCP_LOG_LEVEL", None)
+        try:
+            with patch("sys.argv", ["markdown-vault-mcp", "-v", "index"]):
+                main()
+            assert os.environ.get("FASTMCP_LOG_LEVEL") == "DEBUG"
+        finally:
+            if old is not None:
+                os.environ["FASTMCP_LOG_LEVEL"] = old
+            else:
+                os.environ.pop("FASTMCP_LOG_LEVEL", None)
+
+    @patch("markdown_vault_mcp.cli._COMMANDS")
+    def test_no_verbose_does_not_set_fastmcp_log_level(
+        self, mock_commands: MagicMock
+    ) -> None:
+        """Without ``-v``, FASTMCP_LOG_LEVEL is not touched."""
+        import os
+
+        mock_handler = MagicMock()
+        mock_commands.__getitem__ = MagicMock(return_value=mock_handler)
+        old = os.environ.pop("FASTMCP_LOG_LEVEL", None)
+        try:
+            with patch("sys.argv", ["markdown-vault-mcp", "index"]):
+                main()
+            assert os.environ.get("FASTMCP_LOG_LEVEL") is None
+        finally:
+            if old is not None:
+                os.environ["FASTMCP_LOG_LEVEL"] = old
+
+    @patch("markdown_vault_mcp.cli._COMMANDS")
     def test_root_handler_added_when_none_exist(self, mock_commands: MagicMock) -> None:
         """A StreamHandler is added to root when it has no handlers."""
         import logging

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,8 @@ class TestMainDispatch:
         finally:
             if old is not None:
                 os.environ["FASTMCP_LOG_LEVEL"] = old
+            else:
+                os.environ.pop("FASTMCP_LOG_LEVEL", None)
 
     @patch("markdown_vault_mcp.cli._COMMANDS")
     def test_root_handler_added_when_none_exist(self, mock_commands: MagicMock) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3132,3 +3132,51 @@ class TestBuildRemoteAuth:
 
         assert "Remote auth config:" in caplog.text
         assert "jwks_uri" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Middleware stack
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareStack:
+    """Verify that create_server() wires the expected middleware."""
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_default_middleware_stack(self) -> None:
+        """Server has ErrorHandling, Timing, and Logging middleware by default."""
+        from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+        from fastmcp.server.middleware.logging import LoggingMiddleware
+        from fastmcp.server.middleware.timing import TimingMiddleware
+
+        server = create_server()
+        types = [type(m) for m in server.middleware]
+        assert ErrorHandlingMiddleware in types
+        assert TimingMiddleware in types
+        assert LoggingMiddleware in types
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_structured_logging_when_rich_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FASTMCP_ENABLE_RICH_LOGGING=false selects StructuredLoggingMiddleware."""
+        from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
+
+        monkeypatch.setenv("FASTMCP_ENABLE_RICH_LOGGING", "false")
+        server = create_server()
+        types = [type(m) for m in server.middleware]
+        assert StructuredLoggingMiddleware in types
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_middleware_order(self) -> None:
+        """ErrorHandling is first, then Timing, then Logging."""
+        from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+        from fastmcp.server.middleware.logging import LoggingMiddleware
+        from fastmcp.server.middleware.timing import TimingMiddleware
+
+        server = create_server()
+        types = [type(m) for m in server.middleware]
+        eh_idx = types.index(ErrorHandlingMiddleware)
+        tm_idx = types.index(TimingMiddleware)
+        lg_idx = types.index(LoggingMiddleware)
+        assert eh_idx < tm_idx < lg_idx

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3176,6 +3176,9 @@ class TestMiddlewareStack:
 
         server = create_server()
         types = [type(m) for m in server.middleware]
+        assert ErrorHandlingMiddleware in types, "ErrorHandlingMiddleware missing"
+        assert TimingMiddleware in types, "TimingMiddleware missing"
+        assert LoggingMiddleware in types, "LoggingMiddleware missing"
         eh_idx = types.index(ErrorHandlingMiddleware)
         tm_idx = types.index(TimingMiddleware)
         lg_idx = types.index(LoggingMiddleware)

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "1.18.1"
+version = "1.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-frontmatter" },


### PR DESCRIPTION
Wire ErrorHandlingMiddleware, TimingMiddleware, and LoggingMiddleware/
StructuredLoggingMiddleware into create_server(). Sync FASTMCP_LOG_LEVEL
env var when -v CLI flag is used. Add FASTMCP_ENABLE_RICH_LOGGING support
to toggle between rich and structured JSON log output.

Add Hard PR Acceptance Gates, GitHub Review Types, and Logging Standard
sections to CLAUDE.md, adapted from pvliesdonk/scholar-mcp#99.

https://claude.ai/code/session_01QB7c5GFyEq6V2uutc7vYg4