### PR TITLE
ci: publish docs only on release, not on every push to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -35,13 +37,13 @@ jobs:
         run: uv run mkdocs build --strict
 
       - name: Upload artifact
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'release'
         uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
   deploy:
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'release'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

The documentation workflow currently redeploys the MkDocs site on every merge to main. That means WIP docs (new prompts, mid-flight guides, spec drafts) go live immediately, possibly ahead of the matching server release. This change gates the deploy step on GitHub Release events so published docs track released server versions.

## Change

- Added \`release: types: [published]\` to the workflow triggers.
- Changed the \`Upload artifact\` step and the \`deploy\` job's \`if:\` condition from \`github.ref == 'refs/heads/main'\` to \`github.event_name == 'release'\`.

Build (mkdocs --strict) still runs on every push and PR so doc regressions are caught at review time. Only the deploy portion gates on release.

## Trade-off

- **Good:** published docs match the released version; PR previews and push CI still validate docs.
- **Not addressed:** manual redeploy without a release. If needed, tag/publish a new release (the canonical action) or temporarily relax the condition. Could be revisited if an ops need arises.

## Test plan

- [ ] Merge. Confirm the docs workflow runs but only the build job completes (no deploy) on the merge commit.
- [ ] On next release, confirm deploy runs and GitHub Pages updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)