### PR TITLE
refactor(auth): delegate auth builders to fastmcp-pvl-core (MV-PR2)

### DIFF
--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -784,8 +784,6 @@ def resolve_auth_mode(config: CollectionConfig) -> str | None:
     Returns:
         ``"remote"``, ``"oidc-proxy"``, or ``None``.
     """
-    from dataclasses import replace
-
     server = _server_from_collection(config)
     mode = _core_resolve_auth_mode(server)
     if mode == "multi":

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from fastmcp_pvl_core import ServerConfig
+from fastmcp_pvl_core import build_bearer_auth as _core_build_bearer_auth
+from fastmcp_pvl_core import build_oidc_proxy_auth as _core_build_oidc_proxy_auth
+from fastmcp_pvl_core import build_remote_auth as _core_build_remote_auth
 from fastmcp_pvl_core import env as _core_env
 
 # Direct re-exports: parse_bool/parse_list match MV's old call shape (take a
@@ -22,6 +24,7 @@ from fastmcp_pvl_core import env as _core_env
 from fastmcp_pvl_core import parse_bool as _parse_bool
 from fastmcp_pvl_core import parse_list as _parse_list
 from fastmcp_pvl_core import parse_scopes as _core_parse_scopes
+from fastmcp_pvl_core import resolve_auth_mode as _core_resolve_auth_mode
 
 logger = logging.getLogger(__name__)
 
@@ -730,20 +733,50 @@ def load_config() -> CollectionConfig:
 
 
 # ---------------------------------------------------------------------------
-# Auth builder functions
+# Auth builder functions — thin wrappers that delegate to fastmcp-pvl-core.
+#
+# Each wrapper accepts the legacy :class:`CollectionConfig` (which still
+# carries duplicated auth/OIDC fields), constructs a transient
+# :class:`ServerConfig` view via :func:`_server_from_collection`, and
+# delegates to the core implementation.  The duplicates on
+# :class:`CollectionConfig` will be removed in a later PR once consumers
+# (currently :mod:`markdown_vault_mcp.mcp_server`) read directly from
+# ``config.server`` instead.
 # ---------------------------------------------------------------------------
 
 
+def _server_from_collection(config: CollectionConfig) -> ServerConfig:
+    """Build a :class:`ServerConfig` view from CollectionConfig duplicates.
+
+    The duplicate auth fields on :class:`CollectionConfig` are still the
+    source of truth for the auth wrappers in this module — until consumers
+    migrate to :attr:`CollectionConfig.server`, we synthesize a transient
+    :class:`ServerConfig` from the same duplicates so ``fastmcp_pvl_core``
+    can do the actual work.
+    """
+    return ServerConfig(
+        base_url=config.base_url,
+        bearer_token=config.bearer_token,
+        oidc_config_url=config.oidc_config_url,
+        oidc_client_id=config.oidc_client_id,
+        oidc_client_secret=config.oidc_client_secret,
+        oidc_audience=config.oidc_audience,
+        oidc_required_scopes=tuple(_parse_scopes(config.oidc_required_scopes) or ()),
+        oidc_jwt_signing_key=config.oidc_jwt_signing_key,
+        oidc_verify_access_token=config.oidc_verify_access_token,
+        auth_mode=config.auth_mode,
+    )
+
+
 def resolve_auth_mode(config: CollectionConfig) -> str | None:
-    """Determine which OIDC auth mode to use.
+    """Return the OIDC auth flavor for *config*, or ``None`` for no OIDC.
 
-    Checks ``config.auth_mode`` for an explicit override.  When not set,
-    auto-detects based on which config fields are populated:
-
-    - All four OIDC fields (base_url, oidc_config_url, oidc_client_id,
-      oidc_client_secret) -> ``"oidc-proxy"``
-    - Only base_url + oidc_config_url -> ``"remote"``
-    - Otherwise -> ``None`` (no OIDC)
+    Existing callers (``mcp_server.create_server``) compose multi-auth
+    themselves by combining the OIDC flavor with the bearer verifier, so
+    this wrapper hides core's ``"multi"`` outcome by re-resolving with
+    the bearer token suppressed — the caller still sees just the OIDC
+    flavor (``"remote"`` / ``"oidc-proxy"``) and ``None`` for bearer-only
+    or no-auth configurations.
 
     Args:
         config: Populated configuration object.
@@ -751,263 +784,41 @@ def resolve_auth_mode(config: CollectionConfig) -> str | None:
     Returns:
         ``"remote"``, ``"oidc-proxy"``, or ``None``.
     """
