### PR TITLE
chore(copier): converge drifted template-owned files to v1.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,41 @@
+# Python bytecode
 __pycache__/
 *.py[cod]
 *$py.class
+*.so
+
+# Distribution / packaging
 *.egg-info/
+*.egg
 dist/
 build/
 .eggs/
-*.egg
+
+# Virtualenvs
 .venv/
 venv/
-.env
-*.so
+
+# Tooling caches
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
+
+# Test / coverage artifacts
 .coverage
 coverage.xml
+coverage.json
 htmlcov/
-*.npy
-*.npz
+
+# MkDocs build output
 site/
+
+# Local environment
+.env
+.env.local
+
+# --- Development / ecosystem ignores (don't ship)
 .mcpregistry_*
 .worktrees/
-docs/superpowers/
-
-# Claude Code local overrides (scope narrowly so project-shared assets
-# under .claude/ — hooks, custom commands, agents — stay committable)
 .claude/worktrees/
 .claude/settings.local.json
+docs/superpowers/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 
+# DOCKERFILE-APT-DEPS-START — add domain apt packages below; kept across copier update
 RUN apt-get update && apt-get install -y --no-install-recommends git git-lfs gosu \
     && rm -rf /var/lib/apt/lists/* \
     && git lfs install --system
+# DOCKERFILE-APT-DEPS-END
 
 COPY --from=ghcr.io/astral-sh/uv:0.6 /uv /uvx /bin/
 
@@ -11,6 +13,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /app
 
+# DOCKERFILE-UV-EXTRAS-START — append `--extra <name>` flags below to pull domain-specific extras; kept across copier update
 # Install dependencies first (cache layer).
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
@@ -21,6 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra all
+# DOCKERFILE-UV-EXTRAS-END
 
 # Create non-root user with configurable UID/GID for bind-mount compatibility.
 ARG APP_UID=1000

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -2,18 +2,21 @@
 """Bump versioned manifests to match the semantic-release version.
 
 Invoked by python-semantic-release via ``[tool.semantic_release] build_command``.
-PSR sets ``NEW_VERSION`` in the environment and, because ``server.json`` is
-listed in ``[tool.semantic_release] assets``, PSR stages and commits it
-together with ``pyproject.toml`` + ``CHANGELOG.md`` as the single release
+PSR sets ``NEW_VERSION`` in the environment and, because the three manifest
+paths are listed in ``[tool.semantic_release] assets``, PSR stages and commits
+them together with ``pyproject.toml`` + ``CHANGELOG.md`` as the single release
 commit — which is the commit it then tags.
 
 The script runs inside PSR's Docker action container (python:3.14-slim), which
 has Python but no ``jq`` — hence Python rather than a shell+jq wrapper.
 
-Projects that ship additional versioned manifests (e.g. a Claude Code
-``plugin.json``, an ``.mcp.json``, or other lockstep JSON/TOML files) should
-add the extra paths to this script and list them in
-``pyproject.toml`` ``[tool.semantic_release] assets``.
+This MV-specific version extends the template's single-manifest (server.json)
+bumper with two extra Claude Code plugin manifests that also need to move in
+lockstep with the released package version:
+
+- ``.claude-plugin/plugin/.claude-plugin/plugin.json`` — plugin ``version``
+- ``.claude-plugin/plugin/.mcp.json`` — ``uvx --from markdown-vault-mcp[all]==<ver>``
+  pin in the server's launch args.
 """
 
 from __future__ import annotations
@@ -100,7 +103,26 @@ def main() -> int:
             pkg["identifier"] = new_id
     _dump(server_path, server)
 
+    # Claude Code plugin.json: plugin version, lockstep with the package.
+    plugin_path = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
+    plugin = _load(plugin_path)
+    plugin["version"] = version
+    _dump(plugin_path, plugin)
+
+    # Claude Code .mcp.json: pin uvx --from spec to the released version.
+    mcp_path = Path(".claude-plugin/plugin/.mcp.json")
+    mcp = _load(mcp_path)
+    mcp["markdown-vault-mcp"]["args"] = [
+        "--from",
+        f"markdown-vault-mcp[all]=={version}",
+        "markdown-vault-mcp",
+        "serve",
+    ]
+    _dump(mcp_path, mcp)
+
     print(f"bump_manifests: server.json → {version}")
+    print(f"bump_manifests: {plugin_path} → {version}")
+    print(f"bump_manifests: {mcp_path} → markdown-vault-mcp[all]=={version}")
     return 0
 
 

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 """Bump versioned manifests to match the semantic-release version.
 
-Invoked by python-semantic-release via `[tool.semantic_release] build_command`.
-PSR sets ``NEW_VERSION`` in the environment and, because the three manifest
-paths are listed in ``[tool.semantic_release] assets``, PSR stages and commits
-them together with ``pyproject.toml`` + ``CHANGELOG.md`` as the single release
+Invoked by python-semantic-release via ``[tool.semantic_release] build_command``.
+PSR sets ``NEW_VERSION`` in the environment and, because ``server.json`` is
+listed in ``[tool.semantic_release] assets``, PSR stages and commits it
+together with ``pyproject.toml`` + ``CHANGELOG.md`` as the single release
 commit — which is the commit it then tags.
 
 The script runs inside PSR's Docker action container (python:3.14-slim), which
 has Python but no ``jq`` — hence Python rather than a shell+jq wrapper.
+
+Projects that ship additional versioned manifests (e.g. a Claude Code
+``plugin.json``, an ``.mcp.json``, or other lockstep JSON/TOML files) should
+add the extra paths to this script and list them in
+``pyproject.toml`` ``[tool.semantic_release] assets``.
 """
 
 from __future__ import annotations
@@ -47,32 +52,55 @@ def main() -> int:
     # Replace only the ``:v<old>`` suffix of the OCI identifier so forks/renames
     # keep their own ``ghcr.io/<owner>/<image>`` base.
     server_path = Path("server.json")
+    if not server_path.exists():
+        print(
+            f"server.json not found in {Path.cwd()} — run from repo root",
+            file=sys.stderr,
+        )
+        return 1
     server = _load(server_path)
+    if not isinstance(server, dict):
+        print(
+            f"{server_path} must contain a JSON object (top-level), "
+            f"got {type(server).__name__}",
+            file=sys.stderr,
+        )
+        return 1
     server["version"] = version
-    for pkg in server.get("packages", []):
+    packages = server.get("packages", [])
+    if not isinstance(packages, list):
+        print(
+            f"{server_path}: 'packages' must be a JSON array, got "
+            f"{type(packages).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+    for i, pkg in enumerate(packages):
+        if not isinstance(pkg, dict):
+            print(
+                f"WARNING: packages[{i}] is not a JSON object "
+                f"(got {type(pkg).__name__}) — skipped",
+                file=sys.stderr,
+            )
+            continue
         if pkg.get("registryType") == "pypi":
             pkg["version"] = version
         elif pkg.get("registryType") == "oci":
-            pkg["identifier"] = re.sub(r":v[^:]+$", f":v{version}", pkg["identifier"])
+            # ``or ""`` covers both the absent-key and the JSON-null cases;
+            # ``dict.get(key, default)`` only returns default when the key
+            # is absent, not when the value is None.
+            identifier = pkg.get("identifier") or ""
+            new_id, n = re.subn(r":v[^:]+$", f":v{version}", identifier)
+            if n == 0:
+                print(
+                    f"WARNING: OCI identifier {identifier!r} has no ':v<tag>' "
+                    "suffix to bump — left unchanged",
+                    file=sys.stderr,
+                )
+            pkg["identifier"] = new_id
     _dump(server_path, server)
 
-    # Claude Code plugin.json: plugin version, lockstep with the package.
-    plugin_path = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
-    plugin = _load(plugin_path)
-    plugin["version"] = version
-    _dump(plugin_path, plugin)
-
-    # Claude Code .mcp.json: pin uvx --from spec to the released version.
-    mcp_path = Path(".claude-plugin/plugin/.mcp.json")
-    mcp = _load(mcp_path)
-    mcp["markdown-vault-mcp"]["args"] = [
-        "--from",
-        f"markdown-vault-mcp[all]=={version}",
-        "markdown-vault-mcp",
-        "serve",
-    ]
-    _dump(mcp_path, mcp)
-
+    print(f"bump_manifests: server.json → {version}")
     return 0
 
 


### PR DESCRIPTION
## Summary

Pre-emptive alignment before the Phase 4 copier-update bot PR lands.
See spec in fastmcp-server-template repo: `docs/superpowers/specs/2026-04-22-copier-sync-and-claude-md-parity-design.md` section 2.4 (drift audit) + section 3.3 Phase 1.5.

## What changed

Dry-rendered `fastmcp-server-template@v1.1.5` with MV's `.copier-answers.yml` and diffed each drifted template-owned file against MV's working copy. Converged pure-drift files; preserved files with real MV domain customization; migrated `Dockerfile` into the new `DOCKERFILE-APT-DEPS-*` / `DOCKERFILE-UV-EXTRAS-*` sentinel blocks.

### Converged (cp reference over MV)

- `scripts/bump_manifests.py` — adopts v1.1.5 shape (single `server.json` bump, input validation, warnings on missing `:v<tag>`). MV no longer ships `plugin.json` or `.mcp.json`, so the old per-file bump branches were dead code.
- `.gitignore` — pure structural drift (section-header comments, `coverage.json` + `.env.local` additions).

### Edited into sentinels

- `Dockerfile` — added `DOCKERFILE-APT-DEPS-START/END` and `DOCKERFILE-UV-EXTRAS-START/END` markers around the apt install + uv sync blocks. MV's `--extra all` and `COPY . .` customizations now live inside the UV-EXTRAS sentinel (preserved across future copier updates). MV's `/data/vault` + `embeddings` + `fastembed` mkdir paths and the `VOLUME ["/data/vault", "/data/state"]` line remain outside any sentinel — those are MV domain state paths that the template v1.1.5 does not yet provide escape hatches for.

### Preserved (real MV domain, not converged)

- `docker-entrypoint.sh` — MV-specific `mkdir -p /data/state/embeddings /data/state/fastembed /data/state/fastmcp` and "bind-mounted vault files" comment.
- `compose.yml` — MV-specific bind-mounted vault source dir, four `MARKDOWN_VAULT_MCP_*` env vars for index/embeddings/fastembed paths, Traefik labels with MV hostnames.
- `docs/deployment/docker.md` — 236-line MV-specific doc with vault mount guidance, Traefik setup, v1.8.x upgrade note, MV env vars. Reference is 33 generic lines.
- `docs/deployment/oidc.md` — 287-line MV-specific doc covering remote vs oidc-proxy mode selection, full Authelia config, `MARKDOWN_VAULT_MCP_*` env-var prefix. Reference uses generic `MCP_SERVER_*` prefix.
- `docs/guides/authentication.md` — 259-line MV-specific auth guide with five auth modes incl. multi-auth, remote-vs-proxy trade-offs. Reference has only four generic modes.

## Gate results (local)

- `uv sync --all-extras --dev` — clean
- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — 67 files already formatted
- `uv run mypy src/` — no issues (31 files)
- `uv run pytest -x -q` — 1395 passed

## Follow-up

The Dockerfile's `mkdir -p /data/...` and `VOLUME [...]` lines are not inside any sentinel, so a future copier update would clobber MV's `/data/vault` paths. Consider a follow-up issue on `fastmcp-server-template` to add `DOCKERFILE-STATE-DIRS-*` + `DOCKERFILE-VOLUMES-*` sentinels so those become truly escape-hatched.