### PR TITLE
ci: docs workflow checks out main on release to avoid tag-moved race

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # On release events the triggering tag may move after the workflow is
+          # queued (the release workflow pushes a version-bump commit and
+          # updates the tag). Checkout main explicitly on releases to avoid the
+          # "ref does not point to the expected commit" error from
+          # actions/checkout's SHA-verification.
+          ref: ${{ github.event_name == 'release' && 'main' || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0


### PR DESCRIPTION
## Problem

The v1.23.0 release-triggered docs build failed:

\`\`\`
##[error]The ref 'refs/tags/v1.23.0' does not point to the expected commit
'a337271735b1997e7c4ad6b9be3a5c1c065bc268'. The ref may have been updated
after the workflow was triggered.
\`\`\`

The release workflow publishes the tag, then pushes a version-bump commit to main and updates the tag to point at the new HEAD. The docs workflow was queued with the tag pointing at one SHA; by the time it runs, the tag points at a different SHA, and \`actions/checkout@v6\`'s SHA-verification fails.

This failure is independent of PR #389 (which gated deploy on release). The build itself is what fails, before mkdocs runs.

## Fix

On release events, checkout \`main\` explicitly. Docs reflect current main at the time the release was published — which is what we want anyway, and what avoids the tag race.

\`\`\`yaml
- uses: actions/checkout@v6
  with:
    ref: \${{ github.event_name == 'release' && 'main' || github.ref }}
\`\`\`

Push and pull_request events fall through to the default \`github.ref\` as before.

## Recovery for v1.23.0

The v1.23.0 release is already published but its docs didn't deploy. After this PR merges, recovery options:

- **Rerun the failed workflow** from the Actions UI (Actions → Documentation → run 24637267113 → Re-run failed jobs). The tag has settled by now, so the checkout will succeed.
- Or publish v1.23.1 when ready — the fresh release event will deploy docs automatically.

## Test plan

- [ ] Merge.
- [ ] Rerun the v1.23.0 docs build or wait for the next release. Verify deploy completes and the research-workflows guide appears on [the docs site](https://pvliesdonk.github.io/markdown-vault-mcp/guides/research-workflows/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)