### PR TITLE
refactor(config): centralize environment and auth configuration

### DIFF
--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -73,25 +73,14 @@ def _build_collection(args: argparse.Namespace) -> Collection:
     if index_path_override:
         kwargs["index_path"] = Path(index_path_override)
 
-    # Resolve embedding provider if embeddings_path is configured.
-    if config.embeddings_path is not None:
-        try:
-            from markdown_vault_mcp.providers import get_embedding_provider
-
-            kwargs["embedding_provider"] = get_embedding_provider()
-        except Exception:
-            logger.warning(
-                "Could not load embedding provider; semantic search disabled",
-                exc_info=True,
-            )
-
     return Collection(**kwargs)
 
 
 def _cmd_serve(args: argparse.Namespace) -> None:
     """Run the MCP server."""
     try:
-        from markdown_vault_mcp.mcp_server import build_event_store, create_server
+        from markdown_vault_mcp.config import build_event_store
+        from markdown_vault_mcp.mcp_server import create_server
     except ImportError:
         logger.error(
             "FastMCP is not installed. Install with: "

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -8,13 +8,325 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from fastmcp.server.event_store import EventStore
 
 logger = logging.getLogger(__name__)
 
 _ENV_PREFIX = "MARKDOWN_VAULT_MCP"
+
+# ---------------------------------------------------------------------------
+# Event store
+# ---------------------------------------------------------------------------
+
+_DEFAULT_EVENT_STORE_DIR = "/data/state/events"
+
+
+def build_event_store(url: str | None = None) -> EventStore:
+    """Build an ``EventStore`` for SSE polling/resumability.
+
+    Parses the *url* scheme to select a storage backend:
+
+    - ``None`` or empty → ``FileTreeStore`` at :data:`_DEFAULT_EVENT_STORE_DIR`
+    - ``file:///path`` → ``FileTreeStore`` at the given path
+    - ``memory://`` → in-memory (lost on restart, for development)
+
+    Args:
+        url: Event store URL from ``MARKDOWN_VAULT_MCP_EVENT_STORE_URL``.
+
+    Returns:
+        A configured :class:`~fastmcp.server.event_store.EventStore`.
+    """
+    from fastmcp.server.event_store import EventStore as _EventStore
+
+    if not url:
+        url = f"file://{_DEFAULT_EVENT_STORE_DIR}"
+
+    parsed = urlparse(url)
+
+    if parsed.scheme == "memory":
+        logger.info("Event store: in-memory (sessions lost on restart)")
+        return _EventStore(max_events_per_stream=100, ttl=3600)
+
+    if parsed.scheme == "file":
+        directory = parsed.path
+        if not directory:
+            directory = _DEFAULT_EVENT_STORE_DIR
+        Path(directory).mkdir(parents=True, exist_ok=True)
+        logger.info("Event store: file-backed at %s", directory)
+
+        try:
+            from key_value.aio.stores.filetree import FileTreeStore
+        except ImportError:
+            raise ImportError(
+                "FileTreeStore requires fastmcp>=3.0 with key-value support. "
+                "Install with: pip install 'markdown-vault-mcp[mcp]'"
+            ) from None
+
+        storage = FileTreeStore(data_directory=directory)
+        return _EventStore(storage=storage, max_events_per_stream=100, ttl=3600)
+
+    raise ValueError(
+        f"Unsupported EVENT_STORE_URL scheme {parsed.scheme!r}. "
+        "Use 'file:///path' or 'memory://'."
+    )
+
+
+def _resolve_auth_mode(config: CollectionConfig) -> str | None:
+    """Determine which OIDC auth mode to use.
+
+    Uses ``config.auth_mode`` for an explicit override.
+    When not set, auto-detects based on which config fields are present:
+
+    - All four OIDC fields (base_url, oidc_config_url, oidc_client_id, oidc_client_secret) → ``"oidc-proxy"``
+    - Only base_url + oidc_config_url → ``"remote"``
+    - Otherwise → ``None`` (no OIDC)
+
+    Returns:
+        ``"remote"``, ``"oidc-proxy"``, or ``None``.
+    """
+    if config.auth_mode in ("remote", "oidc-proxy"):
+        logger.info("OIDC auth mode: %s (explicit via AUTH_MODE)", config.auth_mode)
+        return config.auth_mode
+    if config.auth_mode:
+        logger.warning(
+            "Unknown AUTH_MODE %r — ignoring, falling back to auto-detection",
+            config.auth_mode,
+        )
+
+    if all(
+        [
+            config.base_url,
+            config.oidc_config_url,
+            config.oidc_client_id,
+            config.oidc_client_secret,
+        ]
+    ):
+        logger.info(
+            "OIDC auth mode: oidc-proxy (auto-detected — all four OIDC vars set)"
+        )
+        return "oidc-proxy"
+
+    if config.base_url and config.oidc_config_url:
+        logger.info(
+            "OIDC auth mode: remote (auto-detected — BASE_URL + OIDC_CONFIG_URL set)"
+        )
+        return "remote"
+
+    return None
+
+
+def _build_remote_auth(config: CollectionConfig) -> Any:
+    """Build a RemoteAuthProvider from OIDC discovery.
+
+    Fetches the OIDC discovery document at startup to extract ``jwks_uri``
+    and ``issuer``, then constructs a ``JWTVerifier`` for local token
+    validation via JWKS.  No client credentials are needed — tokens are
+    validated locally.
+
+    Returns:
+        A configured ``RemoteAuthProvider``, or ``None`` when env vars are
+        missing or the discovery fetch fails.
+    """
+    if not config.base_url or not config.oidc_config_url:
+        logger.debug("Remote auth: disabled — missing BASE_URL or OIDC_CONFIG_URL")
+        return None
+
+    try:
+        import httpx
+    except ImportError:
+        logger.error(
+            "Remote auth: 'httpx' is not installed. "
+            "Install it with: pip install 'markdown-vault-mcp[all]' "
+            "or pip install httpx"
+        )
+        return None
+
+    try:
+        resp = httpx.get(config.oidc_config_url, timeout=10)
+        resp.raise_for_status()
+        discovery = resp.json()
+    except Exception:
+        logger.exception(
+            "Remote auth: failed to fetch OIDC discovery from %s",
+            config.oidc_config_url,
+        )
+        return None
+
+    jwks_uri = discovery.get("jwks_uri")
+    issuer = discovery.get("issuer")
+    if not jwks_uri or not issuer:
+        logger.error(
+            "Remote auth: OIDC discovery missing jwks_uri or issuer (got jwks_uri=%s, issuer=%s)",
+            jwks_uri,
+            issuer,
+        )
+        return None
+
+    logger.debug(
+        "Remote auth config:\n"
+        "  config_url      = %s\n"
+        "  jwks_uri        = %s\n"
+        "  issuer          = %s\n"
+        "  base_url        = %s\n"
+        "  audience        = %s\n"
+        "  required_scopes = %s",
+        config.oidc_config_url,
+        jwks_uri,
+        issuer,
+        config.base_url,
+        config.oidc_audience or "(not set)",
+        config.oidc_required_scopes or "(not set)",
+    )
+
+    from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider
+
+    verifier = JWTVerifier(
+        jwks_uri=jwks_uri,
+        issuer=issuer,
+        audience=config.oidc_audience,
+        required_scopes=config.oidc_required_scopes,
+    )
+    return RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[issuer],
+        base_url=config.base_url,
+    )
+
+
+def _build_bearer_auth(config: CollectionConfig) -> Any:
+    """Build a StaticTokenVerifier from configured bearer token.
+
+    When ``config.bearer_token`` is set (non-empty), returns a
+    :class:`~fastmcp.server.auth.StaticTokenVerifier` that
+    validates ``Authorization: Bearer <token>`` headers against the
+    configured static token.
+
+    Returns:
+        A configured ``StaticTokenVerifier``, or ``None`` when the token
+        is absent or empty.
+    """
+    if not config.bearer_token:
+        logger.debug("Bearer auth: BEARER_TOKEN not set — skipping")
+        return None
+    logger.debug("Bearer auth: BEARER_TOKEN is set (value redacted)")
+    from fastmcp.server.auth import StaticTokenVerifier
+
+    return StaticTokenVerifier(
+        tokens={
+            config.bearer_token: {"client_id": "bearer", "scopes": ["read", "write"]}
+        }
+    )
+
+
+def _build_oidc_auth(config: CollectionConfig) -> Any:
+    """Build an OIDCProxy auth provider from config, or return None.
+
+    All four of ``base_url``, ``oidc_config_url``, ``oidc_client_id``, and
+    ``oidc_client_secret`` must be set to enable authentication.
+
+    Returns:
+        A configured :class:`~fastmcp.server.auth.oidc_proxy.OIDCProxy` instance,
+        or ``None`` when authentication is disabled.
+    """
+    if not all(
+        [
+            config.base_url,
+            config.oidc_config_url,
+            config.oidc_client_id,
+            config.oidc_client_secret,
+        ]
+    ):
+        missing = [
+            name
+            for name, val in [
+                ("BASE_URL", config.base_url),
+                ("OIDC_CONFIG_URL", config.oidc_config_url),
+                ("OIDC_CLIENT_ID", config.oidc_client_id),
+                ("OIDC_CLIENT_SECRET", config.oidc_client_secret),
+            ]
+            if not val
+        ]
+        logger.debug("OIDC auth: disabled — missing env vars: %s", ", ".join(missing))
+        return None
+
+    from fastmcp.server.auth.oidc_proxy import OIDCProxy
+
+    required_scopes = config.oidc_required_scopes or ["openid"]
+    verify_id_token = not config.oidc_verify_access_token
+
+    logger.debug(
+        "OIDC auth config:\n"
+        "  config_url          = %s\n"
+        "  client_id           = %s\n"
+        "  client_secret       = <redacted>\n"
+        "  base_url            = %s\n"
+        "  audience            = %s\n"
+        "  required_scopes     = %s\n"
+        "  jwt_signing_key     = %s\n"
+        "  verify_id_token     = %s\n"
+        "  verify_access_token = %s",
+        config.oidc_config_url,
+        config.oidc_client_id,
+        config.base_url,
+        config.oidc_audience or "(not set)",
+        required_scopes,
+        "(set)" if config.oidc_jwt_signing_key else "(not set)",
+        verify_id_token,
+        config.oidc_verify_access_token,
+    )
+
+    if verify_id_token and "openid" not in required_scopes:
+        logger.warning(
+            "OIDC: verify_id_token=True requires the 'openid' scope but it is "
+            "not in MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES — the id_token may "
+            "be absent from the token response; add 'openid' to the scope list "
+            "or set MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN=true"
+        )
+
+    if config.oidc_jwt_signing_key is None and sys.platform.startswith("linux"):
+        logger.warning(
+            "OIDC: MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY is not set — "
+            "the JWT signing key is ephemeral on Linux; all clients must "
+            "re-authenticate after every server restart"
+        )
+
+    if verify_id_token:
+        logger.info(
+            "OIDC: verifying upstream id_token (works with opaque access tokens)"
+        )
+    else:
+        logger.info(
+            "OIDC: verifying upstream access_token as JWT "
+            "(MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN=true)"
+        )
+
+    assert config.oidc_config_url is not None
+    assert config.oidc_client_id is not None
+    assert config.base_url is not None
+
+    return OIDCProxy(
+        config_url=config.oidc_config_url,
+        client_id=config.oidc_client_id,
+        client_secret=config.oidc_client_secret or "",
+        base_url=config.base_url,
+        audience=config.oidc_audience,
+        required_scopes=required_scopes,
+        jwt_signing_key=config.oidc_jwt_signing_key,
+        verify_id_token=verify_id_token,
+        require_authorization_consent=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Configuration loading
+# ---------------------------------------------------------------------------
 
 
 def _env(name: str, default: str | None = None) -> str | None:
@@ -89,6 +401,26 @@ class CollectionConfig:
             strategy initialisation so LFS pointers are resolved before reads.
         git_pull_interval_s: Interval in seconds for periodic git fetch +
             fast-forward-only updates (default ``600``). Set to ``0`` to disable.
+        auth_mode: Explicit authentication mode (``"remote"``, ``"oidc-proxy"``,
+            or ``None`` for auto-detect).
+        base_url: Base URL for OIDC redirects and token verification.
+        oidc_config_url: OIDC discovery endpoint URL.
+        oidc_client_id: OIDC client ID.
+        oidc_client_secret: OIDC client secret.
+        oidc_audience: Expected audience claim in tokens.
+        oidc_required_scopes: List of scopes required for access.
+        oidc_jwt_signing_key: Static key for signing OIDC session JWTs.
+        oidc_verify_access_token: If ``True``, verify the access token instead
+            of the ID token.
+        bearer_token: Static token for simple bearer authentication.
+        embedding_provider: Explicit provider (``"openai"``, ``"ollama"``,
+            ``"fastembed"``).
+        ollama_host: Base URL of the Ollama server.
+        ollama_model: Ollama model name.
+        ollama_cpu_only: Force CPU-only inference for Ollama.
+        openai_api_key: OpenAI API key.
+        fastembed_model: FastEmbed model identifier.
+        fastembed_cache_dir: Local directory to cache FastEmbed models.
 
     Example::
 
@@ -117,6 +449,31 @@ class CollectionConfig:
     templates_folder: str = "_templates"
     prompts_folder: str | None = None
     event_store_url: str | None = None
+
+    # Server settings
+    server_name: str = "markdown-vault-mcp"
+    instructions: str | None = None
+
+    # Auth settings
+    auth_mode: str | None = None
+    base_url: str | None = None
+    oidc_config_url: str | None = None
+    oidc_client_id: str | None = None
+    oidc_client_secret: str | None = None
+    oidc_audience: str | None = None
+    oidc_required_scopes: list[str] | None = None
+    oidc_jwt_signing_key: str | None = None
+    oidc_verify_access_token: bool = False
+    bearer_token: str | None = None
+
+    # Embedding settings
+    embedding_provider: str | None = None
+    ollama_host: str = "http://localhost:11434"
+    ollama_model: str = "nomic-embed-text"
+    ollama_cpu_only: bool = False
+    openai_api_key: str | None = None
+    fastembed_model: str = "BAAI/bge-small-en-v1.5"
+    fastembed_cache_dir: str | None = None
 
     def to_collection_kwargs(self) -> dict[str, Any]:
         """Return keyword arguments suitable for ``Collection(**kwargs)``.
@@ -147,6 +504,17 @@ class CollectionConfig:
             "max_attachment_size_mb": self.max_attachment_size_mb,
             "git_pull_interval_s": 0,
         }
+
+        if self.embeddings_path:
+            try:
+                from markdown_vault_mcp.providers import get_embedding_provider
+
+                kwargs["embedding_provider"] = get_embedding_provider(self)
+            except Exception:
+                logger.warning(
+                    "Could not load embedding provider; semantic search disabled",
+                    exc_info=True,
+                )
         from markdown_vault_mcp.git import GitWriteStrategy
 
         if self.git_repo_url is not None:
@@ -206,7 +574,7 @@ class CollectionConfig:
         return kwargs
 
 
-def load_config() -> CollectionConfig:
+def load_config(strict: bool = True) -> CollectionConfig:
     """Load configuration from environment variables.
 
     Reads the following environment variables:
@@ -271,12 +639,12 @@ def load_config() -> CollectionConfig:
         collection = Collection(**config.to_collection_kwargs())
     """
     raw_source_dir = (_env("SOURCE_DIR") or "").strip()
-    if not raw_source_dir:
+    if not raw_source_dir and strict:
         raise ValueError(
             "MARKDOWN_VAULT_MCP_SOURCE_DIR is required but not set. "
             "Set it to the path of your markdown collection."
         )
-    source_dir = Path(raw_source_dir)
+    source_dir = Path(raw_source_dir or ".")
     logger.debug("load_config: source_dir=%s", source_dir)
 
     raw_read_only = _env("READ_ONLY")
@@ -431,6 +799,33 @@ def load_config() -> CollectionConfig:
         "load_config: event_store_url=%s", event_store_url or "not set (file default)"
     )
 
+    # Auth settings
+    auth_mode = (_env("AUTH_MODE") or "").strip().lower() or None
+    base_url = (_env("BASE_URL") or "").strip() or None
+    oidc_config_url = (_env("OIDC_CONFIG_URL") or "").strip() or None
+    oidc_client_id = (_env("OIDC_CLIENT_ID") or "").strip() or None
+    oidc_client_secret = (_env("OIDC_CLIENT_SECRET") or "").strip() or None
+    oidc_audience = (_env("OIDC_AUDIENCE") or "").strip() or None
+    oidc_required_scopes = _parse_list(_env("OIDC_REQUIRED_SCOPES") or "") or None
+    oidc_jwt_signing_key = (_env("OIDC_JWT_SIGNING_KEY") or "").strip() or None
+    oidc_verify_access_token = _parse_bool(_env("OIDC_VERIFY_ACCESS_TOKEN") or "false")
+    bearer_token = (_env("BEARER_TOKEN") or "").strip() or None
+
+    # Server settings
+    server_name = _env("SERVER_NAME", "markdown-vault-mcp")
+    instructions = _env("INSTRUCTIONS")
+
+    # Embedding settings
+    embedding_provider = (
+        os.environ.get("EMBEDDING_PROVIDER", "").strip().lower() or None
+    )
+    ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+    ollama_model = _env("OLLAMA_MODEL", "nomic-embed-text")
+    ollama_cpu_only = _parse_bool(_env("OLLAMA_CPU_ONLY") or "false")
+    openai_api_key = os.environ.get("OPENAI_API_KEY")
+    fastembed_model = _env("FASTEMBED_MODEL", "BAAI/bge-small-en-v1.5")
+    fastembed_cache_dir = _env("FASTEMBED_CACHE_DIR")
+
     return CollectionConfig(
         source_dir=source_dir,
         read_only=read_only,
@@ -453,4 +848,23 @@ def load_config() -> CollectionConfig:
         templates_folder=templates_folder,
         prompts_folder=prompts_folder,
         event_store_url=event_store_url,
+        server_name=server_name or "markdown-vault-mcp",
+        instructions=instructions,
+        auth_mode=auth_mode,
+        base_url=base_url,
+        oidc_config_url=oidc_config_url,
+        oidc_client_id=oidc_client_id,
+        oidc_client_secret=oidc_client_secret,
+        oidc_audience=oidc_audience,
+        oidc_required_scopes=oidc_required_scopes,
+        oidc_jwt_signing_key=oidc_jwt_signing_key,
+        oidc_verify_access_token=oidc_verify_access_token,
+        bearer_token=bearer_token,
+        embedding_provider=embedding_provider,
+        ollama_host=ollama_host,
+        ollama_model=ollama_model or "nomic-embed-text",
+        ollama_cpu_only=ollama_cpu_only,
+        openai_api_key=openai_api_key,
+        fastembed_model=fastembed_model or "BAAI/bge-small-en-v1.5",
+        fastembed_cache_dir=fastembed_cache_dir,
     )

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -13,15 +13,8 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
-
-if TYPE_CHECKING:
-    from fastmcp.server.event_store import EventStore
 
 from fastmcp import FastMCP
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
@@ -31,7 +24,13 @@ from fastmcp.server.middleware.logging import (
 )
 from fastmcp.server.middleware.timing import TimingMiddleware
 
-from markdown_vault_mcp.config import _ENV_PREFIX, load_config
+from markdown_vault_mcp.config import (
+    _build_bearer_auth,
+    _build_oidc_auth,
+    _build_remote_auth,
+    _resolve_auth_mode,
+    load_config,
+)
 
 from ._icons import _SERVER_ICON
 from ._server_apps import register_apps
@@ -41,63 +40,6 @@ from ._server_resources import register_resources
 from ._server_tools import register_tools
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Event store
-# ---------------------------------------------------------------------------
-
-_DEFAULT_EVENT_STORE_DIR = "/data/state/events"
-
-
-def build_event_store(url: str | None = None) -> EventStore:
-    """Build an ``EventStore`` for SSE polling/resumability.
-
-    Parses the *url* scheme to select a storage backend:
-
-    - ``None`` or empty → ``FileTreeStore`` at :data:`_DEFAULT_EVENT_STORE_DIR`
-    - ``file:///path`` → ``FileTreeStore`` at the given path
-    - ``memory://`` → in-memory (lost on restart, for development)
-
-    Args:
-        url: Event store URL from ``MARKDOWN_VAULT_MCP_EVENT_STORE_URL``.
-
-    Returns:
-        A configured :class:`~fastmcp.server.event_store.EventStore`.
-    """
-    from fastmcp.server.event_store import EventStore as _EventStore
-
-    if not url:
-        url = f"file://{_DEFAULT_EVENT_STORE_DIR}"
-
-    parsed = urlparse(url)
-
-    if parsed.scheme == "memory":
-        logger.info("Event store: in-memory (sessions lost on restart)")
-        return _EventStore(max_events_per_stream=100, ttl=3600)
-
-    if parsed.scheme == "file":
-        directory = parsed.path
-        if not directory:
-            directory = _DEFAULT_EVENT_STORE_DIR
-        Path(directory).mkdir(parents=True, exist_ok=True)
-        logger.info("Event store: file-backed at %s", directory)
-
-        try:
-            from key_value.aio.stores.filetree import FileTreeStore
-        except ImportError:
-            raise ImportError(
-                "FileTreeStore requires fastmcp>=3.0 with key-value support. "
-                "Install with: pip install 'markdown-vault-mcp[mcp]'"
-            ) from None
-
-        storage = FileTreeStore(data_directory=directory)
-        return _EventStore(storage=storage, max_events_per_stream=100, ttl=3600)
-
-    raise ValueError(
-        f"Unsupported EVENT_STORE_URL scheme {parsed.scheme!r}. "
-        "Use 'file:///path' or 'memory://'."
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -139,275 +81,6 @@ def _build_default_instructions(*, read_only: bool) -> str:
     )
 
 
-def _resolve_auth_mode() -> str | None:
-    """Determine which OIDC auth mode to use.
-
-    Reads ``MARKDOWN_VAULT_MCP_AUTH_MODE`` for an explicit override.
-    When not set, auto-detects based on which env vars are present:
-
-    - All four OIDC vars (BASE_URL, CONFIG_URL, CLIENT_ID, CLIENT_SECRET) → ``"oidc-proxy"``
-    - Only BASE_URL + CONFIG_URL → ``"remote"``
-    - Otherwise → ``None`` (no OIDC)
-
-    Returns:
-        ``"remote"``, ``"oidc-proxy"``, or ``None``.
-    """
-    explicit = os.environ.get(f"{_ENV_PREFIX}_AUTH_MODE", "").strip().lower()
-    if explicit in ("remote", "oidc-proxy"):
-        logger.info("OIDC auth mode: %s (explicit via AUTH_MODE)", explicit)
-        return explicit
-    if explicit:
-        logger.warning(
-            "Unknown AUTH_MODE %r — ignoring, falling back to auto-detection",
-            explicit,
-        )
-
-    base_url = os.environ.get(f"{_ENV_PREFIX}_BASE_URL", "").strip()
-    config_url = os.environ.get(f"{_ENV_PREFIX}_OIDC_CONFIG_URL", "").strip()
-    client_id = os.environ.get(f"{_ENV_PREFIX}_OIDC_CLIENT_ID", "").strip()
-    client_secret = os.environ.get(f"{_ENV_PREFIX}_OIDC_CLIENT_SECRET", "").strip()
-
-    if all([base_url, config_url, client_id, client_secret]):
-        logger.info(
-            "OIDC auth mode: oidc-proxy (auto-detected — all four OIDC vars set)"
-        )
-        return "oidc-proxy"
-
-    if base_url and config_url:
-        logger.info(
-            "OIDC auth mode: remote (auto-detected — BASE_URL + OIDC_CONFIG_URL set)"
-        )
-        return "remote"
-
-    return None
-
-
-def _build_remote_auth() -> Any:
-    """Build a RemoteAuthProvider from OIDC discovery.
-
-    Fetches the OIDC discovery document at startup to extract ``jwks_uri``
-    and ``issuer``, then constructs a ``JWTVerifier`` for local token
-    validation via JWKS.  No client credentials are needed — tokens are
-    validated locally.
-
-    Requires ``BASE_URL`` and ``OIDC_CONFIG_URL`` env vars.
-
-    Returns:
-        A configured ``RemoteAuthProvider``, or ``None`` when env vars are
-        missing or the discovery fetch fails.
-    """
-    base_url = os.environ.get(f"{_ENV_PREFIX}_BASE_URL", "").strip()
-    config_url = os.environ.get(f"{_ENV_PREFIX}_OIDC_CONFIG_URL", "").strip()
-
-    if not base_url or not config_url:
-        logger.debug("Remote auth: disabled — missing BASE_URL or OIDC_CONFIG_URL")
-        return None
-
-    audience = os.environ.get(f"{_ENV_PREFIX}_OIDC_AUDIENCE", "").strip() or None
-    raw_scopes = os.environ.get(f"{_ENV_PREFIX}_OIDC_REQUIRED_SCOPES", "").strip()
-    required_scopes = [s.strip() for s in raw_scopes.split(",") if s.strip()] or None
-
-    try:
-        import httpx
-    except ImportError:
-        logger.error(
-            "Remote auth: 'httpx' is not installed. "
-            "Install it with: pip install 'markdown-vault-mcp[all]' "
-            "or pip install httpx"
-        )
-        return None
-
-    try:
-        resp = httpx.get(config_url, timeout=10)
-        resp.raise_for_status()
-        discovery = resp.json()
-    except Exception:
-        logger.exception(
-            "Remote auth: failed to fetch OIDC discovery from %s", config_url
-        )
-        return None
-
-    jwks_uri = discovery.get("jwks_uri")
-    issuer = discovery.get("issuer")
-    if not jwks_uri or not issuer:
-        logger.error(
-            "Remote auth: OIDC discovery missing jwks_uri or issuer (got jwks_uri=%s, issuer=%s)",
-            jwks_uri,
-            issuer,
-        )
-        return None
-
-    logger.debug(
-        "Remote auth config:\n"
-        "  config_url      = %s\n"
-        "  jwks_uri        = %s\n"
-        "  issuer          = %s\n"
-        "  base_url        = %s\n"
-        "  audience        = %s\n"
-        "  required_scopes = %s",
-        config_url,
-        jwks_uri,
-        issuer,
-        base_url,
-        audience or "(not set)",
-        required_scopes or "(not set)",
-    )
-
-    from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider
-
-    verifier = JWTVerifier(
-        jwks_uri=jwks_uri,
-        issuer=issuer,
-        audience=audience,
-        required_scopes=required_scopes,
-    )
-    return RemoteAuthProvider(
-        token_verifier=verifier,
-        authorization_servers=[issuer],
-        base_url=base_url,
-    )
-
-
-def _build_bearer_auth() -> Any:
-    """Build a StaticTokenVerifier from ``MARKDOWN_VAULT_MCP_BEARER_TOKEN``.
-
-    When the env var is set (non-empty), returns a
-    :class:`~fastmcp.server.auth.StaticTokenVerifier` that
-    validates ``Authorization: Bearer <token>`` headers against the
-    configured static token.
-
-    Returns:
-        A configured ``StaticTokenVerifier``, or ``None`` when the env var
-        is absent or empty.
-    """
-    token = os.environ.get(f"{_ENV_PREFIX}_BEARER_TOKEN", "").strip()
-    if not token:
-        logger.debug("Bearer auth: BEARER_TOKEN not set — skipping")
-        return None
-    logger.debug("Bearer auth: BEARER_TOKEN is set (value redacted)")
-    from fastmcp.server.auth import StaticTokenVerifier
-
-    return StaticTokenVerifier(
-        tokens={token: {"client_id": "bearer", "scopes": ["read", "write"]}}
-    )
-
-
-def _build_oidc_auth() -> Any:
-    """Build an OIDCProxy auth provider from environment variables, or return None.
-
-    All four of ``BASE_URL``, ``OIDC_CONFIG_URL``, ``OIDC_CLIENT_ID``, and
-    ``OIDC_CLIENT_SECRET`` must be set to enable authentication.  If any is
-    absent the server starts unauthenticated.
-
-    By default the proxy verifies the upstream ``id_token`` (a standard JWT
-    per OIDC Core) instead of the ``access_token``.  This works with every
-    OIDC provider — including those that issue opaque access tokens (e.g.
-    Authelia).  Set ``MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN=true`` to revert to
-    access-token verification when you know the provider issues JWT access
-    tokens and you need audience-claim validation on that token.
-
-    Returns:
-        A configured :class:`~fastmcp.server.auth.oidc_proxy.OIDCProxy` instance,
-        or ``None`` when authentication is disabled.
-    """
-    base_url = os.environ.get(f"{_ENV_PREFIX}_BASE_URL", "").strip()
-    config_url = os.environ.get(f"{_ENV_PREFIX}_OIDC_CONFIG_URL", "").strip()
-    client_id = os.environ.get(f"{_ENV_PREFIX}_OIDC_CLIENT_ID", "").strip()
-    client_secret = os.environ.get(f"{_ENV_PREFIX}_OIDC_CLIENT_SECRET", "").strip()
-
-    if not all([base_url, config_url, client_id, client_secret]):
-        missing = [
-            name
-            for name, val in [
-                ("BASE_URL", base_url),
-                ("OIDC_CONFIG_URL", config_url),
-                ("OIDC_CLIENT_ID", client_id),
-                ("OIDC_CLIENT_SECRET", client_secret),
-            ]
-            if not val
-        ]
-        logger.debug("OIDC auth: disabled — missing env vars: %s", ", ".join(missing))
-        return None
-
-    from fastmcp.server.auth.oidc_proxy import OIDCProxy
-
-    jwt_signing_key = (
-        os.environ.get(f"{_ENV_PREFIX}_OIDC_JWT_SIGNING_KEY", "").strip() or None
-    )
-    audience = os.environ.get(f"{_ENV_PREFIX}_OIDC_AUDIENCE", "").strip() or None
-    raw_scopes = os.environ.get(f"{_ENV_PREFIX}_OIDC_REQUIRED_SCOPES", "openid").strip()
-    required_scopes = [s.strip() for s in raw_scopes.split(",") if s.strip()] or [
-        "openid"
-    ]
-
-    # Default: verify id_token (works with all providers, including opaque
-    # access-token issuers like Authelia).  Opt out with
-    # MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN=true when you need direct
-    # JWT access-token audience validation.
-    verify_access_token = os.environ.get(
-        f"{_ENV_PREFIX}_OIDC_VERIFY_ACCESS_TOKEN", ""
-    ).strip().lower() in ("true", "1", "yes")
-    verify_id_token = not verify_access_token
-
-    logger.debug(
-        "OIDC auth config:\n"
-        "  config_url          = %s\n"
-        "  client_id           = %s\n"
-        "  client_secret       = <redacted>\n"
-        "  base_url            = %s\n"
-        "  audience            = %s\n"
-        "  required_scopes     = %s\n"
-        "  jwt_signing_key     = %s\n"
-        "  verify_id_token     = %s\n"
-        "  verify_access_token = %s",
-        config_url,
-        client_id,
-        base_url,
-        audience or "(not set)",
-        required_scopes,
-        "(set)" if jwt_signing_key else "(not set)",
-        verify_id_token,
-        verify_access_token,
-    )
-
-    if verify_id_token and "openid" not in required_scopes:
-        logger.warning(
-            "OIDC: verify_id_token=True requires the 'openid' scope but it is "
-            "not in MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES — the id_token may "
-            "be absent from the token response; add 'openid' to the scope list "
-            "or set MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN=true"
-        )
-
-    if jwt_signing_key is None and sys.platform.startswith("linux"):
-        logger.warning(
-            "OIDC: MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY is not set — "
-            "the JWT signing key is ephemeral on Linux; all clients must "
-            "re-authenticate after every server restart"
-        )
-
-    if verify_id_token:
-        logger.info(
-            "OIDC: verifying upstream id_token (works with opaque access tokens)"
-        )
-    else:
-        logger.info(
-            "OIDC: verifying upstream access_token as JWT "
-            "(MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN=true)"
-        )
-
-    return OIDCProxy(
-        config_url=config_url,
-        client_id=client_id,
-        client_secret=client_secret,
-        base_url=base_url,
-        audience=audience,
-        required_scopes=required_scopes,
-        jwt_signing_key=jwt_signing_key,
-        verify_id_token=verify_id_token,
-        require_authorization_consent=False,
-    )
-
-
 def create_server(transport: str = "stdio") -> FastMCP:
     """Create and configure the FastMCP server.
 
@@ -415,34 +88,24 @@ def create_server(transport: str = "stdio") -> FastMCP:
     Write tools are tagged with ``{"write"}`` and hidden via
     ``mcp.disable(tags={"write"})`` when ``READ_ONLY=true``.
 
-    Server identity is configurable via:
-
-    - ``MARKDOWN_VAULT_MCP_SERVER_NAME``: MCP server name shown to clients
-      (default ``"markdown-vault-mcp"``).
-    - ``MARKDOWN_VAULT_MCP_INSTRUCTIONS``: system-level instructions injected
-      into LLM context (default: dynamic description reflecting read-only state).
-    - ``MARKDOWN_VAULT_MCP_PROMPTS_FOLDER``: directory of user-defined ``.md``
-      prompt files.  User prompts with the same name as a built-in override the
-      built-in.  Default: disabled.
-
     Returns:
         A fully configured :class:`~fastmcp.FastMCP` instance ready to run.
     """
     config = load_config()
     is_read_only = config.read_only
 
-    server_name = os.environ.get(f"{_ENV_PREFIX}_SERVER_NAME", "markdown-vault-mcp")
+    server_name = config.server_name
     default_instructions = _build_default_instructions(read_only=is_read_only)
-    instructions = os.environ.get(f"{_ENV_PREFIX}_INSTRUCTIONS", default_instructions)
+    instructions = config.instructions or default_instructions
 
-    bearer_auth = _build_bearer_auth()
-    oidc_mode = _resolve_auth_mode()
+    bearer_auth = _build_bearer_auth(config)
+    oidc_mode = _resolve_auth_mode(config)
 
     oidc_auth = None
     if oidc_mode == "remote":
-        oidc_auth = _build_remote_auth()
+        oidc_auth = _build_remote_auth(config)
     elif oidc_mode == "oidc-proxy":
-        oidc_auth = _build_oidc_auth()
+        oidc_auth = _build_oidc_auth(config)
 
     if oidc_mode and not oidc_auth:
         logger.warning(

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 import logging
 import os
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from markdown_vault_mcp.config import _ENV_PREFIX
+if TYPE_CHECKING:
+    from markdown_vault_mcp.config import CollectionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -67,20 +69,20 @@ class EmbeddingProvider(ABC):
 
 
 class OllamaProvider(EmbeddingProvider):
-    """Embedding provider backed by the Ollama REST API.
+    """Embedding provider backed by the Ollama REST API."""
 
-    Configuration via environment variables:
+    def __init__(
+        self,
+        host: str = "http://localhost:11434",
+        model: str = "nomic-embed-text",
+        cpu_only: bool = False,
+    ) -> None:
+        """Initialise OllamaProvider.
 
-    - ``OLLAMA_HOST``: base URL of the Ollama server
-      (default: ``http://localhost:11434``).
-    - ``MARKDOWN_VAULT_MCP_OLLAMA_MODEL``: model name to use
-      (default: ``nomic-embed-text``).
-    - ``MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY``: set to ``true`` to force CPU-only
-      inference (default: ``false``).
-    """
-
-    def __init__(self) -> None:
-        """Initialise OllamaProvider from environment variables.
+        Args:
+            host: Base URL of the Ollama server.
+            model: Model name to use.
+            cpu_only: Force CPU-only inference.
 
         Raises:
             ImportError: If ``httpx`` is not installed.
@@ -94,10 +96,9 @@ class OllamaProvider(EmbeddingProvider):
             ) from exc
 
         self._httpx = httpx
-        self._host = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
-        self._model = os.environ.get(f"{_ENV_PREFIX}_OLLAMA_MODEL", "nomic-embed-text")
-        cpu_only_raw = os.environ.get(f"{_ENV_PREFIX}_OLLAMA_CPU_ONLY", "false").lower()
-        self._cpu_only = cpu_only_raw in ("1", "true", "yes")
+        self._host = host.rstrip("/")
+        self._model = model
+        self._cpu_only = cpu_only
         self._dimension: int | None = None
 
         logger.debug(
@@ -173,22 +174,21 @@ class OllamaProvider(EmbeddingProvider):
 class OpenAIProvider(EmbeddingProvider):
     """Embedding provider backed by the OpenAI Embeddings API.
 
-    Configuration via environment variables:
-
-    - ``OPENAI_API_KEY``: required API key.
-
     Uses the ``text-embedding-3-small`` model.
     """
 
     _MODEL = "text-embedding-3-small"
     _ENDPOINT = "https://api.openai.com/v1/embeddings"
 
-    def __init__(self) -> None:
-        """Initialise OpenAIProvider from environment variables.
+    def __init__(self, api_key: str | None = None) -> None:
+        """Initialise OpenAIProvider.
+
+        Args:
+            api_key: OpenAI API key.
 
         Raises:
             ImportError: If ``httpx`` is not installed.
-            RuntimeError: If ``OPENAI_API_KEY`` is not set.
+            RuntimeError: If ``api_key`` is not provided.
         """
         try:
             import httpx
@@ -199,10 +199,9 @@ class OpenAIProvider(EmbeddingProvider):
             ) from exc
 
         self._httpx = httpx
