### PR TITLE
fix: cli `_build_collection` propagates all `CollectionConfig` fields

### DIFF
--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -47,8 +47,11 @@ def _normalise_http_path(path: str | None) -> str:
 def _build_collection(args: argparse.Namespace) -> Collection:
     """Build a Collection from environment variables and CLI overrides.
 
-    CLI arguments ``--source-dir`` and ``--index-path`` override the
-    corresponding environment variables when provided.
+    Delegates to :meth:`~markdown_vault_mcp.config.CollectionConfig.to_collection_kwargs`
+    so the CLI path stays in sync with the server path in
+    :func:`~markdown_vault_mcp._server_deps.make_collection_lifespan`. CLI
+    arguments ``--source-dir`` and ``--index-path`` override the corresponding
+    environment variables when provided.
 
     Args:
         args: Parsed CLI arguments (may contain ``source_dir`` and
@@ -63,33 +66,26 @@ def _build_collection(args: argparse.Namespace) -> Collection:
         os.environ[f"{_ENV_PREFIX}_SOURCE_DIR"] = source_dir_override
 
     config = load_config()
+    kwargs = config.to_collection_kwargs()
 
-    # CLI --index-path overrides env var.
+    # CLI --index-path overrides env var / config default.
     index_path_override = getattr(args, "index_path", None)
-    index_path = Path(index_path_override) if index_path_override else config.index_path
+    if index_path_override:
+        kwargs["index_path"] = Path(index_path_override)
 
-    embedding_provider = None
+    # Resolve embedding provider if embeddings_path is configured.
     if config.embeddings_path is not None:
         try:
             from markdown_vault_mcp.providers import get_embedding_provider
 
-            embedding_provider = get_embedding_provider()
+            kwargs["embedding_provider"] = get_embedding_provider()
         except Exception:
             logger.warning(
                 "Could not load embedding provider; semantic search disabled",
                 exc_info=True,
             )
 
-    return Collection(
-        source_dir=config.source_dir,
-        read_only=config.read_only,
-        index_path=index_path,
-        embeddings_path=config.embeddings_path,
-        embedding_provider=embedding_provider,
-        state_path=config.state_path,
-        indexed_frontmatter_fields=config.indexed_frontmatter_fields,
-        required_frontmatter=config.required_frontmatter,
-    )
+    return Collection(**kwargs)
 
 
 def _cmd_serve(args: argparse.Namespace) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -743,13 +743,13 @@ class TestBuildCollectionConfigFields:
         vault.mkdir()
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", ".pdf,.png,.jpg")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", "pdf,png,jpg")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "25")
 
         args = _build_parser().parse_args(["index"])
         collection = _build_collection(args)
 
-        assert collection._attachment_extensions == [".pdf", ".png", ".jpg"]
+        assert collection._attachment_extensions == ["pdf", "png", "jpg"]
         assert collection._max_attachment_size_mb == 25.0
 
     def test_exclude_patterns_are_functional_via_cli_path(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -697,6 +697,94 @@ class TestBuildCollectionEmbeddingFailure:
         assert any("semantic search disabled" in r.message for r in caplog.records)
 
 
+class TestBuildCollectionConfigFields:
+    """`_build_collection` must propagate every field `CollectionConfig.to_collection_kwargs` produces.
+
+    Regression tests for a bug where the CLI path hardcoded a subset of kwargs
+    (``source_dir``, ``read_only``, ``index_path``, ``embeddings_path``,
+    ``embedding_provider``, ``state_path``, ``indexed_frontmatter_fields``,
+    ``required_frontmatter``) and silently dropped the rest — including
+    ``exclude_patterns``, ``attachment_extensions``, and
+    ``max_attachment_size_mb``. All CLI subcommands (``index``, ``reindex``,
+    ``search``) that route through ``_build_collection`` were affected, so
+    ``MARKDOWN_VAULT_MCP_EXCLUDE`` was silently ignored on the CLI side even
+    though the serve path via ``_server_deps.make_collection_lifespan`` honored
+    it correctly.
+    """
+
+    def test_exclude_patterns_propagated_from_env(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``MARKDOWN_VAULT_MCP_EXCLUDE`` reaches ``Collection._exclude_patterns``."""
+        from markdown_vault_mcp.cli import _build_collection
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_EXCLUDE", "**/*.log.md,.obsidian/**")
+
+        args = _build_parser().parse_args(["index"])
+        collection = _build_collection(args)
+
+        assert collection._exclude_patterns == ["**/*.log.md", ".obsidian/**"]
+
+    def test_attachment_fields_propagated_from_env(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``MARKDOWN_VAULT_MCP_ATTACHMENT_*`` env vars reach the Collection."""
+        from markdown_vault_mcp.cli import _build_collection
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", ".pdf,.png,.jpg")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "25")
+
+        args = _build_parser().parse_args(["index"])
+        collection = _build_collection(args)
+
+        assert collection._attachment_extensions == [".pdf", ".png", ".jpg"]
+        assert collection._max_attachment_size_mb == 25.0
+
+    def test_exclude_patterns_are_functional_via_cli_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Behavioural regression: Collection built via the CLI actually excludes.
+
+        The bug was that ``_build_collection`` constructed the Collection
+        without ``exclude_patterns``, so
+        :meth:`~markdown_vault_mcp.collection.Collection._is_path_excluded`
+        always returned ``False`` — because ``self._exclude_patterns`` was
+        ``None``. Assert the exclusion logic is live end-to-end.
+        """
+        from markdown_vault_mcp.cli import _build_collection
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_EXCLUDE", "**/*.log.md,.obsidian/**")
+
+        args = _build_parser().parse_args(["index"])
+        collection = _build_collection(args)
+
+        # These should be excluded via the newly-propagated patterns.
+        assert collection._is_path_excluded("sessions/2026-04-09/chat.log.md") is True
+        assert collection._is_path_excluded(".obsidian/workspace.json.md") is True
+
+        # And these should still pass through unaffected.
+        assert collection._is_path_excluded("notes/alpha.md") is False
+        assert collection._is_path_excluded("decisions/2026-04-09-auth.md") is False
+
+
 class TestCmdSearchJsonOutput:
     """Verify --json flag in _cmd_search produces valid parseable output."""
 


### PR DESCRIPTION
## Summary

Fixes #334. `cli._build_collection()` constructed a `Collection` with a hardcoded subset of kwargs and silently dropped `exclude_patterns`, `attachment_extensions`, `max_attachment_size_mb`, and `git_strategy`/`on_write`. CLI subcommands (`index`, `reindex`, `search`) therefore ignored `MARKDOWN_VAULT_MCP_EXCLUDE` and related env vars, while the serve path via `_server_deps.make_collection_lifespan` → `config.to_collection_kwargs()` correctly honored them.

This is distinct from #255 — that fixed `Collection.reindex()` itself, but the purge block it introduced at `collection.py:1206-1234` is gated on `if self._exclude_patterns:`, which is always falsy on a Collection built via `_build_collection` because the field never got set.

## Fix

Replace the hardcoded kwarg list in `_build_collection` with `config.to_collection_kwargs()`, mirroring the server path. Apply CLI-specific overrides (`--index-path`) and the embedding provider on top. Any future field `CollectionConfig` learns about is now picked up automatically — the CLI and server paths stay in sync by construction.

```python
def _build_collection(args: argparse.Namespace) -> Collection:
    source_dir_override = getattr(args, "source_dir", None)
    if source_dir_override:
        os.environ[f"{_ENV_PREFIX}_SOURCE_DIR"] = source_dir_override

    config = load_config()
    kwargs = config.to_collection_kwargs()

    index_path_override = getattr(args, "index_path", None)
    if index_path_override:
        kwargs["index_path"] = Path(index_path_override)

    if config.embeddings_path is not None:
        try:
            from markdown_vault_mcp.providers import get_embedding_provider
            kwargs["embedding_provider"] = get_embedding_provider()
        except Exception:
            logger.warning(
                "Could not load embedding provider; semantic search disabled",
                exc_info=True,
            )

    return Collection(**kwargs)
```

## Tests

New test class `TestBuildCollectionConfigFields` in `tests/test_cli.py` with three tests:

1. `test_exclude_patterns_propagated_from_env` — sets `MARKDOWN_VAULT_MCP_EXCLUDE=**/*.log.md,.obsidian/**` and asserts `collection._exclude_patterns == ["**/*.log.md", ".obsidian/**"]`.
2. `test_attachment_fields_propagated_from_env` — sets `MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS` and `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB`, asserts they reach the Collection.
3. `test_exclude_patterns_are_functional_via_cli_path` — behavioural check that `collection._is_path_excluded("sessions/2026-04-09/chat.log.md")` returns `True` via the CLI-built Collection (which it didn't before the fix).

All three fail on `main` and pass with this patch.

## Gates

- [x] `uv run pytest -x -q` — 1112 passed
- [x] `uv run ruff check --fix .` — clean
- [x] `uv run ruff format .` → `ruff format --check .` — clean
- [x] `uv run mypy src/` — no issues in 21 source files
- [x] Patch coverage ≥ 80% — `cli.py` at 95.24% (up from baseline)
- [x] Docs — no user-facing changes; `docs/configuration.md` already documents `MARKDOWN_VAULT_MCP_EXCLUDE` as working. This restores the documented behavior for CLI subcommands.

## Reproduction (before fix)

```bash
mkdir -p /tmp/mvm-repro/sessions
cat > /tmp/mvm-repro/ok.md <<'MD'
---
name: ok
type: note
---
body
MD
cat > /tmp/mvm-repro/sessions/big.log.md <<'MD'
---
name: big log
type: session
---
huge log body
MD

MARKDOWN_VAULT_MCP_SOURCE_DIR=/tmp/mvm-repro \
MARKDOWN_VAULT_MCP_INDEX_PATH=/tmp/mvm-repro/.index.sqlite \
MARKDOWN_VAULT_MCP_REQUIRED_FIELDS=name,type \
MARKDOWN_VAULT_MCP_EXCLUDE='**/*.log.md' \
  markdown-vault-mcp index --force

# Before: 2 documents indexed (both files).
# After:  1 document indexed (ok.md only).
```

## Notes

Found while configuring `markdown-vault-mcp` to exclude session log files from a Claude Code memory vault — `MARKDOWN_VAULT_MCP_EXCLUDE=**/*.log.md` was being silently ignored on the CLI side, and tracing the divergence between serve and CLI construction revealed the missing kwargs. Thanks for the great docs that made this easy to triage!