### PR TITLE
ci: move manifest bump into semantic-release build_command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,50 +58,6 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
           prerelease_token: rc
 
-      - name: Update versioned manifests to released version
-        if: steps.release.outputs.released == 'true' && !inputs.prerelease
-        env:
-          VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          # server.json (existing logic)
-          jq --arg v "$VERSION" '
-            .version = $v |
-            .packages |= map(
-              if .registryType == "pypi" then .version = $v
-              elif .registryType == "oci" then .identifier = ("ghcr.io/pvliesdonk/markdown-vault-mcp:v" + $v)
-              else . end
-            )
-          ' server.json > server.json.tmp
-          mv server.json.tmp server.json
-
-          # Claude Code plugin.json (new)
-          jq --arg v "$VERSION" '.version = $v' \
-            .claude-plugin/plugin/.claude-plugin/plugin.json > plugin.json.tmp
-          mv plugin.json.tmp .claude-plugin/plugin/.claude-plugin/plugin.json
-
-          # Claude Code .mcp.json — keep --from spec in lockstep with plugin.json (new)
-          jq --arg v "$VERSION" '
-            ."markdown-vault-mcp".args = [
-              "--from", ("markdown-vault-mcp[all]==" + $v),
-              "markdown-vault-mcp", "serve"
-            ]
-          ' .claude-plugin/plugin/.mcp.json > mcp.json.tmp
-          mv mcp.json.tmp .claude-plugin/plugin/.mcp.json
-
-          git config user.name "github-actions"
-          git config user.email "actions@users.noreply.github.com"
-          git add server.json \
-                  .claude-plugin/plugin/.claude-plugin/plugin.json \
-                  .claude-plugin/plugin/.mcp.json
-          git diff --cached --quiet || git commit -m "chore: update manifests to v${VERSION} [skip ci]"
-          git push
-
-          # Re-point the release tag to the manifest-bump commit so that
-          # marketplace installs (which checkout .claude-plugin/plugin at
-          # ref: vVERSION) get the updated plugin.json and .mcp.json.
-          git tag -f "v${VERSION}"
-          git push --force origin "refs/tags/v${VERSION}"
-
       - name: Build package
         if: steps.release.outputs.released == 'true'
         run: uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,17 @@ ignore_errors = true
 version_toml = ["pyproject.toml:project.version"]
 commit_parser = "angular"
 tag_format = "v{version}"
+# Bump the versioned manifests inside the release commit rather than in a
+# follow-up commit + force-retag. See issue #392.
+build_command = "bash scripts/bump_manifests.sh"
+# PSR stages and commits files listed in `assets` together with pyproject.toml
+# and CHANGELOG.md, so the release tag points at a single commit containing
+# all version-coupled files.
+assets = [
+    "server.json",
+    ".claude-plugin/plugin/.claude-plugin/plugin.json",
+    ".claude-plugin/plugin/.mcp.json",
+]
 
 [tool.semantic_release.changelog]
 changelog_file = "CHANGELOG.md"

--- a/scripts/bump_manifests.sh
+++ b/scripts/bump_manifests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Bump versioned manifests to match the semantic-release version.
+#
+# Invoked by python-semantic-release via `[tool.semantic_release] build_command`.
+# PSR sets NEW_VERSION in the environment and, because the three manifest
+# paths are listed in `[tool.semantic_release] assets`, PSR stages and commits
+# them together with pyproject.toml + CHANGELOG.md as the single release
+# commit — which is the commit it then tags. This keeps the tag, the manifest
+# bumps, and the pyproject version atomic (no force-retag, no race for
+# release-triggered workflows).
+set -euo pipefail
+
+: "${NEW_VERSION:?NEW_VERSION must be set (python-semantic-release build_command env)}"
+
+V="$NEW_VERSION"
+
+# server.json — top-level version, PyPI package version, OCI tag identifier.
+jq --arg v "$V" '
+  .version = $v
+  | .packages |= map(
+      if .registryType == "pypi" then .version = $v
+      elif .registryType == "oci" then .identifier = ("ghcr.io/pvliesdonk/markdown-vault-mcp:v" + $v)
+      else . end
+    )
+' server.json > server.json.tmp
+mv server.json.tmp server.json
+
+# Claude Code plugin.json — plugin version (lockstep with package).
+jq --arg v "$V" '.version = $v' \
+  .claude-plugin/plugin/.claude-plugin/plugin.json > plugin.json.tmp
+mv plugin.json.tmp .claude-plugin/plugin/.claude-plugin/plugin.json
+
+# Claude Code .mcp.json — pin uvx --from spec to the released version.
+jq --arg v "$V" '
+  ."markdown-vault-mcp".args = [
+    "--from", ("markdown-vault-mcp[all]==" + $v),
+    "markdown-vault-mcp", "serve"
+  ]
+' .claude-plugin/plugin/.mcp.json > mcp.json.tmp
+mv mcp.json.tmp .claude-plugin/plugin/.mcp.json