-        api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError(
-                "OpenAIProvider requires the OPENAI_API_KEY environment variable."
+                "OpenAIProvider requires the OPENAI_API_KEY environment variable (passed as api_key)."
             )
         self._api_key = api_key
         self._dimension: int | None = None
@@ -288,7 +287,7 @@ class FastEmbedProvider(EmbeddingProvider):
 
     def __init__(
         self,
-        model_name: str | None = None,
+        model_name: str = "BAAI/bge-small-en-v1.5",
         cache_dir: str | None = None,
     ) -> None:
         """Initialise FastEmbed model.
@@ -308,12 +307,8 @@ class FastEmbedProvider(EmbeddingProvider):
                 "Install it with: pip install 'markdown-vault-mcp[embeddings]'"
             ) from exc
 
-        self._model_name = model_name or os.environ.get(
-            f"{_ENV_PREFIX}_FASTEMBED_MODEL", "BAAI/bge-small-en-v1.5"
-        )
-        self._cache_dir = cache_dir or os.environ.get(
-            f"{_ENV_PREFIX}_FASTEMBED_CACHE_DIR"
-        )
+        self._model_name = model_name
+        self._cache_dir = cache_dir
         kwargs: dict[str, object] = {"model_name": self._model_name}
         if self._cache_dir:
             kwargs["cache_dir"] = self._cache_dir
@@ -369,65 +364,96 @@ class FastEmbedProvider(EmbeddingProvider):
         return self._model_name
 
 
-def get_embedding_provider() -> EmbeddingProvider:
+def get_embedding_provider(config: CollectionConfig | None = None) -> EmbeddingProvider:
     """Auto-detect and return an embedding provider.
 
