### PR TITLE
refactor(collection): split Collection into managers with DI (#376)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,23 @@ The authoritative design specification lives at [`docs/design.md`](docs/design.m
 
 ```
 src/markdown_vault_mcp/
-  scanner.py        -- file discovery, frontmatter parsing, chunking
-  fts_index.py      -- SQLite FTS5 schema, BM25 search
-  vector_index.py   -- numpy embeddings, cosine similarity
-  providers.py      -- embedding provider ABC + implementations
-  tracker.py        -- hash-based change detection
-  collection.py     -- thin facade: init, lazy loading, public API
-  config.py         -- configuration loading
-  mcp_server.py     -- generic FastMCP server with tool annotations
-  cli.py            -- CLI entry point
+  utils/
+    text.py            -- text normalization, position mapping, fuzzy matching
+    links.py           -- link target computation and replacement
+  managers/
+    link.py            -- LinkManager: backlinks, outlinks, broken, orphans, hubs, paths
+    search.py          -- SearchManager: keyword/semantic/hybrid search, list, context
+    index.py           -- IndexManager: build_index, reindex, embeddings, flush
+    document.py        -- DocumentManager: CRUD, attachments, path validation, backlinks
+  scanner.py           -- file discovery, frontmatter parsing, chunking
+  fts_index.py         -- SQLite FTS5 schema, BM25 search
+  vector_index.py      -- numpy embeddings, cosine similarity
+  providers.py         -- embedding provider ABC + implementations
+  tracker.py           -- hash-based change detection
+  collection.py        -- thin facade: lifecycle, wiring, delegation
+  config.py            -- configuration loading
+  mcp_server.py        -- generic FastMCP server with tool annotations
+  cli.py               -- CLI entry point
 ```
 
 ## Conventions

--- a/docs/design.md
+++ b/docs/design.md
@@ -52,10 +52,18 @@ markdown-vault-mcp (new package)
 +-- vector_index.py   -- numpy embeddings, cosine similarity
 +-- providers.py      -- Ollama / OpenAI / SentenceTransformers
 +-- tracker.py        -- hash-based change detection
-+-- collection.py     -- thin facade: init, lazy loading, public API
++-- collection.py     -- thin facade: lifecycle, wiring, delegation
 +-- config.py         -- configuration loading
 +-- mcp_server.py     -- generic FastMCP server
 +-- cli.py            -- CLI entry point
++-- utils/
+|   +-- text.py       -- text normalization and fuzzy matching
+|   +-- links.py      -- link target computation and replacement
++-- managers/
+|   +-- link.py       -- LinkManager: backlinks, outlinks, broken, orphans, hubs, paths
+|   +-- search.py     -- SearchManager: keyword/semantic/hybrid search, list, context
+|   +-- index.py      -- IndexManager: build_index, reindex, embeddings, flush
+|   +-- document.py   -- DocumentManager: CRUD, attachments, path validation
 
 ifcraftcorpus (existing, refactored later)
 +-- depends on markdown-vault-mcp
@@ -754,7 +762,26 @@ The MCP tool `get_connection_path` returns
 
 ### `collection.py` -- Thin Facade
 
-The main interface. Orchestrates specialized modules. Target: ~200 lines.
+The main interface. Orchestrates specialized manager modules via dependency
+injection. Collection creates managers in ``__init__`` and delegates all
+operations to them. No manager holds a back-reference to Collection.
+
+#### Internal Manager Architecture
+
+| Manager | Responsibility | Dependencies |
+|---------|---------------|-------------|
+| ``LinkManager`` | Backlinks, outlinks, broken links, orphans, hubs, connection paths | ``FTSIndex``, ``source_dir`` |
+| ``SearchManager`` | Keyword/semantic/hybrid search, list, folders, tags, recent, similar, context | ``FTSIndex``, ``source_dir``, embedding config, ``LinkManager`` |
+| ``IndexManager`` | build_index, reindex, build_embeddings, embedding flush | ``FTSIndex``, ``ChangeTracker``, ``source_dir``, write lock, chunk strategy |
+| ``DocumentManager`` | read, write, edit, delete, rename, attachments, TOC | ``FTSIndex``, ``source_dir``, write lock, callbacks |
+
+Each manager receives its dependencies as constructor arguments. This enables
+isolated unit testing and clear dependency boundaries. Pure utility functions
+live in ``utils/text.py`` (normalization, position mapping, fuzzy matching) and
+``utils/links.py`` (link target computation and replacement).
+
+Collection's public API signatures remain unchanged — clients interact with
+Collection, never with managers directly.
 
 ```python
 class Collection:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -12,16 +12,13 @@ import fnmatch
 import json
 import logging
 import mimetypes
-import os.path as osp
 import queue
 import re
 import shutil
 import sqlite3
 import tempfile
 import threading
-import unicodedata
 from collections import defaultdict
-from difflib import SequenceMatcher
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -68,6 +65,21 @@ from markdown_vault_mcp.types import (
     WriteCallback,
     WriteResult,
 )
+from markdown_vault_mcp.utils.links import (
+    apply_link_replacement as _apply_link_replacement,
+)
+from markdown_vault_mcp.utils.links import (
+    compute_new_raw_target as _compute_new_raw_target,
+)
+from markdown_vault_mcp.utils.text import (
+    build_position_map as _build_position_map,
+)
+from markdown_vault_mcp.utils.text import (
+    find_closest_match as _find_closest_match,
+)
+from markdown_vault_mcp.utils.text import (
+    normalize_text as _normalize_text,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -81,294 +93,6 @@ logger = logging.getLogger(__name__)
 _DEFAULT_STATE_SUBDIR = ".markdown_vault_mcp"
 _DEFAULT_STATE_FILENAME = "state.json"
 _CONTEXT_FOLDER_PEERS_LIMIT = 20
-
-# ---------------------------------------------------------------------------
-# Edit helpers
-# ---------------------------------------------------------------------------
-
-# Direct single-character substitutions applied during normalization.
-# Used by _build_position_map to avoid calling _normalize_text() per
-# character, which would (a) be O(n²) and (b) incorrectly strip a lone
-# space/tab as "trailing whitespace" of a one-char string.
-_CHAR_SUBS: dict[str, str] = {
-    "\u2013": "-",  # en-dash
-    "\u2014": "-",  # em-dash
-    "\u201c": '"',  # left double quotation mark
-    "\u201d": '"',  # right double quotation mark
-    "\u2018": "'",  # left single quotation mark
-    "\u2019": "'",  # right single quotation mark
-}
-
-
-def _normalize_text(text: str) -> str:
-    """Normalize text for fuzzy edit matching.
-
-    Applied to both old_text and file content for comparison only — the
-    actual file replacement uses original bytes.
-
-    Steps:
-        1. Unicode NFC normalization.
-        2. En-dash / em-dash → hyphen.
-        3. Smart quotes → straight quotes.
-        4. Collapse whitespace runs within lines (not across newlines).
-        5. Strip trailing whitespace per line.
-    """
-    text = unicodedata.normalize("NFC", text)
-    text = text.replace("\u2013", "-").replace("\u2014", "-")
-    text = text.replace("\u201c", '"').replace("\u201d", '"')
-    text = text.replace("\u2018", "'").replace("\u2019", "'")
-    lines = text.split("\n")
-    lines = [re.sub(r"[ \t]+", " ", line).rstrip() for line in lines]
-    return "\n".join(lines)
-
-
-def _build_position_map(original: str, normalized: str) -> list[int]:
-    """Map each normalized character index to its original character index.
-
-    Walks both strings in parallel, advancing the original pointer past
-    characters that were removed or merged by normalization.
-
-    Args:
-        original: The original (un-normalized) text.
-        normalized: The result of ``_normalize_text(original)``.
-
-    Returns:
-        A list of *len(normalized) + 1* entries where ``pos_map[i]`` is the
-        index in *original* corresponding to ``normalized[i]``, and the final
-        sentinel ``pos_map[len(normalized)]`` equals ``len(original)``.  The
-        sentinel lets callers compute the original end-position of a match
-        as ``pos_map[norm_end]`` without special-casing the last character.
-    """
-    pos_map: list[int] = []
-    orig_idx = 0
-    norm_idx = 0
-    orig_len = len(original)
-    norm_len = len(normalized)
-
-    while norm_idx < norm_len:
-        if orig_idx >= orig_len:
-            # Safety: normalized should never be longer.
-            break
-
-        norm_char = normalized[norm_idx]
-        orig_char = original[orig_idx]
-
-        # Newlines anchor both streams.
-        if norm_char == "\n" and orig_char == "\n":
-            pos_map.append(orig_idx)
-            orig_idx += 1
-            norm_idx += 1
-            continue
-
-        # Trailing whitespace was stripped: skip original trailing ws
-        # before a newline or end-of-string.
-        if norm_char == "\n" or (norm_idx == norm_len - 1 and norm_char != "\n"):
-            if norm_char != "\n":
-                # last char of normalized, not a newline — emit it first
-                pos_map.append(orig_idx)
-                orig_idx += 1
-                norm_idx += 1
-            # skip trailing whitespace in original before newline/end
-            while orig_idx < orig_len and original[orig_idx] in " \t":
-                orig_idx += 1
-            continue
-
-        # Whitespace collapse: normalized has single space, original has one or
-        # more spaces/tabs. Checked before the direct-match step so that runs
-        # of whitespace are always consumed in full (a single space would pass
-        # the direct-match test below, leaving trailing spaces unadvanced).
-        if norm_char == " " and orig_char in " \t":
-            pos_map.append(orig_idx)
-            orig_idx += 1
-            # skip remaining whitespace in original
-            while orig_idx < orig_len and original[orig_idx] in " \t":
-                orig_idx += 1
-            norm_idx += 1
-            continue
-
-        # Direct character match (possibly after NFC + char substitution).
-        # Using _normalize_text(orig_char) would be O(n²) and would also
-        # incorrectly strip a lone space as "trailing whitespace", so we
-        # apply NFC and _CHAR_SUBS directly instead.
-        nfc_char = unicodedata.normalize("NFC", orig_char)
-        sub_char = _CHAR_SUBS.get(nfc_char, nfc_char)
-        if sub_char == norm_char:
-            pos_map.append(orig_idx)
-            orig_idx += 1
-            norm_idx += 1
-            continue
-
-        # Unicode NFC: original may have multiple chars for one normalized.
-        # Try expanding original chars until they normalize to norm_char.
-        consumed = 1
-        while orig_idx + consumed <= orig_len:
-            chunk = original[orig_idx : orig_idx + consumed]
-            if unicodedata.normalize("NFC", chunk) == norm_char:
-                pos_map.append(orig_idx)
-                orig_idx += consumed
-                norm_idx += 1
-                break
-            consumed += 1
-        else:
-            # Fallback: advance both by one.
-            pos_map.append(orig_idx)
-            orig_idx += 1
-            norm_idx += 1
-
-    # Sentinel: pos_map[norm_len] = orig_len so callers can compute
-    # orig_end = pos_map[norm_end] for any norm_end including norm_len.
-    pos_map.append(orig_len)
-    return pos_map
-
-
-def _find_closest_match(old_text: str, file_content: str) -> dict[str, Any]:
-    """Find the closest fuzzy match for diagnostic error reporting.
-
-    Compares the first line of *old_text* against every line in the file
-    using ``difflib.SequenceMatcher``.  If a match with ratio >= 0.6 is
-    found, returns diagnostic info about the first character divergence.
-
-    Args:
-        old_text: The text the caller tried to match.
-        file_content: The full file content.
-
-    Returns:
-        A dict with ``closest_match_line``, ``first_diff_char``,
-        ``expected_snippet``, and ``found_snippet``; or an empty dict
-        if no match with ratio >= 0.6 is found.
-    """
-    first_line = old_text.split("\n", 1)[0]
-    file_lines = file_content.split("\n")
-    best_ratio = 0.0
-    best_line_num = 0
-    best_line_text = ""
-
-    for i, line in enumerate(file_lines, 1):
-        ratio = SequenceMatcher(None, first_line, line).ratio()
-        if ratio > best_ratio:
-            best_ratio = ratio
-            best_line_num = i
-            best_line_text = line
-
-    if best_ratio < 0.6:
-        return {}
-
-    # Find first character difference.
-    diff_pos = 0
-    min_len = min(len(first_line), len(best_line_text))
-    while diff_pos < min_len and first_line[diff_pos] == best_line_text[diff_pos]:
-        diff_pos += 1
-
-    ctx = 30
-    return {
-        "closest_match_line": best_line_num,
-        "first_diff_char": diff_pos,
-        "expected_snippet": first_line[max(0, diff_pos - ctx) : diff_pos + ctx],
-        "found_snippet": best_line_text[max(0, diff_pos - ctx) : diff_pos + ctx],
-    }
-
-
-# ---------------------------------------------------------------------------
-# Link-update helpers (used by Collection.rename update_links logic)
-# ---------------------------------------------------------------------------
-
-
-def _compute_new_raw_target(
-    link_type: str,
-    raw_target: str,
-    fragment: str | None,
-    new_path: str,
-    source_path: str = "",
-    old_path: str = "",
-) -> str:
-    """Compute the replacement raw_target string when a file is renamed.
-
-    Args:
-        link_type: One of ``"markdown"``, ``"reference"``, ``"wikilink"``.
-        raw_target: The literal link string stored in the source file.
-        fragment: The heading fragment (``#heading``) of the link, if any.
-        new_path: The vault-relative path of the renamed file (e.g.
-            ``"notes/new-name.md"``).
-        source_path: Vault-relative path of the file that contains the link.
-            Required for correct relative-path handling in markdown and
-            reference links (cross-directory links would otherwise be silently
-            broken).
-        old_path: Vault-relative path of the file being renamed.  Used to
-            detect whether *raw_target* was written as a vault-root-relative
-            or source-directory-relative path.
-
-    Returns:
-        The replacement raw_target string to write into the source file.
-    """
-    if link_type == "wikilink":
-        # Determine whether the original wikilink included the .md extension.
-        old_path_part = raw_target.split("#")[0]
-        if old_path_part.lower().endswith(".md"):
-            new_path_part = new_path
-        else:
-            new_path_part = new_path[:-3]
-        return new_path_part + ("#" + fragment if fragment else "")
-    else:
-        # markdown and reference links.
-        # Detect whether the link was written as vault-root-relative (raw_target
-        # matches old_path) or as a path relative to the source file's directory
-        # (raw_target != old_path, e.g. "../archive/target.md" from docs/).
-        raw_path_part = raw_target.split("#")[0]
-        if source_path and old_path and raw_path_part != old_path:
-            # Relative-to-source link: compute the correct new relative path so
-            # cross-directory links continue to resolve after the rename.
-            source_dir = str(Path(source_path).parent)
-            new_rel = osp.relpath(new_path, source_dir)
-            # os.path.relpath uses OS separators on Windows; normalise to /.
-            new_path_part = new_rel.replace("\\", "/")
-        else:
-            new_path_part = new_path
-        return new_path_part + ("#" + fragment if fragment else "")
-
-
-def _apply_link_replacement(
-    content: str, link_type: str, old_raw: str, new_raw: str
-) -> str:
-    """Replace a single link target occurrence in file content.
-
-    Args:
-        content: Full file content to modify.
-        link_type: One of ``"markdown"``, ``"reference"``, ``"wikilink"``.
-        old_raw: The original raw_target string to find.
-        new_raw: The replacement raw_target string.
-
-    Returns:
-        Updated content with all occurrences of *old_raw* replaced.
-    """
-    if link_type == "markdown":
-        # Negative lookbehind (?<!!) excludes image links ![](url) — the `!`
-        # immediately before `[` is the discriminator. Anchored to [text]( so
-        # bare (old_raw) occurrences in plain text are also excluded.
-        # Captures and preserves optional link title (e.g. "title" or 'title').
-        # NOTE: operates on raw file content; occurrences inside backtick code
-        # spans would also be rewritten. Risk is low in practice.
-        return re.sub(
-            r"(?<!!)(\[[^\]]*?\])\(" + re.escape(old_raw) + r"((?:\s[^)]*)?)\)",
-            lambda m: m.group(1) + "(" + new_raw + m.group(2) + ")",
-            content,
-        )
-    elif link_type == "reference":
-        # Match reference definition lines: [id]: url optional-title
-        # Anchored to line start with MULTILINE so we don't match inline text.
-        return re.sub(
-            r"^(\[.*?\]:\s+)" + re.escape(old_raw) + r"([ \t].*|$)",
-            lambda m: m.group(1) + new_raw + m.group(2),
-            content,
-            flags=re.MULTILINE,
-        )
-    elif link_type == "wikilink":
-        return re.sub(
-            r"\[\[" + re.escape(old_raw) + r"(\|[^\]]*)?\]\]",
-            lambda m: "[[" + new_raw + (m.group(1) or "") + "]]",
-            content,
-        )
-    return content
-
 
 # RRF constant — standard value recommended in the original paper.
 _RRF_K = 60

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -291,6 +291,11 @@ class Collection:
         )
         self._tracker = ChangeTracker(self._state_path)
 
+        # Manager modules (dependency-injected, no back-reference).
+        from markdown_vault_mcp.managers.link import LinkManager
+
+        self._link_mgr = LinkManager(fts=self._fts, source_dir=self._source_dir)
+
         # Vector index is loaded lazily (only if embeddings_path is set).
         self._vectors: VectorIndex | None = None
 
@@ -1373,21 +1378,7 @@ class Collection:
             ValueError: If no document exists at the given path.
         """
         self._ensure_initialized()
-        self._validate_path(path)
-        if self._fts.get_note(path) is None:
-            raise ValueError(f"Document not found: {path}")
-        rows = self._fts.get_backlinks(path)
-        return [
-            BacklinkInfo(
-                source_path=row["source_path"],
-                source_title=row["source_title"],
-                link_text=row["link_text"],
-                link_type=row["link_type"],
-                fragment=row["fragment"],
-                raw_target=row["raw_target"],
-            )
-            for row in rows
-        ]
+        return self._link_mgr.get_backlinks(path)
 
     def get_outlinks(self, path: str) -> list[OutlinkInfo]:
         """Return all links from the given document to other documents.
@@ -1407,21 +1398,7 @@ class Collection:
             ValueError: If no document exists at the given path.
         """
         self._ensure_initialized()
-        self._validate_path(path)
-        if self._fts.get_note(path) is None:
-            raise ValueError(f"Document not found: {path}")
-        rows = self._fts.get_outlinks(path)
-        return [
-            OutlinkInfo(
-                target_path=row["target_path"],
-                link_text=row["link_text"],
-                link_type=row["link_type"],
-                fragment=row["fragment"],
-                exists=bool(row["target_exists"]),
-                raw_target=row["raw_target"],
-            )
-            for row in rows
-        ]
+        return self._link_mgr.get_outlinks(path)
 
     def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
         """Return all links whose target does not exist in the collection.
@@ -1434,19 +1411,7 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.BrokenLinkInfo` objects.
         """
         self._ensure_initialized()
-        rows = self._fts.get_broken_links(folder=folder)
-        return [
-            BrokenLinkInfo(
-                source_path=row["source_path"],
-                source_title=row["source_title"],
-                target_path=row["target_path"],
-                link_text=row["link_text"],
-                link_type=row["link_type"],
-                fragment=row["fragment"],
-                raw_target=row["raw_target"],
-            )
-            for row in rows
-        ]
+        return self._link_mgr.get_broken_links(folder=folder)
 
     def get_similar(self, path: str, *, limit: int = 10) -> list[SearchResult]:
         """Return the most semantically similar chunks from other documents.
@@ -1647,8 +1612,7 @@ class Collection:
             ordered by path.
         """
         self._ensure_initialized()
-        rows = self._fts.get_orphan_notes()
-        return [_fts_row_to_note_info(r) for r in rows]
+        return self._link_mgr.get_orphan_notes()
 
     def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]:
         """Return the documents with the most inbound links.
@@ -1661,7 +1625,7 @@ class Collection:
             by backlink_count descending.
         """
         self._ensure_initialized()
-        return [MostLinkedNote(**row) for row in self._fts.get_most_linked(limit=limit)]
+        return self._link_mgr.get_most_linked(limit=limit)
 
     def get_connection_path(
         self, source: str, target: str, max_depth: int = 10
@@ -1685,9 +1649,7 @@ class Collection:
             ValueError: If *source* or *target* is not found in the index.
         """
         self._ensure_initialized()
-        self._validate_path(source)
-        self._validate_path(target)
-        return self._fts.get_connection_path(source, target, max_depth=max_depth)
+        return self._link_mgr.get_connection_path(source, target, max_depth=max_depth)
 
     # ------------------------------------------------------------------
     # Git history query methods

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -200,6 +200,8 @@ class Collection:
             exclude_patterns=self._exclude_patterns,
             required_frontmatter=self._required_frontmatter,
             indexed_frontmatter_fields=self._indexed_frontmatter_fields,
+            # Late-binding closures: self._search_mgr is assigned below and
+            # only accessed at call-time, not during IndexManager.__init__.
             get_vectors=lambda: self._search_mgr.vectors,
             set_vectors=lambda v: setattr(self._search_mgr, "vectors", v),
         )
@@ -862,8 +864,6 @@ class Collection:
     def _validate_path(self, path: str) -> Path:
         """Resolve a relative path and validate it is inside source_dir.
 
-        Delegates to :meth:`DocumentManager._validate_path`.
-
         Args:
             path: Relative document path.
 
@@ -874,13 +874,12 @@ class Collection:
             ValueError: If the path escapes the source directory or does
                 not end with ``.md``.
         """
-        return self._doc_mgr._validate_path(path)
+        from markdown_vault_mcp.utils import validate_path
+
+        return validate_path(path, self._source_dir)
 
     def _validate_attachment_path(self, path: str) -> Path:
-        """Resolve and validate a non-.md attachment path.
-
-        Delegates to :meth:`DocumentManager._validate_attachment_path`.
-        """
+        """Resolve and validate a non-.md attachment path."""
         return self._doc_mgr._validate_attachment_path(path)
 
     def _ensure_callback_worker(self) -> None:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -367,31 +367,6 @@ class Collection:
             query, limit=limit, mode=mode, filters=filters, folder=folder
         )
 
-    def _require_vectors(self) -> None:
-        """Raise ValueError if semantic search is not configured."""
-        self._search_mgr._require_vectors()
-
-    def _load_vectors(self) -> VectorIndex:
-        """Load or return the cached VectorIndex.
-
-        Returns:
-            A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
-        """
-        return self._search_mgr._load_vectors()
-
-    def _get_frontmatter(self, path: str) -> dict:
-        """Return the frontmatter dict for a document from the FTS index.
-
-        Falls back to an empty dict if the document is not found.
-
-        Args:
-            path: Relative document path.
-
-        Returns:
-            Parsed frontmatter dict.
-        """
-        return self._search_mgr._get_frontmatter(path)
-
     # ------------------------------------------------------------------
     # Read / list
     # ------------------------------------------------------------------
@@ -895,20 +870,6 @@ class Collection:
                 not end with ``.md``.
         """
         return self._doc_mgr._validate_path(path)
-
-    def _is_attachment(self, path: str) -> bool:
-        """Return True if *path* is an allowed non-.md attachment.
-
-        Delegates to :meth:`DocumentManager._is_attachment`.
-        """
-        return self._doc_mgr._is_attachment(path)
-
-    def _is_path_excluded(self, path: str) -> bool:
-        """Check whether *path* matches any configured exclude pattern.
-
-        Delegates to :meth:`DocumentManager._is_path_excluded`.
-        """
-        return self._doc_mgr._is_path_excluded(path)
 
     def _validate_attachment_path(self, path: str) -> Path:
         """Resolve and validate a non-.md attachment path.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -6,41 +6,21 @@ LangChain wrappers, and CLI commands all go through this class.
 
 from __future__ import annotations
 
-import base64
 import contextlib
-import fnmatch
 import logging
-import mimetypes
 import queue
 import re
-import shutil
-import sqlite3
-import tempfile
 import threading
-from collections import defaultdict
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-import frontmatter as fm
-
-from markdown_vault_mcp.exceptions import (
-    ConcurrentModificationError,
-    DocumentExistsError,
-    DocumentNotFoundError,
-    EditConflictError,
-    ReadOnlyError,
-)
 from markdown_vault_mcp.fts_index import FTSIndex
