### PR TITLE
refactor(server): adopt core wire_middleware_stack + configure_logging_from_env (MV-PR3)

### DIFF
--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -15,7 +15,7 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
-from fastmcp.utilities.logging import configure_logging
+from fastmcp_pvl_core import configure_logging_from_env
 
 from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.config import _ENV_PREFIX, load_config
@@ -310,21 +310,26 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
-    # App loggers (markdown_vault_mcp.*) propagate to root; FastMCP
-    # loggers (fastmcp.*) have propagate=False and are configured via
-    # FASTMCP_LOG_LEVEL at import time.  -v overrides both to DEBUG.
-    level = logging.DEBUG if args.verbose else logging.INFO
+    # Logging setup routes through fastmcp_pvl_core, which aligns
+    # ``FASTMCP_LOG_LEVEL`` with ``-v`` and calls FastMCP's own
+    # ``configure_logging`` so our loggers and FastMCP's produce
+    # matching output.
+    configure_logging_from_env(verbose=args.verbose)
+
+    # FastMCP's configure_logging installs a rich handler on its own
+    # logger tree; the root logger still needs a plain StreamHandler so
+    # that our ``markdown_vault_mcp.*`` loggers produce output when the
+    # CLI is invoked outside an environment that has already configured
+    # one.
     root = logging.getLogger()
-    root.setLevel(level)
     if not root.handlers:
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
         root.addHandler(handler)
 
+    # httpx / httpcore are domain-specific noise we silence inline;
+    # the core helper stays pure and doesn't know about our deps.
     if args.verbose:
-        os.environ["FASTMCP_LOG_LEVEL"] = "DEBUG"
-        configure_logging("DEBUG")
-        # httpx is noisy at DEBUG — keep it at WARNING.
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("httpcore").setLevel(logging.WARNING)
 

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -310,25 +310,16 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
-    # Logging setup routes through fastmcp_pvl_core, which aligns
-    # ``FASTMCP_LOG_LEVEL`` with ``-v`` and calls FastMCP's own
-    # ``configure_logging`` so our loggers and FastMCP's produce
-    # matching output.
     configure_logging_from_env(verbose=args.verbose)
 
-    # FastMCP's configure_logging installs a rich handler on its own
-    # logger tree; the root logger still needs a plain StreamHandler so
-    # that our ``markdown_vault_mcp.*`` loggers produce output when the
-    # CLI is invoked outside an environment that has already configured
-    # one.
+    # Root handler for markdown_vault_mcp.* — FastMCP's configure_logging only covers its own logger tree.
     root = logging.getLogger()
     if not root.handlers:
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
         root.addHandler(handler)
 
-    # httpx / httpcore are domain-specific noise we silence inline;
-    # the core helper stays pure and doesn't know about our deps.
+    # Silence httpx/httpcore at DEBUG — kept inline, core doesn't own these deps.
     if args.verbose:
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("httpcore").setLevel(logging.WARNING)

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -12,7 +12,6 @@ configured :class:`~fastmcp.FastMCP` instance.
 from __future__ import annotations
 
 import logging
-import os
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -23,12 +22,7 @@ if TYPE_CHECKING:
     from fastmcp.server.event_store import EventStore
 
 from fastmcp import FastMCP
-from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
-from fastmcp.server.middleware.logging import (
-    LoggingMiddleware,
-    StructuredLoggingMiddleware,
-)
-from fastmcp.server.middleware.timing import TimingMiddleware
+from fastmcp_pvl_core import wire_middleware_stack
 
 from markdown_vault_mcp.config import (
     build_bearer_auth,
@@ -238,26 +232,13 @@ def create_server(transport: str = "stdio") -> FastMCP:
         auth=auth,
     )
 
