### PR TITLE
refactor(artifacts): adopt core ArtifactStore with eager bytes (MV-PR5)

### DIFF
--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -76,22 +76,15 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # Start background tasks (e.g. git pull loop) after index is built.
         collection.start()
 
-        # Initialise artifact store singletons so the HTTP artifact endpoint
-        # can resolve vault paths outside of FastMCP's DI context.
-        from markdown_vault_mcp.artifacts import (
-            ArtifactStore,
-            set_artifact_store,
-            set_collection_store,
-        )
-
-        set_artifact_store(ArtifactStore())
-        set_collection_store(collection)
+        # Artifact store singleton is wired in create_server(), not here —
+        # the HTTP route captures the store at server-construction time and
+        # tool handlers reach it via get_artifact_store().  Tokens carry
+        # eager bytes now, so the lifespan no longer needs to expose the
+        # Collection to the HTTP handler.
 
         try:
             yield {"collection": collection, "config": config}
         finally:
-            set_artifact_store(None)
-            set_collection_store(None)
             collection.close()
             logger.info("Collection shut down")
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1473,14 +1473,20 @@ def _register_download_link_tool(mcp: FastMCP) -> None:
         Args:
             path: Vault-relative path to the file (e.g.
                 ``"notes/report.md"`` or ``"assets/diagram.png"``).
-            ttl_seconds: Link lifetime in seconds (default 300 / 5
-                minutes).
+            ttl_seconds: Requested link lifetime in seconds (default
+                300 / 5 minutes).  The server enforces a single
+                process-wide TTL on its artifact store; the actual
+                expiry returned in ``expires_in_seconds`` reflects that
+                store setting, which may differ from the requested
+                value.
 
         Returns:
             JSON-encoded string with the following fields:
 
             - download_url (str): One-time HTTP URL to download the file.
-            - expires_in_seconds (int): Link lifetime (equals ttl_seconds).
+            - expires_in_seconds (int): Link lifetime actually enforced
+              by the server (may differ from the requested
+              ``ttl_seconds``).
             - path (str): Vault-relative path of the served file.
             - content_type (str): MIME type of the file.
 
@@ -1517,21 +1523,32 @@ def _register_download_link_tool(mcp: FastMCP) -> None:
         if not abs_path.is_file():
             raise ValueError(f"File not found: {path}")
 
-        from markdown_vault_mcp.artifacts import get_artifact_store
+        # Eagerly read bytes so the HTTP handler doesn't touch disk at
+        # serve time — the artifact store stores (bytes, filename, mime).
+        data = await asyncio.to_thread(abs_path.read_bytes)
+        filename = path.rsplit("/", 1)[-1]
+
+        from markdown_vault_mcp.artifacts import (
+            ARTIFACT_TTL_SECONDS,
+            get_artifact_store,
+        )
 
         store = get_artifact_store()
-        token = store.create_token(path, ttl_seconds=ttl_seconds)
+        token = store.add(data, filename=filename, mime_type=content_type)
+        effective_ttl = ARTIFACT_TTL_SECONDS
 
         download_url = f"{base_url}/artifacts/{token}"
         result = {
             "download_url": download_url,
-            "expires_in_seconds": ttl_seconds,
+            "expires_in_seconds": effective_ttl,
             "path": path,
             "content_type": content_type,
         }
         logger.info(
-            "Created download link for path=%r ttl=%ds",
+            "Created download link path=%r size=%d requested_ttl=%ds effective_ttl=%ds",
             path,
+            len(data),
             ttl_seconds,
+            effective_ttl,
         )
         return json.dumps(result, indent=2)

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1526,7 +1526,7 @@ def _register_download_link_tool(mcp: FastMCP) -> None:
         # Eagerly read bytes so the HTTP handler doesn't touch disk at
         # serve time — the artifact store stores (bytes, filename, mime).
         data = await asyncio.to_thread(abs_path.read_bytes)
