### PR TITLE
chore(copier): update to v1.1.4 + pre-create test_smoke.py

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.1.1
+_commit: v1.1.4
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown collection MCP server with FTS5 + semantic search

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -45,7 +45,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run copier update
-        id: copier
         env:
           VCS_REF: ${{ inputs.vcs_ref }}
         run: |
@@ -95,24 +94,33 @@ jobs:
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
           echo "conflict_count=${conflict_count}" >> "$GITHUB_OUTPUT"
 
-      - name: Ensure `copier` label exists
+      - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
+          # `gh pr create --label foo` fails if the label doesn't exist,
+          # so ensure both labels are present first.  `|| true` keeps the
+          # step idempotent across repeat runs.
           gh label create copier \
             --color C5DEF5 \
             --description "Automated copier template sync" \
             2>/dev/null || true
+          gh label create dependencies \
+            --color 0075CA \
+            --description "Pull requests that update a dependency file" \
+            2>/dev/null || true
 
       - name: Commit and push to copier/update branch
         if: steps.changes.outputs.changed == 'true'
+        env:
+          REF: ${{ steps.meta.outputs.ref }}
         run: |
           set -euo pipefail
           branch="copier/update"
           git checkout -B "${branch}"
           git add -A
-          git commit -m "chore(copier): update to ${{ steps.meta.outputs.ref }}" \
+          git commit -m "chore(copier): update to ${REF}" \
             -m "Automated \`copier update\` run — review the diff and merge if CI is green."
           git push --force-with-lease origin "${branch}"
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,30 @@
+"""Smoke tests for Markdown Vault MCP.
+
+This file diverges from the template's scaffold because MV's
+``make_server`` calls ``load_config`` which requires a non-empty
+``MARKDOWN_VAULT_MCP_SOURCE_DIR``.  The template's bare
+``server = make_server(); assert server`` would raise before the
+assertion ever runs.  Providing a throwaway ``tmp_path`` via
+``monkeypatch`` keeps the check meaningful without tying the smoke
+test to any real vault.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.server import make_server
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_make_server_constructs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """make_server() returns a FastMCP instance without raising."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    server = make_server()
+    assert server is not None


### PR DESCRIPTION
## Summary

Catches MV up from template v1.1.1 → **v1.1.4**. Small diff, coherent story:

- `.copier-answers.yml`: `_commit` bumped.
- `.github/workflows/copier-update.yml`: refreshed — commit step now passes `REF` via `env:` instead of direct shell interpolation (template PR #26).
- `tests/test_smoke.py`: **new**, with MV-specific adaptation.

## Why test_smoke.py needs an MV-specific variant

Template's canonical `tests/test_smoke.py`:

```python
from markdown_vault_mcp.server import make_server

def test_make_server_constructs():
    server = make_server()
    assert server is not None
```

…raises on MV because `make_server` calls `load_config` which requires `MARKDOWN_VAULT_MCP_SOURCE_DIR`. Setting a throwaway `tmp_path` via `monkeypatch` keeps the check meaningful without tying the smoke test to any real vault.

The file is `_skip_if_exists`-protected so future template updates won't re-emit the bare scaffold version over this.

## Why pre-create rather than let the cron do it

Without this, the next weekly cron would produce a surprise PR creating the broken scaffold test. Pre-creating removes that class of surprise.

## Test plan

- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → clean
- [x] `uv run mypy src/` → clean
- [x] `uv run pytest -x -q` → 1395 passed (up 1)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)