### PR TITLE
chore(copier): update to v1.2.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.1.8
+_commit: v1.2.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown collection MCP server with FTS5 + semantic search

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run mypy
-        run: uv run mypy src/
+        run: uv run mypy src/ tests/
 
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -45,10 +45,19 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run copier update
+        id: copier
         env:
           VCS_REF: ${{ inputs.vcs_ref }}
         run: |
           set -euo pipefail
+          # Capture the pre-update `_commit` BEFORE copier rewrites
+          # `.copier-answers.yml` with the new ref — the PR body uses it to
+          # render the prev_ref→ref delta and a compare link.  `|| true` so
+          # a missing/corrupt answers file doesn't abort before the update
+          # (the post-update meta step re-parses and hard-fails if needed).
+          prev_ref=$(awk '/^_commit:[[:space:]]/ {print $2; exit}' .copier-answers.yml || true)
+          echo "prev_ref=${prev_ref}" >> "$GITHUB_OUTPUT"
+
           # `--conflict=inline` runs a real 3-way merge and writes standard
           # `<<<<<<< before updating / ||||||| last update / ======= / >>>>>>> after updating`
           # markers when local edits collide with template changes.  The
@@ -72,7 +81,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Read template ref + count conflicts
+      - name: Read template ref + collect conflict files
         if: steps.changes.outputs.changed == 'true'
         id: meta
         run: |
@@ -86,13 +95,42 @@ jobs:
             exit 1
           fi
           # `--conflict=inline` writes standard `<<<<<<< before updating`
-          # markers (not `.rej` sidecars).  Count files that contain at
+          # markers (not `.rej` sidecars).  Collect files that contain at
           # least one conflict marker; skip binary files with `git grep -I`.
           # `|| true` swallows git grep's exit code 1 on no-match so the
           # happy path (zero conflicts) doesn't trip `set -euo pipefail`.
-          conflict_count=$( { git grep -lI '^<<<<<<< before updating$' || true; } | wc -l | tr -d ' ')
+          # We emit the file *list* (not just the count) so the PR body can
+          # tell the reviewer exactly which files need manual resolution.
+          conflict_files=$( { git grep -lI '^<<<<<<< before updating$' || true; } )
+          if [ -n "${conflict_files}" ]; then
+            conflict_count=$(printf '%s\n' "${conflict_files}" | wc -l | tr -d ' ')
+          else
+            conflict_count=0
+          fi
+          # Derive the template source repo from `_src_path` in .copier-answers.yml
+          # rather than synthesising from `{{ github_org }}` — `github_org` is the
+          # *consumer's* org (for Docker paths, etc.), not the template source's.
+          # Normalize the common forms copier may have stored ({gh:,https://github.com/,
+          # git@github.com:}org/repo[.git]) down to `org/repo`; local paths or anything
+          # else unrecognised becomes empty and the PR step skips the release-notes
+          # and compare-link sections gracefully.
+          src_path=$(awk '/^_src_path:[[:space:]]/ {print $2; exit}' .copier-answers.yml || true)
+          template_repo=$(printf '%s' "${src_path}" \
+            | sed -E 's|^gh:||; s|^https?://github\.com/||; s|^git@github\.com:||; s|\.git$||; s|/+$||')
+          if ! printf '%s' "${template_repo}" | grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            template_repo=""
+          fi
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
           echo "conflict_count=${conflict_count}" >> "$GITHUB_OUTPUT"
