### PR TITLE
feat: add propose-links prompt + surface LLM-native flows in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **MCP resources** — 9 resources exposing vault configuration, statistics, tags, folders, document outlines, similar notes, recent notes, and an interactive SPA
 - **MCP prompts** — 6 prompt templates including template-driven note creation
 
+## What you can do with it
+
+With this server mounted in Claude, you can:
+
+- **Capture a URL as a note.** "Fetch <url>, summarize as a Resource note under `3-Resources/`, and link any existing notes on the topic." — Claude composes `fetch` + `search` + `write`.
+- **Research a topic into your vault.** "Research product security regulations, compare them, and create a set of interlinked notes — one per regulation, plus a map-of-content." — Claude composes web-search tools (client-side) + `write` with wikilinks.
+- **Distill today's thinking.** "Summarize today's conversations into Inbox notes." — Claude.ai only; uses `conversation_search` + `recent_chats` + `write`. The [`para-capture-chats`](examples/para/prompts/para-capture-chats.md) prompt is the one-click version.
+- **Find missing links.** Fire the [`propose-links`](https://pvliesdonk.github.io/markdown-vault-mcp/prompts/#propose-links) prompt from the `+` menu — it scans recently-modified notes, proposes meaningful connections, and writes them on confirmation.
+- **Split or merge captures.** "Split this Inbox note into two." / "Merge this into `<existing note>` instead of duplicating." — Claude composes `read` + `write` + `delete`.
+
+No external scheduler, no separate capture app — the vault sits behind your conversations and absorbs their output.
+
 ## Installation
 
 ### From PyPI

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -358,3 +358,7 @@ Claude uses the `show_context` tool to open the Context Card for that note.
     Clients that don't support MCP Apps (e.g., Claude Code) receive a text-only summary instead of the interactive view. All the underlying data is still accessible via the `get_context`, `get_backlinks`, and other link graph tools.
 
 For full details on views, configuration, and architecture, see the [MCP Apps guide](mcp-apps.md).
+
+### Firing prompts from Claude.ai's `+` menu
+
+This guide covers Claude Desktop. If you also use Claude.ai with the same server, its prompts can be fired from the compose area's `+` menu once the server is added as a connector. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the prompt scaffolded. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts).

--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -95,3 +95,7 @@ The app integrates with the host client via the ext-apps SDK:
 ## Client support
 
 MCP Apps views require a client that supports the MCP Apps protocol. Currently supported by Claude on claude.ai. Clients without Apps support receive a text-only fallback from `browse_vault` and `show_context`.
+
+### Firing prompts from Claude.ai's `+` menu
+
+MCP Apps surface interactive views, but this server also ships MCP *prompts* — `summarize`, `research`, `propose-links`, and the workflow prompts from the PARA and Zettelkasten packs. On Claude.ai, every prompt appears in the compose area's `+` menu once the server is added as a connector. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the invocation scaffolded. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts).

--- a/docs/guides/obsidian-everywhere.md
+++ b/docs/guides/obsidian-everywhere.md
@@ -123,6 +123,10 @@ Verification checklist:
 3. Server commits and pushes that note to the repository
 4. Desktop/mobile clients pull and see the same note
 
+### Firing prompts from Claude.ai's `+` menu
+
+When Claude.ai is part of your setup, every MCP prompt this server exposes can be fired from the compose area's `+` menu once the server is added as a connector. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the invocation scaffolded. This is the recommended way to invoke multi-step prompts like `propose-links` or the PARA / Zettelkasten workflow prompts. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts) for the full invocation reference.
+
 ## Limitations & troubleshooting
 
 - Diverged branches: when both Obsidian and MCP commit on different files, the server rebases local commits onto upstream automatically. When the same file is edited on both sides, the server resolves the conflict by accepting the upstream version and saving the MCP version as a `*.conflict-mcp-YYYYMMDD-HHMMSS.md` file with `conflict_with` frontmatter on both files. Neither version is authoritative — reconcile manually or let the AI merge them.

--- a/docs/guides/para.md
+++ b/docs/guides/para.md
@@ -438,3 +438,4 @@ After a triage session produces 5-10 new projects, ask Claude to propose an `are
 - **Explore the MCP tools** to understand the full API: [`tools/index.md`](../tools/index.md)
 - **Review the examples** for templates and prompts: [`examples/para/`](../../examples/para/)
 - **Prefer idea-centric knowledge management?** See the alternative workflow: [`docs/guides/zettelkasten.md`](zettelkasten.md)
+- **Ambient patterns**: [`docs/prompts.md`](../prompts.md#ambient-patterns-without-prompts) — flows the LLM handles from prose alone (URL capture, research, ad-hoc link proposal)

--- a/docs/guides/zettelkasten.md
+++ b/docs/guides/zettelkasten.md
@@ -415,6 +415,8 @@ markdown-vault-mcp serve
 
 Then in Claude, the `zettelkasten` prompt is available for use.
 
+**Fire the prompt from Claude.ai's `+` menu.** Once the server is added as a connector on Claude.ai, every MCP prompt — including `zettelkasten` — appears in the compose area's `+` menu. Click `+`, select **connectors**, pick the server, pick the prompt. Claude opens with the invocation scaffolded, so you don't need to remember the arguments. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts) for other clients.
+
 **Use the prompt:**
 
 ```
@@ -509,9 +511,19 @@ tags: [system-type-1, category-a-variant-b]
 
 Use search and links for discovery. Tags are just shortcuts.
 
+### Let Claude split or merge fleeting notes
+
+Two shape operations that an LLM handles cleanly but manual workflows usually skip:
+
+- **Split.** When a fleeting note contains two ideas — one literature reference and one nascent permanent claim — ask Claude to split it into two notes. Each is then developed independently.
+- **Merge.** When a fleeting note restates or extends an existing permanent note, ask Claude to merge it (add as a new paragraph or `## Extension` section) rather than letting near-duplicates accumulate. The [`search`](../tools/index.md#search) + `read` + `write` + `delete` composition handles this in a single prompt turn.
+
+Resist pre-splitting or pre-merging before review. Claude does both in one pass.
+
 ## Next Steps
 
 - **Read the design document** for details on the linking system and search algorithms: [`docs/design.md`](../design.md)
 - **Explore the MCP tools** to understand the full API: [`tools/index.md`](../tools/index.md)
 - **Review the examples** for templates and prompts: [`examples/zettelkasten/`](../../examples/zettelkasten/)
 - **Prefer an action-oriented workflow?** Try the [PARA guide](para.md) — Projects, Areas, Resources, Archive with triage, kickoff, and weekly review prompts
+- **Ambient patterns**: [`docs/prompts.md`](../prompts.md#ambient-patterns-without-prompts) — flows the LLM handles from prose alone (URL capture, research, split/merge, ad-hoc link proposal)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,17 @@ Point it at a directory of Markdown files — an Obsidian vault, a docs folder, 
 - **MCP prompts** — summarize, research, discuss, create from template, compare, and find related notes
 - **MCP Apps** — four browser-based views (Context Card, Graph Explorer, Vault Browser, Note Preview) for clients supporting the MCP Apps protocol
 
+## What you can do with it
+
+A few flows the server enables with an LLM on top — none of these require a bespoke prompt:
+
+- **"Fetch <url> and summarize into a Resource note."** Claude composes `fetch` + `search` + `write`.
+- **"Research <topic> and create a set of interlinked notes."** Claude composes web tools + `write` with wikilinks.
+- **"Summarize today's conversations into Inbox notes."** Claude.ai composes `conversation_search` + `recent_chats` + `write`; the [`para-capture-chats`](guides/para.md#using-the-para-prompts) prompt is the one-click version.
+- **Find missing links.** The [`propose-links`](prompts.md) builtin prompt scans recently-modified notes and proposes meaningful connections.
+
+See [MCP Prompts](prompts.md) for the codified workflows and the ambient-pattern reference.
+
 ## Quick Start
 
 ### As a library

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -12,6 +12,7 @@ Prompt templates guide the LLM through multi-step workflows using the vault tool
 | [`create_from_template`](#create_from_template) | `template_name` (optional) | Write | Create a new note from a template in your templates folder |
 | [`related`](#related) | `path` | Read | Find related notes and suggest cross-references |
 | [`compare`](#compare) | `path1`, `path2` | Read | Side-by-side comparison of two documents |
+| [`propose-links`](#propose-links) | `scope`, `per_note_limit` (both optional) | Write | Propose meaningful new links between semantically-close notes that aren't already connected |
 
 ---
 
@@ -124,3 +125,96 @@ Read two documents and produce a side-by-side comparison.
 - What both documents agree on
 - Where they differ or contradict
 - Information present in one but absent from the other
+
+## `propose-links`
+
+Scan a bounded set of notes for semantically close pairs that aren't already linked, apply LLM judgment to keep only the meaningful connections, and write them to the vault on confirmation.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `scope` | string \| null | Candidate set: a folder path (e.g. `"1-Projects"`), the literal `"recent"` (default; notes modified in the last 30 days), or the literal `"all"`. No trailing slashes. |
+| `per_note_limit` | integer \| null | Max candidates per note to evaluate. Defaults to 5. |
+
+**Workflow:**
+
+1. Resolve `scope` to a list of notes, warning if more than 100 notes match.
+2. For each note, gather candidates via `get_similar` (with a `search(mode='keyword')` fallback when embeddings aren't configured).
+3. Filter out pairs where A already links to B (via `get_outlinks`).
+4. LLM judgment: read each candidate's title and opening to confirm the connection is meaningful, not merely lexical.
+5. Pick direction (one-way `A → B`) and placement per note shape (inline citation, `## Related` section, hub bullet list, footnote — whichever fits).
+6. Show a batch preview of every proposed edit.
+7. Write approved edits; skip failures (e.g., `ConcurrentModificationError`) and report reasons.
+
+!!! note "Write prompt"
+    This prompt modifies documents and is only available when `READ_ONLY=false`.
+
+!!! note "Embeddings recommended"
+    `propose-links` falls back to keyword search without embeddings, but the quality of candidates is noticeably better when `get_similar` is available. See [Embeddings](guides/embeddings.md) for setup.
+
+## Ambient patterns without prompts
+
+Not every LLM-native workflow needs a codified MCP prompt. With a capable model and the server's tools, several high-value flows work from prose intent alone. The examples below document these composable patterns — which tools the model orchestrates and why each pattern doesn't need its own prompt.
+
+### Capture a URL as a note
+
+> "Fetch https://example.com/article, summarize as a Resource note under `3-Resources/`, and link any existing notes on the topic."
+
+**Tools composed:** `fetch` → LLM summarization → `search` (to find related existing notes) → `write` (with frontmatter and wikilinks).
+
+**Why no codified prompt:** the only knob is the target folder, and the user expresses it in the ask. No structure worth pre-specifying.
+
+### Research a topic into interlinked notes
+
+> "Research product security regulations, compare the major frameworks, and create a set of interlinked notes — one per regulation, plus a map-of-content."
+
+**Tools composed:** client-side web search → LLM synthesis → multiple `write` calls with `[[wikilinks]]` connecting the resulting notes.
+
+**Why no codified prompt:** modern LLMs cross-link naturally when asked for "a set of interlinked notes." The single-note version (`research` prompt) handles the simpler case where one note is enough.
+
+### Distill conversations into Inbox notes
+
+> "Summarize today's conversations into Inbox notes — one per topic."
+
+**Tools composed:** `conversation_search` + `recent_chats` (Claude.ai client-side) → LLM distillation → `write` per topic.
+
+**Why (partially) codified:** the [`para-capture-chats`](guides/para.md#using-the-para-prompts) prompt exists as the one-click version because it has platform-specific tool names to call out and constraints on what to skip (pure Q&A, debugging). Outside the PARA pack, the ambient ask works fine.
+
+### Split and merge captures
+
+> "Split this Inbox note into two — one for the Postgres upgrade, one for the CRA compliance work."
+>
+> "Merge this into `3-Resources/distributed-consensus.md` instead of creating a duplicate."
+
+**Tools composed:** `read` + `search` (to find merge target) + `write` (new notes or extended target) + `delete` (the source note).
+
+**Why no codified prompt:** the split/merge heuristic is codified inside `para-triage` where it's most useful. Outside triage, the ambient ask is a direct one-sentence instruction.
+
+### Ad-hoc link proposal for a single note
+
+> "Get the context for `1-Projects/migrate-postgres.md` and identify any notes we haven't linked yet."
+
+**Tools composed:** `get_context` (surfaces the `similar` field) → LLM filtering → `edit` or `write` to add selected links.
+
+**Why no codified prompt:** [`related`](#related) covers the find-candidates case read-only; the per-note write case is a natural extension and doesn't add enough structure to warrant a standalone prompt. The vault-wide sweep *is* codified, as [`propose-links`](#propose-links).
+
+## How to invoke prompts
+
+Three invocation affordances, roughly in order of convenience:
+
+### 1. Claude.ai: the `+` menu (recommended)
+
+On Claude.ai, once the server is added as a connector, every prompt appears in the compose area's `+` menu. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the invocation scaffolded. No typing; no remembering argument names.
+
+This is the best UX for frequent prompts (`propose-links`, `summarize`, the PARA / Zettelkasten workflow prompts).
+
+### 2. Claude Code: the `/` menu
+
+In Claude Code, MCP prompts appear in the slash-command menu after the server is configured in the workspace's MCP settings. Same effect as the Claude.ai `+` menu — the prompt is pre-scaffolded.
+
+### 3. Plain conversation
+
+Every prompt can be invoked from prose ("use the propose-links prompt with scope='1-Projects'"). The model resolves the name and calls the prompt. This is the fallback — more typing, but works in any MCP client.
+
+The ambient-pattern flows above *only* use plain conversation; they don't have a prompt name to invoke. The trade-off: no menu shortcut, but no prompt to maintain either.

--- a/docs/superpowers/plans/2026-04-19-llm-native-flows.md
+++ b/docs/superpowers/plans/2026-04-19-llm-native-flows.md
@@ -1,0 +1,860 @@
+# LLM-Native Flows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one new builtin MCP prompt (`propose-links`), refresh top-level documentation to surface ambient LLM workflows as first-class examples, and improve tool docstrings so the model can proactively suggest composable patterns. Closes [#386](https://github.com/pvliesdonk/markdown-vault-mcp/issues/386) and [#387](https://github.com/pvliesdonk/markdown-vault-mcp/issues/387).
+
+**Architecture:** One file addition under `src/markdown_vault_mcp/static/prompts/`, one-line registration in `_server_prompts.py`, short-line docstring additions to eight tools in `_server_tools.py`, and prose edits to README + seven documentation files. No schema changes; no new tools; no new tests beyond the single prompt-registration test.
+
+**Tech Stack:** Python 3.10+, FastMCP, mkdocs-material. Tests use `pytest` with `fastmcp.Client`.
+
+**Reference spec:** [`docs/superpowers/specs/2026-04-19-llm-native-flows-design.md`](../specs/2026-04-19-llm-native-flows-design.md)
+
+---
+
+## Task 1: Add the `propose-links` builtin prompt
+
+**Files:**
+- Create: `src/markdown_vault_mcp/static/prompts/propose-links.md`
+- Modify: `src/markdown_vault_mcp/_server_prompts.py:332` (the `for md_name in [...]` list)
+- Modify: `tests/test_prompts.py` (add assertion in `test_all_builtins_present_without_prompts_folder` plus a new focused test)
+
+- [ ] **Step 1: Write the failing test — assert `propose-links` is in the builtin set**
+
+Add to `tests/test_prompts.py` inside `class TestNoPromptsFolder` at the end of `test_all_builtins_present_without_prompts_folder`:
+
+```python
+    async def test_all_builtins_present_without_prompts_folder(self) -> None:
+        server = create_server()
+        async with Client(server) as client:
+            prompts = await client.list_prompts()
+        names = {p.name for p in prompts}
+        # Read-only mode: these built-ins should be present
+        assert "summarize" in names
+        assert "related" in names
+        assert "compare" in names
+        assert "propose-links" in names
+```
+
+The existing test already checks three other builtins; the new assertion extends it. This test covers registration; a separate test below covers description and arguments.
+
+- [ ] **Step 2: Add a focused test for `propose-links` description and arguments**
+
+Append this new class at the end of `tests/test_prompts.py`:
+
+```python
+class TestProposeLinks:
+    """The propose-links builtin prompt is registered with the expected shape."""
+
+    async def test_propose_links_registered(self) -> None:
+        from markdown_vault_mcp.mcp_server import create_server
+
+        server = create_server()
+        async with Client(server) as client:
+            prompts = await client.list_prompts()
+        propose_links = next(p for p in prompts if p.name == "propose-links")
+        assert (
+            propose_links.description is not None
+            and "link" in propose_links.description.lower()
+        )
+        # Both arguments are optional (scope, per_note_limit).
+        arg_names = {arg.name for arg in (propose_links.arguments or [])}
+        assert arg_names == {"scope", "per_note_limit"}
+        assert all(arg.required is False for arg in (propose_links.arguments or []))
+```
+
+If the `create_server` import pattern already exists elsewhere in the file (e.g., the `TestNoPromptsFolder` class imports it at module scope), move the import up to match the existing pattern rather than inlining inside the method. The existing file imports at the top; use the top-level import.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/test_prompts.py::TestNoPromptsFolder::test_all_builtins_present_without_prompts_folder tests/test_prompts.py::TestProposeLinks -v
+```
+Expected: both fail with `AssertionError` mentioning `propose-links` (the registered names set does not contain it yet).
+
+- [ ] **Step 4: Create `src/markdown_vault_mcp/static/prompts/propose-links.md`**
+
+```markdown
+---
+description: Propose meaningful new links between semantically-close notes that aren't already connected.
+arguments:
+  - name: scope
+    description: "Candidate set. Accepts a folder path (e.g. '1-Projects'), the literal 'recent' (default; notes modified in the last 30 days), or the literal 'all'. No trailing slashes on folder paths."
+    required: false
+  - name: per_note_limit
+    description: "Max candidates per note to evaluate (default 5)."
+    required: false
+tags:
+  - write
+icons: write
+---
+
+You are proposing meaningful new links between notes in a markdown vault. Focus on connections that a reader would genuinely benefit from, not notes that merely share vocabulary.
+
+## Step 1: Resolve scope
+
+Interpret `$scope`:
+
+- Empty or `'recent'`: call `list_documents()`, then filter client-side for notes where `modified_at > <now - 30 * 86400>` (i.e., modified within the last 30 days). If the current Unix timestamp is not available, ask the user for today's date.
+- `'all'`: call `list_documents()` unfiltered.
+- Otherwise treat as a folder path. Strip any trailing `/` and call `list_documents(folder='<scope>')`.
+
+If the resolved set contains more than 100 notes, pause and ask the user whether to proceed or narrow the scope. Above 100 notes, the subsequent steps become slow and noisy.
+
+## Step 2: Gather candidates per note
+
+For each note in scope:
+
+1. Call `get_similar(path=<note path>, limit=$per_note_limit)` (default limit: 5).
+2. If `get_similar` returns an empty list (no embeddings configured), fall back to `search(query=<note title>, mode='keyword', limit=$per_note_limit)` and drop the note itself from the result.
+
+## Step 3: Filter out already-linked pairs
+
+For each scanned note, call `get_outlinks(path=<note>)` once. For each candidate pair (A, B), drop the candidate if A already links to B — compare the candidate path against each outlink's `raw_target` (also consider the wikilink form, e.g., `[[B-title]]` without the `.md` extension).
+
+## Step 4: Apply LLM judgment
+
+For each surviving candidate pair, `read(path=<B>)` and inspect B's title, first section heading, and opening paragraph. Keep only pairs where the content justifies an explicit link — the reader of A would benefit from knowing about B in context, not merely because the two share words.
+
+## Step 5: Pick direction and placement
+
+For each kept pair:
+
+- **Direction:** one-way `A → B` as a wikilink from A. `get_backlinks` recovers the reverse; explicit bidirectional wikilinks are redundant. Pick A as the note where the link reads most naturally: atomic → hub, specific → general, newer → older.
+- **Placement:** pick per note shape, using judgment:
+  - Short atomic note → new `## Related` section (create if missing).
+  - Prose note → inline citation in a relevant paragraph.
+  - MOC / hub note → append under an existing thematic bullet list.
+  - Reference note → `## See Also` or footnote-style link.
+
+Do not prescribe a fixed placement. The shape of the host note dictates where the link belongs.
+
+## Step 6: Batch preview
+
+Render a preview of every proposed edit, numbered. Example:
+
+```
+1. 1-Projects/migrate-postgres.md — inline citation after line 23: mention [[postgres-16-json-path]]
+2. 3-Resources/distributed-consensus.md — new `## Related` section with [[raft-paper-notes]] and [[paxos-made-simple]]
+3. 2-Areas/team-hiring.md — append to existing `## Related` list: [[interview-rubric]]
+```
+
+Ask the user: "Apply all N? Apply specific ones? Skip all?"
+
+## Step 7: Execute on confirmation
+
+For each approved edit:
+
+- Prefer `edit(path=<A>, old_text=<current>, new_text=<current with link added>)` for small in-place insertions (inline citations, bullet-list appends).
+- Use `write(path=<A>, content=<full body>, frontmatter=<current frontmatter>)` when the change restructures the note (new `## Related` section at the end of a long note, or any change easier to express as a full-body rewrite). Always `read` the current state first to preserve unmodified content.
+- If a write fails (for example, `ConcurrentModificationError`), skip that edit, record the reason, and continue with the rest.
+
+## Step 8: Summary
+
+Report the counts:
+
+- Links added
+- Notes updated
+- Pairs skipped (and the reason for each: already linked, rejected by LLM judgment, write conflict)
+
+## Constraints
+
+- Never write without explicit user confirmation. The batch preview in Step 6 is the only gating point; per-edit confirmation is available on request.
+- Never propose self-links.
+- Do not propose MOC-to-MOC links by default. Mention them in the preview as observations but do not include them as edits unless the user explicitly asks.
+- Budget guard: if the scope resolves to more than 100 notes, stop and ask before proceeding.
+- Graceful degradation: if neither `get_similar` nor `search` produces candidates for a note, skip it silently. Do not warn per-note.
+```
+
+- [ ] **Step 5: Register the prompt in `_server_prompts.py`**
+
+Modify the list at `src/markdown_vault_mcp/_server_prompts.py:332`. Current:
+
+```python
+    for md_name in ["summarize", "research", "discuss", "related", "compare"]:
+```
+
+Change to:
+
+```python
+    for md_name in ["summarize", "research", "discuss", "related", "compare", "propose-links"]:
+```
+
+Do not touch the derived-variables logic at lines 254-264 — `propose-links` has no derived variables like `research`'s `topic_slug`. The existing pattern handles parameter passthrough without modification.
+
+- [ ] **Step 6: Run both tests — expect pass**
+
+Run:
+```bash
+uv run pytest tests/test_prompts.py::TestNoPromptsFolder::test_all_builtins_present_without_prompts_folder tests/test_prompts.py::TestProposeLinks -v
+```
+Expected: both PASS.
+
+- [ ] **Step 7: Run the full prompt test file to catch regressions**
+
+Run:
+```bash
+uv run pytest tests/test_prompts.py -x -q
+```
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/markdown_vault_mcp/static/prompts/propose-links.md \
+  src/markdown_vault_mcp/_server_prompts.py \
+  tests/test_prompts.py
+git commit -m "feat: add propose-links builtin prompt"
+```
+
+---
+
+## Task 2: Improve tool docstrings to surface composable patterns
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/_server_tools.py` (eight tools: `search`, `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, `write`, `delete`, `fetch`)
+
+Each edit is a short sentence appended to the **Notes** or the trailing paragraph of the existing docstring — not a structural rewrite. Keep every addition to one sentence. Do not touch signature or Args sections.
+
+- [ ] **Step 1: Run the test suite to establish a green baseline**
+
+Run:
+```bash
+uv run pytest -x -q
+```
+Expected: all tests pass (propose-links was added in Task 1).
+
+- [ ] **Step 2: Update `search` docstring (line 83)**
+
+Find the `search` docstring. It ends with a `Raises:` section documenting `ValueError`. Insert a new paragraph **after** the `Returns:` block and **before** the `Raises:` section:
+
+```
+        Also useful for finding merge candidates during triage — if a
+        close match exists for a new capture, prefer merging over
+        creating a near-duplicate.
+```
+
+If the docstring has no blank line before `Raises:`, add one. Match the 8-space indentation of the surrounding docstring body.
+
+- [ ] **Step 3: Update `get_backlinks` docstring (line 371)**
+
+Find the `get_backlinks` docstring. Append a one-sentence paragraph at the very end of the docstring body (before the closing `"""`):
+
+```
+        Combine with ``get_similar`` to find connection gaps — notes that are
+        semantically close to the target but not yet linked.
+```
+
+Use the 8-space indentation used elsewhere in the file.
+
+- [ ] **Step 4: Update `get_outlinks` docstring (line 414)**
+
+Find the `get_outlinks` docstring. Append the same one-sentence paragraph at the end:
+
+```
+        Combine with ``get_similar`` to find connection gaps — notes that are
+        semantically close to the target but not yet linked.
+```
+
+- [ ] **Step 5: Update `get_similar` docstring (line 497)**
+
+Find the `get_similar` docstring. Append a one-sentence paragraph at the end:
+
+```
+        Useful for finding link candidates that aren't yet wikilinked — the
+        vault's organic graph is almost always denser than its explicit one.
+        See the ``propose-links`` prompt for a full vault-wide sweep.
+```
+
+- [ ] **Step 6: Update `get_context` docstring (line 580)**
+
+Find the `get_context` docstring. Append a one-sentence paragraph at the end:
+
+```
+        The ``similar`` field in the response surfaces notes that may warrant
+        explicit links to the context note but don't yet — a common input to
+        manual or automated link proposal.
+```
+
+- [ ] **Step 7: Update `write` docstring (line 977)**
+
+Find the `write` docstring. Append a one-sentence paragraph at the very end:
+
+```
+        Supports split (write several new notes from one source) and merge
+        (extend an existing note with content from another) when composed with
+        ``read`` and ``delete``.
+```
+
+- [ ] **Step 8: Update `delete` docstring (line 1134)**
+
+Find the `delete` docstring. Append a one-sentence paragraph at the end:
+
+```
+        Typically called after a split or merge to remove the source note once
+        its content has been relocated.
+```
+
+- [ ] **Step 9: Update `fetch` docstring (line 1237)**
+
+Find the `fetch` docstring. Append a one-sentence paragraph at the end:
+
+```
+        Primary building block for URL-to-note capture flows: call ``fetch`` to
+        retrieve the source, summarize via the LLM, and ``write`` the result
+        as a new note.
+```
+
+- [ ] **Step 10: Verify lint and types still pass**
+
+Run:
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/
+```
+Expected: no lint, format, or type errors. Docstring edits should not affect any of these gates, but run them as a safety net.
+
+- [ ] **Step 11: Run the test suite**
+
+Run:
+```bash
+uv run pytest -x -q
+```
+Expected: all tests pass. No tests assert on docstring content; this is just a regression check.
+
+- [ ] **Step 12: Verify MkDocs picks up the docstring changes**
+
+Run:
+```bash
+uv run mkdocs build --strict 2>&1 | tail -10
+```
+Expected: clean build (same pre-existing INFO notices as before about `design.md` exclusion and `examples/` relative links). The rendered `docs/tools/index.md` page is regenerated from the Python source docstrings, so the new sentences will appear there automatically on site build.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/markdown_vault_mcp/_server_tools.py
+git commit -m "docs: add composable-pattern hints to tool docstrings"
+```
+
+---
+
+## Task 3: Add "What you can do with it" teaser sections to README and docs/index.md
+
+**Files:**
+- Modify: `README.md` (insert new section)
+- Modify: `docs/index.md` (insert shorter mirror)
+
+- [ ] **Step 1: Locate the insertion point in `README.md`**
+
+Read `README.md` and find the end of the features list or tool-count block that currently precedes the Installation section. Exact line depends on current content — grep for the Installation heading to find the boundary:
+
+```bash
+grep -n "^## Installation" README.md
+```
+
+Insert the new section immediately above that `## Installation` heading.
+
+- [ ] **Step 2: Add the "What you can do with it" section to `README.md`**
+
+Insert the following block immediately before `## Installation`:
+
+```markdown
+## What you can do with it
+
+With this server mounted in Claude, you can:
+
+- **Capture a URL as a note.** "Fetch <url>, summarize as a Resource note under `3-Resources/`, and link any existing notes on the topic." — Claude composes `fetch` + `search` + `write`.
+- **Research a topic into your vault.** "Research product security regulations, compare them, and create a set of interlinked notes — one per regulation, plus a map-of-content." — Claude composes web-search tools (client-side) + `write` with wikilinks.
+- **Distill today's thinking.** "Summarize today's conversations into Inbox notes." — Claude.ai only; uses `conversation_search` + `recent_chats` + `write`. The [`para-capture-chats`](examples/para/prompts/para-capture-chats.md) prompt is the one-click version.
+- **Find missing links.** Fire the [`propose-links`](https://pvliesdonk.github.io/markdown-vault-mcp/prompts/#propose-links) prompt from the `+` menu — it scans recently-modified notes, proposes meaningful connections, and writes them on confirmation.
+- **Split or merge captures.** "Split this Inbox note into two." / "Merge this into `<existing note>` instead of duplicating." — Claude composes `read` + `write` + `delete`.
+
+No external scheduler, no separate capture app — the vault sits behind your conversations and absorbs their output.
+```
+
+- [ ] **Step 3: Locate the insertion point in `docs/index.md`**
+
+Read `docs/index.md` and find the main features bullet list (early in the file, before the deployment scenarios table). The mirror goes immediately after that list.
+
+Grep the file to pick a stable anchor — the exact heading depends on current state:
+
+```bash
+grep -n "^##" docs/index.md | head -10
+```
+
+Insert the shorter mirror before the second major section heading (often `## Installation` or `## Deployment scenarios`).
+
+- [ ] **Step 4: Add the shorter mirror to `docs/index.md`**
+
+Insert the following block immediately before the second-section heading identified in Step 3:
+
+```markdown
+## What you can do with it
+
+A few flows the server enables with an LLM on top — none of these require a bespoke prompt:
+
+- **"Fetch <url> and summarize into a Resource note."** Claude composes `fetch` + `search` + `write`.
+- **"Research <topic> and create a set of interlinked notes."** Claude composes web tools + `write` with wikilinks.
+- **"Summarize today's conversations into Inbox notes."** Claude.ai composes `conversation_search` + `recent_chats` + `write`; the [`para-capture-chats`](guides/para.md#using-the-para-prompts) prompt is the one-click version.
+- **Find missing links.** The [`propose-links`](prompts.md#propose-links) builtin prompt scans recently-modified notes and proposes meaningful connections.
+
+See [MCP Prompts](prompts.md) for the codified workflows and the ambient-pattern reference.
+```
+
+- [ ] **Step 5: Verify MkDocs build is clean**
+
+Run:
+```bash
+uv run mkdocs build --strict 2>&1 | tail -10
+```
+Expected: build succeeds; any new INFO notices (e.g., unresolvable link anchors) should be investigated and fixed. Anchors like `#propose-links` on `prompts.md` will work once Task 4 adds that heading; verify Task 4 writes the heading text exactly as `## `propose-links`` so this anchor resolves.
+
+If `--strict` fails due to the unresolvable `#propose-links` anchor, reorder: complete Task 4 first, then redo Step 5. Alternatively, use a non-anchor link for now (`[propose-links](prompts.md)`) and refine in Task 4. The subagent should choose one and proceed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md docs/index.md
+git commit -m "docs: add 'what you can do with it' teaser to README and docs index"
+```
+
+---
+
+## Task 4: Extend `docs/prompts.md` with `propose-links` entry, ambient-patterns section, and invocation-mechanics section
+
+**Files:**
+- Modify: `docs/prompts.md`
+
+- [ ] **Step 1: Add `propose-links` to the Quick Reference table**
+
+Find the table at the top of `docs/prompts.md`. Add a new row after the existing `related` row (preserve alphabetic-by-name ordering isn't followed in the current table — match the existing ordering which seems roughly read-then-write). Insert just before the closing of the table body. The updated table should contain, in order: `summarize`, `research`, `discuss`, `create_from_template`, `related`, `compare`, `propose-links`. The new row:
+
+```markdown
+| [`propose-links`](#propose-links) | `scope`, `per_note_limit` (both optional) | Write | Propose meaningful new links between semantically-close notes that aren't already connected |
+```
+
+- [ ] **Step 2: Add the `## `propose-links`` section**
+
+Append a new section at the end of the per-prompt listings (after the `compare` section). Exact content:
+
+```markdown
+## `propose-links`
+
+Scan a bounded set of notes for semantically close pairs that aren't already linked, apply LLM judgment to keep only the meaningful connections, and write them to the vault on confirmation.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `scope` | string \| null | Candidate set: a folder path (e.g. `"1-Projects"`), the literal `"recent"` (default; notes modified in the last 30 days), or the literal `"all"`. No trailing slashes. |
+| `per_note_limit` | integer \| null | Max candidates per note to evaluate. Defaults to 5. |
+
+**Workflow:**
+
+1. Resolve `scope` to a list of notes, warning if more than 100 notes match.
+2. For each note, gather candidates via `get_similar` (with a `search(mode='keyword')` fallback when embeddings aren't configured).
+3. Filter out pairs where A already links to B (via `get_outlinks`).
+4. LLM judgment: read each candidate's title and opening to confirm the connection is meaningful, not merely lexical.
+5. Pick direction (one-way `A → B`) and placement per note shape (inline citation, `## Related` section, hub bullet list, footnote — whichever fits).
+6. Show a batch preview of every proposed edit.
+7. Write approved edits; skip failures (e.g., `ConcurrentModificationError`) and report reasons.
+
+!!! note "Write prompt"
+    This prompt modifies documents and is only available when `READ_ONLY=false`.
+
+!!! note "Embeddings recommended"
+    `propose-links` falls back to keyword search without embeddings, but the quality of candidates is noticeably better when `get_similar` is available. See [Embeddings](guides/embeddings.md) for setup.
+```
+
+- [ ] **Step 3: Add the "Ambient patterns without prompts" section**
+
+Append after the `propose-links` section:
+
+```markdown
+## Ambient patterns without prompts
+
+Not every LLM-native workflow needs a codified MCP prompt. With a capable model and the server's tools, several high-value flows work from prose intent alone. The examples below document these composable patterns — which tools the model orchestrates and why each pattern doesn't need its own prompt.
+
+### Capture a URL as a note
+
+> "Fetch https://example.com/article, summarize as a Resource note under `3-Resources/`, and link any existing notes on the topic."
+
+**Tools composed:** `fetch` → LLM summarization → `search` (to find related existing notes) → `write` (with frontmatter and wikilinks).
+
+**Why no codified prompt:** the only knob is the target folder, and the user expresses it in the ask. No structure worth pre-specifying.
+
+### Research a topic into interlinked notes
+
+> "Research product security regulations, compare the major frameworks, and create a set of interlinked notes — one per regulation, plus a map-of-content."
+
+**Tools composed:** client-side web search → LLM synthesis → multiple `write` calls with `[[wikilinks]]` connecting the resulting notes.
+
+**Why no codified prompt:** modern LLMs cross-link naturally when asked for "a set of interlinked notes." The single-note version (`research` prompt) handles the simpler case where one note is enough.
+
+### Distill conversations into Inbox notes
+
+> "Summarize today's conversations into Inbox notes — one per topic."
+
+**Tools composed:** `conversation_search` + `recent_chats` (Claude.ai client-side) → LLM distillation → `write` per topic.
+
+**Why (partially) codified:** the [`para-capture-chats`](guides/para.md#using-the-para-prompts) prompt exists as the one-click version because it has platform-specific tool names to call out and constraints on what to skip (pure Q&A, debugging). Outside the PARA pack, the ambient ask works fine.
+
+### Split and merge captures
+
+> "Split this Inbox note into two — one for the Postgres upgrade, one for the CRA compliance work."
+>
+> "Merge this into `3-Resources/distributed-consensus.md` instead of creating a duplicate."
+
+**Tools composed:** `read` + `search` (to find merge target) + `write` (new notes or extended target) + `delete` (the source note).
+
+**Why no codified prompt:** the split/merge heuristic is codified inside `para-triage` where it's most useful. Outside triage, the ambient ask is a direct one-sentence instruction.
+
+### Ad-hoc link proposal for a single note
+
+> "Get the context for `1-Projects/migrate-postgres.md` and identify any notes we haven't linked yet."
+
+**Tools composed:** `get_context` (surfaces the `similar` field) → LLM filtering → `edit` or `write` to add selected links.
+
+**Why no codified prompt:** [`related`](#related) covers the find-candidates case read-only; the per-note write case is a natural extension and doesn't add enough structure to warrant a standalone prompt. The vault-wide sweep *is* codified, as [`propose-links`](#propose-links).
+```
+
+- [ ] **Step 4: Add the "How to invoke" section**
+
+Append after the "Ambient patterns without prompts" section:
+
+```markdown
+## How to invoke prompts
+
+Three invocation affordances, roughly in order of convenience:
+
+### 1. Claude.ai: the `+` menu (recommended)
+
+On Claude.ai, once the server is added as a connector, every prompt appears in the compose area's `+` menu. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the invocation scaffolded. No typing; no remembering argument names.
+
+This is the best UX for frequent prompts (`propose-links`, `summarize`, the PARA / Zettelkasten workflow prompts).
+
+### 2. Claude Code: the `/` menu
+
+In Claude Code, MCP prompts appear in the slash-command menu after the server is configured in the workspace's MCP settings. Same effect as the Claude.ai `+` menu — the prompt is pre-scaffolded.
+
+### 3. Plain conversation
+
+Every prompt can be invoked from prose ("use the propose-links prompt with scope='1-Projects'"). The model resolves the name and calls the prompt. This is the fallback — more typing, but works in any MCP client.
+
+The ambient-pattern flows above *only* use plain conversation; they don't have a prompt name to invoke. The trade-off: no menu shortcut, but no prompt to maintain either.
+```
+
+- [ ] **Step 5: Verify MkDocs build is clean with the new anchors**
+
+Run:
+```bash
+uv run mkdocs build --strict 2>&1 | tail -10
+```
+Expected: build succeeds. The anchors `#propose-links`, `#ambient-patterns-without-prompts`, `#how-to-invoke-prompts` should exist and match any links from Task 3 (`docs/index.md`) and Tasks 5–7.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/prompts.md
+git commit -m "docs: add propose-links entry, ambient patterns, and invocation sections to prompts.md"
+```
+
+---
+
+## Task 5: Update `docs/guides/zettelkasten.md` — connector menu, split/merge tip, cross-link
+
+**Files:**
+- Modify: `docs/guides/zettelkasten.md`
+
+- [ ] **Step 1: Locate the Zettelkasten prompt section**
+
+Find the "Using the Zettelkasten Prompt" section (approximately line 395-420 based on current content). The connector-menu paragraph goes right after the description of how to invoke the prompt.
+
+- [ ] **Step 2: Add the connector-menu paragraph**
+
+After the existing explanation of how to run the Zettelkasten prompt via `PROMPTS_FOLDER`, insert the following paragraph:
+
+```markdown
+**Fire the prompt from Claude.ai's `+` menu.** Once the server is added as a connector on Claude.ai, every MCP prompt — including `zettelkasten` — appears in the compose area's `+` menu. Click `+`, select **connectors**, pick the server, pick the prompt. Claude opens with the invocation scaffolded, so you don't need to remember the arguments. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts) for other clients.
+```
+
+- [ ] **Step 3: Find the existing Tips section**
+
+Find the "Tips and Best Practices" section (near the end of the file, before Next Steps). The new split/merge tip goes after the existing "Tag for grouping, not taxonomy" tip.
+
+- [ ] **Step 4: Add a split/merge tip**
+
+Insert this new subsection after the last existing tip and before the Next Steps section:
+
+```markdown
+### Let Claude split or merge fleeting notes
+
+Two shape operations that an LLM handles cleanly but manual workflows usually skip:
+
+- **Split.** When a fleeting note contains two ideas — one literature reference and one nascent permanent claim — ask Claude to split it into two notes. Each is then developed independently.
+- **Merge.** When a fleeting note restates or extends an existing permanent note, ask Claude to merge it (add as a new paragraph or `## Extension` section) rather than letting near-duplicates accumulate. The [`search`](../tools/index.md#search) + `read` + `write` + `delete` composition handles this in a single prompt turn.
+
+Resist pre-splitting or pre-merging before review. Claude does both in one pass.
+```
+
+- [ ] **Step 5: Add an ambient-patterns cross-link to Next Steps**
+
+Find the "Next Steps" section at the end of the file. It currently contains three or four bullet items. Append this bullet at the end:
+
+```markdown
+- **Ambient patterns**: [`docs/prompts.md`](../prompts.md#ambient-patterns-without-prompts) — flows the LLM handles from prose alone (URL capture, research, split/merge, ad-hoc link proposal)
+```
+
+- [ ] **Step 6: Verify MkDocs build is clean**
+
+Run:
+```bash
+uv run mkdocs build --strict 2>&1 | tail -10
+```
+Expected: clean build; no new broken-link warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/guides/zettelkasten.md
+git commit -m "docs(zettelkasten): add connector + menu, split/merge tip, ambient-patterns cross-link"
+```
+
+---
+
+## Task 6: Update `docs/guides/para.md` — cross-link to ambient patterns
+
+**Files:**
+- Modify: `docs/guides/para.md`
+
+The PARA guide already covers connector menu, split/merge, and the PARA prompts. Only the ambient-patterns cross-link needs adding.
+
+- [ ] **Step 1: Find the Next Steps section**
+
+Open `docs/guides/para.md` and find the Next Steps section at the end of the file.
+
+- [ ] **Step 2: Append the ambient-patterns cross-link**
+
+Append this bullet at the end of the Next Steps list:
+
+```markdown
+- **Ambient patterns**: [`docs/prompts.md`](../prompts.md#ambient-patterns-without-prompts) — flows the LLM handles from prose alone (URL capture, research, ad-hoc link proposal)
+```
+
+- [ ] **Step 3: Verify MkDocs build is clean**
+
+Run:
+```bash
+uv run mkdocs build --strict 2>&1 | tail -10
+```
+Expected: clean build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guides/para.md
+git commit -m "docs(para): cross-link to ambient patterns section"
+```
+
+---
+
+## Task 7: Add connector-menu paragraph to other guides
+
+**Files:**
+- Modify: `docs/guides/claude-desktop.md`
+- Modify: `docs/guides/obsidian-everywhere.md`
+- Modify: `docs/guides/mcp-apps.md`
+
+Three small, identical edits. The target location in each file is "wherever invocation of tools or prompts is first discussed" — typically after the initial setup steps.
+
+- [ ] **Step 1: Identify the insertion point in `docs/guides/claude-desktop.md`**
+
+Grep for invocation-related headings:
+
+```bash
+grep -n "^##" docs/guides/claude-desktop.md | head -20
+```
+
+Pick the heading most closely related to "invoking prompts" or "using the server from Claude Desktop." If the file doesn't have a dedicated invocation section, insert after the "Verify" / "Test" section near the end.
+
+- [ ] **Step 2: Add the connector-menu paragraph to `docs/guides/claude-desktop.md`**
+
+Insert this new subsection at the chosen insertion point:
+
+```markdown
+### Firing prompts from Claude.ai's `+` menu
+
+This guide covers Claude Desktop. If you also use Claude.ai with the same server, its prompts can be fired from the compose area's `+` menu once the server is added as a connector. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the prompt scaffolded. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts).
+```
+
+- [ ] **Step 3: Identify the insertion point in `docs/guides/obsidian-everywhere.md`**
+
+Grep for section headings:
+
+```bash
+grep -n "^##" docs/guides/obsidian-everywhere.md | head -20
+```
+
+This guide likely has a "Claude.ai" or "Using with Claude" section — insert the paragraph there. If not, insert near the end before any closing Next-Steps block.
+
+- [ ] **Step 4: Add the connector-menu paragraph to `docs/guides/obsidian-everywhere.md`**
+
+Insert the same subsection (adjust surrounding heading level to match the rest of the file — likely `###`):
+
+```markdown
+### Firing prompts from Claude.ai's `+` menu
+
+When Claude.ai is part of your setup, every MCP prompt this server exposes can be fired from the compose area's `+` menu once the server is added as a connector. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the invocation scaffolded. This is the recommended way to invoke multi-step prompts like `propose-links` or the PARA / Zettelkasten workflow prompts. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts) for the full invocation reference.
+```
+
+- [ ] **Step 5: Identify the insertion point in `docs/guides/mcp-apps.md`**
+
+Grep for section headings:
+
+```bash
+grep -n "^##" docs/guides/mcp-apps.md | head -20
+```
+
+Insert the paragraph where the guide first discusses invoking server functionality (tools, resources, or prompts from the client side).
+
+- [ ] **Step 6: Add the connector-menu paragraph to `docs/guides/mcp-apps.md`**
+
+Insert the same subsection:
+
+```markdown
+### Firing prompts from Claude.ai's `+` menu
+
+MCP Apps surface interactive views, but this server also ships MCP *prompts* — `summarize`, `research`, `propose-links`, and the workflow prompts from the PARA and Zettelkasten packs. On Claude.ai, every prompt appears in the compose area's `+` menu once the server is added as a connector. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the invocation scaffolded. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts).
+```
+
+- [ ] **Step 7: Verify MkDocs build is clean**
+
+Run:
+```bash
+uv run mkdocs build --strict 2>&1 | tail -15
+```
+Expected: clean build, no new warnings about broken anchors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/guides/claude-desktop.md docs/guides/obsidian-everywhere.md docs/guides/mcp-apps.md
+git commit -m "docs: add Claude.ai connector + menu paragraph to three guides"
+```
+
+---
+
+## Task 8: End-to-end verification and issue closure
+
+**Files:** (none modified directly)
+
+- [ ] **Step 1: Run full pre-commit**
+
+Run:
+```bash
+uv run pre-commit run --all-files
+```
+Expected: all hooks pass (ruff, ruff format, mypy, vendored SPA, trailing whitespace, EOF, YAML, large files, JSON).
+
+- [ ] **Step 2: Run the full test suite**
+
+Run:
+```bash
+uv run pytest -x -q
+```
+Expected: all tests pass, including the new `TestProposeLinks` class and the updated `test_all_builtins_present_without_prompts_folder`.
+
+- [ ] **Step 3: Run MkDocs `--strict`**
+
+Run:
+```bash
+uv run mkdocs build --strict 2>&1 | tail -20
+```
+Expected: clean build. The only remaining INFO notices should be the pre-existing ones (`design.md` excluded, `examples/` relative links in both zettelkasten and para guides, the `oidc-providers.md` anchor).
+
+Sanity-check that the ambient-patterns anchor resolves: open `site/guides/zettelkasten/index.html` in a browser and click the "Ambient patterns" Next-Steps link; it should jump to the right place in `site/prompts/index.html`. If any internal link fails, fix it in the originating file.
+
+- [ ] **Step 4: Smoke-test `propose-links` against a seed vault**
+
+Set up a minimal vault and verify the prompt is callable:
+
+```bash
+mkdir -p /tmp/propose-vault/Notes
+cat > /tmp/propose-vault/Notes/a.md <<'EOF'
+---
+title: "Distributed consensus"
+tags: [systems]
+---
+
+# Distributed consensus
+
+Overview of consensus algorithms in distributed systems.
+EOF
+
+cat > /tmp/propose-vault/Notes/b.md <<'EOF'
+---
+title: "Raft paper notes"
+tags: [systems, reading]
+---
+
+# Raft paper notes
+
+Notes from Ongaro and Ousterhout's Raft paper.
+EOF
+
+MARKDOWN_VAULT_MCP_SOURCE_DIR=/tmp/propose-vault \
+MARKDOWN_VAULT_MCP_READ_ONLY=false \
+uv run python -c "
+import asyncio
+from fastmcp import Client
+from markdown_vault_mcp.mcp_server import create_server
+
+async def main():
+    server = create_server()
+    async with Client(server) as client:
+        prompts = await client.list_prompts()
+        names = sorted(p.name for p in prompts)
+        print('Registered prompts:', names)
+        assert 'propose-links' in names
+        result = await client.get_prompt('propose-links', {'scope': 'Notes'})
+        print('Prompt body length:', sum(len(m.content.text) for m in result.messages if hasattr(m.content, 'text')))
+
+asyncio.run(main())
+"
+rm -rf /tmp/propose-vault
+```
+
+Expected: the script prints the registered prompts list (includes `propose-links`), invokes `get_prompt('propose-links', {'scope': 'Notes'})`, and prints a non-zero body length. If the body length is zero, the substitution is broken.
+
+- [ ] **Step 5: Review the branch commit history**
+
+Run:
+```bash
+git log --oneline main..HEAD
+```
+Expected: seven commits from Tasks 1–7 (the verification task has no commit).
+
+- [ ] **Step 6: No commit for this task**
+
+This task is verification-only. If any step failed, diagnose, fix in the relevant source file, amend the appropriate task's commit (or create a fix-up commit with an explicit message referencing what was missed), and re-run the entire verification sequence from Step 1.
+
+- [ ] **Step 7: Note issue closures for the PR description**
+
+When opening the PR, include in the body:
+
+```
+Closes #386
+Closes #387
+```
+
+so both issues auto-close on merge.
+
+---
+
+## Out of Scope (Future Work — do not implement now)
+
+- Similarity-score threshold knob for `propose-links` (currently relies on LLM judgment over `get_similar`'s top-N; a cosine-threshold parameter would give deterministic-ish filtering at a tuning cost).
+- Scheduled / periodic execution of `propose-links` (cron, systemd timer, or in-server scheduler).
+- Dedicated prompts for split, merge, URL capture, research, or summarize-URL. These are ambient in the current design; revisit only if real usage shows the prose form is too verbose.
+- Restructuring `docs/prompts.md` into multiple pages. Current size is manageable; revisit after two or three more prompts are added.

--- a/docs/superpowers/specs/2026-04-19-llm-native-flows-design.md
+++ b/docs/superpowers/specs/2026-04-19-llm-native-flows-design.md
@@ -1,0 +1,238 @@
+# LLM-Native Flows — Design
+
+**Date:** 2026-04-19
+**Status:** Approved design; plan pending
+**Audience:** Contributors adding a new builtin prompt and refreshing docs to surface LLM-native workflows
+
+## Summary
+
+This change has three threads under one theme — **surface the LLM-native workflows this server already enables**:
+
+1. Add one new builtin prompt, `propose-links`, that scans a bounded set of notes and proposes meaningful links between semantically-close pairs that aren't already connected.
+2. Refresh the docs to showcase *ambient* LLM flows (URL capture, research into interlinked notes, conversation distillation, split/merge) as examples — without adding prompts for them, because the LLM handles them well from prose intent.
+3. Tweak tool docstrings to surface composable patterns, so the model itself can propose these flows before the user asks.
+
+Closes [#386](https://github.com/pvliesdonk/markdown-vault-mcp/issues/386) (connector `+` menu affordance) and [#387](https://github.com/pvliesdonk/markdown-vault-mcp/issues/387) (split/merge as generic note operations) as part of the agnostic docs work.
+
+## Goals
+
+1. Make it obvious to a first-time reader that this server enables workflows beyond "search and read markdown" — ambient Claude flows are the differentiator.
+2. Ship exactly *one* new prompt, chosen because a vault-wide link-proposal sweep is genuinely non-obvious (the LLM won't do it proactively from prose intent alone).
+3. Document the ambient patterns in prose, not codified prompts — avoid prompt sprawl for things the LLM already handles naturally.
+4. Use tool docstrings as affordances for the model itself, not just reference material for humans.
+
+## Non-Goals
+
+- New prompts for URL summarization, external-doc ingestion, or research-into-interlinked-notes. These work well from conversational intent and don't benefit from codification.
+- Example-pack-specific versions of `propose-links`. The prompt is pack-agnostic.
+- Any server-side feature changes (no new tools, no new resources, no behavior changes to existing tools).
+
+## Design Decision: Why Only One New Prompt
+
+Prompts add value when one or more of the following is true:
+
+1. **One-click `+` menu shortcut** — the flow is frequent enough that a menu item beats prose invocation.
+2. **Non-obvious structure** — heuristics, thresholds, or sequencing that a casual "ask Claude" won't produce (e.g., staleness windows, bucket classification rules, filter-out-already-linked-pairs sweeps).
+3. **Platform-specific tool dance** — the flow has to name specific client tools the LLM wouldn't guess (e.g., `conversation_search`, `recent_chats`).
+
+By that test:
+
+| Flow | Passes? | Reasoning |
+|------|---------|-----------|
+| `propose-links` | ✓ | Non-obvious sweep; LLM won't enumerate vault-wide, run `get_similar` per note, filter out already-linked pairs, and propose the remainder without being explicitly prompted to do so. |
+| Capture today's chats (`para-capture-chats`, shipped in PR #385) | ✓ | Platform dance; frequent. |
+| Summarize a URL into a note | ✗ | "Fetch <url>, summarize as a Resource note" works from prose. No structure worth codifying. |
+| Research topic → interlinked notes | ✗ | Confirmed ambient: "research X, compare, create interlinked notes" works in Claude.ai without scaffolding. |
+| Split / merge captures | ✗ (as standalone prompt) | Already codified inside `para-triage` Step 3. Generic version doesn't need its own prompt; surfaces via tool docstrings and documentation. |
+
+## The `propose-links` Prompt
+
+**File:** `src/markdown_vault_mcp/static/prompts/propose-links.md`
+**Registration:** `src/markdown_vault_mcp/_server_prompts.py` — add `"propose-links"` to the list of builtin prompt names registered at startup (alongside `summarize`, `research`, `discuss`, `related`, `compare`).
+
+### Frontmatter
+
+```yaml
+---
+description: Propose meaningful new links between semantically-close notes that aren't already connected.
+arguments:
+  - name: scope
+    description: "Candidate set. Accepts a folder path (e.g. '1-Projects'), the literal 'recent' (default; notes modified in the last 30 days), or the literal 'all'. No trailing slashes on folder paths."
+    required: false
+  - name: per_note_limit
+    description: "Max candidates per note to evaluate (default 5)."
+    required: false
+tags: [write]
+icons: write
+---
+```
+
+### Body
+
+1. **Resolve scope.** Interpret `$scope`:
+   - Empty or `'recent'`: `list_documents()`, filter client-side on `modified_at > now - 30*86400`.
+   - `'all'`: `list_documents()` unfiltered.
+   - Otherwise treat as a folder path (strip trailing `/`): `list_documents(folder=$scope)`.
+
+   If the resolved set contains more than 100 notes, pause and ask the user whether to proceed or narrow the scope.
+
+2. **Gather candidates per note.** For each note in scope:
+   - Call `get_similar(path=<note>, limit=$per_note_limit)` (default 5).
+   - If `get_similar` returns empty (no embeddings configured), fall back to `search(query=<note title>, mode='keyword', limit=$per_note_limit)` and filter the results to exclude the note itself.
+
+3. **Filter out already-linked pairs.** For each candidate pair (A, B), check whether A already links to B. Call `get_outlinks(path=A)` once per scanned note and compare `raw_target` against the candidate B's path (also compare the wikilink text form — `[[B-title]]` without the `.md` extension).
+
+4. **LLM judgment pass.** For each surviving candidate pair, `read(path=B)` and inspect the title, first section heading, and opening paragraph. Keep only pairs where the content justifies an explicit link — meaning the reader of A would genuinely benefit from knowing about B in context, not merely that they share vocabulary.
+
+5. **Pick direction and placement per kept pair.**
+   - Direction: one-way (`A → B` as a wikilink from A). The reverse is recoverable via `get_backlinks`; explicit bidirectional edits are redundant.
+   - Direction heuristic: atomic → hub, specific → general, newer → older; whichever reads most naturally in context. Break ties in favor of the direction that produces the more meaningful in-context citation.
+   - Placement: pick per note shape, as LLM judgment. Examples:
+     - Short atomic note → new `## Related` section (create if missing).
+     - Prose note → inline citation at a relevant paragraph.
+     - MOC / hub note → append under an existing thematic bullet list.
+     - Reference note → `## See Also` or footnote-style link.
+   - The prompt does not prescribe a fixed placement. Let the model judge per note.
+
+6. **Batch preview.** Render a preview showing each proposed edit:
+
+   ```
+   1. `1-Projects/migrate-postgres.md` — inline citation after line 23: mention [[postgres-16-json-path]]
+   2. `3-Resources/distributed-consensus.md` — new `## Related` section with [[raft-paper-notes]] and [[paxos-made-simple]]
+   3. `2-Areas/team-hiring.md` — append to existing `## Related` list: [[interview-rubric]]
+   ```
+
+   Ask the user: "Apply all N? Apply specific ones? Skip all?"
+
+7. **Execute on confirmation.** For each approved edit:
+   - Prefer `edit(path=..., old_text=..., new_text=...)` for small in-place insertions (inline citations, bullet-list appends).
+   - Use `write(path=..., content=..., frontmatter=...)` when the change restructures the file (new `## Related` section at the bottom of a long note, or the placement is easier to express as a full-body rewrite).
+   - If a write fails (e.g., `ConcurrentModificationError`), skip that edit, record the reason, and continue.
+
+8. **Summary.** Report the counts: links added, notes updated, pairs skipped (with reasons: already linked, rejected by LLM judgment, write conflict).
+
+### Constraints
+
+- **Never write without user confirmation.** The batch preview (Step 6) is the only gating point; per-edit confirmation is available on request.
+- **Don't propose self-links.**
+- **Don't propose MOC-to-MOC links by default.** Hub-to-hub connections are usually noise. The LLM may surface them as "worth mentioning" in the preview text but should not propose them as edits unless the user explicitly asks.
+- **Budget guard.** If scope resolves to > 100 notes, ask before proceeding.
+- **Graceful degradation.** If neither `get_similar` nor `search` produces candidates for a note, skip it silently — do not warn per-note.
+- **No silent writes on skipped edits.** If the batch contains 10 edits and the user approves 7, execute 7 and report which 3 were skipped.
+
+## Documentation Structure
+
+### `README.md` — new "What you can do with it" section
+
+Positioned after the features list / tool count block, before Installation. Aim: ~25 lines.
+
+Content template (exact wording tuned during implementation):
+
+```markdown
+## What you can do with it
+
+With this server mounted in Claude, you can:
+
+- **Capture a URL as a note:** "Fetch <url>, summarize as a Resource note under `3-Resources/`, and link any existing notes on the topic." — Claude uses `fetch` + `search` + `write`.
+- **Research a topic into your vault:** "Research product security regulations, compare them, and create a set of interlinked notes, one per regulation, plus a MOC." — Claude uses web-search tools (client-side) + `write` with cross-linking.
+- **Distill today's thinking:** "Summarize today's conversations into Inbox notes." — Claude.ai only; uses `conversation_search` + `recent_chats` + `write`. Or invoke the `para-capture-chats` prompt for a one-click version.
+- **Find missing links:** Invoke `propose-links` from the `+` menu — it scans recently modified notes, proposes meaningful connections, and writes them on confirmation.
+- **Split or merge captures:** "Split this Inbox note into two" or "Merge this capture into `<existing note>` instead of duplicating." — Claude uses `read` + `write` + `delete`.
+
+No external scheduler, no separate capture app — the vault sits behind your conversations and absorbs their output.
+```
+
+### `docs/index.md` — shorter mirror
+
+Two or three of the five examples above, with a pointer to `docs/prompts.md` for the full list. Goal: orient readers without duplicating the README in full.
+
+### `docs/prompts.md` — new entry + new section
+
+1. Add `propose-links` to the existing prompts table / per-prompt subsections (same format as `summarize`, `research`, etc.).
+2. New section **"Ambient patterns without prompts"** — extends the README teaser with depth. For each example, list which tools the LLM composes, and explain why the pattern doesn't need its own MCP prompt:
+
+   - URL capture: `fetch` + `search` + `write` — prose is sufficient because target folder is the only knob, and the user expresses it in the ask.
+   - Research into interlinked notes: web-search + `write` with wikilinks — the LLM already composes cross-links naturally when asked for "a set of interlinked notes."
+   - Split / merge: `read` + `write` + `delete` — codified as part of `para-triage` for the Inbox case; generic form is just prose.
+
+3. New section **"How to invoke"** — unifies the invocation mechanics across platforms:
+   - Prose conversation ("ask Claude: ...")
+   - MCP prompt in the Claude Code `/` menu
+   - Claude.ai `+` → connectors → pick server → pick prompt
+
+   This is the canonical home for the #386 content (the connector `+` menu paragraph).
+
+### Tool docstring improvements
+
+Edits in `src/markdown_vault_mcp/_server_tools.py`:
+
+| Tool | Addition |
+|------|----------|
+| `get_similar` | "Useful for finding link candidates that aren't yet wikilinked — the vault's organic graph is always denser than its explicit one. Combine with `propose-links` for a sweep, or use ad-hoc per-note." |
+| `get_context` | "The `similar` field surfaces notes that may warrant explicit links to the context note but don't yet — a common input to manual or automated link proposal." |
+| `get_backlinks` / `get_outlinks` | "Combine with `get_similar` to find connection gaps — notes that are semantically close to the target but not yet linked." |
+| `search` | One-sentence hint about split/merge: "Also useful for finding merge candidates when triaging a new capture — if a close match exists, prefer merging over creating a near-duplicate." |
+| `write` | One-sentence hint: "Supports split (write new notes from one source) and merge (extend an existing note with content from another) when combined with `delete`." |
+| `delete` | One-sentence hint: "Used after split or merge to remove the source note once its content has been relocated." |
+| `fetch` | One-sentence hint: "Primary path for URL-to-note capture flows: fetch, summarize via the LLM, and `write` as a new note." |
+
+**Rationale:** tool docstrings are the canonical source for MCP tool schemas shown to the model at runtime. A hint about composable patterns in the docstring increases the chance the model proposes the pattern proactively before the user asks.
+
+### Guide cross-references
+
+- `docs/guides/zettelkasten.md`:
+  - New subsection in "Using the Zettelkasten prompt" area documenting the connector `+` menu affordance (#386 content, reusable paragraph).
+  - New tip on split/merge (#387 content), parallel to the one in the PARA guide.
+  - New "See also: ambient patterns" bullet in Next Steps, pointing at `docs/prompts.md#ambient-patterns-without-prompts`.
+- `docs/guides/para.md`:
+  - "See also: ambient patterns" bullet added to Tips or Next Steps.
+  - Existing split/merge coverage stays as-is.
+- `docs/guides/claude-desktop.md`, `docs/guides/obsidian-everywhere.md`, `docs/guides/mcp-apps.md`:
+  - Each gets the connector `+` menu paragraph (#386 content) in the relevant "how to invoke prompts/tools" area.
+
+### Navigation
+
+The `propose-links` prompt is indexed by `docs/prompts.md`. No `mkdocs.yml` nav change needed — `prompts.md` already appears under MCP Interface.
+
+## Testing Strategy
+
+Content-only change plus one new prompt file. Testing:
+
+1. **Unit tests** — `tests/test_prompts.py` currently tests that each builtin prompt registers and renders. Add `propose-links` to the test list.
+2. **Prompt YAML validation** — `static/prompts/propose-links.md` must parse; existing test covers this pattern.
+3. **Docstring rendering** — `uv run mkdocs build --strict` must pass; `tools/index.md` is auto-generated via mkdocstrings and will pick up the docstring edits.
+4. **Manual walkthroughs** — against a small seed vault:
+   - `propose-links()` with default scope (recent), with `scope='1-Projects'`, with `scope='all'`.
+   - Verify the batch preview, verify confirmation gate, verify skipped-edits reporting.
+   - Verify graceful fallback when embeddings are not configured.
+
+No additional integration tests required.
+
+## Risks / Tradeoffs
+
+- **Propose-links noise on dense vaults.** On a vault with lots of tangentially-related notes, the LLM-judgment pass may keep too many pairs. Mitigation: the user sees the full batch preview and can reject individually. Future mitigation: add a similarity-score threshold knob.
+- **`get_similar` required for best experience.** The prompt falls back to keyword search but performs notably worse without embeddings. Documentation should call this out in the prompt's `description` field and in `prompts.md`.
+- **Ambient-pattern examples may age.** The README's ambient examples reference flows that depend on client tools (`conversation_search`) and Claude.ai UI (`+` menu). If these change, the examples need updating. Mitigation: keep the examples concise; use footnotes for platform caveats.
+- **Tool docstring edits affect a file in `src/`.** This is the only server-code change in an otherwise docs-only PR. Keep the edits to one-sentence additions per tool to minimize review surface.
+
+## Future Work
+
+- **Similarity threshold knob** on `propose-links` (minimum cosine; skip anything below).
+- **Periodic mode** — schedule `propose-links` via a cron/systemd timer, notify when new links are suggested.
+- **Split / merge prompts** if the `para-triage` codification proves valuable enough to standalone-ize.
+- **URL-capture prompt** if the ambient flow proves too verbose to re-type across sessions (reverse of this spec's decision).
+
+## Acceptance Criteria
+
+- `src/markdown_vault_mcp/static/prompts/propose-links.md` exists, passes YAML frontmatter parse, matches the frontmatter/body structure in this spec.
+- `_server_prompts.py` includes `propose-links` in the builtin prompt list; unit test confirms registration.
+- `README.md` has a new "What you can do with it" section (~25 lines) with the five ambient-pattern examples.
+- `docs/index.md` has a shorter mirror with 2-3 examples.
+- `docs/prompts.md` has an entry for `propose-links`, an "Ambient patterns without prompts" section, and a "How to invoke" section covering the connector `+` menu affordance.
+- Tool docstrings for `get_similar`, `get_context`, `get_backlinks`, `get_outlinks`, `search`, `write`, `delete`, `fetch` updated per the table in §Documentation Structure.
+- `docs/guides/zettelkasten.md` has the connector `+` menu paragraph, a split/merge tip, and a Next Steps cross-link to the ambient-patterns section.
+- `docs/guides/para.md` has a cross-link to the ambient-patterns section.
+- `docs/guides/claude-desktop.md`, `docs/guides/obsidian-everywhere.md`, `docs/guides/mcp-apps.md` each have the connector `+` menu paragraph.
+- `uv run mkdocs build --strict` passes with no new warnings.
+- `uv run pytest -x -q` passes.
+- Issues #386 and #387 closed by this PR.

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -329,7 +329,14 @@ def register_prompts(
     # a body that uses $var / ${var} (string.Template) substitution.
     # ``create_from_template`` has path-traversal safety logic and stays inline.
 
-    for md_name in ["summarize", "research", "discuss", "related", "compare"]:
+    for md_name in [
+        "summarize",
+        "research",
+        "discuss",
+        "related",
+        "compare",
+        "propose-links",
+    ]:
         if md_name in user_prompt_defs:
             continue
         defn = _load_builtin_prompt(md_name)

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -125,6 +125,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - search_type (str): "keyword" or "semantic".
             - frontmatter (dict): Parsed YAML frontmatter of the document.
 
+        Also useful for finding merge candidates during triage — if a
+        close match exists for a new capture, prefer merging over
+        creating a near-duplicate.
+
         Raises:
             ValueError: If mode is "semantic" or "hybrid" and no embedding
                 provider is configured.
@@ -397,6 +401,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - fragment (str | None): Heading anchor (e.g. "#section"), or null.
             - raw_target (str): Literal link target as written in the source.
 
+        Combine with ``get_similar`` to find connection gaps — notes that are
+        semantically close to the target but not yet linked.
+
         Raises:
             ValueError: If no document exists at the given path.
         """
@@ -437,6 +444,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - fragment (str | None): Heading anchor (e.g. "#section"), or null.
             - raw_target (str): Literal link target as written in the source.
             - exists (bool): True if the target document is indexed.
+
+        Combine with ``get_similar`` to find connection gaps — notes the
+        source is semantically close to but hasn't linked yet.
 
         Raises:
             ValueError: If no document exists at the given path.
@@ -524,6 +534,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - score (float): Cosine similarity, 0.0-1.0; higher = more similar.
             - search_type (str): Always "semantic".
             - frontmatter (dict): Parsed YAML frontmatter.
+
+        Useful for finding link candidates that aren't yet wikilinked — the
+        vault's organic graph is almost always denser than its explicit one.
+        See the ``propose-links`` prompt for a full vault-wide sweep.
 
         Raises:
             ValueError: If no document exists at the given path.
@@ -643,6 +657,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
               folder (up to 20). Plain strings, not dicts.
             - tags (dict[str, list[str]]): Indexed frontmatter field →
               distinct values for this note.
+
+        The ``similar`` field in the response surfaces notes that may warrant
+        explicit links to the context note but don't yet — a common input to
+        manual or automated link proposal.
 
         Raises:
             ValueError: If no document exists at the given path.
@@ -1012,6 +1030,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             Dict with path (str) and created (bool — true if new file,
             false if overwrite).
 
+        Supports split (write several new notes from one source) and merge
+        (extend an existing note with content from another) when composed with
+        ``read`` and ``delete``.
+
         Raises:
             ValueError: If content_base64 is missing/invalid for
                 attachments, or the content exceeds the size limit.
@@ -1154,6 +1176,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Returns:
             Dict with path (str) of the deleted file.
 
+        Typically called after a split or merge to remove the source note once
+        its content has been relocated.
+
         Raises:
             DocumentNotFoundError: If no file exists at the given path.
             McpError: If if_match is provided and the file has been modified
@@ -1276,6 +1301,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - created (bool): true if new file, false if overwrite
             - content_length (int): bytes downloaded
             - content_type (str or null): Content-Type from the response
+
+        Primary building block for URL-to-note capture flows: call ``fetch`` to
+        retrieve the source, summarize via the LLM, and ``write`` the result
+        as a new note.
 
         Raises:
             ValueError: If the URL scheme is not http/https, the download

--- a/src/markdown_vault_mcp/static/prompts/propose-links.md
+++ b/src/markdown_vault_mcp/static/prompts/propose-links.md
@@ -18,7 +18,7 @@ You are proposing meaningful new links between notes in a markdown vault. Focus 
 
 Interpret `$scope`:
 
-- Empty or `'recent'`: call `list_documents()`, then filter client-side for notes where `modified_at > <now - 30 * 86400>` (i.e., modified within the last 30 days). If the current Unix timestamp is not available, ask the user for today's date.
+- Empty or `'recent'`: call `get_recent(limit=100)` — it returns the 100 most-recently-modified notes pre-sorted by `modified_at`. Then filter client-side to keep only notes where `modified_at > <now - 30 * 86400>` (within the last 30 days). If the current Unix timestamp is not available, ask the user for today's date. Using `get_recent` here is strictly better than `list_documents()`: it bounds the payload and pre-sorts by recency in one tool call.
 - `'all'`: call `list_documents()` unfiltered.
 - Otherwise treat as a folder path. Strip any trailing `/` and call `list_documents(folder='<scope>')`.
 
@@ -33,7 +33,7 @@ For each note in scope:
 
 ## Step 3: Filter out already-linked pairs
 
-For each scanned note, call `get_outlinks(path=<note>)` once. For each candidate pair (A, B), drop the candidate if A already links to B — compare the candidate path against each outlink's `raw_target` (also consider the wikilink form, e.g., `[[B-title]]` without the `.md` extension).
+For each scanned note, call `get_outlinks(path=<note>)` once. For each candidate pair (A, B), drop the candidate if A already links to B — compare the candidate path `B` against each outlink's `target_path` (the resolved vault-relative path of the link target, which is what you want for equality checks). `raw_target` is the literal link text as written (and may be a wikilink without `.md`) — only fall back to comparing against `raw_target` when `target_path` is empty (e.g., the link hasn't been resolved).
 
 ## Step 4: Apply LLM judgment
 

--- a/src/markdown_vault_mcp/static/prompts/propose-links.md
+++ b/src/markdown_vault_mcp/static/prompts/propose-links.md
@@ -1,0 +1,89 @@
+---
+description: Propose meaningful new links between semantically-close notes that aren't already connected.
+arguments:
+  - name: scope
+    description: "Candidate set. Accepts a folder path (e.g. '1-Projects'), the literal 'recent' (default; notes modified in the last 30 days), or the literal 'all'. No trailing slashes on folder paths."
+    required: false
+  - name: per_note_limit
+    description: "Max candidates per note to evaluate (default 5)."
+    required: false
+tags:
+  - write
+icons: write
+---
+
+You are proposing meaningful new links between notes in a markdown vault. Focus on connections that a reader would genuinely benefit from, not notes that merely share vocabulary.
+
+## Step 1: Resolve scope
+
+Interpret `$scope`:
+
+- Empty or `'recent'`: call `list_documents()`, then filter client-side for notes where `modified_at > <now - 30 * 86400>` (i.e., modified within the last 30 days). If the current Unix timestamp is not available, ask the user for today's date.
+- `'all'`: call `list_documents()` unfiltered.
+- Otherwise treat as a folder path. Strip any trailing `/` and call `list_documents(folder='<scope>')`.
+
+If the resolved set contains more than 100 notes, pause and ask the user whether to proceed or narrow the scope. Above 100 notes, the subsequent steps become slow and noisy.
+
+## Step 2: Gather candidates per note
+
+For each note in scope:
+
+1. Call `get_similar(path=<note path>, limit=$per_note_limit)` (default limit: 5).
+2. If `get_similar` returns an empty list (no embeddings configured), fall back to `search(query=<note title>, mode='keyword', limit=$per_note_limit)` and drop the note itself from the result.
+
+## Step 3: Filter out already-linked pairs
+
+For each scanned note, call `get_outlinks(path=<note>)` once. For each candidate pair (A, B), drop the candidate if A already links to B — compare the candidate path against each outlink's `raw_target` (also consider the wikilink form, e.g., `[[B-title]]` without the `.md` extension).
+
+## Step 4: Apply LLM judgment
+
+For each surviving candidate pair, `read(path=<B>)` and inspect B's title, first section heading, and opening paragraph. Keep only pairs where the content justifies an explicit link — the reader of A would benefit from knowing about B in context, not merely because the two share words.
+
+## Step 5: Pick direction and placement
+
+For each kept pair:
+
+- **Direction:** one-way `A → B` as a wikilink from A. `get_backlinks` recovers the reverse; explicit bidirectional wikilinks are redundant. Pick A as the note where the link reads most naturally: atomic → hub, specific → general, newer → older.
+- **Placement:** pick per note shape, using judgment:
+  - Short atomic note → new `## Related` section (create if missing).
+  - Prose note → inline citation in a relevant paragraph.
+  - MOC / hub note → append under an existing thematic bullet list.
+  - Reference note → `## See Also` or footnote-style link.
+
+Do not prescribe a fixed placement. The shape of the host note dictates where the link belongs.
+
+## Step 6: Batch preview
+
+Render a preview of every proposed edit, numbered. Example:
+
+```
+1. 1-Projects/migrate-postgres.md — inline citation after line 23: mention [[postgres-16-json-path]]
+2. 3-Resources/distributed-consensus.md — new `## Related` section with [[raft-paper-notes]] and [[paxos-made-simple]]
+3. 2-Areas/team-hiring.md — append to existing `## Related` list: [[interview-rubric]]
+```
+
+Ask the user: "Apply all N? Apply specific ones? Skip all?"
+
+## Step 7: Execute on confirmation
+
+For each approved edit:
+
+- Prefer `edit(path=<A>, old_text=<current>, new_text=<current with link added>)` for small in-place insertions (inline citations, bullet-list appends).
+- Use `write(path=<A>, content=<full body>, frontmatter=<current frontmatter>)` when the change restructures the note (new `## Related` section at the end of a long note, or any change easier to express as a full-body rewrite). Always `read` the current state first to preserve unmodified content.
+- If a write fails (for example, `ConcurrentModificationError`), skip that edit, record the reason, and continue with the rest.
+
+## Step 8: Summary
+
+Report the counts:
+
+- Links added
+- Notes updated
+- Pairs skipped (and the reason for each: already linked, rejected by LLM judgment, write conflict)
+
+## Constraints
+
+- Never write without explicit user confirmation. The batch preview in Step 6 is the only gating point; per-edit confirmation is available on request.
+- Never propose self-links.
+- Do not propose MOC-to-MOC links by default. Mention them in the preview as observations but do not include them as edits unless the user explicitly asks.
+- Budget guard: if the scope resolves to more than 100 notes, stop and ask before proceeding.
+- Graceful degradation: if neither `get_similar` nor `search` produces candidates for a note, skip it silently. Do not warn per-note.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -469,4 +469,21 @@ class TestProposeLinks:
         # Both arguments are optional (scope, per_note_limit).
         arg_names = {arg.name for arg in (propose_links.arguments or [])}
         assert arg_names == {"scope", "per_note_limit"}
-        assert all(arg.required is False for arg in (propose_links.arguments or []))
+        assert all(not arg.required for arg in (propose_links.arguments or []))
+
+    @pytest.mark.usefixtures("_clear_vars")
+    async def test_propose_links_substitutes_arguments(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Invoking propose-links substitutes $scope and $per_note_limit into the body."""
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+        server = create_server()
+        async with Client(server) as client:
+            result = await client.get_prompt(
+                "propose-links", {"scope": "1-Projects", "per_note_limit": "7"}
+            )
+        text = result.messages[0].content.text
+        assert "1-Projects" in text
+        assert "7" in text
+        assert "$scope" not in text
+        assert "$per_note_limit" not in text

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -443,3 +443,30 @@ class TestNoPromptsFolder:
         assert "summarize" in names
         assert "related" in names
         assert "compare" in names
+        # Write-tagged builtins (research, discuss, propose-links) should be hidden.
+        assert "research" not in names
+        assert "discuss" not in names
+        assert "propose-links" not in names
+
+
+class TestProposeLinks:
+    """The propose-links builtin prompt is registered with the expected shape."""
+
+    @pytest.mark.usefixtures("_clear_vars")
+    async def test_propose_links_registered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # propose-links is tagged "write"; must enable write mode to see it.
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+        server = create_server()
+        async with Client(server) as client:
+            prompts = await client.list_prompts()
+        propose_links = next(p for p in prompts if p.name == "propose-links")
+        assert (
+            propose_links.description is not None
+            and "link" in propose_links.description.lower()
+        )
+        # Both arguments are optional (scope, per_note_limit).
+        arg_names = {arg.name for arg in (propose_links.arguments or [])}
+        assert arg_names == {"scope", "per_note_limit"}
+        assert all(arg.required is False for arg in (propose_links.arguments or []))


### PR DESCRIPTION
## Summary

Adds one new builtin MCP prompt (`propose-links`) and refreshes top-level documentation to surface ambient LLM workflows as first-class examples. Closes #386 and #387 as part of the agnostic docs work.

## What changed

- **New builtin prompt `propose-links`.** Vault-wide sweep that uses `get_similar` (with `search` fallback), filters already-linked pairs via `get_outlinks`, applies LLM judgment over candidates, and proposes a batch of directional wikilink edits with placement picked per note shape. Body lives at `src/markdown_vault_mcp/static/prompts/propose-links.md`; registered alongside `summarize`/`research`/`discuss`/`related`/`compare` in `_server_prompts.py`.
- **Tool docstring hints** on 8 tools (`search`, `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, `write`, `delete`, `fetch`). One-sentence composable-pattern hints so the model proposes split/merge, URL capture, and link-discovery flows proactively.
- **README + `docs/index.md` teaser sections** showcasing five ambient-flow examples (URL capture, research-into-interlinked-notes, conversation distillation, find missing links, split/merge).
- **`docs/prompts.md` overhaul:** new `propose-links` entry, new "Ambient patterns without prompts" section documenting composable flows, new "How to invoke prompts" section covering the Claude.ai `+` menu, Claude Code `/` menu, and plain conversation.
- **Zettelkasten guide**: connector `+` menu paragraph, new split/merge tip, ambient-patterns cross-link in Next Steps.
- **PARA guide**: ambient-patterns cross-link in Next Steps.
- **Claude Desktop / Obsidian Everywhere / MCP Apps guides**: connector `+` menu paragraph each.

## Design decision: prompts only when they add value

Three criteria for codifying a flow as an MCP prompt: one-click menu shortcut value, non-obvious structure, or platform-specific tool dance. `propose-links` passes (non-obvious sweep the LLM won't run proactively). Summarize-URL, research-into-interlinked-notes, and ad-hoc split/merge fail — they work from prose alone. Those three are documented as ambient patterns in `docs/prompts.md`, not codified as prompts. Full rationale in [`docs/superpowers/specs/2026-04-19-llm-native-flows-design.md`](docs/superpowers/specs/2026-04-19-llm-native-flows-design.md).

## Test plan

- [x] `uv run pytest -x -q` — 1396 tests pass (+1 for propose-links registration)
- [x] `uv run pre-commit run --all-files` — all hooks clean
- [x] `uv run mkdocs build --strict` — no new warnings; only pre-existing INFO notices
- [x] End-to-end smoke test: server registers `propose-links`, prompt body renders (~4k chars) when invoked with `scope='Notes'` on a seed vault

## Closes

Closes #386
Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)