### PR TITLE
refactor(server): collapse auth dispatch into build_auth() (MV-PR7)

### DIFF
--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -771,12 +771,14 @@ def _server_from_collection(config: CollectionConfig) -> ServerConfig:
 def resolve_auth_mode(config: CollectionConfig) -> str | None:
     """Return the OIDC auth flavor for *config*, or ``None`` for no OIDC.
 
-    Existing callers (``mcp_server.create_server``) compose multi-auth
-    themselves by combining the OIDC flavor with the bearer verifier, so
-    this wrapper hides core's ``"multi"`` outcome by re-resolving with
-    the bearer token suppressed — the caller still sees just the OIDC
-    flavor (``"remote"`` / ``"oidc-proxy"``) and ``None`` for bearer-only
-    or no-auth configurations.
+    Preserved for the test surface that constructs :class:`CollectionConfig`
+    directly with auth fields populated — the wrapper bridges to core's
+    resolver via :func:`_server_from_collection` and hides the ``"multi"``
+    / ``"bearer"`` / ``"none"`` outcomes behind ``None`` so callers that
+    only branch on the OIDC flavor (``"remote"`` / ``"oidc-proxy"``) keep
+    working.  Production code in :mod:`mcp_server` now calls core's
+    :func:`~fastmcp_pvl_core.resolve_auth_mode` directly on
+    ``config.server``.
 
     Args:
         config: Populated configuration object.

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -141,12 +141,11 @@ def create_server(transport: str = "stdio") -> FastMCP:
     else:
         instructions = _build_default_instructions(read_only=is_read_only)
 
-    # Core owns the auth dispatch: bearer/remote/oidc-proxy/multi/none are
-    # all resolved from config.server field presence via resolve_auth_mode,
-    # and build_auth composes the right provider (wrapping bearer + OIDC in
-    # MultiAuth(required_scopes=[]) when both are configured).
     auth = build_auth(config.server)
-    auth_mode = resolve_auth_mode(config.server)
+    # Collapse to "none" whenever build_auth actually returned None (e.g.
+    # OIDC discovery failed) so the log reflects the real security posture,
+    # not whatever resolve_auth_mode would report from field presence alone.
+    auth_mode = resolve_auth_mode(config.server) if auth is not None else "none"
     if auth_mode == "none":
         logger.warning(
             "No auth configured — server accepts unauthenticated connections"

--- a/src/markdown_vault_mcp/mcp_server.py
+++ b/src/markdown_vault_mcp/mcp_server.py
@@ -23,6 +23,8 @@ from fastmcp import FastMCP
 from fastmcp_pvl_core import (
     ArtifactStore,
     ServerConfig,
+    build_auth,
+    resolve_auth_mode,
     wire_middleware_stack,
 )
 from fastmcp_pvl_core import (
@@ -34,11 +36,7 @@ from fastmcp_pvl_core import (
 
 from markdown_vault_mcp.config import (
     _ENV_PREFIX,
-    build_bearer_auth,
-    build_oidc_auth,
-    build_remote_auth,
     load_config,
-    resolve_auth_mode,
 )
 
 from ._icons import _SERVER_ICON
@@ -143,47 +141,18 @@ def create_server(transport: str = "stdio") -> FastMCP:
     else:
         instructions = _build_default_instructions(read_only=is_read_only)
 
-    bearer_auth = build_bearer_auth(config)
-    oidc_mode = resolve_auth_mode(config)
-
-    oidc_auth = None
-    if oidc_mode == "remote":
-        oidc_auth = build_remote_auth(config)
-    elif oidc_mode == "oidc-proxy":
-        oidc_auth = build_oidc_auth(config)
-
-    if oidc_mode and not oidc_auth:
-        logger.warning(
-            "OIDC auth mode '%s' was selected but auth failed to initialize — "
-            "server will start without OIDC",
-            oidc_mode,
-        )
-
-    if bearer_auth and oidc_auth:
-        from fastmcp.server.auth import MultiAuth
-
-        # Override required_scopes to empty — OIDC's required_scopes
-        # (e.g. ["openid"]) would otherwise propagate to the HTTP
-        # middleware and reject bearer tokens that lack "openid".
-        auth = MultiAuth(server=oidc_auth, verifiers=[bearer_auth], required_scopes=[])
-        auth_mode = f"multi({oidc_mode}+bearer)"
-        logger.info(
-            "Multi-auth enabled: bearer token + OIDC %s (either accepted)", oidc_mode
-        )
-    elif bearer_auth:
-        auth = bearer_auth
-        auth_mode = "bearer"
-        logger.info("Bearer token auth enabled")
-    elif oidc_auth:
-        auth = oidc_auth
-        auth_mode = oidc_mode or "oidc"
-        logger.info("OIDC auth enabled (mode: %s)", oidc_mode)
-    else:
-        auth = None
-        auth_mode = "none"
+    # Core owns the auth dispatch: bearer/remote/oidc-proxy/multi/none are
+    # all resolved from config.server field presence via resolve_auth_mode,
+    # and build_auth composes the right provider (wrapping bearer + OIDC in
+    # MultiAuth(required_scopes=[]) when both are configured).
+    auth = build_auth(config.server)
+    auth_mode = resolve_auth_mode(config.server)
+    if auth_mode == "none":
         logger.warning(
             "No auth configured — server accepts unauthenticated connections"
         )
+    else:
+        logger.info("Auth enabled: mode=%s", auth_mode)
 
     try:
         pkg_ver = _pkg_version("markdown-vault-mcp")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2450,7 +2450,9 @@ class TestAuthModeSelection:
 
         assert isinstance(server.auth, MultiAuth)
         assert "using bearer token auth" not in caplog.text
-        assert "Multi-auth enabled" in caplog.text
+        # create_server now logs "Auth enabled: mode=multi" via core's
+        # resolve_auth_mode, which reports the unified 5-mode vocabulary.
+        assert "Auth enabled: mode=multi" in caplog.text
 
     def test_multi_auth_contains_both_verifiers(
         self,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2571,12 +2571,15 @@ class TestAuthModeSelection:
 
         with (
             patch("markdown_vault_mcp.mcp_server.build_auth", return_value=None),
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.INFO),
         ):
             server = create_server()
 
         assert server.auth is None
         assert "unauthenticated" in caplog.text
+        # Guard against the misleading "Auth enabled: mode=<flavor>" log
+        # that the stale auth_mode could otherwise produce.
+        assert "Auth enabled" not in caplog.text
 
 
 class TestAuthDebugLogging:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2450,8 +2450,6 @@ class TestAuthModeSelection:
 
         assert isinstance(server.auth, MultiAuth)
         assert "using bearer token auth" not in caplog.text
-        # create_server now logs "Auth enabled: mode=multi" via core's
-        # resolve_auth_mode, which reports the unified 5-mode vocabulary.
         assert "Auth enabled: mode=multi" in caplog.text
 
     def test_multi_auth_contains_both_verifiers(
@@ -2551,6 +2549,34 @@ class TestAuthModeSelection:
         assert any("unauthenticated" in r.message for r in warning_records), (
             "No-auth message must be logged at WARNING level, not INFO"
         )
+
+    def test_auth_mode_reports_none_when_build_auth_fails(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """If build_auth returns None despite OIDC config, log ``mode=none``.
+
+        Guards against the log drifting from reality when e.g. OIDC
+        discovery fails: ``resolve_auth_mode`` would still report
+        ``oidc-proxy`` from field presence, but the actual auth object
+        is ``None`` so the startup summary must say ``none``.
+        """
+        from unittest.mock import patch
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+        for var, val in _OIDC_REQUIRED.items():
+            monkeypatch.setenv(var, val)
+
+        with (
+            patch("markdown_vault_mcp.mcp_server.build_auth", return_value=None),
+            caplog.at_level(logging.WARNING),
+        ):
+            server = create_server()
+
+        assert server.auth is None
+        assert "unauthenticated" in caplog.text
 
 
 class TestAuthDebugLogging:


### PR DESCRIPTION
## Summary

Seventh and final PR in the fastmcp-pvl-core adoption series.

\`create_server()\` shrinks from 244 → 213 lines. The 40-line auth orchestration block (bearer/oidc_mode resolution, conditional \`build_remote_auth\`/\`build_oidc_auth\`, manual \`MultiAuth\` composition with \`required_scopes=[]\`) collapses to two calls:

\`\`\`python
auth = build_auth(config.server)
auth_mode = resolve_auth_mode(config.server)
\`\`\`

Core's \`build_auth\` owns the full dispatch:

- \`none\`       → \`None\` (warning logged)
- \`bearer\`     → \`StaticTokenVerifier\`
- \`oidc-proxy\` → \`OIDCProxy\`
- \`remote\`     → \`RemoteAuthProvider\`
- \`multi\`      → \`MultiAuth(server=oidc, verifiers=[bearer], required_scopes=[])\`

MV's \`config.py\` wrappers (\`build_bearer_auth\` / \`build_oidc_auth\` / \`build_remote_auth\` / \`resolve_auth_mode\` taking \`CollectionConfig\`) stay in place — they're still used by the existing test suite which constructs \`CollectionConfig\` with auth fields directly, exercising the \`_server_from_collection\` shim. The wrappers cost ~30 lines and keep the test surface stable; a future cleanup PR can migrate tests to pass \`config.server\` directly and drop them.

## Audit of remaining generic infra in \`src/markdown_vault_mcp/\`

- **No direct imports** of \`ErrorHandlingMiddleware\` / \`TimingMiddleware\` / \`LoggingMiddleware\` / \`StructuredLoggingMiddleware\` / \`OIDCProxy\` / \`JWTVerifier\` / \`RemoteAuthProvider\` / \`StaticTokenVerifier\` (all routed through core).
- Remaining \`from fastmcp.*\` imports are legitimate domain glue: DI (\`CurrentContext\`, \`Depends\`, \`Context\`, \`lifespan\`), \`ToolError\`, \`AppConfig\`, and the \`EventStore\` type alias.

### Line-count delta vs start of series

| File | Before MV-PR1 | After MV-PR7 | Δ |
|---|---:|---:|---:|
| \`mcp_server.py\` | 313 | 213 | −100 (~32%) |
| \`config.py\` | 1027 | 822 | −205 (~20%) |
| \`artifacts.py\` | 267 | 66 | −201 (~75%) |

## Test plan

- [x] \`uv run ruff check --fix . && uv run ruff format .\` — clean
- [x] \`uv run mypy src/\` — no errors
- [x] \`uv run pytest -x -q\` — 1393 passed
- [x] \`diff-cover\` on changed lines: 100%
- [x] Total coverage 93.18% (≥80% gate)

## Behavioural notes

- Log string \`"Multi-auth enabled: bearer token + OIDC <mode>"\` was replaced by \`"Auth enabled: mode=<mode>"\` from core's unified 5-mode vocabulary (\`none\` / \`bearer\` / \`remote\` / \`oidc-proxy\` / \`multi\`). \`test_multi_auth_when_both_configured\` updated to match.

## Next steps after merge

1. Cut \`fastmcp-pvl-core==1.0.0\` stable (run the core Release workflow with \`prerelease=false\`) now that all 7 MV adoption PRs landed cleanly against rc builds.
2. Re-pin MV to \`fastmcp-pvl-core>=1.0.0,<2\`.
3. MV release via PSR auto-bump (will be v1.24.0 given the feat commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)