### PR TITLE
docs: add research workflows guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 With this server mounted in Claude, you can:
 
 - **Capture a URL as a note.** "Fetch <url>, summarize as a Resource note under `3-Resources/`, and link any existing notes on the topic." — Claude composes `fetch` + `search` + `write`.
-- **Research a topic into your vault.** "Research product security regulations, compare them, and create a set of interlinked notes — one per regulation, plus a map-of-content." — Claude composes web-search tools (client-side) + `write` with wikilinks.
+- **Research a topic into your vault.** "Research product security regulations, compare them, and create a set of interlinked notes — one per regulation, plus a map-of-content." — Claude composes web-search tools (client-side) + `write` with wikilinks. See the [Research workflows guide](https://pvliesdonk.github.io/markdown-vault-mcp/guides/research-workflows/) for the full loop.
 - **Distill today's thinking.** "Summarize today's conversations into Inbox notes." — Claude.ai only; uses `conversation_search` + `recent_chats` + `write`. The [`para-capture-chats`](examples/para/prompts/para-capture-chats.md) prompt is the one-click version.
 - **Find missing links.** Fire the [`propose-links`](https://pvliesdonk.github.io/markdown-vault-mcp/prompts/#propose-links) prompt from the `+` menu — it scans recently-modified notes, proposes meaningful connections, and writes them on confirmation.
 - **Split or merge captures.** "Split this Inbox note into two." / "Merge this into `<existing note>` instead of duplicating." — Claude composes `read` + `write` + `delete`.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -15,6 +15,7 @@ Step-by-step walkthroughs for common deployment scenarios. Each guide takes you 
 | Protect my server with a bearer token | [Authentication](authentication.md#bearer-token) |
 | Protect my server with OIDC authentication | [Authentication](authentication.md#oidc) |
 | Access my vault from desktop, mobile, AND Claude | [Obsidian Everywhere](obsidian-everywhere.md) |
+| Do research (literature grounding, interconnected notes, paper drafting) | [Research workflows](research-workflows.md) |
 | Use FastEmbed for local embeddings | [Embeddings](embeddings.md#fastembed) |
 | Use Ollama for embeddings (CPU-only) | [Embeddings](embeddings.md#ollama) |
 | Use OpenAI for embeddings | [Embeddings](embeddings.md#openai) |

--- a/docs/guides/para.md
+++ b/docs/guides/para.md
@@ -439,3 +439,4 @@ After a triage session produces 5-10 new projects, ask Claude to propose an `are
 - **Review the examples** for templates and prompts: [`examples/para/`](../../examples/para/)
 - **Prefer idea-centric knowledge management?** See the alternative workflow: [`docs/guides/zettelkasten.md`](zettelkasten.md)
 - **Ambient patterns**: [`docs/prompts.md`](../prompts.md#ambient-patterns-without-prompts) — flows the LLM handles from prose alone (URL capture, research, ad-hoc link proposal)
+- **Research workflows**: [research-workflows.md](research-workflows.md) — literature grounding, fact-checking, and writing papers from notes

--- a/docs/guides/research-workflows.md
+++ b/docs/guides/research-workflows.md
@@ -113,7 +113,7 @@ The `## Open claims` section at the bottom is the secondary tracker. Inline mark
 
 A final point on frontmatter: keep it minimal at the seeding stage. A seed doesn't need a `type` field, a `status` field, or a rigid tag taxonomy. It needs a title, a `draft` tag, and a `created` date. If your vault follows a scheme like [Zettelkasten](zettelkasten.md) or [PARA](para.md), the triage step — not the seed step — is where a note acquires its typed frontmatter.
 
-**Finding seeds later.** Seeds are easy to lose track of. A simple convention is to tag all seeds `draft` and periodically run `list_documents()`, then filter on `frontmatter.tags` containing `"draft"`, to see what's still unresolved. (The keyword-search path won't work for pure tag filtering — `search` requires a non-empty query string; `list_documents` returns the full tag-bearing metadata without one.) Anything that's been a draft for more than a month is either worth grounding or worth deleting; the middle path — a permanent pile of unresolved seeds — is where vault rot starts.
+**Finding seeds later.** Seeds are easy to lose track of. A simple convention is to tag all seeds `draft` and periodically run `list_documents()`, then filter on `frontmatter.tags` containing `"draft"`, to see what's still unresolved. (The keyword-search path won't work for pure tag filtering — `search` requires a non-empty query string; `list_documents` returns the full tag-bearing metadata without requiring a query.) Anything that's been a draft for more than a month is either worth grounding or worth deleting; the middle path — a permanent pile of unresolved seeds — is where vault rot starts.
 
 ## Phase 2: Literature grounding
 

--- a/docs/guides/research-workflows.md
+++ b/docs/guides/research-workflows.md
@@ -1,0 +1,395 @@
+# Research workflows with markdown-vault-mcp
+
+Research in a vault treats Claude as a persistent sparring partner. The vault is the durable workspace that outlives any single session — notes, links, literature, drafts — and Claude is the reasoning agent you rent by the conversation. Claude's memory doesn't persist; the vault's does. The workflow is to keep pushing what matters into notes, so the next session starts where the previous one stopped.
+
+This guide describes a five-phase research loop: **seed → ground → absorb → interconnect → produce**. It is a loop, not a pipeline — most sessions touch two or three phases and cycle. You seed a note, ground one of its claims against the literature, bounce back to interconnection when Claude notices a similar note you'd forgotten, and end up back in seeding because a new question fell out of what you read. The phases give you a shared vocabulary; they do not prescribe a fixed order.
+
+This guide's baseline works with just Claude, markdown-vault-mcp, and web search. [scholar-mcp](https://github.com/pvliesdonk/scholar-mcp) is a separate MCP server that adds rigour — citation graphs, BibTeX export, PDF-to-Markdown conversion — optional but recommended when you need real paper IDs and don't trust the model's memory for citations. Every phase below shows the baseline flow first; the scholar-mcp callouts describe the correctness gain, not a different workflow.
+
+!!! note
+    This guide is organising-scheme-agnostic. It works with [Zettelkasten](zettelkasten.md), [PARA](para.md), or no opinionated structure at all. The phase model in this guide composes the vault's generic search, linking, and write tools; it doesn't assume a particular folder layout.
+
+## Setup
+
+Install and configure markdown-vault-mcp per the [Claude Desktop guide](claude-desktop.md) or [Obsidian Everywhere](obsidian-everywhere.md) for the full multi-device setup. This guide assumes your vault is already connected to Claude and that you can invoke vault tools (`search`, `read`, `write`, `get_similar`, `get_context`) from a conversation.
+
+### Adding scholar-mcp (optional)
+
+Skip this section for the baseline. Every flow below works without scholar-mcp; you can add it later once you've decided the power-ups are worth the setup.
+
+**Claude.ai:** add scholar-mcp as a connector from the settings page. See the [scholar-mcp repository](https://github.com/pvliesdonk/scholar-mcp) for the connector URL and auth details.
+
+**Claude Desktop:** add a second entry to `mcpServers` in your config. The vault entry stays as it was; scholar-mcp lives alongside:
+
+```json
+{
+  "mcpServers": {
+    "vault": {
+      "command": "uvx",
+      "args": ["--from", "markdown-vault-mcp", "markdown-vault-mcp", "serve"]
+    },
+    "scholar": {
+      "command": "uvx",
+      "args": ["--from", "pvliesdonk-scholar-mcp", "scholar-mcp", "serve"],
+      "env": {
+        "SCHOLAR_MCP_S2_API_KEY": "your-key-optional"
+      }
+    }
+  }
+}
+```
+
+**Claude Code:** add scholar-mcp via `claude mcp add` or in the MCP settings UI, following the same pattern — a second server entry alongside the vault.
+
+scholar-mcp's own documentation covers API keys, OIDC auth, transport options, and tool details. This guide only references the tools by name. See <https://pvliesdonk.github.io/scholar-mcp/> for setup specifics.
+
+**Web-search caveat.** The baseline flows assume Claude has web-search tools available. Claude.ai and Claude Desktop do by default; other clients vary. Without web search, fall back to scholar-mcp for the grounding phase or skip straight to manual source collection — paste a URL into the conversation and let Claude extract from there.
+
+## How the phases compose
+
+The five phases are not a linear pipeline. A typical session starts in one phase, spends most of its time in another, and ends in a third. Some common session shapes:
+
+- **Seed + ground.** You have a new idea. You write the seed, mark the load-bearing claims, and start grounding one or two of them. The session ends with the seed half-grounded; remaining markers wait for next time.
+- **Absorb + interconnect.** You read a paper and want to capture it. You write the literature note, then immediately run `get_similar` against it to see which existing research notes it connects to. You add links in both directions before closing the session.
+- **Produce + all four predecessors.** You're writing a draft. Every paragraph touches an earlier phase — you reseed when a new question appears, ground when a claim gets challenged, absorb when you realise a source is underdeveloped, interconnect when Claude surfaces a forgotten note.
+
+The phases are vocabulary for the shape of what you're doing in the moment. When stuck, ask: which phase am I in, and which phase should I be in? The answer usually shifts the next ten minutes of work productively.
+
+## Phase 1: Seeding notes
+
+**Intent.** Get a new note into the vault quickly without worrying about its final shape.
+
+### Baseline flow
+
+Seeding covers three common entry points, each corresponding to a different origin story for a research idea:
+
+- **From a conversation.** If your client exposes chat history (Claude.ai has `conversation_search` and `recent_chats`), the [`para-capture-chats`](para.md#para-capture-chats) prompt distils recent chats into Inbox-shaped notes ready for later triage. The vault doesn't need to be a PARA vault — the prompt produces plain notes with titles and bodies; you choose where they land.
+- **From a research question.** The [`research`](../prompts.md#research) builtin prompt takes a topic and produces a single synthesis note with a topic slug. Good for "I want to know what's out there on X" before you have a thesis.
+- **From a raw thesis.** Just write it. Prose to Claude: "Create a note at `research/consent-dynamics.md` with this thesis: *Informed consent in platform terms of service is structurally impossible because…* Tag it `draft`."
+
+All three paths end at the same place: a new note in the vault with a title, a rough body, and at least one `[citation needed]` or `[verify]` marker on anything that isn't yet grounded. You are not trying to produce polished prose. You are trying to produce something you can come back to.
+
+Claude composes `write(path="research/consent-dynamics.md", content=..., frontmatter={"tags": ["draft"], "created": "2026-04-19"})` and you have a seed. A reasonable seed looks like this:
+
+```markdown
+---
+title: "Consent dynamics in platform terms of service"
+tags: [draft]
+created: 2026-04-19
+---
+
+# Consent dynamics in platform terms of service
+
+Informed consent in platform terms of service is structurally impossible:
+users face a take-it-or-leave-it offer, the text is unreadable at scale,
+and the cost of reading is asymmetric with the benefit. [citation needed]
+
+## Open claims
+
+- Cost asymmetry claim above
+- Are there empirical studies on the "unreadable at scale" assertion?
+```
+
+### With scholar-mcp
+
+Not meaningfully different. scholar-mcp doesn't participate in capture — it enters the picture during grounding, when you need to verify what's true, not when you need to get a thought into the vault. The seeding phase is the same with or without it.
+
+### Common failure
+
+Waiting to polish before committing a note. The seed should land rough and be revised across multiple sessions. If you find yourself editing the seed for twenty minutes before saving, you've skipped phase 1 and jumped to phase 5 without the evidence.
+
+The reverse failure mode is also common: committing too many seeds and never returning to any of them. If your `research/` folder is accumulating seeds faster than you're grounding them, that's a signal to stop seeding and start phase 2 on what you already have. Seeding is cheap; that's its strength and its trap.
+
+Write the shape; leave the `[citation needed]` markers. Come back.
+
+!!! tip "Signals you're in phase 1"
+    - You're writing prose you don't fully believe yet.
+    - Claude is proposing structure; you're pushing back on detail.
+    - The only verifiable thing in the note is the frontmatter.
+
+    All three are fine. None are signals to polish.
+
+The `## Open claims` section at the bottom is the secondary tracker. Inline markers flag a specific sentence; the bottom list captures claims too big to fit in a sentence — methodological questions, unresolved scope, "I need to decide whether this is about platforms-as-a-category or just the large ones." Both forms compose; neither is mandatory. Pick what you'll revisit.
+
+A final point on frontmatter: keep it minimal at the seeding stage. A seed doesn't need a `type` field, a `status` field, or a rigid tag taxonomy. It needs a title, a `draft` tag, and a `created` date. If your vault follows a scheme like [Zettelkasten](zettelkasten.md) or [PARA](para.md), the triage step — not the seed step — is where a note acquires its typed frontmatter.
+
+**Finding seeds later.** Seeds are easy to lose track of. A simple convention is to tag all seeds `draft` and periodically run `list_documents()`, then filter on `frontmatter.tags` containing `"draft"`, to see what's still unresolved. (The keyword-search path won't work for pure tag filtering — `search` requires a non-empty query string; `list_documents` returns the full tag-bearing metadata without one.) Anything that's been a draft for more than a month is either worth grounding or worth deleting; the middle path — a permanent pile of unresolved seeds — is where vault rot starts.
+
+## Phase 2: Literature grounding
+
+**Intent.** Back a claim in a note with real sources; prevent fabricated citations.
+
+### Baseline flow
+
+Grounding converts a seed's confident-but-unsourced claims into claims with sources attached — or flags them clearly as unresolved. Claude + web search does most of the work when web search is available.
+
+Ask template:
+
+> For each claim in `research/consent-dynamics.md` marked `[citation needed]`, search the web for supporting or refuting literature. Update the marker with a linked source and a one-line summary of what the source says. If you can't find anything solid, leave the marker in place and add a line explaining what you looked for.
+
+Claude reads the note, runs web searches, and updates the body via `edit(path=..., old_text="...", new_text="...")`. You review the diff — don't skip this; see [Pitfalls](#pitfalls) — and keep or reject each update. Rejecting is just as valuable as accepting: a claim that web search couldn't ground should stay marked, not be quietly deleted.
+
+The claim-tracking convention. Both forms are recommendations, not requirements:
+
+- **Inline markers** — `[citation needed]` in prose, searchable by grep and familiar from other research contexts. Variants like `[verify]`, `[my guess]`, or `[check]` are fine; pick what you'll actually use.
+- **Note-level aggregation** — a `## Open claims` or `## Evidence gaps` section where outstanding items accumulate. As literature fills in, you move items out of this section and into the body as sourced prose.
+
+You can combine them — inline markers for claims that live inside paragraphs, a bottom section for claims that are too big for a single sentence. The section becomes a checklist the next session can pick up without re-reading the whole note.
+
+The discipline is what matters, not the syntax. Name every unverified claim so you can come back to it. A note without markers is either fully sourced (rare early on) or hiding fabrication (common). Pick a convention you'll remember and stick to it; switching midway through a project fragments the vault's grep-ability.
+
+### With scholar-mcp
+
+`search_papers` returns real paper IDs and metadata — no hallucinated DOIs, no confidently wrong authors. You ask Claude to search for literature on a topic; scholar-mcp returns titles, authors, years, and stable identifiers you can cite. `get_references` walks what a seminal paper cites (backward through the literature graph); `get_citations` finds who cites a paper (forward through the graph). Together they let you traverse the argument a field has had with itself rather than guess at it.
+
+`get_paper(doi=...)` returns structured metadata including BibTeX, so the literature notes you produce in the next phase start with a frontmatter source that resolves. When citation rigour matters — a paper, a grant proposal, a blog post that people will check — scholar-mcp is where it earns its keep.
+
+A typical scholar-mcp grounding flow: Claude runs `search_papers(query="adhesion contracts platform terms of service", limit=10)` for each marked claim, filters to the most relevant results based on titles and venues, calls `get_paper(doi=...)` on the shortlist to get structured metadata, and updates the note with links to the real DOIs. You still review — fabrication risk is lower but not zero when the model is summarising what a paper says — but the identifiers are now anchored to real objects.
+
+### Common failure
+
+Trusting the first plausible-sounding paper without verifying. Always verify the DOI resolves, the authors exist, and the title matches what Claude reports. Claude sometimes writes a confident paragraph citing a paper that does not exist; see the [Pitfalls](#pitfalls) section. Web search reduces this but does not eliminate it — Claude can still summarise a search result incorrectly or mis-attribute a claim to the wrong paper from the same page of results.
+
+A secondary failure: grounding stops at the first source that supports the claim. One paper is a lead, not evidence. Push for at least one corroborating source and at least a quick check for dissent. Claude will happily fetch a second paper if you ask; it rarely volunteers one.
+
+!!! tip "Grounding checklist"
+    Before you remove a `[citation needed]` marker:
+
+    - The source exists (DOI resolves, paper is findable).
+    - The source actually supports the claim, not a tangentially related claim.
+    - You have at least one corroborating source or have actively looked for dissent.
+    - The source is linked from the note (URL or DOI in frontmatter or body).
+
+## Phase 3: Absorbing sources
+
+**Intent.** Turn a retrieved source into a durable literature note; decide when a summary suffices versus full text.
+
+### Baseline flow
+
+Once a source is identified, you write a literature note against it. The shape follows the existing Zettelkasten [`literature.md` template](../../examples/zettelkasten/), adapted to the research-specific concerns of relevance and open questions:
+
+```markdown
+---
+title: "Platform terms of service as adhesion contracts"
+type: literature
+tags: [literature]
+source: "https://doi.org/10.XXXX/example"
+created: 2026-04-19
+---
+
+# Platform terms of service as adhesion contracts
+
+**Authors:** Smith, Jones · 2023
+**Source:** https://doi.org/10.XXXX/example
+
+## Key Ideas
+
+- Terms of service operate as contracts of adhesion: one party drafts, the
+  other accepts without negotiation.
+- Empirically, over 90% of users accept ToS without reading any portion.
+- The authors argue adhesion-contract doctrine has evolved to tolerate
+  asymmetric drafting as long as the terms are not "unconscionable."
+
+## Relevance
+
+Supports the "structural impossibility" framing in
+[[consent-dynamics]]. The 90% statistic is the number I was after.
+
+## Open Questions
+
+- Is the 90% figure replicated in subsequent studies?
+- Does the adhesion-contract framing predate the platform era, or was it
+  reshaped by it?
+```
+
+Claude composes this from the abstract, web snippets, and whatever you've told it about the paper. The output is a vault note linked from the originating research note via `[[wikilink]]`.
+
+The "Relevance" section is the part you cannot skip. A literature note without a relevance paragraph is a bookmark, not a note — it captures what the paper says but not why you care. Six months later, when `get_similar` surfaces the note against a new research question, the relevance paragraph is what tells future-you whether to open it.
+
+### With scholar-mcp
+
+For open-access papers, `convert_pdf_to_markdown` returns the full paper as Markdown text; Claude then `write`s it into the vault at a path like `research/lit/full/smith-2023.md`, creating a Markdown companion to the literature note you're composing. You then write the literature note against the full text rather than just the abstract — the "Key Ideas" section gets the actual argument, not a press-release summary. `get_paper(doi=...)` returns structured metadata (authors, venue, year, BibTeX) for the frontmatter, so you don't guess at how a name is spelled or what year the paper came out.
+
+When the paper is central to your research and you're going to cite it multiple times, converting the full text pays for itself — the vault becomes searchable against the paper's actual claims, and `get_similar` can surface it against future notes. For tangential papers, skip the conversion.
+
+A middle path: convert the PDF to markdown but keep it outside the main note tree, linked from the literature note. The literature note stays short (summary + relevance + open questions); the full text lives as a companion under `research/lit/full/` and is there when you need to verify a direct quote or check a footnote. `read(path="research/lit/full/smith-2023.md")` pulls the full text when you need it; otherwise the lighter literature note is what surfaces in search results.
+
+### Common failure
+
+Reflexively fetching the full PDF. Most of the time the abstract plus the argument you're trying to support is enough, and the literature note stays short. Saving PDF conversion for when you need to dive deep keeps the vault from drowning in attachments and keeps your own reading time honest. Rule of thumb: convert the full text when the paper is the spine of an argument; summarise from the abstract when it's a supporting reference.
+
+A related failure is producing a literature note that is a disguised abstract — same content, same voice, no synthesis. If the note could be generated by the abstract alone, it doesn't belong in the vault; bookmark the paper and move on. The literature notes worth keeping have at least one sentence that the abstract doesn't: a connection to your own thinking, a methodological caveat, a question the paper raises. That sentence is the reason the note exists.
+
+!!! tip "When to convert full text"
+    | Signal | Convert? |
+    |--------|----------|
+    | Paper is the central source for an argument | Yes |
+    | You've quoted from it twice | Yes |
+    | You need to verify a specific claim's context | Yes |
+    | Paper is a supporting reference only | No (abstract suffices) |
+    | You already have 3+ notes about the paper | Yes (it's spine, not support) |
+    | The abstract answers the question you had | No |
+
+## Phase 4: Interconnection
+
+**Intent.** Surface existing vault notes semantically close to the one you're working on; find forgotten work.
+
+### Baseline flow
+
+Your vault has notes you've forgotten you wrote. The tangent you chased six months ago is probably already a note — named something you'd never think to search for. `get_similar` catches these.
+
+Ask template:
+
+> I'm working on `research/incentive-misalignment.md`. Run `get_similar(path="research/incentive-misalignment.md")` and tell me which of the top 5 candidates should be linked. For each one you think is a link, read it briefly and explain why it connects.
+
+Claude runs the tool, reads the candidates, and proposes links with one-line rationales. You confirm; Claude adds wikilinks via `edit`. The rationale is the important part — a raw `get_similar` score tells you two notes share vocabulary, not that linking them serves the reader. Ask Claude to name the connection in a sentence; reject candidates where the best available rationale is "both notes talk about X."
+
+For a vault-wide sweep — "find every note that should probably be linked but isn't" — invoke [`propose-links`](../prompts.md#propose-links) from Claude.ai's `+` menu (or as a prompt in any MCP client). It walks recent notes, runs `get_similar` per note, filters out pairs that are already linked via `get_outlinks`, applies LLM judgment on the remainder, and produces a batch preview. You approve in bulk; Claude applies the edits.
+
+For examining a specific note's neighborhood without committing to edits, ask Claude to run `get_context(path="research/incentive-misalignment.md")`. It returns backlinks, outlinks, similar notes, folder peers, and tags in one call — the full dossier for deciding what to link and what to write next. Use it before starting a writing session on an existing note: it is cheap, it is comprehensive, and it often surfaces a link you were about to miss.
+
+A useful ancillary is `get_backlinks(path=<note>)` on its own when you specifically want to know "who cites this?" without the rest of `get_context`'s payload. Backlinks are the measure of how load-bearing a note is in the rest of the vault; a literature note with many backlinks is spine for multiple arguments and deserves care. `get_most_linked` surfaces these globally if you want to find the vault's hubs.
+
+### With scholar-mcp
+
+Cross-referencing papers. Your literature notes have DOIs. `get_paper(doi=...)` followed by `get_references` or `get_citations` sometimes reveals that two strands you've been researching separately share a seminal paper — one literature note cites it directly, another cites a paper that cites it. Your literature graph is richer than your note graph; scholar-mcp exposes it.
+
+This is how you notice that a 2018 paper on platform governance and a 2022 paper on AI alignment both build on the same 1997 essay. The vault wouldn't have surfaced this — you hadn't written a note on the 1997 essay. scholar-mcp walked the citation graph and found the common ancestor.
+
+The workflow: for each literature note's DOI, ask Claude to pull `get_references(doi=...)` and compare against the DOIs in other literature notes. Overlap above a threshold is a signal that the notes are closer than their vault topology suggests. You then decide whether to write a note on the shared ancestor, link the two notes directly, or both.
+
+`get_citations` (forward direction) is the complementary tool. When a paper in your vault has been cited a lot since you wrote the literature note, some of those citations may have replied to the original argument. Running `get_citations(doi=<paper>)` a few months after absorbing a paper sometimes surfaces a newer paper that moved the argument forward — grounds for an updated literature note or a new one.
+
+### Common failure
+
+Missing an existing note because you'd forgotten what you called it. Memory alone fails: you remember you had a thought about consent and autonomy, but you titled the note "user-agency-and-dark-patterns" and haven't looked at it since. `get_similar` catches these; `propose-links` catches them at scale. The failure mode isn't "I don't have the note" — it's "I have the note and can't recall the search term that would surface it."
+
+A second failure: the opposite — over-linking noise. `get_similar` will return five candidates every time, and at least one is usually a stretch. Keep the rationale bar high. A link that exists only because both notes mention "platforms" dilutes the link graph; three weeks later when you're running `get_context` to orient yourself, that spurious link is a false signal you have to read past. Link when the connection is specific; reject when the connection is vocabulary.
+
+!!! tip "Link rationale heuristics"
+    Accept a proposed link when at least one of these holds:
+
+    - The linked note would change what you write in the current note.
+    - The current note answers a question the linked note raises.
+    - The two notes share a source, mechanism, or methodological concern.
+
+    Reject when:
+
+    - The rationale is "both discuss X" with no further specificity.
+    - The linked note is a hub note you'd link to by default anyway.
+    - The connection is a category label, not a substantive claim.
+
+## Phase 5: Writing a paper from notes
+
+**Intent.** Draft a paper from the vault, fact-check as you go, and let the paper and source notes co-evolve.
+
+### Baseline flow
+
+Start a `Draft/consent-essay.md` note. Ask Claude to pull paragraphs from the research notes you've built up — "Draft section 2 by composing from `[[consent-dynamics]]`, `[[platform-adhesion-contracts]]`, and `[[unreadable-at-scale]]`." Claude reads each note, composes prose, and writes the draft.
+
+This is also a good moment to run `get_outlinks(path="Draft/consent-essay.md")` after the first compose, to see which source notes the draft depends on. Any source note that appears here without a prior link *from* the draft's earlier sections is a potential gap — either the new section needs to be linked from the intro, or the source note needs to be foregrounded earlier.
+
+The `list_documents(folder="research/lit")` call also helps at this stage: it enumerates every literature note, and you can ask Claude "which of these isn't linked from the draft yet, and should be?" The answer is sometimes "none, you've used everything relevant"; sometimes it's "these three, and their absence is a gap in section 4."
+
+Then run the grounding loop in reverse. Ask Claude to flag every unsourced or weakly-sourced claim in the draft against `[citation needed]` markers, and for each marker, check whether the originating source note has a citation that fills the gap. If it does, pull the citation into both the draft and the source note (so future readers of the source note see the same grounded version). If it doesn't, you've discovered a gap in the underlying research — flag it, decide whether to go find literature or to soften the claim, and repeat.
+
+Tangents will appear. A paragraph you're writing for the paper wants to veer into a related question that isn't central to the paper's argument. Don't discard it and don't let it dilute the draft. Triage it: capture the tangent as a new note in the vault (PARA Inbox, Zettelkasten Fleeting, or just a standalone file) at the moment it appears, then return to the paper. The note is cheap; the diluted paragraph is expensive.
+
+Claude is good at this triage in flow. Prose to Claude: "That paragraph on signalling is a tangent. Pull it into a new note at `research/signalling-in-platform-design.md` with a link back to this draft, then continue section 3." The draft stays tight; the tangent lives on. You don't have to stop writing to manage the split.
+
+### With scholar-mcp
+
+Generate the references file in the author's preferred format. For every literature note linked from the draft, `get_paper(doi=...)` produces a BibTeX entry; Claude composes these into a single file via `write(path="Draft/consent-essay.bib", content=...)`. Ask template:
+
+> For every literature note linked from `Draft/consent-essay.md`, fetch the paper's BibTeX via scholar-mcp and append to `Draft/consent-essay.bib`. Skip any that are already in the file.
+
+For CSL-JSON (Pandoc, Zotero) or other formats, the same pattern applies — scholar-mcp returns structured metadata; Claude writes the format you specify. This eliminates the hand-curation step that usually accumulates errors at submission time.
+
+An end-to-end scholar-mcp-assisted flow for a paper submission:
+
+1. Literature notes accumulate throughout research, each with a verified DOI in frontmatter (`source: "https://doi.org/..."`).
+2. Draft composes via wikilinks to literature notes.
+3. `get_outlinks(path="Draft/paper.md")` enumerates the draft's literature dependencies.
+4. For each outlink with a literature note, Claude calls `get_paper(doi=<source>)` and appends BibTeX to `Draft/paper.bib`.
+5. Pandoc (or your build chain) renders the final paper with `--bibliography=Draft/paper.bib`.
+
+The human step is reviewing the BibTeX — not typing it.
+
+### Common failure
+
+Letting tangents dilute the paper. The failure mode is believing that you'll come back to the tangent later if you just keep it in the draft. You won't. The tangent is interesting precisely because it isn't the paper's core argument; keeping it in the draft means the core argument gets less attention. Fix: capture the tangent as a separate note *at the moment it appears*, not at the end of the session. The interrupt is two minutes; the cleanup is an hour.
+
+A related failure is the paper and its source notes drifting out of sync. You strengthen a claim in the draft based on something Claude re-read during composition, but you don't push that strengthening back into the source note. Two months later the source note still says what it said before. Fix: at the end of every writing session, ask Claude to diff the draft against the source notes — "For each note linked from the draft, has anything in the draft added to what the source note says? If so, propose the additions back into the source." Co-evolution only works if both sides evolve.
+
+!!! tip "End-of-session checklist for a draft"
+    - Every `[citation needed]` either resolved or explicitly carried forward.
+    - Tangent notes captured (and linked from the draft's `## Related tangents` section, if you keep one).
+    - Source notes updated with anything the draft discovered that they didn't have.
+    - `get_outlinks(path=<draft>)` reviewed; every linked source has a reciprocal backlink (or is an intentional one-way pointer).
+
+## Pitfalls
+
+Research with Claude is fast. Fluency is not evidence of correctness. Most of what follows is how to catch the model before it convinces both of you that an incorrect answer is settled.
+
+### False confidence
+
+Claude writes confidently, even when wrong. The confidence is in the prose, not the content — the same sentence structure that makes a verified claim read clearly makes a fabricated claim read clearly.
+
+A session produced a confident assertion backed by a plausible-sounding paper. The title read like something that should exist, the DOI was formatted correctly, the authors were prominent in the field. The paper did not exist. Only a targeted follow-up — search for the paper, verify authors, check the DOI — caught it. The paragraph around the citation had been convincing enough that the first read didn't flag anything.
+
+Treat every citation as unverified until you've resolved the DOI or found the paper via scholar-mcp or web search. Verification is cheap; unrolling a paper draft that cites a non-existent source six weeks later is not.
+
+A minimal verification protocol:
+
+1. Copy the DOI (or canonical identifier) into a browser or into `get_paper` via scholar-mcp.
+2. Confirm the paper resolves and the title matches what Claude reported.
+3. Confirm the authors exist and are plausibly the authors of that paper (look for the same names on a citation database).
+4. Spot-check one claim the note attributes to the paper against the abstract.
+
+If any step fails, the citation is fabricated — or, more charitably, confused with a different paper. Either way the note is lying to you until you fix it.
+
+### Make uncertainty explicit
+
+AI-written text looks like a finished deliverable even when it's a first draft. Colleagues who read the note assume it's been verified. Future Claude sessions read the note back and treat confident prose as settled fact. The same fluency that makes Claude useful for drafting makes Claude dangerous as a reader of its own prior work.
+
+Fix: mark uncertainty in the note, not just in your head. `[citation needed]`, `[verify]`, `[my guess]` — any convention you'll actually use. The marker is a signal to both future-you and future-Claude that the surrounding prose has not cleared the verification bar yet. Without the marker, the note reads as done. With the marker, the note reads as in-progress, which is the truth.
+
+Claude reads its own output as authoritative when it surfaces again in a future session. This is the mechanism by which confidence compounds: session 1 writes a confident-but-unverified claim, session 2 reads the same claim back through `read` or `get_similar`, treats it as prior work, and cites it in a new note. The fabrication propagates without anyone noticing. Markers break this chain — a future Claude session seeing `[citation needed]` knows the claim is not yet load-bearing.
+
+### Verify before polishing
+
+If a note reads like a deliverable but its claims aren't verified, it's premature polish. The verification loop is the workflow, not a step to skip when you're in flow. The temptation to keep writing while the momentum is there is real; the cost of skipping verification is that the polish compounds the confidence problem. A rough note with markers is safer than a polished note without them.
+
+Order of operations matters. Do the grounding pass first; polish second. If you polish first, the prose reads as finished to both you and to future Claude, and the grounding pass becomes a formality — you tick boxes instead of actually reading sources. If you ground first, the prose is ugly until it's right, which keeps you honest about what still needs work.
+
+A practical rule: a note is only allowed to lose its `[citation needed]` markers when the claim is backed by a specific source you have actually checked. Not "Claude said this paper supports it" — actually checked. The verification step is the workflow's load-bearing element. Every other step is optional; this one is not.
+
+If you're short on time and can't verify a claim in the current session, the honest move is to leave the marker in place and write a brief note next to it explaining what you looked at and what was inconclusive. A marker with context is more useful in the next session than a marker with no trail; a note that deletes the marker without verification is actively misleading.
+
+## A worked example
+
+Here's how the five phases thread together across a month of intermittent work. The scenario: abandoned software dependencies — open-source libraries that stop receiving maintenance while still being depended on by live systems. The goal: a short blog post summarising early-warning signals.
+
+*Seed.* You start with a thesis: abandoned dependencies usually show warning signs 6–12 months before the final commit — slowing commit cadence, unanswered issues, a shrinking maintainer pool. You write it as a seed note at `research/abandoned-deps.md` with the thesis in the body and a `[citation needed]` marker on the 6–12 month claim. Tags: `[draft, supply-chain]`. Five minutes, total.
+
+*Grounding.* A week later you come back. The 6–12 month claim is still marked. You ask Claude to run web searches for empirical work on maintainer attrition and dependency abandonment, with specific attention to timing. Claude returns three candidates: a 2021 paper on open-source project mortality, a 2023 blog post with ecosystem-wide metrics, and a 2020 empirical study on commit cadence as a leading indicator. You skim the blog; one of the papers has a DOI you can verify. You tell Claude to go ahead and write literature notes for the two papers and to drop the blog (interesting, but not a citable source for the claim you're making).
+
+*Absorbing.* Claude produces two literature notes. The 2020 empirical study becomes `research/lit/xie-2020-commit-cadence.md` — full key-ideas section, a relevance paragraph tying it to the seed note, and open questions about sample selection. The 2021 project-mortality paper becomes a shorter summary note: one paragraph of key ideas, one of relevance, no open questions because the paper is peripheral. You don't convert either PDF; the abstracts plus what Claude retrieved are enough.
+
+At the end of the absorbing session, you ask Claude to add reciprocal links from the seed note into each literature note, using `edit` to insert `[[xie-2020-commit-cadence]]` and `[[fritz-2021-project-mortality]]` into the relevant paragraphs. The vault now has a small interconnected cluster where a week ago there was one seed.
+
+*Interconnection.* You ask Claude to run `get_similar` on the seed note. The top result is a note from six months ago titled `maintainer-burnout-signals.md` — you'd completely forgotten about it. You open it; it's directly relevant. Claude adds `[[maintainer-burnout-signals]]` to the seed note and a reciprocal link in the burnout note. The vault graph just got richer without you having to remember anything.
+
+A second `get_similar` candidate is a note on supply-chain attacks from last year; the rationale Claude offers is "both concern open-source library lifecycles," which is vocabulary-level, not substantive. You reject it. Over-linking would have dragged the supply-chain note into every future `get_context` call on this cluster, for no gain.
+
+*Producing.* A month later you write a short blog draft on the topic. You ask Claude to compose from the seed note, the two literature notes, and the burnout note. The draft has one tangent — a paragraph on how package managers could surface abandonment signals programmatically — that doesn't fit the blog's scope. Instead of deleting it, you capture it as a new standalone note, `research/package-manager-abandonment-signals.md`, and return to the blog. The blog ships tight; the tangent lives in the vault, ready for the next session to pick up.
+
+The whole loop took four sessions across a month: seed (5 minutes), ground (20 minutes), absorb (30 minutes), interconnect (10 minutes), produce (90 minutes). Each session picked up where the previous one left off. Claude didn't remember any of it — the vault did. That's the point.
+
+## Next steps
+
+- [Zettelkasten](zettelkasten.md) — idea-centric organisation; pairs well with literature notes and atomic permanent notes.
+- [PARA](para.md) — action-oriented organisation; research fits under Resources (reference material) and Projects (active research outputs).
+- [Obsidian Everywhere](obsidian-everywhere.md) — multi-device setup for phone-first capture between sessions.
+- [MCP Prompts reference](../prompts.md) — especially the [ambient patterns](../prompts.md#ambient-patterns-without-prompts) and [`propose-links`](../prompts.md#propose-links).
+- [scholar-mcp](https://github.com/pvliesdonk/scholar-mcp) — when citation rigour matters: citation graphs, BibTeX, full-text PDF conversion.

--- a/docs/guides/research-workflows.md
+++ b/docs/guides/research-workflows.md
@@ -166,7 +166,7 @@ A secondary failure: grounding stops at the first source that supports the claim
 
 ### Baseline flow
 
-Once a source is identified, you write a literature note against it. The shape follows the existing Zettelkasten [`literature.md` template](../../examples/zettelkasten/), adapted to the research-specific concerns of relevance and open questions:
+Once a source is identified, you write a literature note against it. The shape follows the existing Zettelkasten [`literature.md` template](../../examples/zettelkasten/) (under `templates/`), adapted to the research-specific concerns of relevance and open questions:
 
 ```markdown
 ---

--- a/docs/guides/zettelkasten.md
+++ b/docs/guides/zettelkasten.md
@@ -527,3 +527,4 @@ Resist pre-splitting or pre-merging before review. Claude does both in one pass.
 - **Review the examples** for templates and prompts: [`examples/zettelkasten/`](../../examples/zettelkasten/)
 - **Prefer an action-oriented workflow?** Try the [PARA guide](para.md) — Projects, Areas, Resources, Archive with triage, kickoff, and weekly review prompts
 - **Ambient patterns**: [`docs/prompts.md`](../prompts.md#ambient-patterns-without-prompts) — flows the LLM handles from prose alone (URL capture, research, split/merge, ad-hoc link proposal)
+- **Research workflows**: [research-workflows.md](research-workflows.md) — literature grounding, fact-checking, and writing papers from notes

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Point it at a directory of Markdown files — an Obsidian vault, a docs folder, 
 A few flows the server enables with an LLM on top — none of these require a bespoke prompt:
 
 - **"Fetch <url> and summarize into a Resource note."** Claude composes `fetch` + `search` + `write`.
-- **"Research <topic> and create a set of interlinked notes."** Claude composes web tools + `write` with wikilinks.
+- **"Research <topic> and create a set of interlinked notes."** Claude composes web tools + `write` with wikilinks. See the [Research workflows guide](guides/research-workflows.md) for the full loop.
 - **"Summarize today's conversations into Inbox notes."** Claude.ai composes `conversation_search` + `recent_chats` + `write`; the [`para-capture-chats`](guides/para.md#using-the-para-prompts) prompt is the one-click version.
 - **Find missing links.** The [`propose-links`](prompts.md) builtin prompt scans recently-modified notes and proposes meaningful connections.
 

--- a/docs/superpowers/plans/2026-04-19-research-workflows-guide.md
+++ b/docs/superpowers/plans/2026-04-19-research-workflows-guide.md
@@ -1,0 +1,490 @@
+# Research Workflows Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a new `docs/guides/research-workflows.md` guide (~500 lines) that codifies the LLM-augmented research loop in a markdown vault, with scholar-mcp as an optional power-up. Wire it into navigation, the Guides index, and cross-links from README / `docs/index.md` / Zettelkasten / PARA guides.
+
+**Architecture:** Pure documentation PR. Five files created or modified; no `src/`, `tests/`, or `examples/` changes. The guide is organising-scheme-agnostic (works with Zettelkasten, PARA, or neither) and scholar-mcp-optional (every baseline flow works without it).
+
+**Tech Stack:** Markdown, MkDocs Material (existing stack); no new dependencies.
+
+**Reference spec:** [`docs/superpowers/specs/2026-04-19-research-workflows-guide-design.md`](../specs/2026-04-19-research-workflows-guide-design.md)
+
+---
+
+## Task 1: Write `docs/guides/research-workflows.md`
+
+**Files:**
+- Create: `docs/guides/research-workflows.md`
+
+**Before you start:** read these reference files to orient on style, tone, and cross-link targets.
+
+- `docs/guides/zettelkasten.md` — closest structural match. Study its heading hierarchy, admonition use, mix of prose and code blocks, and Next Steps section.
+- `docs/guides/para.md` — similar shape with baseline-vs-prompt framing; good reference for the "baseline flow + with X callout" pattern.
+- `docs/superpowers/specs/2026-04-19-research-workflows-guide-design.md` — the authoritative design; everything in this task conforms to it.
+- `src/markdown_vault_mcp/static/prompts/propose-links.md` — the prompt this guide references by name.
+- `examples/zettelkasten/templates/literature.md` — the existing literature note template the guide recommends.
+
+### Content anchors — the guide has six sections and must include the following
+
+**Section 1 — Intro (~30 lines)**
+
+- Title: `# Research workflows with markdown-vault-mcp`
+- Opening paragraph: research in a vault with Claude as a persistent sparring partner; the vault is the durable workspace across sessions, Claude is the reasoning agent.
+- Second paragraph: the five phases as a non-linear loop (seed → ground → absorb → interconnect → produce), not a pipeline. Most sessions touch two or three phases.
+- Third paragraph: scholar-mcp framing — "This guide's baseline works with just Claude, markdown-vault-mcp, and web search. [scholar-mcp](https://github.com/pvliesdonk/scholar-mcp) is a separate MCP server that adds rigour (citation graphs, BibTeX export, PDF-to-Markdown conversion) — optional but recommended when you need real paper IDs and don't trust the model's memory for citations."
+- Admonition:
+  ```markdown
+  !!! note
+      This guide is organising-scheme-agnostic. It works with [Zettelkasten](zettelkasten.md), [PARA](para.md), or no opinionated structure at all. The phase model in this guide composes the vault's generic search, linking, and write tools; it doesn't assume a particular folder layout.
+  ```
+
+**Section 2 — Setup (~40 lines)**
+
+- Prerequisite pointer: "Install and configure markdown-vault-mcp per the [Claude Desktop guide](claude-desktop.md) or [Obsidian Everywhere](obsidian-everywhere.md) for the full multi-device setup. This guide assumes your vault is already connected to Claude."
+- Subsection `### Adding scholar-mcp (optional)`:
+  - One paragraph: "Skip this section if you want to start with the baseline. You can add scholar-mcp later without changing any of the workflows in this guide."
+  - Claude.ai: one sentence pointer to "connectors" add flow, linking to the [scholar-mcp repo](https://github.com/pvliesdonk/scholar-mcp).
+  - Claude Desktop: show a JSON snippet adding scholar-mcp as a second entry in `mcpServers`:
+    ```json
+    {
+      "mcpServers": {
+        "vault": {
+          "command": "uvx",
+          "args": ["--from", "markdown-vault-mcp", "markdown-vault-mcp", "serve"]
+        },
+        "scholar": {
+          "command": "uvx",
+          "args": ["--from", "pvliesdonk-scholar-mcp", "scholar-mcp", "serve"],
+          "env": {
+            "SCHOLAR_MCP_S2_API_KEY": "your-key-optional"
+          }
+        }
+      }
+    }
+    ```
+  - Claude Code: one sentence pointer to MCP settings + same structural pattern.
+  - Note: "scholar-mcp's [own documentation](https://pvliesdonk.github.io/scholar-mcp/) covers API keys, OIDC auth, transport options, and tool details. This guide only references the tools by name."
+- Web-search caveat: "The baseline flows assume Claude has web-search tools available. Claude.ai and Claude Desktop do by default; other clients vary. Without web search, fall back to scholar-mcp for the grounding phase or skip straight to manual source collection."
+
+**Section 3 — The five phases (~300 lines, ~60 lines each)**
+
+Each phase is a `## Phase N: <Name>` section with this internal structure:
+
+```markdown
+## Phase N: <Name>
+
+**Intent.** <one sentence>
+
+### Baseline flow
+
+<One paragraph describing the flow. Include a concrete example of a prose ask to Claude and which markdown-vault-mcp tools the model composes. Show one short code block illustrating the end state (e.g., a sample note body with the claim-tracking markers, or a wikilink being added).>
+
+### With scholar-mcp
+
+<One-two paragraphs describing what changes when scholar-mcp is available. Name specific scholar-mcp tools. Describe what's materially better — not just "faster" but what correctness/rigour gain you get.>
+
+### Common failure
+
+<One paragraph naming the thing that typically goes wrong in this phase and how to catch it. Not a list of edge cases — one crisp failure mode per phase.>
+```
+
+Phase-by-phase content:
+
+**Phase 1: Seeding notes**
+- Intent: get a new note into the vault quickly without worrying about shape yet.
+- Baseline: pointer to existing patterns — `para-capture-chats` prompt for conversation capture (Claude.ai only), the `research` builtin prompt for a single-note synthesis of a topic, or just prose: "Create a note at `research/<slug>.md` with this thesis: <paragraph>. Tag it `draft`." Show example frontmatter + body.
+- With scholar-mcp: not meaningfully different here; scholar-mcp doesn't participate in seed capture. One line noting this.
+- Common failure: waiting to polish before committing a note; the seed should land rough and be revised over multiple sessions.
+
+**Phase 2: Literature grounding**
+- Intent: back a claim in a note with real sources; prevent fabricated citations.
+- Baseline: Claude + web search. Example ask: "For each claim in `research/consent-dynamics.md` marked `[citation needed]`, search the web for supporting or refuting papers and update the marker with a linked source." Introduce the claim-tracking convention here:
+  - Inline markers: `[citation needed]` in prose. Searchable via `grep`. Familiar from other research contexts.
+  - Note-level aggregation: a `## Open claims` or `## Evidence gaps` section where outstanding items accumulate.
+  - The convention is a recommendation, not a requirement. Pick markers that you'll remember.
+- With scholar-mcp: use `search_papers` to get real paper IDs and metadata (no hallucinated DOIs), `get_references` to walk what a seminal paper cites (backward), `get_citations` to find who cites it (forward). Example: "Ground the claim in line 47 using scholar-mcp: search for papers on <topic>, then for the top 3 results fetch their references to find foundational work." Mention BibTeX generation via `get_paper` — writes a Markdown citation block the model can attach to the literature note's frontmatter.
+- Common failure: trusting the first plausible-sounding paper without verifying. Fabricated citations look like real ones. Always verify the DOI resolves, the authors exist, the title matches.
+
+**Phase 3: Absorbing sources**
+- Intent: turn a retrieved source into a durable literature note; decide when a summary suffices vs when the full text is needed.
+- Baseline: Claude reads the abstract (and any web snippets it can get), writes a literature note. Show the shape (referring readers to `examples/zettelkasten/templates/literature.md` for a starting frontmatter):
+  ```markdown
+  ---
+  title: "<paper title>"
+  type: literature
+  tags: [literature]
+  source: "<DOI or URL>"
+  created: 2026-04-19
+  ---
+
+  # <paper title>
+
+  **Authors:** <names> · <year>
+  **Source:** <DOI>
+
+  ## Key Ideas
+
+  <two-three bullet points>
+
+  ## Relevance
+
+  <one paragraph on how this connects to the vault's current research>
+
+  ## Open Questions
+
+  <if any>
+  ```
+- With scholar-mcp: `convert_pdf_to_markdown` pulls the full paper into the vault as a Markdown companion (for open-access papers); you write the literature note against the full text rather than the abstract. `get_paper` gives structured metadata (authors, venue, year) for the frontmatter without guessing.
+- Common failure: reflexively fetching the full PDF. Most of the time the abstract + the author's argument is enough to decide relevance; saving the PDF conversion for when you actually need to dive deep keeps the vault from drowning in attachments.
+
+**Phase 4: Interconnection**
+- Intent: surface existing vault notes semantically close to the one you're working on; find work you'd forgotten.
+- Baseline: ask Claude to run `get_similar(path=<current note>)`, inspect the candidates, and pick the meaningful ones. For a vault-wide sweep, invoke [`propose-links`](../prompts.md#propose-links) from the `+` menu. Example: "I'm working on `research/incentive-misalignment.md`. Run `get_similar` and tell me which of the top 5 candidates should be linked."
+- With scholar-mcp: the scholar-mcp-specific angle here is cross-referencing papers. `get_paper(doi=<...>)` followed by `get_references` / `get_citations` sometimes reveals that two apparently unrelated strands in the vault share a seminal paper. Worth describing as "your literature graph is richer than your note graph; scholar-mcp exposes it."
+- Common failure: missing an existing note because you'd forgotten what you called it. `get_similar` and `propose-links` catch these; left to memory alone, you end up rewriting notes that already exist.
+
+**Phase 5: Writing a paper from notes**
+- Intent: draft a paper from the vault, fact-check as you go, and let the paper and the source notes co-evolve.
+- Baseline: start a `Draft/<paper-slug>.md` note, pull paragraphs from existing research notes (Claude can compose them), ask Claude to flag unsourced claims against `[citation needed]` markers, run the grounding loop from Phase 2, push citations back into both the paper draft and the originating source notes. Tangents encountered during writing that don't fit this paper's scope — don't discard, triage them into the vault (PARA Inbox, Zettelkasten Fleeting, or just a standalone note).
+- With scholar-mcp: generate the references file in the author's preferred format (BibTeX via `get_paper`, or CSL-JSON for tools like Pandoc). "For every literature note linked from this draft, generate a BibTeX entry and append to `Draft/<paper-slug>.bib`."
+- Common failure: letting tangents dilute the paper. The fix is to capture them separately at the moment they appear, not "I'll come back to that later" — that later rarely comes.
+
+**Section 4 — Pitfalls (~60 lines)**
+
+- Heading: `## Pitfalls`
+- Opening: "Research with Claude is fast. Fluency is not evidence of correctness. Most of what follows is how to catch the model before it convinces both of you that an incorrect answer is settled."
+- Subsection `### False confidence`:
+  - One paragraph: Claude writes confidently, even when wrong. The confidence is in the prose, not the content.
+  - Real example (one paragraph): "A session produced a confident assertion backed by a plausible-sounding paper. The title read like something that should exist, the DOI was formatted correctly, the authors were prominent in the field. The paper did not exist. Only a targeted follow-up — search for the paper, verify authors, check the DOI — caught it."
+  - What to do: treat every citation as unverified until you've resolved the DOI or found the paper via scholar-mcp / web search.
+- Subsection `### Make uncertainty explicit`:
+  - One paragraph: AI-written text looks like a finished deliverable even when it's a first draft. Colleagues who read the note assume it's been verified. Future Claude sessions read the note back and treat confident prose as settled fact.
+  - The fix: mark uncertainty in the note, not just in your head. `[citation needed]`, `[verify]`, `[my guess]` — any convention you'll actually use.
+- Subsection `### Verify before polishing`:
+  - Short paragraph: if a note reads like a deliverable but its claims aren't verified, it's premature polish. The verification loop is the workflow, not a step to skip when you're in flow.
+
+No moralising. Three short subsections, each landing a specific lesson, grounded in the fabricated-citation example.
+
+**Section 5 — A worked example (~40 lines)**
+
+- Heading: `## A worked example`
+- Opening: "Here's how the five phases thread together in a real session." One paragraph framing.
+- The narrative (3-4 paragraphs): a generic scenario — do NOT use security-economics or any specific domain. Pick something like "understanding how software dependencies get abandoned" or "what makes a refactor feel risky" — open enough to apply to any reader, concrete enough to be useful. The narrative should:
+  - Seed: a note captures the thesis ("abandoned dependencies usually show warning signs 6-12 months before the final commit").
+  - Grounding: the claim about 6-12 months is flagged as `[citation needed]`. The user asks Claude to find literature.
+  - Absorbing: Claude + web search turns up three relevant papers. Two get short summary notes; one (the central methodological paper) gets a full literature note.
+  - Interconnection: `get_similar` surfaces a forgotten note from six months ago on maintainer burnout — highly related, worth cross-linking.
+  - Producing: the user writes a short blog draft pulling from all the notes; one tangent (how package managers signal abandonment) becomes a new standalone note instead of diluting the blog.
+- Keep it tight. No code blocks. Prose only. The reader should finish it thinking "I can do this."
+
+**Section 6 — Next steps (~20 lines)**
+
+- Heading: `## Next steps`
+- Bullet list, four to six items:
+  ```markdown
+  - [Zettelkasten](zettelkasten.md) — idea-centric organisation; pairs well with literature notes and atomic permanent notes.
+  - [PARA](para.md) — action-oriented organisation; research fits under Resources (reference material) and Projects (active research outputs).
+  - [Obsidian Everywhere](obsidian-everywhere.md) — multi-device setup for phone-first capture between sessions.
+  - [MCP Prompts reference](../prompts.md) — especially the [ambient patterns](../prompts.md#ambient-patterns-without-prompts) and [`propose-links`](../prompts.md#propose-links).
+  - [scholar-mcp](https://github.com/pvliesdonk/scholar-mcp) — when citation rigour matters: citation graphs, BibTeX, full-text PDF conversion.
+  ```
+
+### How to build
+
+- [ ] **Step 1: Read reference files**
+
+Open and skim:
+- `docs/guides/zettelkasten.md` (for structural pattern)
+- `docs/guides/para.md` (for "baseline + variant" framing pattern)
+- `docs/superpowers/specs/2026-04-19-research-workflows-guide-design.md` (authoritative design)
+- `examples/zettelkasten/templates/literature.md` (the literature template this guide references)
+
+- [ ] **Step 2: Draft the guide**
+
+Create `docs/guides/research-workflows.md`. Follow the six-section structure above. Target: ~450-550 lines. Match the tone of the Zettelkasten guide: direct, second-person, short paragraphs, no marketing language.
+
+For the worked example in Section 5, use the "abandoned software dependencies" scenario described above. Do NOT use security-economics or any domain that could identify the user's actual research.
+
+Content accuracy requirements (verify against the actual tool signatures before committing):
+- `markdown-vault-mcp` tools referenced: `get_similar`, `get_context`, `get_outlinks`, `get_backlinks`, `read`, `write`, `edit`, `list_documents`, `search`. No trailing slashes on folder arguments.
+- scholar-mcp tools referenced: `search_papers`, `get_paper`, `get_references`, `get_citations`, `convert_pdf_to_markdown`. (These are names from the scholar-mcp README at `github.com/pvliesdonk/scholar-mcp`; verify at implementation time by fetching the latest README if signatures might have changed.)
+- Reference `examples/zettelkasten/templates/literature.md` for the literature note shape, but don't copy its content verbatim — adapt it to the research-specific shape shown in Phase 3.
+- Use `[[wikilinks]]` for internal vault references in examples.
+- Use relative paths for docs cross-links (`zettelkasten.md`, `para.md`, `obsidian-everywhere.md`, `../prompts.md`). Do not use absolute GitHub Pages URLs inside the guide.
+
+- [ ] **Step 3: Verify MkDocs builds the page**
+
+Run:
+```bash
+uv run mkdocs build --strict 2>&1 | tail -20
+```
+
+Expected: build completes. Because the guide isn't in nav yet (Task 2 wires it), you'll see one `INFO` line like `The following pages exist in the docs directory, but are not included in the "nav" configuration: - guides/research-workflows.md`. That's expected at this task boundary.
+
+If `--strict` fails on any other warning (broken internal link, missing anchor, malformed table), fix it in the guide before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guides/research-workflows.md
+git commit -m "docs: add research workflows guide"
+```
+
+---
+
+## Task 2: Wire the guide into navigation
+
+**Files:**
+- Modify: `mkdocs.yml` (two nav blocks)
+- Modify: `docs/guides/index.md` (new table row)
+
+- [ ] **Step 1: Read `mkdocs.yml` to orient**
+
+```bash
+grep -n "guides/" mkdocs.yml | head -30
+```
+
+You'll see both the llmstxt `Guides:` block (around line 60-72) and the visible `nav: - Guides:` block (around line 125-140). Both need the new entry in the same relative position.
+
+- [ ] **Step 2: Add research-workflows to the llmstxt Guides section in `mkdocs.yml`**
+
+Find the llmstxt block. After the `guides/obsidian-everywhere.md:` line and before the `guides/zettelkasten.md:` line, insert:
+
+```yaml
+          - guides/research-workflows.md: Research workflows (seed → ground → absorb → interconnect → produce, with optional scholar-mcp integration)
+```
+
+The surrounding context should become:
+
+```yaml
+          - guides/obsidian-everywhere.md: Reference architecture for desktop + mobile + Claude on one vault
+          - guides/research-workflows.md: Research workflows (seed → ground → absorb → interconnect → produce, with optional scholar-mcp integration)
+          - guides/zettelkasten.md: Zettelkasten workflow (fleeting → literature → permanent notes, MOCs, graph navigation)
+```
+
+- [ ] **Step 3: Add research-workflows to the visible `nav:` Guides block in `mkdocs.yml`**
+
+Find the visible nav block. After `- Obsidian Everywhere: guides/obsidian-everywhere.md` and before `- Zettelkasten: guides/zettelkasten.md`, insert:
+
+```yaml
+      - Research Workflows: guides/research-workflows.md
+```
+
+Updated context:
+
+```yaml
+      - Obsidian Everywhere: guides/obsidian-everywhere.md
+      - Research Workflows: guides/research-workflows.md
+      - Zettelkasten: guides/zettelkasten.md
+```
+
+- [ ] **Step 4: Add research-workflows row to `docs/guides/index.md` table**
+
+In `docs/guides/index.md`, find the "Which guide do I need?" table. Insert a new row after the Obsidian Everywhere row and before the Zettelkasten / PARA rows:
+
+```markdown
+| Do research (literature grounding, interconnected notes, paper drafting) | [Research workflows](research-workflows.md) |
+```
+
+The surrounding context:
+
+```markdown
+| Access my vault from desktop, mobile, AND Claude | [Obsidian Everywhere](obsidian-everywhere.md) |
+| Do research (literature grounding, interconnected notes, paper drafting) | [Research workflows](research-workflows.md) |
+| Use FastEmbed for local embeddings | [Embeddings](embeddings.md#fastembed) |
+```
+
+- [ ] **Step 5: Verify MkDocs `--strict` is clean**
+
+```bash
+uv run mkdocs build --strict 2>&1 | tail -15
+```
+
+Expected: the "pages exist in docs directory but not in nav" notice for `research-workflows.md` is now GONE (Steps 2-3 wired the nav). All other INFO notices (`design.md` excluded, `examples/` relative links in zettelkasten/para, `oidc-providers.md` anchor) remain as pre-existing. No new warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mkdocs.yml docs/guides/index.md
+git commit -m "docs: wire research-workflows guide into nav and Guides index"
+```
+
+---
+
+## Task 3: Update the "What you can do with it" sections in README and docs/index.md
+
+**Files:**
+- Modify: `README.md` (one bullet in the existing section)
+- Modify: `docs/index.md` (one bullet in the existing section)
+
+The existing "Research a topic into your vault" bullets in both files should link to the new guide. This is a one-line edit per file.
+
+- [ ] **Step 1: Update the Research bullet in `README.md`**
+
+Find the existing bullet (around line 32). It currently reads:
+
+```markdown
+- **Research a topic into your vault.** "Research product security regulations, compare them, and create a set of interlinked notes — one per regulation, plus a map-of-content." — Claude composes web-search tools (client-side) + `write` with wikilinks.
+```
+
+Change to:
+
+```markdown
+- **Research a topic into your vault.** "Research product security regulations, compare them, and create a set of interlinked notes — one per regulation, plus a map-of-content." — Claude composes web-search tools (client-side) + `write` with wikilinks. See the [Research workflows guide](https://pvliesdonk.github.io/markdown-vault-mcp/guides/research-workflows/) for the full loop.
+```
+
+Note: README uses absolute `https://pvliesdonk.github.io/...` URLs consistently (the README renders on GitHub and PyPI where relative doc links would break). Stay consistent with that convention.
+
+- [ ] **Step 2: Update the Research bullet in `docs/index.md`**
+
+Find the parallel bullet (around line 28). It currently reads:
+
+```markdown
+- **"Research <topic> and create a set of interlinked notes."** Claude composes web tools + `write` with wikilinks.
+```
+
+Change to:
+
+```markdown
+- **"Research <topic> and create a set of interlinked notes."** Claude composes web tools + `write` with wikilinks. See the [Research workflows guide](guides/research-workflows.md) for the full loop.
+```
+
+Note: `docs/index.md` uses relative paths (renders inside the docs tree). Stay consistent.
+
+- [ ] **Step 3: Verify MkDocs build is clean**
+
+```bash
+uv run mkdocs build --strict 2>&1 | tail -10
+```
+
+Expected: no new warnings. The relative link in `docs/index.md` resolves to the new guide.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/index.md
+git commit -m "docs: link 'Research a topic' bullet to the new research-workflows guide"
+```
+
+---
+
+## Task 4: Add Next Steps cross-links from Zettelkasten and PARA guides
+
+**Files:**
+- Modify: `docs/guides/zettelkasten.md`
+- Modify: `docs/guides/para.md`
+
+- [ ] **Step 1: Add a Next Steps bullet to `docs/guides/zettelkasten.md`**
+
+Find the Next Steps section at the end. It currently has a few bullets including "Ambient patterns" (added in PR #388). Append this new bullet as the last item:
+
+```markdown
+- **Research workflows**: [research-workflows.md](research-workflows.md) — literature grounding, fact-checking, and writing papers from notes
+```
+
+- [ ] **Step 2: Add a Next Steps bullet to `docs/guides/para.md`**
+
+Find the Next Steps section at the end of `docs/guides/para.md`. Append this bullet as the last item:
+
+```markdown
+- **Research workflows**: [research-workflows.md](research-workflows.md) — literature grounding, fact-checking, and writing papers from notes
+```
+
+- [ ] **Step 3: Verify MkDocs build is clean**
+
+```bash
+uv run mkdocs build --strict 2>&1 | tail -10
+```
+
+Expected: no new warnings. The relative link `research-workflows.md` resolves.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guides/zettelkasten.md docs/guides/para.md
+git commit -m "docs: cross-link Zettelkasten and PARA guides to research-workflows"
+```
+
+---
+
+## Task 5: End-to-end verification
+
+**Files:** (none modified directly)
+
+- [ ] **Step 1: Run full pre-commit**
+
+```bash
+uv run pre-commit run --all-files
+```
+
+Expected: all hooks pass (ruff, ruff format, mypy, vendored SPA, trailing whitespace, EOF, YAML, large files, JSON). Most will skip since no Python changed; the markdown/YAML/whitespace hooks will run and pass.
+
+- [ ] **Step 2: Run the full test suite as a regression check**
+
+```bash
+uv run pytest -x -q
+```
+
+Expected: all tests pass. No code changed, but run the suite to confirm nothing in the docs build broke a test (e.g., a docstring-link test if any).
+
+- [ ] **Step 3: Run MkDocs `--strict`**
+
+```bash
+uv run mkdocs build --strict 2>&1 | tail -20
+```
+
+Expected: clean build. The only remaining INFO notices should be the pre-existing ones (`design.md` excluded, `examples/` relative links in zettelkasten and para guides, `oidc-providers.md` anchor).
+
+Sanity-check the generated output:
+
+```bash
+ls site/guides/research-workflows/ && ls site/guides/index.html > /dev/null && echo 'guides index ok'
+```
+
+Expected: `site/guides/research-workflows/index.html` exists; the guides index builds.
+
+- [ ] **Step 4: Link-resolve audit**
+
+Inside the new guide, verify every internal link resolves by running:
+
+```bash
+for link in $(grep -oE '\]\(\.\./[^)]+\)' docs/guides/research-workflows.md); do
+  target=$(echo "$link" | sed -E 's/^\]\(//; s/\)$//')
+  if [[ "$target" == *#* ]]; then
+    file="${target%%#*}"
+  else
+    file="$target"
+  fi
+  resolved="docs/${file#../}"
+  if [[ -f "$resolved" ]]; then
+    echo "OK:  $link"
+  else
+    echo "BROKEN: $link (resolved to $resolved)"
+  fi
+done
+```
+
+Expected: all links print `OK`. Any `BROKEN` entry must be fixed.
+
+- [ ] **Step 5: Review the branch commit history**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: four commits from Tasks 1-4 (verification task has no commit).
+
+- [ ] **Step 6: No commit for this task**
+
+If any step failed, diagnose, fix in the relevant file, amend the appropriate task's commit or create a fix-up commit, and re-run the verification sequence from Step 1.
+
+---
+
+## Out of Scope (Future Work — do not implement now)
+
+- A new example pack under `examples/research/`. The guide references the existing Zettelkasten `literature.md` template; a research-specific template pack is only justified if real usage shows demand.
+- Vault-to-paper authoring tutorials (LaTeX/Markdown-to-PDF pipelines, reference manager sync). Out of scope; would be a separate guide.
+- Server-side integration between markdown-vault-mcp and scholar-mcp (e.g., a tool that auto-creates a literature note from a scholar-mcp paper lookup). Not a design concern for this PR.
+- Claim-tracking automation (e.g., a prompt that scans the vault for `[citation needed]` markers and queues them for verification). If the convention catches on, consider a `verify-claims` prompt as a follow-up.
+- A follow-up PR to link back from the blog to the guide once (if) the blog is published.

--- a/docs/superpowers/specs/2026-04-19-research-workflows-guide-design.md
+++ b/docs/superpowers/specs/2026-04-19-research-workflows-guide-design.md
@@ -1,0 +1,213 @@
+# Research Workflows Guide — Design
+
+**Date:** 2026-04-19
+**Status:** Approved design; plan pending
+**Audience:** Contributors writing a new user-facing guide that describes LLM-augmented research workflows in a markdown vault
+
+## Summary
+
+Add `docs/guides/research-workflows.md`: a practical guide to using Claude + markdown-vault-mcp to do interlinked research in a vault, optionally augmented with [scholar-mcp](https://github.com/pvliesdonk/scholar-mcp) for rigorous literature handling.
+
+The guide is **organising-scheme-agnostic** (works with Zettelkasten, PARA, or neither) and **scholar-mcp-optional** (baseline is Claude + vault + web search; scholar-mcp is a power-up for citation graphs, BibTeX, and full-text PDF conversion).
+
+## Goals
+
+1. Codify the phased research loop observed in practice — seed → ground → absorb → interconnect → produce — as a sequence of composable, prose-invocable workflows.
+2. Capture the claim-tracking discipline and the false-confidence gate as load-bearing advice. Both come from real practitioner experience and prevent the main failure mode of LLM-assisted research (fluent-but-wrong output).
+3. Position scholar-mcp as an enhancement, not a prerequisite. Each phase shows the baseline flow (Claude + vault + web search), then adds a "With scholar-mcp" callout describing what's gained.
+4. Tie the guide into the existing docs graph — referenced from Zettelkasten and PARA Next Steps, indexed in the Guides table, linked to from the README's "what you can do with it" section.
+
+## Non-Goals
+
+- A scholar-mcp setup tutorial. Scholar-mcp's own docs cover installation. This guide gives only the one-line "install via Claude plugin" or "add as a connector on Claude.ai" pointer.
+- A deep tutorial on vault-to-paper authoring (LaTeX integration, reference manager sync). That's a separate workflow; this guide stops at "you can write a paper from notes."
+- Replicating the companion blog post. The blog won't be published; the guide absorbs the load-bearing material from the blog directly (the fabricated-citation story, the claim-tracking convention, the practitioner-vs-literature framing). The guide doesn't reference the blog.
+- A new example pack under `examples/`. The guide references the existing Zettelkasten `literature.md` template rather than introducing a parallel research pack.
+- Any server code changes. Guide-only PR.
+
+## Design Decisions
+
+### 1. Baseline + power-up framing
+
+Each workflow phase is presented in two tiers:
+
+- **Baseline** — Claude + markdown-vault-mcp + web search. Works for everyone. No extra install. Good enough for 80% of research work.
+- **With scholar-mcp** — adds citation graph traversal, BibTeX/CSL-JSON/RIS export, full-text PDF → Markdown conversion, and real paper IDs (reduces hallucination risk). Scoped callouts; skippable.
+
+Rationale: most readers won't set up scholar-mcp initially. Making it mandatory suppresses adoption. Baseline-first also matches the existing "prompts only when they add value" framing — the guide teaches a workflow that composes existing primitives, and scholar-mcp is documented as the case where codification (via a second MCP server) pays off.
+
+### 2. Phase-oriented structure
+
+Five phases, each a named workflow stage:
+
+1. **Seeding notes** — research starts (from a conversation, a research question, a raw opinion). Mostly pointers to existing capture patterns.
+2. **Literature grounding** — backing a claim with real sources. Where web search and scholar-mcp earn their keep. Introduces the claim-tracking convention.
+3. **Absorbing sources** — creating literature notes from retrieved sources; when to summarise vs full-PDF. References the Zettelkasten literature template.
+4. **Interconnection** — `get_similar`, `get_context`, `propose-links` surface tangentially-related existing work.
+5. **Writing a paper from notes** — the co-evolution loop: draft from notes → find claims needing citations → update both the paper and the source notes. Tangents during writing become standalone notes.
+
+Each phase has an "Intent" sentence, a "Baseline flow" with a concrete Claude ask, a "With scholar-mcp" callout, and a "Common failure" note.
+
+### 3. Claim-tracking convention
+
+The guide recommends a simple, plaintext convention without introducing new markup:
+
+- **Inline markers** — `[citation needed]` in prose. Searchable with a literal `grep`. Familiar from other research contexts.
+- **Note-level aggregation** — a `## Open claims` or `## Evidence gaps` section in notes where outstanding items accumulate. Gets cleared as literature fills in.
+
+The convention is a recommendation, not a requirement. Users can adopt their own markers. The guide's value is naming the discipline, not prescribing syntax.
+
+### 4. False-confidence gate
+
+Dedicated "Pitfalls" section at the end, codifying the single most load-bearing piece of practitioner wisdom from the blog:
+
+- Claude writes confidently — even when wrong. Fluency is not evidence of correctness.
+- Real example: a session produced a plausible citation to a paper that didn't exist. The paragraph read well, the DOI was plausible, the reference was fabricated. Only a targeted follow-up (search for the paper, verify authors, check the DOI) caught it.
+- Make uncertainty explicit in the notes, not just in your head. AI-written text looks like a finished deliverable even when it's a first draft; colleagues and *future Claude sessions* treat it as established fact.
+- Verification is the workflow, not an afterthought. The claim-tracking loop isn't optional.
+
+### 5. Integration with existing docs
+
+- Guide is organising-scheme-agnostic. Cross-linked from both Zettelkasten and PARA Next Steps, not scoped to either.
+- Referenced from the README's existing "What you can do with it" section — update the "Research a topic into your vault" bullet to link to this guide.
+- MkDocs nav entry positioned after `obsidian-everywhere` (which covers the multi-device setup this guide assumes) and before `zettelkasten` / `para` (which this guide references).
+- `docs/guides/index.md` gets a new table row.
+
+## Guide Structure
+
+Target ~500 lines. The file lives at `docs/guides/research-workflows.md`.
+
+### Section 1 — Intro (~30 lines)
+
+- One paragraph: research in a vault with Claude as a sparring partner; the vault is the persistent workspace across sessions, Claude is the reasoning agent.
+- One paragraph: the five phases as a non-linear loop, not a pipeline. Most research sessions touch 2-3 of the phases.
+- One admonition: "This guide is organising-scheme-agnostic. It works with Zettelkasten, PARA, or no opinionated structure at all."
+- One paragraph framing scholar-mcp as optional.
+
+### Section 2 — Setup (~40 lines)
+
+- Install markdown-vault-mcp per existing guides (one-line pointer to installation docs; no duplication).
+- Add scholar-mcp as a second MCP server when you want the power-ups:
+  - Claude.ai: add as a connector (one sentence).
+  - Claude Desktop: second entry in `mcpServers` (one code block).
+  - Claude Code: second entry in MCP settings (one code block).
+- Note: scholar-mcp has its own setup docs for API keys and options; this guide only covers what's needed to have both servers visible in your client.
+
+### Section 3 — The five phases (~300 lines, ~60 lines each)
+
+Each phase is a `##` subsection with the same internal structure:
+
+- **Intent** — one sentence describing what this phase accomplishes.
+- **Baseline flow** — a concrete example Claude ask, the tools the model composes, and what lands in the vault. Shows this working without scholar-mcp.
+- **With scholar-mcp** — what changes when scholar-mcp is available. Reference specific scholar-mcp tools by name (`search_papers`, `get_references`, `convert_pdf_to_markdown`, `get_paper` for BibTeX).
+- **Common failure** — the thing that typically goes wrong in this phase; how to catch it.
+
+Concrete phase outlines:
+
+**3.1 Seeding notes** — capture a note from a conversation (pointer to `para-capture-chats` and the ambient-patterns section of `docs/prompts.md`), from a research question (`research` builtin prompt or prose intent), or from a raw thesis/opinion (just write it; triage later). Load-bearing idea: "capture first, classify later." Common failure: waiting until a note is polished before committing it.
+
+**3.2 Literature grounding** — back a claim in a note with sources. Baseline: `search` + web search (Claude runs web queries), write literature notes with `write`. Ask template: "For each claim in this note marked `[citation needed]`, search for supporting or refuting literature and update the claim with a source link." With scholar-mcp: `search_papers` returns real paper IDs and metadata (no fabrication), `get_references` walks the citation graph, `get_paper` generates BibTeX for a separate references file. Introduce the claim-tracking convention here.
+
+**3.3 Absorbing sources** — once literature is identified, decide per source whether a summary suffices or you need the full text. Baseline: Claude summarises from abstract + web search; write a literature note using the existing Zettelkasten `literature.md` template shape (summary + relevance + source link). With scholar-mcp: `convert_pdf_to_markdown` pulls the full paper into the vault as an attachment + extracts a Markdown companion; citation generation preserves DOI and venue info in the literature note's frontmatter. Common failure: fetching the PDF reflexively when the abstract answers the question.
+
+**3.4 Interconnection** — surface existing vault notes related to new research. Baseline: ask Claude to run `get_similar` on the note under development, and inspect the candidates. For a whole-vault sweep, invoke `propose-links`. Idea: the tangent you chased three months ago is probably already a note — find it. With scholar-mcp: cross-reference papers in your literature notes — `get_paper`'s reference/citation graph sometimes reveals that two things you've been researching separately share a canonical paper. Common failure: missing an existing note because you forgot what you called it; `get_similar` catches these.
+
+**3.5 Writing a paper from notes** — the co-evolution loop. Baseline: start a `Draft/{paper-slug}.md` note, pull paragraphs from existing research notes, ask Claude to flag unsourced claims, run the grounding loop, push citations back into both the paper and the source notes. Tangents encountered while writing that don't fit this paper's scope → standalone notes, triaged normally (PARA Inbox / Zettelkasten Fleeting / etc.). With scholar-mcp: generate the references file in the author's preferred format (BibTeX, CSL-JSON, RIS) from the literature notes' DOIs. Common failure: letting tangents dilute the paper draft because capturing them separately feels like overhead.
+
+### Section 4 — Pitfalls (~60 lines)
+
+- False confidence is the real risk. One paragraph framing.
+- Real example: the fabricated-citation story from the blog, condensed and generalised (don't expose the original domain). Something like: "A session produced a confident assertion backed by a plausible-sounding paper. The title read like something that should exist, the DOI was formatted correctly, the authors were prominent in the field. The paper did not exist. Only a targeted follow-up — search for the paper, verify authors, check the DOI — caught it."
+- Make uncertainty explicit *in the notes*, not just in your head. Future Claude sessions read the note back and treat confident prose as settled fact.
+- The `[citation needed]` marker is not a nice-to-have. It's how you keep the workflow honest.
+- Verify before the note looks like a deliverable. Polish is premature if claims aren't checked.
+- Don't let the guide sound preachy — one short section, emphasis on the lesson, not the finger-wagging.
+
+### Section 5 — A worked example (~40 lines)
+
+One generic scenario (not security-economics, not tied to a specific field) that threads all five phases in 3-4 paragraphs:
+
+- Seed: a note capturing a half-formed opinion on some topic.
+- Grounding: find supporting literature, mark unsourced claims.
+- Absorbing: one detailed literature note for the central source, short summaries for two others.
+- Interconnection: `get_similar` surfaces a forgotten note from six months ago that covers an adjacent angle.
+- Producing: a short draft uses the material; one tangent becomes a new standalone note for later.
+
+Written as narrative, not a step-by-step. Shows the loop in action. ~40 lines.
+
+### Section 6 — Next steps (~20 lines)
+
+Cross-links:
+
+- [Zettelkasten guide](zettelkasten.md) — idea-centric organisation; pairs well with literature notes.
+- [PARA guide](para.md) — action-oriented organisation; research fits under Resources (reference material) and Projects (active research outputs).
+- [Obsidian Everywhere](obsidian-everywhere.md) — multi-device setup for phone-first capture.
+- [MCP Prompts reference](../prompts.md) — especially the ambient-patterns section and `propose-links`.
+- [scholar-mcp](https://github.com/pvliesdonk/scholar-mcp) — when citation rigour matters.
+
+## Integration Touchpoints
+
+### New files
+
+- `docs/guides/research-workflows.md` — the guide itself.
+
+### Updated files
+
+- `mkdocs.yml` — two nav entries:
+  - llmstxt Guides section (~line 70): `- guides/research-workflows.md: Research workflows (seed → ground → absorb → interconnect → produce, with optional scholar-mcp integration)`. Positioned after `guides/obsidian-everywhere.md` (the multi-device setup dependency) and before `guides/zettelkasten.md` (since those guides reference research-workflows from Next Steps).
+  - Visible nav block (~line 135): `- Research workflows: guides/research-workflows.md`, in the same position.
+- `docs/guides/index.md` — add a table row: `| Do research (literature grounding, interconnected notes, paper drafting) | [Research workflows](research-workflows.md) |`. Positioned after Obsidian Everywhere and before Zettelkasten.
+- `docs/guides/zettelkasten.md` — one bullet added to Next Steps: `- **Research workflows**: [docs/guides/research-workflows.md](research-workflows.md) — literature grounding, fact-checking, and writing papers from notes`.
+- `docs/guides/para.md` — one bullet added to Next Steps: same wording as above.
+- `README.md` — update the existing "Research a topic into your vault" bullet in the "What you can do with it" section to link to the new guide: `- **Research a topic into your vault.** "Research product security regulations..." [...] — see the [Research workflows guide](https://pvliesdonk.github.io/markdown-vault-mcp/guides/research-workflows/) for the full loop.`
+- `docs/index.md` — update the parallel bullet in its mirror section to link to the new guide using a relative path: `[Research workflows guide](guides/research-workflows.md)`.
+
+### Zero changes
+
+- `src/` — no code changes.
+- `tests/` — no new tests. Pure content PR.
+- `examples/` — no new pack or template additions. Guide references the existing Zettelkasten `literature.md` template.
+- No new env vars, no new prompts, no new tools.
+
+## Testing Strategy
+
+Content-only PR. Testing:
+
+1. **MkDocs strict build** — `uv run mkdocs build --strict` passes. Catches broken internal links, missing nav entries, unresolved anchors.
+2. **Link audit** — every internal link in the new guide resolves. Specifically:
+   - `../prompts.md#ambient-patterns-without-prompts` (added in PR #388)
+   - `../prompts.md#propose-links` (same PR)
+   - `zettelkasten.md` and `para.md` as siblings
+   - `obsidian-everywhere.md` for the setup reference
+   - The Zettelkasten `literature.md` template path from `../../examples/zettelkasten/templates/literature.md`
+3. **Pre-commit** — all hooks pass (trailing whitespace, EOF, YAML, large files). No Python changes, so ruff/mypy skip cleanly.
+4. **Manual read-through** — the guide flows from intro → phases → pitfalls → example → next steps without redundancy. Each phase's Baseline/With scholar-mcp/Common failure structure is consistent.
+
+No new unit or integration tests.
+
+## Risks / Tradeoffs
+
+- **scholar-mcp callouts may drift as scholar-mcp evolves.** The guide names specific scholar-mcp tools (`search_papers`, `get_references`, `convert_pdf_to_markdown`, `get_paper`). If scholar-mcp renames or removes any of these, the callouts become inaccurate. Mitigation: the SYNC.md file or a similar cross-repo tracker gets an entry noting the guide's scholar-mcp tool references; when scholar-mcp's tool surface changes, the guide gets updated. Low-risk; scholar-mcp tool names are stable.
+- **Web-search capabilities vary by client.** The baseline assumes Claude has web-search tools. Claude Desktop does; Claude.ai does; Claude Code depends on the configured tools. The guide calls this out in a short note so readers on a web-search-less client know to add web search or fall back to scholar-mcp.
+- **Worked example risks feeling contrived.** A generic scenario lacks the texture of a real session. Mitigation: keep the example short (3-4 paragraphs), name the phases explicitly, don't over-invent. If it feels thin, the reader still has the phase sections.
+- **Overlap with Zettelkasten and PARA guides.** Both guides mention research in passing. The new guide is the canonical home; the older guides stay as-is (their existing content is scheme-specific, not research-specific) and get a Next Steps pointer. No content is moved; no duplication is removed. Low risk of drift.
+- **The false-confidence warning may read as preachy.** One short section, not a sermon. The real example (fabricated citation) grounds it. Avoid moralising.
+
+## Future Work
+
+- **Vault-to-paper authoring workflows.** A follow-up guide could cover LaTeX/Markdown-to-PDF pipelines, citation manager integration, and collaborative review. Out of scope here.
+- **A research template pack.** If usage shows the Zettelkasten `literature.md` template is widely adopted for research and users ask for a research-specific template with a `relevance` field or a claims section, a small `examples/research/templates/` pack is justified. Not needed now.
+- **Integration with the blog, if it's ever published.** The blog could link back to the guide as the practical companion. Not a design concern for this PR.
+
+## Acceptance Criteria
+
+- `docs/guides/research-workflows.md` exists, ~500 lines, follows the section structure in §Guide Structure.
+- The five phases each have the Intent / Baseline flow / With scholar-mcp / Common failure structure.
+- The Pitfalls section includes the fabricated-citation story (absorbed from the blog) and codifies the claim-tracking convention.
+- scholar-mcp is positioned as optional throughout; every baseline flow works without it.
+- MkDocs nav has the new entry in both the llmstxt and visible blocks.
+- `docs/guides/index.md` has a new table row.
+- Zettelkasten and PARA guides each have a Next Steps bullet linking to the new guide.
+- README and `docs/index.md` update their existing "Research a topic" bullets to link to the new guide.
+- `uv run mkdocs build --strict` passes with no new warnings.
+- No `src/`, `tests/`, or `examples/` changes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ plugins:
           - guides/authentication.md: Authentication modes — bearer token, OIDC, and troubleshooting
           - guides/oidc-providers.md: OIDC provider setup (Authelia, Keycloak, Google, GitHub via broker)
           - guides/obsidian-everywhere.md: Reference architecture for desktop + mobile + Claude on one vault
+          - guides/research-workflows.md: Research workflows (seed → ground → absorb → interconnect → produce, with optional scholar-mcp integration)
           - guides/zettelkasten.md: Zettelkasten workflow (fleeting → literature → permanent notes, MOCs, graph navigation)
           - guides/para.md: PARA workflow (Projects/Areas/Resources/Archive with triage, kickoff, and weekly review prompts)
           - guides/mcp-apps.md: MCP Apps — Context Card, Graph Explorer, Vault Browser, and Note Preview views
@@ -132,6 +133,7 @@ nav:
       - Authentication: guides/authentication.md
       - OIDC Providers: guides/oidc-providers.md
       - Obsidian Everywhere: guides/obsidian-everywhere.md
+      - Research Workflows: guides/research-workflows.md
       - Zettelkasten: guides/zettelkasten.md
       - PARA: guides/para.md
       - MCP Apps: guides/mcp-apps.md


### PR DESCRIPTION
## Summary

Adds a new user-facing guide at \`docs/guides/research-workflows.md\` codifying the LLM-augmented research loop in a markdown vault: seed → ground → absorb → interconnect → produce. Pure-docs PR, no code changes.

## Design

- **Organising-scheme-agnostic.** Works with [Zettelkasten](docs/guides/zettelkasten.md), [PARA](docs/guides/para.md), or neither. Phase model composes generic search/linking/write tools without assuming a folder layout.
- **scholar-mcp-optional.** Baseline flows assume only Claude + markdown-vault-mcp + web search. Each phase has a "With scholar-mcp" callout showing what's gained (real paper IDs, citation graphs, BibTeX export, PDF-to-Markdown) — a power-up, not a prerequisite.
- **Absorbs load-bearing content from an unpublished companion blog post.** The fabricated-citation anecdote (Pitfalls → False confidence) and the claim-tracking discipline (inline \`[citation needed]\` markers + \`## Open claims\` sections) are grounded in real practitioner experience.

Spec: [\`docs/superpowers/specs/2026-04-19-research-workflows-guide-design.md\`](docs/superpowers/specs/2026-04-19-research-workflows-guide-design.md)

## Changes

- **New:** \`docs/guides/research-workflows.md\` (395 lines, six sections: intro, setup, five phases, pitfalls, worked example, next steps).
- **Nav wiring:** \`mkdocs.yml\` (both llmstxt and visible nav blocks), \`docs/guides/index.md\` (new table row).
- **Teaser updates:** README and \`docs/index.md\` "What you can do with it" Research bullets now link to the new guide (absolute URL in README per project convention; relative path in \`docs/index.md\`).
- **Cross-links:** Zettelkasten and PARA guides each get a Next Steps bullet pointing at the new guide.

## Test plan

- [x] \`uv run pytest -x -q\` — 1397 tests pass (no code changed, regression check only)
- [x] \`uv run pre-commit run --all-files\` — all hooks clean
- [x] \`uv run mkdocs build --strict\` — clean build, only pre-existing INFO notices
- [x] Code-quality review caught two real issues, both fixed: a \`search(query="")\` no-op (replaced with \`list_documents()\` + client-side filter, matching actual server behaviour) and an implicit \`write()\` step in the \`convert_pdf_to_markdown\` callout (made explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)