-    explicit = (config.auth_mode or "").strip().lower()
-    if explicit in ("remote", "oidc-proxy"):
-        logger.info("OIDC auth mode: %s (explicit via AUTH_MODE)", explicit)
-        return explicit
-    if explicit:
-        logger.warning(
-            "Unknown AUTH_MODE %r — ignoring, falling back to auto-detection",
-            explicit,
-        )
+    from dataclasses import replace
 
-    if all(
-        [
-            config.base_url,
-            config.oidc_config_url,
-            config.oidc_client_id,
-            config.oidc_client_secret,
-        ]
-    ):
-        logger.info(
-            "OIDC auth mode: oidc-proxy (auto-detected — all four OIDC vars set)"
-        )
-        return "oidc-proxy"
-
-    if config.base_url and config.oidc_config_url:
-        logger.info(
-            "OIDC auth mode: remote (auto-detected — BASE_URL + OIDC_CONFIG_URL set)"
-        )
-        return "remote"
-
-    return None
+    server = _server_from_collection(config)
+    mode = _core_resolve_auth_mode(server)
+    if mode == "multi":
+        mode = _core_resolve_auth_mode(replace(server, bearer_token=None))
+    return None if mode in ("none", "bearer") else mode
 
 
 def build_remote_auth(config: CollectionConfig) -> Any:
-    """Build a RemoteAuthProvider from OIDC discovery.
+    """Build a :class:`RemoteAuthProvider` from OIDC discovery.
 
-    Fetches the OIDC discovery document at startup to extract ``jwks_uri``
-    and ``issuer``, then constructs a ``JWTVerifier`` for local token
-    validation via JWKS.  No client credentials are needed -- tokens are
-    validated locally.
-
-    Requires ``base_url`` and ``oidc_config_url`` on *config*.
-
-    Args:
-        config: Populated configuration object.
-
-    Returns:
-        A configured ``RemoteAuthProvider``, or ``None`` when required
-        fields are missing or the discovery fetch fails.
+    Delegates to :func:`fastmcp_pvl_core.build_remote_auth`.  Returns
+    ``None`` when ``base_url`` / ``oidc_config_url`` are missing, when
+    ``httpx`` is not installed, when discovery fails, or when the
+    discovery document is missing required keys.
     """
-    if not config.base_url or not config.oidc_config_url:
-        logger.debug("Remote auth: disabled — missing BASE_URL or OIDC_CONFIG_URL")
-        return None
-
-    audience = config.oidc_audience
-    required_scopes = _parse_scopes(config.oidc_required_scopes)
-
-    try:
-        import httpx
-    except ImportError:
-        logger.error(
-            "Remote auth: 'httpx' is not installed. "
-            "Install it with: pip install 'markdown-vault-mcp[all]' "
-            "or pip install httpx"
-        )
-        return None
-
-    try:
-        resp = httpx.get(config.oidc_config_url, timeout=10)
-        resp.raise_for_status()
-        discovery = resp.json()
-    except Exception:
-        logger.exception(
-            "Remote auth: failed to fetch OIDC discovery from %s",
-            config.oidc_config_url,
-        )
-        return None
-
-    jwks_uri = discovery.get("jwks_uri")
-    issuer = discovery.get("issuer")
-    if not jwks_uri or not issuer:
-        logger.error(
-            "Remote auth: OIDC discovery missing jwks_uri or issuer "
-            "(got jwks_uri=%s, issuer=%s)",
-            jwks_uri,
-            issuer,
-        )
-        return None
-
-    logger.debug(
-        "Remote auth config:\n"
-        "  config_url      = %s\n"
-        "  jwks_uri        = %s\n"
-        "  issuer          = %s\n"
-        "  base_url        = %s\n"
-        "  audience        = %s\n"
-        "  required_scopes = %s",
-        config.oidc_config_url,
-        jwks_uri,
-        issuer,
-        config.base_url,
-        audience or "(not set)",
-        required_scopes or "(not set)",
-    )
-
-    from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider
-
-    verifier = JWTVerifier(
-        jwks_uri=jwks_uri,
-        issuer=issuer,
-        audience=audience,
-        required_scopes=required_scopes,
-    )
-    return RemoteAuthProvider(
-        token_verifier=verifier,
-        authorization_servers=[issuer],
-        base_url=config.base_url,
-    )
+    return _core_build_remote_auth(_server_from_collection(config))
 
 
 def build_bearer_auth(config: CollectionConfig) -> Any:
-    """Build a StaticTokenVerifier from ``config.bearer_token``.
+    """Build a :class:`StaticTokenVerifier` from ``config.bearer_token``.
 
-    When the bearer token is set (non-empty), returns a
-    :class:`~fastmcp.server.auth.StaticTokenVerifier` that validates
-    ``Authorization: Bearer <token>`` headers against the configured
-    static token.
-
-    Args:
-        config: Populated configuration object.
-
-    Returns:
-        A configured ``StaticTokenVerifier``, or ``None`` when the
-        bearer token is absent or empty.
+    Delegates to :func:`fastmcp_pvl_core.build_bearer_auth`.  Returns
+    ``None`` when the bearer token is absent or blank.
     """