-from markdown_vault_mcp.hashing import compute_etag, compute_file_hash
 from markdown_vault_mcp.scanner import (
     ChunkStrategy,
     HeadingChunker,
     WholeDocumentChunker,
-    parse_note,
 )
 from markdown_vault_mcp.tracker import ChangeTracker
 from markdown_vault_mcp.types import (
-    DEFAULT_ATTACHMENT_EXTENSIONS,
     AttachmentContent,
     AttachmentInfo,
     BacklinkInfo,
@@ -56,31 +36,16 @@ from markdown_vault_mcp.types import (
     NoteContext,
     NoteInfo,
     OutlinkInfo,
-    ParsedNote,
     ReindexResult,
     RenameResult,
     SearchResult,
     WriteCallback,
     WriteResult,
 )
-from markdown_vault_mcp.utils.links import (
-    apply_link_replacement as _apply_link_replacement,
-)
-from markdown_vault_mcp.utils.links import (
-    compute_new_raw_target as _compute_new_raw_target,
-)
-from markdown_vault_mcp.utils.text import (
-    build_position_map as _build_position_map,
-)
-from markdown_vault_mcp.utils.text import (
-    find_closest_match as _find_closest_match,
-)
-from markdown_vault_mcp.utils.text import (
-    normalize_text as _normalize_text,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
     from markdown_vault_mcp.git import GitWriteStrategy
     from markdown_vault_mcp.providers import EmbeddingProvider
@@ -212,6 +177,7 @@ class Collection:
         self._write_lock = threading.RLock()
 
         # Manager modules (dependency-injected, no back-reference).
+        from markdown_vault_mcp.managers.document import DocumentManager
         from markdown_vault_mcp.managers.index import IndexManager
         from markdown_vault_mcp.managers.link import LinkManager
         from markdown_vault_mcp.managers.search import SearchManager
@@ -245,6 +211,19 @@ class Collection:
         self._search_mgr._flush_embeddings = self._index_mgr.flush_dirty_embeddings
         self._search_mgr._rebuild_embeddings = lambda: self._index_mgr.build_embeddings(
             force=True
+        )
+        self._doc_mgr = DocumentManager(
+            fts=self._fts,
+            source_dir=self._source_dir,
+            write_lock=self._write_lock,
+            chunk_strategy=self._chunk_strategy,
+            read_only=self._read_only,
+            exclude_patterns=self._exclude_patterns,
+            attachment_extensions=self._attachment_extensions,
+            max_attachment_size_mb=self._max_attachment_size_mb,
+            on_write_callback=self._fire_write_callback,
+            on_vector_update=self._index_mgr.update_vector_index,
+            on_vector_dirty=self._index_mgr.mark_dirty,
         )
 
         # Deferred write callback queue (issue #175).  Git commit (on_write
@@ -428,36 +407,7 @@ class Collection:
             if the file does not exist.
         """
         self._ensure_initialized()
-
-        abs_path = (self._source_dir / path).resolve()
-        if not abs_path.is_relative_to(self._source_dir.resolve()):
-            return None
-        if not abs_path.is_file():
-            return None
-
-        try:
-            note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-        except (UnicodeDecodeError, OSError) as exc:
-            logger.warning("read(%s): could not parse file — %s", path, exc)
-            return None
-
-        raw_content = abs_path.read_text(encoding="utf-8")
-        etag = (
-            note.content_hash
-        )  # already computed by parse_note (SHA-256 of raw bytes)
-        folder = str(Path(path).parent)
-        if folder == ".":
-            folder = ""
-
-        return NoteContent(
-            path=note.path,
-            title=note.title,
-            folder=folder,
-            content=raw_content,
-            frontmatter=note.frontmatter,
-            modified_at=note.modified_at,
-            etag=etag,
-        )
+        return self._doc_mgr.read(path)
 
     def list(
         self,
@@ -603,22 +553,7 @@ class Collection:
             ValueError: If no document exists at the given path.
         """
         self._ensure_initialized()
-        self._validate_path(path)
-
-        row = self._fts.get_note(path)
-        if row is None:
-            raise ValueError(f"Document not found: {path}")
-
-        title: str = row["title"]
-        headings = self._fts.get_toc(path)
-
-        # Prepend a synthetic H1 for the document title, filtering out any
-        # real H1 that duplicates it (common when docs start with ``# Title``).
-        toc: list[dict[str, Any]] = [{"heading": title, "level": 1}]
-        toc.extend(
-            h for h in headings if not (h["level"] == 1 and h["heading"] == title)
-        )
-        return toc
+        return self._doc_mgr.get_toc(path)
 
     def get_backlinks(self, path: str) -> list[BacklinkInfo]:
         """Return all documents that link to the given document.
@@ -925,7 +860,7 @@ class Collection:
             self._embedding_provider is not None and self._embeddings_path is not None
         )
 
-        exts = self._effective_attachment_extensions()
+        exts = self._doc_mgr._effective_attachment_extensions()
         attachment_extensions = ["*"] if "*" in exts else sorted(exts)
 
         return CollectionStats(
@@ -941,62 +876,13 @@ class Collection:
         )
 
     # ------------------------------------------------------------------
-    # Write operations
+    # Write operations (delegated to DocumentManager)
     # ------------------------------------------------------------------
-
-    def _check_writable(self) -> None:
-        """Raise ReadOnlyError if the collection is configured as read-only.
-
-        Raises:
-            ReadOnlyError: If ``read_only=True``.
-        """
-        if self._read_only:
-            raise ReadOnlyError(
-                "Collection is read-only; write operations are not permitted."
-            )
-
-    def _effective_attachment_extensions(self) -> frozenset[str]:
-        """Return the effective set of allowed attachment extensions.
-
-        Returns:
-            Frozenset of lower-case extension strings (without leading dot).
-            The special value ``frozenset(["*"])`` means all non-.md files.
-        """
-        if self._attachment_extensions is None:
-            return DEFAULT_ATTACHMENT_EXTENSIONS
-        return frozenset(self._attachment_extensions)
-
-    def _is_attachment(self, path: str) -> bool:
-        """Return True if *path* is an allowed non-.md attachment.
-
-        Args:
-            path: Relative path to check.
-
-        Returns:
-            ``True`` when the extension is in the allowlist and is not ``.md``.
-        """
-        if path.endswith(".md"):
-            return False
-        suffix = Path(path).suffix.lstrip(".").lower()
-        exts = self._effective_attachment_extensions()
-        return "*" in exts or suffix in exts
-
-    def _is_path_excluded(self, path: str) -> bool:
-        """Check whether *path* matches any configured exclude pattern.
-
-        Args:
-            path: Relative POSIX path string.
-
-        Returns:
-            ``True`` if the path matches any pattern in
-            ``self._exclude_patterns``.
-        """
-        if not self._exclude_patterns:
-            return False
-        return any(fnmatch.fnmatch(path, pat) for pat in self._exclude_patterns)
 
     def _validate_path(self, path: str) -> Path:
         """Resolve a relative path and validate it is inside source_dir.
+
+        Delegates to :meth:`DocumentManager._validate_path`.
 
         Args:
             path: Relative document path.
@@ -1008,53 +894,28 @@ class Collection:
             ValueError: If the path escapes the source directory or does
                 not end with ``.md``.
         """
-        if not path.endswith(".md"):
-            raise ValueError(f"Path must end with '.md': {path}")
-        abs_path = (self._source_dir / path).resolve()
-        if not abs_path.is_relative_to(self._source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {path}")
-        return abs_path
+        return self._doc_mgr._validate_path(path)
+
+    def _is_attachment(self, path: str) -> bool:
+        """Return True if *path* is an allowed non-.md attachment.
+
+        Delegates to :meth:`DocumentManager._is_attachment`.
+        """
+        return self._doc_mgr._is_attachment(path)
+
+    def _is_path_excluded(self, path: str) -> bool:
+        """Check whether *path* matches any configured exclude pattern.
+
+        Delegates to :meth:`DocumentManager._is_path_excluded`.
+        """
+        return self._doc_mgr._is_path_excluded(path)
 
     def _validate_attachment_path(self, path: str) -> Path:
         """Resolve and validate a non-.md attachment path.
 
-        Args:
-            path: Relative attachment path.
-
-        Returns:
-            The resolved absolute path.
-
-        Raises:
-            ValueError: If the path escapes the source directory, ends with
-                ``.md``, or has an extension not in the attachment allowlist.
+        Delegates to :meth:`DocumentManager._validate_attachment_path`.
         """
-        if path.endswith(".md"):
-            raise ValueError(
-                f"Path ends with '.md' — use the note read/write methods instead: {path}"
-            )
-        exts = self._effective_attachment_extensions()
-        suffix = Path(path).suffix.lstrip(".").lower()
-        if "*" not in exts and suffix not in exts:
-            allowed_str = ", ".join(f".{e}" for e in sorted(exts))
-            raise ValueError(
-                f"Extension '.{suffix}' is not in the attachment allowlist. "
-                f"Allowed: {allowed_str}. "
-                "Set MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS=* to allow all non-.md files."
-            )
-        abs_path = (self._source_dir / path).resolve()
-        if not abs_path.is_relative_to(self._source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {path}")
-        return abs_path
-
-    def _update_vector_index(self, note: ParsedNote) -> None:
-        """Mark a document for deferred embedding update.
-
-        Delegates to :meth:`IndexManager.update_vector_index`.
-
-        Args:
-            note: Parsed document to mark dirty.
-        """
-        self._index_mgr.update_vector_index(note)
+        return self._doc_mgr._validate_attachment_path(path)
 
     def _ensure_callback_worker(self) -> None:
         """Start the background write-callback worker if not running."""
@@ -1102,115 +963,19 @@ class Collection:
     def read_attachment(self, path: str) -> AttachmentContent:
         """Read the binary content of a non-.md attachment.
 
-        Args:
-            path: Relative attachment path (e.g. ``"assets/diagram.pdf"``).
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.AttachmentContent` with
-            base64-encoded content and MIME type.
-
-        Raises:
-            ValueError: If the path escapes the source directory, has an
-                extension not in the allowlist, or the file does not exist.
-            ValueError: If the file exceeds the configured size limit.
+        Delegates to :meth:`DocumentManager.read_attachment`.
         """
-        abs_path = self._validate_attachment_path(path)
-        if not abs_path.is_file():
-            raise ValueError(f"Attachment not found: {path}")
-
-        stat = abs_path.stat()
-        size_bytes = stat.st_size
-        if self._max_attachment_size_mb > 0:
-            limit_bytes = int(self._max_attachment_size_mb * 1024 * 1024)
-            if size_bytes > limit_bytes:
-                raise ValueError(
-                    f"Attachment {path!r} is {size_bytes} bytes, which exceeds "
-                    f"the limit of {self._max_attachment_size_mb} MB "
-                    f"({limit_bytes} bytes). "
-                    "Raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB or set it "
-                    "to 0 to disable the limit."
-                )
-
-        mime_type, _ = mimetypes.guess_type(path)
-        raw = abs_path.read_bytes()
-        content_base64 = base64.b64encode(raw).decode("ascii")
-        etag = compute_etag(raw)
-        return AttachmentContent(
-            path=path,
-            mime_type=mime_type,
-            size_bytes=size_bytes,
-            content_base64=content_base64,
-            modified_at=stat.st_mtime,
-            etag=etag,
-        )
+        return self._doc_mgr.read_attachment(path)
 
     def write_attachment(
         self, path: str, content: bytes, if_match: str | None = None
     ) -> WriteResult:
         """Create or overwrite a non-.md attachment.
 
-        Args:
-            path: Relative attachment path (e.g. ``"assets/diagram.pdf"``).
-            content: Raw bytes to write.
-            if_match: Optional etag from a previous :meth:`read_attachment`
-                call. When provided, the write is only performed if the
-                current file hash matches this value, preventing overwrites
-                of concurrent modifications. Pass ``None`` (default) to skip
-                the check.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.WriteResult`.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash.
-            ValueError: If the path escapes the source directory, has an
-                extension not in the allowlist, or the content exceeds the
-                size limit.
+        Delegates to :meth:`DocumentManager.write_attachment`.
         """
-        self._check_writable()
-        with self._write_lock:
-            self._ensure_initialized()
-            abs_path = self._validate_attachment_path(path)
-            if if_match is not None:
-                if not abs_path.is_file():
-                    raise ConcurrentModificationError(
-                        path, expected=if_match, actual="(file does not exist)"
-                    )
-                current_hash = compute_file_hash(abs_path)
-                if current_hash != if_match:
-                    raise ConcurrentModificationError(
-                        path, expected=if_match, actual=current_hash
-                    )
-            if self._max_attachment_size_mb > 0:
-                limit_bytes = int(self._max_attachment_size_mb * 1024 * 1024)
-                if len(content) > limit_bytes:
-                    raise ValueError(
-                        f"Content ({len(content)} bytes) exceeds the limit of "
-                        f"{self._max_attachment_size_mb} MB ({limit_bytes} bytes). "
-                        "Raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB or set "
-                        "it to 0 to disable the limit."
-                    )
-            created = not abs_path.is_file()
-            abs_path.parent.mkdir(parents=True, exist_ok=True)
-            with tempfile.NamedTemporaryFile(
-                dir=abs_path.parent, mode="wb", suffix=".tmp", delete=False
-            ) as tmp:
-                tmp.write(content)
-                tmp_name = tmp.name
-            if abs_path.is_file():
-                shutil.copymode(abs_path, tmp_name)
-            try:
-                Path(tmp_name).replace(abs_path)
-            except Exception:
-                Path(tmp_name).unlink(missing_ok=True)
-                raise
-            result = WriteResult(path=path, created=created)
-
-        self._fire_write_callback(abs_path, "", "write")
-
-        return result
+        self._ensure_initialized()
+        return self._doc_mgr.write_attachment(path, content, if_match=if_match)
 
     def write(
         self,
@@ -1221,87 +986,12 @@ class Collection:
     ) -> WriteResult:
         """Create or overwrite a document.
 
-        Creates intermediate directories as needed.  If *frontmatter* is
-        provided, it is serialised as a YAML header at the top of the file.
-
-        Args:
-            path: Relative document path.
-            content: Markdown body (excluding frontmatter).
-            frontmatter: Optional frontmatter dict serialised as YAML header.
-            if_match: Optional etag from a previous :meth:`read` call.
-                When provided, the write is only performed if the current
-                file hash matches this value, preventing overwrites of
-                concurrent modifications. Supplying *if_match* for a file
-                that does not yet exist raises
-                :exc:`~markdown_vault_mcp.exceptions.ConcurrentModificationError`.
-                Pass ``None`` (default) to skip the check.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.WriteResult`.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash (or the file does not exist).
-            ValueError: If *path* escapes the source directory.
+        Delegates to :meth:`DocumentManager.write`.
         """
-        self._check_writable()
-        with self._write_lock:
-            self._ensure_initialized()
-
-            abs_path = self._validate_path(path)
-            if if_match is not None:
-                if not abs_path.is_file():
-                    raise ConcurrentModificationError(
-                        path, expected=if_match, actual="(file does not exist)"
-                    )
-                current_hash = compute_file_hash(abs_path)
-                if current_hash != if_match:
-                    raise ConcurrentModificationError(
-                        path, expected=if_match, actual=current_hash
-                    )
-            created = not abs_path.is_file()
-
-            # Create intermediate directories.
-            abs_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Build file content with optional frontmatter.
-            if frontmatter is not None:
-                post = fm.Post(content, **frontmatter)
-                file_content = fm.dumps(post)
-            else:
-                file_content = content
-
-            with tempfile.NamedTemporaryFile(
-                dir=abs_path.parent,
-                mode="w",
-                encoding="utf-8",
-                suffix=".tmp",
-                delete=False,
-            ) as tmp:
-                tmp.write(file_content)
-                tmp_name = tmp.name
-            if abs_path.is_file():
-                shutil.copymode(abs_path, tmp_name)
-            try:
-                Path(tmp_name).replace(abs_path)
-            except Exception:
-                Path(tmp_name).unlink(missing_ok=True)
-                raise
-
-            # Update FTS index.
-            note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-            self._fts.upsert_note(note)
-
-            # Mark for deferred embedding update.
-            self._update_vector_index(note)
-
-            result = WriteResult(path=path, created=created)
-
-        # Fire git callback in background thread.
-        self._fire_write_callback(abs_path, file_content, "write")
-
-        return result
+        self._ensure_initialized()
+        return self._doc_mgr.write(
+            path, content, frontmatter=frontmatter, if_match=if_match
+        )
 
     def edit(
         self,
@@ -1314,411 +1004,25 @@ class Collection:
     ) -> EditResult:
         """Patch a section of a document.
 
-        Supports three modes:
-
-        - **Exact match** (``old_text`` only): verifies *old_text* exists
-          exactly once in the full file content (including frontmatter),
-          replaces it with *new_text*.
-        - **Line-range** (``line_start``/``line_end`` only): replaces the
-          specified line range with *new_text*.
-        - **Scoped match** (both): searches for *old_text* only within the
-          specified line range, allowing disambiguation of repeated text.
-
-        When exact match fails, a normalized comparison is attempted
-        (Unicode NFC, dash/quote normalization, whitespace collapsing).
-        If a unique normalized match is found, it is used and
-        ``match_type="normalized"`` is returned.
-
-        Args:
-            path: Relative document path.
-            old_text: Text to replace. Required for exact-match and
-                scoped-match modes.  Must appear exactly once (in the
-                file or in the line range).
-            new_text: Replacement text. When using line-range mode with an
-                empty string (``""``), the selected lines are replaced with a
-                single blank line. To delete lines entirely, pass the literal
-                content of those lines as *old_text* (scoped-match mode) and
-                supply an empty *new_text*, which removes that text span
-                without inserting a blank line.
-            if_match: Optional etag from a previous :meth:`read` call.
-                When provided, the edit is only performed if the current
-                file hash matches this value, preventing edits based on
-                stale content. Pass ``None`` (default) to skip the check.
-            line_start: First line to replace (1-based, inclusive).
-                Must be provided together with *line_end*.
-            line_end: Last line to replace (1-based, inclusive).
-                Must be provided together with *line_start*.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.EditResult`.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            DocumentNotFoundError: If the file does not exist.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash.
-            EditConflictError: If *old_text* is not found or appears
-                more than once.
-            ValueError: If parameter combination is invalid, or line
-                numbers are out of range.
+        Delegates to :meth:`DocumentManager.edit`.
         """
-        self._check_writable()
-
-        # --- Parameter validation ---
-        if old_text is not None and not old_text:
-            raise ValueError("old_text must not be empty")
-        has_lines = line_start is not None or line_end is not None
-        if old_text is None and not has_lines:
-            raise ValueError("Must provide old_text, line_start/line_end, or both")
-        if (line_start is None) != (line_end is None):
-            raise ValueError("Must provide both line_start and line_end, not just one")
-        if line_start is not None and line_end is not None:
-            if line_start < 1:
-                raise ValueError("line_start must be >= 1 (lines are 1-based)")
-            if line_start > line_end:
-                raise ValueError(
-                    f"line_start ({line_start}) must be <= line_end ({line_end})"
-                )
-
-        with self._write_lock:
-            self._ensure_initialized()
-
-            abs_path = self._validate_path(path)
-            if not abs_path.is_file():
-                raise DocumentNotFoundError(f"Document not found: {path}")
-
-            if if_match is not None:
-                current_hash = compute_file_hash(abs_path)
-                if current_hash != if_match:
-                    raise ConcurrentModificationError(
-                        path, expected=if_match, actual=current_hash
-                    )
-
-            file_content = abs_path.read_text(encoding="utf-8")
-
-            if has_lines:
-                assert line_start is not None and line_end is not None
-                new_content, match_type = self._edit_with_lines(
-                    file_content, old_text, new_text, line_start, line_end, path
-                )
-            else:
-                assert old_text is not None
-                new_content, match_type = self._edit_with_text(
-                    file_content, old_text, new_text, path
-                )
-
-            with tempfile.NamedTemporaryFile(
-                dir=abs_path.parent,
-                mode="w",
-                encoding="utf-8",
-                suffix=".tmp",
-                delete=False,
-            ) as tmp:
-                tmp.write(new_content)
-                tmp_name = tmp.name
-            shutil.copymode(abs_path, tmp_name)
-            try:
-                Path(tmp_name).replace(abs_path)
-            except Exception:
-                Path(tmp_name).unlink(missing_ok=True)
-                raise
-
-            # Update FTS index.
-            note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-            self._fts.upsert_note(note)
-
-            # Mark for deferred embedding update.
-            self._update_vector_index(note)
-
-        # Fire git callback in background thread.
-        self._fire_write_callback(abs_path, new_content, "edit")
-
-        return EditResult(path=path, replacements=1, match_type=match_type)
-
-    def _edit_with_lines(
-        self,
-        file_content: str,
-        old_text: str | None,
-        new_text: str,
-        line_start: int,
-        line_end: int,
-        path: str,
-    ) -> tuple[str, str]:
-        """Handle line-range and scoped-match edit modes.
-
-        Returns:
-            Tuple of (new_file_content, match_type).
-        """
-        lines = file_content.split("\n")
-        # The split produces an extra empty string after a trailing newline.
-        # Total addressable lines = len(lines) if last is non-empty, else
-        # len(lines) - 1 (the trailing empty element isn't a real line).
-        total_lines = len(lines) - 1 if lines and lines[-1] == "" else len(lines)
-        if line_end > total_lines:
-            raise ValueError(
-                f"line_end ({line_end}) out of range (file has {total_lines} lines)"
-            )
-
-        # Convert to 0-based indices for slicing.
-        start_idx = line_start - 1
-        end_idx = line_end  # exclusive for slice
-
-        if old_text is not None:
-            # Scoped match: search within the line range only.
-            scope = "\n".join(lines[start_idx:end_idx])
-            context_desc = f"lines {line_start}-{line_end} of {path}"
-            new_scope, match_type = self._match_and_replace(
-                scope, old_text, new_text, path, context_desc=context_desc
-            )
-            lines[start_idx:end_idx] = new_scope.split("\n")
-        else:
-            # Pure line-range replacement.
-            match_type = "exact"
-            # Reconstruct: new_text replaces lines, preserving structure.
-            # Strip trailing newline from new_text if present to avoid
-            # double-newline when rejoining.
-            replacement_lines = new_text.rstrip("\n").split("\n") if new_text else [""]
-            lines[start_idx:end_idx] = replacement_lines
-
-        return "\n".join(lines), match_type
-
-    def _edit_with_text(
-        self,
-        file_content: str,
-        old_text: str,
-        new_text: str,
-        path: str,
-    ) -> tuple[str, str]:
-        """Handle exact-match edit mode (with normalized fallback).
-
-        Thin wrapper so ``edit()`` has a symmetric call site for both modes
-        (line-range via ``_edit_with_lines``, text via this method).
-
-        Returns:
-            Tuple of (new_file_content, match_type).
-        """
-        return self._match_and_replace(file_content, old_text, new_text, path)
-
-    def _match_and_replace(
-        self,
-        content: str,
-        old_text: str,
-        new_text: str,
-        path: str,
-        context_desc: str | None = None,
-    ) -> tuple[str, str]:
-        """Try exact match, then normalized match, then raise with diagnostics.
-
-        Args:
-            content: The text to search within (full file or a line-range scope).
-            old_text: Text to find and replace.
-            new_text: Replacement text.
-            path: Vault-relative file path, used in error messages.
-            context_desc: Optional human-readable context for error messages
-                (e.g. ``"lines 5-10 of notes/foo.md"``). When omitted, errors
-                refer to *path* directly.
-
-        Returns:
-            Tuple of (new_content, match_type).
-        """
-        location = context_desc or path
-        count = content.count(old_text)
-
-        if count == 1:
-            return content.replace(old_text, new_text, 1), "exact"
-
-        if count > 1:
-            raise EditConflictError(
-                f"old_text appears {count} times in {location}; must appear exactly once"
-            )
-
-        # count == 0: try normalized matching.
-        normalized_content = _normalize_text(content)
-        normalized_old = _normalize_text(old_text)
-        norm_count = normalized_content.count(normalized_old)
-
-        if norm_count == 1:
-            pos_map = _build_position_map(content, normalized_content)
-            norm_start = normalized_content.index(normalized_old)
-            norm_end = norm_start + len(normalized_old)
-            orig_start = pos_map[norm_start]
-            orig_end = pos_map[norm_end]
-            new_content = content[:orig_start] + new_text + content[orig_end:]
-            return new_content, "normalized"
-
-        if norm_count > 1:
-            raise EditConflictError(
-                f"old_text appears {norm_count} times in {location} after "
-                f"normalization; must appear exactly once"
-            )
-
-        # norm_count == 0: raise with diagnostics.
-        diag = _find_closest_match(old_text, content)
-        raise EditConflictError(f"old_text not found in {location}", **diag)
+        self._ensure_initialized()
+        return self._doc_mgr.edit(
+            path,
+            old_text=old_text,
+            new_text=new_text,
+            if_match=if_match,
+            line_start=line_start,
+            line_end=line_end,
+        )
 
     def delete(self, path: str, if_match: str | None = None) -> DeleteResult:
         """Delete a document or attachment.
 
-        Removes the file from disk.  For ``.md`` documents, also removes all
-        FTS and embedding index entries.  For attachments, only the file is
-        deleted (no index update).
-
-        Args:
-            path: Relative document or attachment path.
-            if_match: Optional etag from a previous :meth:`read` or
-                :meth:`read_attachment` call. When provided, the deletion is
-                only performed if the current file hash matches this value.
-                Pass ``None`` (default) to skip the check.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.DeleteResult`.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            DocumentNotFoundError: If the file does not exist.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash.
-            ValueError: If the path escapes the source directory, or (for
-                non-.md paths) has an extension not in the attachment allowlist.
+        Delegates to :meth:`DocumentManager.delete`.
         """
-        self._check_writable()
-        with self._write_lock:
-            self._ensure_initialized()
-
-            if path.endswith(".md"):
-                abs_path = self._validate_path(path)
-                if not abs_path.is_file():
-                    raise DocumentNotFoundError(f"Document not found: {path}")
-                if if_match is not None:
-                    current_hash = compute_file_hash(abs_path)
-                    if current_hash != if_match:
-                        raise ConcurrentModificationError(
-                            path, expected=if_match, actual=current_hash
-                        )
-                abs_path.unlink()
-                self._fts.delete_by_path(path)
-                # Mark for deferred vector index cleanup.
-                self._index_mgr.mark_dirty(path)
-            else:
-                abs_path = self._validate_attachment_path(path)
-                if not abs_path.is_file():
-                    raise DocumentNotFoundError(f"Attachment not found: {path}")
-                if if_match is not None:
-                    current_hash = compute_file_hash(abs_path)
-                    if current_hash != if_match:
-                        raise ConcurrentModificationError(
-                            path, expected=if_match, actual=current_hash
-                        )
-                abs_path.unlink()
-
-        # Fire git callback in background thread.
-        self._fire_write_callback(abs_path, "", "delete")
-
-        return DeleteResult(path=path)
-
-    def _update_backlinks(
-        self,
-        old_path: str,
-        new_path: str,
-        backlinks: list[dict],
-    ) -> list[tuple[Path, str]]:
-        """Rewrite every source file that links to *old_path* so it points to *new_path*.
-
-        Called by :meth:`rename` after the file has already been moved on disk
-        and the FTS index updated.  Each source file is read, all of its links
-        to *old_path* are rewritten in a single pass, then written back.
-        Per-file failures are logged at ``WARNING`` and do not abort the batch.
-
-        This method must be called while :attr:`_write_lock` is held.  It does
-        **not** fire write callbacks itself — callers must do so after releasing
-        the lock, using the returned list of ``(abs_path, content)`` pairs.
-
-        Args:
-            old_path: Vault-relative path that was renamed (the old location).
-            new_path: Vault-relative path after the rename (the new location).
-            backlinks: Rows returned by :meth:`FTSIndex.get_backlinks` before
-                the rename — each must contain ``source_path``, ``link_type``,
-                ``raw_target``, and ``fragment`` keys.
-
-        Returns:
-            List of ``(abs_path, new_content)`` pairs for every source document
-            that was successfully rewritten.  Callers should fire a write
-            callback for each pair after releasing :attr:`_write_lock`.
-        """
-        if not backlinks:
-            return []
-
-        by_source: dict[str, list[dict]] = defaultdict(list)
-        for row in backlinks:
-            by_source[row["source_path"]].append(row)
-
-        # If the renamed file self-links, its source key is
-        # old_path — but the file now lives at new_path.  Remap
-        # before iterating so we read/write the correct file.
-        if old_path in by_source:
-            by_source[new_path] = by_source.pop(old_path)
-
-        pending_callbacks: list[tuple[Path, str]] = []
-        for source_path, rows in by_source.items():
-            try:
-                source_abs = self._validate_path(source_path)
-                if not source_abs.is_file():
-                    logger.warning(
-                        "_update_backlinks: skipping %s — file not found",
-                        source_path,
-                    )
-                    continue
-                content = source_abs.read_text(encoding="utf-8")
-                for row in rows:
-                    new_raw = _compute_new_raw_target(
-                        row["link_type"],
-                        row["raw_target"],
-                        row["fragment"],
-                        new_path,
-                        source_path=source_path,
-                        old_path=old_path,
-                    )
-                    content = _apply_link_replacement(
-                        content,
-                        row["link_type"],
-                        row["raw_target"],
-                        new_raw,
-                    )
-                with tempfile.NamedTemporaryFile(
-                    dir=source_abs.parent,
-                    mode="w",
-                    encoding="utf-8",
-                    suffix=".tmp",
-                    delete=False,
-                ) as tmp:
-                    tmp.write(content)
-                    tmp_name = tmp.name
-                shutil.copymode(source_abs, tmp_name)
-                try:
-                    Path(tmp_name).replace(source_abs)
-                except Exception:
-                    Path(tmp_name).unlink(missing_ok=True)
-                    raise
-                updated_note = parse_note(
-                    source_abs, self._source_dir, self._chunk_strategy
-                )
-                self._fts.upsert_note(updated_note)
-                self._update_vector_index(updated_note)
-                pending_callbacks.append((source_abs, content))
-            except (OSError, UnicodeDecodeError, ValueError, sqlite3.Error) as exc:
-                logger.warning(
-                    "_update_backlinks: failed to update %s: %s",
-                    source_path,
-                    exc,
-                )
-            except Exception as exc:
-                logger.warning(
-                    "_update_backlinks: unexpected error updating %s: %s",
-                    source_path,
-                    exc,
-                    exc_info=True,
-                )
-        return pending_callbacks
+        self._ensure_initialized()
+        return self._doc_mgr.delete(path, if_match=if_match)
 
     def rename(
         self,
@@ -1730,111 +1034,9 @@ class Collection:
     ) -> RenameResult:
         """Rename or move a document or attachment.
 
-        Renames the file on disk.  For ``.md`` documents, also updates FTS
-        and embedding index entries.  For attachments, only the file is moved
-        (no index update).  Creates intermediate directories for *new_path*
-        as needed.
-
-        When *update_links* is ``True`` and *old_path* is a ``.md`` document,
-        every document that links to *old_path* is also updated so its links
-        point to *new_path*.  Replacement is best-effort: failures are logged
-        at ``WARNING`` but do not prevent the rename from succeeding.
-
-        Args:
-            old_path: Current relative document or attachment path.
-            new_path: Target relative document or attachment path.
-            if_match: Optional etag from a previous :meth:`read` or
-                :meth:`read_attachment` call for *old_path*. When provided,
-                the rename is only performed if the current file hash matches
-                this value. Pass ``None`` (default) to skip the check.
-            update_links: When ``True``, find all documents that link to
-                *old_path* and rewrite their link targets to point to
-                *new_path*. Only applies to ``.md`` documents.  Default
-                ``False``.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.RenameResult` with
-            *updated_links* counting source documents successfully updated.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            DocumentNotFoundError: If *old_path* does not exist.
-            DocumentExistsError: If *new_path* already exists.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match the current hash of *old_path*.
-            ValueError: If either path escapes the source directory, or (for
-                non-.md paths) has an extension not in the attachment allowlist.
+        Delegates to :meth:`DocumentManager.rename`.
         """
-        self._check_writable()
-        updated_links = 0
-        backlink_callbacks: list[tuple[Path, str]] = []
-
-        with self._write_lock:
-            self._ensure_initialized()
-
-            if old_path.endswith(".md"):
-                old_abs = self._validate_path(old_path)
-                new_abs = self._validate_path(new_path)
-
-                if not old_abs.is_file():
-                    raise DocumentNotFoundError(f"Document not found: {old_path}")
-                if new_abs.is_file():
-                    raise DocumentExistsError(f"Target already exists: {new_path}")
-                if if_match is not None:
-                    current_hash = compute_file_hash(old_abs)
-                    if current_hash != if_match:
-                        raise ConcurrentModificationError(
-                            old_path, expected=if_match, actual=current_hash
-                        )
-
-                # Collect backlinks before the rename so the index still
-                # reflects old_path as the target.
-                backlinks = self._fts.get_backlinks(old_path) if update_links else []
-
-                new_abs.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(old_abs), str(new_abs))
-
-                self._fts.delete_by_path(old_path)
-
-                note = parse_note(new_abs, self._source_dir, self._chunk_strategy)
-                self._fts.upsert_note(note)
-
-                # Mark both paths for deferred vector update: old_path
-                # entries are deleted (file gone), new_path re-embedded.
-                self._index_mgr.mark_dirty(old_path)
-                self._index_mgr.mark_dirty(note.path)
-
-                callback_content = new_abs.read_text(encoding="utf-8")
-
-                backlink_callbacks = self._update_backlinks(
-                    old_path, new_path, backlinks
-                )
-                updated_links = len(backlink_callbacks)
-            else:
-                old_abs = self._validate_attachment_path(old_path)
-                new_abs = self._validate_attachment_path(new_path)
-
-                if not old_abs.is_file():
-                    raise DocumentNotFoundError(f"Attachment not found: {old_path}")
-                if new_abs.is_file():
-                    raise DocumentExistsError(f"Target already exists: {new_path}")
-                if if_match is not None:
-                    current_hash = compute_file_hash(old_abs)
-                    if current_hash != if_match:
-                        raise ConcurrentModificationError(
-                            old_path, expected=if_match, actual=current_hash
-                        )
-
-                new_abs.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(old_abs), str(new_abs))
-
-                callback_content = ""
-
-        # Fire git callbacks in background thread (outside write lock).
-        self._fire_write_callback(new_abs, callback_content, "rename")
-        for src_abs, src_content in backlink_callbacks:
-            self._fire_write_callback(src_abs, src_content, "edit")
-
-        return RenameResult(
-            old_path=old_path, new_path=new_path, updated_links=updated_links
+        self._ensure_initialized()
+        return self._doc_mgr.rename(
+            old_path, new_path, if_match=if_match, update_links=update_links
         )

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -42,6 +42,7 @@ from markdown_vault_mcp.scanner import (
 )
 from markdown_vault_mcp.tracker import ChangeTracker
 from markdown_vault_mcp.types import (
+    DEFAULT_ATTACHMENT_EXTENSIONS,
     AttachmentContent,
     AttachmentInfo,
     BacklinkInfo,
@@ -61,7 +62,6 @@ from markdown_vault_mcp.types import (
     ReindexResult,
     RenameResult,
     SearchResult,
-    SimilarItem,
     WriteCallback,
     WriteResult,
 )
@@ -92,11 +92,6 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_STATE_SUBDIR = ".markdown_vault_mcp"
 _DEFAULT_STATE_FILENAME = "state.json"
-_CONTEXT_FOLDER_PEERS_LIMIT = 20
-
-# RRF constant — standard value recommended in the original paper.
-_RRF_K = 60
-
 # Maximum chunks per embedding provider call.  Keeps memory bounded during
 # build_embeddings() — FastEmbed/ONNX can allocate pathologically large buffers
 # when the entire corpus is sent in one batch (see issue #159).
@@ -105,51 +100,6 @@ _EMBEDDING_BATCH_SIZE = 4
 # Seconds between automatic background flushes of dirty embeddings to disk.
 # Write operations mark documents as dirty; the flush re-embeds them in bulk.
 _EMBEDDING_FLUSH_INTERVAL = 30
-
-# Default set of allowed attachment extensions (without leading dot, lower-case).
-# .md is always excluded — it is always handled as a markdown note.
-_DEFAULT_ATTACHMENT_EXTENSIONS: frozenset[str] = frozenset(
-    [
-        # Documents
-        "pdf",
-        "docx",
-        "xlsx",
-        "pptx",
-        "odt",
-        "ods",
-        "odp",
-        # Images
-        "png",
-        "jpg",
-        "jpeg",
-        "gif",
-        "webp",
-        "svg",
-        "bmp",
-        "tiff",
-        # Archives
-        "zip",
-        "tar",
-        "gz",
-        # Audio / Video
-        "mp3",
-        "mp4",
-        "wav",
-        "ogg",
-        # Text and data
-        "txt",
-        "csv",
-        "tsv",
-        "json",
-        "yaml",
-        "toml",
-        "xml",
-        "html",
-        "css",
-        "js",
-        "ts",
-    ]
-)
 
 
 def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
@@ -175,34 +125,6 @@ def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
             "Valid string values: 'heading', 'whole'."
         )
     return strategy
-
-
-def _fts_row_to_note_info(row: dict) -> NoteInfo:
-    """Convert an FTSIndex list_notes() row dict to a :class:`NoteInfo`.
-
-    Args:
-        row: Dict returned by :meth:`FTSIndex.list_notes` or
-            :meth:`FTSIndex.get_note`.
-
-    Returns:
-        A populated :class:`NoteInfo` instance.
-    """
-    frontmatter: dict = {}
-    raw_json = row.get("frontmatter_json")
-    if raw_json:
-        try:
-            frontmatter = json.loads(raw_json)
-        except (json.JSONDecodeError, TypeError):
-            logger.warning(
-                "Could not parse frontmatter_json for path %s", row.get("path")
-            )
-    return NoteInfo(
-        path=row["path"],
-        title=row["title"],
-        folder=row["folder"],
-        frontmatter=frontmatter,
-        modified_at=row["modified_at"],
-    )
 
 
 class Collection:
@@ -293,11 +215,21 @@ class Collection:
 
         # Manager modules (dependency-injected, no back-reference).
         from markdown_vault_mcp.managers.link import LinkManager
+        from markdown_vault_mcp.managers.search import SearchManager
 
         self._link_mgr = LinkManager(fts=self._fts, source_dir=self._source_dir)
-
-        # Vector index is loaded lazily (only if embeddings_path is set).
-        self._vectors: VectorIndex | None = None
+        self._search_mgr = SearchManager(
+            fts=self._fts,
+            source_dir=self._source_dir,
+            embeddings_path=self._embeddings_path,
+            embedding_provider=self._embedding_provider,
+            indexed_frontmatter_fields=self._indexed_frontmatter_fields,
+            exclude_patterns=self._exclude_patterns,
+            attachment_extensions=self._attachment_extensions,
+            link_manager=self._link_mgr,
+            flush_embeddings=self._flush_dirty_embeddings,
+            rebuild_embeddings=lambda: self.build_embeddings(force=True),
+        )
 
         # Lazy initialisation flag.
         self._initialized = False
@@ -409,6 +341,15 @@ class Collection:
         if not self._initialized:
             self.build_index()
 
+    @property
+    def _vectors(self) -> VectorIndex | None:
+        """Bridge property: vector index is owned by SearchManager."""
+        return self._search_mgr.vectors
+
+    @_vectors.setter
+    def _vectors(self, value: VectorIndex | None) -> None:
+        self._search_mgr.vectors = value
+
     # ------------------------------------------------------------------
     # Search
     # ------------------------------------------------------------------
@@ -443,29 +384,13 @@ class Collection:
                 embedding provider or embeddings path is configured.
         """
         self._ensure_initialized()
-
-        if mode == "keyword":
-            return self._keyword_search(
-                query, limit=limit, filters=filters, folder=folder
-            )
-
-        if mode == "semantic":
-            self._require_vectors()
-            return self._semantic_search(
-                query, limit=limit, filters=filters, folder=folder
-            )
-
-        # hybrid
-        self._require_vectors()
-        return self._hybrid_search(query, limit=limit, filters=filters, folder=folder)
+        return self._search_mgr.search(
+            query, limit=limit, mode=mode, filters=filters, folder=folder
+        )
 
     def _require_vectors(self) -> None:
         """Raise ValueError if semantic search is not configured."""
-        if self._embedding_provider is None or self._embeddings_path is None:
-            raise ValueError(
-                "Semantic search requires both 'embedding_provider' and "
-                "'embeddings_path' to be configured."
-            )
+        self._search_mgr._require_vectors()
 
     def _load_vectors(self) -> VectorIndex:
         """Load or return the cached VectorIndex.
@@ -473,237 +398,7 @@ class Collection:
         Returns:
             A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
         """
-        if self._vectors is not None:
-            return self._vectors
-
-        from markdown_vault_mcp.vector_index import (
-            VectorIndex,
-            VectorIndexCompatibilityError,
-        )
-
-        assert self._embeddings_path is not None
-        assert self._embedding_provider is not None
-
-        npy_path = Path(str(self._embeddings_path) + ".npy")
-        if npy_path.exists():
-            try:
-                self._vectors = VectorIndex.load(
-                    self._embeddings_path, self._embedding_provider
-                )
-                logger.info("Loaded vector index from %s", self._embeddings_path)
-            except VectorIndexCompatibilityError as exc:
-                logger.warning("%s Rebuilding embeddings.", exc)
-                self.build_embeddings(force=True)
-                assert self._vectors is not None
-        else:
-            self._vectors = VectorIndex(self._embedding_provider)
-            logger.info("No vector index on disk; created empty VectorIndex")
-
-        return self._vectors
-
-    def _keyword_search(
-        self,
-        query: str,
-        *,
-        limit: int,
-        filters: dict[str, str] | None,
-        folder: str | None,
-    ) -> list[SearchResult]:
-        fts_results = self._fts.search(
-            query, limit=limit, filters=filters, folder=folder
-        )
-        return [
-            SearchResult(
-                path=r.path,
-                title=r.title,
-                folder=r.folder,
-                heading=r.heading,
-                content=r.content,
-                score=r.score,
-                search_type="keyword",
-                frontmatter=self._get_frontmatter(r.path),
-            )
-            for r in fts_results
-        ]
-
-    def _semantic_search(
-        self,
-        query: str,
-        *,
-        limit: int,
-        filters: dict[str, str] | None = None,
-        folder: str | None = None,
-    ) -> list[SearchResult]:
-        # Flush deferred embedding updates so results are consistent.
-        self._flush_dirty_embeddings()
-        vectors = self._load_vectors()
-        # Fetch extra candidates so post-filtering still yields *limit* results.
-        candidate_limit = max(limit * 3, 30) if (folder or filters) else limit
-        raw = vectors.search(query, limit=candidate_limit)
-
-        results: list[SearchResult] = []
-        for r in raw:
-            if len(results) >= limit:
-                break
-
-            # Apply folder prefix filter.
-            if folder is not None:
-                r_folder = r.get("folder", "")
-                if r_folder != folder and not r_folder.startswith(folder + "/"):
-                    continue
-
-            # Apply tag filters: check FTS index for each required tag.
-            if filters:
-                note_row = self._fts.get_note(r["path"])
-                if note_row is None:
-                    continue
-                fm_raw = note_row.get("frontmatter_json")
-                fm: dict = {}
-                if fm_raw:
-                    with contextlib.suppress(ValueError, TypeError):
-                        fm = json.loads(fm_raw)
-                match = True
-                for key, value in filters.items():
-                    fm_val = fm.get(key)
-                    if fm_val is None:
-                        match = False
-                        break
-                    # Support both scalar and list values.
-                    if isinstance(fm_val, list):
-                        if str(value) not in [str(v) for v in fm_val]:
-                            match = False
-                            break
-                    else:
-                        if str(fm_val) != str(value):
-                            match = False
-                            break
-                if not match:
-                    continue
-
-            results.append(
-                SearchResult(
-                    path=r["path"],
-                    title=r["title"],
-                    folder=r["folder"],
-                    heading=r.get("heading"),
-                    content=r["content"],
-                    score=r["score"],
-                    search_type="semantic",
-                    frontmatter=self._get_frontmatter(r["path"]),
-                )
-            )
-        return results
-
-    def _hybrid_search(
-        self,
-        query: str,
-        *,
-        limit: int,
-        filters: dict[str, str] | None,
-        folder: str | None,
-    ) -> list[SearchResult]:
-        """RRF merge of keyword and semantic results.
-
-        Each result set is ranked independently.  Merged score:
-        ``1 / (k + rank)`` where k=60.  Results appearing in both sets have
-        their scores summed.  Returns top *limit* by total RRF score.
-        """
-        # Fetch more candidates than needed so RRF has enough to rank.
-        candidate_limit = max(limit * 2, 20)
-
-        # Flush deferred embedding updates so results are consistent.
-        self._flush_dirty_embeddings()
-
-        fts_results = self._fts.search(
-            query, limit=candidate_limit, filters=filters, folder=folder
-        )
-        vectors = self._load_vectors()
-        vec_results = vectors.search(query, limit=candidate_limit)
-
-        # Build a key for deduplication: (path, heading) identifies a chunk.
-        # Use a dict to accumulate RRF scores and store metadata.
-        rrf_scores: dict[tuple[str, str | None], float] = {}
-        # Store the best metadata dict keyed by (path, heading).
-        chunk_meta: dict[tuple[str, str | None], dict] = {}
-
-        for rank, r in enumerate(fts_results, start=1):
-            key = (r.path, r.heading)
-            rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (_RRF_K + rank)
-            if key not in chunk_meta:
-                chunk_meta[key] = {
-                    "path": r.path,
-                    "title": r.title,
-                    "folder": r.folder,
-                    "heading": r.heading,
-                    "content": r.content,
-                    "search_type": "keyword",
-                }
-
-        for rank, r in enumerate(vec_results, start=1):
-            # Apply folder prefix filter to semantic results.
-            if folder is not None:
-                r_folder = r.get("folder", "")
-                if r_folder != folder and not r_folder.startswith(folder + "/"):
-                    continue
-
-            # Apply tag filters to semantic results via frontmatter lookup.
-            if filters:
-                note_row = self._fts.get_note(r["path"])
-                if note_row is None:
-                    continue
-                fm_raw = note_row.get("frontmatter_json")
-                fm: dict = {}
-                if fm_raw:
-                    with contextlib.suppress(json.JSONDecodeError, TypeError):
-                        fm = json.loads(fm_raw)
-                skip = False
-                for key, value in filters.items():
-                    fm_val = fm.get(key)
-                    if fm_val is None:
-                        skip = True
-                        break
-                    if isinstance(fm_val, list):
-                        if str(value) not in [str(v) for v in fm_val]:
-                            skip = True
-                            break
-                    else:
-                        if str(fm_val) != str(value):
-                            skip = True
-                            break
-                if skip:
-                    continue
-
-            heading = r.get("heading")
-            key = (r["path"], heading)
-            rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (_RRF_K + rank)
-            if key not in chunk_meta:
-                chunk_meta[key] = {
-                    "path": r["path"],
-                    "title": r["title"],
-                    "folder": r["folder"],
-                    "heading": heading,
-                    "content": r["content"],
-                    "search_type": "semantic",
-                }
-
-        # Sort by descending RRF score, take top limit.
-        sorted_keys = sorted(rrf_scores, key=lambda k: rrf_scores[k], reverse=True)[
-            :limit
-        ]
-
-        return [
-            SearchResult(
-                path=chunk_meta[k]["path"],
-                title=chunk_meta[k]["title"],
-                folder=chunk_meta[k]["folder"],
-                heading=chunk_meta[k]["heading"],
-                content=chunk_meta[k]["content"],
-                score=rrf_scores[k],
-                search_type=chunk_meta[k]["search_type"],
-                frontmatter=self._get_frontmatter(chunk_meta[k]["path"]),
-            )
-            for k in sorted_keys
-        ]
+        return self._search_mgr._load_vectors()
 
     def _get_frontmatter(self, path: str) -> dict:
         """Return the frontmatter dict for a document from the FTS index.
@@ -716,19 +411,7 @@ class Collection:
         Returns:
             Parsed frontmatter dict.
         """
-        row = self._fts.get_note(path)
-        if row is None:
-            return {}
-        raw = row.get("frontmatter_json")
-        if not raw:
-            return {}
-        try:
-            return json.loads(raw)
-        except (json.JSONDecodeError, TypeError) as exc:
-            logger.warning(
-                "_get_frontmatter: invalid JSON for %s — %s", row.get("path"), exc
-            )
-            return {}
+        return self._search_mgr._get_frontmatter(path)
 
     # ------------------------------------------------------------------
     # Read / list
@@ -801,78 +484,9 @@ class Collection:
             objects.
         """
         self._ensure_initialized()
-
-        rows = self._fts.list_notes(folder=folder)
-        notes: list[NoteInfo | AttachmentInfo] = [
-            _fts_row_to_note_info(row) for row in rows
-        ]
-
-        if pattern:
-            notes = [n for n in notes if fnmatch.fnmatch(n.path, pattern)]
-
-        if not include_attachments:
-            return notes
-
-        exts = self._effective_attachment_extensions()
-        source_resolved = self._source_dir.resolve()
-        attachments: list[AttachmentInfo] = []
-
-        # Attachment scan runs outside _write_lock — result is a best-effort
-        # snapshot and is not atomic with the FTS note listing above.
-        for abs_path in self._source_dir.rglob("*"):
-            if not abs_path.is_file():
-                continue
-            if abs_path.suffix.lower() == ".md":
-                continue
-            suffix = abs_path.suffix.lstrip(".").lower()
-            if "*" not in exts and suffix not in exts:
-                continue
-            try:
-                rel = abs_path.relative_to(source_resolved)
-            except ValueError as exc:
-                logger.warning(
-                    "_list_attachments: skipping %s — outside source_dir (%s)",
-                    abs_path,
-                    exc,
-                )
-                continue
-            rel_path = str(rel)
-            # Skip files where any path component (including the filename itself) starts with ".".
-            if any(part.startswith(".") for part in rel.parts):
-                continue
-            # Apply exclude_patterns — mirrors scan_directory behaviour.
-            if self._is_path_excluded(rel.as_posix()):
-                continue
-            if pattern and not fnmatch.fnmatch(rel_path, pattern):
-                continue
-            rel_folder = str(Path(rel_path).parent)
-            if rel_folder == ".":
-                rel_folder = ""
-            if (
-                folder is not None
-                and rel_folder != folder
-                and not rel_folder.startswith(folder + "/")
-            ):
-                continue
-            try:
-                stat = abs_path.stat()
-            except OSError as exc:
-                logger.warning(
-                    "_list_attachments: skipping %s — stat error (%s)", abs_path, exc
-                )
-                continue
-            mime_type, _ = mimetypes.guess_type(rel_path)
-            attachments.append(
-                AttachmentInfo(
-                    path=rel_path,
-                    folder=rel_folder,
-                    mime_type=mime_type,
-                    size_bytes=stat.st_size,
-                    modified_at=stat.st_mtime,
-                )
-            )
-
-        return notes + attachments
+        return self._search_mgr.list(
+            folder=folder, pattern=pattern, include_attachments=include_attachments
+        )
 
     # ------------------------------------------------------------------
     # Index management
@@ -1313,7 +927,7 @@ class Collection:
             Sorted list of folder strings (``""`` for the collection root).
         """
         self._ensure_initialized()
-        return self._fts.list_folders()
+        return self._search_mgr.list_folders()
 
     def list_tags(self, field: str = "tags") -> list[str]:
         """Return all distinct values indexed for a given frontmatter field.
@@ -1327,7 +941,7 @@ class Collection:
             Sorted list of distinct value strings.
         """
         self._ensure_initialized()
-        return self._fts.list_field_values(field)
+        return self._search_mgr.list_tags(field)
 
     def get_toc(self, path: str) -> list[dict[str, Any]]:
         """Return table of contents for a document.
@@ -1434,31 +1048,7 @@ class Collection:
             ValueError: If no document exists at the given path.
         """
         self._ensure_initialized()
-        self._validate_path(path)
-        if self._fts.get_note(path) is None:
-            raise ValueError(f"Document not found: {path}")
-
-        if self._embedding_provider is None or self._embeddings_path is None:
-            return []
-
-        self._load_vectors()
-        if self._vectors is None or self._vectors.count == 0:
-            return []
-
-        raw_results = self._vectors.search_by_path(path, limit=limit)
-        return [
-            SearchResult(
-                path=r["path"],
-                title=r.get("title", ""),
-                folder=r.get("folder", ""),
-                heading=r.get("heading"),
-                content=r.get("content", ""),
-                score=r.get("score", 0.0),
-                search_type="semantic",
-                frontmatter=self._get_frontmatter(r["path"]),
-            )
-            for r in raw_results
-        ]
+        return self._search_mgr.get_similar(path, limit=limit)
 
     def get_recent(
         self, *, limit: int = 20, folder: str | None = None
@@ -1475,8 +1065,7 @@ class Collection:
             ordered by modification time (most recent first).
         """
         self._ensure_initialized()
-        rows = self._fts.get_recent(limit=limit, folder=folder)
-        return [_fts_row_to_note_info(row) for row in rows]
+        return self._search_mgr.get_recent(limit=limit, folder=folder)
 
     def get_context(
         self,
@@ -1503,102 +1092,8 @@ class Collection:
             ValueError: If no document exists at the given path.
         """
         self._ensure_initialized()
-        self._validate_path(path)
-        row = self._fts.get_note(path)
-        if row is None:
-            raise ValueError(f"Document not found: {path}")
-
-        frontmatter = self._get_frontmatter(path)
-
-        # Backlinks — capped at link_limit; graceful if links table absent.
-        try:
-            backlinks = self._fts.get_backlinks(path, limit=link_limit)
-            backlink_objs = [
-                BacklinkInfo(
-                    source_path=r["source_path"],
-                    source_title=r["source_title"],
-                    link_text=r["link_text"],
-                    link_type=r["link_type"],
-                    fragment=r["fragment"],
-                    raw_target=r["raw_target"],
-                )
-                for r in backlinks
-            ]
-        except sqlite3.OperationalError as exc:
-            logger.warning(
-                "get_context: failed to retrieve backlinks for %s: %s", path, exc
-            )
-            backlink_objs = []
-
-        # Outlinks — capped at link_limit; graceful if links table absent.
-        try:
-            outlinks = self._fts.get_outlinks(path, limit=link_limit)
-            outlink_objs = [
-                OutlinkInfo(
-                    target_path=r["target_path"],
-                    link_text=r["link_text"],
-                    link_type=r["link_type"],
-                    fragment=r["fragment"],
-                    exists=bool(r["target_exists"]),
-                    raw_target=r["raw_target"],
-                )
-                for r in outlinks
-            ]
-        except sqlite3.OperationalError as exc:
-            logger.warning(
-                "get_context: failed to retrieve outlinks for %s: %s", path, exc
-            )
-            outlink_objs = []
-
-        # Similar notes — empty if embeddings not configured or similar_limit is 0.
-        similar_dicts: list[SimilarItem] = []
-        if (
-            similar_limit > 0
-            and self._embedding_provider is not None
-            and self._embeddings_path is not None
-        ):
-            self._load_vectors()
-            if self._vectors is not None and self._vectors.count > 0:
-                raw = self._vectors.search_by_path(path, limit=similar_limit)
-                similar_dicts = [
-                    SimilarItem(
-                        path=r["path"],
-                        title=r["title"],
-                        score=r["score"],
-                    )
-                    for r in raw
-                ]
-
-        # Folder peers — other notes in the same folder, capped at limit.
-        # folder is always a str (empty string for root-level docs) — never None.
-        folder = row["folder"]
-        folder_rows = self._fts.list_notes(folder=folder)
-        folder_notes = [r["path"] for r in folder_rows if r["path"] != path][
-            :_CONTEXT_FOLDER_PEERS_LIMIT
-        ]
-
-        # Tags — indexed frontmatter fields present on this document.
-        tags: dict[str, list[str]] = {}
-        for field in self._indexed_frontmatter_fields:
-            value = frontmatter.get(field)
-            if value is None:
-                continue
-            if isinstance(value, list):
-                tags[field] = [str(v) for v in value]
-            else:
-                tags[field] = [str(value)]
-
-        return NoteContext(
-            path=path,
-            title=row["title"],
-            folder=folder,
-            frontmatter=frontmatter,
-            modified_at=row["modified_at"],
-            backlinks=backlink_objs,
-            outlinks=outlink_objs,
-            similar=similar_dicts,
-            folder_notes=folder_notes,
-            tags=tags,
+        return self._search_mgr.get_context(
+            path, similar_limit=similar_limit, link_limit=link_limit
         )
 
     def get_orphan_notes(self) -> list[NoteInfo]:
@@ -1825,7 +1320,7 @@ class Collection:
             The special value ``frozenset(["*"])`` means all non-.md files.
         """
         if self._attachment_extensions is None:
-            return _DEFAULT_ATTACHMENT_EXTENSIONS
+            return DEFAULT_ATTACHMENT_EXTENSIONS
         return frozenset(self._attachment_extensions)
 
     def _is_attachment(self, path: str) -> bool:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -42,6 +42,7 @@ from markdown_vault_mcp.types import (
     WriteCallback,
     WriteResult,
 )
+from markdown_vault_mcp.utils import effective_attachment_extensions
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -182,17 +183,12 @@ class Collection:
         from markdown_vault_mcp.managers.link import LinkManager
         from markdown_vault_mcp.managers.search import SearchManager
 
+        # 1. LinkManager (no deps)
         self._link_mgr = LinkManager(fts=self._fts, source_dir=self._source_dir)
-        self._search_mgr = SearchManager(
-            fts=self._fts,
-            source_dir=self._source_dir,
-            embeddings_path=self._embeddings_path,
-            embedding_provider=self._embedding_provider,
-            indexed_frontmatter_fields=self._indexed_frontmatter_fields,
-            exclude_patterns=self._exclude_patterns,
-            attachment_extensions=self._attachment_extensions,
-            link_manager=self._link_mgr,
-        )
+        # 2. IndexManager (needs fts, tracker, write_lock — NOT search_mgr)
+        #    get_vectors/set_vectors use late-binding lambdas that capture
+        #    self._search_mgr; they are only called at runtime after all
+        #    managers are constructed.
         self._index_mgr = IndexManager(
             fts=self._fts,
             tracker=self._tracker,
@@ -207,11 +203,20 @@ class Collection:
             get_vectors=lambda: self._search_mgr.vectors,
             set_vectors=lambda v: setattr(self._search_mgr, "vectors", v),
         )
-        # Wire IndexManager callbacks into SearchManager.
-        self._search_mgr._flush_embeddings = self._index_mgr.flush_dirty_embeddings
-        self._search_mgr._rebuild_embeddings = lambda: self._index_mgr.build_embeddings(
-            force=True
+        # 3. SearchManager (receives IndexManager callbacks via constructor)
+        self._search_mgr = SearchManager(
+            fts=self._fts,
+            source_dir=self._source_dir,
+            embeddings_path=self._embeddings_path,
+            embedding_provider=self._embedding_provider,
+            indexed_frontmatter_fields=self._indexed_frontmatter_fields,
+            exclude_patterns=self._exclude_patterns,
+            attachment_extensions=self._attachment_extensions,
+            link_manager=self._link_mgr,
+            flush_embeddings=self._index_mgr.flush_dirty_embeddings,
+            rebuild_embeddings=lambda: self._index_mgr.build_embeddings(force=True),
         )
+        # 4. DocumentManager (needs index_mgr callbacks)
         self._doc_mgr = DocumentManager(
             fts=self._fts,
             source_dir=self._source_dir,
@@ -835,7 +840,7 @@ class Collection:
             self._embedding_provider is not None and self._embeddings_path is not None
         )
 
-        exts = self._doc_mgr._effective_attachment_extensions()
+        exts = effective_attachment_extensions(self._attachment_extensions)
         attachment_extensions = ["*"] if "*" in exts else sorted(exts)
 
         return CollectionStats(

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import base64
 import contextlib
 import fnmatch
-import json
 import logging
 import mimetypes
 import queue
@@ -31,14 +30,13 @@ from markdown_vault_mcp.exceptions import (
     EditConflictError,
     ReadOnlyError,
 )
-from markdown_vault_mcp.fts_index import FTSIndex, _derive_folder
+from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.hashing import compute_etag, compute_file_hash
 from markdown_vault_mcp.scanner import (
     ChunkStrategy,
     HeadingChunker,
     WholeDocumentChunker,
     parse_note,
-    scan_directory,
 )
 from markdown_vault_mcp.tracker import ChangeTracker
 from markdown_vault_mcp.types import (
@@ -92,14 +90,6 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_STATE_SUBDIR = ".markdown_vault_mcp"
 _DEFAULT_STATE_FILENAME = "state.json"
-# Maximum chunks per embedding provider call.  Keeps memory bounded during
-# build_embeddings() — FastEmbed/ONNX can allocate pathologically large buffers
-# when the entire corpus is sent in one batch (see issue #159).
-_EMBEDDING_BATCH_SIZE = 4
-
-# Seconds between automatic background flushes of dirty embeddings to disk.
-# Write operations mark documents as dirty; the flush re-embeds them in bulk.
-_EMBEDDING_FLUSH_INTERVAL = 30
 
 
 def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
@@ -213,7 +203,16 @@ class Collection:
         )
         self._tracker = ChangeTracker(self._state_path)
 
+        # Lazy initialisation flag.
+        self._initialized = False
+
+        # Serialise concurrent write operations on this instance.
+        # Re-entrant: periodic pull tick blocks writes, then reindex() acquires
+        # this lock again for its mutation phase.
+        self._write_lock = threading.RLock()
+
         # Manager modules (dependency-injected, no back-reference).
+        from markdown_vault_mcp.managers.index import IndexManager
         from markdown_vault_mcp.managers.link import LinkManager
         from markdown_vault_mcp.managers.search import SearchManager
 
@@ -227,25 +226,26 @@ class Collection:
             exclude_patterns=self._exclude_patterns,
             attachment_extensions=self._attachment_extensions,
             link_manager=self._link_mgr,
-            flush_embeddings=self._flush_dirty_embeddings,
-            rebuild_embeddings=lambda: self.build_embeddings(force=True),
         )
-
-        # Lazy initialisation flag.
-        self._initialized = False
-
-        # Serialise concurrent write operations on this instance.
-        # Re-entrant: periodic pull tick blocks writes, then reindex() acquires
-        # this lock again for its mutation phase.
-        self._write_lock = threading.RLock()
-
-        # Deferred embedding updates (issue #175).  Write operations add
-        # document paths here instead of re-embedding inline.  A background
-        # timer flushes the set periodically; semantic_search() and close()
-        # flush synchronously.
-        self._dirty_embeddings: set[str] = set()
-        self._embedding_flush_timer: threading.Timer | None = None
-        self._embedding_flush_lock = threading.Lock()
+        self._index_mgr = IndexManager(
+            fts=self._fts,
+            tracker=self._tracker,
+            source_dir=self._source_dir,
+            embeddings_path=self._embeddings_path,
+            embedding_provider=self._embedding_provider,
+            write_lock=self._write_lock,
+            chunk_strategy=self._chunk_strategy,
+            exclude_patterns=self._exclude_patterns,
+            required_frontmatter=self._required_frontmatter,
+            indexed_frontmatter_fields=self._indexed_frontmatter_fields,
+            get_vectors=lambda: self._search_mgr.vectors,
+            set_vectors=lambda v: setattr(self._search_mgr, "vectors", v),
+        )
+        # Wire IndexManager callbacks into SearchManager.
+        self._search_mgr._flush_embeddings = self._index_mgr.flush_dirty_embeddings
+        self._search_mgr._rebuild_embeddings = lambda: self._index_mgr.build_embeddings(
+            force=True
+        )
 
         # Deferred write callback queue (issue #175).  Git commit (on_write
         # callback) runs in a background worker thread so write methods
@@ -307,7 +307,7 @@ class Collection:
         closes the SQLite connection and git strategy.
         """
         # 1. Flush any deferred embedding updates.
-        self._flush_dirty_embeddings()
+        self._index_mgr.flush_dirty_embeddings()
 
         # 2. Drain the write-callback queue (git commits).
         if self._callback_worker is not None and self._callback_worker.is_alive():
@@ -519,264 +519,19 @@ class Collection:
                     skipped=0,
                 )
 
-        if force:
-            # Drop all data by rebuilding from an empty scan then re-populate.
-            logger.info("build_index(force=True): dropping and rebuilding index")
-            # Delete all existing documents.
-            for row in self._fts.list_notes():
-                self._fts.delete_by_path(row["path"])
-
-        logger.info("build_index: scanning %s", self._source_dir)
-
-        notes = list(
-            scan_directory(
-                self._source_dir,
-                required_frontmatter=self._required_frontmatter,
-                chunk_strategy=self._chunk_strategy,
-                exclude_patterns=self._exclude_patterns,
-            )
-        )
-
-        total_chunks = 0
-        errored = 0
-        for note in notes:
-            try:
-                total_chunks += self._fts.upsert_note(note)
-            except Exception:
-                errored += 1
-                logger.warning(
-                    "build_index: failed to index %s", note.path, exc_info=True
-                )
-
-        # Purge stale excluded docs from a persistent index that was built
-        # before exclude_patterns were configured (upgrade scenario, #255).
-        indexed_paths = {note.path for note in notes}
-        if self._exclude_patterns:
-            # Load persisted vectors so stale entries are purged from the
-            # .npy sidecar too (build_embeddings skips if count > 0).
-            if (
-                self._vectors is None
-                and self._embedding_provider is not None
-                and self._embeddings_path is not None
-            ):
-                self._load_vectors()
-
-            purged = 0
-            for row in self._fts.list_notes():
-                if row["path"] not in indexed_paths and self._is_path_excluded(
-                    row["path"]
-                ):
-                    self._fts.delete_by_path(row["path"])
-                    if self._vectors is not None:
-                        self._vectors.delete_by_path(row["path"])
-                    purged += 1
-
-            if (
-                purged
-                and self._vectors is not None
-                and self._embeddings_path is not None
-            ):
-                self._vectors.save(self._embeddings_path)
-
-        # Count how many files were skipped due to required_frontmatter.
-        # scan_directory logs skipped counts itself; we compute it by comparing
-        # indexed count to total files on disk.
-        all_files = list(self._source_dir.glob("**/*.md"))
-        skipped = len(all_files) - len(notes)
-
-        # Resolve vault-wide wikilinks now that all documents are indexed.
-        self._fts.resolve_vault_wikilinks()
-
-        # Update tracker state so reindex() knows the baseline.
-        self._tracker.update_state(notes)
-
+        result = self._index_mgr.build_index(force=force)
         self._initialized = True
-        if errored:
-            logger.warning(
-                "build_index: indexed %d documents, %d chunks (%d skipped, %d errors)",
-                len(notes) - errored,
-                total_chunks,
-                skipped,
-                errored,
-            )
-        else:
-            logger.info(
-                "build_index: indexed %d documents, %d chunks (%d skipped)",
-                len(notes),
-                total_chunks,
-                skipped,
-            )
-        return IndexStats(
-            documents_indexed=len(notes) - errored,
-            chunks_indexed=total_chunks,
-            skipped=max(skipped, 0),
-        )
+        return result
 
     def reindex(self) -> ReindexResult:
         """Incrementally update the index based on file changes.
-
-        Uses :class:`~markdown_vault_mcp.tracker.ChangeTracker` to detect which
-        files have been added, modified, or deleted since the last scan.
-        Only changed files are re-parsed and re-indexed.  Files matching
-        ``exclude_patterns`` are skipped, and any previously indexed documents
-        that now match the patterns are purged from the FTS and vector indexes.
-
-        Thread-safety: the filesystem scan runs without holding ``_write_lock``
-        (read-only), then the mutation phase acquires the lock to prevent races
-        with concurrent write/edit/delete/rename operations.
 
         Returns:
             :class:`~markdown_vault_mcp.types.ReindexResult` with counts of changes
             applied.
         """
         self._ensure_initialized()
-
-        # Phase 1: scan (outside lock — read-only filesystem walk + hashing).
-        changes = self._tracker.detect_changes(self._source_dir)
-        logger.info(
-            "reindex: %d added, %d modified, %d deleted, %d unchanged",
-            len(changes.added),
-            len(changes.modified),
-            len(changes.deleted),
-            changes.unchanged,
-        )
-
-        # Pre-parse notes outside the lock to minimise lock hold time.
-        # NOTE: there is an inherent TOCTOU window between detecting a change
-        # in Phase 1 (hash comparison) and re-reading the file for indexing
-        # here.  If the file is modified again in that window, the newly
-        # written content is indexed rather than the version that triggered
-        # the change.  This is acceptable — the next reindex() call will
-        # reconcile the difference.
-        parsed: list[tuple[str, ParsedNote]] = []
-        for path in changes.added + changes.modified:
-            # Apply exclude_patterns — mirrors scan_directory behaviour.
-            if self._is_path_excluded(path):
-                logger.debug("reindex: excluding %s (matched exclude pattern)", path)
-                continue
-
-            abs_path = self._source_dir / path
-            try:
-                note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-            except (UnicodeDecodeError, OSError) as exc:
-                logger.warning("reindex: skipping %s — %s", path, exc)
-                continue
-            except Exception as exc:
-                logger.warning(
-                    "reindex: skipping %s — parse error (%s)",
-                    path,
-                    exc,
-                    exc_info=True,
-                )
-                continue
-
-            # Apply required_frontmatter filter.
-            if self._required_frontmatter:
-                missing = [
-                    f for f in self._required_frontmatter if f not in note.frontmatter
-                ]
-                if missing:
-                    logger.info(
-                        "reindex: skipping %s — missing frontmatter: %s", path, missing
-                    )
-                    continue
-
-            parsed.append((path, note))
-
-        # Phase 2: apply mutations (inside lock — prevents races with writes).
-        with self._write_lock:
-            # Delete removed documents.
-            for path in changes.deleted:
-                self._fts.delete_by_path(path)
-                if self._vectors is not None:
-                    self._vectors.delete_by_path(path)
-
-            # Purge stale excluded docs that were indexed before
-            # exclude_patterns were enforced in reindex() (issue #255).
-            stale_excluded = 0
-            if self._exclude_patterns:
-                # Load persisted vectors so stale entries are purged from
-                # the .npy sidecar too (not just FTS).
-                if (
-                    self._vectors is None
-                    and self._embedding_provider is not None
-                    and self._embeddings_path is not None
-                ):
-                    self._load_vectors()
-
-                for row in self._fts.list_notes():
-                    if self._is_path_excluded(row["path"]):
-                        self._fts.delete_by_path(row["path"])
-                        if self._vectors is not None:
-                            self._vectors.delete_by_path(row["path"])
-                        stale_excluded += 1
-                if stale_excluded:
-                    logger.info(
-                        "reindex: purged %d stale excluded document(s)",
-                        stale_excluded,
-                    )
-
-            # Upsert parsed notes.
-            indexed_added = 0
-            indexed_modified = 0
-            added_set = set(changes.added)
-
-            for path, note in parsed:
-                try:
-                    self._fts.upsert_note(note)
-                except Exception:
-                    logger.warning("reindex: failed to index %s", path, exc_info=True)
-                    continue
-                if path in added_set:
-                    indexed_added += 1
-                else:
-                    indexed_modified += 1
-
-                # Update vector index for changed notes if loaded.
-                if self._vectors is not None and self._embeddings_path is not None:
-                    self._vectors.delete_by_path(note.path)
-                    texts = [c.content for c in note.chunks]
-                    meta = [
-                        {
-                            "path": note.path,
-                            "title": note.title,
-                            "folder": _derive_folder(note.path),
-                            "heading": c.heading,
-                            "content": c.content,
-                        }
-                        for c in note.chunks
-                    ]
-                    if texts:
-                        self._vectors.add(texts, meta)
-
-            # Persist updated vector index.
-            if self._vectors is not None and self._embeddings_path is not None:
-                self._vectors.save(self._embeddings_path)
-
-            # Re-resolve vault-wide wikilinks: adding/removing documents may
-            # fix previously broken links or expose new ones.
-            self._fts.resolve_vault_wikilinks()
-
-            # Update tracker state: rebuild from current FTS index contents.
-            state_notes: list[ParsedNote] = [
-                ParsedNote(
-                    path=r["path"],
-                    frontmatter={},
-                    title=r["title"],
-                    chunks=[],
-                    content_hash=r["content_hash"],
-                    modified_at=r["modified_at"],
-                )
-                for r in self._fts.list_notes()
-            ]
-            self._tracker.update_state(state_notes)
-
-        return ReindexResult(
-            added=indexed_added,
-            modified=indexed_modified,
-            deleted=len(changes.deleted),
-            unchanged=changes.unchanged,
-        )
+        return self._index_mgr.reindex()
 
     def build_embeddings(self, *, force: bool = False) -> int:
         """Build the vector index from all chunks currently in the FTS index.
@@ -793,83 +548,7 @@ class Collection:
                 not configured.
         """
         self._ensure_initialized()
-        self._require_vectors()
-
-        assert self._embeddings_path is not None
-        assert self._embedding_provider is not None
-
-        from markdown_vault_mcp.vector_index import VectorIndex
-
-        if force:
-            self._vectors = VectorIndex(self._embedding_provider)
-        else:
-            # Load persisted vectors (or create empty) so we can check count.
-            self._load_vectors()
-            if self._vectors.count > 0:
-                logger.info(
-                    "build_embeddings: index already exists (%d chunks), skipping",
-                    self._vectors.count,
-                )
-                return self._vectors.count
-            # Empty index — fall through to build from scratch.
-
-        rows = self._fts.list_notes()
-        num_notes = len(rows)
-        logger.info("build_embeddings: parsing %d notes into chunks", num_notes)
-        texts: list[str] = []
-        meta: list[dict] = []
-
-        for i, row in enumerate(rows, 1):
-            path = row["path"]
-            title = row["title"]
-            folder = row["folder"]
-            # Re-parse to get chunks with content.
-            abs_path = self._source_dir / path
-            try:
-                note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-            except (UnicodeDecodeError, OSError) as exc:
-                logger.warning("build_embeddings: skipping %s — %s", path, exc)
-                continue
-            for chunk in note.chunks:
-                texts.append(chunk.content)
-                meta.append(
-                    {
-                        "path": path,
-                        "title": title,
-                        "folder": folder,
-                        "heading": chunk.heading,
-                        "content": chunk.content,
-                    }
-                )
-            if i % 100 == 0 or i == num_notes:
-                logger.info(
-                    "build_embeddings: parsed %d/%d notes (%d chunks so far)",
-                    i,
-                    num_notes,
-                    len(texts),
-                )
-
-        # Embed in bounded batches to avoid pathological memory allocation
-        # (see issue #159 -- FastEmbed/ONNX can request >200 GB for a single
-        # oversized batch).  Save once at the end so a mid-run crash does not
-        # leave a partial index that the skip-if-exists check treats as complete.
-        total = len(texts)
-        for start in range(0, total, _EMBEDDING_BATCH_SIZE):
-            end = min(start + _EMBEDDING_BATCH_SIZE, total)
-            self._vectors.add(texts[start:end], meta[start:end])
-            logger.info(
-                "build_embeddings: embedded chunks %d-%d of %d",
-                start + 1,
-                end,
-                total,
-            )
-
-        if total > 0:
-            self._vectors.save(self._embeddings_path)
-            logger.info("build_embeddings: embedded and saved %d chunks", total)
-        else:
-            logger.info("build_embeddings: nothing to embed")
-        return total
+        return self._index_mgr.build_embeddings(force=force)
 
     def embeddings_status(self) -> dict:
         """Return status information about the vector index.
@@ -878,43 +557,7 @@ class Collection:
             Dict with keys ``provider``, ``chunk_count``, ``path``,
             ``available``.
         """
-        if self._embedding_provider is None or self._embeddings_path is None:
-            return {
-                "available": False,
-                "provider": None,
-                "chunk_count": 0,
-                "path": None,
-            }
-
-        count = 0
-        if self._vectors is not None:
-            count = self._vectors.count
-        else:
-            npy_path = Path(str(self._embeddings_path) + ".npy")
-            if npy_path.exists():
-                # Peek at metadata file for count without loading full matrix.
-                json_path = Path(str(self._embeddings_path) + ".json")
-                if json_path.exists():
-                    try:
-                        with json_path.open(encoding="utf-8") as fh:
-                            loaded_meta = json.load(fh)
-                        if isinstance(loaded_meta, list):
-                            count = len(loaded_meta)
-                        else:
-                            count = len(loaded_meta.get("rows", []))
-                    except (OSError, json.JSONDecodeError) as exc:
-                        logger.warning(
-                            "embeddings_status: could not read metadata from %s — %s",
-                            json_path,
-                            exc,
-                        )
-
-        return {
-            "available": True,
-            "provider": type(self._embedding_provider).__name__,
-            "chunk_count": count,
-            "path": str(self._embeddings_path),
-        }
+        return self._index_mgr.embeddings_status()
 
     # ------------------------------------------------------------------
     # Metadata
@@ -1406,109 +1049,12 @@ class Collection:
     def _update_vector_index(self, note: ParsedNote) -> None:
         """Mark a document for deferred embedding update.
 
-        The actual re-embedding and save happen during the next flush
-        (periodic timer, semantic search, or close).
+        Delegates to :meth:`IndexManager.update_vector_index`.
 
         Args:
-            note: Parsed document to index.
+            note: Parsed document to mark dirty.
         """
-        if self._embeddings_path is None or self._embedding_provider is None:
-            return
-        with self._embedding_flush_lock:
-            self._dirty_embeddings.add(note.path)
-        self._schedule_embedding_flush()
-
-    def _schedule_embedding_flush(self) -> None:
-        """Schedule a deferred flush of dirty embeddings."""
-        with self._embedding_flush_lock:
-            if self._embedding_flush_timer is not None:
-                self._embedding_flush_timer.cancel()
-            self._embedding_flush_timer = threading.Timer(
-                _EMBEDDING_FLUSH_INTERVAL,
-                self._flush_dirty_embeddings,
-            )
-            self._embedding_flush_timer.daemon = True
-            self._embedding_flush_timer.start()
-
-    def _flush_dirty_embeddings(self) -> None:
-        """Re-embed all dirty documents and save the vector index once.
-
-        Called by the periodic timer, before semantic search, and on close.
-        Thread-safe: the dirty-set swap is atomic under ``_embedding_flush_lock``;
-        Phase 2 vector mutations are serialised by ``_write_lock``.
-
-        Two-phase design to minimise lock hold time:
-
-        1. **Outside** ``_write_lock``: parse each dirty document and call
-           the (potentially slow) embedding provider.
-        2. **Inside** ``_write_lock``: apply the fast numpy mutations
-           (delete old rows, append pre-computed vectors, save).
-
-        This prevents the embedding provider from blocking foreground
-        write operations for the duration of CPU/network embedding work.
-        """
-        if self._embeddings_path is None or self._embedding_provider is None:
-            return
-
-        with self._embedding_flush_lock:
-            # Cancel pending timer (we're flushing now).
-            if self._embedding_flush_timer is not None:
-                self._embedding_flush_timer.cancel()
-                self._embedding_flush_timer = None
-
-            # Atomically swap the dirty set.
-            if not self._dirty_embeddings:
-                return
-            paths = self._dirty_embeddings.copy()
-            self._dirty_embeddings.clear()
-
-        # Phase 1: parse and embed OUTSIDE _write_lock.
-        # provider.embed() can be slow (seconds on CPU) — don't hold the
-        # write lock during it.  Collect (path, raw_vectors, meta) tuples
-        # for paths that still exist; paths that have been deleted will
-        # have raw_vectors=None so only a delete_by_path is applied.
-        pre_embedded: list[tuple[str, list[list[float]] | None, list[dict] | None]] = []
-        for path in paths:
-            abs_path = self._source_dir / path
-            if abs_path.is_file() and path.endswith(".md"):
-                try:
-                    note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-                    texts = [c.content for c in note.chunks]
-                    meta = [
-                        {
-                            "path": note.path,
-                            "title": note.title,
-                            "folder": _derive_folder(note.path),
-                            "heading": c.heading,
-                            "content": c.content,
-                        }
-                        for c in note.chunks
-                    ]
-                    if texts:
-                        raw_vecs = self._embedding_provider.embed(texts)
-                        pre_embedded.append((path, raw_vecs, meta))
-                    else:
-                        pre_embedded.append((path, None, None))
-                except (UnicodeDecodeError, OSError) as exc:
-                    logger.warning("Deferred embedding failed for %s: %s", path, exc)
-                    # Preserve original semantics: still delete stale vectors.
-                    pre_embedded.append((path, None, None))
-            else:
-                # File deleted or non-.md — remove stale vectors only.
-                pre_embedded.append((path, None, None))
-
-        # Phase 2: mutate vector index under _write_lock.
-        # All operations here are fast numpy mutations — no I/O or embedding.
-        with self._write_lock:
-            vectors = self._load_vectors()
-
-            for path, raw_vecs, meta in pre_embedded:
-                vectors.delete_by_path(path)
-                if raw_vecs is not None and meta:
-                    vectors.add_vectors(raw_vecs, meta)
-
-            vectors.save(self._embeddings_path)
-            logger.debug("Flushed deferred embeddings for %d paths", len(paths))
+        self._index_mgr.update_vector_index(note)
 
     def _ensure_callback_worker(self) -> None:
         """Start the background write-callback worker if not running."""
@@ -2052,13 +1598,7 @@ class Collection:
                 abs_path.unlink()
                 self._fts.delete_by_path(path)
                 # Mark for deferred vector index cleanup.
-                if (
-                    self._embeddings_path is not None
-                    and self._embedding_provider is not None
-                ):
-                    with self._embedding_flush_lock:
-                        self._dirty_embeddings.add(path)
-                    self._schedule_embedding_flush()
+                self._index_mgr.mark_dirty(path)
             else:
                 abs_path = self._validate_attachment_path(path)
                 if not abs_path.is_file():
@@ -2261,14 +1801,8 @@ class Collection:
 
                 # Mark both paths for deferred vector update: old_path
                 # entries are deleted (file gone), new_path re-embedded.
-                if (
-                    self._embeddings_path is not None
-                    and self._embedding_provider is not None
-                ):
-                    with self._embedding_flush_lock:
-                        self._dirty_embeddings.add(old_path)
-                        self._dirty_embeddings.add(note.path)
-                    self._schedule_embedding_flush()
+                self._index_mgr.mark_dirty(old_path)
+                self._index_mgr.mark_dirty(note.path)
 
                 callback_content = new_abs.read_text(encoding="utf-8")
 

--- a/src/markdown_vault_mcp/managers/__init__.py
+++ b/src/markdown_vault_mcp/managers/__init__.py
@@ -1,7 +1,8 @@
 """Manager modules for markdown-vault-mcp."""
 
+from markdown_vault_mcp.managers.document import DocumentManager
 from markdown_vault_mcp.managers.index import IndexManager
 from markdown_vault_mcp.managers.link import LinkManager
 from markdown_vault_mcp.managers.search import SearchManager
 
-__all__ = ["IndexManager", "LinkManager", "SearchManager"]
+__all__ = ["DocumentManager", "IndexManager", "LinkManager", "SearchManager"]

--- a/src/markdown_vault_mcp/managers/__init__.py
+++ b/src/markdown_vault_mcp/managers/__init__.py
@@ -1,0 +1,5 @@
+"""Manager modules for markdown-vault-mcp."""
+
+from markdown_vault_mcp.managers.link import LinkManager
+
+__all__ = ["LinkManager"]

--- a/src/markdown_vault_mcp/managers/__init__.py
+++ b/src/markdown_vault_mcp/managers/__init__.py
@@ -1,5 +1,6 @@
 """Manager modules for markdown-vault-mcp."""
 
 from markdown_vault_mcp.managers.link import LinkManager
+from markdown_vault_mcp.managers.search import SearchManager
 
-__all__ = ["LinkManager"]
+__all__ = ["LinkManager", "SearchManager"]

--- a/src/markdown_vault_mcp/managers/__init__.py
+++ b/src/markdown_vault_mcp/managers/__init__.py
@@ -1,6 +1,7 @@
 """Manager modules for markdown-vault-mcp."""
 
+from markdown_vault_mcp.managers.index import IndexManager
 from markdown_vault_mcp.managers.link import LinkManager
 from markdown_vault_mcp.managers.search import SearchManager
 
-__all__ = ["LinkManager", "SearchManager"]
+__all__ = ["IndexManager", "LinkManager", "SearchManager"]

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -1,0 +1,1018 @@
+"""Document CRUD, attachment, and path-validation manager.
+
+Handles all read/write/edit/delete/rename operations, attachment I/O,
+path validation, and backlink updates — all with dependency injection
+and no back-reference to :class:`Collection`.
+"""
+
+from __future__ import annotations
+
+import base64
+import fnmatch
+import logging
+import mimetypes
+import shutil
+import sqlite3
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import frontmatter as fm
+
+from markdown_vault_mcp.exceptions import (
+    ConcurrentModificationError,
+    DocumentExistsError,
+    DocumentNotFoundError,
+    EditConflictError,
+    ReadOnlyError,
+)
+from markdown_vault_mcp.hashing import compute_etag, compute_file_hash
+from markdown_vault_mcp.scanner import parse_note
+from markdown_vault_mcp.types import (
+    DEFAULT_ATTACHMENT_EXTENSIONS,
+    AttachmentContent,
+    DeleteResult,
+    EditResult,
+    NoteContent,
+    RenameResult,
+    WriteResult,
+)
+from markdown_vault_mcp.utils.links import (
+    apply_link_replacement as _apply_link_replacement,
+)
+from markdown_vault_mcp.utils.links import (
+    compute_new_raw_target as _compute_new_raw_target,
+)
+from markdown_vault_mcp.utils.text import (
+    build_position_map as _build_position_map,
+)
+from markdown_vault_mcp.utils.text import (
+    find_closest_match as _find_closest_match,
+)
+from markdown_vault_mcp.utils.text import (
+    normalize_text as _normalize_text,
+)
+
+if TYPE_CHECKING:
+    import threading
+    from collections.abc import Callable
+
+    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.scanner import ChunkStrategy
+    from markdown_vault_mcp.types import ParsedNote
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentManager:
+    """Manages document CRUD, attachments, path validation, and backlinks.
+
+    All file I/O, FTS index mutations, and write-callback dispatch for
+    individual documents flow through this class.
+
+    Args:
+        fts: The FTS index for upsert/delete operations.
+        source_dir: Absolute path to the vault root directory.
+        write_lock: Shared re-entrant lock serialising write operations.
+        chunk_strategy: Strategy for splitting documents into chunks.
+        read_only: When ``True``, write operations raise
+            :exc:`~markdown_vault_mcp.exceptions.ReadOnlyError`.
+        exclude_patterns: Glob patterns for paths to exclude.
+        attachment_extensions: Allowlist of attachment file extensions.
+        max_attachment_size_mb: Maximum attachment size in megabytes.
+        on_write_callback: Fires after a successful write to enqueue a
+            git commit.  Signature: ``(abs_path, content, operation)``.
+        on_vector_update: Marks a parsed note for deferred embedding
+            re-index.
+        on_vector_dirty: Marks a path dirty by string (for delete/rename
+            where a full :class:`ParsedNote` is unavailable).
+    """
+
+    def __init__(
+        self,
+        fts: FTSIndex,
+        source_dir: Path,
+        *,
+        write_lock: threading.RLock,
+        chunk_strategy: ChunkStrategy,
+        read_only: bool = True,
+        exclude_patterns: list[str] | None = None,
+        attachment_extensions: list[str] | None = None,
+        max_attachment_size_mb: float = 10.0,
+        on_write_callback: Callable[[Path, str, str], None] | None = None,
+        on_vector_update: Callable[[ParsedNote], None] | None = None,
+        on_vector_dirty: Callable[[str], None] | None = None,
+    ) -> None:
+        self._fts = fts
+        self._source_dir = source_dir
+        self._write_lock = write_lock
+        self._chunk_strategy = chunk_strategy
+        self._read_only = read_only
+        self._exclude_patterns = exclude_patterns
+        self._attachment_extensions = attachment_extensions
+        self._max_attachment_size_mb = max_attachment_size_mb
+        self._on_write_callback = on_write_callback or (lambda *_a: None)
+        self._on_vector_update = on_vector_update or (lambda *_a: None)
+        self._on_vector_dirty = on_vector_dirty or (lambda *_a: None)
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+
+    def _check_writable(self) -> None:
+        """Raise ReadOnlyError if the collection is configured as read-only.
+
+        Raises:
+            ReadOnlyError: If ``read_only=True``.
+        """
+        if self._read_only:
+            raise ReadOnlyError(
+                "Collection is read-only; write operations are not permitted."
+            )
+
+    def _effective_attachment_extensions(self) -> frozenset[str]:
+        """Return the effective set of allowed attachment extensions.
+
+        Returns:
+            Frozenset of lower-case extension strings (without leading dot).
+            The special value ``frozenset(["*"])`` means all non-.md files.
+        """
+        if self._attachment_extensions is None:
+            return DEFAULT_ATTACHMENT_EXTENSIONS
+        return frozenset(self._attachment_extensions)
+
+    def _is_attachment(self, path: str) -> bool:
+        """Return True if *path* is an allowed non-.md attachment.
+
+        Args:
+            path: Relative path to check.
+
+        Returns:
+            ``True`` when the extension is in the allowlist and is not ``.md``.
+        """
+        if path.endswith(".md"):
+            return False
+        suffix = Path(path).suffix.lstrip(".").lower()
+        exts = self._effective_attachment_extensions()
+        return "*" in exts or suffix in exts
+
+    def _is_path_excluded(self, path: str) -> bool:
+        """Check whether *path* matches any configured exclude pattern.
+
+        Args:
+            path: Relative POSIX path string.
+
+        Returns:
+            ``True`` if the path matches any pattern in
+            ``self._exclude_patterns``.
+        """
+        if not self._exclude_patterns:
+            return False
+        return any(fnmatch.fnmatch(path, pat) for pat in self._exclude_patterns)
+
+    def _validate_path(self, path: str) -> Path:
+        """Resolve a relative path and validate it is inside source_dir.
+
+        Args:
+            path: Relative document path.
+
+        Returns:
+            The resolved absolute path.
+
+        Raises:
+            ValueError: If the path escapes the source directory or does
+                not end with ``.md``.
+        """
+        if not path.endswith(".md"):
+            raise ValueError(f"Path must end with '.md': {path}")
+        abs_path = (self._source_dir / path).resolve()
+        if not abs_path.is_relative_to(self._source_dir.resolve()):
+            raise ValueError(f"Path traversal detected: {path}")
+        return abs_path
+
+    def _validate_attachment_path(self, path: str) -> Path:
+        """Resolve and validate a non-.md attachment path.
+
+        Args:
+            path: Relative attachment path.
+
+        Returns:
+            The resolved absolute path.
+
+        Raises:
+            ValueError: If the path escapes the source directory, ends with
+                ``.md``, or has an extension not in the attachment allowlist.
+        """
+        if path.endswith(".md"):
+            raise ValueError(
+                f"Path ends with '.md' — use the note read/write methods "
+                f"instead: {path}"
+            )
+        exts = self._effective_attachment_extensions()
+        suffix = Path(path).suffix.lstrip(".").lower()
+        if "*" not in exts and suffix not in exts:
+            allowed_str = ", ".join(f".{e}" for e in sorted(exts))
+            raise ValueError(
+                f"Extension '.{suffix}' is not in the attachment allowlist. "
+                f"Allowed: {allowed_str}. "
+                "Set MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS=* to allow "
+                "all non-.md files."
+            )
+        abs_path = (self._source_dir / path).resolve()
+        if not abs_path.is_relative_to(self._source_dir.resolve()):
+            raise ValueError(f"Path traversal detected: {path}")
+        return abs_path
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    def read(self, path: str) -> NoteContent | None:
+        """Read the full content of a document from disk.
+
+        Args:
+            path: Relative document path (e.g. ``"Journal/note.md"``).
+
+        Returns:
+            A :class:`~markdown_vault_mcp.types.NoteContent` instance, or
+            ``None`` if the file does not exist.
+        """
+        abs_path = (self._source_dir / path).resolve()
+        if not abs_path.is_relative_to(self._source_dir.resolve()):
+            return None
+        if not abs_path.is_file():
+            return None
+
+        try:
+            note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
+        except (UnicodeDecodeError, OSError) as exc:
+            logger.warning("read(%s): could not parse file — %s", path, exc)
+            return None
+
+        raw_content = abs_path.read_text(encoding="utf-8")
+        etag = note.content_hash
+        folder = str(Path(path).parent)
+        if folder == ".":
+            folder = ""
+
+        return NoteContent(
+            path=note.path,
+            title=note.title,
+            folder=folder,
+            content=raw_content,
+            frontmatter=note.frontmatter,
+            modified_at=note.modified_at,
+            etag=etag,
+        )
+
+    def read_attachment(self, path: str) -> AttachmentContent:
+        """Read the binary content of a non-.md attachment.
+
+        Args:
+            path: Relative attachment path (e.g. ``"assets/diagram.pdf"``).
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.AttachmentContent` with
+            base64-encoded content and MIME type.
+
+        Raises:
+            ValueError: If the path escapes the source directory, has an
+                extension not in the allowlist, or the file does not exist.
+            ValueError: If the file exceeds the configured size limit.
+        """
+        abs_path = self._validate_attachment_path(path)
+        if not abs_path.is_file():
+            raise ValueError(f"Attachment not found: {path}")
+
+        stat = abs_path.stat()
+        size_bytes = stat.st_size
+        if self._max_attachment_size_mb > 0:
+            limit_bytes = int(self._max_attachment_size_mb * 1024 * 1024)
+            if size_bytes > limit_bytes:
+                raise ValueError(
+                    f"Attachment {path!r} is {size_bytes} bytes, which "
+                    f"exceeds the limit of {self._max_attachment_size_mb} MB "
+                    f"({limit_bytes} bytes). "
+                    "Raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB or set "
+                    "it to 0 to disable the limit."
+                )
+
+        mime_type, _ = mimetypes.guess_type(path)
+        raw = abs_path.read_bytes()
+        content_base64 = base64.b64encode(raw).decode("ascii")
+        etag = compute_etag(raw)
+        return AttachmentContent(
+            path=path,
+            mime_type=mime_type,
+            size_bytes=size_bytes,
+            content_base64=content_base64,
+            modified_at=stat.st_mtime,
+            etag=etag,
+        )
+
+    def get_toc(self, path: str) -> list[dict[str, Any]]:
+        """Return table of contents for a document.
+
+        Queries the FTS sections table for headings and prepends the document
+        title as a synthetic H1 entry.
+
+        Args:
+            path: Relative path to the document (e.g. ``"notes/intro.md"``).
+
+        Returns:
+            List of ``{"heading": str, "level": int}`` dicts ordered by
+            position, with the document title prepended as level 1.
+
+        Raises:
+            ValueError: If no document exists at the given path.
+        """
+        self._validate_path(path)
+
+        row = self._fts.get_note(path)
+        if row is None:
+            raise ValueError(f"Document not found: {path}")
+
+        title: str = row["title"]
+        headings = self._fts.get_toc(path)
+
+        toc: list[dict[str, Any]] = [{"heading": title, "level": 1}]
+        toc.extend(
+            h for h in headings if not (h["level"] == 1 and h["heading"] == title)
+        )
+        return toc
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    def write(
+        self,
+        path: str,
+        content: str,
+        frontmatter: dict[str, Any] | None = None,
+        if_match: str | None = None,
+    ) -> WriteResult:
+        """Create or overwrite a document.
+
+        Creates intermediate directories as needed.  If *frontmatter* is
+        provided, it is serialised as a YAML header at the top of the file.
+
+        Args:
+            path: Relative document path.
+            content: Markdown body (excluding frontmatter).
+            frontmatter: Optional frontmatter dict serialised as YAML header.
+            if_match: Optional etag from a previous :meth:`read` call.
+                When provided, the write is only performed if the current
+                file hash matches this value, preventing overwrites of
+                concurrent modifications. Supplying *if_match* for a file
+                that does not yet exist raises
+                :exc:`~markdown_vault_mcp.exceptions.ConcurrentModificationError`.
+                Pass ``None`` (default) to skip the check.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.WriteResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current file hash (or the file does not exist).
+            ValueError: If *path* escapes the source directory.
+        """
+        self._check_writable()
+        with self._write_lock:
+            abs_path = self._validate_path(path)
+            if if_match is not None:
+                if not abs_path.is_file():
+                    raise ConcurrentModificationError(
+                        path,
+                        expected=if_match,
+                        actual="(file does not exist)",
+                    )
+                current_hash = compute_file_hash(abs_path)
+                if current_hash != if_match:
+                    raise ConcurrentModificationError(
+                        path, expected=if_match, actual=current_hash
+                    )
+            created = not abs_path.is_file()
+
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if frontmatter is not None:
+                post = fm.Post(content, **frontmatter)
+                file_content = fm.dumps(post)
+            else:
+                file_content = content
+
+            with tempfile.NamedTemporaryFile(
+                dir=abs_path.parent,
+                mode="w",
+                encoding="utf-8",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                tmp.write(file_content)
+                tmp_name = tmp.name
+            if abs_path.is_file():
+                shutil.copymode(abs_path, tmp_name)
+            try:
+                Path(tmp_name).replace(abs_path)
+            except Exception:
+                Path(tmp_name).unlink(missing_ok=True)
+                raise
+
+            note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
+            self._fts.upsert_note(note)
+            self._on_vector_update(note)
+
+            result = WriteResult(path=path, created=created)
+
+        self._on_write_callback(abs_path, file_content, "write")
+        return result
+
+    def write_attachment(
+        self, path: str, content: bytes, if_match: str | None = None
+    ) -> WriteResult:
+        """Create or overwrite a non-.md attachment.
+
+        Args:
+            path: Relative attachment path (e.g. ``"assets/diagram.pdf"``).
+            content: Raw bytes to write.
+            if_match: Optional etag from a previous :meth:`read_attachment`
+                call. When provided, the write is only performed if the
+                current file hash matches this value, preventing overwrites
+                of concurrent modifications. Pass ``None`` (default) to skip
+                the check.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.WriteResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current file hash.
+            ValueError: If the path escapes the source directory, has an
+                extension not in the allowlist, or the content exceeds the
+                size limit.
+        """
+        self._check_writable()
+        with self._write_lock:
+            abs_path = self._validate_attachment_path(path)
+            if if_match is not None:
+                if not abs_path.is_file():
+                    raise ConcurrentModificationError(
+                        path,
+                        expected=if_match,
+                        actual="(file does not exist)",
+                    )
+                current_hash = compute_file_hash(abs_path)
+                if current_hash != if_match:
+                    raise ConcurrentModificationError(
+                        path, expected=if_match, actual=current_hash
+                    )
+            if self._max_attachment_size_mb > 0:
+                limit_bytes = int(self._max_attachment_size_mb * 1024 * 1024)
+                if len(content) > limit_bytes:
+                    raise ValueError(
+                        f"Content ({len(content)} bytes) exceeds the limit "
+                        f"of {self._max_attachment_size_mb} MB "
+                        f"({limit_bytes} bytes). "
+                        "Raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB or "
+                        "set it to 0 to disable the limit."
+                    )
+            created = not abs_path.is_file()
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                dir=abs_path.parent,
+                mode="wb",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                tmp.write(content)
+                tmp_name = tmp.name
+            if abs_path.is_file():
+                shutil.copymode(abs_path, tmp_name)
+            try:
+                Path(tmp_name).replace(abs_path)
+            except Exception:
+                Path(tmp_name).unlink(missing_ok=True)
+                raise
+            result = WriteResult(path=path, created=created)
+
+        self._on_write_callback(abs_path, "", "write")
+        return result
+
+    def edit(
+        self,
+        path: str,
+        old_text: str | None = None,
+        new_text: str = "",
+        if_match: str | None = None,
+        line_start: int | None = None,
+        line_end: int | None = None,
+    ) -> EditResult:
+        """Patch a section of a document.
+
+        Supports three modes:
+
+        - **Exact match** (``old_text`` only): verifies *old_text* exists
+          exactly once in the full file content (including frontmatter),
+          replaces it with *new_text*.
+        - **Line-range** (``line_start``/``line_end`` only): replaces the
+          specified line range with *new_text*.
+        - **Scoped match** (both): searches for *old_text* only within the
+          specified line range, allowing disambiguation of repeated text.
+
+        When exact match fails, a normalized comparison is attempted
+        (Unicode NFC, dash/quote normalization, whitespace collapsing).
+        If a unique normalized match is found, it is used and
+        ``match_type="normalized"`` is returned.
+
+        Args:
+            path: Relative document path.
+            old_text: Text to replace. Required for exact-match and
+                scoped-match modes.  Must appear exactly once (in the
+                file or in the line range).
+            new_text: Replacement text. When using line-range mode with an
+                empty string (``""``), the selected lines are replaced with a
+                single blank line. To delete lines entirely, pass the literal
+                content of those lines as *old_text* (scoped-match mode) and
+                supply an empty *new_text*, which removes that text span
+                without inserting a blank line.
+            if_match: Optional etag from a previous :meth:`read` call.
+                When provided, the edit is only performed if the current
+                file hash matches this value, preventing edits based on
+                stale content. Pass ``None`` (default) to skip the check.
+            line_start: First line to replace (1-based, inclusive).
+                Must be provided together with *line_end*.
+            line_end: Last line to replace (1-based, inclusive).
+                Must be provided together with *line_start*.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.EditResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            DocumentNotFoundError: If the file does not exist.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current file hash.
+            EditConflictError: If *old_text* is not found or appears
+                more than once.
+            ValueError: If parameter combination is invalid, or line
+                numbers are out of range.
+        """
+        self._check_writable()
+
+        # --- Parameter validation ---
+        if old_text is not None and not old_text:
+            raise ValueError("old_text must not be empty")
+        has_lines = line_start is not None or line_end is not None
+        if old_text is None and not has_lines:
+            raise ValueError("Must provide old_text, line_start/line_end, or both")
+        if (line_start is None) != (line_end is None):
+            raise ValueError("Must provide both line_start and line_end, not just one")
+        if line_start is not None and line_end is not None:
+            if line_start < 1:
+                raise ValueError("line_start must be >= 1 (lines are 1-based)")
+            if line_start > line_end:
+                raise ValueError(
+                    f"line_start ({line_start}) must be <= line_end ({line_end})"
+                )
+
+        with self._write_lock:
+            abs_path = self._validate_path(path)
+            if not abs_path.is_file():
+                raise DocumentNotFoundError(f"Document not found: {path}")
+
+            if if_match is not None:
+                current_hash = compute_file_hash(abs_path)
+                if current_hash != if_match:
+                    raise ConcurrentModificationError(
+                        path, expected=if_match, actual=current_hash
+                    )
+
+            file_content = abs_path.read_text(encoding="utf-8")
+
+            if has_lines:
+                assert line_start is not None and line_end is not None
+                new_content, match_type = self._edit_with_lines(
+                    file_content,
+                    old_text,
+                    new_text,
+                    line_start,
+                    line_end,
+                    path,
+                )
+            else:
+                assert old_text is not None
+                new_content, match_type = self._edit_with_text(
+                    file_content, old_text, new_text, path
+                )
+
+            with tempfile.NamedTemporaryFile(
+                dir=abs_path.parent,
+                mode="w",
+                encoding="utf-8",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                tmp.write(new_content)
+                tmp_name = tmp.name
+            shutil.copymode(abs_path, tmp_name)
+            try:
+                Path(tmp_name).replace(abs_path)
+            except Exception:
+                Path(tmp_name).unlink(missing_ok=True)
+                raise
+
+            note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
+            self._fts.upsert_note(note)
+            self._on_vector_update(note)
+
+        self._on_write_callback(abs_path, new_content, "edit")
+        return EditResult(path=path, replacements=1, match_type=match_type)
+
+    def _edit_with_lines(
+        self,
+        file_content: str,
+        old_text: str | None,
+        new_text: str,
+        line_start: int,
+        line_end: int,
+        path: str,
+    ) -> tuple[str, str]:
+        """Handle line-range and scoped-match edit modes.
+
+        Returns:
+            Tuple of (new_file_content, match_type).
+        """
+        lines = file_content.split("\n")
+        total_lines = len(lines) - 1 if lines and lines[-1] == "" else len(lines)
+        if line_end > total_lines:
+            raise ValueError(
+                f"line_end ({line_end}) out of range (file has {total_lines} lines)"
+            )
+
+        start_idx = line_start - 1
+        end_idx = line_end
+
+        if old_text is not None:
+            scope = "\n".join(lines[start_idx:end_idx])
+            context_desc = f"lines {line_start}-{line_end} of {path}"
+            new_scope, match_type = self._match_and_replace(
+                scope, old_text, new_text, path, context_desc=context_desc
+            )
+            lines[start_idx:end_idx] = new_scope.split("\n")
+        else:
+            match_type = "exact"
+            replacement_lines = new_text.rstrip("\n").split("\n") if new_text else [""]
+            lines[start_idx:end_idx] = replacement_lines
+
+        return "\n".join(lines), match_type
+
+    def _edit_with_text(
+        self,
+        file_content: str,
+        old_text: str,
+        new_text: str,
+        path: str,
+    ) -> tuple[str, str]:
+        """Handle exact-match edit mode (with normalized fallback).
+
+        Returns:
+            Tuple of (new_file_content, match_type).
+        """
+        return self._match_and_replace(file_content, old_text, new_text, path)
+
+    def _match_and_replace(
+        self,
+        content: str,
+        old_text: str,
+        new_text: str,
+        path: str,
+        context_desc: str | None = None,
+    ) -> tuple[str, str]:
+        """Try exact match, then normalized match, then raise with diagnostics.
+
+        Args:
+            content: The text to search within (full file or line-range scope).
+            old_text: Text to find and replace.
+            new_text: Replacement text.
+            path: Vault-relative file path, used in error messages.
+            context_desc: Optional human-readable context for error messages.
+
+        Returns:
+            Tuple of (new_content, match_type).
+        """
+        location = context_desc or path
+        count = content.count(old_text)
+
+        if count == 1:
+            return content.replace(old_text, new_text, 1), "exact"
+
+        if count > 1:
+            raise EditConflictError(
+                f"old_text appears {count} times in {location}; "
+                f"must appear exactly once"
+            )
+
+        # count == 0: try normalized matching.
+        normalized_content = _normalize_text(content)
+        normalized_old = _normalize_text(old_text)
+        norm_count = normalized_content.count(normalized_old)
+
+        if norm_count == 1:
+            pos_map = _build_position_map(content, normalized_content)
+            norm_start = normalized_content.index(normalized_old)
+            norm_end = norm_start + len(normalized_old)
+            orig_start = pos_map[norm_start]
+            orig_end = pos_map[norm_end]
+            new_content = content[:orig_start] + new_text + content[orig_end:]
+            return new_content, "normalized"
+
+        if norm_count > 1:
+            raise EditConflictError(
+                f"old_text appears {norm_count} times in {location} after "
+                f"normalization; must appear exactly once"
+            )
+
+        # norm_count == 0: raise with diagnostics.
+        diag = _find_closest_match(old_text, content)
+        raise EditConflictError(f"old_text not found in {location}", **diag)
+
+    def delete(self, path: str, if_match: str | None = None) -> DeleteResult:
+        """Delete a document or attachment.
+
+        Removes the file from disk.  For ``.md`` documents, also removes all
+        FTS and embedding index entries.  For attachments, only the file is
+        deleted (no index update).
+
+        Args:
+            path: Relative document or attachment path.
+            if_match: Optional etag from a previous :meth:`read` or
+                :meth:`read_attachment` call. When provided, the deletion is
+                only performed if the current file hash matches this value.
+                Pass ``None`` (default) to skip the check.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.DeleteResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            DocumentNotFoundError: If the file does not exist.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current file hash.
+            ValueError: If the path escapes the source directory, or (for
+                non-.md paths) has an extension not in the attachment
+                allowlist.
+        """
+        self._check_writable()
+        with self._write_lock:
+            if path.endswith(".md"):
+                abs_path = self._validate_path(path)
+                if not abs_path.is_file():
+                    raise DocumentNotFoundError(f"Document not found: {path}")
+                if if_match is not None:
+                    current_hash = compute_file_hash(abs_path)
+                    if current_hash != if_match:
+                        raise ConcurrentModificationError(
+                            path, expected=if_match, actual=current_hash
+                        )
+                abs_path.unlink()
+                self._fts.delete_by_path(path)
+                self._on_vector_dirty(path)
+            else:
+                abs_path = self._validate_attachment_path(path)
+                if not abs_path.is_file():
+                    raise DocumentNotFoundError(f"Attachment not found: {path}")
+                if if_match is not None:
+                    current_hash = compute_file_hash(abs_path)
+                    if current_hash != if_match:
+                        raise ConcurrentModificationError(
+                            path, expected=if_match, actual=current_hash
+                        )
+                abs_path.unlink()
+
+        self._on_write_callback(abs_path, "", "delete")
+        return DeleteResult(path=path)
+
+    def rename(
+        self,
+        old_path: str,
+        new_path: str,
+        if_match: str | None = None,
+        *,
+        update_links: bool = False,
+    ) -> RenameResult:
+        """Rename or move a document or attachment.
+
+        Renames the file on disk.  For ``.md`` documents, also updates FTS
+        and embedding index entries.  For attachments, only the file is moved
+        (no index update).  Creates intermediate directories for *new_path*
+        as needed.
+
+        When *update_links* is ``True`` and *old_path* is a ``.md`` document,
+        every document that links to *old_path* is also updated so its links
+        point to *new_path*.
+
+        Args:
+            old_path: Current relative document or attachment path.
+            new_path: Target relative document or attachment path.
+            if_match: Optional etag from a previous :meth:`read` or
+                :meth:`read_attachment` call for *old_path*. When provided,
+                the rename is only performed if the current file hash matches
+                this value. Pass ``None`` (default) to skip the check.
+            update_links: When ``True``, find all documents that link to
+                *old_path* and rewrite their link targets to point to
+                *new_path*. Only applies to ``.md`` documents.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.RenameResult` with
+            *updated_links* counting source documents successfully updated.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            DocumentNotFoundError: If *old_path* does not exist.
+            DocumentExistsError: If *new_path* already exists.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current hash of *old_path*.
+            ValueError: If either path escapes the source directory, or (for
+                non-.md paths) has an extension not in the attachment
+                allowlist.
+        """
+        self._check_writable()
+        updated_links = 0
+        backlink_callbacks: list[tuple[Path, str]] = []
+
+        with self._write_lock:
+            if old_path.endswith(".md"):
+                old_abs = self._validate_path(old_path)
+                new_abs = self._validate_path(new_path)
+
+                if not old_abs.is_file():
+                    raise DocumentNotFoundError(f"Document not found: {old_path}")
+                if new_abs.is_file():
+                    raise DocumentExistsError(f"Target already exists: {new_path}")
+                if if_match is not None:
+                    current_hash = compute_file_hash(old_abs)
+                    if current_hash != if_match:
+                        raise ConcurrentModificationError(
+                            old_path,
+                            expected=if_match,
+                            actual=current_hash,
+                        )
+
+                backlinks = self._fts.get_backlinks(old_path) if update_links else []
+
+                new_abs.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(old_abs), str(new_abs))
+
+                self._fts.delete_by_path(old_path)
+
+                note = parse_note(new_abs, self._source_dir, self._chunk_strategy)
+                self._fts.upsert_note(note)
+
+                self._on_vector_dirty(old_path)
+                self._on_vector_dirty(note.path)
+
+                callback_content = new_abs.read_text(encoding="utf-8")
+
+                backlink_callbacks = self._update_backlinks(
+                    old_path, new_path, backlinks
+                )
+                updated_links = len(backlink_callbacks)
+            else:
+                old_abs = self._validate_attachment_path(old_path)
+                new_abs = self._validate_attachment_path(new_path)
+
+                if not old_abs.is_file():
+                    raise DocumentNotFoundError(f"Attachment not found: {old_path}")
+                if new_abs.is_file():
+                    raise DocumentExistsError(f"Target already exists: {new_path}")
+                if if_match is not None:
+                    current_hash = compute_file_hash(old_abs)
+                    if current_hash != if_match:
+                        raise ConcurrentModificationError(
+                            old_path,
+                            expected=if_match,
+                            actual=current_hash,
+                        )
+
+                new_abs.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(old_abs), str(new_abs))
+
+                callback_content = ""
+
+        self._on_write_callback(new_abs, callback_content, "rename")
+        for src_abs, src_content in backlink_callbacks:
+            self._on_write_callback(src_abs, src_content, "edit")
+
+        return RenameResult(
+            old_path=old_path,
+            new_path=new_path,
+            updated_links=updated_links,
+        )
+
+    def _update_backlinks(
+        self,
+        old_path: str,
+        new_path: str,
+        backlinks: list[dict[str, Any]],
+    ) -> list[tuple[Path, str]]:
+        """Rewrite source files that link to *old_path* to point to *new_path*.
+
+        Called by :meth:`rename` after the file has already been moved on disk
+        and the FTS index updated.  Each source file is read, all of its links
+        to *old_path* are rewritten in a single pass, then written back.
+
+        This method must be called while ``_write_lock`` is held.  It does
+        **not** fire write callbacks itself — callers must do so after
+        releasing the lock, using the returned list of ``(abs_path, content)``
+        pairs.
+
+        Args:
+            old_path: Vault-relative path that was renamed (the old location).
+            new_path: Vault-relative path after the rename (the new location).
+            backlinks: Rows returned by :meth:`FTSIndex.get_backlinks` before
+                the rename.
+
+        Returns:
+            List of ``(abs_path, new_content)`` pairs for every source
+            document that was successfully rewritten.
+        """
+        if not backlinks:
+            return []
+
+        by_source: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in backlinks:
+            by_source[row["source_path"]].append(row)
+
+        if old_path in by_source:
+            by_source[new_path] = by_source.pop(old_path)
+
+        pending_callbacks: list[tuple[Path, str]] = []
+        for source_path, rows in by_source.items():
+            try:
+                source_abs = self._validate_path(source_path)
+                if not source_abs.is_file():
+                    logger.warning(
+                        "_update_backlinks: skipping %s — file not found",
+                        source_path,
+                    )
+                    continue
+                content = source_abs.read_text(encoding="utf-8")
+                for row in rows:
+                    new_raw = _compute_new_raw_target(
+                        row["link_type"],
+                        row["raw_target"],
+                        row["fragment"],
+                        new_path,
+                        source_path=source_path,
+                        old_path=old_path,
+                    )
+                    content = _apply_link_replacement(
+                        content,
+                        row["link_type"],
+                        row["raw_target"],
+                        new_raw,
+                    )
+                with tempfile.NamedTemporaryFile(
+                    dir=source_abs.parent,
+                    mode="w",
+                    encoding="utf-8",
+                    suffix=".tmp",
+                    delete=False,
+                ) as tmp:
+                    tmp.write(content)
+                    tmp_name = tmp.name
+                shutil.copymode(source_abs, tmp_name)
+                try:
+                    Path(tmp_name).replace(source_abs)
+                except Exception:
+                    Path(tmp_name).unlink(missing_ok=True)
+                    raise
+                updated_note = parse_note(
+                    source_abs, self._source_dir, self._chunk_strategy
+                )
+                self._fts.upsert_note(updated_note)
+                self._on_vector_update(updated_note)
+                pending_callbacks.append((source_abs, content))
+            except (
+                OSError,
+                UnicodeDecodeError,
+                ValueError,
+                sqlite3.Error,
+            ) as exc:
+                logger.warning(
+                    "_update_backlinks: failed to update %s: %s",
+                    source_path,
+                    exc,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "_update_backlinks: unexpected error updating %s: %s",
+                    source_path,
+                    exc,
+                    exc_info=True,
+                )
+        return pending_callbacks

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -8,7 +8,6 @@ and no back-reference to :class:`Collection`.
 from __future__ import annotations
 
 import base64
-import fnmatch
 import logging
 import mimetypes
 import shutil
@@ -30,13 +29,17 @@ from markdown_vault_mcp.exceptions import (
 from markdown_vault_mcp.hashing import compute_etag, compute_file_hash
 from markdown_vault_mcp.scanner import parse_note
 from markdown_vault_mcp.types import (
-    DEFAULT_ATTACHMENT_EXTENSIONS,
     AttachmentContent,
     DeleteResult,
     EditResult,
     NoteContent,
     RenameResult,
     WriteResult,
+)
+from markdown_vault_mcp.utils import (
+    effective_attachment_extensions,
+    is_path_excluded,
+    validate_path,
 )
 from markdown_vault_mcp.utils.links import (
     apply_link_replacement as _apply_link_replacement,
@@ -138,9 +141,7 @@ class DocumentManager:
             Frozenset of lower-case extension strings (without leading dot).
             The special value ``frozenset(["*"])`` means all non-.md files.
         """
-        if self._attachment_extensions is None:
-            return DEFAULT_ATTACHMENT_EXTENSIONS
-        return frozenset(self._attachment_extensions)
+        return effective_attachment_extensions(self._attachment_extensions)
 
     def _is_attachment(self, path: str) -> bool:
         """Return True if *path* is an allowed non-.md attachment.
@@ -167,9 +168,7 @@ class DocumentManager:
             ``True`` if the path matches any pattern in
             ``self._exclude_patterns``.
         """
-        if not self._exclude_patterns:
-            return False
-        return any(fnmatch.fnmatch(path, pat) for pat in self._exclude_patterns)
+        return is_path_excluded(path, self._exclude_patterns)
 
     def _validate_path(self, path: str) -> Path:
         """Resolve a relative path and validate it is inside source_dir.
@@ -184,12 +183,7 @@ class DocumentManager:
             ValueError: If the path escapes the source directory or does
                 not end with ``.md``.
         """
-        if not path.endswith(".md"):
-            raise ValueError(f"Path must end with '.md': {path}")
-        abs_path = (self._source_dir / path).resolve()
-        if not abs_path.is_relative_to(self._source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {path}")
-        return abs_path
+        return validate_path(path, self._source_dir)
 
     def _validate_attachment_path(self, path: str) -> Path:
         """Resolve and validate a non-.md attachment path.

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -8,7 +8,6 @@ dependency injection and no back-reference to :class:`Collection`.
 
 from __future__ import annotations
 
-import fnmatch
 import json
 import logging
 import threading
@@ -18,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 from markdown_vault_mcp.fts_index import _derive_folder
 from markdown_vault_mcp.scanner import parse_note, scan_directory
 from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult
+from markdown_vault_mcp.utils import is_path_excluded
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -111,9 +111,7 @@ class IndexManager:
             ``True`` if the path matches any pattern in
             ``self._exclude_patterns``.
         """
-        if not self._exclude_patterns:
-            return False
-        return any(fnmatch.fnmatch(path, pat) for pat in self._exclude_patterns)
+        return is_path_excluded(path, self._exclude_patterns)
 
     def _require_vectors(self) -> None:
         """Raise ValueError if embedding support is not configured."""
@@ -138,8 +136,10 @@ class IndexManager:
             VectorIndexCompatibilityError,
         )
 
-        assert self._embeddings_path is not None
-        assert self._embedding_provider is not None
+        if self._embeddings_path is None or self._embedding_provider is None:
+            raise RuntimeError(
+                "_require_vectors() must be called before _load_vectors()"
+            )
 
         npy_path = Path(str(self._embeddings_path) + ".npy")
         if npy_path.exists():
@@ -150,13 +150,21 @@ class IndexManager:
             except VectorIndexCompatibilityError as exc:
                 logger.warning("%s Rebuilding embeddings.", exc)
                 self.build_embeddings(force=True)
-                assert self._get_vectors() is not None
+                if self._get_vectors() is None:
+                    raise ValueError(
+                        "Failed to rebuild vector index after a compatibility error."
+                    ) from exc
         else:
             vi = VectorIndex(self._embedding_provider)
             self._set_vectors(vi)
             logger.info("No vector index on disk; created empty VectorIndex")
 
-        return self._get_vectors()  # type: ignore[return-value]
+        result = self._get_vectors()
+        if result is None:
+            raise ValueError(
+                "Failed to rebuild vector index after a compatibility error."
+            )
+        return result
 
     # ------------------------------------------------------------------
     # Index building
@@ -443,8 +451,11 @@ class IndexManager:
         """
         self._require_vectors()
 
-        assert self._embeddings_path is not None
-        assert self._embedding_provider is not None
+        # _require_vectors() guarantees these are not None.
+        if self._embeddings_path is None or self._embedding_provider is None:
+            raise RuntimeError(
+                "_require_vectors() must be called before build_embeddings()"
+            )
 
         from markdown_vault_mcp.vector_index import VectorIndex
 
@@ -454,7 +465,8 @@ class IndexManager:
         else:
             self._load_vectors()
             vectors = self._get_vectors()
-            assert vectors is not None
+            if vectors is None:
+                raise ValueError("Failed to load vector index after _load_vectors()")
             if vectors.count > 0:
                 logger.info(
                     "build_embeddings: index already exists (%d chunks), skipping",
@@ -498,7 +510,8 @@ class IndexManager:
                 )
 
         vectors = self._get_vectors()
-        assert vectors is not None
+        if vectors is None:
+            raise ValueError("Vector index unexpectedly None after initialisation")
         total = len(texts)
         for start in range(0, total, _EMBEDDING_BATCH_SIZE):
             end = min(start + _EMBEDDING_BATCH_SIZE, total)

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -1,0 +1,702 @@
+"""Index build, reindex, embedding, and deferred-flush manager.
+
+Handles FTS index construction, incremental reindexing via
+:class:`~markdown_vault_mcp.tracker.ChangeTracker`, vector embedding
+lifecycle, and the two-phase deferred embedding flush — all with
+dependency injection and no back-reference to :class:`Collection`.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from markdown_vault_mcp.fts_index import _derive_folder
+from markdown_vault_mcp.scanner import parse_note, scan_directory
+from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.providers import EmbeddingProvider
+    from markdown_vault_mcp.scanner import ChunkStrategy
+    from markdown_vault_mcp.tracker import ChangeTracker
+    from markdown_vault_mcp.vector_index import VectorIndex
+
+logger = logging.getLogger(__name__)
+
+# Maximum chunks per embedding provider call.  Keeps memory bounded during
+# build_embeddings() — FastEmbed/ONNX can allocate pathologically large buffers
+# when the entire corpus is sent in one batch (see issue #159).
+_EMBEDDING_BATCH_SIZE = 4
+
+# Seconds between automatic background flushes of dirty embeddings to disk.
+# Write operations mark documents as dirty; the flush re-embeds them in bulk.
+_EMBEDDING_FLUSH_INTERVAL = 30
+
+
+class IndexManager:
+    """Manages index building, reindexing, and embedding lifecycle.
+
+    Args:
+        fts: The FTS index to populate and query.
+        tracker: Hash-based change tracker for incremental reindexing.
+        source_dir: Absolute path to the vault root directory.
+        embeddings_path: Base path for ``.npy`` / ``.json`` sidecar files.
+            ``None`` disables embedding support.
+        embedding_provider: Provider used to generate embeddings.
+        write_lock: Shared re-entrant lock serialising write operations.
+        chunk_strategy: Strategy for splitting documents into chunks.
+        exclude_patterns: Glob patterns for paths to exclude from indexing.
+        required_frontmatter: If provided, documents missing any listed
+            field are excluded from the index entirely.
+        indexed_frontmatter_fields: Frontmatter keys promoted to the
+            ``document_tags`` table for structured filtering.
+        get_vectors: Callback returning the current
+            :class:`~markdown_vault_mcp.vector_index.VectorIndex` (or
+            ``None``).
+        set_vectors: Callback to set the vector index on the owner.
+    """
+
+    def __init__(
+        self,
+        fts: FTSIndex,
+        tracker: ChangeTracker,
+        source_dir: Path,
+        *,
+        embeddings_path: Path | None = None,
+        embedding_provider: EmbeddingProvider | None = None,
+        write_lock: threading.RLock,
+        chunk_strategy: ChunkStrategy,
+        exclude_patterns: list[str] | None = None,
+        required_frontmatter: list[str] | None = None,
+        indexed_frontmatter_fields: list[str] | None = None,
+        get_vectors: Callable[[], VectorIndex | None],
+        set_vectors: Callable[[VectorIndex | None], None],
+    ) -> None:
+        self._fts = fts
+        self._tracker = tracker
+        self._source_dir = source_dir
+        self._embeddings_path = embeddings_path
+        self._embedding_provider = embedding_provider
+        self._write_lock = write_lock
+        self._chunk_strategy = chunk_strategy
+        self._exclude_patterns = exclude_patterns
+        self._required_frontmatter = required_frontmatter
+        self._indexed_frontmatter_fields: list[str] = indexed_frontmatter_fields or []
+        self._get_vectors = get_vectors
+        self._set_vectors = set_vectors
+
+        # Deferred embedding state.
+        self._dirty_embeddings: set[str] = set()
+        self._embedding_flush_timer: threading.Timer | None = None
+        self._embedding_flush_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_path_excluded(self, path: str) -> bool:
+        """Check whether *path* matches any configured exclude pattern.
+
+        Args:
+            path: Relative POSIX path string.
+
+        Returns:
+            ``True`` if the path matches any pattern in
+            ``self._exclude_patterns``.
+        """
+        if not self._exclude_patterns:
+            return False
+        return any(fnmatch.fnmatch(path, pat) for pat in self._exclude_patterns)
+
+    def _require_vectors(self) -> None:
+        """Raise ValueError if embedding support is not configured."""
+        if self._embedding_provider is None or self._embeddings_path is None:
+            raise ValueError(
+                "Embeddings require both 'embedding_provider' and "
+                "'embeddings_path' to be configured."
+            )
+
+    def _load_vectors(self) -> VectorIndex:
+        """Load or return the cached VectorIndex.
+
+        Returns:
+            A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+        """
+        vectors = self._get_vectors()
+        if vectors is not None:
+            return vectors
+
+        from markdown_vault_mcp.vector_index import (
+            VectorIndex,
+            VectorIndexCompatibilityError,
+        )
+
+        assert self._embeddings_path is not None
+        assert self._embedding_provider is not None
+
+        npy_path = Path(str(self._embeddings_path) + ".npy")
+        if npy_path.exists():
+            try:
+                vi = VectorIndex.load(self._embeddings_path, self._embedding_provider)
+                self._set_vectors(vi)
+                logger.info("Loaded vector index from %s", self._embeddings_path)
+            except VectorIndexCompatibilityError as exc:
+                logger.warning("%s Rebuilding embeddings.", exc)
+                self.build_embeddings(force=True)
+                assert self._get_vectors() is not None
+        else:
+            vi = VectorIndex(self._embedding_provider)
+            self._set_vectors(vi)
+            logger.info("No vector index on disk; created empty VectorIndex")
+
+        return self._get_vectors()  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Index building
+    # ------------------------------------------------------------------
+
+    def build_index(self, *, force: bool = False) -> IndexStats:
+        """Scan source_dir and build the FTS index.
+
+        If the index already contains documents and *force* is ``False``,
+        this is a no-op.  ``force=True`` drops all existing data and rebuilds
+        from scratch.
+
+        Note: the caller is responsible for setting any ``_initialized``
+        flag after this method returns.
+
+        Args:
+            force: When ``True``, drop and rebuild the index unconditionally.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.IndexStats` describing what
+            was indexed.
+        """
+        if force:
+            logger.info("build_index(force=True): dropping and rebuilding index")
+            for row in self._fts.list_notes():
+                self._fts.delete_by_path(row["path"])
+
+        logger.info("build_index: scanning %s", self._source_dir)
+
+        notes = list(
+            scan_directory(
+                self._source_dir,
+                required_frontmatter=self._required_frontmatter,
+                chunk_strategy=self._chunk_strategy,
+                exclude_patterns=self._exclude_patterns,
+            )
+        )
+
+        total_chunks = 0
+        errored = 0
+        for note in notes:
+            try:
+                total_chunks += self._fts.upsert_note(note)
+            except Exception:
+                errored += 1
+                logger.warning(
+                    "build_index: failed to index %s",
+                    note.path,
+                    exc_info=True,
+                )
+
+        # Purge stale excluded docs from a persistent index that was built
+        # before exclude_patterns were configured (upgrade scenario, #255).
+        indexed_paths = {note.path for note in notes}
+        if self._exclude_patterns:
+            vectors = self._get_vectors()
+            if (
+                vectors is None
+                and self._embedding_provider is not None
+                and self._embeddings_path is not None
+            ):
+                self._load_vectors()
+                vectors = self._get_vectors()
+
+            purged = 0
+            for row in self._fts.list_notes():
+                if row["path"] not in indexed_paths and self._is_path_excluded(
+                    row["path"]
+                ):
+                    self._fts.delete_by_path(row["path"])
+                    if vectors is not None:
+                        vectors.delete_by_path(row["path"])
+                    purged += 1
+
+            if purged and vectors is not None and self._embeddings_path is not None:
+                vectors.save(self._embeddings_path)
+
+        # Count how many files were skipped due to required_frontmatter.
+        all_files = list(self._source_dir.glob("**/*.md"))
+        skipped = len(all_files) - len(notes)
+
+        # Resolve vault-wide wikilinks now that all documents are indexed.
+        self._fts.resolve_vault_wikilinks()
+
+        # Update tracker state so reindex() knows the baseline.
+        self._tracker.update_state(notes)
+
+        if errored:
+            logger.warning(
+                "build_index: indexed %d documents, %d chunks (%d skipped, %d errors)",
+                len(notes) - errored,
+                total_chunks,
+                skipped,
+                errored,
+            )
+        else:
+            logger.info(
+                "build_index: indexed %d documents, %d chunks (%d skipped)",
+                len(notes),
+                total_chunks,
+                skipped,
+            )
+        return IndexStats(
+            documents_indexed=len(notes) - errored,
+            chunks_indexed=total_chunks,
+            skipped=max(skipped, 0),
+        )
+
+    # ------------------------------------------------------------------
+    # Incremental reindex
+    # ------------------------------------------------------------------
+
+    def reindex(self) -> ReindexResult:
+        """Incrementally update the index based on file changes.
+
+        Uses :class:`~markdown_vault_mcp.tracker.ChangeTracker` to detect
+        which files have been added, modified, or deleted since the last
+        scan.  Only changed files are re-parsed and re-indexed.  Files
+        matching ``exclude_patterns`` are skipped, and any previously indexed
+        documents that now match the patterns are purged.
+
+        Thread-safety: the filesystem scan runs without holding
+        ``_write_lock`` (read-only), then the mutation phase acquires the
+        lock to prevent races with concurrent write/edit/delete/rename
+        operations.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.ReindexResult` with counts
+            of changes applied.
+        """
+        # Phase 1: scan (outside lock — read-only filesystem walk + hashing).
+        changes = self._tracker.detect_changes(self._source_dir)
+        logger.info(
+            "reindex: %d added, %d modified, %d deleted, %d unchanged",
+            len(changes.added),
+            len(changes.modified),
+            len(changes.deleted),
+            changes.unchanged,
+        )
+
+        # Pre-parse notes outside the lock to minimise lock hold time.
+        parsed: list[tuple[str, ParsedNote]] = []
+        for path in changes.added + changes.modified:
+            if self._is_path_excluded(path):
+                logger.debug("reindex: excluding %s (matched exclude pattern)", path)
+                continue
+
+            abs_path = self._source_dir / path
+            try:
+                note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
+            except (UnicodeDecodeError, OSError) as exc:
+                logger.warning("reindex: skipping %s — %s", path, exc)
+                continue
+            except Exception as exc:
+                logger.warning(
+                    "reindex: skipping %s — parse error (%s)",
+                    path,
+                    exc,
+                    exc_info=True,
+                )
+                continue
+
+            if self._required_frontmatter:
+                missing = [
+                    f for f in self._required_frontmatter if f not in note.frontmatter
+                ]
+                if missing:
+                    logger.info(
+                        "reindex: skipping %s — missing frontmatter: %s",
+                        path,
+                        missing,
+                    )
+                    continue
+
+            parsed.append((path, note))
+
+        # Phase 2: apply mutations (inside lock).
+        with self._write_lock:
+            vectors = self._get_vectors()
+
+            for path in changes.deleted:
+                self._fts.delete_by_path(path)
+                if vectors is not None:
+                    vectors.delete_by_path(path)
+
+            # Purge stale excluded docs (issue #255).
+            stale_excluded = 0
+            if self._exclude_patterns:
+                if (
+                    vectors is None
+                    and self._embedding_provider is not None
+                    and self._embeddings_path is not None
+                ):
+                    self._load_vectors()
+                    vectors = self._get_vectors()
+
+                for row in self._fts.list_notes():
+                    if self._is_path_excluded(row["path"]):
+                        self._fts.delete_by_path(row["path"])
+                        if vectors is not None:
+                            vectors.delete_by_path(row["path"])
+                        stale_excluded += 1
+                if stale_excluded:
+                    logger.info(
+                        "reindex: purged %d stale excluded document(s)",
+                        stale_excluded,
+                    )
+
+            indexed_added = 0
+            indexed_modified = 0
+            added_set = set(changes.added)
+
+            for path, note in parsed:
+                try:
+                    self._fts.upsert_note(note)
+                except Exception:
+                    logger.warning("reindex: failed to index %s", path, exc_info=True)
+                    continue
+                if path in added_set:
+                    indexed_added += 1
+                else:
+                    indexed_modified += 1
+
+                if vectors is not None and self._embeddings_path is not None:
+                    vectors.delete_by_path(note.path)
+                    texts = [c.content for c in note.chunks]
+                    meta = [
+                        {
+                            "path": note.path,
+                            "title": note.title,
+                            "folder": _derive_folder(note.path),
+                            "heading": c.heading,
+                            "content": c.content,
+                        }
+                        for c in note.chunks
+                    ]
+                    if texts:
+                        vectors.add(texts, meta)
+
+            if vectors is not None and self._embeddings_path is not None:
+                vectors.save(self._embeddings_path)
+
+            # Re-resolve vault-wide wikilinks.
+            self._fts.resolve_vault_wikilinks()
+
+            # Rebuild tracker state from current FTS index contents.
+            state_notes: list[ParsedNote] = [
+                ParsedNote(
+                    path=r["path"],
+                    frontmatter={},
+                    title=r["title"],
+                    chunks=[],
+                    content_hash=r["content_hash"],
+                    modified_at=r["modified_at"],
+                )
+                for r in self._fts.list_notes()
+            ]
+            self._tracker.update_state(state_notes)
+
+        return ReindexResult(
+            added=indexed_added,
+            modified=indexed_modified,
+            deleted=len(changes.deleted),
+            unchanged=changes.unchanged,
+        )
+
+    # ------------------------------------------------------------------
+    # Embeddings
+    # ------------------------------------------------------------------
+
+    def build_embeddings(self, *, force: bool = False) -> int:
+        """Build the vector index from all chunks currently in the FTS index.
+
+        Args:
+            force: If ``True``, rebuild from scratch even if a vector index
+                already exists on disk.
+
+        Returns:
+            Total number of chunks embedded.
+
+        Raises:
+            ValueError: If ``embedding_provider`` or ``embeddings_path`` is
+                not configured.
+        """
+        self._require_vectors()
+
+        assert self._embeddings_path is not None
+        assert self._embedding_provider is not None
+
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        if force:
+            vi = VectorIndex(self._embedding_provider)
+            self._set_vectors(vi)
+        else:
+            self._load_vectors()
+            vectors = self._get_vectors()
+            assert vectors is not None
+            if vectors.count > 0:
+                logger.info(
+                    "build_embeddings: index already exists (%d chunks), skipping",
+                    vectors.count,
+                )
+                return vectors.count
+
+        rows = self._fts.list_notes()
+        num_notes = len(rows)
+        logger.info("build_embeddings: parsing %d notes into chunks", num_notes)
+        texts: list[str] = []
+        meta: list[dict[str, Any]] = []
+
+        for i, row in enumerate(rows, 1):
+            path = row["path"]
+            title = row["title"]
+            folder = row["folder"]
+            abs_path = self._source_dir / path
+            try:
+                note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
+            except (UnicodeDecodeError, OSError) as exc:
+                logger.warning("build_embeddings: skipping %s — %s", path, exc)
+                continue
+            for chunk in note.chunks:
+                texts.append(chunk.content)
+                meta.append(
+                    {
+                        "path": path,
+                        "title": title,
+                        "folder": folder,
+                        "heading": chunk.heading,
+                        "content": chunk.content,
+                    }
+                )
+            if i % 100 == 0 or i == num_notes:
+                logger.info(
+                    "build_embeddings: parsed %d/%d notes (%d chunks so far)",
+                    i,
+                    num_notes,
+                    len(texts),
+                )
+
+        vectors = self._get_vectors()
+        assert vectors is not None
+        total = len(texts)
+        for start in range(0, total, _EMBEDDING_BATCH_SIZE):
+            end = min(start + _EMBEDDING_BATCH_SIZE, total)
+            vectors.add(texts[start:end], meta[start:end])
+            logger.info(
+                "build_embeddings: embedded chunks %d-%d of %d",
+                start + 1,
+                end,
+                total,
+            )
+
+        if total > 0:
+            vectors.save(self._embeddings_path)
+            logger.info("build_embeddings: embedded and saved %d chunks", total)
+        else:
+            logger.info("build_embeddings: nothing to embed")
+        return total
+
+    def embeddings_status(self) -> dict[str, Any]:
+        """Return status information about the vector index.
+
+        Returns:
+            Dict with keys ``provider``, ``chunk_count``, ``path``,
+            ``available``.
+        """
+        if self._embedding_provider is None or self._embeddings_path is None:
+            return {
+                "available": False,
+                "provider": None,
+                "chunk_count": 0,
+                "path": None,
+            }
+
+        vectors = self._get_vectors()
+        count = 0
+        if vectors is not None:
+            count = vectors.count
+        else:
+            npy_path = Path(str(self._embeddings_path) + ".npy")
+            if npy_path.exists():
+                json_path = Path(str(self._embeddings_path) + ".json")
+                if json_path.exists():
+                    try:
+                        with json_path.open(encoding="utf-8") as fh:
+                            loaded_meta = json.load(fh)
+                        if isinstance(loaded_meta, list):
+                            count = len(loaded_meta)
+                        else:
+                            count = len(loaded_meta.get("rows", []))
+                    except (OSError, json.JSONDecodeError) as exc:
+                        logger.warning(
+                            "embeddings_status: could not read metadata from %s — %s",
+                            json_path,
+                            exc,
+                        )
+
+        return {
+            "available": True,
+            "provider": type(self._embedding_provider).__name__,
+            "chunk_count": count,
+            "path": str(self._embeddings_path),
+        }
+
+    # ------------------------------------------------------------------
+    # Deferred embedding flush
+    # ------------------------------------------------------------------
+
+    def update_vector_index(self, note: ParsedNote) -> None:
+        """Mark a document for deferred embedding update.
+
+        The actual re-embedding and save happen during the next flush
+        (periodic timer, semantic search, or close).
+
+        Args:
+            note: Parsed document to mark dirty.
+        """
+        if self._embeddings_path is None or self._embedding_provider is None:
+            return
+        with self._embedding_flush_lock:
+            self._dirty_embeddings.add(note.path)
+        self._schedule_embedding_flush()
+
+    def mark_dirty(self, path: str) -> None:
+        """Mark a path as needing deferred embedding update.
+
+        Used by write operations (e.g. delete, rename) that need to mark
+        a path dirty without a full :class:`ParsedNote`.
+
+        Args:
+            path: Relative vault path.
+        """
+        if self._embeddings_path is None or self._embedding_provider is None:
+            return
+        with self._embedding_flush_lock:
+            self._dirty_embeddings.add(path)
+        self._schedule_embedding_flush()
+
+    def remove_from_dirty(self, path: str) -> None:
+        """Remove a path from the dirty embeddings set.
+
+        Called when a document is deleted and its embedding cleanup is
+        handled through the normal dirty-flush mechanism.
+
+        Args:
+            path: Relative vault path to remove.
+        """
+        with self._embedding_flush_lock:
+            self._dirty_embeddings.discard(path)
+
+    def _schedule_embedding_flush(self) -> None:
+        """Schedule a deferred flush of dirty embeddings."""
+        with self._embedding_flush_lock:
+            if self._embedding_flush_timer is not None:
+                self._embedding_flush_timer.cancel()
+            self._embedding_flush_timer = threading.Timer(
+                _EMBEDDING_FLUSH_INTERVAL,
+                self.flush_dirty_embeddings,
+            )
+            self._embedding_flush_timer.daemon = True
+            self._embedding_flush_timer.start()
+
+    def flush_dirty_embeddings(self) -> None:
+        """Re-embed all dirty documents and save the vector index once.
+
+        Called by the periodic timer, before semantic search, and on close.
+        Thread-safe: the dirty-set swap is atomic under
+        ``_embedding_flush_lock``; Phase 2 vector mutations are serialised
+        by ``_write_lock``.
+
+        Two-phase design to minimise lock hold time:
+
+        1. **Outside** ``_write_lock``: parse each dirty document and call
+           the (potentially slow) embedding provider.
+        2. **Inside** ``_write_lock``: apply the fast numpy mutations
+           (delete old rows, append pre-computed vectors, save).
+        """
+        if self._embeddings_path is None or self._embedding_provider is None:
+            return
+
+        with self._embedding_flush_lock:
+            if self._embedding_flush_timer is not None:
+                self._embedding_flush_timer.cancel()
+                self._embedding_flush_timer = None
+
+            if not self._dirty_embeddings:
+                return
+            paths = self._dirty_embeddings.copy()
+            self._dirty_embeddings.clear()
+
+        # Phase 1: parse and embed OUTSIDE _write_lock.
+        pre_embedded: list[
+            tuple[str, list[list[float]] | None, list[dict[str, Any]] | None]
+        ] = []
+        for path in paths:
+            abs_path = self._source_dir / path
+            if abs_path.is_file() and path.endswith(".md"):
+                try:
+                    note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
+                    texts = [c.content for c in note.chunks]
+                    meta = [
+                        {
+                            "path": note.path,
+                            "title": note.title,
+                            "folder": _derive_folder(note.path),
+                            "heading": c.heading,
+                            "content": c.content,
+                        }
+                        for c in note.chunks
+                    ]
+                    if texts:
+                        raw_vecs = self._embedding_provider.embed(texts)
+                        pre_embedded.append((path, raw_vecs, meta))
+                    else:
+                        pre_embedded.append((path, None, None))
+                except (UnicodeDecodeError, OSError) as exc:
+                    logger.warning("Deferred embedding failed for %s: %s", path, exc)
+                    pre_embedded.append((path, None, None))
+            else:
+                pre_embedded.append((path, None, None))
+
+        # Phase 2: mutate vector index under _write_lock.
+        with self._write_lock:
+            vectors = self._load_vectors()
+
+            for entry in pre_embedded:
+                vectors.delete_by_path(entry[0])
+                if entry[1] is not None and entry[2]:
+                    vectors.add_vectors(entry[1], entry[2])
+
+            vectors.save(self._embeddings_path)
+            logger.debug("Flushed deferred embeddings for %d paths", len(paths))
+
+    def cancel_flush_timer(self) -> None:
+        """Cancel any pending flush timer without flushing.
+
+        Called during shutdown before the synchronous flush.
+        """
+        with self._embedding_flush_lock:
+            if self._embedding_flush_timer is not None:
+                self._embedding_flush_timer.cancel()
+                self._embedding_flush_timer = None

--- a/src/markdown_vault_mcp/managers/link.py
+++ b/src/markdown_vault_mcp/managers/link.py
@@ -8,9 +8,8 @@ receives only :class:`~markdown_vault_mcp.fts_index.FTSIndex` and a
 
 from __future__ import annotations
 
-import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.types import (
     BacklinkInfo,
@@ -19,6 +18,7 @@ from markdown_vault_mcp.types import (
     NoteInfo,
     OutlinkInfo,
 )
+from markdown_vault_mcp.utils import fts_row_to_note_info, validate_path
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -26,34 +26,6 @@ if TYPE_CHECKING:
     from markdown_vault_mcp.fts_index import FTSIndex
 
 logger = logging.getLogger(__name__)
-
-
-def _fts_row_to_note_info(row: dict[str, Any]) -> NoteInfo:
-    """Convert an FTSIndex row dict to a :class:`NoteInfo`.
-
-    Args:
-        row: Dict returned by :meth:`FTSIndex.list_notes`,
-            :meth:`FTSIndex.get_note`, or :meth:`FTSIndex.get_orphan_notes`.
-
-    Returns:
-        A populated :class:`NoteInfo` instance.
-    """
-    frontmatter: dict[str, Any] = {}
-    raw_json = row.get("frontmatter_json")
-    if raw_json:
-        try:
-            frontmatter = json.loads(raw_json)
-        except (json.JSONDecodeError, TypeError):
-            logger.warning(
-                "Could not parse frontmatter_json for path %s", row.get("path")
-            )
-    return NoteInfo(
-        path=row["path"],
-        title=row["title"],
-        folder=row["folder"],
-        frontmatter=frontmatter,
-        modified_at=row["modified_at"],
-    )
 
 
 class LinkManager:
@@ -82,11 +54,7 @@ class LinkManager:
             ValueError: If the path does not end with ``.md`` or escapes
                 the source directory.
         """
-        if not path.endswith(".md"):
-            raise ValueError(f"Path must end with '.md': {path}")
-        abs_path = (self._source_dir / path).resolve()
-        if not abs_path.is_relative_to(self._source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {path}")
+        validate_path(path, self._source_dir)
 
     def _require_note(self, path: str) -> None:
         """Validate *path* and ensure a document exists in the index.
@@ -206,7 +174,7 @@ class LinkManager:
             ordered by path.
         """
         rows = self._fts.get_orphan_notes()
-        return [_fts_row_to_note_info(r) for r in rows]
+        return [fts_row_to_note_info(r) for r in rows]
 
     def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]:
         """Return the documents with the most inbound links.
@@ -241,6 +209,10 @@ class LinkManager:
         Raises:
             ValueError: If *source* or *target* is not found in the index.
         """
+        # Note: we use _validate_path (not _require_note) here because
+        # FTSIndex.get_connection_path already raises ValueError for
+        # nonexistent source/target paths, and handles the trivial
+        # source == target case by returning [source].
         self._validate_path(source)
         self._validate_path(target)
         return self._fts.get_connection_path(source, target, max_depth=max_depth)

--- a/src/markdown_vault_mcp/managers/link.py
+++ b/src/markdown_vault_mcp/managers/link.py
@@ -1,0 +1,246 @@
+"""Link graph query manager.
+
+Handles all link-related queries (backlinks, outlinks, broken links,
+orphans, most-linked, connection paths) with dependency injection —
+receives only :class:`~markdown_vault_mcp.fts_index.FTSIndex` and a
+``source_dir`` path, no back-reference to :class:`Collection`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from markdown_vault_mcp.types import (
+    BacklinkInfo,
+    BrokenLinkInfo,
+    MostLinkedNote,
+    NoteInfo,
+    OutlinkInfo,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from markdown_vault_mcp.fts_index import FTSIndex
+
+logger = logging.getLogger(__name__)
+
+
+def _fts_row_to_note_info(row: dict[str, Any]) -> NoteInfo:
+    """Convert an FTSIndex row dict to a :class:`NoteInfo`.
+
+    Args:
+        row: Dict returned by :meth:`FTSIndex.list_notes`,
+            :meth:`FTSIndex.get_note`, or :meth:`FTSIndex.get_orphan_notes`.
+
+    Returns:
+        A populated :class:`NoteInfo` instance.
+    """
+    frontmatter: dict[str, Any] = {}
+    raw_json = row.get("frontmatter_json")
+    if raw_json:
+        try:
+            frontmatter = json.loads(raw_json)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Could not parse frontmatter_json for path %s", row.get("path")
+            )
+    return NoteInfo(
+        path=row["path"],
+        title=row["title"],
+        folder=row["folder"],
+        frontmatter=frontmatter,
+        modified_at=row["modified_at"],
+    )
+
+
+class LinkManager:
+    """Manages link graph queries against the FTS index.
+
+    Args:
+        fts: The FTS index to query.
+        source_dir: Absolute path to the vault root directory.
+    """
+
+    def __init__(self, fts: FTSIndex, source_dir: Path) -> None:
+        self._fts = fts
+        self._source_dir = source_dir
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _validate_path(self, path: str) -> None:
+        """Validate that *path* ends with ``.md`` and stays inside source_dir.
+
+        Args:
+            path: Relative vault path to validate.
+
+        Raises:
+            ValueError: If the path does not end with ``.md`` or escapes
+                the source directory.
+        """
+        if not path.endswith(".md"):
+            raise ValueError(f"Path must end with '.md': {path}")
+        abs_path = (self._source_dir / path).resolve()
+        if not abs_path.is_relative_to(self._source_dir.resolve()):
+            raise ValueError(f"Path traversal detected: {path}")
+
+    def _require_note(self, path: str) -> None:
+        """Validate *path* and ensure a document exists in the index.
+
+        Args:
+            path: Relative vault path.
+
+        Raises:
+            ValueError: If validation fails or the document is not indexed.
+        """
+        self._validate_path(path)
+        if self._fts.get_note(path) is None:
+            raise ValueError(f"Document not found: {path}")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_backlinks(
+        self, path: str, *, limit: int | None = None
+    ) -> list[BacklinkInfo]:
+        """Return all documents that link to the given document.
+
+        Args:
+            path: Relative path of the target document
+                (e.g. ``"notes/topic.md"``).
+            limit: Maximum number of results to return.  ``None`` means
+                unlimited.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.BacklinkInfo` objects
+            for each document that contains a link pointing to ``path``.
+
+        Raises:
+            ValueError: If no document exists at the given path.
+        """
+        self._require_note(path)
+        rows = self._fts.get_backlinks(path, limit=limit)
+        return [
+            BacklinkInfo(
+                source_path=row["source_path"],
+                source_title=row["source_title"],
+                link_text=row["link_text"],
+                link_type=row["link_type"],
+                fragment=row["fragment"],
+                raw_target=row["raw_target"],
+            )
+            for row in rows
+        ]
+
+    def get_outlinks(self, path: str, *, limit: int | None = None) -> list[OutlinkInfo]:
+        """Return all links from the given document to other documents.
+
+        The ``exists`` field on each
+        :class:`~markdown_vault_mcp.types.OutlinkInfo` indicates whether the
+        target document is currently indexed.
+
+        Args:
+            path: Relative path of the source document
+                (e.g. ``"notes/topic.md"``).
+            limit: Maximum number of results to return.  ``None`` means
+                unlimited.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.OutlinkInfo` objects for
+            each link originating from ``path``.
+
+        Raises:
+            ValueError: If no document exists at the given path.
+        """
+        self._require_note(path)
+        rows = self._fts.get_outlinks(path, limit=limit)
+        return [
+            OutlinkInfo(
+                target_path=row["target_path"],
+                link_text=row["link_text"],
+                link_type=row["link_type"],
+                fragment=row["fragment"],
+                exists=bool(row["target_exists"]),
+                raw_target=row["raw_target"],
+            )
+            for row in rows
+        ]
+
+    def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
+        """Return all links whose target does not exist in the collection.
+
+        Args:
+            folder: If provided, restrict to source documents in this folder
+                (exact match or sub-folder prefix).
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.BrokenLinkInfo` objects.
+        """
+        rows = self._fts.get_broken_links(folder=folder)
+        return [
+            BrokenLinkInfo(
+                source_path=row["source_path"],
+                source_title=row["source_title"],
+                target_path=row["target_path"],
+                link_text=row["link_text"],
+                link_type=row["link_type"],
+                fragment=row["fragment"],
+                raw_target=row["raw_target"],
+            )
+            for row in rows
+        ]
+
+    def get_orphan_notes(self) -> list[NoteInfo]:
+        """Return all documents with no inbound or outbound links.
+
+        A document is an orphan if it has zero outlinks and is not referenced
+        by any other document's links.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.NoteInfo` objects,
+            ordered by path.
+        """
+        rows = self._fts.get_orphan_notes()
+        return [_fts_row_to_note_info(r) for r in rows]
+
+    def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]:
+        """Return the documents with the most inbound links.
+
+        Args:
+            limit: Maximum number of results to return. Default 10.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.MostLinkedNote` ordered
+            by backlink_count descending.
+        """
+        return [MostLinkedNote(**row) for row in self._fts.get_most_linked(limit=limit)]
+
+    def get_connection_path(
+        self, source: str, target: str, *, max_depth: int = 10
+    ) -> list[str] | None:
+        """Return the shortest undirected path between two notes.
+
+        Treats the link graph as undirected — a link in either direction
+        counts as a connection.  Uses BFS with a configurable depth cap.
+
+        Args:
+            source: Vault-relative path of the starting note.
+            target: Vault-relative path of the destination note.
+            max_depth: Maximum path length in edges.  Clamped to ``[1, 10]``.
+                Defaults to ``10``.
+
+        Returns:
+            Ordered list of vault-relative paths from *source* to *target*
+            (inclusive), or ``None`` if unreachable within *max_depth* hops.
+
+        Raises:
+            ValueError: If *source* or *target* is not found in the index.
+        """
+        self._validate_path(source)
+        self._validate_path(target)
+        return self._fts.get_connection_path(source, target, max_depth=max_depth)

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -26,6 +26,12 @@ from markdown_vault_mcp.types import (
     SearchResult,
     SimilarItem,
 )
+from markdown_vault_mcp.utils import (
+    effective_attachment_extensions,
+    fts_row_to_note_info,
+    is_path_excluded,
+    validate_path,
+)
 
 if TYPE_CHECKING:
     import builtins
@@ -43,34 +49,6 @@ _RRF_K = 60
 
 # Maximum folder peers returned by get_context().
 _CONTEXT_FOLDER_PEERS_LIMIT = 20
-
-
-def _fts_row_to_note_info(row: dict[str, Any]) -> NoteInfo:
-    """Convert an FTSIndex row dict to a :class:`NoteInfo`.
-
-    Args:
-        row: Dict returned by :meth:`FTSIndex.list_notes`,
-            :meth:`FTSIndex.get_note`, or :meth:`FTSIndex.get_recent`.
-
-    Returns:
-        A populated :class:`NoteInfo` instance.
-    """
-    frontmatter: dict[str, Any] = {}
-    raw_json = row.get("frontmatter_json")
-    if raw_json:
-        try:
-            frontmatter = json.loads(raw_json)
-        except (json.JSONDecodeError, TypeError):
-            logger.warning(
-                "Could not parse frontmatter_json for path %s", row.get("path")
-            )
-    return NoteInfo(
-        path=row["path"],
-        title=row["title"],
-        folder=row["folder"],
-        frontmatter=frontmatter,
-        modified_at=row["modified_at"],
-    )
 
 
 class SearchManager:
@@ -149,11 +127,7 @@ class SearchManager:
             ValueError: If the path does not end with ``.md`` or escapes
                 the source directory.
         """
-        if not path.endswith(".md"):
-            raise ValueError(f"Path must end with '.md': {path}")
-        abs_path = (self._source_dir / path).resolve()
-        if not abs_path.is_relative_to(self._source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {path}")
+        validate_path(path, self._source_dir)
 
     def _require_vectors(self) -> None:
         """Raise ValueError if semantic search is not configured."""
@@ -177,8 +151,10 @@ class SearchManager:
             VectorIndexCompatibilityError,
         )
 
-        assert self._embeddings_path is not None
-        assert self._embedding_provider is not None
+        if self._embeddings_path is None or self._embedding_provider is None:
+            raise RuntimeError(
+                "_require_vectors() must be called before _load_vectors()"
+            )
 
         npy_path = Path(str(self._embeddings_path) + ".npy")
         if npy_path.exists():
@@ -190,7 +166,10 @@ class SearchManager:
             except VectorIndexCompatibilityError as exc:
                 logger.warning("%s Rebuilding embeddings.", exc)
                 self._rebuild_embeddings()
-                assert self._vectors is not None
+                if self._vectors is None:
+                    raise ValueError(
+                        "Failed to rebuild vector index after a compatibility error."
+                    ) from exc
         else:
             self._vectors = VectorIndex(self._embedding_provider)
             logger.info("No vector index on disk; created empty VectorIndex")
@@ -232,11 +211,7 @@ class SearchManager:
             Frozenset of lower-case extension strings (without leading dot).
             The special value ``frozenset(["*"])`` means all non-.md files.
         """
-        from markdown_vault_mcp.types import DEFAULT_ATTACHMENT_EXTENSIONS
-
-        if self._attachment_extensions is None:
-            return DEFAULT_ATTACHMENT_EXTENSIONS
-        return frozenset(self._attachment_extensions)
+        return effective_attachment_extensions(self._attachment_extensions)
 
     def _is_path_excluded(self, path: str) -> bool:
         """Check whether *path* matches any configured exclude pattern.
@@ -248,9 +223,7 @@ class SearchManager:
             ``True`` if the path matches any pattern in
             ``self._exclude_patterns``.
         """
-        if not self._exclude_patterns:
-            return False
-        return any(fnmatch.fnmatch(path, pat) for pat in self._exclude_patterns)
+        return is_path_excluded(path, self._exclude_patterns)
 
     # ------------------------------------------------------------------
     # Search
@@ -536,7 +509,7 @@ class SearchManager:
         """
         rows = self._fts.list_notes(folder=folder)
         notes: list[NoteInfo | AttachmentInfo] = [
-            _fts_row_to_note_info(row) for row in rows
+            fts_row_to_note_info(row) for row in rows
         ]
 
         if pattern:
@@ -648,7 +621,7 @@ class SearchManager:
             ordered by modification time (most recent first).
         """
         rows = self._fts.get_recent(limit=limit, folder=folder)
-        return [_fts_row_to_note_info(row) for row in rows]
+        return [fts_row_to_note_info(row) for row in rows]
 
     def get_similar(self, path: str, *, limit: int = 10) -> builtins.list[SearchResult]:
         """Return the most semantically similar chunks from other documents.

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -1,0 +1,837 @@
+"""Search, list, and query manager.
+
+Handles all search operations (keyword, semantic, hybrid), document listing,
+folder/tag enumeration, recent notes, similar notes, and consolidated
+context queries with dependency injection — receives only the FTS index,
+source directory, and optional collaborators.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fnmatch
+import json
+import logging
+import mimetypes
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from markdown_vault_mcp.types import (
+    AttachmentInfo,
+    BacklinkInfo,
+    NoteContext,
+    NoteInfo,
+    OutlinkInfo,
+    SearchResult,
+    SimilarItem,
+)
+
+if TYPE_CHECKING:
+    import builtins
+    from collections.abc import Callable
+
+    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.managers.link import LinkManager
+    from markdown_vault_mcp.providers import EmbeddingProvider
+    from markdown_vault_mcp.vector_index import VectorIndex
+
+logger = logging.getLogger(__name__)
+
+# RRF constant — standard value recommended in the original paper.
+_RRF_K = 60
+
+# Maximum folder peers returned by get_context().
+_CONTEXT_FOLDER_PEERS_LIMIT = 20
+
+
+def _fts_row_to_note_info(row: dict[str, Any]) -> NoteInfo:
+    """Convert an FTSIndex row dict to a :class:`NoteInfo`.
+
+    Args:
+        row: Dict returned by :meth:`FTSIndex.list_notes`,
+            :meth:`FTSIndex.get_note`, or :meth:`FTSIndex.get_recent`.
+
+    Returns:
+        A populated :class:`NoteInfo` instance.
+    """
+    frontmatter: dict[str, Any] = {}
+    raw_json = row.get("frontmatter_json")
+    if raw_json:
+        try:
+            frontmatter = json.loads(raw_json)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Could not parse frontmatter_json for path %s", row.get("path")
+            )
+    return NoteInfo(
+        path=row["path"],
+        title=row["title"],
+        folder=row["folder"],
+        frontmatter=frontmatter,
+        modified_at=row["modified_at"],
+    )
+
+
+class SearchManager:
+    """Manages search, listing, and query operations against the vault.
+
+    Args:
+        fts: The FTS index to query.
+        source_dir: Absolute path to the vault root directory.
+        embeddings_path: Base path for ``.npy`` / ``.json`` sidecar files.
+            ``None`` disables semantic search.
+        embedding_provider: Provider used to generate embeddings.
+        indexed_frontmatter_fields: Frontmatter keys promoted to
+            ``document_tags`` for structured filtering.
+        exclude_patterns: Glob patterns for paths to exclude from listing.
+        attachment_extensions: Allowed non-.md extensions.  ``None`` uses
+            the default set.
+        link_manager: Optional :class:`LinkManager` for context queries.
+        flush_embeddings: Callback to flush deferred embedding updates
+            before semantic search.
+        rebuild_embeddings: Callback to rebuild all embeddings from scratch
+            (used when vector index compatibility fails).
+    """
+
+    def __init__(
+        self,
+        fts: FTSIndex,
+        source_dir: Path,
+        *,
+        embeddings_path: Path | None = None,
+        embedding_provider: EmbeddingProvider | None = None,
+        indexed_frontmatter_fields: list[str] | None = None,
+        exclude_patterns: list[str] | None = None,
+        attachment_extensions: list[str] | None = None,
+        link_manager: LinkManager | None = None,
+        flush_embeddings: Callable[[], None] | None = None,
+        rebuild_embeddings: Callable[[], None] | None = None,
+    ) -> None:
+        self._fts = fts
+        self._source_dir = source_dir
+        self._embeddings_path = embeddings_path
+        self._embedding_provider = embedding_provider
+        self._indexed_frontmatter_fields: list[str] = indexed_frontmatter_fields or []
+        self._exclude_patterns = exclude_patterns
+        self._attachment_extensions = attachment_extensions
+        self._link_manager = link_manager
+        self._flush_embeddings = flush_embeddings or (lambda: None)
+        self._rebuild_embeddings = rebuild_embeddings or (lambda: None)
+
+        # Vector index is loaded lazily (only if embeddings_path is set).
+        self._vectors: VectorIndex | None = None
+
+    # ------------------------------------------------------------------
+    # Vector index property (shared with IndexManager)
+    # ------------------------------------------------------------------
+
+    @property
+    def vectors(self) -> VectorIndex | None:
+        """Return the lazily-loaded vector index, or ``None``."""
+        return self._vectors
+
+    @vectors.setter
+    def vectors(self, value: VectorIndex | None) -> None:
+        self._vectors = value
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _validate_path(self, path: str) -> None:
+        """Validate that *path* ends with ``.md`` and stays inside source_dir.
+
+        Args:
+            path: Relative vault path to validate.
+
+        Raises:
+            ValueError: If the path does not end with ``.md`` or escapes
+                the source directory.
+        """
+        if not path.endswith(".md"):
+            raise ValueError(f"Path must end with '.md': {path}")
+        abs_path = (self._source_dir / path).resolve()
+        if not abs_path.is_relative_to(self._source_dir.resolve()):
+            raise ValueError(f"Path traversal detected: {path}")
+
+    def _require_vectors(self) -> None:
+        """Raise ValueError if semantic search is not configured."""
+        if self._embedding_provider is None or self._embeddings_path is None:
+            raise ValueError(
+                "Semantic search requires both 'embedding_provider' and "
+                "'embeddings_path' to be configured."
+            )
+
+    def _load_vectors(self) -> VectorIndex:
+        """Load or return the cached VectorIndex.
+
+        Returns:
+            A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+        """
+        if self._vectors is not None:
+            return self._vectors
+
+        from markdown_vault_mcp.vector_index import (
+            VectorIndex,
+            VectorIndexCompatibilityError,
+        )
+
+        assert self._embeddings_path is not None
+        assert self._embedding_provider is not None
+
+        npy_path = Path(str(self._embeddings_path) + ".npy")
+        if npy_path.exists():
+            try:
+                self._vectors = VectorIndex.load(
+                    self._embeddings_path, self._embedding_provider
+                )
+                logger.info("Loaded vector index from %s", self._embeddings_path)
+            except VectorIndexCompatibilityError as exc:
+                logger.warning("%s Rebuilding embeddings.", exc)
+                self._rebuild_embeddings()
+                assert self._vectors is not None
+        else:
+            self._vectors = VectorIndex(self._embedding_provider)
+            logger.info("No vector index on disk; created empty VectorIndex")
+
+        return self._vectors
+
+    def _get_frontmatter(self, path: str) -> dict[str, Any]:
+        """Return the frontmatter dict for a document from the FTS index.
+
+        Falls back to an empty dict if the document is not found.
+
+        Args:
+            path: Relative document path.
+
+        Returns:
+            Parsed frontmatter dict.
+        """
+        row = self._fts.get_note(path)
+        if row is None:
+            return {}
+        raw = row.get("frontmatter_json")
+        if not raw:
+            return {}
+        try:
+            result: dict[str, Any] = json.loads(raw)
+            return result
+        except (json.JSONDecodeError, TypeError) as exc:
+            logger.warning(
+                "_get_frontmatter: invalid JSON for %s — %s",
+                row.get("path"),
+                exc,
+            )
+            return {}
+
+    def _effective_attachment_extensions(self) -> frozenset[str]:
+        """Return the effective set of allowed attachment extensions.
+
+        Returns:
+            Frozenset of lower-case extension strings (without leading dot).
+            The special value ``frozenset(["*"])`` means all non-.md files.
+        """
+        from markdown_vault_mcp.types import DEFAULT_ATTACHMENT_EXTENSIONS
+
+        if self._attachment_extensions is None:
+            return DEFAULT_ATTACHMENT_EXTENSIONS
+        return frozenset(self._attachment_extensions)
+
+    def _is_path_excluded(self, path: str) -> bool:
+        """Check whether *path* matches any configured exclude pattern.
+
+        Args:
+            path: Relative POSIX path string.
+
+        Returns:
+            ``True`` if the path matches any pattern in
+            ``self._exclude_patterns``.
+        """
+        if not self._exclude_patterns:
+            return False
+        return any(fnmatch.fnmatch(path, pat) for pat in self._exclude_patterns)
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+        filters: dict[str, str] | None = None,
+        folder: str | None = None,
+    ) -> list[SearchResult]:
+        """Search the collection.
+
+        Args:
+            query: Search string.
+            limit: Maximum number of results to return.
+            mode: ``"keyword"`` for BM25 FTS5, ``"semantic"`` for cosine
+                similarity, or ``"hybrid"`` for Reciprocal Rank Fusion of
+                both.
+            filters: Dict of ``{frontmatter_key: value}`` pairs (AND
+                semantics).  Only works for fields in
+                ``indexed_frontmatter_fields``.
+            folder: If provided, restrict results to documents in this
+                folder (and its sub-folders).
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.SearchResult` ordered
+            by relevance.
+
+        Raises:
+            ValueError: If *mode* is ``"semantic"`` or ``"hybrid"`` but no
+                embedding provider or embeddings path is configured.
+        """
+        if mode == "keyword":
+            return self._keyword_search(
+                query, limit=limit, filters=filters, folder=folder
+            )
+
+        if mode == "semantic":
+            self._require_vectors()
+            return self._semantic_search(
+                query, limit=limit, filters=filters, folder=folder
+            )
+
+        # hybrid
+        self._require_vectors()
+        return self._hybrid_search(query, limit=limit, filters=filters, folder=folder)
+
+    def _keyword_search(
+        self,
+        query: str,
+        *,
+        limit: int,
+        filters: dict[str, str] | None,
+        folder: str | None,
+    ) -> list[SearchResult]:
+        fts_results = self._fts.search(
+            query, limit=limit, filters=filters, folder=folder
+        )
+        return [
+            SearchResult(
+                path=r.path,
+                title=r.title,
+                folder=r.folder,
+                heading=r.heading,
+                content=r.content,
+                score=r.score,
+                search_type="keyword",
+                frontmatter=self._get_frontmatter(r.path),
+            )
+            for r in fts_results
+        ]
+
+    def _semantic_search(
+        self,
+        query: str,
+        *,
+        limit: int,
+        filters: dict[str, str] | None = None,
+        folder: str | None = None,
+    ) -> list[SearchResult]:
+        # Flush deferred embedding updates so results are consistent.
+        self._flush_embeddings()
+        vectors = self._load_vectors()
+        # Fetch extra candidates so post-filtering still yields *limit* results.
+        candidate_limit = max(limit * 3, 30) if (folder or filters) else limit
+        raw = vectors.search(query, limit=candidate_limit)
+
+        results: list[SearchResult] = []
+        for r in raw:
+            if len(results) >= limit:
+                break
+
+            # Apply folder prefix filter.
+            if folder is not None:
+                r_folder = r.get("folder", "")
+                if r_folder != folder and not r_folder.startswith(folder + "/"):
+                    continue
+
+            # Apply tag filters: check FTS index for each required tag.
+            if filters:
+                note_row = self._fts.get_note(r["path"])
+                if note_row is None:
+                    continue
+                fm_raw = note_row.get("frontmatter_json")
+                fm: dict[str, Any] = {}
+                if fm_raw:
+                    with contextlib.suppress(json.JSONDecodeError, TypeError):
+                        fm = json.loads(fm_raw)
+                match = True
+                for key, value in filters.items():
+                    fm_val = fm.get(key)
+                    if fm_val is None:
+                        match = False
+                        break
+                    # Support both scalar and list values.
+                    if isinstance(fm_val, list):
+                        if str(value) not in [str(v) for v in fm_val]:
+                            match = False
+                            break
+                    else:
+                        if str(fm_val) != str(value):
+                            match = False
+                            break
+                if not match:
+                    continue
+
+            results.append(
+                SearchResult(
+                    path=r["path"],
+                    title=r["title"],
+                    folder=r["folder"],
+                    heading=r.get("heading"),
+                    content=r["content"],
+                    score=r["score"],
+                    search_type="semantic",
+                    frontmatter=self._get_frontmatter(r["path"]),
+                )
+            )
+        return results
+
+    def _hybrid_search(
+        self,
+        query: str,
+        *,
+        limit: int,
+        filters: dict[str, str] | None,
+        folder: str | None,
+    ) -> list[SearchResult]:
+        """RRF merge of keyword and semantic results.
+
+        Each result set is ranked independently.  Merged score:
+        ``1 / (k + rank)`` where k=60.  Results appearing in both sets
+        have their scores summed.  Returns top *limit* by total RRF score.
+        """
+        # Fetch more candidates than needed so RRF has enough to rank.
+        candidate_limit = max(limit * 2, 20)
+
+        # Flush deferred embedding updates so results are consistent.
+        self._flush_embeddings()
+
+        fts_results = self._fts.search(
+            query, limit=candidate_limit, filters=filters, folder=folder
+        )
+        vectors = self._load_vectors()
+        vec_results = vectors.search(query, limit=candidate_limit)
+
+        # Build a key for deduplication: (path, heading) identifies a chunk.
+        # Use a dict to accumulate RRF scores and store metadata.
+        rrf_scores: dict[tuple[str, str | None], float] = {}
+        # Store the best metadata dict keyed by (path, heading).
+        chunk_meta: dict[tuple[str, str | None], dict[str, Any]] = {}
+
+        for rank, r in enumerate(fts_results, start=1):
+            key = (r.path, r.heading)
+            rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (_RRF_K + rank)
+            if key not in chunk_meta:
+                chunk_meta[key] = {
+                    "path": r.path,
+                    "title": r.title,
+                    "folder": r.folder,
+                    "heading": r.heading,
+                    "content": r.content,
+                    "search_type": "keyword",
+                }
+
+        for rank, vr in enumerate(vec_results, start=1):
+            # Apply folder prefix filter to semantic results.
+            if folder is not None:
+                vr_folder = vr.get("folder", "")
+                if vr_folder != folder and not vr_folder.startswith(folder + "/"):
+                    continue
+
+            # Apply tag filters to semantic results via frontmatter lookup.
+            if filters:
+                note_row = self._fts.get_note(vr["path"])
+                if note_row is None:
+                    continue
+                fm_raw = note_row.get("frontmatter_json")
+                fm: dict[str, Any] = {}
+                if fm_raw:
+                    with contextlib.suppress(json.JSONDecodeError, TypeError):
+                        fm = json.loads(fm_raw)
+                skip = False
+                for fk, fv in filters.items():
+                    fm_val = fm.get(fk)
+                    if fm_val is None:
+                        skip = True
+                        break
+                    if isinstance(fm_val, list):
+                        if str(fv) not in [str(v) for v in fm_val]:
+                            skip = True
+                            break
+                    else:
+                        if str(fm_val) != str(fv):
+                            skip = True
+                            break
+                if skip:
+                    continue
+
+            heading = vr.get("heading")
+            vkey = (vr["path"], heading)
+            rrf_scores[vkey] = rrf_scores.get(vkey, 0.0) + 1.0 / (_RRF_K + rank)
+            if vkey not in chunk_meta:
+                chunk_meta[vkey] = {
+                    "path": vr["path"],
+                    "title": vr["title"],
+                    "folder": vr["folder"],
+                    "heading": heading,
+                    "content": vr["content"],
+                    "search_type": "semantic",
+                }
+
+        # Sort by descending RRF score, take top limit.
+        sorted_keys = sorted(rrf_scores, key=lambda k: rrf_scores[k], reverse=True)[
+            :limit
+        ]
+
+        return [
+            SearchResult(
+                path=chunk_meta[k]["path"],
+                title=chunk_meta[k]["title"],
+                folder=chunk_meta[k]["folder"],
+                heading=chunk_meta[k]["heading"],
+                content=chunk_meta[k]["content"],
+                score=rrf_scores[k],
+                search_type=chunk_meta[k]["search_type"],
+                frontmatter=self._get_frontmatter(chunk_meta[k]["path"]),
+            )
+            for k in sorted_keys
+        ]
+
+    # ------------------------------------------------------------------
+    # List / enumerate
+    # ------------------------------------------------------------------
+
+    def list(
+        self,
+        *,
+        folder: str | None = None,
+        pattern: str | None = None,
+        include_attachments: bool = False,
+    ) -> list[NoteInfo | AttachmentInfo]:
+        """List documents (and optionally attachments) in the collection.
+
+        Args:
+            folder: If provided, only return documents in this folder (and
+                sub-folders).
+            pattern: Unix glob matched against the relative path using
+                :func:`fnmatch.fnmatch`.  Example: ``"Journal/*.md"``.
+            include_attachments: When ``True``, also return non-.md files
+                that match the attachment allowlist.  Each
+                :class:`~markdown_vault_mcp.types.AttachmentInfo` entry
+                includes ``kind="attachment"`` and ``mime_type``.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.NoteInfo` (and
+            optionally :class:`~markdown_vault_mcp.types.AttachmentInfo`)
+            objects.
+        """
+        rows = self._fts.list_notes(folder=folder)
+        notes: list[NoteInfo | AttachmentInfo] = [
+            _fts_row_to_note_info(row) for row in rows
+        ]
+
+        if pattern:
+            notes = [n for n in notes if fnmatch.fnmatch(n.path, pattern)]
+
+        if not include_attachments:
+            return notes
+
+        exts = self._effective_attachment_extensions()
+        source_resolved = self._source_dir.resolve()
+        attachments: list[AttachmentInfo] = []
+
+        # Attachment scan runs outside _write_lock — result is a best-effort
+        # snapshot and is not atomic with the FTS note listing above.
+        for abs_path in self._source_dir.rglob("*"):
+            if not abs_path.is_file():
+                continue
+            if abs_path.suffix.lower() == ".md":
+                continue
+            suffix = abs_path.suffix.lstrip(".").lower()
+            if "*" not in exts and suffix not in exts:
+                continue
+            try:
+                rel = abs_path.relative_to(source_resolved)
+            except ValueError as exc:
+                logger.warning(
+                    "_list_attachments: skipping %s — outside source_dir (%s)",
+                    abs_path,
+                    exc,
+                )
+                continue
+            rel_path = str(rel)
+            # Skip files where any path component starts with ".".
+            if any(part.startswith(".") for part in rel.parts):
+                continue
+            # Apply exclude_patterns — mirrors scan_directory behaviour.
+            if self._is_path_excluded(rel.as_posix()):
+                continue
+            if pattern and not fnmatch.fnmatch(rel_path, pattern):
+                continue
+            rel_folder = str(Path(rel_path).parent)
+            if rel_folder == ".":
+                rel_folder = ""
+            if (
+                folder is not None
+                and rel_folder != folder
+                and not rel_folder.startswith(folder + "/")
+            ):
+                continue
+            try:
+                stat = abs_path.stat()
+            except OSError as exc:
+                logger.warning(
+                    "_list_attachments: skipping %s — stat error (%s)",
+                    abs_path,
+                    exc,
+                )
+                continue
+            mime_type, _ = mimetypes.guess_type(rel_path)
+            attachments.append(
+                AttachmentInfo(
+                    path=rel_path,
+                    folder=rel_folder,
+                    mime_type=mime_type,
+                    size_bytes=stat.st_size,
+                    modified_at=stat.st_mtime,
+                )
+            )
+
+        return notes + attachments
+
+    def list_folders(self) -> builtins.list[str]:
+        """Return all distinct folder values across the indexed collection.
+
+        Returns:
+            Sorted list of folder strings (``""`` for the collection root).
+        """
+        return self._fts.list_folders()
+
+    def list_tags(self, field: str = "tags") -> builtins.list[str]:
+        """Return all distinct values indexed for a given frontmatter field.
+
+        If *field* was not in ``indexed_frontmatter_fields``, returns ``[]``.
+
+        Args:
+            field: Frontmatter key to query (default: ``"tags"``).
+
+        Returns:
+            Sorted list of distinct value strings.
+        """
+        return self._fts.list_field_values(field)
+
+    # ------------------------------------------------------------------
+    # Recent / similar / context
+    # ------------------------------------------------------------------
+
+    def get_recent(
+        self, *, limit: int = 20, folder: str | None = None
+    ) -> builtins.list[NoteInfo]:
+        """Return the most recently modified documents.
+
+        Args:
+            limit: Maximum number of documents to return.
+            folder: If provided, restrict to documents in this folder
+                (exact match or sub-folder prefix).
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.NoteInfo` objects
+            ordered by modification time (most recent first).
+        """
+        rows = self._fts.get_recent(limit=limit, folder=folder)
+        return [_fts_row_to_note_info(row) for row in rows]
+
+    def get_similar(self, path: str, *, limit: int = 10) -> builtins.list[SearchResult]:
+        """Return the most semantically similar chunks from other documents.
+
+        Uses the stored embedding vectors for ``path`` (averaged across
+        chunks) to compute cosine similarity against all other documents.
+        No re-embedding is needed.  Results are at chunk granularity —
+        the same document may appear multiple times if it has many chunks.
+
+        Args:
+            path: Relative path of the reference document.
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.SearchResult` objects
+            ordered by descending similarity.  Returns ``[]`` when
+            embeddings are not configured or the document has no stored
+            vectors.
+
+        Raises:
+            ValueError: If no document exists at the given path.
+        """
+        self._validate_path(path)
+        if self._fts.get_note(path) is None:
+            raise ValueError(f"Document not found: {path}")
+
+        if self._embedding_provider is None or self._embeddings_path is None:
+            return []
+
+        self._load_vectors()
+        if self._vectors is None or self._vectors.count == 0:
+            return []
+
+        raw_results = self._vectors.search_by_path(path, limit=limit)
+        return [
+            SearchResult(
+                path=r["path"],
+                title=r.get("title", ""),
+                folder=r.get("folder", ""),
+                heading=r.get("heading"),
+                content=r.get("content", ""),
+                score=r.get("score", 0.0),
+                search_type="semantic",
+                frontmatter=self._get_frontmatter(r["path"]),
+            )
+            for r in raw_results
+        ]
+
+    def get_context(
+        self,
+        path: str,
+        *,
+        similar_limit: int = 5,
+        link_limit: int = 10,
+    ) -> NoteContext:
+        """Return a consolidated context dossier for a document.
+
+        Combines backlinks, outlinks, similar notes, folder peers, and
+        indexed frontmatter tags into a single response, saving the caller
+        multiple round trips.
+
+        Args:
+            path: Relative path of the document (e.g.
+                ``"notes/topic.md"``).
+            similar_limit: Maximum number of similar notes to include.
+            link_limit: Maximum number of backlinks and outlinks to include.
+
+        Returns:
+            A :class:`~markdown_vault_mcp.types.NoteContext` object.
+
+        Raises:
+            ValueError: If no document exists at the given path.
+        """
+        self._validate_path(path)
+        row = self._fts.get_note(path)
+        if row is None:
+            raise ValueError(f"Document not found: {path}")
+
+        frontmatter = self._get_frontmatter(path)
+
+        # Backlinks — via LinkManager if available, else direct FTS.
+        backlink_objs: list[BacklinkInfo] = []
+        if self._link_manager is not None:
+            try:
+                backlink_objs = self._link_manager.get_backlinks(path, limit=link_limit)
+            except (ValueError, sqlite3.OperationalError) as exc:
+                logger.warning("get_context: backlinks for %s: %s", path, exc)
+        else:
+            try:
+                backlinks = self._fts.get_backlinks(path, limit=link_limit)
+                backlink_objs = [
+                    BacklinkInfo(
+                        source_path=r["source_path"],
+                        source_title=r["source_title"],
+                        link_text=r["link_text"],
+                        link_type=r["link_type"],
+                        fragment=r["fragment"],
+                        raw_target=r["raw_target"],
+                    )
+                    for r in backlinks
+                ]
+            except sqlite3.OperationalError as exc:
+                logger.warning(
+                    "get_context: failed to retrieve backlinks for %s: %s",
+                    path,
+                    exc,
+                )
+
+        # Outlinks — via LinkManager if available, else direct FTS.
+        outlink_objs: list[OutlinkInfo] = []
+        if self._link_manager is not None:
+            try:
+                outlink_objs = self._link_manager.get_outlinks(path, limit=link_limit)
+            except (ValueError, sqlite3.OperationalError) as exc:
+                logger.warning("get_context: outlinks for %s: %s", path, exc)
+        else:
+            try:
+                outlinks = self._fts.get_outlinks(path, limit=link_limit)
+                outlink_objs = [
+                    OutlinkInfo(
+                        target_path=r["target_path"],
+                        link_text=r["link_text"],
+                        link_type=r["link_type"],
+                        fragment=r["fragment"],
+                        exists=bool(r["target_exists"]),
+                        raw_target=r["raw_target"],
+                    )
+                    for r in outlinks
+                ]
+            except sqlite3.OperationalError as exc:
+                logger.warning(
+                    "get_context: failed to retrieve outlinks for %s: %s",
+                    path,
+                    exc,
+                )
+
+        # Similar notes — empty if embeddings not configured or
+        # similar_limit is 0.
+        similar_dicts: list[SimilarItem] = []
+        if (
+            similar_limit > 0
+            and self._embedding_provider is not None
+            and self._embeddings_path is not None
+        ):
+            self._load_vectors()
+            if self._vectors is not None and self._vectors.count > 0:
+                raw = self._vectors.search_by_path(path, limit=similar_limit)
+                similar_dicts = [
+                    SimilarItem(
+                        path=r["path"],
+                        title=r["title"],
+                        score=r["score"],
+                    )
+                    for r in raw
+                ]
+
+        # Folder peers — other notes in the same folder, capped.
+        folder = row["folder"]
+        folder_rows = self._fts.list_notes(folder=folder)
+        folder_notes = [r["path"] for r in folder_rows if r["path"] != path][
+            :_CONTEXT_FOLDER_PEERS_LIMIT
+        ]
+
+        # Tags — indexed frontmatter fields present on this document.
+        tags: dict[str, list[str]] = {}
+        for field in self._indexed_frontmatter_fields:
+            value = frontmatter.get(field)
+            if value is None:
+                continue
+            if isinstance(value, list):
+                tags[field] = [str(v) for v in value]
+            else:
+                tags[field] = [str(value)]
+
+        return NoteContext(
+            path=path,
+            title=row["title"],
+            folder=folder,
+            frontmatter=frontmatter,
+            modified_at=row["modified_at"],
+            backlinks=backlink_objs,
+            outlinks=outlink_objs,
+            similar=similar_dicts,
+            folder_notes=folder_notes,
+            tags=tags,
+        )

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -296,3 +296,48 @@ class CommitDiff:
 WriteCallback = Callable[
     [Path, str, Literal["write", "edit", "delete", "rename"]], None
 ]
+
+# Default set of allowed attachment extensions (without leading dot, lower-case).
+# .md is always excluded — it is always handled as a markdown note.
+DEFAULT_ATTACHMENT_EXTENSIONS: frozenset[str] = frozenset(
+    [
+        # Documents
+        "pdf",
+        "docx",
+        "xlsx",
+        "pptx",
+        "odt",
+        "ods",
+        "odp",
+        # Images
+        "png",
+        "jpg",
+        "jpeg",
+        "gif",
+        "webp",
+        "svg",
+        "bmp",
+        "tiff",
+        # Archives
+        "zip",
+        "tar",
+        "gz",
+        # Audio / Video
+        "mp3",
+        "mp4",
+        "wav",
+        "ogg",
+        # Text and data
+        "txt",
+        "csv",
+        "tsv",
+        "json",
+        "yaml",
+        "toml",
+        "xml",
+        "html",
+        "css",
+        "js",
+        "ts",
+    ]
+)

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -1,5 +1,15 @@
 """Shared pure-function utilities for markdown-vault-mcp."""
 
+from __future__ import annotations
+
+import fnmatch
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.types import DEFAULT_ATTACHMENT_EXTENSIONS
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from markdown_vault_mcp.utils.fts import fts_row_to_note_info
 from markdown_vault_mcp.utils.links import (
     apply_link_replacement,
     compute_new_raw_target,
@@ -11,11 +21,72 @@ from markdown_vault_mcp.utils.text import (
     normalize_text,
 )
 
+
+def is_path_excluded(path: str, exclude_patterns: list[str] | None) -> bool:
+    """Check whether *path* matches any configured exclude pattern.
+
+    Args:
+        path: Relative POSIX path string.
+        exclude_patterns: Glob patterns to check against.  ``None`` or
+            empty means nothing is excluded.
+
+    Returns:
+        ``True`` if the path matches any pattern in *exclude_patterns*.
+    """
+    if not exclude_patterns:
+        return False
+    return any(fnmatch.fnmatch(path, pat) for pat in exclude_patterns)
+
+
+def effective_attachment_extensions(
+    attachment_extensions: list[str] | None,
+) -> frozenset[str]:
+    """Return the effective set of allowed attachment extensions.
+
+    Args:
+        attachment_extensions: User-configured extension list, or ``None``
+            to use the default set.
+
+    Returns:
+        Frozenset of lower-case extension strings (without leading dot).
+        The special value ``frozenset(["*"])`` means all non-.md files.
+    """
+    if attachment_extensions is None:
+        return DEFAULT_ATTACHMENT_EXTENSIONS
+    return frozenset(attachment_extensions)
+
+
+def validate_path(path: str, source_dir: Path) -> Path:
+    """Resolve a relative path and validate it is inside *source_dir*.
+
+    Args:
+        path: Relative document path (must end with ``.md``).
+        source_dir: Absolute path to the vault root directory.
+
+    Returns:
+        The resolved absolute path.
+
+    Raises:
+        ValueError: If the path escapes the source directory or does
+            not end with ``.md``.
+    """
+    if not path.endswith(".md"):
+        raise ValueError(f"Path must end with '.md': {path}")
+    abs_path = (source_dir / path).resolve()
+    if not abs_path.is_relative_to(source_dir.resolve()):
+        raise ValueError(f"Path traversal detected: {path}")
+    return abs_path
+
+
 __all__ = [
     "CHAR_SUBS",
     "apply_link_replacement",
     "build_position_map",
     "compute_new_raw_target",
+    "effective_attachment_extensions",
     "find_closest_match",
+    "fts_row_to_note_info",
+    "is_path_excluded",
     "normalize_text",
+    "validate_path",
 ]

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -1,0 +1,21 @@
+"""Shared pure-function utilities for markdown-vault-mcp."""
+
+from markdown_vault_mcp.utils.links import (
+    apply_link_replacement,
+    compute_new_raw_target,
+)
+from markdown_vault_mcp.utils.text import (
+    CHAR_SUBS,
+    build_position_map,
+    find_closest_match,
+    normalize_text,
+)
+
+__all__ = [
+    "CHAR_SUBS",
+    "apply_link_replacement",
+    "build_position_map",
+    "compute_new_raw_target",
+    "find_closest_match",
+    "normalize_text",
+]

--- a/src/markdown_vault_mcp/utils/fts.py
+++ b/src/markdown_vault_mcp/utils/fts.py
@@ -1,0 +1,40 @@
+"""FTS row conversion utilities shared across managers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from markdown_vault_mcp.types import NoteInfo
+
+logger = logging.getLogger(__name__)
+
+
+def fts_row_to_note_info(row: dict[str, Any]) -> NoteInfo:
+    """Convert an FTSIndex row dict to a :class:`NoteInfo`.
+
+    Args:
+        row: Dict returned by :meth:`FTSIndex.list_notes`,
+            :meth:`FTSIndex.get_note`, :meth:`FTSIndex.get_recent`,
+            or :meth:`FTSIndex.get_orphan_notes`.
+
+    Returns:
+        A populated :class:`NoteInfo` instance.
+    """
+    frontmatter: dict[str, Any] = {}
+    raw_json = row.get("frontmatter_json")
+    if raw_json:
+        try:
+            frontmatter = json.loads(raw_json)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Could not parse frontmatter_json for path %s", row.get("path")
+            )
+    return NoteInfo(
+        path=row["path"],
+        title=row["title"],
+        folder=row["folder"],
+        frontmatter=frontmatter,
+        modified_at=row["modified_at"],
+    )

--- a/src/markdown_vault_mcp/utils/links.py
+++ b/src/markdown_vault_mcp/utils/links.py
@@ -1,0 +1,108 @@
+"""Link-update helpers for file rename operations.
+
+These functions compute replacement link targets and apply substitutions
+in file content when a note is renamed within the vault.
+"""
+
+from __future__ import annotations
+
+import os.path as osp
+import re
+from pathlib import Path
+
+
+def compute_new_raw_target(
+    link_type: str,
+    raw_target: str,
+    fragment: str | None,
+    new_path: str,
+    source_path: str = "",
+    old_path: str = "",
+) -> str:
+    """Compute the replacement raw_target string when a file is renamed.
+
+    Args:
+        link_type: One of ``"markdown"``, ``"reference"``, ``"wikilink"``.
+        raw_target: The literal link string stored in the source file.
+        fragment: The heading fragment (``#heading``) of the link, if any.
+        new_path: The vault-relative path of the renamed file (e.g.
+            ``"notes/new-name.md"``).
+        source_path: Vault-relative path of the file that contains the link.
+            Required for correct relative-path handling in markdown and
+            reference links (cross-directory links would otherwise be silently
+            broken).
+        old_path: Vault-relative path of the file being renamed.  Used to
+            detect whether *raw_target* was written as a vault-root-relative
+            or source-directory-relative path.
+
+    Returns:
+        The replacement raw_target string to write into the source file.
+    """
+    if link_type == "wikilink":
+        # Determine whether the original wikilink included the .md extension.
+        old_path_part = raw_target.split("#")[0]
+        if old_path_part.lower().endswith(".md"):
+            new_path_part = new_path
+        else:
+            new_path_part = new_path[:-3]
+        return new_path_part + ("#" + fragment if fragment else "")
+    else:
+        # markdown and reference links.
+        # Detect whether the link was written as vault-root-relative (raw_target
+        # matches old_path) or as a path relative to the source file's directory
+        # (raw_target != old_path, e.g. "../archive/target.md" from docs/).
+        raw_path_part = raw_target.split("#")[0]
+        if source_path and old_path and raw_path_part != old_path:
+            # Relative-to-source link: compute the correct new relative path so
+            # cross-directory links continue to resolve after the rename.
+            source_dir = str(Path(source_path).parent)
+            new_rel = osp.relpath(new_path, source_dir)
+            # os.path.relpath uses OS separators on Windows; normalise to /.
+            new_path_part = new_rel.replace("\\", "/")
+        else:
+            new_path_part = new_path
+        return new_path_part + ("#" + fragment if fragment else "")
+
+
+def apply_link_replacement(
+    content: str, link_type: str, old_raw: str, new_raw: str
+) -> str:
+    """Replace a single link target occurrence in file content.
+
+    Args:
+        content: Full file content to modify.
+        link_type: One of ``"markdown"``, ``"reference"``, ``"wikilink"``.
+        old_raw: The original raw_target string to find.
+        new_raw: The replacement raw_target string.
+
+    Returns:
+        Updated content with all occurrences of *old_raw* replaced.
+    """
+    if link_type == "markdown":
+        # Negative lookbehind (?<!!) excludes image links ![](url) — the `!`
+        # immediately before `[` is the discriminator. Anchored to [text]( so
+        # bare (old_raw) occurrences in plain text are also excluded.
+        # Captures and preserves optional link title (e.g. "title" or 'title').
+        # NOTE: operates on raw file content; occurrences inside backtick code
+        # spans would also be rewritten. Risk is low in practice.
+        return re.sub(
+            r"(?<!!)(\[[^\]]*?\])\(" + re.escape(old_raw) + r"((?:\s[^)]*)?)\)",
+            lambda m: m.group(1) + "(" + new_raw + m.group(2) + ")",
+            content,
+        )
+    elif link_type == "reference":
+        # Match reference definition lines: [id]: url optional-title
+        # Anchored to line start with MULTILINE so we don't match inline text.
+        return re.sub(
+            r"^(\[.*?\]:\s+)" + re.escape(old_raw) + r"([ \t].*|$)",
+            lambda m: m.group(1) + new_raw + m.group(2),
+            content,
+            flags=re.MULTILINE,
+        )
+    elif link_type == "wikilink":
+        return re.sub(
+            r"\[\[" + re.escape(old_raw) + r"(\|[^\]]*)?\]\]",
+            lambda m: "[[" + new_raw + (m.group(1) or "") + "]]",
+            content,
+        )
+    return content

--- a/src/markdown_vault_mcp/utils/text.py
+++ b/src/markdown_vault_mcp/utils/text.py
@@ -1,0 +1,193 @@
+"""Text normalization and fuzzy-matching utilities for edit operations.
+
+These functions support the edit workflow by normalizing text for comparison
+while preserving exact original positions for replacement.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from difflib import SequenceMatcher
+from typing import Any
+
+# Direct single-character substitutions applied during normalization.
+# Used by build_position_map to avoid calling normalize_text() per
+# character, which would (a) be O(n²) and (b) incorrectly strip a lone
+# space/tab as "trailing whitespace" of a one-char string.
+CHAR_SUBS: dict[str, str] = {
+    "\u2013": "-",  # en-dash
+    "\u2014": "-",  # em-dash
+    "\u201c": '"',  # left double quotation mark
+    "\u201d": '"',  # right double quotation mark
+    "\u2018": "'",  # left single quotation mark
+    "\u2019": "'",  # right single quotation mark
+}
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text for fuzzy edit matching.
+
+    Applied to both old_text and file content for comparison only — the
+    actual file replacement uses original bytes.
+
+    Steps:
+        1. Unicode NFC normalization.
+        2. En-dash / em-dash → hyphen.
+        3. Smart quotes → straight quotes.
+        4. Collapse whitespace runs within lines (not across newlines).
+        5. Strip trailing whitespace per line.
+    """
+    text = unicodedata.normalize("NFC", text)
+    text = text.replace("\u2013", "-").replace("\u2014", "-")
+    text = text.replace("\u201c", '"').replace("\u201d", '"')
+    text = text.replace("\u2018", "'").replace("\u2019", "'")
+    lines = text.split("\n")
+    lines = [re.sub(r"[ \t]+", " ", line).rstrip() for line in lines]
+    return "\n".join(lines)
+
+
+def build_position_map(original: str, normalized: str) -> list[int]:
+    """Map each normalized character index to its original character index.
+
+    Walks both strings in parallel, advancing the original pointer past
+    characters that were removed or merged by normalization.
+
+    Args:
+        original: The original (un-normalized) text.
+        normalized: The result of ``normalize_text(original)``.
+
+    Returns:
+        A list of *len(normalized) + 1* entries where ``pos_map[i]`` is the
+        index in *original* corresponding to ``normalized[i]``, and the final
+        sentinel ``pos_map[len(normalized)]`` equals ``len(original)``.  The
+        sentinel lets callers compute the original end-position of a match
+        as ``pos_map[norm_end]`` without special-casing the last character.
+    """
+    pos_map: list[int] = []
+    orig_idx = 0
+    norm_idx = 0
+    orig_len = len(original)
+    norm_len = len(normalized)
+
+    while norm_idx < norm_len:
+        if orig_idx >= orig_len:
+            # Safety: normalized should never be longer.
+            break
+
+        norm_char = normalized[norm_idx]
+        orig_char = original[orig_idx]
+
+        # Newlines anchor both streams.
+        if norm_char == "\n" and orig_char == "\n":
+            pos_map.append(orig_idx)
+            orig_idx += 1
+            norm_idx += 1
+            continue
+
+        # Trailing whitespace was stripped: skip original trailing ws
+        # before a newline or end-of-string.
+        if norm_char == "\n" or (norm_idx == norm_len - 1 and norm_char != "\n"):
+            if norm_char != "\n":
+                # last char of normalized, not a newline — emit it first
+                pos_map.append(orig_idx)
+                orig_idx += 1
+                norm_idx += 1
+            # skip trailing whitespace in original before newline/end
+            while orig_idx < orig_len and original[orig_idx] in " \t":
+                orig_idx += 1
+            continue
+
+        # Whitespace collapse: normalized has single space, original has one or
+        # more spaces/tabs. Checked before the direct-match step so that runs
+        # of whitespace are always consumed in full (a single space would pass
+        # the direct-match test below, leaving trailing spaces unadvanced).
+        if norm_char == " " and orig_char in " \t":
+            pos_map.append(orig_idx)
+            orig_idx += 1
+            # skip remaining whitespace in original
+            while orig_idx < orig_len and original[orig_idx] in " \t":
+                orig_idx += 1
+            norm_idx += 1
+            continue
+
+        # Direct character match (possibly after NFC + char substitution).
+        # Using normalize_text(orig_char) would be O(n²) and would also
+        # incorrectly strip a lone space as "trailing whitespace", so we
+        # apply NFC and CHAR_SUBS directly instead.
+        nfc_char = unicodedata.normalize("NFC", orig_char)
+        sub_char = CHAR_SUBS.get(nfc_char, nfc_char)
+        if sub_char == norm_char:
+            pos_map.append(orig_idx)
+            orig_idx += 1
+            norm_idx += 1
+            continue
+
+        # Unicode NFC: original may have multiple chars for one normalized.
+        # Try expanding original chars until they normalize to norm_char.
+        consumed = 1
+        while orig_idx + consumed <= orig_len:
+            chunk = original[orig_idx : orig_idx + consumed]
+            if unicodedata.normalize("NFC", chunk) == norm_char:
+                pos_map.append(orig_idx)
+                orig_idx += consumed
+                norm_idx += 1
+                break
+            consumed += 1
+        else:
+            # Fallback: advance both by one.
+            pos_map.append(orig_idx)
+            orig_idx += 1
+            norm_idx += 1
+
+    # Sentinel: pos_map[norm_len] = orig_len so callers can compute
+    # orig_end = pos_map[norm_end] for any norm_end including norm_len.
+    pos_map.append(orig_len)
+    return pos_map
+
+
+def find_closest_match(old_text: str, file_content: str) -> dict[str, Any]:
+    """Find the closest fuzzy match for diagnostic error reporting.
+
+    Compares the first line of *old_text* against every line in the file
+    using ``difflib.SequenceMatcher``.  If a match with ratio >= 0.6 is
+    found, returns diagnostic info about the first character divergence.
+
+    Args:
+        old_text: The text the caller tried to match.
+        file_content: The full file content.
+
+    Returns:
+        A dict with ``closest_match_line``, ``first_diff_char``,
+        ``expected_snippet``, and ``found_snippet``; or an empty dict
+        if no match with ratio >= 0.6 is found.
+    """
+    first_line = old_text.split("\n", 1)[0]
+    file_lines = file_content.split("\n")
+    best_ratio = 0.0
+    best_line_num = 0
+    best_line_text = ""
+
+    for i, line in enumerate(file_lines, 1):
+        ratio = SequenceMatcher(None, first_line, line).ratio()
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_line_num = i
+            best_line_text = line
+
+    if best_ratio < 0.6:
+        return {}
+
+    # Find first character difference.
+    diff_pos = 0
+    min_len = min(len(first_line), len(best_line_text))
+    while diff_pos < min_len and first_line[diff_pos] == best_line_text[diff_pos]:
+        diff_pos += 1
+
+    ctx = 30
+    return {
+        "closest_match_line": best_line_num,
+        "first_diff_char": diff_pos,
+        "expected_snippet": first_line[max(0, diff_pos - ctx) : diff_pos + ctx],
+        "found_snippet": best_line_text[max(0, diff_pos - ctx) : diff_pos + ctx],
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -777,12 +777,20 @@ class TestBuildCollectionConfigFields:
         collection = _build_collection(args)
 
         # These should be excluded via the newly-propagated patterns.
-        assert collection._is_path_excluded("sessions/2026-04-09/chat.log.md") is True
-        assert collection._is_path_excluded(".obsidian/workspace.json.md") is True
+        assert (
+            collection._doc_mgr._is_path_excluded("sessions/2026-04-09/chat.log.md")
+            is True
+        )
+        assert (
+            collection._doc_mgr._is_path_excluded(".obsidian/workspace.json.md") is True
+        )
 
         # And these should still pass through unaffected.
-        assert collection._is_path_excluded("notes/alpha.md") is False
-        assert collection._is_path_excluded("decisions/2026-04-09-auth.md") is False
+        assert collection._doc_mgr._is_path_excluded("notes/alpha.md") is False
+        assert (
+            collection._doc_mgr._is_path_excluded("decisions/2026-04-09-auth.md")
+            is False
+        )
 
     def test_index_path_override_propagated(
         self,

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3132,7 +3132,9 @@ class TestResolveChunkStrategy:
 class TestFtsRowToNoteInfoMalformedJson:
     def test_invalid_frontmatter_json_returns_empty_dict(self) -> None:
         """_fts_row_to_note_info with invalid JSON returns NoteInfo with empty frontmatter."""
-        from markdown_vault_mcp.managers.search import _fts_row_to_note_info
+        from markdown_vault_mcp.utils.fts import (
+            fts_row_to_note_info as _fts_row_to_note_info,
+        )
 
         row = {
             "path": "x.md",
@@ -3149,7 +3151,9 @@ class TestFtsRowToNoteInfoMalformedJson:
 
     def test_none_frontmatter_json_returns_empty_dict(self) -> None:
         """_fts_row_to_note_info with frontmatter_json=None returns empty frontmatter."""
-        from markdown_vault_mcp.managers.search import _fts_row_to_note_info
+        from markdown_vault_mcp.utils.fts import (
+            fts_row_to_note_info as _fts_row_to_note_info,
+        )
 
         row = {
             "path": "y.md",
@@ -3164,7 +3168,9 @@ class TestFtsRowToNoteInfoMalformedJson:
 
     def test_empty_string_frontmatter_json_returns_empty_dict(self) -> None:
         """_fts_row_to_note_info with frontmatter_json='' returns empty frontmatter."""
-        from markdown_vault_mcp.managers.search import _fts_row_to_note_info
+        from markdown_vault_mcp.utils.fts import (
+            fts_row_to_note_info as _fts_row_to_note_info,
+        )
 
         row = {
             "path": "z.md",

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3128,7 +3128,7 @@ class TestResolveChunkStrategy:
 class TestFtsRowToNoteInfoMalformedJson:
     def test_invalid_frontmatter_json_returns_empty_dict(self) -> None:
         """_fts_row_to_note_info with invalid JSON returns NoteInfo with empty frontmatter."""
-        from markdown_vault_mcp.collection import _fts_row_to_note_info
+        from markdown_vault_mcp.managers.search import _fts_row_to_note_info
 
         row = {
             "path": "x.md",
@@ -3145,7 +3145,7 @@ class TestFtsRowToNoteInfoMalformedJson:
 
     def test_none_frontmatter_json_returns_empty_dict(self) -> None:
         """_fts_row_to_note_info with frontmatter_json=None returns empty frontmatter."""
-        from markdown_vault_mcp.collection import _fts_row_to_note_info
+        from markdown_vault_mcp.managers.search import _fts_row_to_note_info
 
         row = {
             "path": "y.md",
@@ -3160,7 +3160,7 @@ class TestFtsRowToNoteInfoMalformedJson:
 
     def test_empty_string_frontmatter_json_returns_empty_dict(self) -> None:
         """_fts_row_to_note_info with frontmatter_json='' returns empty frontmatter."""
-        from markdown_vault_mcp.collection import _fts_row_to_note_info
+        from markdown_vault_mcp.managers.search import _fts_row_to_note_info
 
         row = {
             "path": "z.md",

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -11,12 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from markdown_vault_mcp.collection import (
-    Collection,
-    _build_position_map,
-    _find_closest_match,
-    _normalize_text,
-)
+from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.exceptions import (
     ConcurrentModificationError,
     DocumentExistsError,
@@ -35,6 +30,15 @@ from markdown_vault_mcp.types import (
     NoteInfo,
     RenameResult,
     WriteResult,
+)
+from markdown_vault_mcp.utils.text import (
+    build_position_map as _build_position_map,
+)
+from markdown_vault_mcp.utils.text import (
+    find_closest_match as _find_closest_match,
+)
+from markdown_vault_mcp.utils.text import (
+    normalize_text as _normalize_text,
 )
 
 if TYPE_CHECKING:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -2888,7 +2888,7 @@ class TestBuildEmbeddings:
         mock_provider: MockEmbeddingProvider,
     ) -> None:
         """build_embeddings() calls the provider in batches, not one giant call."""
-        from markdown_vault_mcp.collection import _EMBEDDING_BATCH_SIZE
+        from markdown_vault_mcp.managers.index import _EMBEDDING_BATCH_SIZE
 
         embeddings_path = tmp_path / "embeddings"
         col = Collection(
@@ -2921,7 +2921,7 @@ class TestBuildEmbeddings:
         mock_provider: MockEmbeddingProvider,
     ) -> None:
         """build_embeddings() handles a corpus spanning multiple batches."""
-        from markdown_vault_mcp.collection import _EMBEDDING_BATCH_SIZE
+        from markdown_vault_mcp.managers.index import _EMBEDDING_BATCH_SIZE
 
         # Create a vault with enough chunks to span multiple batches.
         vault = tmp_path / "vault"
@@ -2977,16 +2977,16 @@ class TestBuildIndexNoOp:
         col.build_index()
 
         # Intercept scan_directory to confirm it is NOT called again.
-        import markdown_vault_mcp.collection as col_mod
+        import markdown_vault_mcp.managers.index as idx_mod
 
-        original_scan = col_mod.scan_directory
+        original_scan = idx_mod.scan_directory
         scan_calls: list = []
 
         def tracking_scan(*args, **kwargs):
             scan_calls.append(args)
             return original_scan(*args, **kwargs)
 
-        with patch.object(col_mod, "scan_directory", side_effect=tracking_scan):
+        with patch.object(idx_mod, "scan_directory", side_effect=tracking_scan):
             stats2 = col.build_index()
 
         # scan_directory must not have been invoked on the second call.
@@ -3764,14 +3764,14 @@ class TestDeferredEmbeddings:
             "# Deferred Embedding\n\nUniqueContentForTest.\n",
         )
         # The dirty set should contain this path.
-        assert "deferred_doc.md" in col._dirty_embeddings
+        assert "deferred_doc.md" in col._index_mgr._dirty_embeddings
 
         # Semantic search triggers flush.
         results = col.search("UniqueContentForTest", mode="semantic")
         paths = [r.path for r in results]
         assert "deferred_doc.md" in paths
         # Dirty set should now be empty.
-        assert len(col._dirty_embeddings) == 0
+        assert len(col._index_mgr._dirty_embeddings) == 0
 
     def test_dirty_docs_flushed_on_close(
         self,
@@ -3794,10 +3794,10 @@ class TestDeferredEmbeddings:
             "close_flush.md",
             "# Close Flush\n\nContent to be flushed on close.\n",
         )
-        assert "close_flush.md" in col._dirty_embeddings
+        assert "close_flush.md" in col._index_mgr._dirty_embeddings
 
         col.close()
-        assert len(col._dirty_embeddings) == 0
+        assert len(col._index_mgr._dirty_embeddings) == 0
 
     def test_git_callback_fires_eventually(self, vault_path: Path) -> None:
         """Git callback fires in the background after write returns."""

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1944,25 +1944,25 @@ class TestAttachmentHelpers:
     def test_is_attachment_pdf(self, vault_path: Path) -> None:
         """_is_attachment() returns True for a .pdf path with default allowlist."""
         col = Collection(source_dir=vault_path)
-        assert col._is_attachment("assets/report.pdf") is True
+        assert col._doc_mgr._is_attachment("assets/report.pdf") is True
 
     def test_is_attachment_md_always_false(self, vault_path: Path) -> None:
         """_is_attachment() always returns False for .md paths."""
         col = Collection(source_dir=vault_path)
-        assert col._is_attachment("notes/note.md") is False
+        assert col._doc_mgr._is_attachment("notes/note.md") is False
 
     def test_is_attachment_disallowed_extension(self, vault_path: Path) -> None:
         """_is_attachment() returns False for extensions not in the default list."""
         col = Collection(source_dir=vault_path)
         # .xyz is not in the default list
-        assert col._is_attachment("file.xyz") is False
+        assert col._doc_mgr._is_attachment("file.xyz") is False
 
     def test_is_attachment_wildcard_allows_all(self, vault_path: Path) -> None:
         """_is_attachment() returns True for any non-.md extension when '*' is set."""
         col = Collection(source_dir=vault_path, attachment_extensions=["*"])
-        assert col._is_attachment("file.xyz") is True
-        assert col._is_attachment("file.bin") is True
-        assert col._is_attachment("notes/note.md") is False
+        assert col._doc_mgr._is_attachment("file.xyz") is True
+        assert col._doc_mgr._is_attachment("file.bin") is True
+        assert col._doc_mgr._is_attachment("notes/note.md") is False
 
     def test_validate_attachment_path_rejects_md(self, vault_path: Path) -> None:
         """_validate_attachment_path() raises ValueError for .md paths."""
@@ -2516,7 +2516,7 @@ class TestSemanticSearch:
         # Confirm no .npy file exists before loading.
         assert not (tmp_path / "embeddings.npy").exists()
 
-        vectors = col._load_vectors()
+        vectors = col._search_mgr._load_vectors()
 
         assert vectors is not None
         assert vectors.count == 0
@@ -2549,7 +2549,7 @@ class TestSemanticSearch:
         col2.build_index()
         assert col2._vectors is None  # not yet loaded
 
-        vectors = col2._load_vectors()
+        vectors = col2._search_mgr._load_vectors()
 
         assert vectors.count == chunk_count
 
@@ -2587,7 +2587,7 @@ class TestSemanticSearch:
         )
         col2.build_index()
 
-        vectors = col2._load_vectors()
+        vectors = col2._search_mgr._load_vectors()
         assert vectors.count == expected_count
 
         with (tmp_path / "embeddings.json").open(encoding="utf-8") as fh:
@@ -2600,7 +2600,7 @@ class TestSemanticSearch:
         col = _make_collection(vault_path)
 
         with pytest.raises(ValueError, match="embedding_provider"):
-            col._require_vectors()
+            col._search_mgr._require_vectors()
 
 
 # ---------------------------------------------------------------------------
@@ -3024,7 +3024,7 @@ class TestReindexWithVectors:
         col.build_index()
         col.build_embeddings()
         # Trigger vector load so _vectors is not None.
-        col._load_vectors()
+        col._search_mgr._load_vectors()
         return col
 
     def test_reindex_adds_vector_entries_for_new_files(
@@ -3901,10 +3901,12 @@ class TestLoggingAuditSilentPaths:
             "modified_at": 0.0,
         }
         with (
-            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.collection"),
-            patch.object(col._fts, "get_note", return_value=bad_row),
+            caplog.at_level(
+                logging.WARNING, logger="markdown_vault_mcp.managers.search"
+            ),
+            patch.object(col._search_mgr._fts, "get_note", return_value=bad_row),
         ):
-            result = col._get_frontmatter("note.md")
+            result = col._search_mgr._get_frontmatter("note.md")
         assert result == {}
         assert any(
             "_get_frontmatter: invalid JSON" in rec.message for rec in caplog.records

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -1,0 +1,452 @@
+"""Tests for DocumentManager in isolation (no Collection dependency)."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from markdown_vault_mcp.exceptions import (
+    ConcurrentModificationError,
+    DocumentExistsError,
+    DocumentNotFoundError,
+    EditConflictError,
+    ReadOnlyError,
+)
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.managers.document import DocumentManager
+from markdown_vault_mcp.scanner import HeadingChunker, scan_directory
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def doc_vault(tmp_path: Path) -> Path:
+    """Create a small vault with a few notes and an attachment."""
+    alpha = tmp_path / "alpha.md"
+    alpha.write_text(
+        "---\ntitle: Alpha\n---\n# Alpha\n\nHello world.\n",
+        encoding="utf-8",
+    )
+    beta = tmp_path / "beta.md"
+    beta.write_text(
+        "---\ntitle: Beta\n---\n# Beta\n\nLink to [alpha](alpha.md).\n",
+        encoding="utf-8",
+    )
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    gamma = sub / "gamma.md"
+    gamma.write_text(
+        "---\ntitle: Gamma\n---\n# Gamma\n\n## Section One\n\nContent.\n",
+        encoding="utf-8",
+    )
+    # Attachment
+    img = tmp_path / "image.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+    return tmp_path
+
+
+@pytest.fixture()
+def doc_mgr(doc_vault: Path) -> DocumentManager:
+    """Build a DocumentManager with an indexed FTS and writable vault."""
+    fts = FTSIndex(db_path=":memory:")
+    for note in scan_directory(doc_vault):
+        fts.upsert_note(note)
+    fts.resolve_vault_wikilinks()
+    return DocumentManager(
+        fts=fts,
+        source_dir=doc_vault,
+        write_lock=threading.RLock(),
+        chunk_strategy=HeadingChunker(),
+        read_only=False,
+    )
+
+
+@pytest.fixture()
+def ro_doc_mgr(doc_vault: Path) -> DocumentManager:
+    """Build a read-only DocumentManager."""
+    fts = FTSIndex(db_path=":memory:")
+    for note in scan_directory(doc_vault):
+        fts.upsert_note(note)
+    return DocumentManager(
+        fts=fts,
+        source_dir=doc_vault,
+        write_lock=threading.RLock(),
+        chunk_strategy=HeadingChunker(),
+        read_only=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read tests
+# ---------------------------------------------------------------------------
+
+
+class TestRead:
+    """Tests for DocumentManager.read()."""
+
+    def test_read_existing(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.read("alpha.md")
+        assert result is not None
+        assert result.path == "alpha.md"
+        assert result.title == "Alpha"
+        assert "Hello world" in result.content
+        assert result.etag  # non-empty hash
+
+    def test_read_nonexistent(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.read("nonexistent.md")
+        assert result is None
+
+    def test_read_path_traversal(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.read("../../etc/passwd.md")
+        assert result is None
+
+    def test_read_subfolder(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.read("sub/gamma.md")
+        assert result is not None
+        assert result.folder == "sub"
+
+    def test_read_root_folder_empty_string(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.read("alpha.md")
+        assert result is not None
+        assert result.folder == ""
+
+
+# ---------------------------------------------------------------------------
+# Write tests
+# ---------------------------------------------------------------------------
+
+
+class TestWrite:
+    """Tests for DocumentManager.write()."""
+
+    def test_write_creates_file(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.write("new.md", "# New\n\nContent.\n")
+        assert result.created is True
+        assert result.path == "new.md"
+
+        note = doc_mgr.read("new.md")
+        assert note is not None
+        assert "Content." in note.content
+
+    def test_write_creates_intermediate_dirs(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.write("deep/nested/note.md", "# Deep\n")
+        assert result.created is True
+
+        note = doc_mgr.read("deep/nested/note.md")
+        assert note is not None
+
+    def test_write_with_frontmatter(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.write(
+            "fm.md", "Body.", frontmatter={"title": "FM Note", "tags": ["a"]}
+        )
+        assert result.created is True
+        note = doc_mgr.read("fm.md")
+        assert note is not None
+        assert note.frontmatter.get("title") == "FM Note"
+
+    def test_write_overwrites_existing(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.write("alpha.md", "# Replaced\n")
+        assert result.created is False
+        note = doc_mgr.read("alpha.md")
+        assert note is not None
+        assert "Replaced" in note.content
+
+    def test_write_read_only_raises(self, ro_doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ReadOnlyError):
+            ro_doc_mgr.write("new.md", "# New\n")
+
+    def test_write_path_traversal_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="Path traversal"):
+            doc_mgr.write("../../escape.md", "bad")
+
+
+# ---------------------------------------------------------------------------
+# Edit tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdit:
+    """Tests for DocumentManager.edit()."""
+
+    def test_edit_exact_match(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.edit("alpha.md", old_text="Hello world.", new_text="Goodbye.")
+        assert result.replacements == 1
+        assert result.match_type == "exact"
+
+        note = doc_mgr.read("alpha.md")
+        assert note is not None
+        assert "Goodbye." in note.content
+        assert "Hello world." not in note.content
+
+    def test_edit_returns_edit_result(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.edit("alpha.md", old_text="Hello world.", new_text="X")
+        assert result.path == "alpha.md"
+
+    def test_edit_etag_validation(self, doc_mgr: DocumentManager) -> None:
+        note = doc_mgr.read("alpha.md")
+        assert note is not None
+        # Valid etag should succeed.
+        doc_mgr.edit(
+            "alpha.md",
+            old_text="Hello world.",
+            new_text="Changed.",
+            if_match=note.etag,
+        )
+        # Now the etag is stale.
+        with pytest.raises(ConcurrentModificationError):
+            doc_mgr.edit(
+                "alpha.md",
+                old_text="Changed.",
+                new_text="Oops.",
+                if_match=note.etag,
+            )
+
+    def test_edit_nonexistent_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(DocumentNotFoundError):
+            doc_mgr.edit("missing.md", old_text="x", new_text="y")
+
+    def test_edit_not_found_raises_conflict(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(EditConflictError, match="not found"):
+            doc_mgr.edit("alpha.md", old_text="NOPE NOPE NOPE", new_text="x")
+
+    def test_edit_read_only_raises(self, ro_doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ReadOnlyError):
+            ro_doc_mgr.edit("alpha.md", old_text="Hello", new_text="Bye")
+
+    def test_edit_line_range(self, doc_mgr: DocumentManager) -> None:
+        # alpha.md has: ---\ntitle: Alpha\n---\n# Alpha\n\nHello world.\n
+        # Lines: 1=---, 2=title: Alpha, 3=---, 4=# Alpha, 5=(empty), 6=Hello world.
+        result = doc_mgr.edit(
+            "alpha.md", new_text="Replaced line.", line_start=6, line_end=6
+        )
+        assert result.match_type == "exact"
+        note = doc_mgr.read("alpha.md")
+        assert note is not None
+        assert "Replaced line." in note.content
+
+    def test_edit_empty_old_text_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="old_text must not be empty"):
+            doc_mgr.edit("alpha.md", old_text="", new_text="x")
+
+    def test_edit_no_params_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="Must provide"):
+            doc_mgr.edit("alpha.md")
+
+
+# ---------------------------------------------------------------------------
+# Delete tests
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    """Tests for DocumentManager.delete()."""
+
+    def test_delete_md(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.delete("alpha.md")
+        assert result.path == "alpha.md"
+        assert doc_mgr.read("alpha.md") is None
+
+    def test_delete_nonexistent_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(DocumentNotFoundError):
+            doc_mgr.delete("missing.md")
+
+    def test_delete_read_only_raises(self, ro_doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ReadOnlyError):
+            ro_doc_mgr.delete("alpha.md")
+
+    def test_delete_attachment(self, doc_mgr: DocumentManager, doc_vault: Path) -> None:
+        result = doc_mgr.delete("image.png")
+        assert result.path == "image.png"
+        assert not (doc_vault / "image.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# Rename tests
+# ---------------------------------------------------------------------------
+
+
+class TestRename:
+    """Tests for DocumentManager.rename()."""
+
+    def test_rename_md(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.rename("alpha.md", "alpha_renamed.md")
+        assert result.old_path == "alpha.md"
+        assert result.new_path == "alpha_renamed.md"
+        assert doc_mgr.read("alpha.md") is None
+        assert doc_mgr.read("alpha_renamed.md") is not None
+
+    def test_rename_nonexistent_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(DocumentNotFoundError):
+            doc_mgr.rename("missing.md", "other.md")
+
+    def test_rename_target_exists_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(DocumentExistsError):
+            doc_mgr.rename("alpha.md", "beta.md")
+
+    def test_rename_read_only_raises(self, ro_doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ReadOnlyError):
+            ro_doc_mgr.rename("alpha.md", "other.md")
+
+    def test_rename_attachment(self, doc_mgr: DocumentManager, doc_vault: Path) -> None:
+        result = doc_mgr.rename("image.png", "photo.png")
+        assert result.old_path == "image.png"
+        assert result.new_path == "photo.png"
+        assert not (doc_vault / "image.png").exists()
+        assert (doc_vault / "photo.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# Attachment tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttachments:
+    """Tests for read_attachment and write_attachment."""
+
+    def test_read_attachment(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.read_attachment("image.png")
+        assert result.path == "image.png"
+        assert result.size_bytes > 0
+        assert result.content_base64  # non-empty
+        assert result.etag  # non-empty
+
+    def test_read_attachment_not_found(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            doc_mgr.read_attachment("missing.png")
+
+    def test_write_attachment(self, doc_mgr: DocumentManager, doc_vault: Path) -> None:
+        data = b"fake PDF content"
+        result = doc_mgr.write_attachment("doc.pdf", data)
+        assert result.created is True
+        assert (doc_vault / "doc.pdf").read_bytes() == data
+
+    def test_write_attachment_read_only(self, ro_doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ReadOnlyError):
+            ro_doc_mgr.write_attachment("x.pdf", b"data")
+
+
+# ---------------------------------------------------------------------------
+# TOC tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetToc:
+    """Tests for DocumentManager.get_toc()."""
+
+    def test_get_toc(self, doc_mgr: DocumentManager) -> None:
+        toc = doc_mgr.get_toc("sub/gamma.md")
+        assert len(toc) >= 1
+        assert toc[0]["heading"] == "Gamma"
+        assert toc[0]["level"] == 1
+
+    def test_get_toc_not_found(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="Document not found"):
+            doc_mgr.get_toc("missing.md")
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    """Tests for path validation helpers."""
+
+    def test_validate_path_rejects_traversal(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="Path traversal"):
+            doc_mgr._validate_path("../../etc/passwd.md")
+
+    def test_validate_path_rejects_non_md(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match=r"must end with '\.md'"):
+            doc_mgr._validate_path("file.txt")
+
+    def test_validate_path_valid(
+        self, doc_mgr: DocumentManager, doc_vault: Path
+    ) -> None:
+        result = doc_mgr._validate_path("alpha.md")
+        assert result == (doc_vault / "alpha.md").resolve()
+
+    def test_check_writable_raises_when_read_only(
+        self, ro_doc_mgr: DocumentManager
+    ) -> None:
+        with pytest.raises(ReadOnlyError):
+            ro_doc_mgr._check_writable()
+
+    def test_check_writable_ok_when_writable(self, doc_mgr: DocumentManager) -> None:
+        doc_mgr._check_writable()  # should not raise
+
+    def test_is_attachment(self, doc_mgr: DocumentManager) -> None:
+        assert doc_mgr._is_attachment("image.png") is True
+        assert doc_mgr._is_attachment("note.md") is False
+
+    def test_is_path_excluded(self, doc_vault: Path) -> None:
+        fts = FTSIndex(db_path=":memory:")
+        mgr = DocumentManager(
+            fts=fts,
+            source_dir=doc_vault,
+            write_lock=threading.RLock(),
+            chunk_strategy=HeadingChunker(),
+            exclude_patterns=["*.tmp", "drafts/*"],
+        )
+        assert mgr._is_path_excluded("notes.tmp") is True
+        assert mgr._is_path_excluded("drafts/foo.md") is True
+        assert mgr._is_path_excluded("alpha.md") is False
+
+
+# ---------------------------------------------------------------------------
+# Callback wiring tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallbacks:
+    """Tests that callbacks are invoked during write operations."""
+
+    def test_write_fires_callbacks(self, doc_vault: Path) -> None:
+        fts = FTSIndex(db_path=":memory:")
+        for note in scan_directory(doc_vault):
+            fts.upsert_note(note)
+
+        write_calls: list[tuple] = []
+        vector_calls: list[str] = []
+
+        mgr = DocumentManager(
+            fts=fts,
+            source_dir=doc_vault,
+            write_lock=threading.RLock(),
+            chunk_strategy=HeadingChunker(),
+            read_only=False,
+            on_write_callback=lambda p, _c, op: write_calls.append((p, op)),
+            on_vector_update=lambda note: vector_calls.append(note.path),
+        )
+        mgr.write("cb_test.md", "# Callback test\n")
+        assert len(write_calls) == 1
+        assert write_calls[0][1] == "write"
+        assert "cb_test.md" in vector_calls
+
+    def test_delete_fires_dirty_callback(self, doc_vault: Path) -> None:
+        fts = FTSIndex(db_path=":memory:")
+        for note in scan_directory(doc_vault):
+            fts.upsert_note(note)
+
+        dirty_calls: list[str] = []
+        write_calls: list[str] = []
+
+        mgr = DocumentManager(
+            fts=fts,
+            source_dir=doc_vault,
+            write_lock=threading.RLock(),
+            chunk_strategy=HeadingChunker(),
+            read_only=False,
+            on_write_callback=lambda _p, _c, op: write_calls.append(op),
+            on_vector_dirty=lambda path: dirty_calls.append(path),
+        )
+        mgr.delete("alpha.md")
+        assert "alpha.md" in dirty_calls
+        assert "delete" in write_calls

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1,0 +1,428 @@
+"""Tests for IndexManager in isolation (no Collection dependency)."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.managers.index import IndexManager
+from markdown_vault_mcp.scanner import HeadingChunker
+from markdown_vault_mcp.tracker import ChangeTracker
+from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def index_vault(tmp_path: Path) -> Path:
+    """Create a small vault suitable for index tests.
+
+    Contains:
+        alpha.md   (root, tags: [a, b])
+        beta.md    (root, tags: [b])
+        notes/gamma.md (subfolder, tags: [c])
+        notes/delta.md (subfolder, no tags)
+    """
+    alpha = tmp_path / "alpha.md"
+    alpha.write_text(
+        "---\ntitle: Alpha\ntags:\n  - a\n  - b\n---\n# Alpha\n\nHello world.\n",
+        encoding="utf-8",
+    )
+    beta = tmp_path / "beta.md"
+    beta.write_text(
+        "---\ntitle: Beta\ntags:\n  - b\n---\n# Beta\n\nGoodbye world.\n",
+        encoding="utf-8",
+    )
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    gamma = notes_dir / "gamma.md"
+    gamma.write_text(
+        "---\ntitle: Gamma\ntags:\n  - c\n---\n# Gamma\n\nUnique gamma content.\n",
+        encoding="utf-8",
+    )
+    delta = notes_dir / "delta.md"
+    delta.write_text(
+        "---\ntitle: Delta\n---\n# Delta\n\nDelta content.\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _make_index_mgr(
+    vault: Path,
+    state_dir: Path,
+    **overrides,
+) -> tuple[IndexManager, FTSIndex, dict]:
+    """Build an IndexManager with default wiring.
+
+    Returns (index_mgr, fts, vectors_holder) so tests can inspect state.
+    """
+    fts = overrides.pop("fts", None) or FTSIndex(db_path=":memory:")
+    tracker = overrides.pop("tracker", None) or ChangeTracker(
+        state_dir / ".state" / "state.json"
+    )
+    vectors_holder: dict = {"vectors": None}
+    defaults = {
+        "fts": fts,
+        "tracker": tracker,
+        "source_dir": vault,
+        "write_lock": threading.RLock(),
+        "chunk_strategy": HeadingChunker(),
+        "get_vectors": lambda: vectors_holder["vectors"],
+        "set_vectors": lambda v: vectors_holder.__setitem__("vectors", v),
+    }
+    defaults.update(overrides)
+    mgr = IndexManager(**defaults)
+    return mgr, fts, vectors_holder
+
+
+@pytest.fixture()
+def index_mgr(index_vault: Path, tmp_path: Path) -> tuple[IndexManager, FTSIndex, dict]:
+    """Build an IndexManager from the test vault."""
+    return _make_index_mgr(index_vault, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# build_index
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIndex:
+    """Tests for IndexManager.build_index()."""
+
+    def test_returns_index_stats(self, index_mgr):
+        mgr, _fts, _ = index_mgr
+        result = mgr.build_index()
+        assert isinstance(result, IndexStats)
+        assert result.documents_indexed >= 4
+
+    def test_document_count(self, index_mgr):
+        mgr, fts, _ = index_mgr
+        mgr.build_index()
+        notes = fts.list_notes()
+        assert len(notes) == 4
+
+    def test_idempotent_rebuild(self, index_mgr):
+        """Second build_index without force re-scans (no early exit at mgr level)."""
+        mgr, _fts, _ = index_mgr
+        result1 = mgr.build_index()
+        result2 = mgr.build_index()
+        # IndexManager always rescans; the Collection wrapper handles the no-op.
+        assert result2.documents_indexed == result1.documents_indexed
+
+    def test_force_rebuild(self, index_mgr):
+        mgr, _fts, _ = index_mgr
+        mgr.build_index()
+        result = mgr.build_index(force=True)
+        assert result.documents_indexed >= 4
+
+    def test_respects_exclude_patterns(self, index_vault: Path, tmp_path: Path):
+        mgr, fts, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            exclude_patterns=["notes/*"],
+        )
+        mgr.build_index()
+        notes = fts.list_notes()
+        paths = {n["path"] for n in notes}
+        assert "alpha.md" in paths
+        assert "beta.md" in paths
+        assert not any(p.startswith("notes/") for p in paths)
+
+    def test_continues_on_upsert_error(self, index_vault: Path, tmp_path: Path):
+        """If one document fails to upsert, others still get indexed."""
+        fts = FTSIndex(db_path=":memory:")
+        original_upsert = fts.upsert_note
+        call_count = {"n": 0}
+
+        def failing_upsert(note):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("Simulated upsert failure")
+            return original_upsert(note)
+
+        fts.upsert_note = failing_upsert  # type: ignore[assignment]
+        mgr, _, _ = _make_index_mgr(index_vault, tmp_path, fts=fts)
+        result = mgr.build_index()
+        # One errored, rest succeeded.
+        assert result.documents_indexed == 3
+
+    def test_updates_tracker_state(self, index_mgr):
+        """build_index updates the change tracker baseline."""
+        mgr, _fts, _ = index_mgr
+        mgr.build_index()
+        # After build_index, detect_changes should report no changes.
+        changes = mgr._tracker.detect_changes(mgr._source_dir)
+        assert len(changes.added) == 0
+        assert len(changes.modified) == 0
+        assert len(changes.deleted) == 0
+
+    def test_resolves_wikilinks(self, index_vault: Path, tmp_path: Path):
+        """build_index calls resolve_vault_wikilinks on the FTS index."""
+        fts = MagicMock(spec=FTSIndex)
+        fts.list_notes.return_value = []
+        mgr, _, _ = _make_index_mgr(index_vault, tmp_path, fts=fts)
+        mgr.build_index()
+        fts.resolve_vault_wikilinks.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# reindex
+# ---------------------------------------------------------------------------
+
+
+class TestReindex:
+    """Tests for IndexManager.reindex()."""
+
+    def test_detects_new_file(self, index_vault: Path, tmp_path: Path):
+        mgr, fts, _ = _make_index_mgr(index_vault, tmp_path)
+        mgr.build_index()
+
+        # Add a new file.
+        new_file = index_vault / "new_note.md"
+        new_file.write_text(
+            "---\ntitle: New\n---\n# New\n\nNew content.\n",
+            encoding="utf-8",
+        )
+
+        result = mgr.reindex()
+        assert isinstance(result, ReindexResult)
+        assert result.added >= 1
+
+        paths = {n["path"] for n in fts.list_notes()}
+        assert "new_note.md" in paths
+
+    def test_detects_deleted_file(self, index_vault: Path, tmp_path: Path):
+        mgr, fts, _ = _make_index_mgr(index_vault, tmp_path)
+        mgr.build_index()
+
+        # Delete a file.
+        (index_vault / "beta.md").unlink()
+
+        result = mgr.reindex()
+        assert result.deleted >= 1
+
+        paths = {n["path"] for n in fts.list_notes()}
+        assert "beta.md" not in paths
+
+    def test_detects_modified_file(self, index_vault: Path, tmp_path: Path):
+        mgr, _fts, _ = _make_index_mgr(index_vault, tmp_path)
+        mgr.build_index()
+
+        # Modify a file.
+        (index_vault / "alpha.md").write_text(
+            "---\ntitle: Alpha Updated\n---\n# Alpha\n\nUpdated.\n",
+            encoding="utf-8",
+        )
+
+        result = mgr.reindex()
+        assert result.modified >= 1
+
+
+# ---------------------------------------------------------------------------
+# build_embeddings
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEmbeddings:
+    """Tests for IndexManager.build_embeddings()."""
+
+    def test_returns_zero_without_provider(self, index_vault: Path, tmp_path: Path):
+        """build_embeddings raises ValueError when no provider is configured."""
+        mgr, _fts, _ = _make_index_mgr(index_vault, tmp_path)
+        mgr.build_index()
+        with pytest.raises(ValueError, match="Embeddings require"):
+            mgr.build_embeddings()
+
+    def test_builds_with_provider(self, index_vault: Path, tmp_path: Path):
+        """build_embeddings returns chunk count when provider is configured."""
+        from tests.conftest import MockEmbeddingProvider
+
+        provider = MockEmbeddingProvider()
+        embeddings_path = tmp_path / "embeddings"
+        vectors_holder: dict = {"vectors": None}
+        mgr, _fts, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=provider,
+            get_vectors=lambda: vectors_holder["vectors"],
+            set_vectors=lambda v: vectors_holder.__setitem__("vectors", v),
+        )
+        mgr.build_index()
+        count = mgr.build_embeddings()
+        assert count >= 4
+        assert vectors_holder["vectors"] is not None
+
+
+# ---------------------------------------------------------------------------
+# embeddings_status
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingsStatus:
+    """Tests for IndexManager.embeddings_status()."""
+
+    def test_not_configured(self, index_mgr):
+        mgr, _, _ = index_mgr
+        status = mgr.embeddings_status()
+        assert status["available"] is False
+        assert status["provider"] is None
+        assert status["chunk_count"] == 0
+        assert status["path"] is None
+
+    def test_configured(self, index_vault: Path, tmp_path: Path):
+        from tests.conftest import MockEmbeddingProvider
+
+        provider = MockEmbeddingProvider()
+        embeddings_path = tmp_path / "embeddings"
+        mgr, _, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=provider,
+        )
+        status = mgr.embeddings_status()
+        assert status["available"] is True
+        assert status["provider"] == "MockEmbeddingProvider"
+        assert status["path"] == str(embeddings_path)
+
+
+# ---------------------------------------------------------------------------
+# update_vector_index / mark_dirty / remove_from_dirty
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredEmbeddings:
+    """Tests for deferred embedding methods."""
+
+    def test_update_vector_index_noop_without_embeddings(self, index_mgr):
+        """update_vector_index is a no-op when embeddings are not configured."""
+        mgr, _, _ = index_mgr
+        note = ParsedNote(
+            path="test.md",
+            frontmatter={},
+            title="Test",
+            chunks=[],
+            content_hash="abc123",
+            modified_at=0.0,
+        )
+        mgr.update_vector_index(note)
+        assert len(mgr._dirty_embeddings) == 0
+
+    def test_update_vector_index_adds_to_dirty(self, index_vault: Path, tmp_path: Path):
+        """update_vector_index adds path to dirty set when embeddings configured."""
+        from tests.conftest import MockEmbeddingProvider
+
+        provider = MockEmbeddingProvider()
+        mgr, _, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=provider,
+        )
+        note = ParsedNote(
+            path="test.md",
+            frontmatter={},
+            title="Test",
+            chunks=[],
+            content_hash="abc123",
+            modified_at=0.0,
+        )
+        mgr.update_vector_index(note)
+        # Cancel the timer to avoid background flush.
+        mgr.cancel_flush_timer()
+        assert "test.md" in mgr._dirty_embeddings
+
+    def test_mark_dirty(self, index_vault: Path, tmp_path: Path):
+        """mark_dirty adds path to dirty set."""
+        from tests.conftest import MockEmbeddingProvider
+
+        provider = MockEmbeddingProvider()
+        mgr, _, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=provider,
+        )
+        mgr.mark_dirty("some/path.md")
+        mgr.cancel_flush_timer()
+        assert "some/path.md" in mgr._dirty_embeddings
+
+    def test_remove_from_dirty(self, index_vault: Path, tmp_path: Path):
+        """remove_from_dirty removes path from dirty set."""
+        from tests.conftest import MockEmbeddingProvider
+
+        provider = MockEmbeddingProvider()
+        mgr, _, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=provider,
+        )
+        mgr._dirty_embeddings.add("target.md")
+        mgr.remove_from_dirty("target.md")
+        assert "target.md" not in mgr._dirty_embeddings
+
+    def test_remove_from_dirty_nonexistent(self, index_mgr):
+        """remove_from_dirty is safe when path is not in set."""
+        mgr, _, _ = index_mgr
+        mgr.remove_from_dirty("nonexistent.md")
+
+    def test_flush_noop_when_nothing_dirty(self, index_mgr):
+        """flush_dirty_embeddings is a no-op when nothing is dirty."""
+        mgr, _, _ = index_mgr
+        # Should not raise.
+        mgr.flush_dirty_embeddings()
+
+    def test_flush_noop_without_provider(self, index_mgr):
+        """flush_dirty_embeddings is a no-op without embedding provider."""
+        mgr, _, _ = index_mgr
+        mgr._dirty_embeddings.add("something.md")
+        mgr.flush_dirty_embeddings()
+        # Still in dirty set because provider check skips the flush.
+        assert "something.md" in mgr._dirty_embeddings
+
+    def test_cancel_flush_timer(self, index_vault: Path, tmp_path: Path):
+        """cancel_flush_timer cancels without flushing."""
+        from tests.conftest import MockEmbeddingProvider
+
+        provider = MockEmbeddingProvider()
+        mgr, _, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=provider,
+        )
+        mgr.mark_dirty("test.md")
+        mgr.cancel_flush_timer()
+        # Timer cancelled but dirty set still has the entry.
+        assert "test.md" in mgr._dirty_embeddings
+        assert mgr._embedding_flush_timer is None
+
+
+# ---------------------------------------------------------------------------
+# _is_path_excluded
+# ---------------------------------------------------------------------------
+
+
+class TestIsPathExcluded:
+    """Tests for IndexManager._is_path_excluded()."""
+
+    def test_no_patterns(self, index_mgr):
+        mgr, _, _ = index_mgr
+        assert mgr._is_path_excluded("anything.md") is False
+
+    def test_matching_pattern(self, index_vault: Path, tmp_path: Path):
+        mgr, _, _ = _make_index_mgr(index_vault, tmp_path, exclude_patterns=["notes/*"])
+        assert mgr._is_path_excluded("notes/gamma.md") is True
+        assert mgr._is_path_excluded("alpha.md") is False

--- a/tests/test_managers_link.py
+++ b/tests/test_managers_link.py
@@ -1,0 +1,269 @@
+"""Tests for LinkManager in isolation (no Collection dependency)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.managers.link import LinkManager
+from markdown_vault_mcp.scanner import scan_directory
+from markdown_vault_mcp.types import (
+    BacklinkInfo,
+    BrokenLinkInfo,
+    MostLinkedNote,
+    NoteInfo,
+    OutlinkInfo,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def linked_vault(tmp_path: Path) -> Path:
+    """Create a small vault with interlinked notes.
+
+    Graph:
+        alpha.md -> beta.md  (markdown link)
+        alpha.md -> gamma.md (wikilink)
+        beta.md  -> alpha.md (markdown link)
+        gamma.md -> (no outlinks)
+        orphan.md -> (no outlinks, no inlinks)
+        alpha.md -> missing.md (broken link)
+    """
+    alpha = tmp_path / "alpha.md"
+    alpha.write_text(
+        "---\ntitle: Alpha\n---\n"
+        "# Alpha\n\n"
+        "Link to [beta](beta.md) and [[gamma]].\n"
+        "Also a broken link to [missing](missing.md).\n",
+        encoding="utf-8",
+    )
+    beta = tmp_path / "beta.md"
+    beta.write_text(
+        "---\ntitle: Beta\n---\n# Beta\n\nBack to [alpha](alpha.md).\n",
+        encoding="utf-8",
+    )
+    gamma = tmp_path / "gamma.md"
+    gamma.write_text(
+        "---\ntitle: Gamma\n---\n# Gamma\n\nNo outgoing links here.\n",
+        encoding="utf-8",
+    )
+    orphan = tmp_path / "orphan.md"
+    orphan.write_text(
+        "---\ntitle: Orphan\n---\n# Orphan\n\nCompletely disconnected.\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def link_mgr(linked_vault: Path) -> LinkManager:
+    """Build a LinkManager from a scanned vault."""
+    fts = FTSIndex(db_path=":memory:")
+    for note in scan_directory(linked_vault):
+        fts.upsert_note(note)
+    fts.resolve_vault_wikilinks()
+    return LinkManager(fts=fts, source_dir=linked_vault)
+
+
+# ---------------------------------------------------------------------------
+# get_backlinks
+# ---------------------------------------------------------------------------
+
+
+class TestGetBacklinks:
+    def test_returns_backlink_info(self, link_mgr: LinkManager) -> None:
+        """get_backlinks returns BacklinkInfo objects."""
+        results = link_mgr.get_backlinks("beta.md")
+        assert len(results) >= 1
+        assert all(isinstance(r, BacklinkInfo) for r in results)
+        sources = [r.source_path for r in results]
+        assert "alpha.md" in sources
+
+    def test_finds_correct_sources(self, link_mgr: LinkManager) -> None:
+        """alpha.md has a backlink from beta.md."""
+        results = link_mgr.get_backlinks("alpha.md")
+        sources = [r.source_path for r in results]
+        assert "beta.md" in sources
+
+    def test_nonexistent_raises_value_error(self, link_mgr: LinkManager) -> None:
+        """Querying backlinks for a nonexistent note raises ValueError."""
+        with pytest.raises(ValueError, match="Document not found"):
+            link_mgr.get_backlinks("nonexistent.md")
+
+    def test_path_traversal_rejected(self, link_mgr: LinkManager) -> None:
+        """Path traversal attempt raises ValueError."""
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            link_mgr.get_backlinks("../../etc/passwd.md")
+
+    def test_non_md_rejected(self, link_mgr: LinkManager) -> None:
+        """Non-.md path raises ValueError."""
+        with pytest.raises(ValueError, match=r"Path must end with '\.md'"):
+            link_mgr.get_backlinks("notes.txt")
+
+    def test_limit_parameter(self, link_mgr: LinkManager) -> None:
+        """limit parameter caps the number of results."""
+        # gamma has backlinks from alpha; use limit=1
+        all_results = link_mgr.get_backlinks("gamma.md")
+        limited = link_mgr.get_backlinks("gamma.md", limit=1)
+        assert len(limited) <= 1
+        assert len(limited) <= len(all_results)
+
+
+# ---------------------------------------------------------------------------
+# get_outlinks
+# ---------------------------------------------------------------------------
+
+
+class TestGetOutlinks:
+    def test_returns_outlink_info(self, link_mgr: LinkManager) -> None:
+        """get_outlinks returns OutlinkInfo objects."""
+        results = link_mgr.get_outlinks("alpha.md")
+        assert len(results) >= 2
+        assert all(isinstance(r, OutlinkInfo) for r in results)
+
+    def test_finds_correct_targets(self, link_mgr: LinkManager) -> None:
+        """alpha.md links to beta.md and gamma.md."""
+        results = link_mgr.get_outlinks("alpha.md")
+        targets = [r.target_path for r in results]
+        assert "beta.md" in targets
+        assert "gamma.md" in targets
+
+    def test_exists_flag_correct(self, link_mgr: LinkManager) -> None:
+        """Existing targets have exists=True, missing have exists=False."""
+        results = link_mgr.get_outlinks("alpha.md")
+        by_target = {r.target_path: r for r in results}
+        assert by_target["beta.md"].exists is True
+        assert by_target["missing.md"].exists is False
+
+    def test_nonexistent_raises_value_error(self, link_mgr: LinkManager) -> None:
+        """Querying outlinks for a nonexistent note raises ValueError."""
+        with pytest.raises(ValueError, match="Document not found"):
+            link_mgr.get_outlinks("nonexistent.md")
+
+    def test_limit_parameter(self, link_mgr: LinkManager) -> None:
+        """limit parameter caps the number of results."""
+        limited = link_mgr.get_outlinks("alpha.md", limit=1)
+        assert len(limited) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_broken_links
+# ---------------------------------------------------------------------------
+
+
+class TestGetBrokenLinks:
+    def test_returns_broken_link_info(self, link_mgr: LinkManager) -> None:
+        """get_broken_links returns BrokenLinkInfo objects."""
+        results = link_mgr.get_broken_links()
+        assert len(results) >= 1
+        assert all(isinstance(r, BrokenLinkInfo) for r in results)
+
+    def test_finds_broken_links(self, link_mgr: LinkManager) -> None:
+        """The link from alpha.md to missing.md is broken."""
+        results = link_mgr.get_broken_links()
+        targets = [r.target_path for r in results]
+        assert "missing.md" in targets
+
+    def test_folder_filter(self, link_mgr: LinkManager) -> None:
+        """Folder filter restricts results (empty folder yields no results)."""
+        results = link_mgr.get_broken_links(folder="nonexistent_folder")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# get_orphan_notes
+# ---------------------------------------------------------------------------
+
+
+class TestGetOrphanNotes:
+    def test_returns_note_info(self, link_mgr: LinkManager) -> None:
+        """get_orphan_notes returns NoteInfo objects."""
+        results = link_mgr.get_orphan_notes()
+        assert all(isinstance(r, NoteInfo) for r in results)
+
+    def test_finds_orphans(self, link_mgr: LinkManager) -> None:
+        """orphan.md has no links in or out, so it is an orphan."""
+        results = link_mgr.get_orphan_notes()
+        paths = [r.path for r in results]
+        assert "orphan.md" in paths
+
+    def test_connected_notes_not_orphans(self, link_mgr: LinkManager) -> None:
+        """alpha.md, beta.md, gamma.md are all connected — not orphans."""
+        results = link_mgr.get_orphan_notes()
+        paths = [r.path for r in results]
+        assert "alpha.md" not in paths
+        assert "beta.md" not in paths
+        assert "gamma.md" not in paths
+
+
+# ---------------------------------------------------------------------------
+# get_most_linked
+# ---------------------------------------------------------------------------
+
+
+class TestGetMostLinked:
+    def test_returns_most_linked_note(self, link_mgr: LinkManager) -> None:
+        """get_most_linked returns MostLinkedNote objects."""
+        results = link_mgr.get_most_linked()
+        assert all(isinstance(r, MostLinkedNote) for r in results)
+
+    def test_ordering(self, link_mgr: LinkManager) -> None:
+        """Results are ordered by backlink count descending."""
+        results = link_mgr.get_most_linked()
+        if len(results) >= 2:
+            assert results[0].backlink_count >= results[1].backlink_count
+
+    def test_limit_parameter(self, link_mgr: LinkManager) -> None:
+        """limit parameter caps the number of results."""
+        results = link_mgr.get_most_linked(limit=1)
+        assert len(results) <= 1
+
+
+# ---------------------------------------------------------------------------
+# get_connection_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetConnectionPath:
+    def test_direct_connection(self, link_mgr: LinkManager) -> None:
+        """alpha -> beta is a direct connection."""
+        path = link_mgr.get_connection_path("alpha.md", "beta.md")
+        assert path is not None
+        assert path[0] == "alpha.md"
+        assert path[-1] == "beta.md"
+
+    def test_indirect_connection(self, link_mgr: LinkManager) -> None:
+        """beta -> gamma goes through alpha (beta->alpha->gamma)."""
+        path = link_mgr.get_connection_path("beta.md", "gamma.md")
+        assert path is not None
+        assert path[0] == "beta.md"
+        assert path[-1] == "gamma.md"
+        assert len(path) >= 2
+
+    def test_no_connection_returns_none(self, link_mgr: LinkManager) -> None:
+        """orphan.md has no connections to anyone."""
+        path = link_mgr.get_connection_path("orphan.md", "alpha.md")
+        assert path is None
+
+    def test_path_traversal_rejected(self, link_mgr: LinkManager) -> None:
+        """Path traversal in source raises ValueError."""
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            link_mgr.get_connection_path("../../etc/passwd.md", "alpha.md")
+
+    def test_path_traversal_rejected_target(self, link_mgr: LinkManager) -> None:
+        """Path traversal in target raises ValueError."""
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            link_mgr.get_connection_path("alpha.md", "../../etc/passwd.md")
+
+    def test_non_md_rejected(self, link_mgr: LinkManager) -> None:
+        """Non-.md path raises ValueError."""
+        with pytest.raises(ValueError, match=r"Path must end with '\.md'"):
+            link_mgr.get_connection_path("alpha.txt", "beta.md")

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -1,0 +1,521 @@
+"""Tests for SearchManager in isolation (no Collection dependency)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.managers.link import LinkManager
+from markdown_vault_mcp.managers.search import (
+    SearchManager,
+    _fts_row_to_note_info,
+)
+from markdown_vault_mcp.scanner import scan_directory
+from markdown_vault_mcp.types import (
+    AttachmentInfo,
+    NoteContext,
+    NoteInfo,
+    SearchResult,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def search_vault(tmp_path: Path) -> Path:
+    """Create a small vault suitable for search/list tests.
+
+    Contains:
+        alpha.md   (root, tags: [a, b])
+        beta.md    (root, tags: [b])
+        notes/gamma.md (subfolder, tags: [c])
+        notes/delta.md (subfolder, no tags)
+        alpha.md -> beta.md (link)
+        beta.md -> alpha.md (link)
+    """
+    alpha = tmp_path / "alpha.md"
+    alpha.write_text(
+        "---\ntitle: Alpha\ntags:\n  - a\n  - b\n---\n"
+        "# Alpha\n\nHello world. Link to [beta](beta.md).\n",
+        encoding="utf-8",
+    )
+    beta = tmp_path / "beta.md"
+    beta.write_text(
+        "---\ntitle: Beta\ntags:\n  - b\n---\n"
+        "# Beta\n\nGoodbye world. Back to [alpha](alpha.md).\n",
+        encoding="utf-8",
+    )
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    gamma = notes_dir / "gamma.md"
+    gamma.write_text(
+        "---\ntitle: Gamma\ntags:\n  - c\n---\n"
+        "# Gamma\n\nUnique gamma content in notes folder.\n",
+        encoding="utf-8",
+    )
+    delta = notes_dir / "delta.md"
+    delta.write_text(
+        "---\ntitle: Delta\n---\n# Delta\n\nDelta has no tags.\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def search_mgr(search_vault: Path) -> SearchManager:
+    """Build a SearchManager from a scanned vault."""
+    fts = FTSIndex(db_path=":memory:", indexed_frontmatter_fields=["tags"])
+    for note in scan_directory(search_vault):
+        fts.upsert_note(note)
+    fts.resolve_vault_wikilinks()
+    link_mgr = LinkManager(fts=fts, source_dir=search_vault)
+    return SearchManager(
+        fts=fts,
+        source_dir=search_vault,
+        indexed_frontmatter_fields=["tags"],
+        link_manager=link_mgr,
+        attachment_extensions=["png"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# keyword search
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordSearch:
+    def test_search_returns_results(self, search_mgr: SearchManager) -> None:
+        """Keyword search returns SearchResult objects."""
+        results = search_mgr.search("world")
+        assert len(results) >= 1
+        assert all(isinstance(r, SearchResult) for r in results)
+        assert all(r.search_type == "keyword" for r in results)
+
+    def test_search_respects_limit(self, search_mgr: SearchManager) -> None:
+        """Keyword search respects the limit parameter."""
+        results = search_mgr.search("world", limit=1)
+        assert len(results) <= 1
+
+    def test_search_folder_filter(self, search_mgr: SearchManager) -> None:
+        """Keyword search respects folder filter."""
+        results = search_mgr.search("content", folder="notes")
+        paths = [r.path for r in results]
+        assert all(p.startswith("notes/") for p in paths)
+
+    def test_search_returns_frontmatter(self, search_mgr: SearchManager) -> None:
+        """Keyword search results include frontmatter."""
+        results = search_mgr.search("Hello")
+        alpha_results = [r for r in results if r.path == "alpha.md"]
+        assert len(alpha_results) >= 1
+        assert "tags" in alpha_results[0].frontmatter
+
+    def test_search_no_results(self, search_mgr: SearchManager) -> None:
+        """Keyword search for nonexistent term returns empty list."""
+        results = search_mgr.search("zzzznonexistent")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# semantic search
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticSearch:
+    def test_semantic_raises_without_provider(self, search_mgr: SearchManager) -> None:
+        """Semantic search raises ValueError without embedding config."""
+        with pytest.raises(ValueError, match="Semantic search requires"):
+            search_mgr.search("hello", mode="semantic")
+
+    def test_hybrid_raises_without_provider(self, search_mgr: SearchManager) -> None:
+        """Hybrid search raises ValueError without embedding config."""
+        with pytest.raises(ValueError, match="Semantic search requires"):
+            search_mgr.search("hello", mode="hybrid")
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    def test_list_returns_note_info(self, search_mgr: SearchManager) -> None:
+        """list() returns NoteInfo objects."""
+        items = search_mgr.list()
+        assert len(items) == 4
+        assert all(isinstance(i, NoteInfo) for i in items)
+
+    def test_list_folder_filter(self, search_mgr: SearchManager) -> None:
+        """list() filters by folder."""
+        items = search_mgr.list(folder="notes")
+        assert len(items) == 2
+        assert all(i.path.startswith("notes/") for i in items)
+
+    def test_list_pattern_filter(self, search_mgr: SearchManager) -> None:
+        """list() filters by glob pattern."""
+        items = search_mgr.list(pattern="alpha*")
+        assert len(items) == 1
+        assert items[0].path == "alpha.md"
+
+    def test_list_include_attachments(
+        self, search_vault: Path, search_mgr: SearchManager
+    ) -> None:
+        """list(include_attachments=True) returns AttachmentInfo for non-.md files."""
+        # Create a .png file in the vault.
+        (search_vault / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        items = search_mgr.list(include_attachments=True)
+        attachment_items = [i for i in items if isinstance(i, AttachmentInfo)]
+        assert len(attachment_items) == 1
+        assert attachment_items[0].path == "image.png"
+        assert attachment_items[0].kind == "attachment"
+
+    def test_list_attachments_respects_extension_filter(
+        self, search_vault: Path, search_mgr: SearchManager
+    ) -> None:
+        """Attachments not in allowlist are excluded."""
+        (search_vault / "doc.txt").write_text("hi", encoding="utf-8")
+        items = search_mgr.list(include_attachments=True)
+        attachment_items = [i for i in items if isinstance(i, AttachmentInfo)]
+        # .txt is not in ["png"], so should not appear.
+        assert all(a.path != "doc.txt" for a in attachment_items)
+
+    def test_list_attachments_hidden_dirs_excluded(
+        self, search_vault: Path, search_mgr: SearchManager
+    ) -> None:
+        """Attachments inside hidden directories are excluded."""
+        hidden = search_vault / ".hidden"
+        hidden.mkdir()
+        (hidden / "secret.png").write_bytes(b"\x89PNG")
+        items = search_mgr.list(include_attachments=True)
+        attachment_paths = [i.path for i in items if isinstance(i, AttachmentInfo)]
+        assert ".hidden/secret.png" not in attachment_paths
+
+
+# ---------------------------------------------------------------------------
+# list_folders
+# ---------------------------------------------------------------------------
+
+
+class TestListFolders:
+    def test_list_folders_returns_folders(self, search_mgr: SearchManager) -> None:
+        """list_folders() returns folder strings."""
+        folders = search_mgr.list_folders()
+        assert "" in folders  # root
+        assert "notes" in folders
+
+
+# ---------------------------------------------------------------------------
+# list_tags
+# ---------------------------------------------------------------------------
+
+
+class TestListTags:
+    def test_list_tags_returns_values(self, search_mgr: SearchManager) -> None:
+        """list_tags() returns indexed tag values."""
+        tags = search_mgr.list_tags("tags")
+        assert "a" in tags
+        assert "b" in tags
+        assert "c" in tags
+
+    def test_list_tags_empty_for_unindexed(self, search_mgr: SearchManager) -> None:
+        """list_tags() for unindexed field returns empty list."""
+        assert search_mgr.list_tags("nonexistent") == []
+
+
+# ---------------------------------------------------------------------------
+# get_recent
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecent:
+    def test_get_recent_returns_note_info(self, search_mgr: SearchManager) -> None:
+        """get_recent() returns NoteInfo objects ordered by modified_at."""
+        recent = search_mgr.get_recent(limit=4)
+        assert len(recent) == 4
+        assert all(isinstance(r, NoteInfo) for r in recent)
+        # Should be ordered by modified_at descending.
+        timestamps = [r.modified_at for r in recent]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    def test_get_recent_respects_limit(self, search_mgr: SearchManager) -> None:
+        """get_recent() respects limit parameter."""
+        recent = search_mgr.get_recent(limit=2)
+        assert len(recent) == 2
+
+    def test_get_recent_folder_filter(self, search_mgr: SearchManager) -> None:
+        """get_recent() filters by folder."""
+        recent = search_mgr.get_recent(folder="notes")
+        assert all(r.path.startswith("notes/") for r in recent)
+
+
+# ---------------------------------------------------------------------------
+# get_similar
+# ---------------------------------------------------------------------------
+
+
+class TestGetSimilar:
+    def test_get_similar_empty_without_embeddings(
+        self, search_mgr: SearchManager
+    ) -> None:
+        """get_similar() returns empty list without embedding config."""
+        result = search_mgr.get_similar("alpha.md")
+        assert result == []
+
+    def test_get_similar_raises_for_nonexistent(
+        self, search_mgr: SearchManager
+    ) -> None:
+        """get_similar() raises for non-existent path."""
+        with pytest.raises(ValueError, match="Document not found"):
+            search_mgr.get_similar("no_such.md")
+
+    def test_get_similar_raises_for_non_md(self, search_mgr: SearchManager) -> None:
+        """get_similar() raises for non-.md path."""
+        with pytest.raises(ValueError, match="Path must end with"):
+            search_mgr.get_similar("image.png")
+
+
+# ---------------------------------------------------------------------------
+# get_context
+# ---------------------------------------------------------------------------
+
+
+class TestGetContext:
+    def test_get_context_returns_note_context(self, search_mgr: SearchManager) -> None:
+        """get_context() returns a NoteContext instance."""
+        ctx = search_mgr.get_context("alpha.md")
+        assert isinstance(ctx, NoteContext)
+
+    def test_get_context_basic_fields(self, search_mgr: SearchManager) -> None:
+        """get_context() populates basic fields."""
+        ctx = search_mgr.get_context("alpha.md")
+        assert ctx.path == "alpha.md"
+        assert ctx.title == "Alpha"
+        assert ctx.folder == ""
+        assert "tags" in ctx.frontmatter
+
+    def test_get_context_backlinks(self, search_mgr: SearchManager) -> None:
+        """get_context() includes backlinks from linked notes."""
+        ctx = search_mgr.get_context("alpha.md")
+        # beta links back to alpha.
+        bl_sources = [bl.source_path for bl in ctx.backlinks]
+        assert "beta.md" in bl_sources
+
+    def test_get_context_outlinks(self, search_mgr: SearchManager) -> None:
+        """get_context() includes outlinks."""
+        ctx = search_mgr.get_context("alpha.md")
+        ol_targets = [ol.target_path for ol in ctx.outlinks]
+        assert "beta.md" in ol_targets
+
+    def test_get_context_folder_notes(self, search_mgr: SearchManager) -> None:
+        """get_context() includes folder peers excluding self."""
+        ctx = search_mgr.get_context("alpha.md")
+        # alpha.md is at root, beta.md is peer.
+        assert "alpha.md" not in ctx.folder_notes
+        assert "beta.md" in ctx.folder_notes
+
+    def test_get_context_tags(self, search_mgr: SearchManager) -> None:
+        """get_context() includes indexed tags."""
+        ctx = search_mgr.get_context("alpha.md")
+        assert "tags" in ctx.tags
+        assert "a" in ctx.tags["tags"]
+        assert "b" in ctx.tags["tags"]
+
+    def test_get_context_similar_empty_without_embeddings(
+        self, search_mgr: SearchManager
+    ) -> None:
+        """get_context() returns empty similar list without embeddings."""
+        ctx = search_mgr.get_context("alpha.md")
+        assert ctx.similar == []
+
+    def test_get_context_raises_for_nonexistent(
+        self, search_mgr: SearchManager
+    ) -> None:
+        """get_context() raises for non-existent document."""
+        with pytest.raises(ValueError, match="Document not found"):
+            search_mgr.get_context("no_such.md")
+
+    def test_get_context_raises_for_non_md(self, search_mgr: SearchManager) -> None:
+        """get_context() raises for non-.md path."""
+        with pytest.raises(ValueError, match="Path must end with"):
+            search_mgr.get_context("image.png")
+
+    def test_get_context_link_limit(self, search_mgr: SearchManager) -> None:
+        """get_context() respects link_limit."""
+        ctx = search_mgr.get_context("alpha.md", link_limit=0)
+        assert ctx.backlinks == []
+        assert ctx.outlinks == []
+
+
+# ---------------------------------------------------------------------------
+# _get_frontmatter helper
+# ---------------------------------------------------------------------------
+
+
+class TestGetFrontmatter:
+    def test_returns_dict_for_existing_note(self, search_mgr: SearchManager) -> None:
+        """_get_frontmatter returns parsed dict for existing note."""
+        fm = search_mgr._get_frontmatter("alpha.md")
+        assert isinstance(fm, dict)
+        assert "tags" in fm
+
+    def test_returns_empty_for_missing_note(self, search_mgr: SearchManager) -> None:
+        """_get_frontmatter returns {} for missing note."""
+        fm = search_mgr._get_frontmatter("nonexistent.md")
+        assert fm == {}
+
+
+# ---------------------------------------------------------------------------
+# _fts_row_to_note_info module function
+# ---------------------------------------------------------------------------
+
+
+class TestFtsRowToNoteInfo:
+    def test_valid_row(self) -> None:
+        """_fts_row_to_note_info converts a row dict to NoteInfo."""
+        row = {
+            "path": "test.md",
+            "title": "Test",
+            "folder": "",
+            "frontmatter_json": '{"tags": ["x"]}',
+            "modified_at": 1234567890.0,
+        }
+        result = _fts_row_to_note_info(row)
+        assert isinstance(result, NoteInfo)
+        assert result.path == "test.md"
+        assert result.title == "Test"
+        assert result.frontmatter == {"tags": ["x"]}
+
+    def test_invalid_json(self) -> None:
+        """_fts_row_to_note_info with bad JSON returns empty frontmatter."""
+        row = {
+            "path": "bad.md",
+            "title": "Bad",
+            "folder": "",
+            "frontmatter_json": "not-json{{{",
+            "modified_at": 0.0,
+        }
+        result = _fts_row_to_note_info(row)
+        assert result.frontmatter == {}
+
+    def test_none_json(self) -> None:
+        """_fts_row_to_note_info with None JSON returns empty frontmatter."""
+        row = {
+            "path": "none.md",
+            "title": "None",
+            "folder": "",
+            "frontmatter_json": None,
+            "modified_at": 0.0,
+        }
+        result = _fts_row_to_note_info(row)
+        assert result.frontmatter == {}
+
+
+# ---------------------------------------------------------------------------
+# vectors property
+# ---------------------------------------------------------------------------
+
+
+class TestVectorsProperty:
+    def test_vectors_initially_none(self, search_mgr: SearchManager) -> None:
+        """vectors property is None when no embeddings configured."""
+        assert search_mgr.vectors is None
+
+    def test_vectors_setter(self, search_mgr: SearchManager) -> None:
+        """vectors property can be set."""
+        search_mgr.vectors = None  # type: ignore[assignment]
+        assert search_mgr.vectors is None
+
+
+# ---------------------------------------------------------------------------
+# flush_embeddings callback
+# ---------------------------------------------------------------------------
+
+
+class TestFlushCallback:
+    def test_flush_callback_called_on_semantic(self, search_vault: Path) -> None:
+        """flush_embeddings callback is invoked when semantic search requested."""
+        fts = FTSIndex(db_path=":memory:")
+        for note in scan_directory(search_vault):
+            fts.upsert_note(note)
+        fts.resolve_vault_wikilinks()
+
+        called = []
+
+        def track_flush() -> None:
+            called.append(True)
+
+        mgr = SearchManager(
+            fts=fts,
+            source_dir=search_vault,
+            flush_embeddings=track_flush,
+        )
+        # Semantic search without provider should raise, but flush is
+        # not called because _require_vectors fires first.
+        with pytest.raises(ValueError):
+            mgr.search("test", mode="semantic")
+        assert called == []
+
+
+# ---------------------------------------------------------------------------
+# _is_path_excluded / _effective_attachment_extensions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_is_path_excluded_no_patterns(self, search_mgr: SearchManager) -> None:
+        """_is_path_excluded returns False when no patterns configured."""
+        assert not search_mgr._is_path_excluded("anything.md")
+
+    def test_is_path_excluded_with_patterns(self, search_vault: Path) -> None:
+        """_is_path_excluded returns True for matching patterns."""
+        fts = FTSIndex(db_path=":memory:")
+        mgr = SearchManager(
+            fts=fts,
+            source_dir=search_vault,
+            exclude_patterns=["drafts/*"],
+        )
+        assert mgr._is_path_excluded("drafts/wip.md")
+        assert not mgr._is_path_excluded("notes/final.md")
+
+    def test_effective_attachment_extensions_default(self, search_vault: Path) -> None:
+        """Default attachment extensions are returned when none configured."""
+        fts = FTSIndex(db_path=":memory:")
+        mgr = SearchManager(fts=fts, source_dir=search_vault)
+        exts = mgr._effective_attachment_extensions()
+        assert "png" in exts
+        assert "pdf" in exts
+
+    def test_effective_attachment_extensions_custom(
+        self, search_mgr: SearchManager
+    ) -> None:
+        """Custom attachment extensions are returned when configured."""
+        exts = search_mgr._effective_attachment_extensions()
+        assert exts == frozenset(["png"])
+
+
+# ---------------------------------------------------------------------------
+# _validate_path
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePath:
+    def test_valid_path(self, search_mgr: SearchManager) -> None:
+        """Valid .md path does not raise."""
+        search_mgr._validate_path("alpha.md")  # should not raise
+
+    def test_non_md_path(self, search_mgr: SearchManager) -> None:
+        """Non-.md path raises ValueError."""
+        with pytest.raises(ValueError, match="must end with"):
+            search_mgr._validate_path("image.png")
+
+    def test_traversal_path(self, search_mgr: SearchManager) -> None:
+        """Path traversal raises ValueError."""
+        with pytest.raises(ValueError, match="traversal"):
+            search_mgr._validate_path("../../etc/passwd.md")

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -11,10 +11,7 @@ if TYPE_CHECKING:
 
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.managers.link import LinkManager
-from markdown_vault_mcp.managers.search import (
-    SearchManager,
-    _fts_row_to_note_info,
-)
+from markdown_vault_mcp.managers.search import SearchManager
 from markdown_vault_mcp.scanner import scan_directory
 from markdown_vault_mcp.types import (
     AttachmentInfo,
@@ -22,6 +19,7 @@ from markdown_vault_mcp.types import (
     NoteInfo,
     SearchResult,
 )
+from markdown_vault_mcp.utils.fts import fts_row_to_note_info as _fts_row_to_note_info
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_utils_links.py
+++ b/tests/test_utils_links.py
@@ -1,0 +1,154 @@
+"""Tests for markdown_vault_mcp.utils.links."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.utils.links import (
+    apply_link_replacement,
+    compute_new_raw_target,
+)
+
+# ---------------------------------------------------------------------------
+# compute_new_raw_target
+# ---------------------------------------------------------------------------
+
+
+class TestComputeNewRawTarget:
+    def test_wikilink_without_md_extension(self) -> None:
+        result = compute_new_raw_target(
+            link_type="wikilink",
+            raw_target="old-note",
+            fragment=None,
+            new_path="notes/new-note.md",
+        )
+        # Should strip .md since original didn't have it
+        assert result == "notes/new-note"
+
+    def test_wikilink_with_md_extension(self) -> None:
+        result = compute_new_raw_target(
+            link_type="wikilink",
+            raw_target="old-note.md",
+            fragment=None,
+            new_path="notes/new-note.md",
+        )
+        assert result == "notes/new-note.md"
+
+    def test_wikilink_with_fragment(self) -> None:
+        result = compute_new_raw_target(
+            link_type="wikilink",
+            raw_target="old-note#heading",
+            fragment="heading",
+            new_path="new-note.md",
+        )
+        # original has no .md before #
+        assert result == "new-note#heading"
+
+    def test_markdown_link_root_relative(self) -> None:
+        result = compute_new_raw_target(
+            link_type="markdown",
+            raw_target="notes/old.md",
+            fragment=None,
+            new_path="notes/new.md",
+            source_path="index.md",
+            old_path="notes/old.md",
+        )
+        # raw_target matches old_path, so root-relative
+        assert result == "notes/new.md"
+
+    def test_markdown_link_source_relative(self) -> None:
+        result = compute_new_raw_target(
+            link_type="markdown",
+            raw_target="../archive/old.md",
+            fragment=None,
+            new_path="archive/new.md",
+            source_path="docs/index.md",
+            old_path="archive/old.md",
+        )
+        # raw_target != old_path, so recompute relative
+        assert result == "../archive/new.md"
+
+    def test_reference_link(self) -> None:
+        result = compute_new_raw_target(
+            link_type="reference",
+            raw_target="notes/old.md",
+            fragment=None,
+            new_path="notes/new.md",
+            source_path="index.md",
+            old_path="notes/old.md",
+        )
+        assert result == "notes/new.md"
+
+    def test_markdown_link_with_fragment(self) -> None:
+        result = compute_new_raw_target(
+            link_type="markdown",
+            raw_target="old.md#section",
+            fragment="section",
+            new_path="new.md",
+            source_path="index.md",
+            old_path="old.md",
+        )
+        # raw_target (old.md#section) split on # gives old.md != old.md? No,
+        # raw_path_part = old.md, old_path = old.md => root-relative
+        assert result == "new.md#section"
+
+    def test_wikilink_case_insensitive_md(self) -> None:
+        result = compute_new_raw_target(
+            link_type="wikilink",
+            raw_target="old-note.MD",
+            fragment=None,
+            new_path="new-note.md",
+        )
+        # .MD endswith check is case-insensitive
+        assert result == "new-note.md"
+
+
+# ---------------------------------------------------------------------------
+# apply_link_replacement
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLinkReplacement:
+    def test_markdown_link(self) -> None:
+        content = "See [my link](old.md) for details."
+        result = apply_link_replacement(content, "markdown", "old.md", "new.md")
+        assert result == "See [my link](new.md) for details."
+
+    def test_markdown_link_with_title(self) -> None:
+        content = '[link](old.md "My Title")'
+        result = apply_link_replacement(content, "markdown", "old.md", "new.md")
+        assert result == '[link](new.md "My Title")'
+
+    def test_markdown_image_not_affected(self) -> None:
+        content = "![alt](old.md)"
+        result = apply_link_replacement(content, "markdown", "old.md", "new.md")
+        # Image links should NOT be replaced
+        assert result == "![alt](old.md)"
+
+    def test_wikilink(self) -> None:
+        content = "See [[old-note]] for details."
+        result = apply_link_replacement(content, "wikilink", "old-note", "new-note")
+        assert result == "See [[new-note]] for details."
+
+    def test_wikilink_alias_preserved(self) -> None:
+        content = "See [[old-note|display text]] for details."
+        result = apply_link_replacement(content, "wikilink", "old-note", "new-note")
+        assert result == "See [[new-note|display text]] for details."
+
+    def test_reference_link(self) -> None:
+        content = "[ref]: old.md\nSee [ref] for details."
+        result = apply_link_replacement(content, "reference", "old.md", "new.md")
+        assert "[ref]: new.md" in result
+
+    def test_reference_link_with_title(self) -> None:
+        content = '[ref]: old.md "Title"'
+        result = apply_link_replacement(content, "reference", "old.md", "new.md")
+        assert result == '[ref]: new.md "Title"'
+
+    def test_unknown_link_type_returns_unchanged(self) -> None:
+        content = "some content"
+        result = apply_link_replacement(content, "unknown", "old", "new")
+        assert result == content
+
+    def test_multiple_occurrences(self) -> None:
+        content = "[[old]] and [[old]]"
+        result = apply_link_replacement(content, "wikilink", "old", "new")
+        assert result == "[[new]] and [[new]]"

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -1,0 +1,156 @@
+"""Tests for markdown_vault_mcp.utils.text."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.utils.text import (
+    CHAR_SUBS,
+    build_position_map,
+    find_closest_match,
+    normalize_text,
+)
+
+# ---------------------------------------------------------------------------
+# CHAR_SUBS
+# ---------------------------------------------------------------------------
+
+
+class TestCharSubs:
+    def test_contains_expected_keys(self) -> None:
+        assert "\u2013" in CHAR_SUBS  # en-dash
+        assert "\u2014" in CHAR_SUBS  # em-dash
+        assert "\u201c" in CHAR_SUBS  # left double quote
+        assert "\u201d" in CHAR_SUBS  # right double quote
+        assert "\u2018" in CHAR_SUBS  # left single quote
+        assert "\u2019" in CHAR_SUBS  # right single quote
+
+
+# ---------------------------------------------------------------------------
+# normalize_text
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeText:
+    def test_smart_quotes_replaced(self) -> None:
+        assert normalize_text("\u201chello\u201d") == '"hello"'
+        assert normalize_text("\u2018hi\u2019") == "'hi'"
+
+    def test_dashes_replaced(self) -> None:
+        assert normalize_text("a\u2013b") == "a-b"
+        assert normalize_text("a\u2014b") == "a-b"
+
+    def test_whitespace_collapsed(self) -> None:
+        assert normalize_text("a   b") == "a b"
+        assert normalize_text("a\t\tb") == "a b"
+        assert normalize_text("a \t b") == "a b"
+
+    def test_trailing_whitespace_stripped(self) -> None:
+        assert normalize_text("hello   ") == "hello"
+        assert normalize_text("hello   \nworld  ") == "hello\nworld"
+
+    def test_nfc_normalization(self) -> None:
+        # e + combining acute → NFC é
+        decomposed = "e\u0301"
+        result = normalize_text(decomposed)
+        assert result == "\u00e9"
+
+    def test_newlines_preserved(self) -> None:
+        assert normalize_text("a\nb\nc") == "a\nb\nc"
+
+    def test_empty_string(self) -> None:
+        assert normalize_text("") == ""
+
+    def test_already_normalized(self) -> None:
+        text = "hello world"
+        assert normalize_text(text) == text
+
+
+# ---------------------------------------------------------------------------
+# build_position_map
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPositionMap:
+    def test_identity(self) -> None:
+        """When original == normalized, positions are 0..n."""
+        text = "hello"
+        pm = build_position_map(text, text)
+        assert pm == [0, 1, 2, 3, 4, 5]
+
+    def test_sentinel_value(self) -> None:
+        """Last entry equals len(original)."""
+        original = "abc"
+        normalized = normalize_text(original)
+        pm = build_position_map(original, normalized)
+        assert pm[-1] == len(original)
+
+    def test_whitespace_collapse(self) -> None:
+        """Multiple spaces collapse to one; positions map correctly."""
+        original = "a   b"
+        normalized = normalize_text(original)
+        assert normalized == "a b"
+        pm = build_position_map(original, normalized)
+        # 'a' at 0, ' ' at 1 (first space), 'b' at 4
+        assert pm[0] == 0  # 'a'
+        assert pm[1] == 1  # space maps to first space
+        assert pm[2] == 4  # 'b'
+        assert pm[3] == 5  # sentinel
+
+    def test_trailing_whitespace_stripped(self) -> None:
+        original = "ab  "
+        normalized = normalize_text(original)
+        assert normalized == "ab"
+        pm = build_position_map(original, normalized)
+        assert pm[0] == 0  # 'a'
+        assert pm[1] == 1  # 'b'
+        assert pm[2] == len(original)  # sentinel
+
+    def test_smart_quote_substitution(self) -> None:
+        original = "\u201chello\u201d"
+        normalized = normalize_text(original)
+        assert normalized == '"hello"'
+        pm = build_position_map(original, normalized)
+        assert len(pm) == len(normalized) + 1
+
+    def test_multiline(self) -> None:
+        original = "a  \nb"
+        normalized = normalize_text(original)
+        assert normalized == "a\nb"
+        pm = build_position_map(original, normalized)
+        assert len(pm) == len(normalized) + 1
+        assert pm[-1] == len(original)
+
+
+# ---------------------------------------------------------------------------
+# find_closest_match
+# ---------------------------------------------------------------------------
+
+
+class TestFindClosestMatch:
+    def test_exact_match(self) -> None:
+        result = find_closest_match("hello world", "hello world\ngoodbye")
+        assert result["closest_match_line"] == 1
+
+    def test_no_match(self) -> None:
+        result = find_closest_match("xxxxxxxxx", "hello\nworld")
+        assert result == {}
+
+    def test_close_match(self) -> None:
+        result = find_closest_match("hello wrld", "goodbye\nhello world\nfoo")
+        assert result["closest_match_line"] == 2
+        assert "first_diff_char" in result
+        assert "expected_snippet" in result
+        assert "found_snippet" in result
+
+    def test_threshold_below_0_6(self) -> None:
+        """Completely different strings return empty dict."""
+        result = find_closest_match("abcdef", "xyzxyz\n123456")
+        assert result == {}
+
+    def test_single_line_file(self) -> None:
+        result = find_closest_match("hello", "hello")
+        assert result["closest_match_line"] == 1
+        assert result["first_diff_char"] == 5  # past end
+
+    def test_diff_position_reported(self) -> None:
+        result = find_closest_match("abcXef", "abcdef")
+        assert result["first_diff_char"] == 3


### PR DESCRIPTION
## Summary

Splits `collection.py` (3125 lines, 64 methods) into focused manager modules with explicit dependency injection, as specified in #376. Collection remains the public facade but delegates to managers that receive their dependencies as constructor arguments — no back-references to Collection.

- **`managers/document.py`** (1018 lines) — CRUD, attachments, path validation, backlink updates
- **`managers/index.py`** (702 lines) — build_index, reindex, build_embeddings, embedding flush lifecycle
- **`managers/search.py`** (837 lines) — keyword/semantic/hybrid search, list, folders, tags, context
- **`managers/link.py`** (246 lines) — backlinks, outlinks, broken links, orphans, hubs, connection paths
- **`utils/text.py`** (193 lines) — text normalization, position mapping, fuzzy matching
- **`utils/links.py`** (108 lines) — link target computation and replacement

`collection.py` reduced from 3125 → 1003 lines (68% reduction). Public API unchanged.

### Key design decisions

- Each manager gets **only what it needs** via constructor injection — no god-class back-references
- `SearchManager` owns lazy vector loading; `IndexManager` accesses it via getter/setter callbacks
- `DocumentManager` fires git/vector callbacks without knowing about git or embeddings
- `DEFAULT_ATTACHMENT_EXTENSIONS` moved to `types.py` to avoid manager→collection back-import
- All 6 commits are independently reviewable (one per extraction step)

### Commits

1. `5e7eb14` — Extract pure utilities to `utils/`
2. `2cf5278` — Extract LinkManager with DI
3. `cc70467` — Extract SearchManager with DI
4. `2e45904` — Extract IndexManager with DI
5. `c3c576a` — Extract DocumentManager with DI
6. `c7d8203` — Slim Collection to facade, update docs

## Test plan

- [x] 142 new manager/utils unit tests (each manager tested in isolation, no Collection)
- [x] All 1391 tests pass (`uv run pytest tests/ -x -q`)
- [x] Lint clean (`uv run ruff check --fix . && uv run ruff format .`)
- [x] Type-check clean (`uv run mypy src/`)
- [x] No circular imports (`python -c "from markdown_vault_mcp import Collection"`)
- [x] No Collection reference in any manager constructor
- [x] `docs/design.md` updated with manager architecture table
- [x] `CLAUDE.md` project structure updated
- [ ] CI passes
- [ ] Patch coverage ≥ 80%

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)