### PR TITLE
test: accept PSR prerelease version format in mcpb packaging tests

### DIFF
--- a/tests/test_packaging_mcpb.py
+++ b/tests/test_packaging_mcpb.py
@@ -15,6 +15,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 MCPB_DIR = REPO_ROOT / "packaging" / "mcpb"
 PLUGIN_DIR = REPO_ROOT / ".claude-plugin" / "plugin"
 
+# Stable `X.Y.Z` or python-semantic-release prerelease format `X.Y.Z-rc.N`.
+# The release workflow bumps the manifests for every release including RCs
+# (via PSR's build_command), so main may carry an RC version between stable
+# releases.
+_VERSION_RE = re.compile(r"\d+\.\d+\.\d+(?:-rc\.\d+)?")
+
 
 def test_cli_main_import_target_exists() -> None:
     """The mcpb shim imports markdown_vault_mcp.cli.main — make sure it exists."""
@@ -110,12 +116,11 @@ def test_claude_code_plugin_json_shape() -> None:
     assert plugin["repository"] == "https://github.com/pvliesdonk/markdown-vault-mcp"
     assert plugin["license"] == "MIT"
 
-    # Version must look like a real semver — not a template literal.
+    # Version must look like a real semver (stable or RC) — not a template literal.
     version = plugin["version"]
     assert version != "${VERSION}"
-    parts = version.split(".")
-    assert len(parts) == 3 and all(p.isdigit() for p in parts), (
-        f"expected X.Y.Z semver, got {version!r}"
+    assert _VERSION_RE.fullmatch(version), (
+        f"expected X.Y.Z or X.Y.Z-rc.N, got {version!r}"
     )
 
 
@@ -135,7 +140,7 @@ def test_plugin_mcp_json_pinned_and_matches_plugin_version() -> None:
     assert "--from" in args, f"args must include --from, got {args}"
     from_index = args.index("--from")
     spec = args[from_index + 1]
-    match = re.fullmatch(r"markdown-vault-mcp\[all\]==(\d+\.\d+\.\d+)", spec)
+    match = re.fullmatch(rf"markdown-vault-mcp\[all\]==({_VERSION_RE.pattern})", spec)
     assert match, f"unexpected --from spec: {spec!r}"
 
     plugin_version = _load_plugin_json()["version"]

--- a/tests/test_packaging_mcpb.py
+++ b/tests/test_packaging_mcpb.py
@@ -131,7 +131,7 @@ def _load_plugin_mcp_json() -> dict:
 
 
 def test_plugin_mcp_json_pinned_and_matches_plugin_version() -> None:
-    """.mcp.json must pin --from markdown-vault-mcp[all]==<X.Y.Z> and match plugin.json."""
+    """.mcp.json must pin --from markdown-vault-mcp[all]==<X.Y.Z[-rc.N]> and match plugin.json."""
     mcp_cfg = _load_plugin_mcp_json()
     entry = mcp_cfg["markdown-vault-mcp"]
     assert entry["command"] == "uvx"

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "1.23.0"
+version = "1.23.1rc1"
 source = { editable = "." }
 dependencies = [
     { name = "python-frontmatter" },


### PR DESCRIPTION
## Summary

Fallout from the manifest-bump refactor (#393/#394): PSR's `build_command` now runs for every release including RCs, so `main` can carry `X.Y.Z-rc.N` in `plugin.json` and `.mcp.json` between stable releases (this was the intentional behavior change called out in #392).

Two tests in `tests/test_packaging_mcpb.py` baked in a strict `X.Y.Z` check and broke on the first post-refactor RC push ([run 24638882251](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/24638882251) on `v1.23.1-rc.1`):

- `test_claude_code_plugin_json_shape` — required 3 dot-separated integer parts
- `test_plugin_mcp_json_pinned_and_matches_plugin_version` — required `markdown-vault-mcp[all]==X.Y.Z`

## Fix

Introduce a shared `_VERSION_RE = re.compile(r"\d+\.\d+\.\d+(?:-rc\.\d+)?")` and use it in both assertions. The other invariants the tests check (no template literal, plugin.json/.mcp.json agreement, the `uvx` / `--from` wiring) are untouched.

Also catches up `uv.lock` to `1.23.1rc1` to match the new `pyproject.toml` version (uv normalizes to PEP 440 form).

## Test plan

- [x] `uv run pytest tests/test_packaging_mcpb.py -v` → 6 pass (against current main at `1.23.1-rc.1`)
- [x] Full suite: `uv run pytest -x -q` → 1397 pass
- [x] `uv run ruff check/format`, `uv run mypy src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)