-        filename = path.rsplit("/", 1)[-1]
+        filename = abs_path.name
 
         from markdown_vault_mcp.artifacts import (
             ARTIFACT_TTL_SECONDS,

--- a/src/markdown_vault_mcp/artifacts.py
+++ b/src/markdown_vault_mcp/artifacts.py
@@ -37,12 +37,15 @@ _artifact_store: ArtifactStore | None = None
 def set_artifact_store(store: ArtifactStore | None) -> None:
     """Set the module-level artifact store.
 
-    Called from :func:`markdown_vault_mcp.mcp_server.create_server` when
-    the server is first constructed, and again with ``None`` to clear
-    the singleton on teardown.
+    Called from :func:`markdown_vault_mcp.mcp_server.create_server` on
+    each server construction.  The server owns the store for its
+    lifetime; there is no lifespan teardown hook, so a later
+    ``create_server`` call simply replaces the singleton.  Passing
+    ``None`` is supported (tests use it to exercise the uninitialised
+    path), but is not invoked by the normal server lifecycle.
 
     Args:
-        store: The :class:`ArtifactStore` instance, or ``None`` on shutdown.
+        store: The :class:`ArtifactStore` instance, or ``None`` to clear.
     """
     global _artifact_store
     _artifact_store = store

--- a/src/markdown_vault_mcp/artifacts.py
+++ b/src/markdown_vault_mcp/artifacts.py
@@ -1,130 +1,45 @@
-"""One-time artifact download endpoint for inter-MCP file transfer.
+"""Module-level artifact store wiring for MV tool handlers.
 
-Implements an in-memory token store and a Starlette route handler that
-serves vault file bytes once and then invalidates the token.
+The heavy lifting — UUID tokens, TTL expiry, the HTTP route — lives in
+:mod:`fastmcp_pvl_core._artifacts`.  This module only keeps a
+module-level singleton so ``create_download_link`` (a tool handler
+running outside FastMCP's DI context) can reach the same
+:class:`ArtifactStore` that the HTTP route is serving.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import mimetypes
-import time
-import uuid
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
-from starlette.responses import Response
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
-    from starlette.requests import Request
-
-    from markdown_vault_mcp.collection import Collection
+from fastmcp_pvl_core import ArtifactStore, TokenRecord
 
 logger = logging.getLogger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Token store
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class TokenRecord:
-    """A one-time download token record.
-
-    Attributes:
-        path: The vault-relative path this token grants access to.
-        created_at: Unix timestamp of when the token was created.
-        ttl_seconds: Time-to-live in seconds.
-    """
-
-    path: str
-    created_at: float
-    ttl_seconds: int
+__all__ = [
+    "ARTIFACT_TTL_SECONDS",
+    "ArtifactStore",
+    "TokenRecord",
+    "get_artifact_store",
+    "set_artifact_store",
+]
 
 
-class ArtifactStore:
-    """In-memory one-time token store for artifact downloads.
+# Single process-wide artifact TTL.  Core's ArtifactStore takes this at
+# construction and applies it to every token — per-token TTL isn't
+# supported upstream, so callers that request a shorter lifetime get
+# this value back in ``expires_in_seconds`` for honesty.
+ARTIFACT_TTL_SECONDS = 3600
 
-    Tokens are UUIDs (hex) that grant a single download of a vault file.
-    Expired tokens are cleaned up lazily on each operation.
-
-    Note:
-        The store is in-memory only — tokens do not survive a server
-        restart.
-    """
-
-    def __init__(self) -> None:
-        self._tokens: dict[str, TokenRecord] = {}
-
-    def create_token(self, path: str, ttl_seconds: int = 300) -> str:
-        """Create a one-time download token.
-
-        Args:
-            path: The vault-relative path to grant access to.
-            ttl_seconds: Token lifetime in seconds (default 300).
-
-        Returns:
-            A hex UUID token string.
-        """
-        self._cleanup_expired()
-        token = uuid.uuid4().hex
-        self._tokens[token] = TokenRecord(
-            path=path,
-            created_at=time.time(),
-            ttl_seconds=ttl_seconds,
-        )
-        logger.debug("Created artifact token for path=%r ttl=%ds", path, ttl_seconds)
-        return token
-
-    def consume_token(self, token: str) -> TokenRecord | None:
-        """Consume a token, returning the record or None if invalid/expired.
-
-        The token is always removed from the store (one-time use), even
-        if it has expired.
-
-        Args:
-            token: The hex UUID token string.
-
-        Returns:
-            The :class:`TokenRecord`, or ``None`` if unknown or expired.
-        """
-        # Sweep other expired tokens to bound memory (design spec: lazy
-        # cleanup on each operation).  The explicit check below handles
-        # the consumed token's own expiry.
-        self._cleanup_expired()
-        record = self._tokens.pop(token, None)
-        if record is None:
-            return None
-        if time.time() - record.created_at > record.ttl_seconds:
-            logger.debug("Artifact token expired: %s", token)
-            return None
-        return record
-
-    def _cleanup_expired(self) -> None:
-        """Remove expired tokens (lazy cleanup on each operation)."""
-        now = time.time()
-        expired = [
-            k for k, v in self._tokens.items() if now - v.created_at > v.ttl_seconds
-        ]
-        for k in expired:
-            del self._tokens[k]
-        if expired:
-            logger.debug("Cleaned up %d expired artifact token(s)", len(expired))
-
-
-# ---------------------------------------------------------------------------
-# Module-level store singleton (set by lifespan)
-# ---------------------------------------------------------------------------
 
 _artifact_store: ArtifactStore | None = None
 
 
 def set_artifact_store(store: ArtifactStore | None) -> None:
-    """Set the module-level artifact store (called from lifespan).
+    """Set the module-level artifact store.
+
+    Called from :func:`markdown_vault_mcp.mcp_server.create_server` when
+    the server is first constructed, and again with ``None`` to clear
+    the singleton on teardown.
 
     Args:
         store: The :class:`ArtifactStore` instance, or ``None`` on shutdown.
@@ -140,128 +55,9 @@ def get_artifact_store() -> ArtifactStore:
         The active :class:`ArtifactStore`.
 
     Raises:
-        RuntimeError: If the store has not been initialised via lifespan.
+        RuntimeError: If the store has not been initialised yet.
     """
     if _artifact_store is None:
-        msg = "ArtifactStore not initialised — server lifespan has not run"
+        msg = "ArtifactStore not initialised — server has not been constructed"
         raise RuntimeError(msg)
     return _artifact_store
-
-
-# ---------------------------------------------------------------------------
-# Module-level collection accessor (set by lifespan)
-# ---------------------------------------------------------------------------
-
-_collection_store: Collection | None = None
-
-
-def set_collection_store(collection: Collection | None) -> None:
-    """Set the module-level collection reference (called from lifespan).
-
-    The artifact HTTP handler runs outside FastMCP's request-context
-    dependency injection, so it needs a module-level accessor.
-
-    Args:
-        collection: The :class:`~markdown_vault_mcp.collection.Collection`
-            instance, or ``None`` on shutdown.
-    """
-    global _collection_store
-    _collection_store = collection
-
-
-def _get_collection_from_store() -> Collection:
-    """Return the module-level Collection reference.
-
-    Used by the artifact HTTP handler, which runs outside FastMCP's
-    request-context dependency injection.
-
-    Returns:
-        The active :class:`~markdown_vault_mcp.collection.Collection`.
-
-    Raises:
-        RuntimeError: If the server lifespan has not yet run.
-    """
-    if _collection_store is None:
-        msg = "Collection not initialised — server lifespan has not run"
-        raise RuntimeError(msg)
-    return _collection_store
-
-
-# ---------------------------------------------------------------------------
-# Route handler
-# ---------------------------------------------------------------------------
-
-
-def make_artifact_handler() -> Callable[[Request], Awaitable[Response]]:
-    """Build the Starlette route handler for ``GET /artifacts/{token}``.
-
-    The returned handler accesses the :class:`Collection` via the
-    module-level store, which is populated during server lifespan.
-
-    Returns:
-        An async Starlette request handler.
-    """
-
-    async def artifact_handler(request: Request) -> Response:
-        """Serve a one-time file download and invalidate the token.
-
-        Args:
-            request: Starlette request with ``token`` path param.
-
-        Returns:
-            File bytes response with correct ``Content-Type``, or HTTP 404.
-        """
-        token = request.path_params.get("token", "")
-        store = get_artifact_store()
-        record = store.consume_token(token)
-
-        if record is None:
-            logger.debug("Artifact token not found or expired: %s", token)
-            return Response(content="Not Found", status_code=404)
-
-        collection = _get_collection_from_store()
-        vault_path = record.path
-
-        try:
-            # Read the file bytes directly from disk via the collection's
-            # source directory, after validation.
-            if vault_path.endswith(".md"):
-                abs_path = await asyncio.to_thread(
-                    collection._validate_path, vault_path
-                )
-                content_type = "text/markdown; charset=utf-8"
-            else:
-                abs_path = await asyncio.to_thread(
-                    collection._validate_attachment_path, vault_path
-                )
-                mime, _ = mimetypes.guess_type(vault_path)
-                content_type = mime or "application/octet-stream"
-        except ValueError:
-            logger.warning("Artifact: path validation failed for %r", vault_path)
-            return Response(content="Not Found", status_code=404)
-
-        try:
-            data = await asyncio.to_thread(abs_path.read_bytes)
-        except OSError:
-            logger.warning(
-                "Artifact: file missing for path=%r abs=%s",
-                vault_path,
-                abs_path,
-            )
-            return Response(content="Not Found", status_code=404)
-
-        logger.info(
-            "Artifact served: token=%s path=%r content_type=%s size=%d",
-            token,
-            vault_path,
-            content_type,
-            len(data),
-        )
-        filename = vault_path.rsplit("/", 1)[-1]
-        return Response(
-            content=data,
-            media_type=content_type,
-            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-        )
-
-    return artifact_handler

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 from fastmcp import FastMCP
 from fastmcp_pvl_core import (
+    ArtifactStore,
     ServerConfig,
     wire_middleware_stack,
 )
@@ -219,12 +220,17 @@ def create_server(transport: str = "stdio") -> FastMCP:
         prompts_folder=config.prompts_folder,
     )
 
+    # Artifact store is constructed here (not in lifespan) so the HTTP route
+    # closure can bind to a concrete store instance.  The tool handler reaches
+    # it via set_artifact_store/get_artifact_store in markdown_vault_mcp.artifacts.
+    from markdown_vault_mcp.artifacts import ARTIFACT_TTL_SECONDS, set_artifact_store
+
+    artifact_store = ArtifactStore(ttl_seconds=ARTIFACT_TTL_SECONDS)
+    set_artifact_store(artifact_store)
+
     # --- Artifact download endpoint (HTTP transports only) ---
-
     if transport != "stdio":
-        from markdown_vault_mcp.artifacts import make_artifact_handler
-
-        mcp.custom_route("/artifacts/{token}", methods=["GET"])(make_artifact_handler())
+        ArtifactStore.register_route(mcp, artifact_store)
 
     # --- Visibility: hide write-tagged components in read-only mode ---
 

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -220,16 +220,20 @@ def create_server(transport: str = "stdio") -> FastMCP:
         prompts_folder=config.prompts_folder,
     )
 
-    # Artifact store is constructed here (not in lifespan) so the HTTP route
-    # closure can bind to a concrete store instance.  The tool handler reaches
-    # it via set_artifact_store/get_artifact_store in markdown_vault_mcp.artifacts.
-    from markdown_vault_mcp.artifacts import ARTIFACT_TTL_SECONDS, set_artifact_store
-
-    artifact_store = ArtifactStore(ttl_seconds=ARTIFACT_TTL_SECONDS)
-    set_artifact_store(artifact_store)
-
     # --- Artifact download endpoint (HTTP transports only) ---
+    # The store is constructed here (not in lifespan) so the HTTP route
+    # closure can bind to a concrete instance.  The tool handler reaches
+    # the same instance via get_artifact_store() in markdown_vault_mcp.artifacts.
+    # Skipped entirely on stdio where the create_download_link tool isn't
+    # registered — no need to hold bytes in memory for a feature we don't expose.
     if transport != "stdio":
+        from markdown_vault_mcp.artifacts import (
+            ARTIFACT_TTL_SECONDS,
+            set_artifact_store,
+        )
+
+        artifact_store = ArtifactStore(ttl_seconds=ARTIFACT_TTL_SECONDS)
+        set_artifact_store(artifact_store)
         ArtifactStore.register_route(mcp, artifact_store)
 
     # --- Visibility: hide write-tagged components in read-only mode ---

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -277,6 +277,10 @@ class TestArtifactHandler:
 
         assert response.status_code == 200
         assert "image/png" in response.headers["content-type"]
+        assert (
+            response.headers["content-disposition"]
+            == 'attachment; filename="image.png"'
+        )
         assert response.content == raw
 
     def test_one_time_use(self) -> None:
@@ -325,6 +329,31 @@ class TestCreateServerArtifactRoute:
         routes = server._additional_http_routes
         paths = [getattr(r, "path", "") for r in routes]
         assert any("/artifacts/" in p for p in paths)
+
+    def test_artifact_route_end_to_end_via_http_app(self) -> None:
+        """End-to-end smoke test that exercises core's register_route behaviour.
+
+        Builds the ASGI app via ``mcp.http_app()`` — the same call path
+        ``_cmd_serve`` uses — seeds the store via ``get_artifact_store().add``
+        and hits the real mounted route.  Guards against divergence between
+        TestArtifactHandler's hand-rolled handler and core's
+        ArtifactStore.register_route implementation.
+        """
+        from markdown_vault_mcp.artifacts import get_artifact_store
+
+        server = create_server(transport="http")
+        store = get_artifact_store()
+        token = store.add(
+            b"integration",
+            filename="it.md",
+            mime_type="text/markdown; charset=utf-8",
+        )
+        with TestClient(server.http_app()) as client:
+            response = client.get(f"/artifacts/{token}")
+
+        assert response.status_code == 200
+        assert response.content == b"integration"
+        assert "text/markdown" in response.headers["content-type"]
 
 
 class TestGetArtifactStoreUninitialised:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,10 +1,16 @@
-"""Tests for the ArtifactStore, create_download_link tool, and artifact endpoint.
+"""Tests for the create_download_link tool and artifact HTTP endpoint.
 
-Covers:
-- ArtifactStore: create, consume, expire, double-consume
-- create_download_link tool: valid paths, missing BASE_URL, non-existent path
-- Artifact HTTP handler: serve bytes, one-time use, expired 404
-- Tool not registered on stdio transport
+Covers MV's integration with :mod:`fastmcp_pvl_core._artifacts`:
+
+- Tool registration (HTTP/SSE only, not stdio)
+- Tool behaviour: valid paths, missing BASE_URL, non-existent paths,
+  path traversal
+- Artifact HTTP handler: serves eager bytes, one-time use, 404 on
+  unknown tokens
+
+The :class:`ArtifactStore` and :class:`TokenRecord` internals (UUID
+generation, TTL expiry, cleanup) are covered in ``fastmcp-pvl-core``'s
+own test suite — we only exercise the MV-side wiring here.
 """
 
 from __future__ import annotations
@@ -17,16 +23,12 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from starlette.testclient import TestClient
 
-from markdown_vault_mcp.artifacts import ArtifactStore, TokenRecord
+from markdown_vault_mcp.artifacts import ARTIFACT_TTL_SECONDS, ArtifactStore
 from markdown_vault_mcp.mcp_server import create_server
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-
-# ---------------------------------------------------------------------------
-# Env var list for clean fixture setup
-# ---------------------------------------------------------------------------
 
 _CLEAR_VARS = (
     "MARKDOWN_VAULT_MCP_INDEX_PATH",
@@ -50,17 +52,6 @@ _CLEAR_VARS = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def store() -> ArtifactStore:
-    """Fresh ArtifactStore for each test."""
-    return ArtifactStore()
-
-
 @pytest.fixture
 def _artifact_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Writable vault with a note and an attachment for artifact tests."""
@@ -77,94 +68,6 @@ def _artifact_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         if var != "MARKDOWN_VAULT_MCP_BASE_URL":
             monkeypatch.delenv(var, raising=False)
     return vault
-
-
-# ---------------------------------------------------------------------------
-# ArtifactStore: create and consume
-# ---------------------------------------------------------------------------
-
-
-class TestArtifactStoreCreateConsume:
-    """ArtifactStore basic create/consume contract."""
-
-    def test_create_returns_hex_string(self, store: ArtifactStore) -> None:
-        token = store.create_token("note.md")
-        assert isinstance(token, str)
-        assert len(token) == 32  # uuid4().hex is 32 hex chars
-        int(token, 16)  # raises if not valid hex
-
-    def test_consume_returns_record(self, store: ArtifactStore) -> None:
-        token = store.create_token("note.md", ttl_seconds=60)
-        record = store.consume_token(token)
-        assert record is not None
-        assert record.path == "note.md"
-        assert record.ttl_seconds == 60
-
-    def test_consume_removes_token(self, store: ArtifactStore) -> None:
-        """Consuming a token makes it unavailable for a second attempt."""
-        token = store.create_token("note.md")
-        store.consume_token(token)
-        second = store.consume_token(token)
-        assert second is None
-
-    def test_unknown_token_returns_none(self, store: ArtifactStore) -> None:
-        result = store.consume_token("deadbeef" * 4)
-        assert result is None
-
-    def test_create_stores_correct_path(self, store: ArtifactStore) -> None:
-        path = "assets/diagram.png"
-        token = store.create_token(path)
-        record = store.consume_token(token)
-        assert record is not None
-        assert record.path == path
-
-
-# ---------------------------------------------------------------------------
-# ArtifactStore: expiry
-# ---------------------------------------------------------------------------
-
-
-class TestArtifactStoreExpiry:
-    """Expired tokens return None from consume_token."""
-
-    def test_expired_token_returns_none(self, store: ArtifactStore) -> None:
-        token = store.create_token("note.md", ttl_seconds=1)
-        # Manually backdate the created_at to simulate expiry
-        record = store._tokens[token]
-        store._tokens[token] = TokenRecord(
-            path=record.path,
-            created_at=record.created_at - 10,  # 10 seconds in the past
-            ttl_seconds=1,
-        )
-        result = store.consume_token(token)
-        assert result is None
-
-    def test_expired_token_is_removed_from_store(self, store: ArtifactStore) -> None:
-        """consume_token removes the token even when expired."""
-        token = store.create_token("note.md", ttl_seconds=1)
-        record = store._tokens[token]
-        store._tokens[token] = TokenRecord(
-            path=record.path,
-            created_at=record.created_at - 10,
-            ttl_seconds=1,
-        )
-        store.consume_token(token)
-        # Token is gone from the store
-        assert token not in store._tokens
-
-    def test_cleanup_expired_on_create(self, store: ArtifactStore) -> None:
-        """Creating a token cleans up already-expired tokens."""
-        token = store.create_token("note.md", ttl_seconds=1)
-        # Expire it manually without consuming
-        record = store._tokens[token]
-        store._tokens[token] = TokenRecord(
-            path=record.path,
-            created_at=record.created_at - 10,
-            ttl_seconds=1,
-        )
-        # Creating a new token triggers cleanup
-        store.create_token("other.md")
-        assert token not in store._tokens
 
 
 # ---------------------------------------------------------------------------
@@ -248,7 +151,15 @@ class TestCreateDownloadLinkTool:
         data = json.loads(result.content[0].text)
         assert data["content_type"] == "image/png"
 
-    async def test_expires_in_seconds_matches_ttl(self, _artifact_vault: Path) -> None:
+    async def test_expires_in_seconds_echoes_store_ttl(
+        self, _artifact_vault: Path
+    ) -> None:
+        """The response field reports the store's actual TTL, not the request's.
+
+        Core's ArtifactStore enforces a single process-wide TTL; the tool's
+        ``ttl_seconds`` argument is accepted for backward-compat and
+        validation but does not vary the expiry per token.
+        """
         server = create_server(transport="http")
         async with Client(server) as client:
             result = await client.call_tool(
@@ -256,7 +167,7 @@ class TestCreateDownloadLinkTool:
                 {"path": "note.md", "ttl_seconds": 120},
             )
         data = json.loads(result.content[0].text)
-        assert data["expires_in_seconds"] == 120
+        assert data["expires_in_seconds"] == ARTIFACT_TTL_SECONDS
 
     async def test_raises_on_missing_base_url(
         self, _artifact_vault: Path, monkeypatch: pytest.MonkeyPatch
@@ -305,52 +216,48 @@ class TestCreateDownloadLinkTool:
 
 
 class TestArtifactHandler:
-    """Tests for the GET /artifacts/{token} Starlette handler."""
+    """Tests for the ``GET /artifacts/{token}`` route registered by core.
 
-    def _make_app(self, vault: Path) -> TestClient:
-        """Build a minimal Starlette app with the artifact endpoint."""
+    The route is mounted by :meth:`ArtifactStore.register_route` at
+    ``create_server`` time.  We build a minimal Starlette app with the
+    same route + a shared :class:`ArtifactStore`, seed the store with
+    :meth:`ArtifactStore.add`, and exercise the HTTP contract directly.
+    """
+
+    def _make_app(self, store: ArtifactStore) -> TestClient:
         from starlette.applications import Starlette
+        from starlette.responses import Response
         from starlette.routing import Route
 
-        from markdown_vault_mcp.artifacts import (
-            ArtifactStore,
-            make_artifact_handler,
-            set_artifact_store,
-            set_collection_store,
-        )
-        from markdown_vault_mcp.collection import Collection
+        async def handler(request):  # type: ignore[no-untyped-def]
+            token = request.path_params.get("token", "")
+            record = store.pop(token)
+            if record is None:
+                return Response(content="Not Found", status_code=404)
+            return Response(
+                content=record.content,
+                media_type=record.mime_type,
+                headers={
+                    "Content-Disposition": (
+                        f'attachment; filename="{record.filename}"'
+                    ),
+                },
+            )
 
-        collection = Collection(source_dir=vault, read_only=True)
-        collection.build_index()
-
-        art_store = ArtifactStore()
-        set_artifact_store(art_store)
-        set_collection_store(collection)
-
-        handler = make_artifact_handler()
         app = Starlette(
-            routes=[
-                Route(
-                    "/artifacts/{token}",
-                    endpoint=handler,
-                    methods=["GET"],
-                )
-            ]
+            routes=[Route("/artifacts/{token}", endpoint=handler, methods=["GET"])]
         )
-        client = TestClient(app, raise_server_exceptions=False)
-        client._artifact_store = art_store  # type: ignore[attr-defined]
-        client._collection = collection  # type: ignore[attr-defined]
-        return client
+        return TestClient(app, raise_server_exceptions=False)
 
-    def test_serves_note_bytes(self, tmp_path: Path) -> None:
-        vault = tmp_path / "vault"
-        vault.mkdir()
-        note_text = "# Hello\n\nWorld.\n"
-        (vault / "hello.md").write_text(note_text, encoding="utf-8")
+    def test_serves_note_bytes(self) -> None:
+        store = ArtifactStore()
+        token = store.add(
+            b"# Hello\n\nWorld.\n",
+            filename="hello.md",
+            mime_type="text/markdown; charset=utf-8",
+        )
+        client = self._make_app(store)
 
-        client = self._make_app(vault)
-        art_store: ArtifactStore = client._artifact_store  # type: ignore[attr-defined]
-        token = art_store.create_token("hello.md")
         response = client.get(f"/artifacts/{token}")
 
         assert response.status_code == 200
@@ -358,87 +265,34 @@ class TestArtifactHandler:
         assert (
             response.headers["content-disposition"] == 'attachment; filename="hello.md"'
         )
-        assert response.text == note_text
+        assert response.text == "# Hello\n\nWorld.\n"
 
-    def test_serves_attachment_bytes(self, tmp_path: Path) -> None:
-        vault = tmp_path / "vault"
-        vault.mkdir()
-        (vault / "dummy.md").write_text("# Dummy\n")
-        (vault / "assets").mkdir()
+    def test_serves_attachment_bytes(self) -> None:
         raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
-        (vault / "assets" / "image.png").write_bytes(raw)
+        store = ArtifactStore()
+        token = store.add(raw, filename="image.png", mime_type="image/png")
+        client = self._make_app(store)
 
-        client = self._make_app(vault)
-        art_store: ArtifactStore = client._artifact_store  # type: ignore[attr-defined]
-        token = art_store.create_token("assets/image.png")
         response = client.get(f"/artifacts/{token}")
 
         assert response.status_code == 200
         assert "image/png" in response.headers["content-type"]
-        assert (
-            response.headers["content-disposition"]
-            == 'attachment; filename="image.png"'
-        )
         assert response.content == raw
 
-    def test_one_time_use(self, tmp_path: Path) -> None:
-        """Second request with same token returns 404."""
-        vault = tmp_path / "vault"
-        vault.mkdir()
-        (vault / "note.md").write_text("# Note\n")
+    def test_one_time_use(self) -> None:
+        store = ArtifactStore()
+        token = store.add(b"hi", filename="f.md", mime_type="text/markdown")
+        client = self._make_app(store)
 
-        client = self._make_app(vault)
-        art_store: ArtifactStore = client._artifact_store  # type: ignore[attr-defined]
-        token = art_store.create_token("note.md")
         first = client.get(f"/artifacts/{token}")
         second = client.get(f"/artifacts/{token}")
 
         assert first.status_code == 200
         assert second.status_code == 404
 
-    def test_unknown_token_returns_404(self, tmp_path: Path) -> None:
-        vault = tmp_path / "vault"
-        vault.mkdir()
-        (vault / "note.md").write_text("# Note\n")
-
-        client = self._make_app(vault)
+    def test_unknown_token_returns_404(self) -> None:
+        client = self._make_app(ArtifactStore())
         response = client.get("/artifacts/" + "deadbeef" * 4)
-        assert response.status_code == 404
-
-    def test_expired_token_returns_404(self, tmp_path: Path) -> None:
-        vault = tmp_path / "vault"
-        vault.mkdir()
-        (vault / "note.md").write_text("# Note\n")
-
-        client = self._make_app(vault)
-        art_store: ArtifactStore = client._artifact_store  # type: ignore[attr-defined]
-        token = art_store.create_token("note.md", ttl_seconds=1)
-        # Backdate the token to simulate expiry
-        record = art_store._tokens[token]
-        art_store._tokens[token] = TokenRecord(
-            path=record.path,
-            created_at=record.created_at - 10,
-            ttl_seconds=1,
-        )
-
-        response = client.get(f"/artifacts/{token}")
-        assert response.status_code == 404
-
-    def test_missing_file_returns_404(self, tmp_path: Path) -> None:
-        """Token valid but file deleted from disk returns 404."""
-        vault = tmp_path / "vault"
-        vault.mkdir()
-        note = vault / "note.md"
-        note.write_text("# Note\n")
-
-        client = self._make_app(vault)
-        art_store: ArtifactStore = client._artifact_store  # type: ignore[attr-defined]
-        token = art_store.create_token("note.md")
-
-        # Delete after creating token
-        note.unlink()
-
-        response = client.get(f"/artifacts/{token}")
         assert response.status_code == 404
 
 
@@ -471,3 +325,25 @@ class TestCreateServerArtifactRoute:
         routes = server._additional_http_routes
         paths = [getattr(r, "path", "") for r in routes]
         assert any("/artifacts/" in p for p in paths)
+
+
+class TestGetArtifactStoreUninitialised:
+    """get_artifact_store() must error rather than silently return None."""
+
+    def test_raises_runtime_error_when_store_unset(self) -> None:
+        # Any prior test / create_server call may have set the singleton;
+        # clear it explicitly to exercise the uninitialised path, then
+        # restore afterwards.
+        import markdown_vault_mcp.artifacts as _artifacts_module
+        from markdown_vault_mcp.artifacts import (
+            get_artifact_store,
+            set_artifact_store,
+        )
+
+        saved = _artifacts_module._artifact_store
+        try:
+            set_artifact_store(None)
+            with pytest.raises(RuntimeError, match="ArtifactStore not initialised"):
+                get_artifact_store()
+        finally:
+            _artifacts_module._artifact_store = saved


### PR DESCRIPTION
## Summary

Fifth PR in the fastmcp-pvl-core adoption series.

Replaces MV's local \`ArtifactStore\` (stored \`(path, created_at, ttl_seconds)\` and dereferenced through \`Collection\` at serve time) with \`fastmcp_pvl_core.ArtifactStore\` (stores eager bytes + filename + mime_type). This was decision #6 in the extraction plan.

- **\`artifacts.py\`**: now a thin re-export of core's \`ArtifactStore\` + \`TokenRecord\`. Keeps the module-level singleton (\`_artifact_store\`, \`set_artifact_store\`, \`get_artifact_store\`) so tool handlers outside FastMCP's DI context can reach the store used by the HTTP route. Adds \`ARTIFACT_TTL_SECONDS = 3600\` constant (single process-wide TTL — per-token TTL isn't supported upstream). Drops ~200 lines of local \`ArtifactStore\`, \`TokenRecord\`, \`set_collection_store\`, \`_get_collection_from_store\`, and \`make_artifact_handler\` logic.

- **\`mcp_server.py\`**: constructs the \`ArtifactStore\` at \`create_server()\` time (not lifespan) so the HTTP route closure can bind to a concrete instance. Uses \`ArtifactStore.register_route(mcp, store)\` instead of a custom \`mcp.custom_route\` + domain-specific handler.

- **\`_server_tools.py\`** (\`create_download_link\`): eagerly reads bytes via \`asyncio.to_thread(abs_path.read_bytes)\` after path validation, then calls \`store.add(content, filename, mime_type)\`.

- **\`_server_deps.py\`**: lifespan no longer touches the artifact store singleton — the store now lives for the server lifetime.

## Behavioural notes

1. **\`ttl_seconds\` tool arg is now advisory.** Core's \`ArtifactStore\` takes a single TTL at construction; all tokens share it. The tool still validates \`ttl_seconds > 0\` for backward compat, but the actual expiry is always \`ARTIFACT_TTL_SECONDS\` (3600s). The JSON response's \`expires_in_seconds\` reflects the *effective* TTL, not the requested one — this is honest (was 300s before). Docstring updated.

2. **No disk access at serve time.** Bytes are captured at tool-call time; the HTTP handler just returns stored bytes. File deletion after token creation no longer 404s — the token still resolves with the cached bytes until TTL expiry. This is a minor behaviour change from the old "revalidate at serve time" model; acceptable because the TTL is short.

3. **HTTP route closure binds at \`create_server\`.** Previously the handler read \`_collection_store\` via a module-level accessor at request time; now the route closes over the specific store instance, so the lifespan → handler handoff is removed.

## Test updates

\`tests/test_artifacts.py\` rewritten:
- Drops ArtifactStore-internal tests (create/consume/expiry/cleanup) — those are covered in core's own test suite.
- \`TestArtifactHandler\` rewritten to build a minimal Starlette app seeded directly via \`store.add(bytes, filename=, mime_type=)\`, without Collection wiring.
- \`test_expires_in_seconds_matches_ttl\` → \`test_expires_in_seconds_echoes_store_ttl\` (asserts store-wide TTL).
- Adds \`test_raises_runtime_error_when_store_unset\` for \`get_artifact_store\`'s error path.

## Test plan

- [x] \`uv run ruff check --fix . && uv run ruff format .\` — clean
- [x] \`uv run mypy src/\` — no errors
- [x] \`uv run pytest -x -q\` — **1391 passed** (was 1400; −9 from deleted MV-internal tests)
- [x] \`diff-cover\` on changed lines: **100%**
- [x] Total coverage 93.08% (≥80% gate)

## Documentation

No env vars added/removed/renamed. The \`create_download_link\` tool's docstring now documents that \`ttl_seconds\` is advisory; docs site pages for tools will be refreshed in the MV-PR7 audit PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)