+          echo "template_repo=${template_repo}" >> "$GITHUB_OUTPUT"
+          # Multiline `conflict_files` needs the heredoc form of $GITHUB_OUTPUT.
+          # The `CONFLICT_FILES_EOF` delimiter is safe because git-tracked file paths
+          # can't contain newlines, let alone a line that matches that literal string.
+          {
+            echo "conflict_files<<CONFLICT_FILES_EOF"
+            printf '%s\n' "${conflict_files}"
+            echo "CONFLICT_FILES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'
@@ -131,26 +169,93 @@ jobs:
             -m "Automated \`copier update\` run — review the diff and merge if CI is green."
           git push --force-with-lease origin "${branch}"
 
+      - name: Compute diff summary
+        if: steps.changes.outputs.changed == 'true'
+        id: diff
+        run: |
+          set -euo pipefail
+          # `copier/update` is always `main + 1 commit` because the previous
+          # step does `git checkout -B` off the checked-out default branch
+          # before making a single commit, so HEAD~1..HEAD captures exactly
+          # this update's delta — no merge-base math needed.
+          diff_count=$(git diff --name-only HEAD~1 HEAD | wc -l | tr -d ' ')
+          echo "diff_count=${diff_count}" >> "$GITHUB_OUTPUT"
+          {
+            echo "diff_stat<<DIFF_STAT_EOF"
+            git diff --stat HEAD~1 HEAD
+            echo "DIFF_STAT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Open or update PR
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REF: ${{ steps.meta.outputs.ref }}
+          PREV_REF: ${{ steps.copier.outputs.prev_ref }}
+          TEMPLATE_REPO: ${{ steps.meta.outputs.template_repo }}
           CONFLICT_COUNT: ${{ steps.meta.outputs.conflict_count }}
+          CONFLICT_FILES: ${{ steps.meta.outputs.conflict_files }}
+          DIFF_COUNT: ${{ steps.diff.outputs.diff_count }}
+          DIFF_STAT: ${{ steps.diff.outputs.diff_stat }}
         run: |
           set -euo pipefail
           branch="copier/update"
           title="chore(copier): update to ${REF}"
 
+          # Fetch release notes for the target ref.  Empty when the release
+          # isn't cut yet (e.g. a manual `--vcs-ref` run targeting an unreleased
+          # sha) or when `_src_path` doesn't resolve to a GitHub repo (local
+          # template dev) — in which case the notes section is skipped.
+          release_notes=""
+          if [ -n "${TEMPLATE_REPO}" ]; then
+            release_notes=$(gh release view "${REF}" \
+              --repo "${TEMPLATE_REPO}" \
+              --json body --jq .body 2>/dev/null || true)
+          fi
+
           # Build the PR body piece-by-piece with $'\n' separators — a single
           # multi-line bash string would break the enclosing YAML block scalar
           # because the continuation lines would need to stay at column 11.
-          body="Automated \`copier update\` run against template ref \`${REF}\`."
-          body+=$'\n\n'"Review the diff, resolve any \`<<<<<<< before updating\` conflict markers, and merge if CI is green."
-          body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
-          if [ "${CONFLICT_COUNT}" -gt 0 ]; then
-            body+=$'\n\n'"⚠️ **${CONFLICT_COUNT} file(s) contain unresolved \`<<<<<<< before updating\` conflict markers — review and resolve manually before merging.**"
+
+          # Heading: render prev_ref→ref and a compare link when we have a
+          # previous ref that differs from the new one AND a resolvable
+          # template repo.  Otherwise fall back to a plain "update to REF".
+          if [ -n "${PREV_REF}" ] && [ "${PREV_REF}" != "${REF}" ]; then
+            body="## Template update: \`${PREV_REF}\` → \`${REF}\`"
+            if [ -n "${TEMPLATE_REPO}" ]; then
+              body+=$'\n\n'"[Compare on GitHub](https://github.com/${TEMPLATE_REPO}/compare/${PREV_REF}...${REF})"
+            fi
+          else
+            body="## Template update to \`${REF}\`"
           fi
+
+          # Release notes in a collapsed block so the PR body stays scannable.
+          if [ -n "${release_notes}" ]; then
+            body+=$'\n\n'"<details><summary>Release notes (${REF})</summary>"
+            body+=$'\n\n'"${release_notes}"
+            body+=$'\n\n'"</details>"
+          fi
+
+          # Diff stat — always collapsed; even a handful of files is noisy.
+          body+=$'\n\n'"<details><summary>Files changed (${DIFF_COUNT})</summary>"
+          body+=$'\n\n''```'
+          body+=$'\n'"${DIFF_STAT}"
+          body+=$'\n''```'
+          body+=$'\n\n'"</details>"
+
+          # Conflicts — list the files (not just a count), and call out that
+          # the markers are *committed to the branch*, not sidecar .rej files.
+          if [ "${CONFLICT_COUNT}" -gt 0 ]; then
+            body+=$'\n\n'"### ⚠️ ${CONFLICT_COUNT} file(s) with unresolved conflict markers"
+            body+=$'\n\n'"The \`<<<<<<< before updating\` markers **are committed to this branch** — resolve them before merging:"
+            body+=$'\n'
+            while IFS= read -r f; do
+              [ -n "${f}" ] && body+=$'\n'"- \`${f}\`"
+            done <<< "${CONFLICT_FILES}"
+          fi
+
+          body+=$'\n\n'"---"
+          body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
 
           if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
             gh pr edit "${branch}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,11 +347,30 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           cd catalog
-          jq --arg v "$VERSION" --arg ref "v$VERSION" '
-            .plugins |= map(
-              if .name == "markdown-vault-mcp"
-              then .version = $v | .source.ref = $ref
-              else . end
+          NEW_ENTRY=$(jq -n \
+            --arg name    "markdown-vault-mcp" \
+            --arg url     "https://github.com/pvliesdonk/markdown-vault-mcp.git" \
+            --arg ref     "v$VERSION" \
+            --arg version "$VERSION" \
+            '{
+              name: $name,
+              source: {
+                source: "git-subdir",
+                url: $url,
+                path: ".claude-plugin/plugin",
+                ref: $ref
+              },
+              version: $version
+            }')
+          jq --arg name "markdown-vault-mcp" \
+             --arg v    "$VERSION" \
+             --arg ref  "v$VERSION" \
+             --argjson new "$NEW_ENTRY" '
+            .plugins |= (
+              if any(.[]; .name == $name)
+              then map(if .name == $name then .version = $v | .source.ref = $ref else . end)
+              else . + [$new]
+              end
             )
           ' marketplace.json > marketplace.json.tmp
           mv marketplace.json.tmp marketplace.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,26 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 
 1. **CI passes** — `uv run pytest -x -q` all tests pass
 2. **Lint passes** — run in this exact order: `uv run ruff check --fix .` then `uv run ruff format .` then verify with `uv run ruff format --check .`. Always run format *after* check --fix because check --fix can leave files needing reformatting.
-3. **Type-check passes** — `uv run mypy src/` reports no errors
+3. **Type-check passes** — `uv run mypy src/ tests/` reports no errors
 4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
 5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
 6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically, but if you manually touch any of them, update all three.
+
+## Pre-commit Hooks
+
+This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), mypy on `src/` and `tests/`, gitleaks secret scanning, and standard whitespace/YAML/JSON checks — aligned with the `ci.yml` lint/typecheck/secrets jobs so a clean pre-commit run implies a clean CI lane.
+
+- **Install once per clone:** `uv run pre-commit install`.
+- **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
+- **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
+
+The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, yamllint, project-specific linters, additional file checks) on top of the shipped defaults survive `copier update`.
+
+## PR Discipline
+
+**Every PR must have at least one associated issue.** If the work doesn't have one yet — a bug found in the wild, an opportunistic cleanup, a small improvement — create the issue first, then open the PR with `Closes #N` (or `Refs #N`) in the body. A single PR may close multiple issues (`Closes #A, closes #B`) — bundling related fixes is fine; the rule is "no orphan PRs", not "one PR per issue". This keeps the changelog, release notes, and cross-repo history coherent.
+
+Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
 ## GitHub Review Types
 
@@ -133,6 +149,14 @@ Shared infrastructure (auth providers, middleware stack, logging bootstrap, even
 - [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, and this very section of CLAUDE.md.
 
 Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `README.md`, `CHANGELOG.md`, `LICENSE`, `.env.example`) are written once and require manual reconciliation on template updates — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` and `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels) stays in this repo.
+
+## Contributing fixes upstream
+
+- **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump `fastmcp-pvl-core` in this project's `pyproject.toml`. (Copier update alone won't pick it up unless the template's version constraint in `pyproject.toml.jinja` is also bumped.)
+- **Template-level fix** (anything template-owned — `Dockerfile`, workflows, `server.py` skeleton, `CLAUDE.md` sections): open a PR on `pvliesdonk/fastmcp-server-template`. After merge + release, this project gets the fix on the next weekly `copier update` cron (or dispatch the workflow manually).
+- **Domain-only fix** (anything inside `DOMAIN-START`/`DOMAIN-END` sentinels, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
+
+If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
 
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev --extra all
 
 # Copy source and install project.
-<<<<<<< before updating
-COPY . .
-=======
 COPY pyproject.toml uv.lock README.md /app/
 COPY src/ /app/src/
->>>>>>> after updating
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra all
 # DOCKERFILE-UV-EXTRAS-END
@@ -39,13 +35,9 @@ RUN if [ "$APP_UID" -eq 0 ] || [ "$APP_GID" -eq 0 ]; then \
     fi \
     && groupadd -r --gid $APP_GID --non-unique appuser \
     && useradd -r --uid $APP_UID --gid $APP_GID --no-log-init -d /app appuser \
-<<<<<<< before updating
-    && mkdir -p /data/vault /data/state/embeddings /data/state/fastembed /data/state/fastmcp \
-=======
     # DOCKERFILE-STATE-DIRS-START — domain state subdirs; kept across copier update
-    && mkdir -p /data/service /data/state/fastmcp \
+    && mkdir -p /data/vault /data/state/embeddings /data/state/fastembed /data/state/fastmcp \
     # DOCKERFILE-STATE-DIRS-END
->>>>>>> after updating
     && chown -R appuser:appuser /app /data
 
 COPY --chmod=0755 docker-entrypoint.sh /usr/local/bin/
@@ -54,13 +46,9 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 EXPOSE 8000
 
-<<<<<<< before updating
-VOLUME ["/data/vault", "/data/state"]
-=======
 # DOCKERFILE-VOLUMES-START — mounted volume list; kept across copier update
-VOLUME ["/data/service", "/data/state"]
+VOLUME ["/data/vault", "/data/state"]
 # DOCKERFILE-VOLUMES-END
->>>>>>> after updating
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["markdown-vault-mcp", "serve", "--transport", "http", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev --extra all
 
 # Copy source and install project.
+<<<<<<< before updating
 COPY . .
+=======
+COPY pyproject.toml uv.lock README.md /app/
+COPY src/ /app/src/
+>>>>>>> after updating
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra all
 # DOCKERFILE-UV-EXTRAS-END
@@ -34,7 +39,13 @@ RUN if [ "$APP_UID" -eq 0 ] || [ "$APP_GID" -eq 0 ]; then \
     fi \
     && groupadd -r --gid $APP_GID --non-unique appuser \
     && useradd -r --uid $APP_UID --gid $APP_GID --no-log-init -d /app appuser \
+<<<<<<< before updating
     && mkdir -p /data/vault /data/state/embeddings /data/state/fastembed /data/state/fastmcp \
+=======
+    # DOCKERFILE-STATE-DIRS-START — domain state subdirs; kept across copier update
+    && mkdir -p /data/service /data/state/fastmcp \
+    # DOCKERFILE-STATE-DIRS-END
+>>>>>>> after updating
     && chown -R appuser:appuser /app /data
 
 COPY --chmod=0755 docker-entrypoint.sh /usr/local/bin/
@@ -43,7 +54,13 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 EXPOSE 8000
 
+<<<<<<< before updating
 VOLUME ["/data/vault", "/data/state"]
+=======
+# DOCKERFILE-VOLUMES-START — mounted volume list; kept across copier update
+VOLUME ["/data/service", "/data/state"]
+# DOCKERFILE-VOLUMES-END
+>>>>>>> after updating
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["markdown-vault-mcp", "serve", "--transport", "http", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!-- mcp-name: io.github.pvliesdonk/markdown-vault-mcp -->
 # markdown-vault-mcp
 
+<<<<<<< before updating
 [![CI](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp) [![PyPI](https://img.shields.io/pypi/v/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![Python](https://img.shields.io/pypi/pyversions/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/markdown-vault-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/markdown-vault-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/markdown-vault-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/markdown-vault-mcp/llms.txt) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pvliesdonk/markdown-vault-mcp)
 
 A generic markdown collection [MCP](https://modelcontextprotocol.io/) server with FTS5 full-text search, semantic vector search, frontmatter-aware indexing, incremental reindexing, and non-markdown attachment support.
@@ -35,6 +36,43 @@ With this server mounted in Claude, you can:
 - **Split or merge captures.** "Split this Inbox note into two." / "Merge this into `<existing note>` instead of duplicating." — Claude composes `read` + `write` + `delete`.
 
 No external scheduler, no separate capture app — the vault sits behind your conversations and absorbs their output.
+=======
+[![CI](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp) [![PyPI](https://img.shields.io/pypi/v/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![Python](https://img.shields.io/pypi/pyversions/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/markdown-vault-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/markdown-vault-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/markdown-vault-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/markdown-vault-mcp/llms.txt)
+
+Generic markdown collection MCP server with FTS5 + semantic search
+
+**[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
+
+## Features
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-7 bullets describing what this MCP server does. Kept across copier update. -->
+
+- **[Capability 1]** — one-sentence description of a user-visible feature.
+- **[Capability 2]** — one-sentence description of another capability.
+- **MCP tools** — N LLM-visible tools exposed; see `src/markdown_vault_mcp/tools.py`.
+- **MCP resources** — M resources exposing domain state; see `src/markdown_vault_mcp/resources.py`.
+- **MCP prompts** — K prompt templates; see `src/markdown_vault_mcp/prompts.py`.
+<!-- DOMAIN-END -->
+
+## What you can do with it
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-5 concrete "you can ask Claude to X" examples. Kept across copier update. -->
+
+With this server mounted in an MCP client (Claude, etc.), you can:
+
+- **[Task 1]** — "[example user request]." Composes tools `[tool_a]` + `[tool_b]`.
+- **[Task 2]** — "[another example request]." Uses resource `[resource_x]`.
+- **[Task 3]** — "[third example]."
+
+Short, concrete prompts beat abstract feature lists — replace the
+`[Task N]` placeholders with prompts that actually work against your
+server's tool surface.
+<!-- DOMAIN-END -->
+
+<!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
+>>>>>>> after updating
 
 ## Installation
 
@@ -44,6 +82,7 @@ No external scheduler, no separate capture app — the vault sits behind your co
 pip install markdown-vault-mcp
 ```
 
+<<<<<<< before updating
 With optional dependencies:
 
 ```bash
@@ -52,13 +91,24 @@ pip install markdown-vault-mcp[embeddings-api]  # Ollama/OpenAI embeddings via H
 pip install markdown-vault-mcp[embeddings]      # FastEmbed local embeddings
 pip install markdown-vault-mcp[all]             # MCP + FastEmbed + API embeddings
 ```
+=======
+If you add optional extras via the `PROJECT-EXTRAS-START` / `PROJECT-EXTRAS-END` sentinels in `pyproject.toml`, document them below:
+
+<!-- DOMAIN-START -->
+<!-- List optional extras and their purpose here (e.g. `pip install markdown-vault-mcp[embeddings]`). Kept across copier update. -->
+<!-- DOMAIN-END -->
+>>>>>>> after updating
 
 ### From source
 
 ```bash
 git clone https://github.com/pvliesdonk/markdown-vault-mcp.git
 cd markdown-vault-mcp
+<<<<<<< before updating
 pip install -e ".[all,dev]"
+=======
+uv sync --all-extras --dev
+>>>>>>> after updating
 ```
 
 ### Docker
@@ -67,6 +117,7 @@ pip install -e ".[all,dev]"
 docker pull ghcr.io/pvliesdonk/markdown-vault-mcp:latest
 ```
 
+<<<<<<< before updating
 The Docker image uses `[all]` (MCP + FastEmbed + API embeddings). By default, semantic search works locally with FastEmbed and can switch to Ollama/OpenAI when configured.
 
 ### Linux packages (.deb / .rpm)
@@ -76,11 +127,23 @@ Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com
 ### Claude Desktop (.mcpb bundle)
 
 Download the `.mcpb` bundle from the [GitHub Releases](https://github.com/pvliesdonk/markdown-vault-mcp/releases) page. Double-click to install, or run:
+=======
+A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
+
+### Linux packages (.deb / .rpm)
+
+Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/markdown-vault-mcp/releases) page. Both install a hardened systemd unit; env configuration is sourced from `/etc/markdown-vault-mcp/env` (copy from the shipped `/etc/markdown-vault-mcp/env.example`).
+
+### Claude Desktop (.mcpb bundle)
+
+Download the `.mcpb` bundle from the [GitHub Releases](https://github.com/pvliesdonk/markdown-vault-mcp/releases) page and double-click to install, or run:
+>>>>>>> after updating
 
 ```bash
 mcpb install markdown-vault-mcp-<version>.mcpb
 ```
 
+<<<<<<< before updating
 Claude Desktop opens a GUI wizard that prompts for required env vars — no manual JSON editing needed. See [Step 0 of the Claude Desktop guide](https://pvliesdonk.github.io/markdown-vault-mcp/guides/claude-desktop/#step-0-install-via-mcpb-bundle-easiest) for details.
 
 ### Claude Code plugin
@@ -498,7 +561,123 @@ ruff format src/ tests/
 # Type check
 mypy src/
 ```
+=======
+Claude Desktop prompts for required env vars via a GUI wizard — no manual JSON editing needed.
+
+## Quick start
+
+```bash
+markdown-vault-mcp serve                                # stdio transport
+markdown-vault-mcp serve --transport http --port 8000   # streamable HTTP
+```
+
+For library usage (embedding the domain logic without the MCP transport), import from the `markdown_vault_mcp` package directly — see `src/markdown_vault_mcp/domain.py` for the entry point scaffold.
+
+## Configuration
+
+Core environment variables shared across all `fastmcp-pvl-core`-based services:
+
+| Variable | Default | Description |
+|---|---|---|
+| `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals and app loggers (`DEBUG` / `INFO` / `WARNING` / `ERROR`). The `-v` CLI flag overrides to `DEBUG`. |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain / structured JSON log output. |
+| `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | `memory://` | Event store backend for HTTP session persistence — `memory://` (dev), `file:///path` (survives restarts). |
+
+Domain-specific variables go below under [Domain configuration](#domain-configuration).
+
+## Post-scaffold checklist
+
+After `copier copy` and `gh repo create --push`:
+
+1. **Fill in the DOMAIN blocks** in this README (Features, What you can do with it, Domain configuration, Key design decisions) and in `CLAUDE.md`.
+2. Configure GitHub secrets — see below.
+3. Install dev dependencies: `uv sync --all-extras --dev`.
+4. Install pre-commit hooks: `uv run pre-commit install`.
+5. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
+6. Push the first commit — CI should be green.
+
+## GitHub secrets
+
+CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:
+
+| Secret | Used by | How to generate |
+|---|---|---|
+| `RELEASE_TOKEN` | `release.yml`, `copier-update.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` and `pull_requests: write` (the `copier-update` cron opens PRs). Scoped to this repo. |
+| `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+
+```bash
+gh secret set RELEASE_TOKEN
+gh secret set CODECOV_TOKEN
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`GITHUB_TOKEN` is auto-provided — no action needed.
+
+## Local development
+
+The PR gate (matches CI):
+
+```bash
+uv run pytest -x -q                                  # tests
+uv run ruff check --fix . && uv run ruff format .    # lint + format
+uv run mypy src/ tests/                              # type-check
+```
+
+Pre-commit runs a subset of the gate on each commit; see `.pre-commit-config.yaml` for details, or [`CLAUDE.md`](CLAUDE.md) for the full Hard PR Acceptance Gates.
+
+## Troubleshooting
+
+### Moving a scaffolded project
+
+`uv sync` creates `.venv/bin/*` scripts with absolute shebangs pointing at the venv Python. If you move the repo after scaffolding (`mv /old/path /new/path`), `uv run pytest` fails with `ModuleNotFoundError: No module named 'fastmcp'` because the stale shebang resolves to a different interpreter than the venv's site-packages.
+
+**Fix:**
+
+```bash
+rm -rf .venv
+uv sync --all-extras --dev
+```
+
+`uv run python -m pytest` also works as a one-shot workaround (bypasses the stale entry-script shim).
+
+### `uv.lock` refresh after `copier update`
+
+When `copier update` introduces new dependencies (e.g. a new extra added to `pyproject.toml.jinja`), CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
+>>>>>>> after updating
 
 ## License
 
+<<<<<<< before updating
 MIT
+=======
+- [Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)
+- [llms.txt](https://pvliesdonk.github.io/markdown-vault-mcp/llms.txt)
+- [FastMCP](https://gofastmcp.com)
+- [fastmcp-pvl-core](https://pypi.org/project/fastmcp-pvl-core/)
+
+<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
+
+## Domain configuration
+
+<!-- DOMAIN-START -->
+<!-- Replace with a table of domain-specific env vars. Kept across copier update. -->
+
+Domain environment variables use the `MARKDOWN_VAULT_MCP_` prefix:
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `MARKDOWN_VAULT_MCP_EXAMPLE_VAR` | — | **Yes** | Replace this row with your first required setting. |
+| `MARKDOWN_VAULT_MCP_ANOTHER_VAR` | `default` | No | Replace with an optional setting. |
+
+Domain-config fields are composed inside `src/markdown_vault_mcp/config.py` between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels; env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
+<!-- DOMAIN-END -->
+
+## Key design decisions
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-6 bullets describing non-obvious architectural decisions. Kept across copier update. -->
+
+_Replace this placeholder with a short list of the non-obvious design calls this service makes — e.g. "writes are append-only", "embeddings cached in SQLite", "auth uses OIDC bearer tokens". Three to six bullets is typically enough; link out to longer ADRs under `docs/decisions/` if you maintain any._
+<!-- DOMAIN-END -->
+>>>>>>> after updating

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 <!-- mcp-name: io.github.pvliesdonk/markdown-vault-mcp -->
 # markdown-vault-mcp
 
-<<<<<<< before updating
 [![CI](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp) [![PyPI](https://img.shields.io/pypi/v/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![Python](https://img.shields.io/pypi/pyversions/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/markdown-vault-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/markdown-vault-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/markdown-vault-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/markdown-vault-mcp/llms.txt) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pvliesdonk/markdown-vault-mcp)
 
+<!-- DOMAIN-START -->
 A generic markdown collection [MCP](https://modelcontextprotocol.io/) server with FTS5 full-text search, semantic vector search, frontmatter-aware indexing, incremental reindexing, and non-markdown attachment support.
 
 **[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
 
 Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Zettelkasten, a PARA vault) and it exposes search, read, write, and edit tools over the Model Context Protocol.
+<!-- DOMAIN-END -->
 
 ## Features
 
+<!-- DOMAIN-START -->
 - **Full-text search** — SQLite FTS5 with BM25 scoring, porter stemming
 - **Semantic search** — cosine similarity over embedding vectors (FastEmbed, Ollama, or OpenAI)
 - **Hybrid search** — Reciprocal Rank Fusion combining FTS5 and vector results
@@ -24,9 +26,11 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **MCP tools** — 28 LLM-visible tools including search, read, write, edit, delete, rename, git history, and admin operations; plus 6 app-only tools for MCP Apps clients
 - **MCP resources** — 9 resources exposing vault configuration, statistics, tags, folders, document outlines, similar notes, recent notes, and an interactive SPA
 - **MCP prompts** — 6 prompt templates including template-driven note creation
+<!-- DOMAIN-END -->
 
 ## What you can do with it
 
+<!-- DOMAIN-START -->
 With this server mounted in Claude, you can:
 
 - **Capture a URL as a note.** "Fetch <url>, summarize as a Resource note under `3-Resources/`, and link any existing notes on the topic." — Claude composes `fetch` + `search` + `write`.
@@ -36,43 +40,9 @@ With this server mounted in Claude, you can:
 - **Split or merge captures.** "Split this Inbox note into two." / "Merge this into `<existing note>` instead of duplicating." — Claude composes `read` + `write` + `delete`.
 
 No external scheduler, no separate capture app — the vault sits behind your conversations and absorbs their output.
-=======
-[![CI](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp) [![PyPI](https://img.shields.io/pypi/v/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![Python](https://img.shields.io/pypi/pyversions/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/markdown-vault-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/markdown-vault-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/markdown-vault-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/markdown-vault-mcp/llms.txt)
-
-Generic markdown collection MCP server with FTS5 + semantic search
-
-**[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
-
-## Features
-
-<!-- DOMAIN-START -->
-<!-- Replace with 3-7 bullets describing what this MCP server does. Kept across copier update. -->
-
-- **[Capability 1]** — one-sentence description of a user-visible feature.
-- **[Capability 2]** — one-sentence description of another capability.
-- **MCP tools** — N LLM-visible tools exposed; see `src/markdown_vault_mcp/tools.py`.
-- **MCP resources** — M resources exposing domain state; see `src/markdown_vault_mcp/resources.py`.
-- **MCP prompts** — K prompt templates; see `src/markdown_vault_mcp/prompts.py`.
-<!-- DOMAIN-END -->
-
-## What you can do with it
-
-<!-- DOMAIN-START -->
-<!-- Replace with 3-5 concrete "you can ask Claude to X" examples. Kept across copier update. -->
-
-With this server mounted in an MCP client (Claude, etc.), you can:
-
-- **[Task 1]** — "[example user request]." Composes tools `[tool_a]` + `[tool_b]`.
-- **[Task 2]** — "[another example request]." Uses resource `[resource_x]`.
-- **[Task 3]** — "[third example]."
-
-Short, concrete prompts beat abstract feature lists — replace the
-`[Task N]` placeholders with prompts that actually work against your
-server's tool surface.
 <!-- DOMAIN-END -->
 
 <!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
->>>>>>> after updating
 
 ## Installation
 
@@ -82,7 +52,7 @@ server's tool surface.
 pip install markdown-vault-mcp
 ```
 
-<<<<<<< before updating
+<!-- DOMAIN-START -->
 With optional dependencies:
 
 ```bash
@@ -91,24 +61,14 @@ pip install markdown-vault-mcp[embeddings-api]  # Ollama/OpenAI embeddings via H
 pip install markdown-vault-mcp[embeddings]      # FastEmbed local embeddings
 pip install markdown-vault-mcp[all]             # MCP + FastEmbed + API embeddings
 ```
-=======
-If you add optional extras via the `PROJECT-EXTRAS-START` / `PROJECT-EXTRAS-END` sentinels in `pyproject.toml`, document them below:
-
-<!-- DOMAIN-START -->
-<!-- List optional extras and their purpose here (e.g. `pip install markdown-vault-mcp[embeddings]`). Kept across copier update. -->
 <!-- DOMAIN-END -->
->>>>>>> after updating
 
 ### From source
 
 ```bash
 git clone https://github.com/pvliesdonk/markdown-vault-mcp.git
 cd markdown-vault-mcp
-<<<<<<< before updating
-pip install -e ".[all,dev]"
-=======
 uv sync --all-extras --dev
->>>>>>> after updating
 ```
 
 ### Docker
@@ -117,33 +77,23 @@ uv sync --all-extras --dev
 docker pull ghcr.io/pvliesdonk/markdown-vault-mcp:latest
 ```
 
-<<<<<<< before updating
-The Docker image uses `[all]` (MCP + FastEmbed + API embeddings). By default, semantic search works locally with FastEmbed and can switch to Ollama/OpenAI when configured.
+<!-- DOMAIN-START -->
+The Docker image uses `[all]` (MCP + FastEmbed + API embeddings). By default, semantic search works locally with FastEmbed and can switch to Ollama/OpenAI when configured. A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
 
 ### Linux packages (.deb / .rpm)
 
-Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/markdown-vault-mcp/releases) page. These install a systemd service with security hardening. See the [systemd deployment guide](https://pvliesdonk.github.io/markdown-vault-mcp/deployment/systemd/) for details.
+Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/markdown-vault-mcp/releases) page. Both install a hardened systemd unit; env configuration is sourced from `/etc/markdown-vault-mcp/env` (copy from the shipped `/etc/markdown-vault-mcp/env.example`). See the [systemd deployment guide](https://pvliesdonk.github.io/markdown-vault-mcp/deployment/systemd/) for details.
 
 ### Claude Desktop (.mcpb bundle)
 
 Download the `.mcpb` bundle from the [GitHub Releases](https://github.com/pvliesdonk/markdown-vault-mcp/releases) page. Double-click to install, or run:
-=======
-A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
-
-### Linux packages (.deb / .rpm)
-
-Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/markdown-vault-mcp/releases) page. Both install a hardened systemd unit; env configuration is sourced from `/etc/markdown-vault-mcp/env` (copy from the shipped `/etc/markdown-vault-mcp/env.example`).
-
-### Claude Desktop (.mcpb bundle)
-
-Download the `.mcpb` bundle from the [GitHub Releases](https://github.com/pvliesdonk/markdown-vault-mcp/releases) page and double-click to install, or run:
->>>>>>> after updating
+<!-- DOMAIN-END -->
 
 ```bash
 mcpb install markdown-vault-mcp-<version>.mcpb
 ```
 
-<<<<<<< before updating
+<!-- DOMAIN-START -->
 Claude Desktop opens a GUI wizard that prompts for required env vars — no manual JSON editing needed. See [Step 0 of the Claude Desktop guide](https://pvliesdonk.github.io/markdown-vault-mcp/guides/claude-desktop/#step-0-install-via-mcpb-bundle-easiest) for details.
 
 ### Claude Code plugin
@@ -561,41 +511,6 @@ ruff format src/ tests/
 # Type check
 mypy src/
 ```
-=======
-Claude Desktop prompts for required env vars via a GUI wizard — no manual JSON editing needed.
-
-## Quick start
-
-```bash
-markdown-vault-mcp serve                                # stdio transport
-markdown-vault-mcp serve --transport http --port 8000   # streamable HTTP
-```
-
-For library usage (embedding the domain logic without the MCP transport), import from the `markdown_vault_mcp` package directly — see `src/markdown_vault_mcp/domain.py` for the entry point scaffold.
-
-## Configuration
-
-Core environment variables shared across all `fastmcp-pvl-core`-based services:
-
-| Variable | Default | Description |
-|---|---|---|
-| `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals and app loggers (`DEBUG` / `INFO` / `WARNING` / `ERROR`). The `-v` CLI flag overrides to `DEBUG`. |
-| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain / structured JSON log output. |
-| `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | `memory://` | Event store backend for HTTP session persistence — `memory://` (dev), `file:///path` (survives restarts). |
-
-Domain-specific variables go below under [Domain configuration](#domain-configuration).
-
-## Post-scaffold checklist
-
-After `copier copy` and `gh repo create --push`:
-
-1. **Fill in the DOMAIN blocks** in this README (Features, What you can do with it, Domain configuration, Key design decisions) and in `CLAUDE.md`.
-2. Configure GitHub secrets — see below.
-3. Install dev dependencies: `uv sync --all-extras --dev`.
-4. Install pre-commit hooks: `uv run pre-commit install`.
-5. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
-6. Push the first commit — CI should be green.
-
 ## GitHub secrets
 
 CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:
@@ -606,31 +521,13 @@ CI workflows reference three repository secrets. Configure them via **Settings �
 | `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
 
-```bash
-gh secret set RELEASE_TOKEN
-gh secret set CODECOV_TOKEN
-gh secret set CLAUDE_CODE_OAUTH_TOKEN
-```
-
 `GITHUB_TOKEN` is auto-provided — no action needed.
-
-## Local development
-
-The PR gate (matches CI):
-
-```bash
-uv run pytest -x -q                                  # tests
-uv run ruff check --fix . && uv run ruff format .    # lint + format
-uv run mypy src/ tests/                              # type-check
-```
-
-Pre-commit runs a subset of the gate on each commit; see `.pre-commit-config.yaml` for details, or [`CLAUDE.md`](CLAUDE.md) for the full Hard PR Acceptance Gates.
 
 ## Troubleshooting
 
 ### Moving a scaffolded project
 
-`uv sync` creates `.venv/bin/*` scripts with absolute shebangs pointing at the venv Python. If you move the repo after scaffolding (`mv /old/path /new/path`), `uv run pytest` fails with `ModuleNotFoundError: No module named 'fastmcp'` because the stale shebang resolves to a different interpreter than the venv's site-packages.
+`uv sync` creates `.venv/bin/*` scripts with absolute shebangs pointing at the venv Python. If you move the repo (`mv /old/path /new/path`), `uv run pytest` fails with `ModuleNotFoundError` because the stale shebang resolves to a different interpreter than the venv's site-packages.
 
 **Fix:**
 
@@ -639,45 +536,14 @@ rm -rf .venv
 uv sync --all-extras --dev
 ```
 
-`uv run python -m pytest` also works as a one-shot workaround (bypasses the stale entry-script shim).
+`uv run python -m pytest` also works as a one-shot workaround.
 
 ### `uv.lock` refresh after `copier update`
 
-When `copier update` introduces new dependencies (e.g. a new extra added to `pyproject.toml.jinja`), CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
->>>>>>> after updating
-
-## License
-
-<<<<<<< before updating
-MIT
-=======
-- [Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)
-- [llms.txt](https://pvliesdonk.github.io/markdown-vault-mcp/llms.txt)
-- [FastMCP](https://gofastmcp.com)
-- [fastmcp-pvl-core](https://pypi.org/project/fastmcp-pvl-core/)
+When `copier update` introduces new dependencies, CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
 
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 
-## Domain configuration
+## License
 
-<!-- DOMAIN-START -->
-<!-- Replace with a table of domain-specific env vars. Kept across copier update. -->
-
-Domain environment variables use the `MARKDOWN_VAULT_MCP_` prefix:
-
-| Variable | Default | Required | Description |
-|---|---|---|---|
-| `MARKDOWN_VAULT_MCP_EXAMPLE_VAR` | — | **Yes** | Replace this row with your first required setting. |
-| `MARKDOWN_VAULT_MCP_ANOTHER_VAR` | `default` | No | Replace with an optional setting. |
-
-Domain-config fields are composed inside `src/markdown_vault_mcp/config.py` between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels; env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
-<!-- DOMAIN-END -->
-
-## Key design decisions
-
-<!-- DOMAIN-START -->
-<!-- Replace with 3-6 bullets describing non-obvious architectural decisions. Kept across copier update. -->
-
-_Replace this placeholder with a short list of the non-obvious design calls this service makes — e.g. "writes are append-only", "embeddings cached in SQLite", "auth uses OIDC bearer tokens". Three to six bullets is typically enough; link out to longer ADRs under `docs/decisions/` if you maintain any._
-<!-- DOMAIN-END -->
->>>>>>> after updating
+MIT

--- a/README.md
+++ b/README.md
@@ -499,18 +499,20 @@ For setup instructions, troubleshooting, and provider-specific guides, see the [
 ```bash
 git clone https://github.com/pvliesdonk/markdown-vault-mcp.git
 cd markdown-vault-mcp
-uv pip install -e ".[all,dev]"
+uv sync --all-extras --dev
 
 # Run tests
 uv run python -m pytest tests/ -x -q
 
 # Lint and format
-ruff check src/ tests/
-ruff format src/ tests/
+uv run ruff check src/ tests/
+uv run ruff format src/ tests/
 
 # Type check
-mypy src/
+uv run mypy src/ tests/
 ```
+<!-- DOMAIN-END -->
+
 ## GitHub secrets
 
 CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,15 @@ embeddings-api = ["httpx>=0.25", "numpy>=1.20"]
 embeddings = ["fastembed>=0.3", "numpy>=1.20"]
 all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy>=1.20"]
 # PROJECT-EXTRAS-END
+<<<<<<< before updating
+=======
+
+docs = [
+    "mkdocs-material>=9",
+    "mkdocstrings[python]>=0.28",
+]
+
+>>>>>>> after updating
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
@@ -101,6 +110,7 @@ ignore = ["E501"]
 "src/markdown_vault_mcp/collection.py" = ["ARG002"]
 # Depends() and CurrentContext() calls in argument defaults are the standard
 # FastMCP dependency injection pattern — B008 is a false positive here.
+<<<<<<< before updating
 # Context/FastMCP/Collection imports must stay runtime (not TYPE_CHECKING) for
 # DI resolution — TC001/TC002.
 "src/markdown_vault_mcp/server.py" = ["B008", "TCH002"]
@@ -109,6 +119,20 @@ ignore = ["E501"]
 "src/markdown_vault_mcp/_server_resources.py" = ["B008", "TCH001", "TCH002"]
 "src/markdown_vault_mcp/_server_prompts.py" = ["B008", "TCH002"]
 "src/markdown_vault_mcp/_server_apps.py" = ["B008", "TCH001", "TCH002"]
+=======
+# Context/FastMCP/Service imports must stay runtime (not TYPE_CHECKING) for
+# DI resolution — TC001/TC002/TC003.
+"src/markdown_vault_mcp/cli.py" = ["B008"]
+"src/markdown_vault_mcp/_server_deps.py" = ["B008", "TC002", "TC003"]
+"src/markdown_vault_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
+"src/markdown_vault_mcp/tools.py" = ["B008", "TC001", "TC002"]
+"src/markdown_vault_mcp/resources.py" = ["B008", "TC001", "TC002"]
+"src/markdown_vault_mcp/prompts.py" = ["B008", "TC002"]
+"tests/conftest.py" = ["TC002", "TC003"]
+"tests/test_smoke.py" = ["TC002"]
+"tests/test_tools.py" = ["TC002"]
+# Add project-specific overrides below as needed.
+>>>>>>> after updating
 
 [tool.ruff.lint.isort]
 known-first-party = ["markdown_vault_mcp"]
@@ -168,6 +192,9 @@ ignore_errors = true
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
+# src-layout editable installs use a .pth shim that Pyright does not execute;
+# point Pyright at src/ directly so IDE import resolution matches runtime.
+extraPaths = ["src"]
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,15 +45,6 @@ embeddings-api = ["httpx>=0.25", "numpy>=1.20"]
 embeddings = ["fastembed>=0.3", "numpy>=1.20"]
 all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy>=1.20"]
 # PROJECT-EXTRAS-END
-<<<<<<< before updating
-=======
-
-docs = [
-    "mkdocs-material>=9",
-    "mkdocstrings[python]>=0.28",
-]
-
->>>>>>> after updating
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
@@ -110,29 +101,14 @@ ignore = ["E501"]
 "src/markdown_vault_mcp/collection.py" = ["ARG002"]
 # Depends() and CurrentContext() calls in argument defaults are the standard
 # FastMCP dependency injection pattern — B008 is a false positive here.
-<<<<<<< before updating
 # Context/FastMCP/Collection imports must stay runtime (not TYPE_CHECKING) for
 # DI resolution — TC001/TC002.
-"src/markdown_vault_mcp/server.py" = ["B008", "TCH002"]
-"src/markdown_vault_mcp/_server_deps.py" = ["B008", "TCH002"]
-"src/markdown_vault_mcp/_server_tools.py" = ["B008", "TCH001", "TCH002"]
-"src/markdown_vault_mcp/_server_resources.py" = ["B008", "TCH001", "TCH002"]
-"src/markdown_vault_mcp/_server_prompts.py" = ["B008", "TCH002"]
-"src/markdown_vault_mcp/_server_apps.py" = ["B008", "TCH001", "TCH002"]
-=======
-# Context/FastMCP/Service imports must stay runtime (not TYPE_CHECKING) for
-# DI resolution — TC001/TC002/TC003.
-"src/markdown_vault_mcp/cli.py" = ["B008"]
-"src/markdown_vault_mcp/_server_deps.py" = ["B008", "TC002", "TC003"]
+"src/markdown_vault_mcp/server.py" = ["B008", "TC002"]
+"src/markdown_vault_mcp/_server_deps.py" = ["B008", "TC002"]
+"src/markdown_vault_mcp/_server_tools.py" = ["B008", "TC001", "TC002"]
+"src/markdown_vault_mcp/_server_resources.py" = ["B008", "TC001", "TC002"]
+"src/markdown_vault_mcp/_server_prompts.py" = ["B008", "TC002"]
 "src/markdown_vault_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
-"src/markdown_vault_mcp/tools.py" = ["B008", "TC001", "TC002"]
-"src/markdown_vault_mcp/resources.py" = ["B008", "TC001", "TC002"]
-"src/markdown_vault_mcp/prompts.py" = ["B008", "TC002"]
-"tests/conftest.py" = ["TC002", "TC003"]
-"tests/test_smoke.py" = ["TC002"]
-"tests/test_tools.py" = ["TC002"]
-# Add project-specific overrides below as needed.
->>>>>>> after updating
 
 [tool.ruff.lint.isort]
 known-first-party = ["markdown_vault_mcp"]
@@ -184,6 +160,12 @@ module = [
 ]
 # Phase 1 modules have structural type issues (FTSResult used as dict,
 # numpy dtype mismatches).  TODO: fix in a dedicated type-safety PR.
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+# Tests pre-date the template's `mypy src/ tests/` requirement (added in
+# template v1.2.0).  Typing the full test suite is tracked separately.
+module = ["tests.*"]
 ignore_errors = true
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,13 +102,17 @@ ignore = ["E501"]
 # Depends() and CurrentContext() calls in argument defaults are the standard
 # FastMCP dependency injection pattern — B008 is a false positive here.
 # Context/FastMCP/Collection imports must stay runtime (not TYPE_CHECKING) for
-# DI resolution — TC001/TC002.
+# DI resolution — TC001/TC002/TC003.
+"src/markdown_vault_mcp/cli.py" = ["B008"]
 "src/markdown_vault_mcp/server.py" = ["B008", "TC002"]
-"src/markdown_vault_mcp/_server_deps.py" = ["B008", "TC002"]
+"src/markdown_vault_mcp/_server_deps.py" = ["B008", "TC002", "TC003"]
 "src/markdown_vault_mcp/_server_tools.py" = ["B008", "TC001", "TC002"]
 "src/markdown_vault_mcp/_server_resources.py" = ["B008", "TC001", "TC002"]
 "src/markdown_vault_mcp/_server_prompts.py" = ["B008", "TC002"]
 "src/markdown_vault_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
+# Test fixtures import collection/protocol types only used in annotations.
+"tests/conftest.py" = ["TC002", "TC003"]
+"tests/test_smoke.py" = ["TC002"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["markdown_vault_mcp"]

--- a/uv.lock
+++ b/uv.lock
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "1.27.0"
+version = "1.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Automated `copier update` run against template ref `v1.2.0`.

Review the diff, resolve any `<<<<<<< before updating` conflict markers, and merge if CI is green.

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

⚠️ **3 file(s) contain unresolved `<<<<<<< before updating` conflict markers — review and resolve manually before merging.**