-    token = (config.bearer_token or "").strip()
-    if not token:
-        logger.debug("Bearer auth: BEARER_TOKEN not set — skipping")
-        return None
-    logger.debug("Bearer auth: BEARER_TOKEN is set (value redacted)")
-    from fastmcp.server.auth import StaticTokenVerifier
-
-    return StaticTokenVerifier(
-        tokens={token: {"client_id": "bearer", "scopes": ["read", "write"]}}
-    )
+    return _core_build_bearer_auth(_server_from_collection(config))
 
 
 def build_oidc_auth(config: CollectionConfig) -> Any:
-    """Build an OIDCProxy auth provider from configuration, or return None.
+    """Build an :class:`OIDCProxy` provider, or return ``None``.
 
-    All four of ``base_url``, ``oidc_config_url``, ``oidc_client_id``,
-    and ``oidc_client_secret`` must be set on *config* to enable
-    authentication.  If any is absent the server starts unauthenticated.
-
-    By default the proxy verifies the upstream ``id_token`` (a standard
-    JWT per OIDC Core) instead of the ``access_token``.  This works with
-    every OIDC provider -- including those that issue opaque access
-    tokens (e.g. Authelia).  Set ``oidc_verify_access_token=True`` on
-    *config* to revert to access-token verification.
-
-    Args:
-        config: Populated configuration object.
-
-    Returns:
-        A configured :class:`~fastmcp.server.auth.oidc_proxy.OIDCProxy`
-        instance, or ``None`` when authentication is disabled.
+    Delegates to :func:`fastmcp_pvl_core.build_oidc_proxy_auth`.  Returns
+    ``None`` when any of the four required fields (``base_url``,
+    ``oidc_config_url``, ``oidc_client_id``, ``oidc_client_secret``) is
+    missing.
     """
-    # Check required fields.  The secret is checked separately so it never
-    # enters the dict that feeds the logged "missing" list — this keeps
-    # CodeQL's taint analysis happy.
-    required_public = {
-        "BASE_URL": config.base_url,
-        "OIDC_CONFIG_URL": config.oidc_config_url,
-        "OIDC_CLIENT_ID": config.oidc_client_id,
-    }
-    has_secret = bool(config.oidc_client_secret)
-
-    if not all(required_public.values()) or not has_secret:
-        missing = [k for k, v in required_public.items() if not v]
-        if not has_secret:
-            missing.append("OIDC_CLIENT_SECRET")
-        logger.debug("OIDC auth: disabled — missing env vars: %s", ", ".join(missing))
-        return None
-
-    # All four are guaranteed non-None after the guard above.
-    oidc_base_url: str = config.base_url  # type: ignore[assignment]
-    oidc_config_url: str = config.oidc_config_url  # type: ignore[assignment]
-    oidc_client_id: str = config.oidc_client_id  # type: ignore[assignment]
-    oidc_client_secret: str = config.oidc_client_secret  # type: ignore[assignment]
-
-    from fastmcp.server.auth.oidc_proxy import OIDCProxy
-
-    jwt_signing_key = config.oidc_jwt_signing_key
-    audience = config.oidc_audience
-
-    # Parse scopes: default to ["openid"] when not set.
-    raw_scopes = _parse_scopes(config.oidc_required_scopes)
-    required_scopes = raw_scopes if raw_scopes is not None else ["openid"]
-
-    # Default: verify id_token (works with all providers, including opaque
-    # access-token issuers like Authelia).
-    verify_access_token = config.oidc_verify_access_token
-    verify_id_token = not verify_access_token
-
-    logger.debug(
-        "OIDC auth config:\n"
-        "  config_url          = %s\n"
-        "  client_id           = %s\n"
-        "  client_secret       = <redacted>\n"
-        "  base_url            = %s\n"
-        "  audience            = %s\n"
-        "  required_scopes     = %s\n"
-        "  jwt_signing_key     = %s\n"
-        "  verify_id_token     = %s\n"
-        "  verify_access_token = %s",
-        oidc_config_url,
-        oidc_client_id,
-        oidc_base_url,
-        audience or "(not set)",
-        required_scopes,
-        "(set)" if jwt_signing_key else "(not set)",
-        verify_id_token,
-        verify_access_token,
-    )
-
-    if verify_id_token and "openid" not in required_scopes:
-        logger.warning(
-            "OIDC: verify_id_token=True requires the 'openid' scope but it is "
-            "not in MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES — the id_token may "
-            "be absent from the token response; add 'openid' to the scope list "
-            "or set MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN=true"
-        )
-
-    if jwt_signing_key is None and sys.platform.startswith("linux"):
-        logger.warning(
-            "OIDC: MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY is not set — "
-            "the JWT signing key is ephemeral on Linux; all clients must "
-            "re-authenticate after every server restart"
-        )
-
-    if verify_id_token:
-        logger.info(
-            "OIDC: verifying upstream id_token (works with opaque access tokens)"
-        )
-    else:
-        logger.info(
-            "OIDC: verifying upstream access_token as JWT "
-            "(MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN=true)"
-        )
-
-    return OIDCProxy(
-        config_url=oidc_config_url,
-        client_id=oidc_client_id,
-        client_secret=oidc_client_secret,
-        base_url=oidc_base_url,
-        audience=audience,
-        required_scopes=required_scopes,
-        jwt_signing_key=jwt_signing_key,
-        verify_id_token=verify_id_token,
-        require_authorization_consent=False,
-    )
+    return _core_build_oidc_proxy_auth(_server_from_collection(config))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -947,9 +947,11 @@ class TestBuildOidcAuthConfig:
 
         config = _oidc_config()
         mock_cls = MagicMock()
+        # The ephemeral-signing-key warning lives in fastmcp_pvl_core._auth
+        # since MV-PR2; patch sys there, not in markdown_vault_mcp.config.
         with (
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("markdown_vault_mcp.config.sys") as mock_sys,
+            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
         ):
             mock_sys.platform = "linux"
             build_oidc_auth(config)
@@ -975,12 +977,17 @@ class TestBuildRemoteAuthConfig:
     def test_returns_none_on_discovery_failure(self) -> None:
         from unittest.mock import patch
 
+        import httpx
+
         config = CollectionConfig(
             source_dir=Path("/tmp"),
             base_url="https://mcp.example.com",
             oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
         )
-        with patch("httpx.get", side_effect=Exception("fail")):
+        # Core's build_remote_auth catches httpx.HTTPError + ValueError (the
+        # realistic discovery failures) — narrower than MV's old bare
+        # ``except Exception``.  A bare Exception now propagates by design.
+        with patch("httpx.get", side_effect=httpx.ConnectError("fail")):
             assert build_remote_auth(config) is None
 
     def test_happy_path(self) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -881,7 +881,7 @@ class TestBuildOidcAuth:
         mock_cls = MagicMock()
         with (
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("markdown_vault_mcp.config.sys") as mock_sys,
+            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
         ):
             mock_sys.platform = "linux"
             build_oidc_auth(config)
@@ -900,7 +900,7 @@ class TestBuildOidcAuth:
         mock_cls = MagicMock()
         with (
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("markdown_vault_mcp.config.sys") as mock_sys,
+            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
         ):
             mock_sys.platform = "linux"
             build_oidc_auth(config)
@@ -919,7 +919,7 @@ class TestBuildOidcAuth:
         mock_cls = MagicMock()
         with (
             patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("markdown_vault_mcp.config.sys") as mock_sys,
+            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
         ):
             mock_sys.platform = "darwin"
             build_oidc_auth(config)
@@ -951,40 +951,13 @@ class TestBuildOidcAuth:
 
         assert mock_cls.call_args.kwargs["verify_id_token"] is False
 
-    def test_verify_id_token_log_message(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Default config logs that id_token verification is active."""
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            caplog.at_level(logging.INFO, logger="markdown_vault_mcp.config"),
-        ):
-            build_oidc_auth(config)
-
-        assert any("verifying upstream id_token" in r.message for r in caplog.records)
-
-    def test_verify_access_token_log_message(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """OIDC_VERIFY_ACCESS_TOKEN=true logs access-token verification mode."""
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_verify_access_token=True)
-        mock_cls = MagicMock()
-        with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            caplog.at_level(logging.INFO, logger="markdown_vault_mcp.config"),
-        ):
-            build_oidc_auth(config)
-
-        assert any(
-            "verifying upstream access_token as JWT" in r.message
-            for r in caplog.records
-        )
+    # Note: the previous test_verify_id_token_log_message /
+    # test_verify_access_token_log_message tests asserted MV-specific INFO
+    # log strings ("verifying upstream id_token") that fastmcp_pvl_core
+    # replaced with structured key=value logging.  The behavioural
+    # assertion they backed (verify_id_token kwarg flips correctly) is
+    # already covered by test_default_verify_id_token and
+    # test_verify_access_token_disables_verify_id_token above.
 
     def test_warning_when_openid_scope_missing_with_verify_id_token(
         self, caplog: pytest.LogCaptureFixture
@@ -2575,22 +2548,33 @@ class TestAuthModeSelection:
 
 
 class TestAuthDebugLogging:
-    """Tests for auth DEBUG logging (issue #181)."""
+    """Tests for auth DEBUG logging (issue #181).
+
+    The literal log strings asserted here were updated when MV-PR2
+    delegated auth builders to fastmcp_pvl_core, which uses structured
+    ``key=value`` logging instead of MV's old prose strings.  The
+    security-relevant property — secrets never appearing in logs — is
+    preserved verbatim.
+    """
 
     def test_bearer_debug_logs_presence(self, caplog: pytest.LogCaptureFixture) -> None:
         config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="secret-token")
         with caplog.at_level(logging.DEBUG):
             build_bearer_auth(config)