-    Checks the ``EMBEDDING_PROVIDER`` environment variable first. When that
-    variable is not set, probes for available providers in this order:
-
-    1. If ``OPENAI_API_KEY`` is set → :class:`OpenAIProvider`.
-    2. If Ollama is reachable at ``OLLAMA_HOST`` → :class:`OllamaProvider`.
-    3. If ``fastembed`` can be imported →
-       :class:`FastEmbedProvider`.
-    4. Raises :class:`RuntimeError` with installation instructions.
+    Args:
+        config: Optional :class:`~markdown_vault_mcp.config.CollectionConfig`.
+            When provided, settings from the config take precedence over
+            auto-detection.
 
     Returns:
         An initialised :class:`EmbeddingProvider` instance.
 
     Raises:
-        RuntimeError: If no provider is available and ``EMBEDDING_PROVIDER``
-            is not set, or if the explicitly requested provider cannot be
-            initialised.
-        ValueError: If ``EMBEDDING_PROVIDER`` is set to an unrecognised value.
+        RuntimeError: If no provider is available and no explicit provider is
+            set in *config*, or if the requested provider cannot be initialised.
+        ValueError: If an unrecognised provider is requested.
     """
-    explicit = os.environ.get("EMBEDDING_PROVIDER", "").strip().lower()
+    if config:
+        explicit = config.embedding_provider
+        if explicit == "openai":
+            logger.info("Using OpenAIProvider (config)")
+            return OpenAIProvider(api_key=config.openai_api_key)
+        if explicit == "ollama":
+            logger.info("Using OllamaProvider (config)")
+            return OllamaProvider(
+                host=config.ollama_host,
+                model=config.ollama_model,
+                cpu_only=config.ollama_cpu_only,
+            )
+        if explicit == "fastembed":
+            logger.info("Using FastEmbedProvider (config)")
+            return FastEmbedProvider(
+                model_name=config.fastembed_model, cache_dir=config.fastembed_cache_dir
+            )
+        if explicit:
+            raise ValueError(
+                f"Unrecognised embedding_provider: {explicit!r}. "
+                "Valid values: 'openai', 'ollama', 'fastembed'."
+            )
 
-    if explicit == "openai":
-        logger.info("Using OpenAIProvider (EMBEDDING_PROVIDER=openai)")
-        return OpenAIProvider()
+    # Fallback to auto-detection (uses os.environ internally if config is missing)
+    # but since we want to move away from os.environ, we should ideally always pass config.
+    # For now, we'll maintain backward compatibility by reading env vars if config is None.
+    # Actually, let's just use os.environ as a final fallback if config is None.
 
-    if explicit == "ollama":
-        logger.info("Using OllamaProvider (EMBEDDING_PROVIDER=ollama)")
-        return OllamaProvider()
-
-    if explicit == "fastembed":
-        logger.info(
-            "Using FastEmbedProvider (EMBEDDING_PROVIDER=%s)",
-            explicit,
+    provider_name = os.environ.get("EMBEDDING_PROVIDER", "").strip().lower()
+    if provider_name == "openai":
+        return OpenAIProvider(api_key=os.environ.get("OPENAI_API_KEY"))
+    if provider_name == "ollama":
+        return OllamaProvider(
+            host=os.environ.get("OLLAMA_HOST", "http://localhost:11434"),
+            model=os.environ.get("MARKDOWN_VAULT_MCP_OLLAMA_MODEL", "nomic-embed-text"),
+            cpu_only=os.environ.get(
+                "MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY", "false"
+            ).lower()
+            in ("true", "1", "yes"),
         )
-        return FastEmbedProvider()
-
-    if explicit:
-        raise ValueError(
-            f"Unrecognised EMBEDDING_PROVIDER value: {explicit!r}. "
-            "Valid values: 'openai', 'ollama', 'fastembed'."
+    if provider_name == "fastembed":
+        return FastEmbedProvider(
+            model_name=os.environ.get(
+                "MARKDOWN_VAULT_MCP_FASTEMBED_MODEL", "BAAI/bge-small-en-v1.5"
+            ),
+            cache_dir=os.environ.get("MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR"),
         )
 
     # Auto-detect: OpenAI API key present?
-    if os.environ.get("OPENAI_API_KEY"):
-        logger.info("Auto-detected OpenAIProvider (OPENAI_API_KEY is set)")
-        return OpenAIProvider()
+    api_key = config.openai_api_key if config else os.environ.get("OPENAI_API_KEY")
+    if api_key:
+        logger.info("Auto-detected OpenAIProvider")
+        return OpenAIProvider(api_key=api_key)
 
     # Auto-detect: Ollama reachable?
-    host = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+    host = (
+        config.ollama_host
+        if config
+        else os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+    )
     try:
         import httpx
 
         with httpx.Client(timeout=2.0) as client:
-            response = client.get(f"{host}/api/tags")
+            response = client.get(f"{host.rstrip('/')}/api/tags")
         if response.status_code == 200:
             logger.info("Auto-detected OllamaProvider (Ollama reachable at %s)", host)
-            return OllamaProvider()
+            if config:
+                return OllamaProvider(
+                    host=config.ollama_host,
+                    model=config.ollama_model,
+                    cpu_only=config.ollama_cpu_only,
+                )
+            return OllamaProvider(host=host)
     except Exception:
         logger.debug("Ollama not reachable at %s, skipping", host)
 
@@ -436,6 +462,10 @@ def get_embedding_provider() -> EmbeddingProvider:
         import fastembed  # noqa: F401
 
         logger.info("Auto-detected FastEmbedProvider")
+        if config:
+            return FastEmbedProvider(
+                model_name=config.fastembed_model, cache_dir=config.fastembed_cache_dir
+            )
         return FastEmbedProvider()
     except ImportError:
         logger.debug("fastembed not available, skipping")
@@ -444,6 +474,4 @@ def get_embedding_provider() -> EmbeddingProvider:
         "No embedding provider is available. Install one of:\n"
         "  pip install 'markdown-vault-mcp[embeddings-api]'  # httpx for Ollama or OpenAI\n"
         "  pip install 'markdown-vault-mcp[embeddings]'       # fastembed (local)\n"
-        "Or set OPENAI_API_KEY for the OpenAI provider, "
-        "or start an Ollama server for the Ollama provider."
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,7 +249,7 @@ class TestCmdServe:
     """Test the serve subcommand dispatch."""
 
     @patch("uvicorn.run")
-    @patch("markdown_vault_mcp.mcp_server.build_event_store")
+    @patch("markdown_vault_mcp.config.build_event_store")
     @patch("markdown_vault_mcp.cli.load_config")
     @patch("markdown_vault_mcp.mcp_server.create_server")
     def test_serve_http_calls_http_app_and_uvicorn(
@@ -289,7 +289,7 @@ class TestCmdServe:
         )
 
     @patch("uvicorn.run")
-    @patch("markdown_vault_mcp.mcp_server.build_event_store")
+    @patch("markdown_vault_mcp.config.build_event_store")
     @patch("markdown_vault_mcp.cli.load_config")
     @patch("markdown_vault_mcp.mcp_server.create_server")
     def test_serve_http_custom_path(
@@ -318,7 +318,7 @@ class TestCmdServe:
         assert call_kwargs["path"] == "/vault/mcp"
 
     @patch("uvicorn.run")
-    @patch("markdown_vault_mcp.mcp_server.build_event_store")
+    @patch("markdown_vault_mcp.config.build_event_store")
     @patch("markdown_vault_mcp.cli.load_config")
     @patch("markdown_vault_mcp.mcp_server.create_server")
     def test_serve_http_custom_path_normalised(
@@ -347,7 +347,7 @@ class TestCmdServe:
         assert call_kwargs["path"] == "/vault/mcp"
 
     @patch("uvicorn.run")
-    @patch("markdown_vault_mcp.mcp_server.build_event_store")
+    @patch("markdown_vault_mcp.config.build_event_store")
     @patch("markdown_vault_mcp.cli.load_config")
     @patch("markdown_vault_mcp.mcp_server.create_server")
     def test_serve_http_path_env_fallback(
@@ -375,7 +375,7 @@ class TestCmdServe:
         assert call_kwargs["path"] == "/vault/mcp"
 
     @patch("uvicorn.run")
-    @patch("markdown_vault_mcp.mcp_server.build_event_store")
+    @patch("markdown_vault_mcp.config.build_event_store")
     @patch("markdown_vault_mcp.cli.load_config")
     @patch("markdown_vault_mcp.mcp_server.create_server")
     def test_serve_http_path_cli_overrides_env(

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from markdown_vault_mcp.config import load_config
-from markdown_vault_mcp.mcp_server import build_event_store
+from markdown_vault_mcp.config import (
+    build_event_store,
+    load_config,
+)
 
 
 class TestBuildEventStore:
@@ -16,7 +18,7 @@ class TestBuildEventStore:
         from unittest.mock import patch
 
         with patch(
-            "markdown_vault_mcp.mcp_server._DEFAULT_EVENT_STORE_DIR",
+            "markdown_vault_mcp.config._DEFAULT_EVENT_STORE_DIR",
             str(tmp_path / "events"),
         ):
             store = build_event_store(None)
@@ -29,7 +31,7 @@ class TestBuildEventStore:
         from unittest.mock import patch
 
         with patch(
-            "markdown_vault_mcp.mcp_server._DEFAULT_EVENT_STORE_DIR",
+            "markdown_vault_mcp.config._DEFAULT_EVENT_STORE_DIR",
             str(tmp_path / "events"),
         ):
             store = build_event_store("")
@@ -60,7 +62,7 @@ class TestBuildEventStore:
         from unittest.mock import patch
 
         with patch(
-            "markdown_vault_mcp.mcp_server._DEFAULT_EVENT_STORE_DIR",
+            "markdown_vault_mcp.config._DEFAULT_EVENT_STORE_DIR",
             str(tmp_path / "events"),
         ):
             store = build_event_store("file://")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15,13 +15,14 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from mcp.shared.exceptions import McpError
 
-from markdown_vault_mcp.mcp_server import (
+from markdown_vault_mcp.config import (
     _build_bearer_auth,
     _build_oidc_auth,
     _build_remote_auth,
     _resolve_auth_mode,
-    create_server,
+    load_config,
 )
+from markdown_vault_mcp.mcp_server import create_server
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -736,7 +737,7 @@ _OIDC_REQUIRED = {
 
 
 class TestBuildOidcAuth:
-    """Unit tests for _build_oidc_auth()."""
+    """Unit tests for _build_oidc_auth(load_config(strict=False))."""
 
     @pytest.fixture(autouse=True)
     def _clear_oidc_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -745,7 +746,7 @@ class TestBuildOidcAuth:
             monkeypatch.delenv(var, raising=False)
 
     def test_returns_none_when_no_vars_set(self) -> None:
-        assert _build_oidc_auth() is None
+        assert _build_oidc_auth(load_config(strict=False)) is None
 
     @pytest.mark.parametrize(
         "missing_var",
@@ -763,7 +764,7 @@ class TestBuildOidcAuth:
         for var, val in _OIDC_REQUIRED.items():
             if var != missing_var:
                 monkeypatch.setenv(var, val)
-        assert _build_oidc_auth() is None
+        assert _build_oidc_auth(load_config(strict=False)) is None
 
     def test_returns_non_none_when_all_required_vars_set(
         self, monkeypatch: pytest.MonkeyPatch
@@ -775,7 +776,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            result = _build_oidc_auth()
+            result = _build_oidc_auth(load_config(strict=False))
 
         assert result is not None
         mock_cls.assert_called_once()
@@ -790,7 +791,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         kw = mock_cls.call_args.kwargs
         assert kw["base_url"] == "https://mcp.example.com"
@@ -811,7 +812,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["required_scopes"] == ["openid"]
 
@@ -827,7 +828,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["required_scopes"] == ["openid"]
 
@@ -844,7 +845,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["required_scopes"] == [
             "openid",
@@ -861,7 +862,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["audience"] == "my-api"
 
@@ -875,7 +876,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["audience"] is None
 
@@ -890,7 +891,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["jwt_signing_key"] == "deadbeef1234"
 
@@ -904,7 +905,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["jwt_signing_key"] is None
 
@@ -919,10 +920,10 @@ class TestBuildOidcAuth:
         mock_cls = MagicMock()
         with (
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("markdown_vault_mcp.mcp_server.sys") as mock_sys,
+            patch("markdown_vault_mcp.config.sys") as mock_sys,
         ):
             mock_sys.platform = "linux"
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert any(
             "JWT_SIGNING_KEY" in r.message and r.levelname == "WARNING"
@@ -941,10 +942,10 @@ class TestBuildOidcAuth:
         mock_cls = MagicMock()
         with (
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("markdown_vault_mcp.mcp_server.sys") as mock_sys,
+            patch("markdown_vault_mcp.config.sys") as mock_sys,
         ):
             mock_sys.platform = "linux"
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert not any(
             "JWT_SIGNING_KEY" in r.message and r.levelname == "WARNING"
@@ -962,10 +963,10 @@ class TestBuildOidcAuth:
         mock_cls = MagicMock()
         with (
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("markdown_vault_mcp.mcp_server.sys") as mock_sys,
+            patch("markdown_vault_mcp.config.sys") as mock_sys,
         ):
             mock_sys.platform = "darwin"
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert not any(
             "JWT_SIGNING_KEY" in r.message and r.levelname == "WARNING"
@@ -983,7 +984,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["verify_id_token"] is True
 
@@ -999,7 +1000,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["verify_id_token"] is False
 
@@ -1016,7 +1017,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert mock_cls.call_args.kwargs["verify_id_token"] is True
 
@@ -1034,7 +1035,7 @@ class TestBuildOidcAuth:
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
             caplog.at_level(logging.INFO, logger="markdown_vault_mcp.mcp_server"),
         ):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert any("verifying upstream id_token" in r.message for r in caplog.records)
 
@@ -1053,7 +1054,7 @@ class TestBuildOidcAuth:
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
             caplog.at_level(logging.INFO, logger="markdown_vault_mcp.mcp_server"),
         ):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert any(
             "verifying upstream access_token as JWT" in r.message
@@ -1072,7 +1073,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert any(
             "openid" in r.message and r.levelname == "WARNING" for r in caplog.records
@@ -1089,7 +1090,7 @@ class TestBuildOidcAuth:
 
         mock_cls = MagicMock()
         with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert not any(
             "openid" in r.message and r.levelname == "WARNING" for r in caplog.records
@@ -2462,7 +2463,7 @@ _BEARER_VARS = ("MARKDOWN_VAULT_MCP_BEARER_TOKEN",)
 
 
 class TestBuildBearerAuth:
-    """Unit tests for _build_bearer_auth()."""
+    """Unit tests for _build_bearer_auth(load_config(strict=False))."""
 
     @pytest.fixture(autouse=True)
     def _clear_bearer_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2471,19 +2472,19 @@ class TestBuildBearerAuth:
             monkeypatch.delenv(var, raising=False)
 
     def test_returns_none_when_no_var_set(self) -> None:
-        assert _build_bearer_auth() is None
+        assert _build_bearer_auth(load_config(strict=False)) is None
 
     def test_returns_none_when_empty_string(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "")
-        assert _build_bearer_auth() is None
+        assert _build_bearer_auth(load_config(strict=False)) is None
 
     def test_returns_none_when_whitespace_only(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "   ")
-        assert _build_bearer_auth() is None
+        assert _build_bearer_auth(load_config(strict=False)) is None
 
     def test_returns_static_token_verifier_when_set(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2491,14 +2492,14 @@ class TestBuildBearerAuth:
         from fastmcp.server.auth import StaticTokenVerifier
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "test-secret-123")
-        result = _build_bearer_auth()
+        result = _build_bearer_auth(load_config(strict=False))
         assert isinstance(result, StaticTokenVerifier)
 
     def test_token_dict_has_correct_structure(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "my-token")
-        result = _build_bearer_auth()
+        result = _build_bearer_auth(load_config(strict=False))
         assert "my-token" in result.tokens
         entry = result.tokens["my-token"]
         assert entry["client_id"] == "bearer"
@@ -2508,7 +2509,7 @@ class TestBuildBearerAuth:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "good-token")
-        verifier = _build_bearer_auth()
+        verifier = _build_bearer_auth(load_config(strict=False))
         access = await verifier.verify_token("good-token")
         assert access is not None
         assert access.client_id == "bearer"
@@ -2518,7 +2519,7 @@ class TestBuildBearerAuth:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "good-token")
-        verifier = _build_bearer_auth()
+        verifier = _build_bearer_auth(load_config(strict=False))
         access = await verifier.verify_token("wrong-token")
         assert access is None
 
@@ -2526,7 +2527,7 @@ class TestBuildBearerAuth:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "good-token")
-        verifier = _build_bearer_auth()
+        verifier = _build_bearer_auth(load_config(strict=False))
         access = await verifier.verify_token("")
         assert access is None
 
@@ -2683,13 +2684,13 @@ class TestAuthDebugLogging:
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "secret-token")
         with caplog.at_level(logging.DEBUG):
-            _build_bearer_auth()
+            _build_bearer_auth(load_config(strict=False))
         assert "BEARER_TOKEN is set" in caplog.text
         assert "secret-token" not in caplog.text
 
     def test_bearer_debug_logs_absence(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level(logging.DEBUG):
-            _build_bearer_auth()
+            _build_bearer_auth(load_config(strict=False))
         assert "BEARER_TOKEN not set" in caplog.text
 
     def test_oidc_debug_logs_config(
@@ -2705,7 +2706,7 @@ class TestAuthDebugLogging:
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
             caplog.at_level(logging.DEBUG),
         ):
-            _build_oidc_auth()
+            _build_oidc_auth(load_config(strict=False))
 
         assert "OIDC auth config:" in caplog.text
         assert "config_url" in caplog.text
@@ -2721,7 +2722,7 @@ class TestAuthDebugLogging:
         # Only set BASE_URL, leave others missing
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BASE_URL", "https://example.com")
         with caplog.at_level(logging.DEBUG):
-            result = _build_oidc_auth()
+            result = _build_oidc_auth(load_config(strict=False))
         assert result is None
         assert "missing env vars" in caplog.text
 
@@ -2759,7 +2760,7 @@ class TestAuthDebugLogging:
 
 
 # ---------------------------------------------------------------------------
-# _resolve_auth_mode() — OIDC mode detection
+# _resolve_auth_mode(load_config(strict=False)) — OIDC mode detection
 # ---------------------------------------------------------------------------
 
 _RESOLVE_AUTH_VARS = (
@@ -2772,7 +2773,7 @@ _RESOLVE_AUTH_VARS = (
 
 
 class TestResolveAuthMode:
-    """Tests for _resolve_auth_mode()."""
+    """Tests for _resolve_auth_mode(load_config(strict=False))."""
 
     @pytest.fixture(autouse=True)
     def _clear_auth_mode_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2782,15 +2783,15 @@ class TestResolveAuthMode:
 
     def test_explicit_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_AUTH_MODE", "remote")
-        assert _resolve_auth_mode() == "remote"
+        assert _resolve_auth_mode(load_config(strict=False)) == "remote"
 
     def test_explicit_oidc_proxy(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_AUTH_MODE", "oidc-proxy")
-        assert _resolve_auth_mode() == "oidc-proxy"
+        assert _resolve_auth_mode(load_config(strict=False)) == "oidc-proxy"
 
     def test_explicit_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_AUTH_MODE", "REMOTE")
-        assert _resolve_auth_mode() == "remote"
+        assert _resolve_auth_mode(load_config(strict=False)) == "remote"
 
     def test_auto_detect_oidc_proxy(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """All four OIDC vars set → oidc-proxy."""
@@ -2801,7 +2802,7 @@ class TestResolveAuthMode:
         )
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID", "test-client")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET", "test-secret")
-        assert _resolve_auth_mode() == "oidc-proxy"
+        assert _resolve_auth_mode(load_config(strict=False)) == "oidc-proxy"
 
     def test_auto_detect_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Only BASE_URL + CONFIG_URL → remote."""