-    # --- Middleware stack ---
-    # Order matters: outermost runs first.
-    #  1. ErrorHandlingMiddleware — catches unhandled exceptions
-    #  2. TimingMiddleware — records tool invocation duration
-    #  3. LoggingMiddleware — rich or structured (JSON) output
-    # Capture root log level *now* — works correctly when create_server() is
-    # called after CLI verbose setup.  In library/test usage where logging is
-    # configured later, tracebacks default to off (safe for production).
-    include_traceback = logging.getLogger().isEnabledFor(logging.DEBUG)
-    mcp.add_middleware(
-        ErrorHandlingMiddleware(
-            include_traceback=include_traceback, transform_errors=False
-        )
-    )
-    mcp.add_middleware(TimingMiddleware())
-    rich_logging = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true").strip().lower()
-    if rich_logging in ("false", "0", "no"):
-        mcp.add_middleware(StructuredLoggingMiddleware())
-    else:
-        mcp.add_middleware(LoggingMiddleware())
+    # Middleware stack (ErrorHandling → Timing → Logging) is installed by
+    # fastmcp_pvl_core.  include_traceback=None lets the helper infer the
+    # setting from the root log level at call time — matches MV's previous
+    # behaviour (on under -v, off in production).  transform_errors=False
+    # preserves MV's default of letting exceptions propagate to FastMCP's
+    # own handlers rather than synthesising MCP error responses.
+    wire_middleware_stack(mcp, include_traceback=None, transform_errors=False)
 
     register_tools(mcp, transport=transport)
     register_resources(mcp)

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -232,12 +232,7 @@ def create_server(transport: str = "stdio") -> FastMCP:
         auth=auth,
     )
 
-    # Middleware stack (ErrorHandling → Timing → Logging) is installed by
-    # fastmcp_pvl_core.  include_traceback=None lets the helper infer the
-    # setting from the root log level at call time — matches MV's previous
-    # behaviour (on under -v, off in production).  transform_errors=False
-    # preserves MV's default of letting exceptions propagate to FastMCP's
-    # own handlers rather than synthesising MCP error responses.
+    # include_traceback=None infers from root log level (-v→DEBUG→tracebacks); transform_errors=False lets exceptions propagate to FastMCP's own handlers.
     wire_middleware_stack(mcp, include_traceback=None, transform_errors=False)
 
     register_tools(mcp, transport=transport)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,26 +171,23 @@ class TestMainDispatch:
         mock_handler.assert_called_once()
 
     @patch("markdown_vault_mcp.cli._COMMANDS")
-    @patch("markdown_vault_mcp.cli.configure_logging")
+    @patch("markdown_vault_mcp.cli.configure_logging_from_env")
     def test_verbose_enables_debug_for_both_logger_trees(
         self, mock_configure: MagicMock, mock_commands: MagicMock
     ) -> None:
-        """``-v`` sets root to DEBUG and calls ``configure_logging("DEBUG")``."""
+        """``-v`` routes to configure_logging_from_env and silences httpx/httpcore."""
         mock_handler = MagicMock()
         mock_commands.__getitem__ = MagicMock(return_value=mock_handler)
         with patch("sys.argv", ["markdown-vault-mcp", "-v", "index"]):
             main()
-        mock_configure.assert_called_once_with("DEBUG")
+        mock_configure.assert_called_once_with(verbose=True)
         import logging
 
         assert logging.getLogger("httpx").level == logging.WARNING
         assert logging.getLogger("httpcore").level == logging.WARNING
 
     @patch("markdown_vault_mcp.cli._COMMANDS")
-    @patch("markdown_vault_mcp.cli.configure_logging")
-    def test_verbose_sets_fastmcp_log_level_env(
-        self, _mock_configure: MagicMock, mock_commands: MagicMock
-    ) -> None:
+    def test_verbose_sets_fastmcp_log_level_env(self, mock_commands: MagicMock) -> None:
         """``-v`` sets FASTMCP_LOG_LEVEL=DEBUG in the environment."""
         import os
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,21 +188,32 @@ class TestMainDispatch:
 
     @patch("markdown_vault_mcp.cli._COMMANDS")
     def test_verbose_sets_fastmcp_log_level_env(self, mock_commands: MagicMock) -> None:
-        """``-v`` sets FASTMCP_LOG_LEVEL=DEBUG in the environment."""
+        """``-v`` sets FASTMCP_LOG_LEVEL=DEBUG via the real configure_logging_from_env.
+
+        Intentionally exercises the real helper (not mocked) so it covers the
+        env-var contract MV depends on.  Saves and restores the root logger's
+        level + handlers and FASTMCP_LOG_LEVEL to keep global state clean.
+        """
+        import logging
         import os
 
         mock_handler = MagicMock()
         mock_commands.__getitem__ = MagicMock(return_value=mock_handler)
