### PR TITLE
docs(design): add Shared Infrastructure section pointing at fastmcp-pvl-core

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -41,6 +41,18 @@ vault becomes another.
    the primary interface; MCP is one consumer, not the only one. Other
    frameworks (LangChain, LlamaIndex, etc.) may wrap `Collection` directly.
 
+## Shared Infrastructure
+
+Generic FastMCP infrastructure (auth providers, middleware stack, logging
+bootstrap, server-factory helpers, artifact store, CLI helpers) lives in the
+`fastmcp-pvl-core` PyPI package. markdown-vault-mcp composes this library
+via `ServerConfig` (never inheritance) and imports the building blocks
+directly — see `src/markdown_vault_mcp/mcp_server.py:create_server` for the
+assembled call graph.
+
+Design spec: `docs/superpowers/specs/2026-04-20-fastmcp-core-and-copier-template-design.md`.
+Adoption plan: `docs/superpowers/plans/2026-04-20-fastmcp-pvl-core-extraction.md`.
+
 ## Architecture
 
 Two packages, one dependency edge (eventual):

--- a/docs/design.md
+++ b/docs/design.md
@@ -47,7 +47,7 @@ Generic FastMCP infrastructure (auth providers, middleware stack, logging
 bootstrap, server-factory helpers, artifact store, CLI helpers) lives in the
 `fastmcp-pvl-core` PyPI package. markdown-vault-mcp composes this library
 via `ServerConfig` (never inheritance) and imports the building blocks
-directly — see `src/markdown_vault_mcp/mcp_server.py:create_server` for the
+directly — see `create_server()` in `src/markdown_vault_mcp/mcp_server.py` for the
 assembled call graph.
 
 Design spec: `docs/superpowers/specs/2026-04-20-fastmcp-core-and-copier-template-design.md`.


### PR DESCRIPTION
## Summary

Finishes Task 21 Step 3 of the extraction plan (\`docs/superpowers/plans/2026-04-20-fastmcp-pvl-core-extraction.md\`): adds a \`## Shared Infrastructure\` paragraph to \`docs/design.md\` just above \`## Architecture\`, noting that generic FastMCP primitives live in \`fastmcp-pvl-core\` and that MV composes them via \`ServerConfig\` (never inheritance). Links to the design spec + adoption plan for readers who want the full story.

## Test plan

- [x] Docs-only change; all existing tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)