### PR TITLE
refactor(config): add CONFIG-FIELDS + CONFIG-FROM-ENV sentinel markers

### DIFF
--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -157,6 +157,7 @@ class CollectionConfig:
         collection = Collection(**config.to_collection_kwargs())
     """
 
+    # CONFIG-FIELDS-START — domain fields; kept across copier update
     source_dir: Path
     read_only: bool = True
     index_path: Path | None = None
@@ -203,6 +204,7 @@ class CollectionConfig:
     openai_api_key: str | None = None
     fastembed_model: str = "BAAI/bge-small-en-v1.5"
     fastembed_cache_dir: str | None = None
+    # CONFIG-FIELDS-END
 
     # Universal server fields delegated to fastmcp_pvl_core.ServerConfig.
     # Domain-specific fields above remain on CollectionConfig; subsequent
@@ -688,6 +690,7 @@ def load_config() -> CollectionConfig:
     )
 
     return CollectionConfig(
+        # CONFIG-FROM-ENV-START — domain fields populated from env; kept across copier update
         source_dir=source_dir,
         read_only=read_only,
         index_path=index_path,
@@ -728,6 +731,7 @@ def load_config() -> CollectionConfig:
         openai_api_key=openai_api_key,
         fastembed_model=fastembed_model,
         fastembed_cache_dir=fastembed_cache_dir,
+        # CONFIG-FROM-ENV-END
         server=ServerConfig.from_env(_ENV_PREFIX),
     )
 


### PR DESCRIPTION
## Summary

Template convention (shipped post-MV-retrofit) wraps domain fields on \`ProjectConfig\` in \`CONFIG-FIELDS-START/END\` markers and the \`from_env\` population in \`CONFIG-FROM-ENV-START/END\` markers, so copier's 3-way merge has stable anchors when the template adds/removes fields on \`ServerConfig\` composition.

MV was retrofitted at template v1.0.0 before this convention stabilised. Adding the markers now so future copier updates touching config composition have reliable merge anchors.

## Changes

Pure comment additions — no code changed:

- \`CONFIG-FIELDS-START\` / \`CONFIG-FIELDS-END\` wrap the dataclass domain fields (from \`source_dir: Path\` through \`fastembed_cache_dir: str | None = None\`). Template-owned \`server: ServerConfig = field(...)\` composition line stays outside the zone.
- \`CONFIG-FROM-ENV-START\` / \`CONFIG-FROM-ENV-END\` wrap the \`CollectionConfig(...)\` kwargs in \`load_config()\`, ending just before \`server=ServerConfig.from_env(_ENV_PREFIX)\`.

## Test plan

- [x] \`uv run ruff check .\` → clean
- [x] \`uv run ruff format --check .\` → clean
- [x] \`uv run mypy src/\` → clean
- [x] \`uv run pytest -x -q\` → 1394 passed
- [ ] CI green

## Follow-ups

- All three repos: \`CLAUDE.md\` sentinel alignment (\`DOMAIN-START/END\` + \`TEMPLATE-OWNED SECTIONS\`)
- MV + scholar: pre-create \`tests/test_smoke.py\`
- Scholar: \`pyproject.toml\` sentinel backfill (\`PROJECT-DEPS\` + \`PROJECT-EXTRAS\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)