-        old = os.environ.pop("FASTMCP_LOG_LEVEL", None)
+        root = logging.getLogger()
+        saved_env = os.environ.pop("FASTMCP_LOG_LEVEL", None)
+        saved_level = root.level
+        saved_handlers = root.handlers[:]
         try:
             with patch("sys.argv", ["markdown-vault-mcp", "-v", "index"]):
                 main()
             assert os.environ.get("FASTMCP_LOG_LEVEL") == "DEBUG"
         finally:
-            if old is not None:
-                os.environ["FASTMCP_LOG_LEVEL"] = old
+            if saved_env is not None:
+                os.environ["FASTMCP_LOG_LEVEL"] = saved_env
             else:
                 os.environ.pop("FASTMCP_LOG_LEVEL", None)
+            root.setLevel(saved_level)
+            root.handlers[:] = saved_handlers
 
     @patch("markdown_vault_mcp.cli._COMMANDS")
     def test_no_verbose_does_not_set_fastmcp_log_level(


### PR DESCRIPTION
## Summary

Third PR in the fastmcp-pvl-core adoption series. Replaces MV's inline middleware-stack assembly and CLI logging bootstrap with the corresponding helpers from \`fastmcp-pvl-core==1.0.0rc1\`.

### \`mcp_server.py\`

- Drops the local \`ErrorHandling\` / \`Timing\` / \`Logging\` middleware imports + inline \`add_middleware\` calls (~20 lines).
- Single call to \`wire_middleware_stack(mcp, include_traceback=None, transform_errors=False)\`.
  - \`include_traceback=None\` lets the helper infer from the root log level at call time — matches MV's previous \`isEnabledFor(DEBUG)\` behaviour.
  - \`transform_errors=False\` preserves MV's default of letting exceptions propagate to FastMCP's own handlers (rather than synthesizing MCP error responses inside the middleware).
- Removes the now-unused \`os\` import.

### \`cli.py\`

- Drops the inline \`level = DEBUG if -v else INFO\` / \`setLevel\` / \`configure_logging('DEBUG')\` / \`FASTMCP_LOG_LEVEL=DEBUG\` dance in favour of \`configure_logging_from_env(verbose=args.verbose)\`. The helper sets the env var, sets the root level, and calls FastMCP's own \`configure_logging\` — same end-state as the inline code.
- Keeps the **root-StreamHandler fallback inline**: FastMCP's \`configure_logging\` targets its own logger tree, not root, so MV's \`markdown_vault_mcp.*\` loggers still need a root handler when run from a fresh CLI invocation.
- Keeps **httpx/httpcore noise-tuning inline** (per the adoption plan — these are MV-domain-specific dependencies, not core's concern).

### Tests

- \`test_verbose_enables_debug_for_both_logger_trees\` now patches \`configure_logging_from_env\` (kwarg-mode) instead of the bare \`configure_logging\` that was previously imported into the cli module.
- \`test_verbose_sets_fastmcp_log_level_env\` no longer needs to mock \`configure_logging\` — \`configure_logging_from_env\` handles the env-var side effect itself, and the assertion still holds.
- Existing \`TestMiddlewareStack\` tests (3 cases asserting the installed middleware classes + ordering) pass unchanged because \`wire_middleware_stack\` installs the same FastMCP middleware types in the same order.

## Test plan

- [x] \`uv run ruff check --fix . && uv run ruff format .\` — clean
- [x] \`uv run mypy src/\` — no errors
- [x] \`uv run pytest -x -q\` — 1400 passed
- [x] \`diff-cover\` on changed lines: 100%
- [x] Total coverage 92.96% (≥80% gate)

## Documentation

No env vars added/removed/renamed. \`FASTMCP_LOG_LEVEL\`, \`FASTMCP_ENABLE_RICH_LOGGING\`, and \`-v\` behave identically. No README/docs changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)