### PR TITLE
fix(ci): docs deploy on v* tag push + 3-part concurrency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,13 @@ name: Documentation
 on:
   push:
     branches: [main]
+    # Tag-push also deploys: whichever event fires first (tag-push or
+    # release:published) wins the concurrency group below and performs
+    # the full build+upload+deploy.  The release-event path can race
+    # against tag availability (deploy-pages fetch fails), so tag-push
+    # gives a deterministic second path.  Gates on the `upload-artifact`
+    # step and `deploy` job below accept either event.
+    tags: ["v*"]
   pull_request:
     branches: [main]
   release:
@@ -12,8 +19,13 @@ on:
 permissions:
   contents: read
 
+# Include github.event_name so tag-push and release runs don't share a
+# concurrency key — without this, the tag-push run fired by ``git push``
+# and the release run fired by ``release:published`` collide on the same
+# ref+workflow key and ``cancel-in-progress: true`` cancels whichever
+# arrived first (usually the one carrying the deployment).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -44,13 +56,13 @@ jobs:
         run: uv run mkdocs build --strict
 
       - name: Upload artifact
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
   deploy:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

Port three docs workflow fixes from scholar-mcp (#154) and the template (pvliesdonk/fastmcp-server-template#20):

1. Add \`tags: [\"v*\"]\` to the push trigger so tag-push fires the workflow.
2. Extend \`github.event_name\` into the concurrency group so tag-push and release-event runs don't cancel each other.
3. Extend the gate on \`upload-artifact\` and the \`deploy\` job to accept tag-push on v* (not only \`event_name == 'release'\`).

## Why

The release-event path can race against tag availability in GitHub Pages' deploy-pages action (scholar v1.8.0-rc.1 + IG v1.8.0 both hit this).  Letting tag-push deploy too gives a deterministic second path — whichever event fires first wins the concurrency group and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)