### PR TITLE
fix(ci): stage conflict markers before git checkout -B in copier-update

### DIFF
--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -118,8 +118,15 @@ jobs:
         run: |
           set -euo pipefail
           branch="copier/update"
-          git checkout -B "${branch}"
+          # `git add -A` runs BEFORE `git checkout -B` because copier's
+          # `--conflict=inline` mode leaves conflict-marker files in the
+          # index as `UU` (unmerged).  `git checkout -B` refuses to switch
+          # branches with unresolved merge entries; staging them first
+          # clears the unmerged state and lets the branch creation proceed.
+          # The conflict markers themselves land in the commit for human
+          # resolution in the PR.
           git add -A
+          git checkout -B "${branch}"
           git commit -m "chore(copier): update to ${REF}" \
             -m "Automated \`copier update\` run — review the diff and merge if CI is green."
           git push --force-with-lease origin "${branch}"


### PR DESCRIPTION
Hot-patch the rendered copier-update.yml so the next dispatch can commit conflict-markered files (CLAUDE.md + Dockerfile conflicts expected when updating to template v1.1.8).  Mirrors template PR #34.

## Test plan

- [x] YAML parses
- [x] `git add -A` now precedes `git checkout -B`