### PR TITLE
chore: repin fastmcp-pvl-core to >=1.0.0,<2 (stable)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "fastmcp-pvl-core==1.0.0rc1",
+    "fastmcp-pvl-core>=1.0.0,<2",
     "python-frontmatter>=1.0",
     "requests>=2.33.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -735,14 +735,14 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "1.0.0rc1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/61/71891949c6569c986d01a2f043687a6acb704a2b6b8422f3806036c47e12/fastmcp_pvl_core-1.0.0rc1.tar.gz", hash = "sha256:56925ed645720b956a7d1fe395da6edb9518c4e47470a4d0c24520af2364c26e", size = 144859, upload-time = "2026-04-20T10:12:20.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e8/19d9736dd16b366fcad897c3b305588c6e79d989caa296d0116f1625eb44/fastmcp_pvl_core-1.0.0.tar.gz", hash = "sha256:01a37c824a8929c6267d54ec570d5f6b1639e6c133eb6c36f1ee03ac216603f8", size = 144843, upload-time = "2026-04-20T15:57:19.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/f5/29ef92cfa2a0f61178e3bdd6f4b7fbc24e39507d0085154ec71bdc22a067/fastmcp_pvl_core-1.0.0rc1-py3-none-any.whl", hash = "sha256:5b268ca4dbe9eef50ee99fd58cd55fed32470fcf9c389eb45742a23454dadc6a", size = 18444, upload-time = "2026-04-20T10:12:19.272Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d8/f79abe84d1dbe4be2165755de52b50fae365f5c4a096eea49e97ac12c948/fastmcp_pvl_core-1.0.0-py3-none-any.whl", hash = "sha256:a19e24ec387ae792e62781edbbc8a986545b5eb33eb01580ed707edbbea77e39", size = 18410, upload-time = "2026-04-20T15:57:17.835Z" },
 ]
 
 [[package]]
@@ -1225,7 +1225,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.3" },
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "fastmcp-pvl-core", specifier = "==1.0.0rc1" },
+    { name = "fastmcp-pvl-core", specifier = ">=1.0.0,<2" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25" },
     { name = "httpx", marker = "extra == 'embeddings-api'", specifier = ">=0.25" },
     { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.2" },


### PR DESCRIPTION
## Summary

Move MV's \`fastmcp-pvl-core\` dep from the \`==1.0.0rc1\` pin it rode through MV-PR1..7 to the permissive stable range \`>=1.0.0,<2\`. Future 1.x releases (bug-fixes, minor features) flow in automatically; a future 2.x would need an explicit bump.

Core v1.0.0 went up on PyPI this afternoon now that all 7 MV adoption PRs (#396–#402) landed cleanly against the rc.

## Test plan

- [x] \`uv lock --refresh-package fastmcp-pvl-core\` — resolved \`1.0.0rc1 → 1.0.0\`
- [x] \`uv sync --all-extras --dev\`
- [x] \`uv run pytest -x -q\` — 1394 passed

## Next step

After this merges, run the MV release workflow (PSR auto-bumps to v1.24.0 from the 7 feat/refactor commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)