### PR TITLE
feat: add PARA workflow pack (Projects/Areas/Resources/Archive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A generic markdown collection [MCP](https://modelcontextprotocol.io/) server wit
 
 **[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
 
-Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Zettelkasten) and it exposes search, read, write, and edit tools over the Model Context Protocol.
+Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Zettelkasten, a PARA vault) and it exposes search, read, write, and edit tools over the Model Context Protocol.
 
 ## Features
 
@@ -383,6 +383,7 @@ Templates are regular markdown files. If placeholder template text pollutes sear
 Mount a directory of `.md` prompt files to override or extend the built-in prompts. Set `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` to the path. Each file's frontmatter defines `description`, `arguments` (a list of objects, each with `name`, `description`, and `required` fields), and optional `tags`. A user prompt with the same name as a built-in replaces it.
 
 For a complete example — including Zettelkasten capture, development, and review prompts — see the [Zettelkasten guide](https://pvliesdonk.github.io/markdown-vault-mcp/guides/zettelkasten/).
+For an alternative action-oriented workflow — Projects, Areas, Resources, Archive with triage, kickoff, and weekly review prompts — see the [PARA guide](https://pvliesdonk.github.io/markdown-vault-mcp/guides/para/).
 
 ## MCP Apps
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1170,8 +1170,9 @@ Prompt content here. Use $path and $topic as placeholders (string.Template synta
 
 **Override semantics**: if a user-defined prompt has the same name as a
 built-in, the built-in is skipped and the user's version is registered.
-This allows domain-specific workflows (e.g. a ``zettelkasten`` prompt) to
-live outside the core server and be mounted at deployment time.
+This allows domain-specific workflows (e.g. the ``zettelkasten`` or
+``para-triage`` prompts) to live outside the core server and be mounted
+at deployment time.
 
 ## Configuration
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -23,6 +23,7 @@ Step-by-step walkthroughs for common deployment scenarios. Each guide takes you 
 | Set up OIDC with Google | [OIDC Providers](oidc-providers.md#google) |
 | Set up OIDC with GitHub (via Keycloak) | [OIDC Providers](oidc-providers.md#github) |
 | Build a Zettelkasten workflow | [Zettelkasten](zettelkasten.md) |
+| Build a PARA workflow (Projects/Areas/Resources/Archive) | [PARA](para.md) |
 | Use the browser-based vault views (Context Card, Graph, Browser) | [MCP Apps](mcp-apps.md) |
 
 ## Prerequisites

--- a/docs/guides/para.md
+++ b/docs/guides/para.md
@@ -5,6 +5,8 @@ PARA (Projects, Areas, Resources, Archive) is Tiago Forte's framework for organi
 !!! note
     This is one of many ways to organize a vault with markdown-vault-mcp. The server is a generic markdown collection backend — PARA conventions are applied in this guide but not required or enforced by the server.
 
+This guide assumes you're working with a PARA vault through Claude (or another MCP client) as the primary interface. The three PARA prompts — triage, kickoff, and weekly review — are where most of the value lives; Claude handles surfacing, classification, and batch operations you'd otherwise skip or defer. The Python and CLI examples scattered throughout are the scripting escape hatch, not the day-to-day pattern.
+
 ## Vault Setup
 
 ### Recommended folder structure
@@ -35,7 +37,7 @@ PARA has four note shapes. Each uses a distinct frontmatter block. The templates
 ---
 title: "{{title}}"
 tags: []
-created: {{date}}
+created: "{{date}}"
 ---
 ```
 
@@ -50,7 +52,7 @@ outcome: "<one-sentence definition of done>"
 deadline: YYYY-MM-DD
 area: "<parent area name, or empty>"
 tags: []
-created: {{date}}
+created: "{{date}}"
 ---
 ```
 
@@ -64,7 +66,7 @@ status: active
 standard: "<what 'healthy' looks like for this area>"
 review_cadence: "<weekly | monthly | quarterly>"
 tags: []
-created: {{date}}
+created: "{{date}}"
 ---
 ```
 
@@ -76,7 +78,7 @@ title: "{{title}}"
 type: resource
 status: active
 tags: []
-created: {{date}}
+created: "{{date}}"
 ---
 ```
 
@@ -89,7 +91,7 @@ created: {{date}}
 - `deadline` — Project-only. Target date. Stored as ISO `YYYY-MM-DD` but not indexed for range queries (see [Future Enhancements](#future-enhancements)).
 - `area` — Project-only. Names the parent Area for rollups (e.g., `"Health"`). This field is the authoritative signal for area→project linkage; wikilinks between them are supplementary.
 - `standard` — Area-only. Describes what "healthy" looks like for the area. Used during the Weekly Review.
-- `review_cadence` — Area-only. One of `weekly`, `monthly`, `quarterly`. Drives how often the Area should appear in reviews.
+- `review_cadence` — Area-only. Informational hint about how often this area should be reviewed (`weekly`, `monthly`, `quarterly`). The `para-weekly-review` prompt does not yet act on this field; it audits all active areas each run. Tracked as a Future Enhancement.
 - `tags` — Free-form list. Searchable via `filters={"tags": "value"}`.
 - `created` — ISO date the note was written. Useful for reviewing note age.
 
@@ -140,16 +142,15 @@ The canonical PARA loop: **Capture → Triage → Project Work → Weekly Review
 
 ### 1. Capture (Inbox)
 
-Capture any new idea, task, or reference in `0-Inbox/` immediately, without classifying it. Use the inbox template for minimal friction:
+Capture whatever's in your head into `0-Inbox/` without worrying about classification. The `inbox.md` template exists for this — Claude can create notes from it on request ("create an inbox note titled X with content Y"), or you can drop files directly into the folder via Obsidian, the CLI, or a scripting run. Review the inbox daily or every few days by invoking the triage prompt on the whole folder; Claude walks each note, classifies it, and proposes target paths.
 
-**Via CLI:**
+**Via Claude:**
 
-```bash
-markdown-vault-mcp serve &
-# Then in Claude:  create_from_template(template_name='inbox')
+```
+Use the create_from_template prompt with template_name="inbox"
 ```
 
-**Programmatically:**
+**Programmatically (scripting escape hatch):**
 
 ```python
 from markdown_vault_mcp import Collection
@@ -168,17 +169,13 @@ collection.write(
 - One idea per note
 - Review the Inbox at least once per week
 
-**Review the inbox:**
-
-```python
-inbox = collection.list(folder="0-Inbox")
-for note in inbox:
-    print(note.path, note.title)
-```
-
 ### 2. Triage (Inbox → P/A/R)
 
-Triage is the decision step: every Inbox note either becomes a Project, Area, or Resource, or gets deleted. The `para-triage` prompt codifies the decision procedure.
+Triage is the decision step: every Inbox note either becomes a Project, Area, or Resource, or gets deleted. The `para-triage` prompt codifies the decision procedure. Give Claude the entire `0-Inbox/` folder and it processes each note sequentially, pausing for your call on anything ambiguous — what would take an hour of manual review runs in minutes.
+
+**What Claude does autonomously:** classify unambiguous notes into their bucket, slug the filename from the title, fill type-specific frontmatter fields (`outcome`, `deadline`, `area`, `standard`) from the note body, and execute the rename and write on confirmation.
+
+**What Claude asks about:** anything that could fit two buckets ("is this a one-off project or an ongoing responsibility?"), picking a slug when the title is generic ("thoughts"), deciding whether a note belongs as a new section of an existing permanent note rather than a standalone file. When a note contains two distinct ideas, you can tell Claude to split it — it creates two notes, one per idea, and triages each separately.
 
 The prompt walks through five steps:
 
@@ -201,7 +198,7 @@ The prompt enforces a simple safety rule: **never rename or edit without explici
 
 ### 3. Project Work (`para-project-kickoff`)
 
-Once a note has been classified as a Project, the `para-project-kickoff` prompt turns it into an actionable plan. The prompt bakes in the "just-in-time resurface" workflow: before the project starts, it pulls in related Resources, past archived Projects, and linkable Areas.
+Once a note has been classified as a Project, the `para-project-kickoff` prompt turns it into an actionable plan. This is the resurface work you'd otherwise skip: most people defining a project don't go back through archived work to check what's been tried, don't look across resources to find relevant reference material, don't re-read similar past projects for lessons. Claude does. You give Claude the project note; Claude does the homework and surfaces what's relevant; you approve the links to add.
 
 The prompt walks through six steps:
 
@@ -216,18 +213,26 @@ The prompt walks through six steps:
    - `2-Areas/` → linkable Area
    Folder-prefix classification is one step; reading each note's frontmatter is N steps. Prefer the fast path, fall back to a targeted `search(filters={"type": "resource"})` per bucket when the layout is non-canonical.
 5. **Propose links.** Present a `## Related` section grouped by bucket, with a one-sentence "why this is relevant" per link. Prefer `[[wikilinks]]`.
-6. **Apply on confirmation.** On confirmation, add the `## Related` section via `edit` (if appending to an existing section) or `write` after a fresh `read` (if creating one).
+6. **Apply on confirmation.** On confirmation, `write` the note back with the `## Related` section added (robust to trailing whitespace), or use `edit` if you prefer to avoid rewriting the full file and can match the section heading precisely.
 
 See the full prompt body in `examples/para/prompts/para-project-kickoff.md`.
+
+The kickoff prompt isn't just for project start. Re-invoke it mid-project when you're stuck — Claude will resurface whatever's changed in the vault since kickoff and propose additional links as context evolves.
 
 !!! note "Hybrid mode needs embeddings"
     `search(mode='hybrid')` combines BM25 keyword ranking with vector similarity via Reciprocal Rank Fusion. It requires embeddings to be built. If embeddings aren't configured, the prompt falls back to `mode='keyword'`, which still works but misses semantic matches (paraphrases, conceptual neighbors). Check `stats().semantic_search_available` before picking the mode.
 
 ### 4. Weekly Review (`para-weekly-review`)
 
-The Weekly Review is the maintenance pass that keeps the vault healthy. The `para-weekly-review` prompt produces a dated review note summarizing the state of Projects and Areas and flagging Archive candidates.
+The Weekly Review is a 10-minute guided session, not a manual audit. Invoke the prompt, answer Claude's questions as they come, and decide on the archive candidates it surfaces. The stale-scan, area audit, and archive candidate list are what a manual review would take an hour to produce — the prompt does it in minutes; you just make the calls.
 
-The prompt walks through seven steps:
+Invoke it in Claude with no arguments — it figures out the current ISO week and defaults everything:
+
+```
+In Claude, call: para-weekly-review()
+```
+
+Here is Claude's internal process across seven steps:
 
 1. **Determine the review path.** Default is `3-Resources/reviews/<YYYY-WW>.md` (ISO week), or a user-supplied `review_path`.
 2. **Enumerate active projects** with `list_documents(folder='1-Projects')` and filter client-side for `frontmatter.status == 'active'`. Record each project's path, title, deadline, and `modified_at` timestamp.
@@ -239,13 +244,15 @@ The prompt walks through seven steps:
 
 See the full prompt body in `examples/para/prompts/para-weekly-review.md`.
 
-The prompt is careful to present all findings before asking for any action. It never archives, renames, or edits notes without explicit confirmation, and when the user confirms a batch ("archive all 5"), it still performs each operation individually so failures are isolated.
+The prompt presents all findings before asking for any action. It never archives, renames, or edits notes without explicit confirmation, and when the user confirms a batch ("archive all 5"), it still performs each operation individually so failures are isolated.
 
 ### 5. Archive (lifecycle transition)
 
 Archiving is a two-step operation: flip the `status` to `archived` (and set `archived_at`), then move the file to `4-Archive/`. The order matters — the `status` field is what matters for queries; the folder is for browsing.
 
-The easiest path is to use `para-weekly-review` Step 7, which handles the full lifecycle (surface candidates, flip status, move) with user confirmation. In practice, use that prompt — the snippet below is for manual scripting only.
+The easiest path is to use `para-weekly-review` Step 7, which handles the full lifecycle (surface candidates, flip status, move) with user confirmation. You can also invoke archiving ad-hoc outside the review cadence: "Claude, list everything with `status=completed` in `1-Projects/` and archive them." Claude runs `list_documents(folder='1-Projects')`, filters client-side on the frontmatter, and proposes each move for your confirmation (or batch confirmation if you prefer).
+
+For scripting outside the prompt:
 
 ```python
 from datetime import date
@@ -383,9 +390,19 @@ Date-range filters are tracked as a planned follow-up — see [Future Enhancemen
 
 Same spirit as Zettelkasten: over-linking is better than under-linking. If a Resource touches on a Project's outcome, link it. If an Area has three projects that reference a common book, link the book from each. `get_context(path)` will surface these connections later when you're editing, and `para-project-kickoff` will resurface them when you start a new related project. Don't agonize — the tools will help you rediscover what you linked.
 
+### Let Claude split ambiguous captures
+
+When an inbox note contains two ideas, tell the triage prompt to split it. Claude creates two notes — one per idea — and classifies each separately. Don't try to pre-split before triage; Claude handles it in one pass.
+
+### Ask Claude for area assignments in batches
+
+After a triage session produces 5-10 new projects, ask Claude to propose an `area` value for each based on the project's outcome. It's a one-shot operation that keeps the rollup queries useful and saves you from clicking through each note.
+
 ## Future Enhancements
 
 **Date-range filter support** would enable deadline queries like `filters={"deadline": {"lte": "2026-05-01"}}`. This requires extending the FTS query layer to parse range operators on indexed date fields. Tracked as a planned follow-up issue.
+
+**Review-cadence-aware weekly review.** The `review_cadence` frontmatter on Areas is currently informational. A future version of the `para-weekly-review` prompt could skip areas whose cadence is `monthly` or `quarterly` and it isn't their week.
 
 **Consolidated triage-and-create prompt.** Today, triage classifies an existing Inbox note and moves it; `create_from_template` creates a new note from a template. A combined "triage a thought and create a typed note directly" prompt — with auto-suggested target folder based on classification — is possible as a `create_from_template` extension. It's a usability improvement, not a capability gap.
 

--- a/docs/guides/para.md
+++ b/docs/guides/para.md
@@ -1,0 +1,397 @@
+# PARA with markdown-vault-mcp
+
+PARA (Projects, Areas, Resources, Archive) is Tiago Forte's framework for organizing digital information around action — what you are doing, responsible for, or referencing. Where a Zettelkasten is idea-centric and emergent, PARA is action-oriented and top-down: every note has a home determined by what you do with it. This guide shows how to use markdown-vault-mcp as a PARA backend, leveraging its frontmatter-aware search, linking, and templating to run the canonical Capture → Triage → Project Work → Weekly Review → Archive loop.
+
+!!! note
+    This is one of many ways to organize a vault with markdown-vault-mcp. The server is a generic markdown collection backend — PARA conventions are applied in this guide but not required or enforced by the server.
+
+## Vault Setup
+
+### Recommended folder structure
+
+A canonical PARA vault with markdown-vault-mcp uses five top-level folders plus a templates folder:
+
+```
+vault/
+  0-Inbox/        # quick capture, untyped
+  1-Projects/     # active projects with outcomes
+  2-Areas/        # ongoing responsibilities
+  3-Resources/    # reference material
+  4-Archive/      # status=archived items (any type)
+  _templates/     # pointed at by MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER
+```
+
+The numeric prefixes (`0-`, `1-`, ...) keep the buckets sorting in the canonical PARA order in any file explorer. `0-Inbox/` is added because triage is a named workflow step and deserves a dedicated location — notes land here first and move out once they are classified.
+
+**The server does not enforce this layout.** You can flatten it, rename folders, or skip folders entirely and rely on the `type` and `status` frontmatter fields to drive queries. The prompts shipped with this pack assume the canonical layout but fall back to asking you when they encounter a different structure.
+
+### Frontmatter schemas
+
+PARA has four note shapes. Each uses a distinct frontmatter block. The templates in `examples/para/templates/` provide these exactly:
+
+**Inbox** — untyped quick capture. Triage assigns the `type` later:
+
+```yaml
+---
+title: "{{title}}"
+tags: []
+created: {{date}}
+---
+```
+
+**Project** — a concrete outcome with a deadline:
+
+```yaml
+---
+title: "{{title}}"
+type: project
+status: active
+outcome: "<one-sentence definition of done>"
+deadline: YYYY-MM-DD
+area: "<parent area name, or empty>"
+tags: []
+created: {{date}}
+---
+```
+
+**Area** — an ongoing responsibility with no end state:
+
+```yaml
+---
+title: "{{title}}"
+type: area
+status: active
+standard: "<what 'healthy' looks like for this area>"
+review_cadence: "<weekly | monthly | quarterly>"
+tags: []
+created: {{date}}
+---
+```
+
+**Resource** — reference material, not actionable:
+
+```yaml
+---
+title: "{{title}}"
+type: resource
+status: active
+tags: []
+created: {{date}}
+---
+```
+
+**Field meanings:**
+
+- `title` — The note's heading. Used for display in lists and searches.
+- `type` — One of `project`, `area`, `resource`. Stable across the note's lifetime.
+- `status` — Lifecycle state: `active`, `on-hold`, `completed`, or `archived`. Flipped as the note transitions.
+- `outcome` — Project-only. A specific, one-sentence definition of done. "Ship v2 with feature Y by date Z", not "improve v2".
+- `deadline` — Project-only. Target date. Stored as ISO `YYYY-MM-DD` but not indexed for range queries (see [Future Enhancements](#future-enhancements)).
+- `area` — Project-only. Names the parent Area for rollups (e.g., `"Health"`). This field is the authoritative signal for area→project linkage; wikilinks between them are supplementary.
+- `standard` — Area-only. Describes what "healthy" looks like for the area. Used during the Weekly Review.
+- `review_cadence` — Area-only. One of `weekly`, `monthly`, `quarterly`. Drives how often the Area should appear in reviews.
+- `tags` — Free-form list. Searchable via `filters={"tags": "value"}`.
+- `created` — ISO date the note was written. Useful for reviewing note age.
+
+!!! note "Archive is a status, not a type"
+    Forte's original PARA treats Archive as the fourth top-level category. Mechanically this is awkward: an archived project is still a project; archiving is a lifecycle transition, not a reclassification. This pack models archive as `status=archived`, with `type` preserved across the lifecycle. Queries like `type=project status=archived` remain meaningful, and the Weekly Review filters cleanly on `status=active` without union queries across types. The `4-Archive/` folder is a convenience location for browsing — the authoritative "is this archived" signal is the `status` field.
+
+### Make frontmatter fields searchable
+
+Configure `MARKDOWN_VAULT_MCP_INDEXED_FIELDS` so that `type`, `status`, `tags`, and `area` become structured filters in the search API:
+
+```bash
+export MARKDOWN_VAULT_MCP_INDEXED_FIELDS=type,status,tags,area
+```
+
+Then you can run targeted queries via the Python API:
+
+```python
+# All active projects
+results = collection.search(
+    "project",
+    filters={"type": "project", "status": "active"},
+    limit=50,
+)
+
+# All active projects in the Health area
+results = collection.search(
+    "project",
+    filters={"type": "project", "status": "active", "area": "Health"},
+    limit=50,
+)
+```
+
+The server treats each indexed field as an equality filter. Ranges (e.g., deadlines within the next week) are not yet supported — see [Future Enhancements](#future-enhancements).
+
+### Filename conventions
+
+The server uses the file's path (relative to the vault root) as its identity. Any naming scheme works, but for PARA a title-based lowercase-hyphen form is clearest:
+
+- `1-Projects/ship-v2-launch.md`
+- `2-Areas/health.md`
+- `3-Resources/postgres-connection-pooling.md`
+
+Do not embed dates in filenames — PARA uses the `deadline` and `created` frontmatter fields for dates, and the folder for lifecycle. A project's filename should describe its identity, not its moment in time.
+
+## Workflow
+
+The canonical PARA loop: **Capture → Triage → Project Work → Weekly Review → Archive**. Each stage has a corresponding prompt or manual action.
+
+### 1. Capture (Inbox)
+
+Capture any new idea, task, or reference in `0-Inbox/` immediately, without classifying it. Use the inbox template for minimal friction:
+
+**Via CLI:**
+
+```bash
+markdown-vault-mcp serve &
+# Then in Claude:  create_from_template(template_name='inbox')
+```
+
+**Programmatically:**
+
+```python
+from markdown_vault_mcp import Collection
+
+collection = Collection(source_dir="/path/to/vault")
+collection.write(
+    "0-Inbox/migrate-postgres.md",
+    content="We should look into migrating to Postgres 16.",
+    frontmatter={"tags": [], "created": "2026-04-19"},
+)
+```
+
+**Goals for this stage:**
+
+- Capture without deciding type or folder
+- One idea per note
+- Review the Inbox at least once per week
+
+**Review the inbox:**
+
+```python
+inbox = collection.list(folder="0-Inbox")
+for note in inbox:
+    print(note.path, note.title)
+```
+
+### 2. Triage (Inbox → P/A/R)
+
+Triage is the decision step: every Inbox note either becomes a Project, Area, or Resource, or gets deleted. The `para-triage` prompt codifies the decision procedure.
+
+The prompt walks through five steps:
+
+1. **Load the note(s).** If given a folder, enumerate with `list_documents` and iterate. If given a single note path, read it directly.
+2. **Read and extract the central intent.** Call `read(path=note)` and identify the central subject — is it a concrete deliverable, an ongoing responsibility, or reference material?
+3. **Classify** into one of three buckets:
+   - **Project** — concrete outcome plus a plausible deadline; something that can be completed.
+   - **Area** — ongoing responsibility with no end state (e.g., "Health", "Team Management").
+   - **Resource** — reference material, not actionable.
+   - **Ambiguous** — ask the user. Do not guess.
+4. **Propose the move.** Present the proposed target path (`1-Projects/<slug>.md`, `2-Areas/<slug>.md`, `3-Resources/<slug>.md`) and the typed frontmatter block filled in from the note body.
+5. **Execute on confirmation.**
+    1. `rename(old, new, update_links=True)` preserves backlinks from other notes.
+    2. `read(new)` loads the body at the new path.
+    3. `write(new, content=<body from read>, frontmatter=<typed frontmatter dict>)` rewrites the file with the typed frontmatter, preserving the body.
+
+See the full prompt body in `examples/para/prompts/para-triage.md`.
+
+The prompt enforces a simple safety rule: **never rename or edit without explicit user confirmation**. When the note is ambiguous — a task that could be either a one-off Project or a recurring Area, for example — the prompt asks the user rather than picking.
+
+### 3. Project Work (`para-project-kickoff`)
+
+Once a note has been classified as a Project, the `para-project-kickoff` prompt turns it into an actionable plan. The prompt bakes in the "just-in-time resurface" workflow: before the project starts, it pulls in related Resources, past archived Projects, and linkable Areas.
+
+The prompt walks through six steps:
+
+1. **Verify the project is well-defined.** Read the note, check that `outcome` is a specific one-sentence definition of done (not a placeholder) and that `deadline` is a real date. If either is missing, ask the user.
+2. **Survey the existing neighborhood.** Call `get_context(path=project)` to see existing backlinks, outlinks, similar notes, and tags.
+3. **Resurface related material.** Run two searches:
+   - If `stats()` reports `semantic_search_available=True`, call `search(query=outcome_text, mode='hybrid', limit=15)`. Otherwise fall back to `search(query=outcome_text, mode='keyword', limit=15)`.
+   - `get_similar(path=project, limit=10)` — returns an empty list when embeddings aren't configured, so it is always safe to call.
+4. **Classify results into three buckets.** For each result, use the **folder prefix fast path** when the vault follows the canonical layout:
+   - `3-Resources/` → Resource
+   - `4-Archive/` → archived project (similar past work)
+   - `2-Areas/` → linkable Area
+   Folder-prefix classification is one step; reading each note's frontmatter is N steps. Prefer the fast path, fall back to a targeted `search(filters={"type": "resource"})` per bucket when the layout is non-canonical.
+5. **Propose links.** Present a `## Related` section grouped by bucket, with a one-sentence "why this is relevant" per link. Prefer `[[wikilinks]]`.
+6. **Apply on confirmation.** On confirmation, add the `## Related` section via `edit` (if appending to an existing section) or `write` after a fresh `read` (if creating one).
+
+See the full prompt body in `examples/para/prompts/para-project-kickoff.md`.
+
+!!! note "Hybrid mode needs embeddings"
+    `search(mode='hybrid')` combines BM25 keyword ranking with vector similarity via Reciprocal Rank Fusion. It requires embeddings to be built. If embeddings aren't configured, the prompt falls back to `mode='keyword'`, which still works but misses semantic matches (paraphrases, conceptual neighbors). Check `stats().semantic_search_available` before picking the mode.
+
+### 4. Weekly Review (`para-weekly-review`)
+
+The Weekly Review is the maintenance pass that keeps the vault healthy. The `para-weekly-review` prompt produces a dated review note summarizing the state of Projects and Areas and flagging Archive candidates.
+
+The prompt walks through seven steps:
+
+1. **Determine the review path.** Default is `3-Resources/reviews/<YYYY-WW>.md` (ISO week), or a user-supplied `review_path`.
+2. **Enumerate active projects** with `list_documents(folder='1-Projects')` and filter client-side for `frontmatter.status == 'active'`. Record each project's path, title, deadline, and `modified_at` timestamp.
+3. **Stale scan.** Compute a threshold of `now - 14 * 86400` seconds and flag any active project whose `modified_at` is older. These are the stale projects that need attention.
+4. **Area audit.** `list_documents(folder='2-Areas')`, filter for `status=active`. For each Area, count active projects whose `area` frontmatter field matches the Area's title. Any Area with **zero** active projects is flagged as a candidate for archive or reassessment. The `area` frontmatter field is the authoritative signal; wikilinks between projects and areas are supplementary.
+5. **Archive candidates.** Projects with `status=completed` still sitting in `1-Projects/` (should be moved to `4-Archive/`), plus projects stale for 30+ days (user may want to archive or revive).
+6. **Write the review note** to the path from Step 1 via a direct `write()` call. The frontmatter matches the `weekly-review` template (Resource type, tagged `review`) and the body contains the seeded sections: `## Active projects`, `## Stale projects`, `## Area audit`, `## Archive candidates`, `## New projects / ideas`. The review note's section structure matches the `weekly-review.md` template — for consistency and for users who want to create reviews manually via `create_from_template` — but the prompt writes the note directly.
+7. **Offer next actions.** Ask the user which archive candidates to act on. For each confirmed one: `read` the project to get the current body and frontmatter, `write` it back with `status=archived` and `archived_at=<today>` added, then `rename` it into `4-Archive/`.
+
+See the full prompt body in `examples/para/prompts/para-weekly-review.md`.
+
+The prompt is careful to present all findings before asking for any action. It never archives, renames, or edits notes without explicit confirmation, and when the user confirms a batch ("archive all 5"), it still performs each operation individually so failures are isolated.
+
+### 5. Archive (lifecycle transition)
+
+Archiving is a two-step operation: flip the `status` to `archived` (and set `archived_at`), then move the file to `4-Archive/`. The order matters — the `status` field is what matters for queries; the folder is for browsing.
+
+The easiest path is to use `para-weekly-review` Step 7, which handles the full lifecycle (surface candidates, flip status, move) with user confirmation. In practice, use that prompt — the snippet below is for manual scripting only.
+
+```python
+from datetime import date
+from markdown_vault_mcp import Collection
+
+collection = Collection(source_dir="/path/to/vault")
+
+today = date.today().isoformat()
+
+# Flip status and add archived_at. One targeted replacement each.
+collection.edit(
+    "1-Projects/ship-v2.md",
+    old_text="status: active",
+    new_text=f"status: archived\narchived_at: {today}",
+)
+
+# Move to the archive folder, preserving backlinks.
+collection.rename(
+    "1-Projects/ship-v2.md",
+    "4-Archive/ship-v2.md",
+    update_links=True,
+)
+```
+
+After this sequence, `search(filters={"type": "project", "status": "archived"})` surfaces the note, and `search(filters={"type": "project", "status": "active"})` excludes it — regardless of what folder it physically lives in.
+
+## Using Templates
+
+Templates accelerate note creation. The five PARA templates (`inbox`, `project`, `area`, `resource`, `weekly-review`) live in `examples/para/templates/`.
+
+**Configure the templates folder:**
+
+```bash
+export MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER=/path/to/examples/para/templates
+markdown-vault-mcp serve
+```
+
+**Use in Claude via the `create_from_template` prompt:**
+
+The prompt will:
+
+1. List available templates
+2. Ask you to choose one
+3. Gather required values (title, outcome, deadline, area, etc.)
+4. Create the note with filled-in frontmatter
+
+**Invoke via MCP prompt:**
+
+`create_from_template` is an MCP prompt, not a Python API method. Invoke it through your MCP client (e.g., Claude):
+
+```
+Use the create_from_template prompt with template_name="project"
+```
+
+The prompt calls `list_documents` on the templates folder to enumerate choices, `read`s the chosen template, substitutes placeholders, and `write`s the filled note — all through vault tools.
+
+## Using the PARA Prompts
+
+The three PARA prompts live in `examples/para/prompts/` and are loaded via `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER`:
+
+```bash
+export MARKDOWN_VAULT_MCP_PROMPTS_FOLDER=/path/to/examples/para/prompts
+markdown-vault-mcp serve
+```
+
+Then in Claude, the `para-triage`, `para-project-kickoff`, and `para-weekly-review` prompts are available.
+
+### `para-triage`
+
+**When to use:** after capturing one or more notes in `0-Inbox/`, or any time you want to classify an untyped note into Project, Area, or Resource. Run it as part of a daily or weekly inbox sweep.
+
+```
+In Claude, call: para-triage(path='0-Inbox/')
+```
+
+Or for a single note:
+
+```
+In Claude, call: para-triage(path='0-Inbox/migrate-postgres.md')
+```
+
+The prompt will iterate over the folder (or act on the single note), propose a classification and target path for each, and move them on confirmation.
+
+### `para-project-kickoff`
+
+**When to use:** right after creating a new Project note, or any time you want to define the outcome and pull in related context before starting work. Run it once per project — it's the onboarding step for the project itself.
+
+```
+In Claude, call: para-project-kickoff(path='1-Projects/ship-v2.md')
+```
+
+The prompt will verify the outcome and deadline are real, resurface related Resources and past archived Projects, and add a `## Related` section on confirmation.
+
+### `para-weekly-review`
+
+**When to use:** weekly (or whenever you run your review cadence). Produces a dated review note and flags stale projects, zero-project Areas, and Archive candidates.
+
+```
+In Claude, call: para-weekly-review()
+```
+
+Or with an explicit path:
+
+```
+In Claude, call: para-weekly-review(review_path='3-Resources/reviews/2026-W17.md')
+```
+
+The review note is written as a Resource under `3-Resources/reviews/`, so it is searchable and linkable from other notes. Past reviews form a trail of how the vault has evolved.
+
+## Tips and Best Practices
+
+### Status over folder
+
+The authoritative signal for "is this archived" is `status=archived`. The `4-Archive/` folder is convenience — nice for browsing in a file explorer, nice for ambient separation — but a query that only checks the folder will miss archived items that haven't been moved yet and will mis-flag active items that happen to sit in an archive-adjacent folder. Always filter on `status`, not path, when writing automations.
+
+### Archive by flipping status, then moving
+
+When archiving a note, update `status=archived` and set `archived_at` **first**, then `rename` into `4-Archive/`. If you do the rename first, anyone querying `status=active` between the two steps will still see it as active. The weekly-review prompt enforces this order; if you archive manually, follow the same sequence.
+
+### Link projects to areas via the `area` frontmatter field
+
+The `area` field on a project is indexed (via `MARKDOWN_VAULT_MCP_INDEXED_FIELDS`) and makes area rollups reliable: `search(filters={"type": "project", "area": "Health", "status": "active"})` is precise and fast. Wikilinks from the project note to the area note (e.g., `[[health]]`) are optional and supplementary — they show up in `get_context(path)` as outlinks and help visual exploration, but the `area` field is the source of truth.
+
+### Deadlines aren't indexed
+
+You can store `deadline: YYYY-MM-DD` in project frontmatter, and the date round-trips cleanly, but the server does not yet support range queries like "projects with `deadline <= next week`". To spot upcoming deadlines, either:
+
+- Filter the active-project list from `list_documents(folder='1-Projects')` client-side by parsing the `deadline` field
+- Sort results by title if you use a date prefix (not recommended — complicates renames)
+- Run the `para-weekly-review` prompt, which surfaces project deadlines in the review note
+
+Date-range filters are tracked as a planned follow-up — see [Future Enhancements](#future-enhancements).
+
+### Link aggressively within `## Related`
+
+Same spirit as Zettelkasten: over-linking is better than under-linking. If a Resource touches on a Project's outcome, link it. If an Area has three projects that reference a common book, link the book from each. `get_context(path)` will surface these connections later when you're editing, and `para-project-kickoff` will resurface them when you start a new related project. Don't agonize — the tools will help you rediscover what you linked.
+
+## Future Enhancements
+
+**Date-range filter support** would enable deadline queries like `filters={"deadline": {"lte": "2026-05-01"}}`. This requires extending the FTS query layer to parse range operators on indexed date fields. Tracked as a planned follow-up issue.
+
+**Consolidated triage-and-create prompt.** Today, triage classifies an existing Inbox note and moves it; `create_from_template` creates a new note from a template. A combined "triage a thought and create a typed note directly" prompt — with auto-suggested target folder based on classification — is possible as a `create_from_template` extension. It's a usability improvement, not a capability gap.
+
+## Next Steps
+
+- **Read the design document** for details on the linking system and search algorithms: [`docs/design.md`](../design.md)
+- **Explore the MCP tools** to understand the full API: [`tools/index.md`](../tools/index.md)
+- **Review the examples** for templates and prompts: [`examples/para/`](../../examples/para/)
+- **Prefer idea-centric knowledge management?** See the alternative workflow: [`docs/guides/zettelkasten.md`](zettelkasten.md)

--- a/docs/guides/para.md
+++ b/docs/guides/para.md
@@ -5,7 +5,7 @@ PARA (Projects, Areas, Resources, Archive) is Tiago Forte's framework for organi
 !!! note
     This is one of many ways to organize a vault with markdown-vault-mcp. The server is a generic markdown collection backend — PARA conventions are applied in this guide but not required or enforced by the server.
 
-This guide assumes you're working with a PARA vault through Claude (or another MCP client) as the primary interface. The three PARA prompts — triage, kickoff, and weekly review — are where most of the value lives; Claude handles surfacing, classification, and batch operations you'd otherwise skip or defer. The Python and CLI examples scattered throughout are the scripting escape hatch, not the day-to-day pattern.
+This guide assumes you're working with a PARA vault through Claude (or another MCP client) as the primary interface. The four PARA prompts — capture-from-chats, triage, kickoff, and weekly review — are where most of the value lives; Claude handles surfacing, classification, and batch operations you'd otherwise skip or defer. The Python and CLI examples scattered throughout are the scripting escape hatch, not the day-to-day pattern.
 
 ## Vault Setup
 
@@ -143,6 +143,8 @@ The canonical PARA loop: **Capture → Triage → Project Work → Weekly Review
 ### 1. Capture (Inbox)
 
 Capture whatever's in your head into `0-Inbox/` without worrying about classification. The `inbox.md` template exists for this — Claude can create notes from it on request ("create an inbox note titled X with content Y"), or you can drop files directly into the folder via Obsidian, the CLI, or a scripting run. Review the inbox daily or every few days by invoking the triage prompt on the whole folder; Claude walks each note, classifies it, and proposes target paths.
+
+Capture doesn't have to be something you type. If your MCP client exposes chat-history tools (Claude.ai has `conversation_search` and `recent_chats`), the vault can ingest ideas you've already discussed. The `para-capture-chats` prompt does this in one pass — it distills recent conversations into topic-scoped Inbox notes ready for triage. On Claude.ai you can fire it directly from the compose area's `+` menu once the MCP server is added as a connector — no typing required.
 
 **Via Claude:**
 
@@ -311,14 +313,30 @@ The prompt calls `list_documents` on the templates folder to enumerate choices, 
 
 ## Using the PARA Prompts
 
-The three PARA prompts live in `examples/para/prompts/` and are loaded via `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER`:
+The four PARA prompts live in `examples/para/prompts/` and are loaded via `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER`:
 
 ```bash
 export MARKDOWN_VAULT_MCP_PROMPTS_FOLDER=/path/to/examples/para/prompts
 markdown-vault-mcp serve
 ```
 
-Then in Claude, the `para-triage`, `para-project-kickoff`, and `para-weekly-review` prompts are available.
+Then in Claude, the `para-capture-chats`, `para-triage`, `para-project-kickoff`, and `para-weekly-review` prompts are available. On Claude.ai they also appear in the compose area's `+` menu after adding the MCP server as a connector.
+
+### `para-capture-chats`
+
+**When to use:** at the end of a day or week, when you want ideas from your recent conversations captured into the vault without retyping them. Requires a client that exposes chat-history tools (e.g. Claude.ai's `conversation_search` and `recent_chats`); the prompt stops gracefully if they're not available.
+
+```
+In Claude, call: para-capture-chats()
+```
+
+Or with an explicit window:
+
+```
+In Claude, call: para-capture-chats(window='this week')
+```
+
+The prompt gathers relevant conversations, distills them topic by topic, and proposes one Inbox note per topic for your confirmation. It ends by suggesting you run `para-triage` on the fresh Inbox entries to classify them.
 
 ### `para-triage`
 

--- a/docs/guides/para.md
+++ b/docs/guides/para.md
@@ -177,7 +177,10 @@ Triage is the decision step: every Inbox note either becomes a Project, Area, or
 
 **What Claude does autonomously:** classify unambiguous notes into their bucket, slug the filename from the title, fill type-specific frontmatter fields (`outcome`, `deadline`, `area`, `standard`) from the note body, and execute the rename and write on confirmation.
 
-**What Claude asks about:** anything that could fit two buckets ("is this a one-off project or an ongoing responsibility?"), picking a slug when the title is generic ("thoughts"), deciding whether a note belongs as a new section of an existing permanent note rather than a standalone file. When a note contains two distinct ideas, you can tell Claude to split it — it creates two notes, one per idea, and triages each separately.
+**What Claude asks about:** anything that could fit two buckets ("is this a one-off project or an ongoing responsibility?"), picking a slug when the title is generic ("thoughts"), and two shape decisions worth calling out:
+
+- **Split.** When an Inbox note contains two distinct ideas, tell Claude to split. It creates two notes — one per idea — and triages each separately. Don't pre-split before triage; Claude handles it in one pass.
+- **Merge.** Before classifying, Claude can search for existing notes covering the same ground. If a strong match exists, it proposes merging the inbox content into the existing note as a new section (or extending an existing section), deleting the inbox note after. This prevents the vault from accumulating near-duplicates.
 
 The prompt walks through five steps:
 
@@ -408,9 +411,14 @@ Date-range filters are tracked as a planned follow-up — see [Future Enhancemen
 
 Same spirit as Zettelkasten: over-linking is better than under-linking. If a Resource touches on a Project's outcome, link it. If an Area has three projects that reference a common book, link the book from each. `get_context(path)` will surface these connections later when you're editing, and `para-project-kickoff` will resurface them when you start a new related project. Don't agonize — the tools will help you rediscover what you linked.
 
-### Let Claude split ambiguous captures
+### Let Claude split or merge captures
 
-When an inbox note contains two ideas, tell the triage prompt to split it. Claude creates two notes — one per idea — and classifies each separately. Don't try to pre-split before triage; Claude handles it in one pass.
+Two shape operations the triage prompt handles that manual workflows usually skip:
+
+- **Split** — when an Inbox note contains two ideas, tell the triage prompt to split. Claude creates two notes, one per idea, and classifies each separately.
+- **Merge** — when an Inbox note extends or restates something already in the vault, Claude proposes merging it into the existing note rather than creating a duplicate. This prevents near-duplicate accumulation, which is the main failure mode of long-lived PARA vaults.
+
+Don't pre-split or pre-merge before triage; Claude handles both in one pass.
 
 ### Ask Claude for area assignments in batches
 

--- a/docs/guides/zettelkasten.md
+++ b/docs/guides/zettelkasten.md
@@ -514,3 +514,4 @@ Use search and links for discovery. Tags are just shortcuts.
 - **Read the design document** for details on the linking system and search algorithms: [`docs/design.md`](../design.md)
 - **Explore the MCP tools** to understand the full API: [`tools/index.md`](../tools/index.md)
 - **Review the examples** for templates and prompts: [`examples/zettelkasten/`](../../examples/zettelkasten/)
+- **Prefer an action-oriented workflow?** Try the [PARA guide](para.md) — Projects, Areas, Resources, Archive with triage, kickoff, and weekly review prompts

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 A generic markdown collection [MCP](https://modelcontextprotocol.io/) server with FTS5 full-text search, semantic vector search, frontmatter-aware indexing, incremental reindexing, and non-markdown attachment support.
 
-Point it at a directory of Markdown files — an Obsidian vault, a docs folder, a Zettelkasten — and it exposes search, read, write, and edit tools over the [Model Context Protocol](https://modelcontextprotocol.io/).
+Point it at a directory of Markdown files — an Obsidian vault, a docs folder, a Zettelkasten, a PARA vault — and it exposes search, read, write, and edit tools over the [Model Context Protocol](https://modelcontextprotocol.io/).
 
 ## Features
 

--- a/examples/para/README.md
+++ b/examples/para/README.md
@@ -1,0 +1,90 @@
+# PARA Examples
+
+Ready-made templates and prompts for a [PARA](../../docs/guides/para.md) (Projects, Areas, Resources, Archive) workflow with markdown-vault-mcp.
+
+## Templates
+
+Five note templates covering the PARA lifecycle:
+
+- **`inbox.md`** — Untyped quick capture; triage assigns the type later
+- **`project.md`** — Concrete outcome with a deadline
+- **`area.md`** — Ongoing responsibility with a standard and review cadence
+- **`resource.md`** — Reference material on a topic
+- **`weekly-review.md`** — Dated review note with preset sections
+
+## Prompts
+
+Three prompts that codify the canonical PARA workflow:
+
+- **`para-triage.md`** — Classify an Inbox note into Project, Area, or Resource and move it
+- **`para-project-kickoff.md`** — Define a project's outcome and surface related Resources, Areas, and past Archived projects
+- **`para-weekly-review.md`** — Scan active projects for staleness, audit areas, and identify archive candidates; writes a dated review note
+
+## Usage
+
+### Templates
+
+Mount the `templates/` directory to enable template-based note creation:
+
+```bash
+export MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER=/path/to/examples/para/templates
+markdown-vault-mcp serve
+```
+
+Then in Claude, use the `create_from_template` prompt to create new notes from templates interactively.
+
+### Prompts
+
+Mount the `prompts/` directory via `PROMPTS_FOLDER`:
+
+```bash
+export MARKDOWN_VAULT_MCP_PROMPTS_FOLDER=/path/to/examples/para/prompts
+markdown-vault-mcp serve
+```
+
+Then in Claude, call any of the three PARA prompts by name.
+
+## Configuration
+
+Recommended env vars for a PARA vault:
+
+```bash
+# Core
+export MARKDOWN_VAULT_MCP_SOURCE_DIR=/path/to/vault
+export MARKDOWN_VAULT_MCP_READ_ONLY=false
+
+# Indexing — make type/status/tags/area filterable in search
+export MARKDOWN_VAULT_MCP_INDEXED_FIELDS=type,status,tags,area
+
+# Templates and Prompts
+export MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER=/path/to/examples/para/templates
+export MARKDOWN_VAULT_MCP_PROMPTS_FOLDER=/path/to/examples/para/prompts
+
+# Embeddings (optional, but recommended — project-kickoff resurface relies on semantic search)
+export MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH=/path/to/vault/.vault/embeddings.npy
+export MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=fastembed
+
+# Persistence
+export MARKDOWN_VAULT_MCP_INDEX_PATH=/path/to/vault/.vault/index.db
+```
+
+## Recommended vault layout
+
+```
+vault/
+  0-Inbox/        # quick capture, untyped
+  1-Projects/     # active projects with outcomes
+  2-Areas/        # ongoing responsibilities
+  3-Resources/    # reference material
+  4-Archive/      # status=archived items (any type)
+  _templates/     # pointed at by TEMPLATES_FOLDER
+```
+
+The server does not enforce this layout. The prompts suggest these paths when they need to move notes (triage target, weekly-review location); they fall back to asking if your vault uses a different structure.
+
+## See Also
+
+- **PARA Guide**: [`docs/guides/para.md`](../../docs/guides/para.md) — comprehensive walkthrough
+- **MCP Tools Reference**: [`docs/tools/index.md`](../../docs/tools/index.md) — all available tools
+- **Design Document**: [`docs/design.md`](../../docs/design.md) — linking system and search algorithms
+- **Zettelkasten alternative**: [`docs/guides/zettelkasten.md`](../../docs/guides/zettelkasten.md) — for idea-centric knowledge management

--- a/examples/para/README.md
+++ b/examples/para/README.md
@@ -14,8 +14,9 @@ Five note templates covering the PARA lifecycle:
 
 ## Prompts
 
-Three prompts that codify the canonical PARA workflow:
+Four prompts that codify the canonical PARA workflow:
 
+- **`para-capture-chats.md`** — Distill recent chat conversations (via `conversation_search` / `recent_chats` on Claude.ai) into Inbox notes for later triage
 - **`para-triage.md`** — Classify an Inbox note into Project, Area, or Resource and move it
 - **`para-project-kickoff.md`** — Define a project's outcome and surface related Resources, Areas, and past Archived projects
 - **`para-weekly-review.md`** — Scan active projects for staleness, audit areas, and identify archive candidates; writes a dated review note
@@ -42,7 +43,7 @@ export MARKDOWN_VAULT_MCP_PROMPTS_FOLDER=/path/to/examples/para/prompts
 markdown-vault-mcp serve
 ```
 
-Then in Claude, call any of the three PARA prompts by name.
+Then in Claude, call any of the four PARA prompts by name. On Claude.ai, prompts also appear in the compose area's `+` menu once the MCP server is added as a connector — one click to fire.
 
 ## Configuration
 

--- a/examples/para/prompts/para-capture-chats.md
+++ b/examples/para/prompts/para-capture-chats.md
@@ -1,0 +1,68 @@
+---
+description: "Distill recent chat conversations into PARA Inbox notes for later triage"
+arguments:
+  - name: window
+    description: "Time window to cover. Examples: 'today', 'this week', 'since 2026-04-15'. Defaults to 'today'."
+    required: false
+  - name: target_folder
+    description: "Vault folder for the inbox notes. Defaults to '0-Inbox'."
+    required: false
+tags: ["write"]
+---
+
+You are capturing recent chat conversations into a PARA vault's Inbox for later triage. The vault is a downstream beneficiary of conversations you've already had; this prompt bridges that gap in one pass.
+
+## Step 1: Check your chat-history tools
+
+Look for client-provided tools that expose conversation history. Common examples are `conversation_search` and `recent_chats` (Claude.ai). If no such tools are available in this session, stop and tell the user — this prompt cannot proceed without them. Do not fabricate content from the current conversation's context alone.
+
+## Step 2: Gather relevant conversations
+
+Use the chat-history tools to retrieve conversations within `$window` (default: `today`). Keep conversations that contain:
+
+- Ideas or concepts the user might want to think about again
+- Decisions made or alternatives considered
+- Open questions or things left unresolved
+- References cited (URLs, book titles, person names)
+- Action items or follow-ups
+
+Skip:
+
+- Pure factual Q&A with no follow-up value
+- One-off debugging or troubleshooting sessions
+- Chats that were fully resolved with no durable takeaway
+
+## Step 3: Distill into topics
+
+Group the retained conversations by topic. **One note per distinct topic** is preferred over a single daily mega-note — Inbox triage classifies note-by-note, and smaller topic-scoped notes classify more reliably into Project / Area / Resource.
+
+For each topic, extract:
+
+- The core idea or question (1-2 sentences, in the user's voice)
+- Specific decisions, references, action items
+- A title — use one from the conversation if natural, otherwise synthesise
+
+## Step 4: Propose note paths and content
+
+Before writing, present the proposed notes to the user:
+
+- **Path:** `$target_folder/<slug>.md` (default folder: `0-Inbox`); one note per topic
+- **Frontmatter:** `{title: "<title>", tags: [], created: "<today's ISO date>"}` — no `type` field; Inbox is untyped by convention, triage assigns the type later
+- **Body:** the distilled summary, in the user's voice, with any URLs from the source conversations preserved as links
+
+## Step 5: Write on confirmation
+
+On user confirmation, call `write(path=..., content=..., frontmatter=...)` for each note. If a target path already exists (re-running for the same window), ask whether to overwrite, merge, or pick a different slug.
+
+## Step 6: Suggest next action
+
+After writing, suggest running the `para-triage` prompt on `$target_folder` to classify the new notes into Projects / Areas / Resources.
+
+## Constraints
+
+- Do NOT write without explicit user confirmation.
+- If no chat-history tools are available in the client, stop — do not fabricate content from the current conversation's context alone.
+- Capture ideas, decisions, references, and action items — not transient Q&A or debugging.
+- One topic per note. Resist the urge to write a single daily-log mega-note.
+- Use `$target_folder` as the target folder (default `0-Inbox`); strip any trailing `/`.
+- Preserve the user's voice. These are their ideas from their conversations — write in first person where natural.

--- a/examples/para/prompts/para-project-kickoff.md
+++ b/examples/para/prompts/para-project-kickoff.md
@@ -1,0 +1,60 @@
+---
+description: "Kick off a project note: define outcome and deadline, then resurface related Resources, Areas, and past Archived projects"
+arguments:
+  - name: path
+    description: "Vault-relative path to the project note (e.g., '1-Projects/ship-v2.md')"
+    required: true
+tags: ["write"]
+---
+
+You are helping kick off a project in a PARA vault. Process `$path`.
+
+## Step 1: Verify the project is well-defined
+
+Call `read(path='$path')`. Check the frontmatter:
+
+- `outcome` must be a specific, one-sentence definition of done (not "improve X" — "ship v2 with feature Y by date Z").
+- `deadline` must be a real date (not the placeholder `YYYY-MM-DD`).
+
+If either is missing or still a placeholder, prompt the user to provide values before continuing.
+
+## Step 2: Survey the existing neighborhood
+
+Call `get_context(path='$path')`. Note:
+
+- Existing backlinks and outlinks
+- Similar notes already surfaced by the context call
+- Any tags or frontmatter already present
+
+## Step 3: Resurface related material
+
+Run two queries to gather context the user may not have linked yet:
+
+1. If `stats()` reports `semantic_search_available=True`, call `search(query=<outcome text>, mode='hybrid', limit=15)` for the richest results. Otherwise fall back to `search(query=<outcome text>, mode='keyword', limit=15)`. The hybrid mode fuses keyword BM25 with vector similarity; keyword mode is still useful when embeddings aren't configured.
+2. `get_similar(path='$path', limit=10)` — semantic near-neighbors (returns an empty list when embeddings are unavailable, so it is always safe to call)
+
+## Step 4: Classify results into three buckets
+
+For each result, classify using the folder prefix when available (fast path), otherwise by a targeted `search` with `filters={"type": "resource"}` etc.:
+
+- **Relevant Resources** — from `3-Resources/` or `type=resource`
+- **Similar past Projects (archived)** — from `4-Archive/` or `type=project status=archived`
+- **Linkable Areas** — from `2-Areas/` or `type=area`
+
+Prefer folder-prefix classification (one step) over per-note reads (N steps) when the vault follows the canonical layout.
+
+## Step 5: Propose links
+
+Present a `## Related` section to add to the project note, grouped by bucket. For each suggested link, state why it's relevant in one sentence.
+
+Prefer `[[wikilinks]]` for internal references.
+
+## Step 6: Apply on confirmation
+
+On user confirmation, add the `## Related` section. First call `read(path='$path')` to get the current body. If a `## Related` section already exists, call `edit(path='$path', old_text=<existing section text>, new_text=<existing section + new links>)`. Otherwise, append a new section by calling `edit(path='$path', old_text=<last line of current body>, new_text=<last line>\n\n## Related\n\n- [[link1]] — <why>\n- [[link2]] — <why>\n...)` — or simpler, `write(path='$path', content=<current body + new section>, frontmatter=<current frontmatter>)` after a fresh `read`.
+
+## Constraints
+
+- Do NOT edit the note without explicit user confirmation.
+- If Step 1 finds the note is not yet well-defined, stop and ask the user rather than guessing outcome/deadline.
+- Keep the `## Related` section focused — 5-10 strong links beats 30 weak ones.

--- a/examples/para/prompts/para-project-kickoff.md
+++ b/examples/para/prompts/para-project-kickoff.md
@@ -51,7 +51,7 @@ Prefer `[[wikilinks]]` for internal references.
 
 ## Step 6: Apply on confirmation
 
-On user confirmation, add the `## Related` section. First call `read(path='$path')` to get the current body. If a `## Related` section already exists, call `edit(path='$path', old_text=<existing section text>, new_text=<existing section + new links>)`. Otherwise, append a new section by calling `edit(path='$path', old_text=<last line of current body>, new_text=<last line>\n\n## Related\n\n- [[link1]] — <why>\n- [[link2]] — <why>\n...)` — or simpler, `write(path='$path', content=<current body + new section>, frontmatter=<current frontmatter>)` after a fresh `read`.
+On user confirmation, add the `## Related` section. Call `read(path='$path')` to get the current body and frontmatter, assemble the new body (existing body + new `## Related` section, or existing body with the `## Related` section extended if one exists), then call `write(path='$path', content=<new body>, frontmatter=<current frontmatter>)`. Using `write` is more robust than `edit` for appending — a trailing blank line or whitespace on the note would break an `edit(old_text=<last line>, ...)` match. If you do prefer `edit` to avoid rewriting the full file, match the existing `## Related` section heading precisely.
 
 ## Constraints
 

--- a/examples/para/prompts/para-triage.md
+++ b/examples/para/prompts/para-triage.md
@@ -21,32 +21,45 @@ Call `read(path=<note>)`. Identify:
 - Whether it describes a concrete outcome, an ongoing responsibility, or reference material
 - Any existing tags or signals in the body
 
-## Step 3: Classify
+## Step 3: Classify — and consider split / merge
 
-Assign one of:
+Before picking a bucket, sanity-check the note's shape:
+
+- **Split.** If the note contains two or more distinct ideas, classify each independently. Propose splitting into separate notes (one per idea) and triage each.
+- **Merge.** Run `search(query=<key terms from the note>, mode='hybrid' if available else 'keyword', limit=5)` to find existing notes that cover the same ground. If a strong match exists (same topic, overlapping content), propose **merging** the inbox note's content into the existing note instead of creating a new standalone file. Show the user the target note and the specific section where the new content would go.
+
+Otherwise assign one of:
 
 - **Project** — concrete outcome + a plausible deadline. Something that can be completed.
 - **Area** — ongoing responsibility with no end state (e.g., "Health", "Team Management").
 - **Resource** — reference material, not actionable (e.g., "Postgres connection pooling notes").
 
-If the note is ambiguous, **ask the user** — do not guess.
+If the note is ambiguous between buckets, **ask the user** — do not guess.
 
-## Step 4: Propose the move
+## Step 4: Propose the move (or split / merge)
 
-Present:
+**For a classification:**
 
 - Proposed target path (`1-Projects/<slug>.md`, `2-Areas/<slug>.md`, `3-Resources/<slug>.md`)
 - Proposed frontmatter block (type, status=active, any other relevant fields pre-filled from the note body)
+
+**For a split:** list the two (or more) target notes with their individual paths and frontmatter, then treat each as its own triage in Step 5.
+
+**For a merge:** show the target note path, the section heading the new content will extend (or "new section at end"), and a preview of the merged content.
 
 Wait for confirmation.
 
 ## Step 5: Execute on confirmation
 
-On user confirmation:
+**For a classification**, on user confirmation:
 
 1. `rename(old_path, new_path, update_links=True)` — preserves backlinks from other notes.
 2. `read(path=new_path)` to get the current body content.
 3. `write(path=new_path, content=<existing body>, frontmatter=<typed frontmatter dict>)` — overwrites the file with the typed frontmatter while preserving the body. Include `type`, `status=active`, `tags`, `created` (from the original note, or today's ISO date if missing), and any type-specific fields you inferred (`outcome`, `deadline`, `area` for projects; `standard`, `review_cadence` for areas).
+
+**For a split:** `read` the inbox note once, then for each resulting note call `write(path=<target>, content=<portion of body>, frontmatter=<typed frontmatter>)`. Delete the original inbox note with `delete(path=old_path)` after the splits are written.
+
+**For a merge:** `read(path=<target>)` to get the current body, append the new content (preserving the target's structure), then `write(path=<target>, content=<merged body>, frontmatter=<target's existing frontmatter>)`. Delete the original inbox note with `delete(path=old_path)` after the merge is written and confirmed.
 
 ## Constraints
 

--- a/examples/para/prompts/para-triage.md
+++ b/examples/para/prompts/para-triage.md
@@ -46,7 +46,7 @@ On user confirmation:
 
 1. `rename(old_path, new_path, update_links=True)` — preserves backlinks from other notes.
 2. `read(path=new_path)` to get the current body content.
-3. `write(path=new_path, content=<existing body>, frontmatter=<typed frontmatter dict>)` — overwrites the file with the typed frontmatter while preserving the body. Include `type`, `status=active`, `tags`, `created` (from the original note), and any type-specific fields you inferred (`outcome`, `deadline`, `area` for projects; `standard`, `review_cadence` for areas).
+3. `write(path=new_path, content=<existing body>, frontmatter=<typed frontmatter dict>)` — overwrites the file with the typed frontmatter while preserving the body. Include `type`, `status=active`, `tags`, `created` (from the original note, or today's ISO date if missing), and any type-specific fields you inferred (`outcome`, `deadline`, `area` for projects; `standard`, `review_cadence` for areas).
 
 ## Constraints
 

--- a/examples/para/prompts/para-triage.md
+++ b/examples/para/prompts/para-triage.md
@@ -1,0 +1,55 @@
+---
+description: "Triage an Inbox note (or any untyped note) into a Project, Area, or Resource"
+arguments:
+  - name: path
+    description: "Vault-relative path to a note or folder. Defaults to '0-Inbox/' if empty. Examples: '0-Inbox/my-note.md', '0-Inbox/'"
+    required: false
+tags: ["write"]
+---
+
+You are helping triage notes into a PARA vault. Process `$path` (default: `0-Inbox/`).
+
+## Step 1: Load the note(s)
+
+If `$path` is empty or ends with `/`, treat it as a folder (default: `0-Inbox`). Call `list_documents(folder=<'$path' with any trailing `/` stripped, or '0-Inbox' if empty>)` and iterate over each note. Example: `$path='0-Inbox/'` → call `list_documents(folder='0-Inbox')`. If `$path` is a single note path (ends with `.md`), skip to Step 2.
+
+## Step 2: Read and extract the central intent
+
+Call `read(path=<note>)`. Identify:
+
+- The central intent or subject
+- Whether it describes a concrete outcome, an ongoing responsibility, or reference material
+- Any existing tags or signals in the body
+
+## Step 3: Classify
+
+Assign one of:
+
+- **Project** — concrete outcome + a plausible deadline. Something that can be completed.
+- **Area** — ongoing responsibility with no end state (e.g., "Health", "Team Management").
+- **Resource** — reference material, not actionable (e.g., "Postgres connection pooling notes").
+
+If the note is ambiguous, **ask the user** — do not guess.
+
+## Step 4: Propose the move
+
+Present:
+
+- Proposed target path (`1-Projects/<slug>.md`, `2-Areas/<slug>.md`, `3-Resources/<slug>.md`)
+- Proposed frontmatter block (type, status=active, any other relevant fields pre-filled from the note body)
+
+Wait for confirmation.
+
+## Step 5: Execute on confirmation
+
+On user confirmation:
+
+1. `rename(old_path, new_path, update_links=True)` — preserves backlinks from other notes.
+2. `read(path=new_path)` to get the current body content.
+3. `write(path=new_path, content=<existing body>, frontmatter=<typed frontmatter dict>)` — overwrites the file with the typed frontmatter while preserving the body. Include `type`, `status=active`, `tags`, `created` (from the original note), and any type-specific fields you inferred (`outcome`, `deadline`, `area` for projects; `standard`, `review_cadence` for areas).
+
+## Constraints
+
+- Do NOT rename or edit without explicit user confirmation.
+- If the user has a non-canonical folder layout (no `1-Projects/` etc.), ask where the note should go rather than hard-coding.
+- When in doubt between Project and Area, ask: "Is there a concrete 'done' state?" Yes → Project. No → Area.

--- a/examples/para/prompts/para-weekly-review.md
+++ b/examples/para/prompts/para-weekly-review.md
@@ -26,7 +26,7 @@ Record for each active project: path, title, `frontmatter.deadline`, `modified_a
 Using the `modified_at` values from Step 2 (no additional calls needed), compute:
 
 ```
-stale_threshold = <current Unix timestamp> - 14 * 86400   # 14 days in seconds
+stale_threshold = <current Unix timestamp, ask user if unknown> - 14 * 86400   # 14 days in seconds
 stale_projects = [p for p in active_projects if p.modified_at < stale_threshold]
 ```
 

--- a/examples/para/prompts/para-weekly-review.md
+++ b/examples/para/prompts/para-weekly-review.md
@@ -1,0 +1,78 @@
+---
+description: "Run the PARA weekly review: list active projects, flag stale ones, audit areas, identify archive candidates, and write a dated review note"
+arguments:
+  - name: review_path
+    description: "Where to write the review note. Defaults to '3-Resources/reviews/<YYYY-WW>.md'."
+    required: false
+tags: ["write"]
+---
+
+You are running a PARA weekly review. Produce a dated review note at `$review_path` (default: `3-Resources/reviews/<current-ISO-week>.md`).
+
+## Step 1: Determine the review path
+
+Use `$review_path` if provided, otherwise build it as `3-Resources/reviews/<current-ISO-week>.md` (e.g., `3-Resources/reviews/2026-W17.md`). Do not create the file yet — Step 6 does that.
+
+## Step 2: Enumerate active projects with modification times
+
+Call `list_documents(folder='1-Projects')`. The response includes `frontmatter` and `modified_at` (a Unix timestamp in seconds) for each note. Filter client-side for notes where `frontmatter.status == 'active'`.
+
+Fallback for non-canonical vault layouts: call `list_documents()` (no folder) and filter for `frontmatter.type == 'project' and frontmatter.status == 'active'`. Note: if the vault is very large, prefer passing the canonical folder to reduce the payload and the model's context usage.
+
+Record for each active project: path, title, `frontmatter.deadline`, `modified_at`.
+
+## Step 3: Stale scan — find projects un-edited for 14+ days
+
+Using the `modified_at` values from Step 2 (no additional calls needed), compute:
+
+```
+stale_threshold = <current Unix timestamp> - 14 * 86400   # 14 days in seconds
+stale_projects = [p for p in active_projects if p.modified_at < stale_threshold]
+```
+
+Collect these as "Stale projects".
+
+## Step 4: Area audit
+
+Call `list_documents(folder='2-Areas')` and filter for `frontmatter.status == 'active'`.
+
+For each active Area, count projects referencing it via the indexed `area` frontmatter field. Use the active projects list you already have from Step 2: `count = len([p for p in active_projects if p.frontmatter.get('area') == area.title])`.
+
+Flag any Area with **zero** active projects as a candidate for archive or reassessment.
+
+## Step 5: Archive candidates
+
+Collect:
+
+- Projects with `status=completed` still in `1-Projects/` (should be moved to `4-Archive/`)
+- Projects that are stale for 30+ days (user may want to archive or revive)
+
+## Step 6: Write the review note
+
+Call `write(path=<review-path>, content=<assembled markdown body>, frontmatter={"title": "Weekly Review <today's ISO date, e.g. 2026-04-19>", "type": "resource", "tags": ["review"], "created": "<today's ISO date, e.g. 2026-04-19>"})`.
+
+The body should have these sections, populated from Steps 2-5:
+
+- `## Active projects` — from Step 2, one bullet per project with its deadline
+- `## Stale projects (no edits in 14+ days)` — from Step 3
+- `## Area audit` — from Step 4; Areas with their project counts, zero-project Areas called out
+- `## Archive candidates` — from Step 5
+- `## New projects / ideas` — left empty for the user to fill in during the review
+
+Parent directories are created automatically by `write`.
+
+If the target path already exists (running the review twice in the same week), ask the user whether to overwrite or pick a different path before calling `write`.
+
+## Step 7: Offer next actions
+
+Ask the user which archive candidates they want to move. For each confirmed candidate, perform:
+
+1. `read(path=<project>)` to get the current body and frontmatter.
+2. `write(path=<project>, content=<body>, frontmatter=<frontmatter with status='archived' and archived_at=<today>>)` — this is cleaner than a targeted `edit` for multi-field frontmatter updates.
+3. `rename(old_path, '4-Archive/<basename>', update_links=True)` to move it to the archive folder.
+
+## Constraints
+
+- Do NOT archive, rename, or edit notes without explicit confirmation.
+- Present all findings first, then ask what to act on. Do not interleave questions with data gathering.
+- If the user confirms a batch ("archive all 5"), still perform each operation individually so failures are isolated.

--- a/examples/para/templates/area.md
+++ b/examples/para/templates/area.md
@@ -5,7 +5,7 @@ status: active
 standard: "<what 'healthy' looks like for this area>"
 review_cadence: "<weekly | monthly | quarterly>"
 tags: []
-created: {{date}}
+created: "{{date}}"
 ---
 
 # {{title}}

--- a/examples/para/templates/area.md
+++ b/examples/para/templates/area.md
@@ -1,0 +1,22 @@
+---
+title: "{{title}}"
+type: area
+status: active
+standard: "<what 'healthy' looks like for this area>"
+review_cadence: "<weekly | monthly | quarterly>"
+tags: []
+created: {{date}}
+---
+
+# {{title}}
+
+## Standard
+
+<!-- What does this area look like when it's healthy? -->
+
+## Active projects
+
+<!-- Links to projects under this area. Kept here as a dashboard;
+     the authoritative signal is the `area` field on each project. -->
+
+## Notes

--- a/examples/para/templates/inbox.md
+++ b/examples/para/templates/inbox.md
@@ -1,7 +1,7 @@
 ---
 title: "{{title}}"
 tags: []
-created: {{date}}
+created: "{{date}}"
 ---
 
 # {{title}}

--- a/examples/para/templates/inbox.md
+++ b/examples/para/templates/inbox.md
@@ -1,0 +1,9 @@
+---
+title: "{{title}}"
+tags: []
+created: {{date}}
+---
+
+# {{title}}
+
+<!-- Capture the idea. Don't classify yet — triage will assign type and move it. -->

--- a/examples/para/templates/project.md
+++ b/examples/para/templates/project.md
@@ -6,7 +6,7 @@ outcome: "<one-sentence definition of done>"
 deadline: YYYY-MM-DD
 area: "<parent area name, or empty>"
 tags: []
-created: {{date}}
+created: "{{date}}"
 ---
 
 # {{title}}

--- a/examples/para/templates/project.md
+++ b/examples/para/templates/project.md
@@ -1,0 +1,22 @@
+---
+title: "{{title}}"
+type: project
+status: active
+outcome: "<one-sentence definition of done>"
+deadline: YYYY-MM-DD
+area: "<parent area name, or empty>"
+tags: []
+created: {{date}}
+---
+
+# {{title}}
+
+## Outcome
+
+<!-- Expand on the outcome. Who uses it? What's the acceptance test? -->
+
+## Next actions
+
+- [ ] ...
+
+## Notes

--- a/examples/para/templates/resource.md
+++ b/examples/para/templates/resource.md
@@ -3,7 +3,7 @@ title: "{{title}}"
 type: resource
 status: active
 tags: []
-created: {{date}}
+created: "{{date}}"
 ---
 
 # {{title}}

--- a/examples/para/templates/resource.md
+++ b/examples/para/templates/resource.md
@@ -1,0 +1,17 @@
+---
+title: "{{title}}"
+type: resource
+status: active
+tags: []
+created: {{date}}
+---
+
+# {{title}}
+
+<!-- Reference material, not actionable. Summary + key ideas + source links. -->
+
+## Summary
+
+## Key ideas
+
+## Sources

--- a/examples/para/templates/weekly-review.md
+++ b/examples/para/templates/weekly-review.md
@@ -2,7 +2,7 @@
 title: "Weekly Review {{date}}"
 type: resource
 tags: [review]
-created: {{date}}
+created: "{{date}}"
 ---
 
 # Weekly Review — {{date}}

--- a/examples/para/templates/weekly-review.md
+++ b/examples/para/templates/weekly-review.md
@@ -1,0 +1,20 @@
+---
+title: "Weekly Review {{date}}"
+type: resource
+tags: [review]
+created: {{date}}
+---
+
+# Weekly Review — {{date}}
+
+## Active projects
+
+<!-- Populated by the para-weekly-review prompt -->
+
+## Stale projects (no edits in 14+ days)
+
+## Area audit
+
+## Archive candidates
+
+## New projects / ideas

--- a/examples/zettelkasten/README.md
+++ b/examples/zettelkasten/README.md
@@ -68,3 +68,4 @@ export MARKDOWN_VAULT_MCP_INDEX_PATH=/path/to/vault/.vault/index.db
 - **Zettelkasten Guide**: [`docs/guides/zettelkasten.md`](../../docs/guides/zettelkasten.md) — comprehensive walkthrough
 - **MCP Tools Reference**: [`docs/tools/index.md`](../../docs/tools/index.md) — all available tools
 - **Design Document**: [`docs/design.md`](../../docs/design.md) — linking system and search algorithms
+- **PARA alternative**: [`docs/guides/para.md`](../../docs/guides/para.md) — for action-oriented Projects/Areas/Resources/Archive workflows

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ plugins:
           - guides/oidc-providers.md: OIDC provider setup (Authelia, Keycloak, Google, GitHub via broker)
           - guides/obsidian-everywhere.md: Reference architecture for desktop + mobile + Claude on one vault
           - guides/zettelkasten.md: Zettelkasten workflow (fleeting → literature → permanent notes, MOCs, graph navigation)
+          - guides/para.md: PARA workflow (Projects/Areas/Resources/Archive with triage, kickoff, and weekly review prompts)
           - guides/mcp-apps.md: MCP Apps — Context Card, Graph Explorer, Vault Browser, and Note Preview views
           - guides/claude-code-plugin.md: Claude Code plugin — install via /plugin marketplace
         MCP Interface:
@@ -132,6 +133,7 @@ nav:
       - OIDC Providers: guides/oidc-providers.md
       - Obsidian Everywhere: guides/obsidian-everywhere.md
       - Zettelkasten: guides/zettelkasten.md
+      - PARA: guides/para.md
       - MCP Apps: guides/mcp-apps.md
       - Claude Code Plugin: guides/claude-code-plugin.md
   - MCP Interface:

--- a/packaging/mcpb/manifest.json.in
+++ b/packaging/mcpb/manifest.json.in
@@ -17,7 +17,7 @@
   "documentation": "https://pvliesdonk.github.io/markdown-vault-mcp/",
   "support": "https://github.com/pvliesdonk/markdown-vault-mcp/issues",
   "license": "MIT",
-  "keywords": ["markdown", "vault", "obsidian", "search", "fts5", "embeddings", "zettelkasten"],
+  "keywords": ["markdown", "vault", "obsidian", "search", "fts5", "embeddings", "zettelkasten", "para"],
   "server": {
     "type": "uv",
     "entry_point": "src/server.py",


### PR DESCRIPTION
## Summary

Adds a PARA workflow pack as a peer to the existing Zettelkasten pack. Content-only — no `src/` changes. Archive is modeled as a `status` value (not a type) so notes retain their identity across lifecycle transitions.

- 5 note templates (`examples/para/templates/`): inbox, project, area, resource, weekly-review
- 3 MCP prompts (`examples/para/prompts/`): para-triage, para-project-kickoff, para-weekly-review
- Comprehensive guide at `docs/guides/para.md` (~400 lines), plus `examples/para/README.md` pointer doc
- Nav wiring (`mkdocs.yml` × 2, `docs/guides/index.md`, `docs/index.md`, `README.md` × 2, `docs/design.md`, `packaging/mcpb/manifest.json.in`)
- Bidirectional cross-link: both packs now reference the other

## Design decisions

Spec: [`docs/superpowers/specs/2026-04-19-para-workflow-design.md`](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/docs/superpowers/specs/2026-04-19-para-workflow-design.md).

- **Archive as state, not type.** `type ∈ {project, area, resource}`; `status ∈ {active, on-hold, completed, archived}`. `4-Archive/` folder is convenience for browsing; `status=archived` is the authoritative signal. This keeps `type=project status=archived` queries meaningful.
- **Stale scan and resurface baked into existing prompts.** Rather than shipping standalone "archive stale" and "just-in-time resurface" prompts, those behaviors live inside weekly-review and project-kickoff respectively.
- **Recommended indexed fields:** `MARKDOWN_VAULT_MCP_INDEXED_FIELDS=type,status,tags,area`. The `area` field on projects supports area rollups via search filters.
- **Deadlines not indexed.** FTS equality filters don't support date ranges. Documented as Future Work; tracked for a follow-up.

## Related commit on main

A pre-existing YAML-quoting bug was discovered during end-to-end verification: unquoted `created: {{date}}` in template frontmatter fails `yaml.safe_load`, silently breaking `create_from_template` discovery. Fixed for Zettelkasten directly on main in [`65af8f6`](https://github.com/pvliesdonk/markdown-vault-mcp/commit/65af8f6); the companion PARA fix is included in this branch.

## Test plan

- [x] `uv run pytest -x -q` — 1395 tests pass
- [x] `uv run pre-commit run --all-files` — all hooks pass (ruff, mypy, YAML, EOF, trailing whitespace, large files, vendored SPA)
- [x] `uv run mkdocs build --strict` — clean build (only pre-existing INFO notices about `design.md` exclusion and `examples/` relative links)
- [x] Template discoverability smoke test — all 5 PARA templates discoverable via `list_documents(folder='_templates')` and readable via `read()`
- [ ] Manual review of the PARA guide for tone and completeness
- [ ] Spot-check each prompt behavior in Claude against a seed vault before merging

## Documentation

- New: `docs/guides/para.md`, `examples/para/README.md`, 5 templates, 3 prompts
- Updated: `mkdocs.yml`, `docs/guides/index.md`, `docs/index.md`, `README.md`, `docs/design.md`, `packaging/mcpb/manifest.json.in`, `docs/guides/zettelkasten.md` (added PARA cross-link), `examples/zettelkasten/README.md` (added PARA cross-link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)