-        assert "BEARER_TOKEN is set" in caplog.text
+        assert "bearer_auth_enabled" in caplog.text
+        assert "<redacted>" in caplog.text
         assert "secret-token" not in caplog.text
 
     def test_bearer_debug_logs_absence(self, caplog: pytest.LogCaptureFixture) -> None:
         config = CollectionConfig(source_dir=Path("/tmp"))
         with caplog.at_level(logging.DEBUG):
             build_bearer_auth(config)
-        assert "BEARER_TOKEN not set" in caplog.text
+        assert "bearer_auth_skipped" in caplog.text
 
-    def test_oidc_debug_logs_config(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_oidc_debug_does_not_leak_secret(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """OIDC builder must never log the client_secret value."""
         from unittest.mock import MagicMock, patch
 
         config = _oidc_config()
@@ -2601,10 +2585,6 @@ class TestAuthDebugLogging:
         ):
             build_oidc_auth(config)
 
-        assert "OIDC auth config:" in caplog.text
-        assert "config_url" in caplog.text
-        assert "client_id" in caplog.text
-        assert "<redacted>" in caplog.text  # client_secret is redacted
         assert "test-secret" not in caplog.text
 
     def test_oidc_debug_logs_missing_vars(
@@ -2617,7 +2597,8 @@ class TestAuthDebugLogging:
         with caplog.at_level(logging.DEBUG):
             result = build_oidc_auth(config)
         assert result is None
-        assert "missing env vars" in caplog.text
+        assert "oidc_proxy_auth_skipped" in caplog.text
+        assert "missing=" in caplog.text
 
     def test_startup_summary_logged(
         self,
@@ -2707,7 +2688,9 @@ class TestResolveAuthMode:
         with caplog.at_level(logging.WARNING):
             result = resolve_auth_mode(config)
         assert result == "remote"
-        assert "Unknown AUTH_MODE 'typo'" in caplog.text
+        # Core's structured warning replaces MV's old "Unknown AUTH_MODE 'X'".
+        assert "auth_mode_unknown" in caplog.text
+        assert "'typo'" in caplog.text
 
     def test_only_base_url_returns_none(self) -> None:
         """base_url alone is not enough for any OIDC mode."""
@@ -2760,24 +2743,30 @@ class TestBuildRemoteAuth:
     def test_discovery_fetch_failure_returns_none(self) -> None:
         from unittest.mock import patch
 
+        import httpx
+
         config = self._remote_config()
-        with patch("httpx.get", side_effect=Exception("connection failed")):
+        # Core's build_remote_auth catches httpx.HTTPError + ValueError; a
+        # bare Exception now propagates by design.
+        with patch("httpx.get", side_effect=httpx.ConnectError("connection failed")):
             assert build_remote_auth(config) is None
 
     def test_httpx_import_error_returns_none(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Missing httpx gives a clear error, not a confusing discovery message."""
+        """Missing httpx gives a clear warning, not a confusing discovery message."""
         import sys as _sys
         from unittest.mock import patch
 
         config = self._remote_config()
+        # Core logs the missing-httpx case at WARNING (was ERROR in MV).
         with (
             patch.dict(_sys.modules, {"httpx": None}),
-            caplog.at_level(logging.ERROR),
+            caplog.at_level(logging.WARNING),
         ):
             assert build_remote_auth(config) is None
-        assert "'httpx' is not installed" in caplog.text
+        assert "remote_auth_skipped" in caplog.text
+        assert "httpx_missing" in caplog.text
 
     def test_happy_path_returns_non_none(self) -> None:
         from unittest.mock import MagicMock, patch
@@ -2916,31 +2905,12 @@ class TestBuildRemoteAuth:
         kw = mock_verifier_cls.call_args.kwargs
         assert kw["required_scopes"] is None
 
-    def test_debug_logging_on_success(self, caplog: pytest.LogCaptureFixture) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = self._remote_config()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "issuer": "https://auth.example.com",
-        }
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_jwt_verifier = MagicMock()
-        mock_verifier_cls = MagicMock(return_value=mock_jwt_verifier)
-        mock_remote_cls = MagicMock()
-
-        with (
-            patch("httpx.get", return_value=mock_resp),
-            patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
-            patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
-            caplog.at_level(logging.DEBUG),
-        ):
-            build_remote_auth(config)
-
-        assert "Remote auth config:" in caplog.text
-        assert "jwks_uri" in caplog.text
+    # Removed test_debug_logging_on_success: it asserted MV's verbose
+    # "Remote auth config:" multi-line debug dump, which fastmcp_pvl_core
+    # doesn't emit (core uses structured key=value logging only on
+    # skip/failure paths).  The behavioural property (success builds a
+    # RemoteAuthProvider) is already covered by test_happy_path_returns_non_none
+    # above.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2574,7 +2574,12 @@ class TestAuthDebugLogging:
     def test_oidc_debug_does_not_leak_secret(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """OIDC builder must never log the client_secret value."""
+        """OIDC builder invokes OIDCProxy and never logs the client_secret.
+
+        The positive leg (``mock_cls.assert_called_once()``) guards against
+        a regression where this test would silently pass if build_oidc_auth
+        bailed out before reaching the proxy construction.
+        """
         from unittest.mock import MagicMock, patch
 
         config = _oidc_config()
@@ -2585,6 +2590,7 @@ class TestAuthDebugLogging:
         ):
             build_oidc_auth(config)
 
+        mock_cls.assert_called_once()
         assert "test-secret" not in caplog.text
 
     def test_oidc_debug_logs_missing_vars(


### PR DESCRIPTION
## Summary

Second PR in the fastmcp-pvl-core adoption series. Replaces MV's local \`resolve_auth_mode\` / \`build_remote_auth\` / \`build_bearer_auth\` / \`build_oidc_auth\` implementations with thin wrappers that delegate to the core library.

- **~280 lines deleted** — httpx discovery, OIDCProxy construction, JWTVerifier wiring, missing-var detection, secret redaction all live in core now.
- A new \`_server_from_collection(config)\` helper synthesises a transient \`ServerConfig\` view from the duplicated auth fields on \`CollectionConfig\`. The wrappers each pass that view to core and return what core returns.
- Public surface (\`resolve_auth_mode\`, \`build_*\`) keeps the same signatures and the same return types so \`mcp_server.create_server\` is unchanged.

## Behavioural notes

1. **\`resolve_auth_mode\` hides core's \`"multi"\`.** Core's resolver has 5 modes (\`none\` / \`bearer\` / \`remote\` / \`oidc-proxy\` / \`multi\`), but MV's caller composes multi-auth itself, so the wrapper re-resolves with the bearer token suppressed and returns only \`"remote"\` / \`"oidc-proxy"\` / \`None\`. Existing branches in \`create_server\` keep working unchanged.
2. **Discovery error class narrowed.** Core catches \`(httpx.HTTPError, ValueError)\`; MV used to catch bare \`Exception\`. A bare \`Exception\` from \`httpx.get\` now propagates by design — tests that simulated \"any failure\" updated to use \`httpx.ConnectError\`.
3. **Log-string format change.** Auth log lines moved from prose (\`\"Bearer auth: BEARER_TOKEN is set\"\`) to core's structured \`key=value\` form (\`\"bearer_auth_enabled token=<redacted>\"\`). Test assertions updated; the security-critical property — secrets never appearing in logs — is preserved verbatim with explicit \`secret-token not in caplog.text\` checks.
4. **3 log-text-only tests deleted as redundant.** \`test_verify_id_token_log_message\`, \`test_verify_access_token_log_message\`, and \`test_debug_logging_on_success\` only asserted log-string format; their behavioural intent (\`verify_id_token\` kwarg flips correctly, \`RemoteAuthProvider\` constructed on success) is already covered by sibling tests inspecting the kwargs passed to mocked classes.

The duplicate auth fields on \`CollectionConfig\` (\`base_url\`, \`bearer_token\`, \`oidc_*\`, \`auth_mode\`) are still populated by \`load_config()\` for now — a later MV-PR migrates \`mcp_server.create_server\` to read from \`config.server\` directly and drops the duplicates.

## Test plan

- [x] \`uv run ruff check --fix . && uv run ruff format .\` — clean
- [x] \`uv run mypy src/\` — no errors
- [x] \`uv run pytest -x -q\` — 1400 passed (was 1397; -3 dropped log-text tests, +6 from MV-PR1 retained, but rebased against main so net -3 actually shows as -2 from baseline; final count 1400)
- [x] \`diff-cover\` on changed lines: 100%
- [x] Total coverage 92.98% (≥80% gate)

## Documentation

No env vars added/removed/renamed. Auth public API surface unchanged (\`resolve_auth_mode\`, \`build_bearer_auth\`, etc. still importable with the same shapes from \`markdown_vault_mcp.config\`). Docs updates wait for the consumer-migration PR that drops the duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)