--- a/scripts/bump_manifests.sh
+++ b/scripts/bump_manifests.sh
@@ -15,11 +15,13 @@ set -euo pipefail
 V="$NEW_VERSION"
 
 # server.json — top-level version, PyPI package version, OCI tag identifier.
+# Replace only the `:v<old>` suffix of the OCI identifier so forks/renames
+# keep their own `ghcr.io/<owner>/<image>` base.
 jq --arg v "$V" '
   .version = $v
   | .packages |= map(
       if .registryType == "pypi" then .version = $v
-      elif .registryType == "oci" then .identifier = ("ghcr.io/pvliesdonk/markdown-vault-mcp:v" + $v)
+      elif .registryType == "oci" then .identifier |= sub(":v[^:]+$"; ":v" + $v)
       else . end
     )
 ' server.json > server.json.tmp


### PR DESCRIPTION
## Summary

- Moves the three-manifest version bump (`server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, `.claude-plugin/plugin/.mcp.json`) from a post-release workflow step into python-semantic-release's `build_command`, with the files declared as `assets` so PSR stages + commits them into the release commit it then tags.
- Deletes the 44-line "Update versioned manifests to released version" step in `release.yml`, including the `git tag -f` + force push that was the source of the race.
- Result: one release commit, one tag, no force-retag, no "chore: update manifests [skip ci]" follow-up, and release-triggered workflows (e.g. `docs.yml`) no longer see a tag whose SHA changed mid-run.

Closes #392. Keeps #391's defensive `main`-checkout in `docs.yml` as belt-and-suspenders.

## Why `assets` is needed

PSR's `build_command` runs between `apply_version_to_source_files` and `git_add` (see [`version.py:662-711`](https://github.com/python-semantic-release/python-semantic-release/blob/master/src/semantic_release/cli/commands/version.py)), but it does **not** auto-stage files that the build command modifies — `all_paths_to_add` is built from version-declaration paths + `assets` only. Listing the three manifests in `[tool.semantic_release] assets` is what lands them in the release commit.

## Behavior change

The previous workflow only bumped manifests on stable releases (`!inputs.prerelease`). With `build_command`, PSR runs the script for every release including RCs, so RC commits will now also carry bumped manifests. This is the behavior the issue explicitly endorses — the marketplace PR is still gated on `!inputs.prerelease`, so RC bumps never escape the repo.

## Test plan

- [x] `NEW_VERSION=9.9.9-smoke bash scripts/bump_manifests.sh` — verified all three files update to the expected shape; restored cleanly.
- [x] `uvx --from python-semantic-release==10.5.3 semantic-release --noop version` — config parses cleanly (only pre-existing deprecation warnings for `angular` parser and `changelog_file` location).
- [x] `uv run pytest -x -q` — 1397 passed.
- [x] `uv run mypy src/` — no issues.
- [x] `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .` — clean.
- [ ] Cut an RC release (`workflow_dispatch` with `prerelease: true`) after merge and verify: (1) the release commit contains all three bumped manifests, (2) no separate "chore: update manifests" commit follows, (3) release-triggered workflows check out a stable tag SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)