### PR TITLE
refactor(server): delegate instructions + event store to core (MV-PR4)

### DIFF
--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -14,17 +14,24 @@ from __future__ import annotations
 import logging
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
-from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from fastmcp.server.event_store import EventStore
 
 from fastmcp import FastMCP
-from fastmcp_pvl_core import wire_middleware_stack
+from fastmcp_pvl_core import (
+    build_event_store as _core_build_event_store,
+)
+from fastmcp_pvl_core import (
+    build_instructions as _core_build_instructions,
+)
+from fastmcp_pvl_core import (
+    wire_middleware_stack,
+)
 
 from markdown_vault_mcp.config import (
+    _ENV_PREFIX,
     build_bearer_auth,
     build_oidc_auth,
     build_remote_auth,
@@ -46,17 +53,13 @@ logger = logging.getLogger(__name__)
 # Event store
 # ---------------------------------------------------------------------------
 
-_DEFAULT_EVENT_STORE_DIR = "/data/state/events"
-
 
 def build_event_store(url: str | None = None) -> EventStore:
     """Build an ``EventStore`` for SSE polling/resumability.
 
-    Parses the *url* scheme to select a storage backend:
-
-    - ``None`` or empty → ``FileTreeStore`` at :data:`_DEFAULT_EVENT_STORE_DIR`
-    - ``file:///path`` → ``FileTreeStore`` at the given path
-    - ``memory://`` → in-memory (lost on restart, for development)
+    Thin shim over :func:`fastmcp_pvl_core.build_event_store`: wraps the
+    legacy URL-only call shape used by ``cli.py`` and delegates the actual
+    backend selection (file-tree vs in-memory) to the shared core helper.
 
     Args:
         url: Event store URL from ``MARKDOWN_VAULT_MCP_EVENT_STORE_URL``.
@@ -64,39 +67,9 @@ def build_event_store(url: str | None = None) -> EventStore:
     Returns:
         A configured :class:`~fastmcp.server.event_store.EventStore`.
     """
-    from fastmcp.server.event_store import EventStore as _EventStore
+    from fastmcp_pvl_core import ServerConfig
 
-    if not url:
-        url = f"file://{_DEFAULT_EVENT_STORE_DIR}"
-
-    parsed = urlparse(url)
-
-    if parsed.scheme == "memory":
-        logger.info("Event store: in-memory (sessions lost on restart)")
-        return _EventStore(max_events_per_stream=100, ttl=3600)
-
-    if parsed.scheme == "file":
-        directory = parsed.path
-        if not directory:
-            directory = _DEFAULT_EVENT_STORE_DIR
-        Path(directory).mkdir(parents=True, exist_ok=True)
-        logger.info("Event store: file-backed at %s", directory)
-
-        try:
-            from key_value.aio.stores.filetree import FileTreeStore
-        except ImportError:
-            raise ImportError(
-                "FileTreeStore requires fastmcp>=3.0 with key-value support. "
-                "Install with: pip install 'markdown-vault-mcp[mcp]'"
-            ) from None
-
-        storage = FileTreeStore(data_directory=directory)
-        return _EventStore(storage=storage, max_events_per_stream=100, ttl=3600)
-
-    raise ValueError(
-        f"Unsupported EVENT_STORE_URL scheme {parsed.scheme!r}. "
-        "Use 'file:///path' or 'memory://'."
-    )
+    return _core_build_event_store(_ENV_PREFIX, ServerConfig(event_store_url=url))
 
 
 # ---------------------------------------------------------------------------
@@ -107,34 +80,37 @@ def build_event_store(url: str | None = None) -> EventStore:
 def _build_default_instructions(*, read_only: bool) -> str:
     """Build the default instructions string based on read-only state.
 
-    Args:
-        read_only: Whether write tools are disabled on this instance.
-
-    Returns:
-        Instructions string suitable for the ``instructions`` parameter
-        of :class:`~fastmcp.FastMCP`.
+    Composes MV's domain-specific guidance into a ``domain_line`` and
+    delegates to :func:`fastmcp_pvl_core.build_instructions` for the
+    read-only/read-write line and operator override hint.
     """
-    write_line = (
-        "This instance is READ-ONLY — write tools are not available."
+    prelude = (
+        "A searchable markdown document collection. "
+        "Paths are always relative (e.g. 'Journal/note.md')."
+    )
+    write_guidance = (
+        ""
         if read_only
         else (
-            "This instance is READ-WRITE — use 'write' to create, 'edit' for "
-            "targeted changes (read first), 'rename' to move "
-            "(pass update_links=True to fix links in other notes), 'delete' to remove. "
-            "All write operations update the search index immediately — never call "
-            "'reindex' after write, edit, delete, or rename."
+            " Write tools: use 'write' to create, 'edit' for targeted changes "
+            "(read first), 'rename' to move (pass update_links=True to fix links "
+            "in other notes), 'delete' to remove. All write operations update the "
+            "search index immediately — never call 'reindex' after write, edit, "
+            "delete, or rename."
         )
     )
-    return (
-        "A searchable markdown document collection. "
-        "Paths are always relative (e.g. 'Journal/note.md'). "
-        f"{write_line} "
-        "Use 'search' (mode='hybrid' preferred when available) to find documents, "
+    search_guidance = (
+        " Use 'search' (mode='hybrid' preferred when available) to find documents, "
         "'read' for full content, 'list_documents' to enumerate, 'stats' to check "
-        "capabilities. "
-        "'browse_vault' and 'show_context' open a visual UI for the user — do not "
-        "call them to retrieve vault content; use 'search', 'read', 'list_documents', "
-        "or 'get_context' instead."
+        "capabilities. 'browse_vault' and 'show_context' open a visual UI for the "
+        "user — do not call them to retrieve vault content; use 'search', 'read', "
+        "'list_documents', or 'get_context' instead."
+    )
+    domain_line = f"{prelude}{write_guidance}{search_guidance}"
+    return _core_build_instructions(
+        read_only=read_only,
+        env_prefix=_ENV_PREFIX,
+        domain_line=domain_line,
     )
 
 

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -21,13 +21,14 @@ if TYPE_CHECKING:
 
 from fastmcp import FastMCP
 from fastmcp_pvl_core import (
+    ServerConfig,
+    wire_middleware_stack,
+)
+from fastmcp_pvl_core import (
     build_event_store as _core_build_event_store,
 )
 from fastmcp_pvl_core import (
     build_instructions as _core_build_instructions,
-)
-from fastmcp_pvl_core import (
-    wire_middleware_stack,
 )
 
 from markdown_vault_mcp.config import (
@@ -67,8 +68,6 @@ def build_event_store(url: str | None = None) -> EventStore:
     Returns:
         A configured :class:`~fastmcp.server.event_store.EventStore`.
     """
-    from fastmcp_pvl_core import ServerConfig
-
     return _core_build_event_store(_ENV_PREFIX, ServerConfig(event_store_url=url))
 
 

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -16,7 +16,7 @@ class TestBuildEventStore:
         from unittest.mock import patch
 
         with patch(
-            "markdown_vault_mcp.mcp_server._DEFAULT_EVENT_STORE_DIR",
+            "fastmcp_pvl_core._factory._DEFAULT_EVENT_STORE_DIR",
             str(tmp_path / "events"),
         ):
             store = build_event_store(None)
@@ -29,7 +29,7 @@ class TestBuildEventStore:
         from unittest.mock import patch
 
         with patch(
-            "markdown_vault_mcp.mcp_server._DEFAULT_EVENT_STORE_DIR",
+            "fastmcp_pvl_core._factory._DEFAULT_EVENT_STORE_DIR",
             str(tmp_path / "events"),
         ):
             store = build_event_store("")
@@ -52,7 +52,7 @@ class TestBuildEventStore:
 
     def test_unsupported_scheme_raises(self):
         """Unsupported URL scheme raises ValueError."""
-        with pytest.raises(ValueError, match="Unsupported EVENT_STORE_URL scheme"):
+        with pytest.raises(ValueError, match="Unsupported event store URL scheme"):
             build_event_store("redis://localhost:6379")
 
     def test_file_url_without_path_uses_default(self, tmp_path):
@@ -60,7 +60,7 @@ class TestBuildEventStore:
         from unittest.mock import patch
 
         with patch(
-            "markdown_vault_mcp.mcp_server._DEFAULT_EVENT_STORE_DIR",
+            "fastmcp_pvl_core._factory._DEFAULT_EVENT_STORE_DIR",
             str(tmp_path / "events"),
         ):
             store = build_event_store("file://")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -129,7 +129,11 @@ class TestServerIdentity:
         assert "relative" in server.instructions
         assert "'search'" in server.instructions
         assert "'stats'" in server.instructions
-        assert "MARKDOWN_VAULT_MCP_INSTRUCTIONS" not in server.instructions
+        # Core's build_instructions appends an operator-override hint
+        # (by design — tells anyone reading the instructions that the
+        # env var exists to customise them).
+        assert "MARKDOWN_VAULT_MCP_INSTRUCTIONS" in server.instructions
+        assert "Operators:" in server.instructions
 
     @pytest.mark.usefixtures("_mcp_env")
     def test_custom_server_name(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Fourth PR in the fastmcp-pvl-core adoption series.

- **\`_build_default_instructions\`**: composes MV's domain-specific prelude + write-tool guidance + search guidance into a single \`domain_line\` and delegates to \`fastmcp_pvl_core.build_instructions\`, which appends the read-only/read-write line and an operator-override hint (\"Operators: set \`MARKDOWN_VAULT_MCP_INSTRUCTIONS\` to describe…\").
- **\`build_event_store\`**: now a thin shim that wraps the URL in a transient \`ServerConfig\` and delegates to \`fastmcp_pvl_core.build_event_store\`. Kept for \`cli.py\` callers that still pass a raw URL.
- Drops the now-unused \`_DEFAULT_EVENT_STORE_DIR\` constant, \`pathlib.Path\`, \`urllib.parse.urlparse\`, and the local \`FileTreeStore\` import branch.

## What's intentionally NOT migrated

- **\`_compute_claude_app_domain\`** in \`_server_apps.py\` stays local. It computes Claude's sha256-prefixed \`claudemcpcontent.com\` sandbox subdomain, which is Claude-specific and outside core's \`compute_app_domain\` scope (core's helper returns the explicit override or the \`base_url\` netloc). Per the adoption plan, Claude-specific fallbacks belong in MV.

## Test updates

- \`test_event_store.py\`: monkeypatch path moves from \`markdown_vault_mcp.mcp_server._DEFAULT_EVENT_STORE_DIR\` to \`fastmcp_pvl_core._factory._DEFAULT_EVENT_STORE_DIR\`; error-message regex updated from \"Unsupported EVENT_STORE_URL scheme\" to \"Unsupported event store URL scheme\" (core's wording).
- \`test_mcp_server.py\`: \`test_default_instructions_content\` now asserts the operator-override hint IS present (core appends it deliberately so operators reading the instructions learn about the override env var).

## Test plan

- [x] \`uv run ruff check --fix . && uv run ruff format .\` — clean
- [x] \`uv run mypy src/\` — no errors
- [x] \`uv run pytest -x -q\` — 1400 passed
- [x] \`diff-cover\` on changed lines: 100%
- [x] Total coverage 92.97% (≥80% gate)

## Documentation

No env vars added/removed/renamed. The operator-override hint for \`MARKDOWN_VAULT_MCP_INSTRUCTIONS\` is already documented in \`load_config()\`'s docstring and \`docs/configuration.md\`; the only functional change is that the hint now surfaces in the MCP instructions text itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)