### PR TITLE
chore(ci): bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
 
@@ -38,10 +38,10 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
 
@@ -74,10 +74,10 @@ jobs:
           - python-version: "3.14"
             experimental: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload patch coverage artifact
         if: matrix.python-version == '3.13' && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: patch-coverage
           path: patch-coverage.json
@@ -158,7 +158,7 @@ jobs:
         # the job from failing; coverage-status.yml posts the status via workflow_run instead.
         if: matrix.python-version == '3.13' && github.event_name == 'pull_request' && always()
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PATCH_STATE: ${{ steps.diffcover.outputs.state }}
           PATCH_DESC: ${{ steps.diffcover.outputs.description }}
@@ -185,10 +185,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
 
@@ -207,7 +207,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -27,18 +27,18 @@ jobs:
 
     steps:
       - name: Download patch coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: patch-coverage
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post codecov/patch status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
+            const fs = await import('node:fs');
             const { state, description } = JSON.parse(fs.readFileSync('patch-coverage.json', 'utf8'));
             const sha = context.payload.workflow_run.head_sha;
             core.info(`Posting codecov/patch: ${state} — ${description} to ${sha}`);

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,10 +18,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "0.6"
 
@@ -108,7 +108,7 @@ jobs:
 
       - name: Generate SBOM
         if: steps.release.outputs.released == 'true'
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d  # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
           path: .
           format: cyclonedx-json
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload build artifacts
         if: steps.release.outputs.released == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -154,13 +154,13 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: dist/
           print-hash: true
@@ -183,19 +183,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.release.outputs.tag }}
           fetch-depth: 1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -212,7 +212,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -229,7 +229,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -240,14 +240,14 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
 
       - name: Generate SBOM for Docker image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d  # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-push.outputs.digest }}
           format: cyclonedx-json
@@ -256,7 +256,7 @@ jobs:
           upload-release-assets: false
 
       - name: Attest Docker SBOM
-        uses: actions/attest-sbom@v2
+        uses: actions/attest-sbom@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-push.outputs.digest }}
@@ -273,7 +273,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.release.outputs.tag }}
           fetch-depth: 1
@@ -320,7 +320,7 @@ jobs:
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release.outputs.tag }}
       - name: Install mcpb CLI
@@ -343,7 +343,7 @@ jobs:
           mcpb validate build/mcpb/manifest.json
           mkdir -p dist
           mcpb pack build/mcpb "dist/markdown-vault-mcp-${VERSION}.mcpb"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mcpb-bundle
           path: dist/markdown-vault-mcp-*.mcpb
@@ -356,7 +356,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: mcpb-bundle
           path: dist/
@@ -376,7 +376,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout catalog repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pvliesdonk/claude-plugins
           token: ${{ secrets.CLAUDE_PLUGINS_PAT }}
@@ -395,7 +395,7 @@ jobs:
           ' .claude-plugin/marketplace.json > marketplace.json.tmp
           mv marketplace.json.tmp .claude-plugin/marketplace.json
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           path: catalog
           token: ${{ secrets.CLAUDE_PLUGINS_PAT }}
@@ -418,7 +418,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1


### PR DESCRIPTION
## Summary

- Bump all GitHub Actions to Node.js 24-compatible versions ahead of the June 2, 2026 deadline, eliminating deprecation warnings across all 7 workflow files
- Convert `require('fs')` to ESM `import('node:fs')` in coverage-status.yml for `actions/github-script@v9` compatibility
- Update SHA-pinned actions (`anchore/sbom-action` v0.24.0, `pypa/gh-action-pypi-publish` v1.14.0) to latest Node 24-compatible releases

### Actions bumped

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/github-script` | v7 | **v9** (ESM) |
| `actions/attest-build-provenance` | v2 | **v4** |
| `actions/attest-sbom` | v2 | **v4** |
| `docker/setup-qemu-action` | v3 | **v4** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `docker/metadata-action` | v5 | **v6** |
| `docker/build-push-action` | v6 | **v7** |
| `astral-sh/setup-uv` | v4 | **v8.0.0** |
| `codecov/codecov-action` | v5 | **v6** |
| `peter-evans/create-pull-request` | v7 | **v8** |
| `anchore/sbom-action` | v0.23.1 | **v0.24.0** (SHA) |
| `pypa/gh-action-pypi-publish` | release/v1 | **v1.14.0** (SHA) |

### Already current (no change needed)

`actions/deploy-pages` v4, `github/codeql-action` v3, `anthropics/claude-code-action` v1, `python-semantic-release` v10.5.3, `gitleaks/gitleaks-action` v2.3.9, `burningalchemist/action-gh-nfpm` v1.1

## Test plan

- [ ] CI passes (lint, typecheck, tests) — confirms no YAML syntax errors and no regressions
- [ ] No Node.js 20 deprecation warnings in CI output
- [ ] `codecov/patch` status posts correctly (github-script ESM migration)
- [ ] Verify on next release: Docker build, PyPI publish, attestations, Linux packages all succeed

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)