### PR TITLE
fix(gitignore): narrow .claude/ → specific per-user paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ htmlcov/
 site/
 .mcpregistry_*
 .worktrees/
+docs/superpowers/
 
 # Claude Code local overrides (scope narrowly so project-shared assets
 # under .claude/ — hooks, custom commands, agents — stay committable)

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,7 @@ site/
 .mcpregistry_*
 .worktrees/
 
-# Claude Code local settings
-.claude/
+# Claude Code local overrides (scope narrowly so project-shared assets
+# under .claude/ — hooks, custom commands, agents — stay committable)
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Broad \`.claude/\` entry was too aggressive — blocks committing project-shared Claude assets (hooks, custom commands, agents). Narrow to the two paths that are genuinely per-user/per-checkout:

- \`.claude/worktrees/\` — Claude Code worktree stash
- \`.claude/settings.local.json\` — per-user/per-checkout overrides

Anything else under \`.claude/\` (project agents, shared hooks, custom commands) is now committable.

## Context

Mirrors the starter convention established in pvliesdonk/fastmcp-server-template#19.  That template PR also adds \`.gitignore\` to \`_skip_if_exists\` so future \`copier update\` runs preserve project-specific entries instead of risking a clobber.

## Test plan

- [x] No file changes under \`.claude/\` currently tracked, so narrowing is safe.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)