### PR TITLE
fix(release): publish linux packages on prerelease too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
 
   publish-linux-packages:
     needs: release
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Summary

One-line fix: drop \`!inputs.prerelease\` gate from the \`publish-linux-packages\` job so .deb/.rpm artifacts attach to prerelease GitHub releases too.

## Why

Caught during Step 4 bootstrap-replay smoke: \`v1.26.0-rc.1\` shipped Docker + MCPB but no .deb/.rpm, which defeats the purpose of having an rc to validate the Linux packaging path against.

The gating across publish jobs is now consistent with their actual risk profile:

| Job | Runs on rc? | Reason |
|---|---|---|
| publish-pypi | no | immutable index |
| publish-docker | yes | GHCR is fine for rc tags |
| **publish-linux-packages** | **yes (this PR)** | just artifacts on a GH release |
| publish-mcpb | yes | artifact on the release |
| publish-claude-plugin-pr | no | opens PR to external repo |
| publish-registry | no | immutable index |

Mirrored from pvliesdonk/fastmcp-server-template#11. When that lands and we run \`copier update\` on MV, this file will no-op.

## Test plan

- [x] CI green
- [ ] Next rc release (e.g. \`v1.26.0-rc.2\` or \`v1.27.0-rc.1\`) attaches .deb/.rpm to the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)