@@ -2810,14 +2811,14 @@ class TestResolveAuthMode:
             "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
             "https://auth.example.com/.well-known/openid-configuration",
         )
-        assert _resolve_auth_mode() == "remote"
+        assert _resolve_auth_mode(load_config(strict=False)) == "remote"
 
     def test_no_vars_returns_none(self) -> None:
-        assert _resolve_auth_mode() is None
+        assert _resolve_auth_mode(load_config(strict=False)) is None
 
     def test_invalid_mode_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_AUTH_MODE", "invalid")
-        assert _resolve_auth_mode() is None
+        assert _resolve_auth_mode(load_config(strict=False)) is None
 
     def test_invalid_mode_warns_and_falls_through(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -2830,14 +2831,14 @@ class TestResolveAuthMode:
             "https://auth.example.com/.well-known/openid-configuration",
         )
         with caplog.at_level(logging.WARNING):
-            result = _resolve_auth_mode()
+            result = _resolve_auth_mode(load_config(strict=False))
         assert result == "remote"
         assert "Unknown AUTH_MODE 'typo'" in caplog.text
 
     def test_only_base_url_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """BASE_URL alone is not enough for any OIDC mode."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BASE_URL", "https://mcp.example.com")
-        assert _resolve_auth_mode() is None
+        assert _resolve_auth_mode(load_config(strict=False)) is None
 
     def test_explicit_overrides_auto_detection(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2851,11 +2852,11 @@ class TestResolveAuthMode:
         )
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID", "test-client")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET", "test-secret")
-        assert _resolve_auth_mode() == "remote"
+        assert _resolve_auth_mode(load_config(strict=False)) == "remote"
 
 
 # ---------------------------------------------------------------------------
-# _build_remote_auth() — RemoteAuthProvider construction
+# _build_remote_auth(load_config(strict=False)) — RemoteAuthProvider construction
 # ---------------------------------------------------------------------------
 
 _REMOTE_AUTH_VARS = (
@@ -2867,7 +2868,7 @@ _REMOTE_AUTH_VARS = (
 
 
 class TestBuildRemoteAuth:
-    """Tests for _build_remote_auth()."""
+    """Tests for _build_remote_auth(load_config(strict=False))."""
 
     @pytest.fixture(autouse=True)
     def _clear_remote_auth_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2876,13 +2877,13 @@ class TestBuildRemoteAuth:
             monkeypatch.delenv(var, raising=False)
 
     def test_missing_env_vars_returns_none(self) -> None:
-        assert _build_remote_auth() is None
+        assert _build_remote_auth(load_config(strict=False)) is None
 
     def test_missing_config_url_returns_none(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BASE_URL", "https://mcp.example.com")
-        assert _build_remote_auth() is None
+        assert _build_remote_auth(load_config(strict=False)) is None
 
     def test_missing_base_url_returns_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2891,7 +2892,7 @@ class TestBuildRemoteAuth:
             "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
             "https://auth.example.com/.well-known/openid-configuration",
         )
-        assert _build_remote_auth() is None
+        assert _build_remote_auth(load_config(strict=False)) is None
 
     def test_discovery_fetch_failure_returns_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2904,7 +2905,7 @@ class TestBuildRemoteAuth:
             "https://auth.example.com/.well-known/openid-configuration",
         )
         with patch("httpx.get", side_effect=Exception("connection failed")):
-            assert _build_remote_auth() is None
+            assert _build_remote_auth(load_config(strict=False)) is None
 
     def test_httpx_import_error_returns_none(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -2922,7 +2923,7 @@ class TestBuildRemoteAuth:
             patch.dict(sys.modules, {"httpx": None}),
             caplog.at_level(logging.ERROR),
         ):
-            assert _build_remote_auth() is None
+            assert _build_remote_auth(load_config(strict=False)) is None
         assert "'httpx' is not installed" in caplog.text
 
     def test_happy_path_returns_non_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2940,7 +2941,7 @@ class TestBuildRemoteAuth:
         }
         mock_resp.raise_for_status = MagicMock()
         with patch("httpx.get", return_value=mock_resp):
-            result = _build_remote_auth()
+            result = _build_remote_auth(load_config(strict=False))
         assert result is not None
 
     def test_missing_jwks_uri_returns_none(
@@ -2957,7 +2958,7 @@ class TestBuildRemoteAuth:
         mock_resp.json.return_value = {"issuer": "https://auth.example.com"}
         mock_resp.raise_for_status = MagicMock()
         with patch("httpx.get", return_value=mock_resp):
-            assert _build_remote_auth() is None
+            assert _build_remote_auth(load_config(strict=False)) is None
 
     def test_missing_issuer_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from unittest.mock import MagicMock, patch
@@ -2973,7 +2974,7 @@ class TestBuildRemoteAuth:
         }
         mock_resp.raise_for_status = MagicMock()
         with patch("httpx.get", return_value=mock_resp):
-            assert _build_remote_auth() is None
+            assert _build_remote_auth(load_config(strict=False)) is None
 
     def test_audience_forwarded_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from unittest.mock import MagicMock, patch
@@ -3000,7 +3001,7 @@ class TestBuildRemoteAuth:
             patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
             patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
         ):
-            _build_remote_auth()
+            _build_remote_auth(load_config(strict=False))
 
         kw = mock_verifier_cls.call_args.kwargs
         assert kw["audience"] == "my-api"
@@ -3031,7 +3032,7 @@ class TestBuildRemoteAuth:
             patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
             patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
         ):
-            _build_remote_auth()
+            _build_remote_auth(load_config(strict=False))
 
         kw = mock_verifier_cls.call_args.kwargs
         assert kw["audience"] is None
@@ -3063,7 +3064,7 @@ class TestBuildRemoteAuth:
             patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
             patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
         ):
-            _build_remote_auth()
+            _build_remote_auth(load_config(strict=False))
 
         kw = mock_verifier_cls.call_args.kwargs
         assert kw["required_scopes"] == ["openid", "profile", "email"]
@@ -3096,7 +3097,7 @@ class TestBuildRemoteAuth:
             patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
             patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
         ):
-            _build_remote_auth()
+            _build_remote_auth(load_config(strict=False))
 
         kw = mock_verifier_cls.call_args.kwargs
         assert kw["required_scopes"] is None
@@ -3128,7 +3129,7 @@ class TestBuildRemoteAuth:
             patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
             caplog.at_level(logging.DEBUG),
         ):
-            _build_remote_auth()
+            _build_remote_auth(load_config(strict=False))
 
         assert "Remote auth config:" in caplog.text
         assert "jwks_uri" in caplog.text

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from markdown_vault_mcp.config import load_config
 from markdown_vault_mcp.providers import (
     FastEmbedProvider,
     OllamaProvider,
@@ -48,13 +49,10 @@ class TestOllamaProvider:
         assert provider.provider_name == "ollama"
         assert provider.model_name == "nomic-embed-text"
 
-    def test_embed_payload_includes_model_and_input(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OLLAMA_MODEL", "test-model")
+    def test_embed_payload_includes_model_and_input(self) -> None:
         mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.5, 0.6]]})
         with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider()
+            provider = OllamaProvider(model="test-model")
             provider.embed(["alpha", "beta"])
 
         _, call_kwargs = mock_client.post.call_args
@@ -62,25 +60,19 @@ class TestOllamaProvider:
         assert payload["model"] == "test-model"
         assert payload["input"] == ["alpha", "beta"]
 
-    def test_embed_cpu_only_includes_num_gpu_zero(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY", "true")
+    def test_embed_cpu_only_includes_num_gpu_zero(self) -> None:
         mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[1.0, 2.0]]})
         with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider()
+            provider = OllamaProvider(cpu_only=True)
             provider.embed(["test"])
 
         _, call_kwargs = mock_client.post.call_args
         assert call_kwargs["json"].get("options") == {"num_gpu": 0}
 
-    def test_embed_cpu_only_false_no_options_key(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY", "false")
+    def test_embed_cpu_only_false_no_options_key(self) -> None:
         mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[1.0, 2.0]]})
         with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider()
+            provider = OllamaProvider(cpu_only=False)
             provider.embed(["test"])
 
         _, call_kwargs = mock_client.post.call_args
@@ -126,7 +118,7 @@ class TestOllamaProvider:
         monkeypatch.setenv("OLLAMA_HOST", "http://remote-host:12345")
         mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.9]]})
         with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider()
+            provider = OllamaProvider(host="http://remote-host:12345")
             provider.embed(["x"])
 
         call_args = mock_client.post.call_args
@@ -139,7 +131,7 @@ class TestOllamaProvider:
         monkeypatch.setenv("OLLAMA_HOST", "http://myhost:9999/")
         mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.1]]})
         with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider()
+            provider = OllamaProvider(host="http://myhost:9999/")
             provider.embed(["y"])
 
         call_args = mock_client.post.call_args
@@ -150,7 +142,7 @@ class TestOllamaProvider:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OLLAMA_MODEL", "my-custom-model")
         mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.3, 0.4]]})
         with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider()
+            provider = OllamaProvider(model="my-custom-model")
             provider.embed(["test"])
 
         _, call_kwargs = mock_client.post.call_args
@@ -189,7 +181,7 @@ class TestOpenAIProvider:
             json_body={"data": [{"index": 0, "embedding": [0.1, 0.2]}]}
         )
         with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider()
+            provider = OpenAIProvider(api_key="sk-test-key-123")
             provider.embed(["hello"])
 
         _, call_kwargs = mock_client.post.call_args
@@ -208,7 +200,7 @@ class TestOpenAIProvider:
             }
         )
         with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider()
+            provider = OpenAIProvider(api_key="sk-test")
             result = provider.embed(["first", "second"])
         assert result == [[1.0, 2.0], [9.0, 8.0]]
 
@@ -218,7 +210,7 @@ class TestOpenAIProvider:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         mock_client, _ = _make_httpx_mock(status_code=401, text="Unauthorized")
         with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider()
+            provider = OpenAIProvider(api_key="sk-test")
             with pytest.raises(RuntimeError, match="401"):
                 provider.embed(["secret"])
 
@@ -230,7 +222,7 @@ class TestOpenAIProvider:
             json_body={"data": [{"index": 0, "embedding": [0.1, 0.2, 0.3]}]}
         )
         with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider()
+            provider = OpenAIProvider(api_key="sk-test")
             provider.embed(["probe"])
             dim1 = provider.dimension
             dim2 = provider.dimension
@@ -247,7 +239,7 @@ class TestOpenAIProvider:
             json_body={"data": [{"index": 0, "embedding": [0.5, 0.6, 0.7, 0.8]}]}
         )
         with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider()
+            provider = OpenAIProvider(api_key="sk-test")
             dim = provider.dimension
 
         assert dim == 4
@@ -261,7 +253,7 @@ class TestOpenAIProvider:
             json_body={"data": [{"index": 0, "embedding": [0.1]}]}
         )
         with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider()
+            provider = OpenAIProvider(api_key="sk-test")
             provider.embed(["hello"])
 
         call_args = mock_client.post.call_args
@@ -288,7 +280,10 @@ class TestFastEmbedProvider:
         module.TextEmbedding.return_value = model_instance
 
         with patch.dict("sys.modules", {"fastembed": module}):
-            provider = FastEmbedProvider()
+            provider = FastEmbedProvider(
+                model_name="nomic-ai/nomic-embed-text-v1.5",
+                cache_dir="/tmp/fastembed-cache",
+            )
             result = provider.embed(["hello"])
 
         module.TextEmbedding.assert_called_once_with(
@@ -345,7 +340,7 @@ class TestGetEmbeddingProvider:
         monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         with patch("httpx.Client"):
-            provider = get_embedding_provider()
+            provider = get_embedding_provider(load_config(strict=False))
         assert isinstance(provider, OpenAIProvider)
 
     def test_explicit_ollama_returns_ollama_provider(
@@ -354,7 +349,7 @@ class TestGetEmbeddingProvider:
         monkeypatch.setenv("EMBEDDING_PROVIDER", "ollama")
         monkeypatch.delenv("OLLAMA_HOST", raising=False)
         with patch("httpx.Client"):
-            provider = get_embedding_provider()
+            provider = get_embedding_provider(load_config(strict=False))
         assert isinstance(provider, OllamaProvider)
 
     def test_explicit_fastembed_returns_fastembed_provider(
@@ -364,7 +359,7 @@ class TestGetEmbeddingProvider:
         module = MagicMock()
         module.TextEmbedding.return_value = MagicMock(embed=lambda *_: [])
         with patch.dict("sys.modules", {"fastembed": module}):
-            provider = get_embedding_provider()
+            provider = get_embedding_provider(load_config(strict=False))
         assert isinstance(provider, FastEmbedProvider)
 
     def test_explicit_unknown_raises_value_error(
@@ -374,7 +369,7 @@ class TestGetEmbeddingProvider:
         with pytest.raises(
             ValueError, match="Valid values: 'openai', 'ollama', 'fastembed'"
         ):
-            get_embedding_provider()
+            get_embedding_provider(load_config(strict=False))
 
     def test_autodetect_openai_key_present(
         self, monkeypatch: pytest.MonkeyPatch
@@ -382,7 +377,7 @@ class TestGetEmbeddingProvider:
         monkeypatch.delenv("EMBEDDING_PROVIDER", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-autodetect")
         with patch("httpx.Client"):
-            provider = get_embedding_provider()
+            provider = get_embedding_provider(load_config(strict=False))
         assert isinstance(provider, OpenAIProvider)
 
     def test_autodetect_ollama_reachable(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -394,7 +389,7 @@ class TestGetEmbeddingProvider:
         ollama_client.__enter__ = lambda _: ollama_client
         ollama_client.__exit__ = MagicMock(return_value=False)
         with patch("httpx.Client", side_effect=[probe_client, ollama_client]):
-            provider = get_embedding_provider()
+            provider = get_embedding_provider(load_config(strict=False))
         assert isinstance(provider, OllamaProvider)
 
     def test_autodetect_fastembed_fallback(
@@ -416,7 +411,7 @@ class TestGetEmbeddingProvider:
             patch("httpx.Client", return_value=probe_client),
             patch.dict("sys.modules", {"fastembed": module}),
         ):
-            provider = get_embedding_provider()
+            provider = get_embedding_provider(load_config(strict=False))
         assert isinstance(provider, FastEmbedProvider)
 
     def test_autodetect_no_providers_raises_runtime_error(
@@ -445,4 +440,4 @@ class TestGetEmbeddingProvider:
             patch("builtins.__import__", side_effect=fake_import),
             pytest.raises(RuntimeError, match="No embedding provider"),
         ):
-            get_embedding_provider()
+            get_embedding_provider(load_config(strict=False))

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "1.20.1"
+version = "1.22.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "python-frontmatter" },


### PR DESCRIPTION
- Move OIDC, Bearer, and Remote auth logic from mcp_server.py to config.py
- Refactor embedding providers to be configuration-driven instead of reading os.environ
- Update CollectionConfig to include server identity and auth settings
- Update cli.py and tests to use the new centralized configuration
