### PR TITLE
feat(search): per-doc cap, length downweight, snippet truncation, adaptive chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **Hybrid search** — Reciprocal Rank Fusion combining FTS5 and vector results
 - **Diversity-aware ranking** — each search result list caps a single document at 2 chunks (configurable), downweights chunks of long documents, and returns sentence-scale snippets — bounded LLM context cost per query, with full chunk recovery via `read(path, section=heading)`
 - **Adaptive heading-level chunking** — long sections are recursively re-split at deeper heading levels (H1 → H6) until each chunk fits a configurable word budget, improving retrieval precision on synthesising essays without manual restructuring
+
+> **Upgrading.** As of this release, `search` returns query-relevant snippets in the `content` field by default (approximately 200 words). Pass `snippet_words=0` to recover the prior full-chunk behaviour, or use `read(path, section=heading)` to fetch a specific chunk after seeing a snippet. Documents are also re-chunked on next `reindex` to honour the adaptive `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` threshold (default 400).
 - **Frontmatter-aware** — indexes YAML frontmatter fields, supports required field enforcement
 - **Incremental reindexing** — hash-based change detection, only re-processes modified files
 - **Write operations** — create, edit, delete, rename documents with automatic index updates

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **Full-text search** — SQLite FTS5 with BM25 scoring, porter stemming
 - **Semantic search** — cosine similarity over embedding vectors (FastEmbed, Ollama, or OpenAI)
 - **Hybrid search** — Reciprocal Rank Fusion combining FTS5 and vector results
+- **Diversity-aware ranking** — each search result list caps a single document at 2 chunks (configurable), downweights chunks of long documents, and returns sentence-scale snippets — bounded LLM context cost per query, with full chunk recovery via `read(path, section=heading)`
+- **Adaptive heading-level chunking** — long sections are recursively re-split at deeper heading levels (H1 → H6) until each chunk fits a configurable word budget, improving retrieval precision on synthesising essays without manual restructuring
 - **Frontmatter-aware** — indexes YAML frontmatter fields, supports required field enforcement
 - **Incremental reindexing** — hash-based change detection, only re-processes modified files
 - **Write operations** — create, edit, delete, rename documents with automatic index updates

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA` | `0.25` | float ≥ 0 | Strength of the per-channel length downweight: `score / (1 + alpha · log(chunk_count))`. `0` disables. Operator-only (no per-call override). |
 | `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` | `400` | int ≥ 1 | Threshold above which the adaptive chunker recursively re-splits at deeper heading levels. Set very large (e.g. `100000`) to disable adaptive splitting. |
 
-The first three knobs adjust *ranking and rendering* — they take effect immediately. `MAX_CHUNK_WORDS` changes the chunk *index*; a reindex is required for the new value to take effect.
+The first three knobs adjust *ranking and rendering* — they take effect immediately. `MAX_CHUNK_WORDS` changes the chunk *index*; a reindex is required for the new value to take effect. **Upgrading note:** `search` now returns snippets (≤ ~200 words) by default — set `snippet_words=0` per call or `MARKDOWN_VAULT_MCP_SNIPPET_WORDS=0` globally to restore full-chunk output. Existing vaults are also re-chunked on the next `reindex` when `MAX_CHUNK_WORDS` is set.
 
 ## Search and Embeddings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,17 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `FASTMCP_LOG_LEVEL` | string | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `-v` CLI flag overrides both app and FastMCP loggers to `DEBUG` |
 | `FASTMCP_ENABLE_RICH_LOGGING` | bool | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output |
 
+## Search Ranking and Snippet Truncation
+
+| Env var | Default | Type | Notes |
+|---|---|---|---|
+| `MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC` | `2` | int ≥ 1 | Per-document cap on result list. `0` is rejected. Per-call override available on the `search` tool. |
+| `MARKDOWN_VAULT_MCP_SNIPPET_WORDS` | `200` | int ≥ 0 | Approximate word budget for `SearchResult.content`. `0` returns the full chunk. Per-call override on the `search` tool. |
+| `MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA` | `0.25` | float ≥ 0 | Strength of the per-channel length downweight: `score / (1 + alpha · log(chunk_count))`. `0` disables. Operator-only (no per-call override). |
+| `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` | `400` | int ≥ 1 | Threshold above which the adaptive chunker recursively re-splits at deeper heading levels. Set very large (e.g. `100000`) to disable adaptive splitting. |
+
+The first three knobs adjust *ranking and rendering* — they take effect immediately. `MAX_CHUNK_WORDS` changes the chunk *index*; a reindex is required for the new value to take effect.
+
 ## Search and Embeddings
 
 | Variable | Type | Default | Description |

--- a/docs/design.md
+++ b/docs/design.md
@@ -195,6 +195,44 @@ independently. Merged score: `1 / (k + rank)` where `k` is a constant
 
 This produces sensible merged rankings regardless of the raw score scales.
 
+### Search Ranking and Snippet Truncation
+
+Four complementary mechanisms improve result diversity and bound LLM context cost:
+
+1. **Cap document concentration.** No single document occupies more than `chunks_per_doc`
+   slots in the result list, regardless of search mode. Default cap: 2.
+2. **Length downweight.** Within each search channel (keyword or semantic), each chunk's
+   raw score is adjusted by `score / (1 + alpha · log(chunk_count_in_doc))` before ranking
+   or fusion. Long documents with many chunks slide down; short focused notes rise.
+3. **Snippet truncation.** `SearchResult.content` is truncated to approximately
+   `snippet_words` words (default 200). For keyword and hybrid results, FTS5's built-in
+   `snippet()` function selects a tokenizer-aware window centered on query terms. For
+   semantic-only results, a Python word-window scan picks the densest-matching window.
+   Full chunk recovery is available via `read(path, section=heading)`.
+4. **Adaptive heading-level chunking.** The `HeadingChunker` recursively re-splits
+   oversize chunks at deeper heading levels (H1 → H6) until each fits `max_chunk_words`
+   words or no sub-headings of the next level exist. Default threshold: 400 words.
+
+**Config knobs:**
+
+| Env var | Default | Description |
+|---|---|---|
+| `MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC` | `2` | Per-document cap on result slots. |
+| `MARKDOWN_VAULT_MCP_SNIPPET_WORDS` | `200` | Approximate word budget for `SearchResult.content`. `0` = no truncation. |
+| `MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA` | `0.25` | Strength of length downweight. `0` disables. |
+| `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` | `400` | Adaptive chunker threshold. Set very high to disable. |
+
+**Pipeline order:** Per-channel length downweight → fuse (RRF for hybrid) → cap per path → snippet projection → return `limit` results.
+
+**Non-goal:** No frontmatter-based ranking. The MCP must not require, recommend, or
+special-case any frontmatter convention on vault content (no `kind`, no `noindex`, no
+`boost`). Vault organisation is the user's choice; the server treats all `.md` files
+structurally identically.
+
+**Migration note:** A reindex is required for the adaptive chunker change to take effect
+(the new chunk boundaries and `documents.chunk_count` column differ from older indexes).
+The existing `reindex` MCP tool and startup reindex path handle this automatically.
+
 ### Chunking Strategy
 
 A `ChunkStrategy` protocol enables extensible chunking:
@@ -219,6 +257,11 @@ class ChunkStrategy(Protocol):
 - `HeadingChunker`: split on H1/H2 boundaries. Short documents stay as single
   chunk. Each chunk inherits the document's frontmatter. Default.
 - `WholeDocumentChunker`: one chunk per document. Good for short documents.
+
+**Adaptive heading-level chunking**: When `max_chunk_words` is set, oversize
+chunks are recursively re-split at deeper heading levels (H1 → H6) until each
+fits or no headings of the next level exist inside. `max_chunk_words=None`
+preserves the legacy H1/H2-only behaviour.
 
 **Future** (deferred):
 - `SlidingWindowChunker`: fixed-size overlapping windows with configurable

--- a/docs/superpowers/plans/2026-04-30-search-ranking-and-snippets.md
+++ b/docs/superpowers/plans/2026-04-30-search-ranking-and-snippets.md
@@ -1,0 +1,2717 @@
+# Search ranking and snippet truncation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a single long document from dominating search results, and bound result-payload size, by adding a per-document result cap, a length-based ranking downweight, snippet truncation, and adaptive heading-level chunking.
+
+**Architecture:** New ranking-pipeline stages live in `SearchManager` and run in this order: per-channel length downweight → RRF fusion (hybrid only) → per-path cap → snippet projection. The chunker (`HeadingChunker`) gains a recursive H1→H6 refinement step driven by a word-count threshold. A new `chunk_count` column on the FTS `documents` table feeds the length downweight. The MCP `search` and `read` tools surface the new knobs as optional parameters; defaults come from config / env vars.
+
+**Tech Stack:** Python 3.11+, SQLite FTS5, FastMCP, `uv` for package management, `ruff` for lint/format, `mypy` for type checking, `pytest` for tests.
+
+**Spec:** [`docs/superpowers/specs/2026-04-30-search-ranking-and-snippets-design.md`](../specs/2026-04-30-search-ranking-and-snippets-design.md)
+
+**Conventions used in every task:**
+- Test-driven: write the failing test, run it to confirm it fails, write the minimal code to pass, run it again, commit.
+- Each task ends in a single conventional-commit (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`).
+- Before every commit, run all three gates: `uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q`. Pre-commit hooks duplicate these checks; do not bypass with `--no-verify`.
+- Line numbers in this plan reflect the codebase as of commit `26416f2`. They may drift slightly across earlier tasks — re-check with `grep -n` if a snippet does not match.
+
+---
+
+## Task 1: Add four config fields & env-var reads
+
+**Goal:** Foundation for everything else — the new knobs available on `CollectionConfig` and read from env vars.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/config.py:160-207` (CONFIG-FIELDS sentinel block)
+- Modify: `src/markdown_vault_mcp/config.py:692-734` (CONFIG-FROM-ENV sentinel block)
+- Test: `tests/test_config.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_search_ranking_config_defaults(monkeypatch, tmp_path):
+    """New ranking/snippet knobs default to documented values when env unset."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    # Clear any test-runner-leaked overrides.
+    for var in (
+        "MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC",
+        "MARKDOWN_VAULT_MCP_SNIPPET_WORDS",
+        "MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA",
+        "MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    from markdown_vault_mcp.config import load_config
+
+    cfg = load_config()
+    assert cfg.chunks_per_doc == 2
+    assert cfg.snippet_words == 200
+    assert cfg.length_downweight_alpha == 0.25
+    assert cfg.max_chunk_words == 400
+
+
+def test_search_ranking_config_env_overrides(monkeypatch, tmp_path):
+    """Env vars override the defaults."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC", "1")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SNIPPET_WORDS", "0")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA", "0.0")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS", "100000")
+    from markdown_vault_mcp.config import load_config
+
+    cfg = load_config()
+    assert cfg.chunks_per_doc == 1
+    assert cfg.snippet_words == 0
+    assert cfg.length_downweight_alpha == 0.0
+    assert cfg.max_chunk_words == 100000
+
+
+def test_search_ranking_config_rejects_zero_chunks_per_doc(monkeypatch, tmp_path):
+    """chunks_per_doc=0 is rejected at load_config time (no useful semantics)."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC", "0")
+    from markdown_vault_mcp.config import load_config
+
+    with pytest.raises(ValueError, match="chunks_per_doc"):
+        load_config()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py -k 'search_ranking' -v`
+Expected: FAIL — `AttributeError: 'CollectionConfig' object has no attribute 'chunks_per_doc'`.
+
+- [ ] **Step 3: Add fields to `CollectionConfig`**
+
+Inside the `CONFIG-FIELDS-START` ... `CONFIG-FIELDS-END` block in `src/markdown_vault_mcp/config.py`, append after line 206 (after `fastembed_cache_dir`):
+
+```python
+    # Search ranking and snippet truncation
+    chunks_per_doc: int = 2
+    snippet_words: int = 200
+    length_downweight_alpha: float = 0.25
+    max_chunk_words: int = 400
+```
+
+- [ ] **Step 4: Read from env in `load_config()`**
+
+Just above `return CollectionConfig(` (around line 692), add:
+
+```python
+    raw_chunks_per_doc = (_env("CHUNKS_PER_DOC") or "").strip()
+    chunks_per_doc = int(raw_chunks_per_doc) if raw_chunks_per_doc else 2
+    if chunks_per_doc < 1:
+        raise ValueError(
+            f"chunks_per_doc must be >= 1, got {chunks_per_doc}; set "
+            "MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC to a positive integer."
+        )
+
+    raw_snippet_words = (_env("SNIPPET_WORDS") or "").strip()
+    snippet_words = int(raw_snippet_words) if raw_snippet_words else 200
+    if snippet_words < 0:
+        raise ValueError(f"snippet_words must be >= 0, got {snippet_words}")
+
+    raw_alpha = (_env("LENGTH_DOWNWEIGHT_ALPHA") or "").strip()
+    length_downweight_alpha = float(raw_alpha) if raw_alpha else 0.25
+    if length_downweight_alpha < 0:
+        raise ValueError(
+            f"length_downweight_alpha must be >= 0, got {length_downweight_alpha}"
+        )
+
+    raw_max_chunk_words = (_env("MAX_CHUNK_WORDS") or "").strip()
+    max_chunk_words = int(raw_max_chunk_words) if raw_max_chunk_words else 400
+    if max_chunk_words < 1:
+        raise ValueError(f"max_chunk_words must be >= 1, got {max_chunk_words}")
+```
+
+Then inside the `CONFIG-FROM-ENV` block (just before `# CONFIG-FROM-ENV-END`), add:
+
+```python
+        chunks_per_doc=chunks_per_doc,
+        snippet_words=snippet_words,
+        length_downweight_alpha=length_downweight_alpha,
+        max_chunk_words=max_chunk_words,
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -k 'search_ranking' -v`
+Expected: PASS (all three tests).
+
+- [ ] **Step 6: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/config.py tests/test_config.py
+git commit -m "feat(config): add search ranking and snippet config knobs
+
+Adds four new fields to CollectionConfig with env-var defaults:
+chunks_per_doc=2, snippet_words=200, length_downweight_alpha=0.25,
+max_chunk_words=400. Validation rejects chunks_per_doc=0 and any
+negative value at load time."
+```
+
+---
+
+## Task 2: Adaptive heading-level chunking
+
+**Goal:** When a chunk exceeds `max_chunk_words`, recursively re-split at the next heading level (H1 → H2 → ... → H6).
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/scanner.py:70-172` (`HeadingChunker`)
+- Test: `tests/test_scanner_adaptive_chunking.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_scanner_adaptive_chunking.py`:
+
+```python
+"""Tests for HeadingChunker's adaptive H-level refinement."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.scanner import HeadingChunker
+
+
+def _doc(*sections: tuple[int, str, int]) -> str:
+    """Build a markdown doc from (level, heading, body_word_count) tuples."""
+    parts: list[str] = []
+    for level, heading, words in sections:
+        parts.append("#" * level + " " + heading)
+        parts.append(" ".join(["lorem"] * words))
+        parts.append("")
+    return "\n".join(parts) + "\n"
+
+
+def test_max_chunk_words_none_preserves_h1_h2_only_behavior():
+    """max_chunk_words=None keeps today's H1/H2-only splitting."""
+    body = _doc(
+        (1, "Top", 50),
+        (2, "Sub A", 50),
+        (3, "Deep", 800),  # H3, would not split today and must not split.
+    )
+    chunker = HeadingChunker(max_chunk_words=None)
+    chunks = chunker.chunk(body, {})
+    # H1 + H2 produce 2 chunks; H3 stays inside the H2 chunk.
+    assert len(chunks) == 2
+    headings = [c.heading for c in chunks]
+    assert headings == ["Top", "Sub A"]
+
+
+def test_oversize_h1_splits_at_h2():
+    """An H1 chunk exceeding max_chunk_words is re-split at H2."""
+    body = _doc(
+        (1, "Top", 0),
+        (2, "Sub A", 300),
+        (2, "Sub B", 300),
+    )
+    chunker = HeadingChunker(max_chunk_words=200)
+    chunks = chunker.chunk(body, {})
+    assert [c.heading for c in chunks] == ["Sub A", "Sub B"]
+    assert all(c.heading_level == 2 for c in chunks)
+
+
+def test_recursion_descends_to_h6():
+    """An H1 chunk with deeply nested oversized sub-headings descends to H6."""
+    body = _doc(
+        (1, "L1", 0),
+        (2, "L2", 0),
+        (3, "L3", 0),
+        (4, "L4", 0),
+        (5, "L5", 0),
+        (6, "L6a", 50),
+        (6, "L6b", 50),
+    )
+    chunker = HeadingChunker(max_chunk_words=80)
+    chunks = chunker.chunk(body, {})
+    headings = [c.heading for c in chunks]
+    assert "L6a" in headings and "L6b" in headings
+
+
+def test_oversize_chunk_with_no_deeper_headings_stays_one_chunk():
+    """A 1000-word H6 with no deeper headings stays as one chunk."""
+    body = "###### Solo\n" + " ".join(["lorem"] * 1000) + "\n"
+    chunker = HeadingChunker(max_chunk_words=200)
+    chunks = chunker.chunk(body, {})
+    assert len(chunks) == 1
+    assert chunks[0].heading == "Solo"
+
+
+def test_preamble_stays_one_chunk_regardless_of_size():
+    """Preamble (no heading) is not refined further."""
+    preamble_words = 1000
+    body = (
+        " ".join(["lorem"] * preamble_words)
+        + "\n\n# Heading\n\n"
+        + " ".join(["ipsum"] * 50)
+        + "\n"
+    )
+    chunker = HeadingChunker(max_chunk_words=200)
+    chunks = chunker.chunk(body, {})
+    # First chunk is the oversize preamble (heading=None), preserved.
+    assert chunks[0].heading is None
+    assert len(chunks[0].content.split()) >= preamble_words
+
+
+def test_short_doc_bypass_still_applies():
+    """Documents <= 30 lines return as one chunk."""
+    body = "# A\nbody\n## B\nmore body\n"
+    chunker = HeadingChunker(max_chunk_words=10)
+    chunks = chunker.chunk(body, {})
+    assert len(chunks) == 1
+
+
+def test_heading_level_and_start_line_propagated_through_recursion():
+    """Refined sub-chunks carry correct heading_level and start_line."""
+    body = _doc(
+        (1, "Top", 0),
+        (2, "Inner", 300),
+    )
+    chunker = HeadingChunker(max_chunk_words=200)
+    chunks = chunker.chunk(body, {})
+    inner = next(c for c in chunks if c.heading == "Inner")
+    assert inner.heading_level == 2
+    # start_line points at the H2 line in the document.
+    body_lines = body.splitlines()
+    assert body_lines[inner.start_line].lstrip().startswith("## Inner")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_scanner_adaptive_chunking.py -v`
+Expected: FAIL — `TypeError: HeadingChunker.__init__() got an unexpected keyword argument 'max_chunk_words'`.
+
+- [ ] **Step 3: Implement adaptive chunking**
+
+In `src/markdown_vault_mcp/scanner.py`, replace the existing `HeadingChunker` class (lines 70-172) with:
+
+```python
+class HeadingChunker:
+    """Split document on heading boundaries, descending adaptively when chunks
+    exceed ``max_chunk_words``.
+
+    Default behaviour (``max_chunk_words=None``): split on H1/H2 only — the
+    pre-2026-04 behaviour. With ``max_chunk_words`` set, after the initial
+    H1/H2 split each chunk that exceeds the threshold is recursively re-split
+    at the next heading level (H3, then H4, …, up to H6) until each chunk
+    fits or no headings of the next level exist inside.
+
+    Short documents (fewer than ``short_doc_lines`` lines) are returned as a
+    single chunk without splitting. Preamble (content before the first
+    heading) is never refined further regardless of size — there are no
+    deeper headings to split on.
+
+    This is the default chunking strategy.
+    """
+
+    def __init__(
+        self,
+        short_doc_lines: int = _SHORT_DOC_LINES,
+        *,
+        max_chunk_words: int | None = None,
+    ) -> None:
+        """Initialise the chunker.
+
+        Args:
+            short_doc_lines: Line count at or below which the document is
+                returned as a single chunk rather than split on headings.
+            max_chunk_words: Word-count threshold above which a chunk is
+                recursively re-split at the next heading level. ``None``
+                preserves today's H1/H2-only behaviour.
+        """
+        self.short_doc_lines = short_doc_lines
+        self.max_chunk_words = max_chunk_words
+
+    def chunk(self, content: str, _metadata: dict[str, Any]) -> list[Chunk]:
+        """Split content adaptively on heading boundaries.
+
+        Args:
+            content: Markdown body after frontmatter has been stripped.
+            _metadata: Parsed frontmatter dict (unused).
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.Chunk` objects.
+        """
+        lines = content.splitlines(keepends=True)
+
+        if len(lines) <= self.short_doc_lines:
+            return [Chunk(heading=None, heading_level=0, content=content, start_line=0)]
+
+        chunks = self._split_at_levels(lines, levels=(1, 2), base_line=0)
+        if chunks and self.max_chunk_words is not None:
+            chunks = self._refine_oversize(chunks, current_level=2)
+        return chunks
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _split_at_levels(
+        self,
+        lines: list[str],
+        *,
+        levels: tuple[int, ...],
+        base_line: int,
+    ) -> list[Chunk]:
+        """Split *lines* on any heading whose level is in *levels*.
+
+        ``base_line`` is added to every emitted ``start_line`` so that
+        ``start_line`` always refers to the *original* document, not the
+        sub-slice passed in during recursion.
+
+        Returns an empty list if the slice contains no matching headings.
+        """
+        # Walk and record split points (line index in this slice, level, text).
+        split_points: list[tuple[int, int, str]] = []
+        max_level = max(levels)
+        pat = re.compile(rf"^(#{{1,{max_level}}})\s+(.+)$")
+        for idx, line in enumerate(lines):
+            m = pat.match(line.rstrip())
+            if m:
+                level = len(m.group(1))
+                if level in levels:
+                    split_points.append((idx, level, m.group(2).strip()))
+
+        if not split_points:
+            return []
+
+        chunks: list[Chunk] = []
+
+        # Preamble: anything before the first split point.
+        first_line = split_points[0][0]
+        if first_line > 0:
+            preamble = "".join(lines[:first_line])
+            if preamble.strip():
+                chunks.append(
+                    Chunk(
+                        heading=None,
+                        heading_level=0,
+                        content=preamble,
+                        start_line=base_line,
+                    )
+                )
+
+        for i, (line_idx, level, heading_text) in enumerate(split_points):
+            content_start = line_idx + 1
+            content_end = (
+                split_points[i + 1][0] if i + 1 < len(split_points) else len(lines)
+            )
+            section_content = "".join(lines[content_start:content_end])
+            if not section_content.strip():
+                continue
+            chunks.append(
+                Chunk(
+                    heading=heading_text,
+                    heading_level=level,
+                    content=section_content,
+                    start_line=base_line + line_idx,
+                )
+            )
+        return chunks
+
+    def _refine_oversize(
+        self, chunks: list[Chunk], *, current_level: int
+    ) -> list[Chunk]:
+        """Recursively re-split chunks that exceed ``max_chunk_words``.
+
+        ``current_level`` is the deepest heading level already used as a
+        split point. Refinement attempts ``current_level + 1`` next.
+        """
+        assert self.max_chunk_words is not None  # guarded by caller
+        if current_level >= 6:
+            return chunks
+
+        next_level = current_level + 1
+        out: list[Chunk] = []
+        for chunk in chunks:
+            if chunk.heading is None:
+                # Preamble: no deeper headings exist inside it; keep as-is.
+                out.append(chunk)
+                continue
+            if len(chunk.content.split()) <= self.max_chunk_words:
+                out.append(chunk)
+                continue
+
+            sub_lines = chunk.content.splitlines(keepends=True)
+            sub_chunks = self._split_at_levels(
+                sub_lines, levels=(next_level,), base_line=chunk.start_line + 1
+            )
+            if not sub_chunks:
+                # No headings of next_level inside; cannot split further.
+                out.append(chunk)
+                continue
+            out.extend(self._refine_oversize(sub_chunks, current_level=next_level))
+        return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_scanner_adaptive_chunking.py -v`
+Expected: PASS (all seven tests).
+
+Then run the full scanner suite to confirm no regressions:
+
+Run: `uv run pytest tests/test_scanner.py -v`
+Expected: PASS (existing tests continue to work — `max_chunk_words=None` is the new default and preserves prior behaviour).
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/scanner.py tests/test_scanner_adaptive_chunking.py
+git commit -m "feat(scanner): adaptive heading-level chunker
+
+HeadingChunker now accepts max_chunk_words; when set, oversize H1/H2
+chunks are recursively re-split at deeper heading levels (H3 -> H4
+-> H5 -> H6) until each chunk fits or no deeper headings exist.
+max_chunk_words=None (the default) preserves today's H1/H2-only
+behaviour."
+```
+
+---
+
+## Task 3: `documents.chunk_count` column + migration
+
+**Goal:** Persist the parent-document chunk count so the length downweight has a fast lookup at query time.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/fts_index.py:39-47` (schema), `200+` (`FTSIndex` ctor migration), `260-270` (`_insert_document`), `517+` (`upsert_note`).
+- Test: `tests/test_fts_chunk_count.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_fts_chunk_count.py`:
+
+```python
+"""Tests for the chunk_count column on documents and its migration path."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.scanner import HeadingChunker, parse_note
+
+
+def _make_note(tmp_path, name: str, body: str):
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return parse_note(p, tmp_path, HeadingChunker(max_chunk_words=200))
+
+
+def test_chunk_count_populated_on_upsert(tmp_path):
+    """upsert_note populates documents.chunk_count from len(note.chunks)."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "\n".join(
+        ["# A", "alpha body " * 10, "## B", "beta body " * 10, "## C", "gamma " * 10]
+    )
+    note = _make_note(tmp_path, "doc.md", body)
+    fts.upsert_note(note)
+
+    row = fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = ?", (note.path,)
+    ).fetchone()
+    assert row is not None
+    assert row["chunk_count"] == len(note.chunks)
+
+
+def test_chunk_count_populated_on_build_from_notes(tmp_path):
+    """build_from_notes populates chunk_count for every note."""
+    fts = FTSIndex(db_path=":memory:")
+    notes = [
+        _make_note(tmp_path, "a.md", "# A\nalpha\n## B\nbeta\n"),
+        _make_note(tmp_path, "b.md", "# A\nonly one chunk\n"),
+    ]
+    fts.build_from_notes(notes)
+
+    counts = dict(
+        fts._conn.execute("SELECT path, chunk_count FROM documents").fetchall()
+    )
+    assert counts["a.md"] == len(notes[0].chunks)
+    assert counts["b.md"] == len(notes[1].chunks)
+
+
+def test_chunk_count_updates_on_reupsert(tmp_path):
+    """When a doc is re-upserted with a different chunk count, the column updates."""
+    fts = FTSIndex(db_path=":memory:")
+    note_v1 = _make_note(tmp_path, "doc.md", "# A\nbody\n")
+    fts.upsert_note(note_v1)
+    v1_count = fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = ?", (note_v1.path,)
+    ).fetchone()["chunk_count"]
+
+    note_v2 = _make_note(
+        tmp_path,
+        "doc.md",
+        "# A\nbody\n## B\nmore\n## C\neven more\n",
+    )
+    fts.upsert_note(note_v2)
+    v2_count = fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = ?", (note_v2.path,)
+    ).fetchone()["chunk_count"]
+
+    assert v2_count != v1_count
+    assert v2_count == len(note_v2.chunks)
+
+
+def test_migration_adds_column_to_pre_existing_db(tmp_path):
+    """Opening an FTS DB created without chunk_count adds the column."""
+    db_path = tmp_path / "old.sqlite3"
+    legacy = sqlite3.connect(db_path)
+    legacy.executescript(
+        """
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY,
+            path TEXT UNIQUE NOT NULL,
+            title TEXT NOT NULL,
+            folder TEXT NOT NULL DEFAULT '',
+            frontmatter_json TEXT,
+            content_hash TEXT NOT NULL,
+            modified_at REAL NOT NULL
+        );
+        INSERT INTO documents (path, title, content_hash, modified_at)
+        VALUES ('legacy.md', 'Legacy', 'x', 0.0);
+        """
+    )
+    legacy.commit()
+    legacy.close()
+
+    fts = FTSIndex(db_path=db_path)
+    cols = [
+        r["name"]
+        for r in fts._conn.execute("PRAGMA table_info(documents)").fetchall()
+    ]
+    assert "chunk_count" in cols
+    # Existing legacy row gets the default value.
+    row = fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = 'legacy.md'"
+    ).fetchone()
+    assert row["chunk_count"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_fts_chunk_count.py -v`
+Expected: FAIL — `sqlite3.OperationalError: no such column: chunk_count`.
+
+- [ ] **Step 3: Add the column to the schema literal**
+
+In `src/markdown_vault_mcp/fts_index.py`, edit the `documents` table literal (around lines 39-47). The new shape:
+
+```python
+CREATE TABLE IF NOT EXISTS documents (
+    id INTEGER PRIMARY KEY,
+    path TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    folder TEXT NOT NULL DEFAULT '',
+    frontmatter_json TEXT,
+    content_hash TEXT NOT NULL,
+    modified_at REAL NOT NULL,
+    chunk_count INTEGER NOT NULL DEFAULT 1
+);
+```
+
+- [ ] **Step 4: Add migration step to `FTSIndex.__init__`**
+
+Find the `FTSIndex` constructor (around line 201). Locate where `_open_connection` is called and the schema is applied. Immediately after schema application, add a small migration that ensures the column exists on pre-existing DBs:
+
+```python
+        # Migration: chunk_count was added 2026-04-30. ALTER TABLE is a no-op
+        # if the column already exists, but SQLite has no IF NOT EXISTS for
+        # columns, so we probe PRAGMA first.
+        cols = {
+            r["name"]
+            for r in self._conn.execute("PRAGMA table_info(documents)").fetchall()
+        }
+        if "chunk_count" not in cols:
+            self._conn.execute(
+                "ALTER TABLE documents ADD COLUMN chunk_count INTEGER NOT NULL DEFAULT 1"
+            )
+            self._conn.commit()
+            logger.info(
+                "fts_index: migrated documents table — added chunk_count column"
+            )
+```
+
+(Adapt the indentation to match the surrounding constructor body. The migration must run *after* the schema script and *before* any `SELECT chunk_count` happens.)
+
+- [ ] **Step 5: Populate `chunk_count` in `_insert_document` and `upsert_note`**
+
+Find `_insert_document` (or equivalent — search for the `INSERT INTO documents (...) VALUES (...)` statement). Add `chunk_count` to the column list and pass `len(note.chunks)`:
+
+```python
+                cur.execute(
+                    """
+                    INSERT INTO documents
+                        (path, title, folder, frontmatter_json,
+                         content_hash, modified_at, chunk_count)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        note.path,
+                        note.title,
+                        _derive_folder(note.path),
+                        json.dumps(note.frontmatter, default=_json_default)
+                        if note.frontmatter
+                        else None,
+                        note.content_hash,
+                        note.modified_at,
+                        len(note.chunks),
+                    ),
+                )
+```
+
+If `upsert_note` deletes and re-inserts, the change above suffices. If it does an in-place `UPDATE`, also update the `UPDATE documents SET ... WHERE id = ?` to include `chunk_count = ?`. Re-read the function to confirm which strategy is used; both are common.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_fts_chunk_count.py -v`
+Expected: PASS (all four tests).
+
+Run the full FTS suite for regressions: `uv run pytest tests/test_fts_index.py -v` — Expected: PASS.
+
+- [ ] **Step 7: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/fts_index.py tests/test_fts_chunk_count.py
+git commit -m "feat(fts): add chunk_count column on documents
+
+Stored at index/upsert time as len(note.chunks); used downstream by
+the length-downweight ranking step. Pre-existing FTS databases are
+migrated via ALTER TABLE ADD COLUMN with default 1; existing rows
+will be corrected on next reindex."
+```
+
+---
+
+## Task 4: FTS5 `snippet()` projection + `chunk_count` on `FTSResult`
+
+**Goal:** `FTSIndex.search()` can return a tokenizer-aware snippet of the matched content instead of the full chunk, and exposes `chunk_count` for downstream ranking.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/types.py:96+` (`FTSResult`)
+- Modify: `src/markdown_vault_mcp/fts_index.py:559-667` (`FTSIndex.search`)
+- Test: `tests/test_fts_index.py` (extend) + new `tests/test_fts_snippet.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_fts_snippet.py`:
+
+```python
+"""Tests for FTS5 snippet() projection in FTSIndex.search."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.scanner import HeadingChunker, parse_note
+
+
+def _upsert(tmp_path, fts: FTSIndex, name: str, body: str) -> None:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    fts.upsert_note(parse_note(p, tmp_path, HeadingChunker()))
+
+
+def test_snippet_words_zero_returns_full_content(tmp_path):
+    """snippet_words=0 (or None) returns the full chunk content."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "# A\n" + "alpha " * 50 + "needle " + "alpha " * 50 + "\n"
+    _upsert(tmp_path, fts, "doc.md", body)
+
+    [r] = fts.search("needle", limit=10, snippet_words=0)
+    # Full chunk: ~101 words.
+    assert "alpha alpha" in r.content
+    assert len(r.content.split()) > 50
+
+
+def test_snippet_words_caps_returned_text(tmp_path):
+    """snippet_words=20 returns roughly 20 tokens centered on the match."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "# A\n" + "alpha " * 100 + "needle " + "alpha " * 100 + "\n"
+    _upsert(tmp_path, fts, "doc.md", body)
+
+    [r] = fts.search("needle", limit=10, snippet_words=20)
+    assert "needle" in r.content
+    assert len(r.content.split()) <= 30  # 20 + ellipsis slack
+
+
+def test_snippet_includes_ellipsis_marker_when_truncated(tmp_path):
+    """Truncated snippets include the … marker."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "# A\n" + "alpha " * 200 + "needle " + "alpha " * 200 + "\n"
+    _upsert(tmp_path, fts, "doc.md", body)
+
+    [r] = fts.search("needle", limit=10, snippet_words=10)
+    assert "…" in r.content
+
+
+def test_chunk_count_populated_on_fts_result(tmp_path):
+    """FTSResult exposes the parent doc's chunk_count."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "# A\nalpha needle\n## B\nbeta\n## C\ngamma\n"
+    _upsert(tmp_path, fts, "doc.md", body)
+
+    results = fts.search("needle", limit=10)
+    assert results[0].chunk_count >= 1
+    assert results[0].chunk_count == fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = 'doc.md'"
+    ).fetchone()["chunk_count"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_fts_snippet.py -v`
+Expected: FAIL — `TypeError: search() got an unexpected keyword argument 'snippet_words'` (and `AttributeError: 'FTSResult' object has no attribute 'chunk_count'` once that one runs).
+
+- [ ] **Step 3: Add `chunk_count` to `FTSResult`**
+
+In `src/markdown_vault_mcp/types.py`, find `FTSResult` (around line 96) and add a field:
+
+```python
+@dataclass
+class FTSResult:
+    """A raw search result from the FTS5 index layer.
+
+    Attributes:
+        path: Relative path of the document containing this chunk.
+        title: Document title.
+        folder: Parent folder path.
+        heading: Section heading this chunk falls under, or ``None``.
+        content: Matched chunk text — full chunk by default; truncated to a
+            tokenizer-aware snippet when ``snippet_words`` is passed to the
+            search call.
+        score: BM25 relevance score (higher is better).
+        chunk_count: Total number of chunks belonging to the parent document.
+    """
+
+    path: str
+    title: str
+    folder: str
+    heading: str | None
+    content: str
+    score: float
+    chunk_count: int = 1
+```
+
+- [ ] **Step 4: Add `snippet_words` parameter to `FTSIndex.search`**
+
+In `src/markdown_vault_mcp/fts_index.py`, edit `search` (lines 559-667):
+
+```python
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        folder: str | None = None,
+        filters: dict[str, str] | None = None,
+        snippet_words: int | None = None,
+    ) -> list[FTSResult]:
+        """Full-text search using BM25 ranking.
+
+        Args:
+            query: FTS5 query string.
+            limit: Maximum number of results to return.
+            folder: If provided, only return documents whose ``folder``
+                starts with this string.
+            filters: Dict of ``{tag_key: tag_value}`` pairs (AND semantics).
+            snippet_words: When set to a positive integer, returned
+                ``content`` is replaced with FTS5's ``snippet()`` of the
+                matched content column, sized to approximately this many
+                tokens. ``None`` or ``0`` returns the full chunk.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.FTSResult` ordered by
+            descending BM25 score.
+        """
+        # Build tag subquery filters (one per entry, ANDed).
+        tag_clauses: list[str] = []
+        tag_params: list[str] = []
+        if filters:
+            for key, value in filters.items():
+                tag_clauses.append(
+                    "d.id IN ("
+                    "  SELECT document_id FROM document_tags"
+                    "  WHERE tag_key = ? AND tag_value = ?"
+                    ")"
+                )
+                tag_params.extend([key, value])
+
+        folder_clause = ""
+        folder_params: list[str] = []
+        if folder is not None:
+            escaped = _escape_like(folder)
+            folder_clause = "AND (d.folder = ? OR d.folder LIKE ? ESCAPE '\\')"
+            folder_params = [folder, escaped + "/%"]
+
+        tag_filter_sql = ""
+        if tag_clauses:
+            tag_filter_sql = "AND " + " AND ".join(tag_clauses)
+
+        # column index 4 is the 'content' column in
+        #   notes_fts USING fts5(path, title, folder, heading, content, ...)
+        if snippet_words and snippet_words > 0:
+            content_expr = "snippet(notes_fts, 4, '', '', '…', ?) AS content"
+            snippet_params: list[object] = [snippet_words]
+        else:
+            content_expr = "f.content AS content"
+            snippet_params = []
+
+        sql = f"""
+            SELECT
+                f.path,
+                d.title,
+                d.folder,
+                f.heading,
+                {content_expr},
+                ABS(f.rank) AS score,
+                d.chunk_count AS chunk_count
+            FROM notes_fts f
+            JOIN documents d ON d.path = f.path
+            WHERE notes_fts MATCH ?
+              {folder_clause}
+              {tag_filter_sql}
+            ORDER BY score DESC
+            LIMIT ?
+        """
+
+        if not query:
+            return []
+
+        params: list[object] = [
+            *snippet_params,
+            query,
+            *folder_params,
+            *tag_params,
+            limit,
+        ]
+        logger.debug(
+            "FTS search: query=%r folder=%r filters=%r limit=%d snippet_words=%r",
+            query,
+            folder,
+            filters,
+            limit,
+            snippet_words,
+        )
+        try:
+            cur = self._conn.execute(sql, params)
+        except sqlite3.OperationalError as exc:
+            msg = str(exc).lower()
+            if (
+                "fts5" in msg
+                or "syntax error" in msg
+                or "no such column" in msg
+                or "unterminated" in msg
+            ):
+                logger.debug("FTS search: malformed query %r — %s", query, exc)
+                return []
+            raise
+        rows = cur.fetchall()
+        logger.debug("FTS search: %d results for query=%r", len(rows), query)
+
+        results: list[FTSResult] = []
+        for row in rows:
+            results.append(
+                FTSResult(
+                    path=row["path"],
+                    title=row["title"],
+                    folder=row["folder"],
+                    heading=row["heading"] or None,
+                    content=row["content"],
+                    score=row["score"],
+                    chunk_count=row["chunk_count"],
+                )
+            )
+        return results
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_fts_snippet.py tests/test_fts_index.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/fts_index.py src/markdown_vault_mcp/types.py tests/test_fts_snippet.py
+git commit -m "feat(fts): snippet_words projection and chunk_count on FTSResult
+
+FTSIndex.search now accepts snippet_words; when set, returned
+content is FTS5's tokenizer-aware snippet() of the matched chunk
+instead of the full text. Each FTSResult also exposes the parent
+document's chunk_count for downstream length-downweight ranking."
+```
+
+---
+
+## Task 5: `_apply_length_downweight` helper
+
+**Goal:** A reusable helper that adjusts a result list's scores by `score / (1 + alpha * log(chunk_count))` and re-sorts. Pure function on a list — easy to unit-test in isolation.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/managers/search.py:54+` (add helper near top of `SearchManager`)
+- Test: `tests/test_search_length_downweight.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_search_length_downweight.py`:
+
+```python
+"""Tests for the per-channel length-downweight helper."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from markdown_vault_mcp.managers.search import _apply_length_downweight
+
+
+@dataclass
+class _Row:
+    """Stand-in for either an FTSResult or a vector-search dict."""
+
+    path: str
+    score: float
+    chunk_count: int
+
+
+def test_alpha_zero_is_identity():
+    rows = [_Row("a.md", 1.0, 10), _Row("b.md", 0.5, 1)]
+    out = _apply_length_downweight(rows, alpha=0.0)
+    assert [r.path for r in out] == ["a.md", "b.md"]
+    assert out[0].score == 1.0
+
+
+def test_long_doc_slides_down_with_positive_alpha():
+    """A 10-chunk doc and a 1-chunk doc with equal raw scores: 1-chunk wins."""
+    rows = [_Row("long.md", 1.0, 10), _Row("short.md", 1.0, 1)]
+    out = _apply_length_downweight(rows, alpha=0.25)
+    assert [r.path for r in out] == ["short.md", "long.md"]
+    assert out[1].score == 1.0 / (1 + 0.25 * math.log(10))
+
+
+def test_short_doc_unchanged_for_chunk_count_one():
+    """log(1) = 0, so chunk_count=1 is unaffected by any alpha."""
+    rows = [_Row("only.md", 0.7, 1)]
+    out = _apply_length_downweight(rows, alpha=10.0)
+    assert out[0].score == 0.7
+
+
+def test_higher_alpha_pushes_long_doc_further_down():
+    long10 = _Row("L.md", 1.0, 10)
+    short = _Row("S.md", 0.95, 1)
+    out_low = _apply_length_downweight([long10, short], alpha=0.1)
+    out_high = _apply_length_downweight([long10, short], alpha=2.0)
+    # At low alpha, L.md still ranks first; at high alpha, S.md wins.
+    assert out_low[0].path == "L.md"
+    assert out_high[0].path == "S.md"
+
+
+def test_score_recomputation_does_not_mutate_input():
+    rows = [_Row("a.md", 1.0, 10)]
+    _ = _apply_length_downweight(rows, alpha=0.5)
+    # Original list elements are not mutated in place.
+    assert rows[0].score == 1.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_search_length_downweight.py -v`
+Expected: FAIL — `ImportError: cannot import name '_apply_length_downweight'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/markdown_vault_mcp/managers/search.py`, just after the imports/constants block (around line 50, before `class SearchManager`), add:
+
+```python
+import math
+from dataclasses import replace as _dc_replace
+from typing import TypeVar
+
+
+_RankT = TypeVar("_RankT")
+
+
+def _apply_length_downweight(rows: list[_RankT], *, alpha: float) -> list[_RankT]:
+    """Re-rank ``rows`` by ``score / (1 + alpha * log(chunk_count))``.
+
+    Each element must expose ``score: float`` and ``chunk_count: int``
+    attributes (works for both :class:`FTSResult` and dicts via
+    duck-typed attribute access on dataclass-like rows; for plain dicts
+    the caller should adapt to a tiny shim).
+
+    Returns a new list sorted by descending adjusted score; input is not
+    mutated.
+    """
+    if alpha <= 0 or not rows:
+        return list(rows)
+
+    adjusted: list[tuple[_RankT, float]] = []
+    for row in rows:
+        chunk_count = max(1, getattr(row, "chunk_count", 1))
+        # log(1) = 0 → factor = 1 → no change for short docs.
+        factor = 1.0 + alpha * math.log(chunk_count)
+        new_score = getattr(row, "score") / factor
+        # dataclasses.replace works for FTSResult; for non-frozen ones, a
+        # shallow copy with attribute set is fine. We avoid mutating input.
+        try:
+            new_row = _dc_replace(row, score=new_score)  # type: ignore[type-var]
+        except TypeError:
+            # Not a dataclass — fall back to a plain attribute write on a copy.
+            import copy as _copy
+
+            new_row = _copy.copy(row)
+            new_row.score = new_score  # type: ignore[attr-defined]
+        adjusted.append((new_row, new_score))
+
+    adjusted.sort(key=lambda t: t[1], reverse=True)
+    return [r for r, _ in adjusted]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_search_length_downweight.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/managers/search.py tests/test_search_length_downweight.py
+git commit -m "feat(search): per-channel length-downweight helper
+
+Pure helper that re-ranks a result list by
+score / (1 + alpha * log(chunk_count)). alpha=0 is identity;
+log(1)=0 leaves single-chunk docs unaffected at any alpha. Input
+list is not mutated."
+```
+
+---
+
+## Task 6: `_apply_chunks_per_doc_cap` helper
+
+**Goal:** Drop excess same-doc chunks from a ranked list, keeping at most N per `path` until `limit` results are collected.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/managers/search.py` (add helper next to Task 5's)
+- Test: `tests/test_search_chunks_per_doc_cap.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_search_chunks_per_doc_cap.py`:
+
+```python
+"""Tests for the per-document result cap helper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from markdown_vault_mcp.managers.search import _apply_chunks_per_doc_cap
+
+
+@dataclass
+class _Row:
+    path: str
+    score: float
+
+
+def test_cap_one_keeps_first_per_path():
+    rows = [
+        _Row("a.md", 1.0),
+        _Row("a.md", 0.9),
+        _Row("b.md", 0.8),
+        _Row("a.md", 0.7),
+    ]
+    out = _apply_chunks_per_doc_cap(rows, n=1, limit=10)
+    assert [r.path for r in out] == ["a.md", "b.md"]
+
+
+def test_cap_two_keeps_first_two_per_path():
+    rows = [
+        _Row("a.md", 1.0),
+        _Row("a.md", 0.9),
+        _Row("a.md", 0.8),
+        _Row("b.md", 0.7),
+    ]
+    out = _apply_chunks_per_doc_cap(rows, n=2, limit=10)
+    assert [r.path for r in out] == ["a.md", "a.md", "b.md"]
+
+
+def test_cap_truncates_to_limit():
+    rows = [_Row("a.md", 1.0), _Row("b.md", 0.9), _Row("c.md", 0.8)]
+    out = _apply_chunks_per_doc_cap(rows, n=10, limit=2)
+    assert len(out) == 2
+
+
+def test_cap_preserves_order_of_remaining_results():
+    rows = [
+        _Row("a.md", 1.0),
+        _Row("a.md", 0.9),  # dropped
+        _Row("b.md", 0.8),
+        _Row("c.md", 0.7),
+    ]
+    out = _apply_chunks_per_doc_cap(rows, n=1, limit=10)
+    assert [r.score for r in out] == [1.0, 0.8, 0.7]
+
+
+def test_cap_empty_list_returns_empty():
+    assert _apply_chunks_per_doc_cap([], n=2, limit=10) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_search_chunks_per_doc_cap.py -v`
+Expected: FAIL — `ImportError: cannot import name '_apply_chunks_per_doc_cap'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/markdown_vault_mcp/managers/search.py`, just after `_apply_length_downweight`, add:
+
+```python
+def _apply_chunks_per_doc_cap(
+    rows: list[_RankT], *, n: int, limit: int
+) -> list[_RankT]:
+    """Walk ``rows`` in order; keep at most ``n`` rows per ``path``; stop at ``limit``.
+
+    Each element must expose a ``path`` attribute. Order is preserved.
+    """
+    if n < 1:
+        raise ValueError(f"chunks_per_doc cap must be >= 1, got {n}")
+    out: list[_RankT] = []
+    counts: dict[str, int] = {}
+    for row in rows:
+        path = getattr(row, "path")
+        if counts.get(path, 0) >= n:
+            continue
+        counts[path] = counts.get(path, 0) + 1
+        out.append(row)
+        if len(out) >= limit:
+            break
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_search_chunks_per_doc_cap.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/managers/search.py tests/test_search_chunks_per_doc_cap.py
+git commit -m "feat(search): per-document result cap helper
+
+Walks a ranked list in order and keeps at most n results per path,
+stopping once limit results have been collected. Order of surviving
+results is preserved."
+```
+
+---
+
+## Task 7: `_compute_snippet_for_semantic` helper (word-window scan)
+
+**Goal:** When a result was matched only via cosine similarity, compute a snippet by sliding a `snippet_words`-wide window across the chunk and picking the window with the highest count of query tokens. Falls back to first-N words when no overlap.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/managers/search.py` (add helper next to Tasks 5–6)
+- Test: `tests/test_search_snippets.py` (new — additional cases follow in later tasks)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_search_snippets.py`:
+
+```python
+"""Tests for snippet generation in SearchManager."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.managers.search import _compute_snippet_for_semantic
+
+
+def test_snippet_words_zero_returns_full_content():
+    content = " ".join(f"word{i}" for i in range(50))
+    assert _compute_snippet_for_semantic(content, "anything", snippet_words=0) == content
+
+
+def test_window_centered_on_densest_query_match():
+    """Slide a 10-word window; pick the one with most query tokens."""
+    content = (
+        " ".join(["filler"] * 20)
+        + " needle midway needle "
+        + " ".join(["filler"] * 20)
+    )
+    out = _compute_snippet_for_semantic(content, "needle", snippet_words=10)
+    assert "needle" in out
+    assert len(out.split()) <= 12  # 10 + slack for ellipses
+
+
+def test_no_overlap_falls_back_to_first_n_words():
+    content = " ".join(f"word{i}" for i in range(50))
+    out = _compute_snippet_for_semantic(content, "completely-unrelated-token", snippet_words=10)
+    assert out.split()[0] == "word0"
+    assert len(out.split()) <= 12
+
+
+def test_short_chunk_returned_intact():
+    content = "five word chunk only here"
+    out = _compute_snippet_for_semantic(content, "chunk", snippet_words=200)
+    assert out == content
+
+
+def test_query_tokenization_is_case_insensitive():
+    content = (
+        " ".join(["filler"] * 20)
+        + " Needle hit Needle "
+        + " ".join(["filler"] * 20)
+    )
+    out = _compute_snippet_for_semantic(content, "NEEDLE", snippet_words=10)
+    assert "Needle" in out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_search_snippets.py -v`
+Expected: FAIL — `ImportError: cannot import name '_compute_snippet_for_semantic'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/markdown_vault_mcp/managers/search.py`, after `_apply_chunks_per_doc_cap`, add:
+
+```python
+import re as _re
+
+
+_QUERY_TOKEN_RE = _re.compile(r"[A-Za-z0-9]+")
+
+
+def _compute_snippet_for_semantic(
+    content: str, query: str, *, snippet_words: int
+) -> str:
+    """Pick a ``snippet_words``-wide window from ``content``.
+
+    Returns the full content when ``snippet_words`` is 0, when the chunk is
+    already shorter, or as a fallback when no query tokens overlap (in which
+    case the first ``snippet_words`` words are returned with a trailing
+    ellipsis).
+
+    Uses simple case-insensitive substring matching on alphanumeric tokens.
+    """
+    if snippet_words <= 0:
+        return content
+
+    words = content.split()
+    if len(words) <= snippet_words:
+        return content
+
+    query_tokens = {t.lower() for t in _QUERY_TOKEN_RE.findall(query)}
+    if not query_tokens:
+        return " ".join(words[:snippet_words]) + " …"
+
+    # Score each window position by query-token count.
+    lower_words = [_QUERY_TOKEN_RE.sub("", w).lower() or w.lower() for w in words]
+    # Build initial window count.
+    best_start = 0
+    best_score = sum(1 for w in lower_words[:snippet_words] if w in query_tokens)
+    cur_score = best_score
+    for i in range(1, len(words) - snippet_words + 1):
+        if lower_words[i - 1] in query_tokens:
+            cur_score -= 1
+        if lower_words[i + snippet_words - 1] in query_tokens:
+            cur_score += 1
+        if cur_score > best_score:
+            best_score = cur_score
+            best_start = i
+
+    if best_score == 0:
+        # No literal overlap anywhere — fall back to first-N words.
+        return " ".join(words[:snippet_words]) + " …"
+
+    snippet = " ".join(words[best_start : best_start + snippet_words])
+    if best_start > 0:
+        snippet = "… " + snippet
+    if best_start + snippet_words < len(words):
+        snippet = snippet + " …"
+    return snippet
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_search_snippets.py -v`
+Expected: PASS (all five tests).
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/managers/search.py tests/test_search_snippets.py
+git commit -m "feat(search): word-window snippet helper for semantic-only hits
+
+Slides a snippet_words-wide window across the chunk and picks the
+window with the most case-insensitive query-token matches. Falls back
+to the first N words with an ellipsis when no overlap exists. Used by
+pure-semantic search results and semantic-only hits in hybrid mode."
+```
+
+---
+
+## Task 8: Wire pipeline through `_keyword_search`
+
+**Goal:** Apply length downweight, per-doc cap, and snippet projection in keyword mode.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/managers/search.py` — `_keyword_search`, `SearchManager.__init__`
+- Test: `tests/test_managers_search.py` (extend with new keyword-mode tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_managers_search.py`:
+
+```python
+def test_keyword_search_applies_chunks_per_doc_cap(search_mgr):
+    """Two chunks from the same doc cannot both occupy the top-N."""
+    # alpha.md has only one chunk in the search_vault fixture, so synthesize
+    # a fixture scenario via a fresh manager.
+    # This test relies on the broader integration test in
+    # tests/test_search_pipeline_integration.py — here we just assert the
+    # manager honours the chunks_per_doc parameter.
+    results = search_mgr.search("world", mode="keyword", chunks_per_doc=1, limit=10)
+    paths_in_top = [r.path for r in results]
+    assert len(set(paths_in_top)) == len(paths_in_top)
+
+
+def test_keyword_search_returns_snippet(search_mgr):
+    """When snippet_words is set, content is shorter than the full chunk."""
+    long_results = search_mgr.search("world", mode="keyword", snippet_words=0, limit=10)
+    short_results = search_mgr.search("world", mode="keyword", snippet_words=3, limit=10)
+    assert all(
+        len(s.content.split()) <= len(l.content.split())
+        for s, l in zip(short_results, long_results, strict=False)
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_managers_search.py -k 'chunks_per_doc_cap or keyword_search_returns_snippet' -v`
+Expected: FAIL — `TypeError: search() got an unexpected keyword argument 'chunks_per_doc'`.
+
+- [ ] **Step 3: Add ranking config to `SearchManager.__init__`**
+
+In `src/markdown_vault_mcp/managers/search.py`, extend the `__init__` signature with the four new knobs (with sensible defaults so callers that omit them keep working):
+
+```python
+    def __init__(
+        self,
+        fts: FTSIndex,
+        source_dir: Path,
+        *,
+        embeddings_path: Path | None = None,
+        embedding_provider: EmbeddingProvider | None = None,
+        indexed_frontmatter_fields: list[str] | None = None,
+        exclude_patterns: list[str] | None = None,
+        attachment_extensions: list[str] | None = None,
+        link_manager: LinkManager | None = None,
+        flush_embeddings: Callable[[], None] | None = None,
+        rebuild_embeddings: Callable[[], None] | None = None,
+        chunks_per_doc: int = 2,
+        snippet_words: int = 200,
+        length_downweight_alpha: float = 0.25,
+    ) -> None:
+        ...
+        # store the new fields
+        self._chunks_per_doc = chunks_per_doc
+        self._snippet_words = snippet_words
+        self._length_downweight_alpha = length_downweight_alpha
+```
+
+- [ ] **Step 4: Add the new params to `search()` and rewrite `_keyword_search`**
+
+Rework the public `search()` to accept and thread `chunks_per_doc` and `snippet_words` overrides:
+
+```python
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+        filters: dict[str, str] | None = None,
+        folder: str | None = None,
+        chunks_per_doc: int | None = None,
+        snippet_words: int | None = None,
+    ) -> list[SearchResult]:
+        eff_cap = chunks_per_doc if chunks_per_doc is not None else self._chunks_per_doc
+        eff_snip = snippet_words if snippet_words is not None else self._snippet_words
+
+        if mode == "keyword":
+            return self._keyword_search(
+                query,
+                limit=limit,
+                filters=filters,
+                folder=folder,
+                chunks_per_doc=eff_cap,
+                snippet_words=eff_snip,
+            )
+
+        if mode == "semantic":
+            self._require_vectors()
+            return self._semantic_search(
+                query,
+                limit=limit,
+                filters=filters,
+                folder=folder,
+                chunks_per_doc=eff_cap,
+                snippet_words=eff_snip,
+            )
+
+        # hybrid
+        self._require_vectors()
+        return self._hybrid_search(
+            query,
+            limit=limit,
+            filters=filters,
+            folder=folder,
+            chunks_per_doc=eff_cap,
+            snippet_words=eff_snip,
+        )
+```
+
+Then rewrite `_keyword_search`:
+
+```python
+    def _keyword_search(
+        self,
+        query: str,
+        *,
+        limit: int,
+        filters: dict[str, str] | None,
+        folder: str | None,
+        chunks_per_doc: int,
+        snippet_words: int,
+    ) -> list[SearchResult]:
+        # Widen candidate pool so the cap doesn't starve us of `limit` rows.
+        candidate_limit = max(limit * (chunks_per_doc + 4), 50)
+
+        # NOTE: snippet projection is applied inside FTS only AFTER the cap,
+        # because we don't want to compute snippets for candidates that get
+        # dropped. So fetch raw content first, downweight, cap, then re-fetch
+        # snippets for the survivors via a second FTS query.
+        raw = self._fts.search(
+            query,
+            limit=candidate_limit,
+            filters=filters,
+            folder=folder,
+            snippet_words=None,  # full content for downweight scoring
+        )
+        downweighted = _apply_length_downweight(
+            raw, alpha=self._length_downweight_alpha
+        )
+        capped = _apply_chunks_per_doc_cap(
+            downweighted, n=chunks_per_doc, limit=limit
+        )
+
+        # Snippet projection for the survivors.
+        if snippet_words > 0:
+            snippets_by_key = self._fetch_snippet_map(
+                query, capped, snippet_words=snippet_words
+            )
+        else:
+            snippets_by_key = {}
+
+        return [
+            SearchResult(
+                path=r.path,
+                title=r.title,
+                folder=r.folder,
+                heading=r.heading,
+                content=snippets_by_key.get((r.path, r.heading), r.content),
+                score=r.score,
+                search_type="keyword",
+                frontmatter=self._get_frontmatter(r.path),
+            )
+            for r in capped
+        ]
+
+    def _fetch_snippet_map(
+        self,
+        query: str,
+        survivors: list[FTSResult],
+        *,
+        snippet_words: int,
+    ) -> dict[tuple[str, str | None], str]:
+        """Re-query FTS with snippet projection, restricted to survivor paths.
+
+        Returns a ``{(path, heading): snippet}`` map. Falls back to the
+        survivor's own ``content`` field when an FTS row cannot be located
+        (e.g. because the cap kept a downweighted-only candidate that BM25
+        ranked outside its top-N).
+        """
+        if not survivors:
+            return {}
+        # We use a single FTS5 search with a generous limit and filter by
+        # survivor paths in Python. FTS5 does not support IN(?,?,...) on the
+        # path column directly without a JOIN, but JOIN expansion is more
+        # complex than the post-filter and the survivor count is small.
+        candidate_n = max(len(survivors) * 4, 20)
+        rows = self._fts.search(
+            query,
+            limit=candidate_n,
+            snippet_words=snippet_words,
+        )
+        wanted = {(s.path, s.heading) for s in survivors}
+        return {
+            (r.path, r.heading): r.content for r in rows if (r.path, r.heading) in wanted
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_managers_search.py -v`
+Expected: PASS (existing tests + the two new ones).
+
+- [ ] **Step 6: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/managers/search.py tests/test_managers_search.py
+git commit -m "feat(search): wire pipeline through keyword mode
+
+_keyword_search now applies length downweight, per-doc cap, and FTS5
+snippet projection. snippet_words=0 retains today's full-content
+behaviour; default 200-word snippets centered on BM25-matched terms
+when set. Candidate pool is widened by chunks_per_doc + 4."
+```
+
+---
+
+## Task 9: Wire pipeline through `_semantic_search`
+
+**Goal:** Same pipeline for pure-semantic mode; the snippet stage uses the Python word-window helper from Task 7.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/managers/search.py` — `_semantic_search`
+- Test: extend `tests/test_managers_search.py` and `tests/test_search_snippets.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_managers_search.py`:
+
+```python
+def test_semantic_search_applies_chunks_per_doc_cap_and_snippet(
+    search_mgr_with_embeddings,  # fixture — see below if missing
+):
+    """Semantic mode honours chunks_per_doc and snippet_words."""
+    results = search_mgr_with_embeddings.search(
+        "world",
+        mode="semantic",
+        chunks_per_doc=1,
+        snippet_words=5,
+        limit=10,
+    )
+    paths = [r.path for r in results]
+    assert len(set(paths)) == len(paths)
+    assert all(len(r.content.split()) <= 10 for r in results)
+```
+
+If a `search_mgr_with_embeddings` fixture does not yet exist in `tests/test_managers_search.py`, define it locally (in the same file, near the top of the test). Otherwise, reuse the existing one and skip this step.
+
+```python
+@pytest.fixture()
+def search_mgr_with_embeddings(search_vault: Path) -> SearchManager:
+    """Build a SearchManager with a deterministic mock embedding provider."""
+    from tests.conftest import MockEmbeddingProvider  # standard fixture
+    from markdown_vault_mcp.vector_index import VectorIndex
+
+    fts = FTSIndex(db_path=":memory:", indexed_frontmatter_fields=["tags"])
+    for note in scan_directory(search_vault):
+        fts.upsert_note(note)
+    fts.resolve_vault_wikilinks()
+    provider = MockEmbeddingProvider(dim=8)
+    embeddings_path = search_vault / "embeddings"
+    vectors = VectorIndex(provider)
+    for note in scan_directory(search_vault):
+        vectors.add_document(note)
+    vectors.save(embeddings_path)
+    mgr = SearchManager(
+        fts=fts,
+        source_dir=search_vault,
+        embeddings_path=embeddings_path,
+        embedding_provider=provider,
+        indexed_frontmatter_fields=["tags"],
+    )
+    mgr._vectors = vectors
+    return mgr
+```
+
+(Adjust to match the actual `MockEmbeddingProvider` import location; `tests/conftest.py` already exports it per the project memory.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_managers_search.py -k semantic_search_applies -v`
+Expected: FAIL — same `chunks_per_doc` keyword-arg error or `snippet_words` not honoured.
+
+- [ ] **Step 3: Rewrite `_semantic_search`**
+
+```python
+    def _semantic_search(
+        self,
+        query: str,
+        *,
+        limit: int,
+        filters: dict[str, str] | None,
+        folder: str | None,
+        chunks_per_doc: int,
+        snippet_words: int,
+    ) -> list[SearchResult]:
+        self._flush_embeddings()
+        vectors = self._load_vectors()
+        candidate_limit = max(limit * (chunks_per_doc + 4), 50)
+        raw = vectors.search(query, limit=candidate_limit)
+
+        # Materialise into row objects with score + chunk_count + heading attrs.
+        # vectors.search returns dicts; we adapt to a small RowLike namespace.
+        rows: list[_SemanticRow] = []
+        for r in raw:
+            if folder is not None:
+                r_folder = r.get("folder", "")
+                if r_folder != folder and not r_folder.startswith(folder + "/"):
+                    continue
+            if filters and not self._row_matches_filters(r["path"], filters):
+                continue
+            chunk_count = self._fts_chunk_count_for(r["path"])
+            rows.append(
+                _SemanticRow(
+                    path=r["path"],
+                    title=r["title"],
+                    folder=r["folder"],
+                    heading=r.get("heading"),
+                    content=r["content"],
+                    score=r["score"],
+                    chunk_count=chunk_count,
+                )
+            )
+
+        downweighted = _apply_length_downweight(
+            rows, alpha=self._length_downweight_alpha
+        )
+        capped = _apply_chunks_per_doc_cap(
+            downweighted, n=chunks_per_doc, limit=limit
+        )
+
+        return [
+            SearchResult(
+                path=r.path,
+                title=r.title,
+                folder=r.folder,
+                heading=r.heading,
+                content=_compute_snippet_for_semantic(
+                    r.content, query, snippet_words=snippet_words
+                ),
+                score=r.score,
+                search_type="semantic",
+                frontmatter=self._get_frontmatter(r.path),
+            )
+            for r in capped
+        ]
+```
+
+Add the supporting `_SemanticRow` dataclass and helpers near the top of the file:
+
+```python
+@dataclass
+class _SemanticRow:
+    """Adapter row for vector search results so they expose .score / .chunk_count."""
+
+    path: str
+    title: str
+    folder: str
+    heading: str | None
+    content: str
+    score: float
+    chunk_count: int
+```
+
+And helpers on `SearchManager`:
+
+```python
+    def _fts_chunk_count_for(self, path: str) -> int:
+        """Look up parent doc chunk_count from the FTS index, default 1."""
+        row = self._fts._conn.execute(
+            "SELECT chunk_count FROM documents WHERE path = ?", (path,)
+        ).fetchone()
+        return int(row["chunk_count"]) if row else 1
+
+    def _row_matches_filters(self, path: str, filters: dict[str, str]) -> bool:
+        note_row = self._fts.get_note(path)
+        if note_row is None:
+            return False
+        fm_raw = note_row.get("frontmatter_json")
+        fm: dict[str, Any] = {}
+        if fm_raw:
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                fm = json.loads(fm_raw)
+        for key, value in filters.items():
+            fm_val = fm.get(key)
+            if fm_val is None:
+                return False
+            if isinstance(fm_val, list):
+                if str(value) not in [str(v) for v in fm_val]:
+                    return False
+            else:
+                if str(fm_val) != str(value):
+                    return False
+        return True
+```
+
+(The filter helper consolidates the duplicated logic that previously lived inline in both `_semantic_search` and `_hybrid_search`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_managers_search.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/managers/search.py tests/test_managers_search.py
+git commit -m "feat(search): wire pipeline through semantic mode
+
+_semantic_search applies length downweight, per-doc cap, and word-
+window snippet truncation. Chunk-count lookup uses the new
+documents.chunk_count column. Filter logic consolidated into a
+single helper used by semantic and hybrid modes."
+```
+
+---
+
+## Task 10: Wire pipeline through `_hybrid_search`
+
+**Goal:** RRF first, then cap on the merged list, then per-result snippet — FTS5 snippet for keyword-side hits, Python word-window for semantic-only hits.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/managers/search.py` — `_hybrid_search`
+- Test: `tests/test_managers_search.py` (extend) + `tests/test_search_snippets.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_managers_search.py`:
+
+```python
+def test_hybrid_search_caps_per_doc_after_rrf(search_mgr_with_embeddings):
+    results = search_mgr_with_embeddings.search(
+        "world",
+        mode="hybrid",
+        chunks_per_doc=1,
+        snippet_words=5,
+        limit=10,
+    )
+    paths = [r.path for r in results]
+    assert len(set(paths)) == len(paths)
+
+
+def test_hybrid_search_uses_fts_snippet_for_keyword_hits(search_mgr_with_embeddings):
+    """Results that show up on the keyword side should carry FTS5 ellipsis markers
+    when truncated; semantic-only fallbacks may also include ellipses but use the
+    Python helper."""
+    results = search_mgr_with_embeddings.search(
+        "world",
+        mode="hybrid",
+        chunks_per_doc=2,
+        snippet_words=3,
+        limit=10,
+    )
+    # Just assert size bound; concrete tokenizer behaviour is exercised in
+    # tests/test_fts_snippet.py.
+    assert all(len(r.content.split()) <= 8 for r in results)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_managers_search.py -k hybrid -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite `_hybrid_search`**
+
+```python
+    def _hybrid_search(
+        self,
+        query: str,
+        *,
+        limit: int,
+        filters: dict[str, str] | None,
+        folder: str | None,
+        chunks_per_doc: int,
+        snippet_words: int,
+    ) -> list[SearchResult]:
+        self._flush_embeddings()
+        candidate_limit = max(limit * (chunks_per_doc + 4), 50)
+
+        fts_results = self._fts.search(
+            query,
+            limit=candidate_limit,
+            filters=filters,
+            folder=folder,
+            snippet_words=None,  # full content; snippet applied later
+        )
+        # Apply length downweight inside the keyword channel.
+        fts_results = _apply_length_downweight(
+            fts_results, alpha=self._length_downweight_alpha
+        )
+
+        vectors = self._load_vectors()
+        vec_raw = vectors.search(query, limit=candidate_limit)
+        vec_rows: list[_SemanticRow] = []
+        for r in vec_raw:
+            if folder is not None:
+                r_folder = r.get("folder", "")
+                if r_folder != folder and not r_folder.startswith(folder + "/"):
+                    continue
+            if filters and not self._row_matches_filters(r["path"], filters):
+                continue
+            vec_rows.append(
+                _SemanticRow(
+                    path=r["path"],
+                    title=r["title"],
+                    folder=r["folder"],
+                    heading=r.get("heading"),
+                    content=r["content"],
+                    score=r["score"],
+                    chunk_count=self._fts_chunk_count_for(r["path"]),
+                )
+            )
+        vec_rows = _apply_length_downweight(
+            vec_rows, alpha=self._length_downweight_alpha
+        )
+
+        # RRF fusion on adjusted-rank order.
+        rrf_scores: dict[tuple[str, str | None], float] = {}
+        chunk_meta: dict[tuple[str, str | None], dict[str, Any]] = {}
+        keyword_keys: set[tuple[str, str | None]] = set()
+
+        for rank, r in enumerate(fts_results, start=1):
+            key = (r.path, r.heading)
+            rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (_RRF_K + rank)
+            keyword_keys.add(key)
+            chunk_meta.setdefault(
+                key,
+                {
+                    "path": r.path,
+                    "title": r.title,
+                    "folder": r.folder,
+                    "heading": r.heading,
+                    "content": r.content,
+                    "search_type": "keyword",
+                },
+            )
+
+        for rank, vr in enumerate(vec_rows, start=1):
+            vkey = (vr.path, vr.heading)
+            rrf_scores[vkey] = rrf_scores.get(vkey, 0.0) + 1.0 / (_RRF_K + rank)
+            chunk_meta.setdefault(
+                vkey,
+                {
+                    "path": vr.path,
+                    "title": vr.title,
+                    "folder": vr.folder,
+                    "heading": vr.heading,
+                    "content": vr.content,
+                    "search_type": "semantic",
+                },
+            )
+
+        # Sort merged keys by RRF score, then cap per path.
+        sorted_keys = sorted(rrf_scores, key=lambda k: rrf_scores[k], reverse=True)
+
+        # Wrap in a tiny adapter so _apply_chunks_per_doc_cap can read .path.
+        @dataclass
+        class _CapRow:
+            path: str
+            heading: str | None
+            score: float
+
+        cap_input = [
+            _CapRow(path=k[0], heading=k[1], score=rrf_scores[k]) for k in sorted_keys
+        ]
+        capped = _apply_chunks_per_doc_cap(
+            cap_input, n=chunks_per_doc, limit=limit
+        )
+
+        # Resolve snippets:
+        # - keyword-side hits: re-query FTS with snippet projection.
+        # - semantic-only:    Python word-window.
+        keyword_capped = [c for c in capped if (c.path, c.heading) in keyword_keys]
+        snippet_map: dict[tuple[str, str | None], str] = {}
+        if snippet_words > 0 and keyword_capped:
+            survivor_fts_rows = [
+                fts_r for fts_r in fts_results
+                if (fts_r.path, fts_r.heading) in {(c.path, c.heading) for c in keyword_capped}
+            ]
+            snippet_map = self._fetch_snippet_map(
+                query, survivor_fts_rows, snippet_words=snippet_words
+            )
+
+        out: list[SearchResult] = []
+        for c in capped:
+            key = (c.path, c.heading)
+            meta = chunk_meta[key]
+            if key in snippet_map:
+                content = snippet_map[key]
+            elif key in keyword_keys:
+                # Keyword hit but snippet_words=0 or fetch failed → use raw chunk.
+                content = meta["content"]
+            else:
+                content = _compute_snippet_for_semantic(
+                    meta["content"], query, snippet_words=snippet_words
+                )
+            out.append(
+                SearchResult(
+                    path=meta["path"],
+                    title=meta["title"],
+                    folder=meta["folder"],
+                    heading=meta["heading"],
+                    content=content,
+                    score=rrf_scores[key],
+                    search_type=meta["search_type"],
+                    frontmatter=self._get_frontmatter(meta["path"]),
+                )
+            )
+        return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_managers_search.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/managers/search.py tests/test_managers_search.py
+git commit -m "feat(search): wire pipeline through hybrid mode
+
+Per-channel length downweight, RRF fusion, then cap on merged sorted
+list. Snippet projection uses FTS5 native snippet() for keyword-side
+hits and the Python word-window helper for semantic-only hits."
+```
+
+---
+
+## Task 11: `read(path, *, section=...)` extension
+
+**Goal:** Recovery affordance for snippet-truncated `search` results — fetch the full chunk by `(path, heading)`.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/managers/document.py:225+` (`DocumentManager.read`)
+- Test: `tests/test_documents_read_section.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_documents_read_section.py`:
+
+```python
+"""Tests for DocumentManager.read(path, section=...) section retrieval."""
+
+from __future__ import annotations
+
+import pytest
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.managers.document import DocumentManager
+from markdown_vault_mcp.scanner import HeadingChunker, scan_directory
+
+
+@pytest.fixture()
+def doc_mgr(tmp_path):
+    a = tmp_path / "a.md"
+    a.write_text(
+        "# A\n\nIntro body\n\n## Section One\n\nFirst section body\n\n"
+        "## Section Two\n\nSecond section body\n",
+        encoding="utf-8",
+    )
+    fts = FTSIndex(db_path=":memory:")
+    chunker = HeadingChunker()
+    for note in scan_directory(tmp_path, chunk_strategy=chunker):
+        fts.upsert_note(note)
+    return DocumentManager(fts=fts, source_dir=tmp_path, chunk_strategy=chunker)
+
+
+def test_read_no_section_returns_full_file(doc_mgr):
+    nc = doc_mgr.read("a.md")
+    assert nc is not None
+    assert "Section One" in nc.content
+    assert "Section Two" in nc.content
+
+
+def test_read_with_section_returns_only_that_chunk(doc_mgr):
+    nc = doc_mgr.read("a.md", section="Section One")
+    assert nc is not None
+    assert "First section body" in nc.content
+    assert "Second section body" not in nc.content
+
+
+def test_read_unknown_section_raises(doc_mgr):
+    with pytest.raises(ValueError, match="Section"):
+        doc_mgr.read("a.md", section="No Such Heading")
+
+
+def test_read_empty_section_raises(doc_mgr):
+    with pytest.raises(ValueError):
+        doc_mgr.read("a.md", section="   ")
+
+
+def test_read_returns_none_when_path_unknown(doc_mgr):
+    assert doc_mgr.read("missing.md") is None
+    # With section, missing path also raises (cannot resolve section in
+    # nonexistent doc).
+    with pytest.raises(ValueError):
+        doc_mgr.read("missing.md", section="Anything")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_documents_read_section.py -v`
+Expected: FAIL — `TypeError: read() got an unexpected keyword argument 'section'`.
+
+- [ ] **Step 3: Extend `DocumentManager.read`**
+
+In `src/markdown_vault_mcp/managers/document.py`, replace the existing `read` (around line 225) with:
+
+```python
+    def read(
+        self, path: str, *, section: str | None = None
+    ) -> NoteContent | None:
+        """Read a document or a single section from disk.
+
+        Args:
+            path: Relative document path (e.g. ``"Journal/note.md"``).
+            section: When provided, return only the chunk whose heading
+                matches *section* exactly. ``None`` returns the whole
+                document (today's behaviour).
+
+        Returns:
+            A :class:`~markdown_vault_mcp.types.NoteContent`, or ``None`` if
+            the file does not exist (whole-document mode).
+
+        Raises:
+            ValueError: When *section* is provided and is empty / whitespace,
+                or when the document does not contain a chunk with that
+                heading. (Path-not-found also raises in section mode rather
+                than returning ``None``, since "no document" implies "no
+                section".)
+        """
+        if section is not None:
+            if not section.strip():
+                raise ValueError(
+                    "section must be a non-empty heading or None"
+                )
+            return self._read_section(path, section.strip())
+
+        abs_path = (self._source_dir / path).resolve()
+        if not abs_path.is_relative_to(self._source_dir.resolve()):
+            return None
+        if not abs_path.is_file():
+            return None
+
+        try:
+            note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
+        except (UnicodeDecodeError, OSError) as exc:
+            logger.warning("read(%s): could not parse file — %s", path, exc)
+            return None
+
+        raw_content = abs_path.read_text(encoding="utf-8")
+        etag = note.content_hash
+        folder = str(Path(path).parent)
+        if folder == ".":
+            folder = ""
+
+        return NoteContent(
+            path=note.path,
+            title=note.title,
+            folder=folder,
+            content=raw_content,
+            frontmatter=note.frontmatter,
+            modified_at=note.modified_at,
+            etag=etag,
+        )
+
+    def _read_section(self, path: str, heading: str) -> NoteContent:
+        """Return a NoteContent containing only the named section's chunk."""
+        doc_row = self._fts.get_note(path)
+        if doc_row is None:
+            raise ValueError(
+                f"Section '{heading}' not found in document {path}: "
+                "document is not indexed or does not exist"
+            )
+        section_row = self._fts._conn.execute(
+            """
+            SELECT s.content, s.heading, s.heading_level
+            FROM sections s
+            JOIN documents d ON d.id = s.document_id
+            WHERE d.path = ? AND s.heading = ?
+            ORDER BY s.start_line ASC
+            LIMIT 1
+            """,
+            (path, heading),
+        ).fetchone()
+        if section_row is None:
+            raise ValueError(
+                f"Section '{heading}' not found in document {path}"
+            )
+
+        folder = str(Path(path).parent)
+        if folder == ".":
+            folder = ""
+
+        return NoteContent(
+            path=path,
+            title=doc_row["title"],
+            folder=folder,
+            content=section_row["content"],
+            frontmatter={},  # section reads do not synthesise frontmatter
+            modified_at=doc_row["modified_at"],
+            etag="",  # ETag is whole-file; not meaningful for a section
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_documents_read_section.py tests/test_managers_document.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/managers/document.py tests/test_documents_read_section.py
+git commit -m "feat(document): read(path, section=...) for chunk recovery
+
+Optional section parameter on DocumentManager.read returns just the
+named chunk's content, looked up by exact heading match in the FTS
+sections table. Empty/whitespace section or unknown heading raises
+ValueError. section=None preserves today's whole-document behaviour."
+```
+
+---
+
+## Task 12: Wire config knobs into `Collection` and `HeadingChunker`
+
+**Goal:** Plumb the four new config fields end-to-end so server startup uses them.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/collection.py` — wherever `SearchManager` and `HeadingChunker` are constructed; wherever `to_collection_kwargs()` consumes the config.
+- Test: extend `tests/test_collection.py` and `tests/test_config.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_collection.py`:
+
+```python
+def test_collection_constructs_chunker_with_max_chunk_words(tmp_path):
+    """Collection plumbs max_chunk_words into HeadingChunker."""
+    from markdown_vault_mcp.collection import Collection
+    from markdown_vault_mcp.scanner import HeadingChunker
+
+    coll = Collection(source_dir=tmp_path, max_chunk_words=250)
+    assert isinstance(coll._chunk_strategy, HeadingChunker)
+    assert coll._chunk_strategy.max_chunk_words == 250
+
+
+def test_collection_search_honours_default_chunks_per_doc(tmp_path):
+    """A Collection-level search uses chunks_per_doc=2 by default."""
+    from markdown_vault_mcp.collection import Collection
+
+    # Build a tiny vault with one multi-section doc + a few singletons.
+    (tmp_path / "long.md").write_text(
+        "# Top\n## A\nworld a\n## B\nworld b\n## C\nworld c\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "short.md").write_text("# Short\nworld\n", encoding="utf-8")
+    coll = Collection(source_dir=tmp_path)
+    coll.build_index()
+    results = coll.search("world", mode="keyword", limit=10)
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.path] = counts.get(r.path, 0) + 1
+    assert counts.get("long.md", 0) <= 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_collection.py -k 'collection_constructs_chunker_with_max_chunk_words or honours_default_chunks_per_doc' -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Plumb config knobs through `Collection`**
+
+In `src/markdown_vault_mcp/collection.py`, extend `__init__` to accept the four knobs (with the same defaults as the spec) and pass them to `SearchManager` and `HeadingChunker`. Sketch:
+
+```python
+    def __init__(
+        self,
+        source_dir: Path,
+        *,
+        # ... existing params ...
+        chunks_per_doc: int = 2,
+        snippet_words: int = 200,
+        length_downweight_alpha: float = 0.25,
+        max_chunk_words: int = 400,
+    ) -> None:
+        ...
+        self._chunk_strategy = HeadingChunker(max_chunk_words=max_chunk_words)
+        ...
+        self._search = SearchManager(
+            fts=...,
+            source_dir=source_dir,
+            ...,
+            chunks_per_doc=chunks_per_doc,
+            snippet_words=snippet_words,
+            length_downweight_alpha=length_downweight_alpha,
+        )
+```
+
+- [ ] **Step 4: Update `CollectionConfig.to_collection_kwargs()`**
+
+Find `to_collection_kwargs` in `src/markdown_vault_mcp/config.py` and add the four new fields to the kwargs dict:
+
+```python
+        return {
+            "source_dir": self.source_dir,
+            # ... existing kwargs ...
+            "chunks_per_doc": self.chunks_per_doc,
+            "snippet_words": self.snippet_words,
+            "length_downweight_alpha": self.length_downweight_alpha,
+            "max_chunk_words": self.max_chunk_words,
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_collection.py tests/test_config.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/collection.py src/markdown_vault_mcp/config.py tests/test_collection.py
+git commit -m "feat(collection): wire ranking and snippet config knobs
+
+Collection now constructs HeadingChunker with max_chunk_words and
+SearchManager with chunks_per_doc / snippet_words /
+length_downweight_alpha. CollectionConfig.to_collection_kwargs
+forwards the four fields."
+```
+
+---
+
+## Task 13: Surface `chunks_per_doc` and `snippet_words` on the `search` MCP tool
+
+**Goal:** End-user / agentic consumers can override the cap and snippet width per call.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/_server_tools.py` (around line 83 — the `search` tool definition).
+- Test: `tests/test_server.py` (extend) — drive the tool through `fastmcp.Client`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_server.py`:
+
+```python
+async def test_search_tool_accepts_chunks_per_doc_and_snippet_words(
+    server_factory, tmp_path
+):
+    """The `search` MCP tool surfaces the new knobs as optional parameters."""
+    from fastmcp import Client
+
+    (tmp_path / "long.md").write_text(
+        "# Top\n## A\nworld a\n## B\nworld b\n## C\nworld c\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "short.md").write_text("# S\nworld\n", encoding="utf-8")
+    server = server_factory(source_dir=tmp_path)
+
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "search",
+            {
+                "query": "world",
+                "mode": "keyword",
+                "chunks_per_doc": 1,
+                "snippet_words": 5,
+                "limit": 10,
+            },
+        )
+        results = result.data
+        paths = [r["path"] for r in results]
+        assert len(set(paths)) == len(paths)
+        assert all(len((r["content"] or "").split()) <= 8 for r in results)
+```
+
+(`server_factory` is the existing test fixture that creates a fresh FastMCP server bound to a tmp vault. If a different fixture name is in use, adapt accordingly — see existing `tests/test_server.py`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_server.py -k chunks_per_doc -v`
+Expected: FAIL — `ToolError` or `ValidationError` because the tool does not accept these parameters yet.
+
+- [ ] **Step 3: Update the `search` tool**
+
+In `src/markdown_vault_mcp/_server_tools.py`, locate the `@mcp.tool(...)`-decorated `async def search(...)` (≈ line 83). Update its signature, docstring, and the call into the manager:
+
+```python
+    @mcp.tool(...)  # keep existing decorator args
+    async def search(
+        query: str,
+        *,
+        limit: int = 10,
+        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+        filters: dict[str, str] | None = None,
+        folder: str | None = None,
+        chunks_per_doc: int | None = None,
+        snippet_words: int | None = None,
+    ) -> list[SearchResult]:
+        """Search the vault.
+
+        ...
+
+        Args:
+            ...
+            chunks_per_doc: Maximum number of result chunks per document
+                in the returned list. ``None`` uses the server default
+                (configured via ``MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC``,
+                default 2). Pass an integer to override per call.
+            snippet_words: Approximate word budget for the per-result
+                ``content`` snippet. ``None`` uses the server default
+                (default 200). Pass ``0`` for the full chunk verbatim;
+                recover the full chunk after seeing a snippet via
+                ``read(path, section=heading)``.
+
+        Returns:
+            List of SearchResult. ``content`` is a snippet by default (≤
+            ``snippet_words`` words, centred on the matched terms). Each
+            result's ``heading`` plus ``path`` is the chunk identity used
+            by ``read(path, section=heading)`` for full recovery.
+        """
+        coll = await get_collection()
+        return await asyncio.to_thread(
+            coll.search,
+            query,
+            limit=limit,
+            mode=mode,
+            filters=filters,
+            folder=folder,
+            chunks_per_doc=chunks_per_doc,
+            snippet_words=snippet_words,
+        )
+```
+
+(Confirm the actual `coll.search` signature accepts the two new kwargs from Task 8/11; if the `Collection` facade re-exports `SearchManager.search`, confirm it does too. If not, add a thin pass-through on `Collection.search`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_server.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/_server_tools.py tests/test_server.py
+git commit -m "feat(server): chunks_per_doc and snippet_words on search tool
+
+The search MCP tool surfaces both knobs as optional parameters; None
+falls back to server defaults. Tool docstring documents that content
+is now a snippet by default and points consumers at read(path,
+section=heading) for full chunk recovery."
+```
+
+---
+
+## Task 14: Surface `section` on the `read` MCP tool
+
+**Goal:** Consumers can fetch a specific chunk via `read(path, section=heading)`.
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/_server_tools.py` (≈ line 154 — the `read` tool).
+- Test: `tests/test_server.py` (extend)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_server.py`:
+
+```python
+async def test_read_tool_returns_only_named_section(server_factory, tmp_path):
+    from fastmcp import Client
+
+    (tmp_path / "a.md").write_text(
+        "# A\n## One\nfirst body\n## Two\nsecond body\n",
+        encoding="utf-8",
+    )
+    server = server_factory(source_dir=tmp_path)
+    async with Client(server) as client:
+        whole = await client.call_tool("read", {"path": "a.md"})
+        assert "first body" in whole.data["content"]
+        assert "second body" in whole.data["content"]
+
+        partial = await client.call_tool(
+            "read", {"path": "a.md", "section": "One"}
+        )
+        assert "first body" in partial.data["content"]
+        assert "second body" not in partial.data["content"]
+
+        # Unknown section → tool error.
+        with pytest.raises(Exception) as excinfo:
+            await client.call_tool(
+                "read", {"path": "a.md", "section": "Nope"}
+            )
+        assert "Nope" in str(excinfo.value)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_server.py -k read_tool_returns_only_named_section -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Update the `read` tool**
+
+In `src/markdown_vault_mcp/_server_tools.py`, locate `async def read(...)` (≈ line 154). Update:
+
+```python
+    @mcp.tool(...)  # keep existing decorator args
+    async def read(
+        path: str,
+        *,
+        section: str | None = None,
+    ) -> NoteContent | AttachmentContent:
+        """Read a document — either the whole file or one named section.
+
+        ...
+
+        Args:
+            path: Relative vault path.
+            section: When provided, return just that section's chunk content
+                (matched by exact heading text). ``None`` returns the whole
+                document. Empty / whitespace section or an unknown heading
+                raises ``ValueError``.
+        """
+        coll = await get_collection()
+        return await asyncio.to_thread(coll.read, path, section=section)
+```
+
+If `Collection.read` does not yet accept `section`, add a thin pass-through delegating to `DocumentManager.read`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_server.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add src/markdown_vault_mcp/_server_tools.py tests/test_server.py
+git commit -m "feat(server): section parameter on read tool
+
+read(path, section=heading) returns just that section's chunk content,
+serving as the recovery affordance for snippet-truncated search
+results. Unknown / empty section raises ValueError surfaced as a
+ToolError to consumers."
+```
+
+---
+
+## Task 15: End-to-end pipeline integration test
+
+**Goal:** A single test that mirrors the diagnostic pathology — one long doc + many short notes, verify essay occupies ≤ 2 of 10 slots and snippets are sentence-scale.
+
+**Files:**
+- Test: `tests/test_search_pipeline_integration.py` (new)
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/test_search_pipeline_integration.py`:
+
+```python
+"""End-to-end integration test for the search ranking pipeline.
+
+Mirrors the diagnostic case described in
+docs/superpowers/specs/2026-04-30-search-ranking-and-snippets-design.md:
+one 12-section essay plus many short atomic notes that all mention the
+query terms. The essay must not occupy more than 2 of the top 10 slots,
+result payloads must be bounded, and other notes must get representation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from markdown_vault_mcp.collection import Collection
+
+
+@pytest.fixture()
+def diagnostic_vault(tmp_path: Path) -> Path:
+    # One big essay with 12 sections, all mentioning "etymology" and "secura".
+    sections = []
+    for i in range(12):
+        sections.append(f"## Section {i}")
+        sections.append(
+            (f"On the etymology of secura: this {i} section repeats key "
+             "terms etymology security care.") * 30
+        )
+    essay = "# Lexicon Essay\n" + "\n\n".join(sections) + "\n"
+    (tmp_path / "essay.md").write_text(essay, encoding="utf-8")
+
+    # Twenty short atomic notes, each genuinely related.
+    for i in range(20):
+        (tmp_path / f"note_{i:02d}.md").write_text(
+            f"# Note {i}\n\netymology and secura — note {i} discusses "
+            "security and care in brief.\n",
+            encoding="utf-8",
+        )
+    return tmp_path
+
+
+@pytest.mark.parametrize("mode", ["keyword", "semantic", "hybrid"])
+def test_essay_capped_in_top_ten(diagnostic_vault, mode):
+    coll = Collection(source_dir=diagnostic_vault)
+    coll.build_index()
+    if mode in ("semantic", "hybrid"):
+        coll.build_embeddings()
+
+    results = coll.search(
+        "etymology secura security care", mode=mode, limit=10
+    )
+    essay_slots = sum(1 for r in results if r.path == "essay.md")
+    assert essay_slots <= 2, f"essay.md occupied {essay_slots} of 10 slots ({mode})"
+    # Other docs get representation.
+    other_paths = {r.path for r in results} - {"essay.md"}
+    assert len(other_paths) >= 5, f"too few other docs in top 10 ({mode})"
+
+
+def test_payloads_bounded_by_default(diagnostic_vault):
+    coll = Collection(source_dir=diagnostic_vault)
+    coll.build_index()
+    results = coll.search("etymology secura", mode="keyword", limit=10)
+    for r in results:
+        # Default snippet_words=200; allow slack for ellipsis tokens.
+        assert len(r.content.split()) <= 220
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/test_search_pipeline_integration.py -v`
+Expected: PASS for all four parameter combinations.
+
+- [ ] **Step 3: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add tests/test_search_pipeline_integration.py
+git commit -m "test(search): end-to-end pipeline integration test
+
+Mirrors the diagnostic case: one 12-section essay + 20 short notes,
+all mentioning the query terms. Verifies essay <= 2 of top 10 slots,
+other docs get representation, and default snippet payloads stay
+under ~220 words."
+```
+
+---
+
+## Task 16: Documentation updates
+
+**Goal:** Spec, configuration, tools, and example env files reflect the new behaviour.
+
+**Files:**
+- Modify: `docs/design.md` — add a "Search ranking and snippet truncation" section under Search architecture; update HeadingChunker description for adaptive H-level splitting.
+- Modify: `docs/configuration.md` — document the four new env vars.
+- Modify: `docs/tools/index.md` — update `search` and `read` tool signatures.
+- Modify: `examples/.env.example` — add commented-out entries for the four new vars at their default values.
+- Modify: `README.md` — short paragraph in the Features section noting per-doc cap, snippets, and adaptive chunking.
+
+- [ ] **Step 1: Update `docs/design.md`**
+
+Find the existing "Search" section. Append a new "Search ranking and snippet truncation" subsection summarising goals, the pipeline diagram (copy from spec section "Pipeline overview"), and the four config knobs. Update the chunker subsection to describe adaptive H-level splitting (sentence: "When `max_chunk_words` is set, oversize chunks are recursively re-split at deeper heading levels (H1 → H6) until each fits or no headings of the next level exist inside.").
+
+- [ ] **Step 2: Update `docs/configuration.md`**
+
+Add a new "Search ranking and snippet truncation" section listing each env var (name, default, type, what it controls). Mirror the spec's API-surface table.
+
+- [ ] **Step 3: Update `docs/tools/index.md`**
+
+In the `search` tool entry, update the parameter table and Returns block to mention `chunks_per_doc`, `snippet_words`, and the snippet semantics. In the `read` tool entry, document the optional `section` parameter and how it pairs with snippet results.
+
+- [ ] **Step 4: Update `examples/.env.example`**
+
+Append:
+
+```ini
+# --- Search ranking and snippet truncation ---
+# Per-document result cap. 0 rejected. Per-call override via search tool.
+# MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC=2
+
+# Snippet word budget. 0 = no truncation, full chunk. Per-call override.
+# MARKDOWN_VAULT_MCP_SNIPPET_WORDS=200
+
+# Length downweight strength. 0 disables. Operator-only (no per-call override).
+# MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA=0.25
+
+# Adaptive chunker word threshold. Set very high (e.g. 100000) to disable.
+# MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS=400
+```
+
+- [ ] **Step 5: Update `README.md`**
+
+Add a short bullet to the "Features" or "Search" section, e.g.:
+
+> - **Diversity-aware ranking.** Each search result list caps a single document at 2 chunks (configurable), downweights chunks of long documents, and returns sentence-scale snippets — bounded LLM context cost per query, with full chunk recovery via `read(path, section=heading)`.
+
+- [ ] **Step 6: Verify docs build**
+
+Run: `uv run mkdocs build --strict`
+Expected: PASS, no broken links / orphaned pages.
+
+- [ ] **Step 7: Pre-commit gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/ && uv run pytest -x -q
+git add docs/design.md docs/configuration.md docs/tools/index.md examples/.env.example README.md
+git commit -m "docs: search ranking and snippet truncation
+
+Document the new MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC,
+MARKDOWN_VAULT_MCP_SNIPPET_WORDS,
+MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA, and
+MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS env vars; the new search/read
+tool parameters; and the adaptive chunker behaviour. Updates
+design.md with the ranking pipeline diagram."
+```
+
+---
+
+## Self-Review (before opening the PR)
+
+Run through this checklist locally:
+
+1. **Spec coverage:** Cross-reference the spec's Goals (1–6) and Non-goals (1–4) against the task list. Each goal has at least one task (cap → Tasks 6, 8, 9, 10; downweight → Tasks 5, 8, 9, 10; snippet → Tasks 4, 7, 8, 9, 10; adaptive chunker → Task 2; mode-uniform → Tasks 8, 9, 10; no shape break → preserved by `content`-field reuse in Tasks 8–10). Non-goals: no frontmatter conventions (codified in spec, not in code); no re-embed (Task 7 uses string scan only); no paragraph chunking (Task 2 deliberately stops at H6); no new modes (search tool keeps the same three).
+2. **Reindex required.** Task 16 docs must call this out for operators upgrading.
+3. **Default-behavior change.** Existing search consumers will see shorter `content` after this PR ships. Captured in Task 13's commit message and Task 16's docs; also surface in the eventual PR description.
+4. **Backwards compatibility.** `SearchResult` shape unchanged; `read(path)` unchanged. New parameters are all keyword-only and optional.
+5. **Pre-commit hooks.** Each task ends with the same lint/format/mypy/pytest gauntlet; no `--no-verify`.
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-30-search-ranking-and-snippets.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-30-search-ranking-and-snippets-design.md
+++ b/docs/superpowers/specs/2026-04-30-search-ranking-and-snippets-design.md
@@ -1,0 +1,230 @@
+# Search ranking and snippet truncation — design
+
+**Date:** 2026-04-30
+**Status:** Approved (brainstorming complete; awaiting implementation plan)
+
+## Problem statement
+
+Two distinct retrieval pathologies were observed when a long synthesising essay (a 14-section, ~12000-word multilingual etymology lexicon) was added to a vault alongside many shorter atomic concept notes:
+
+1. **Document concentration.** A hybrid search for `"se-cura etymology security without care"` returned the essay in five of the top ten slots (sections XIV, intro, I, VIII, Caveats), crowding out other relevant material. Section XIV (summary) outranked section I (the original exposition) because XIV repeats key terms more densely.
+2. **Payload variance.** The `search` tool returns the full matching chunk as `content`. Chunk size varies wildly (200–1500 words) because chunking happens at H1/H2 boundaries; consumer context cost per result is unpredictable.
+
+A diagnostic pure-semantic search for `"se-cura"` did not surface the essay at all in the top 10 — embedding signal for the hyphenated Latin compound was weak in isolation. Score distribution was narrow (0.62–0.64). Top hits included false positives (`Restic backup` at 0.638; `NIS2 Directive` at 0.620). This is a separate signal-quality issue that this design does not directly attack.
+
+## Goals
+
+1. **Cap document concentration in result lists.** No single document occupies more than `chunks_per_doc` slots in any search result, regardless of mode (keyword / semantic / hybrid). Default cap: 2.
+2. **Downweight chunks of long documents during ranking.** Apply a single tunable factor (`length_downweight_alpha`, default 0.25) to each chunk's score, per channel, before fusion. Long docs slide down; short focused notes rise.
+3. **Bound result payload size.** Truncate `SearchResult.content` to a query-relevant window of approximately `snippet_words` words (default 200). Full chunk recovery available via `read(path, section=...)`.
+4. **Reduce within-doc chunk-size variance via adaptive heading-level chunking.** Chunker recursively descends from H1 → H2 → … → H6 when a chunk exceeds `max_chunk_words` (default 400). Pairs naturally with goals 1–3: chunk count rises for big docs, length downweight strengthens automatically, snippets operate on already-uniform chunks.
+5. **Behave identically across keyword, semantic, and hybrid modes** for user-visible knobs (cap, snippet truncation). Length downweight is rank-mode-specific in mechanism but uniform in effect.
+6. **No SearchResult shape break.** Same field names and types — the `content` field simply contains less text by default. Existing consumers continue to work; opt back into full chunks with `snippet_words=0`.
+
+## Non-goals
+
+1. **No frontmatter-based ranking.** The MCP must not require, recommend, or special-case any frontmatter convention on vault content (no `kind`, no `noindex`, no `boost`). Vault organisation is the user's choice; the server treats all `.md` files structurally identically. Rationale: a generic-purpose markdown MCP cannot impose a content-modelling discipline on the user. This forecloses the option permanently, not just for this PR.
+2. **No re-embedding at search time.** Snippet selection for semantic-only hits uses cheap word-window heuristics, not per-result chunk re-embedding.
+3. **No paragraph-level or fixed-window chunking.** Splitting follows existing heading structure adaptively. No sliding-window overlap, no sentence splitting, no content-blind size caps. A single 5000-word prose block with no sub-headings stays one chunk; snippet truncation handles the read-time payload.
+4. **No new search modes.** No "diversity-aware" mode, no "essay-mode-on/off". The same tools, with three new knobs (plus the chunker threshold).
+
+## Pipeline overview
+
+```
+                 ┌─ keyword channel ────────────────────────┐
+                 │  FTS5 BM25 search (widened candidates)   │
+                 │  → length downweight per chunk (D1)      │
+                 │  → re-rank within channel                │
+                 └──────────────────────────────────────────┘
+query, mode  →                                                  → fuse →  cap per path  →  snippet  →  SearchResult
+                 ┌─ semantic channel ───────────────────────┐    (RRF in   (C2: drop      (A1: FTS5     (limit
+                 │  cosine top-K (widened)                  │    hybrid)   excess         snippet for   results)
+                 │  → length downweight per chunk (D1)      │              chunks per     keyword/
+                 │  → re-rank within channel                │              path)          hybrid-keyword,
+                 └──────────────────────────────────────────┘                             word-window
+                                                                                          for semantic-only)
+```
+
+**Per mode.**
+- `mode="keyword"` — only the keyword channel runs. Cap → snippet → return.
+- `mode="semantic"` — only the semantic channel runs. Cap → snippet (word-window fallback path) → return.
+- `mode="hybrid"` — both channels, RRF fuse, then cap → snippet → return.
+
+**Candidate widening.** Each channel fetches `max(limit * (chunks_per_doc + 4), 50)` candidates so that capping doesn't starve us of `limit` results. The `+4` is slack for ranking inversions where same-doc chunks cluster at the top.
+
+## Detailed mechanism
+
+### Length downweight (1b, D1)
+
+Each chunk has a known `chunk_count_in_doc` value (its parent doc's total chunks, computed once at index time and stored in a new `documents.chunk_count` column).
+
+Within each channel:
+- Adjusted score: `raw_score / (1 + alpha * log(chunk_count_in_doc))`.
+- Re-sort the channel by adjusted score (rank order is what RRF consumes downstream).
+- For RRF the divisor's magnitude doesn't get combined across BM25 and cosine — only ranks merge.
+
+Effect at the default `alpha = 0.25`: a 10-chunk doc loses ~37% effective rank weight; a 2-chunk doc loses ~17%; a 1-chunk doc is unchanged. `alpha = 0` disables.
+
+### Per-doc cap (1a, C2)
+
+Cap is applied **after RRF fusion**, uniformly across all three modes:
+- Walk the merged-and-sorted list in ranked order.
+- For each result, increment a per-`path` counter.
+- Skip results whose counter has already reached `chunks_per_doc`.
+- Stop when `limit` results are collected.
+
+C2 was preferred over C1 (cap-per-channel) because RRF should see full per-channel information; capping is a presentation/diversity step, not a ranking concern.
+
+### Snippet selection (2a, A1)
+
+Computed **after cap**, so only the `limit` surviving results pay the cost.
+
+- **Keyword hit (or keyword-side hit in hybrid):** select FTS5's `snippet(notes_fts, 4, '', '', '…', snippet_words)` as a column expression in the FTS query. SQLite computes a tokenizer-aware window centered on match terms, with `…` ellipsis on truncated edges. Column index 4 is the `content` column (declared 0-indexed in `notes_fts USING fts5(path, title, folder, heading, content, ...)`).
+- **Semantic-only (came from cosine, never matched keyword):** Python word-window scan of the chunk's full content.
+  - Tokenize query case-insensitively.
+  - Slide a `snippet_words`-wide window across the chunk; pick the window with the highest count of query tokens.
+  - Falls back to the first `snippet_words` words of the chunk body when the query has zero literal overlap. The chunk body already starts at the line *after* the heading (the chunker strips the heading line), and the heading text itself is returned separately on `SearchResult.heading` — so the fallback is heading-anchored in effect without redundant text in `content`.
+- **`snippet_words = 0`:** skip truncation entirely; `content` is the full chunk.
+
+Snippet computation is bounded: O(snippet_words) for FTS5, O(chunk_size) for the Python fallback. Per-result, not per-candidate.
+
+### Adaptive chunking (goal 5)
+
+Algorithm in `HeadingChunker`:
+1. Split at H1.
+2. For each chunk, if word count > `max_chunk_words`, re-split at H2.
+3. Recurse: H2 → H3 → H4 → H5 → H6.
+4. Stop when chunk fits, or when no headings of the next level exist inside.
+5. Preamble (no heading) and "single huge prose block with no sub-headings" cases: leave as-is.
+6. Short-doc bypass (≤ 30 lines) still applies — redundant with adaptive but harmless.
+
+Word count: `len(content.split())`. Recursion depth is bounded by 6 (H1–H6). Migration: existing vault must be reindexed for the new chunker to take effect; reindex is an existing operation.
+
+## Component & file changes
+
+| File | Change |
+|---|---|
+| `src/markdown_vault_mcp/scanner.py` | Extend `HeadingChunker.__init__` with `max_chunk_words: int \| None = None`. Add private `_refine_oversize(chunks, current_level, max_words)` helper. Word count via `len(content.split())`. `max_chunk_words=None` preserves today's H1/H2-only behavior. |
+| `src/markdown_vault_mcp/fts_index.py` | Add `chunk_count INTEGER NOT NULL DEFAULT 1` column to `documents` table. Populate during `upsert_note` and `build_from_notes` from `len(note.chunks)`. Provide a migration step (`ALTER TABLE ADD COLUMN`) for FTS DBs created before this PR. New `FTSIndex.search(...)` parameter `snippet_words: int \| None`: when set, the SQL projects `snippet(notes_fts, 4, '', '', '…', snippet_words)` for the content column instead of raw `content`. New `chunk_count` field on `FTSResult`. |
+| `src/markdown_vault_mcp/types.py` | Add `chunk_count` to `FTSResult` (internal). `SearchResult` shape unchanged. Update the `content` field docstring to reflect snippet semantics and recovery via `read(path, section=...)`. |
+| `src/markdown_vault_mcp/managers/search.py` | New private helpers: `_apply_length_downweight(results, alpha)`, `_apply_chunks_per_doc_cap(results, n)`, `_compute_snippet_for_semantic(content, query, snippet_words)`. Rework `_keyword_search`, `_semantic_search`, `_hybrid_search` to apply the pipeline shown above. Candidate-widening formula moves into a single helper. The public `search()` method gains `chunks_per_doc: int \| None = None` and `snippet_words: int \| None = None` parameters; `None` falls back to config defaults. |
+| `src/markdown_vault_mcp/managers/document.py` | Extend `DocumentManager.read(path)` → `read(path, *, section: str \| None = None)`. When `section` is provided, query the `sections` table for the matching `(document_id, heading)` and return only that chunk's content; raise `ValueError` if not found. `section=None` keeps today's whole-file behavior. Empty / whitespace section raises `ValueError`. Preamble retrieval not exposed. |
+| `src/markdown_vault_mcp/collection.py` | Plumb the new config knobs into `SearchManager` and `HeadingChunker` construction. |
+| `src/markdown_vault_mcp/config.py` | Add four config fields between `CONFIG-FIELDS-START`/`END` sentinels. Read from env in the matching `CONFIG-FROM-ENV` block. |
+| `src/markdown_vault_mcp/_server_tools.py` | On `search` (≈ line 83): surface `chunks_per_doc` and `snippet_words` as per-call parameters; update tool docstring/Returns to describe snippet semantics + recovery via `read(path, section=...)`. On `read` (≈ line 154): surface the new `section` parameter. |
+| `docs/design.md` | New "Search ranking and snippet truncation" section under Search architecture. Update the chunker description for adaptive H-level splitting. |
+| `docs/tools/index.md`, `docs/configuration.md`, `examples/.env.example` | New env vars documented; `search` and `read` tool signatures updated. |
+
+## API surface
+
+### Config / env vars (new)
+
+| Env var | Default | Type | Notes |
+|---|---|---|---|
+| `MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC` | `2` | int ≥ 1 | Per-doc cap on results. `0` rejected. |
+| `MARKDOWN_VAULT_MCP_SNIPPET_WORDS` | `200` | int ≥ 0 | Snippet word budget. `0` = no truncation. |
+| `MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA` | `0.25` | float ≥ 0 | `score / (1 + alpha · log(chunk_count))`. `0` disables. |
+| `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` | `400` | int ≥ 1 | Adaptive chunker threshold. Set very high (e.g. `100000`) to disable adaptive splitting. |
+
+`length_downweight_alpha` is operator-only (env-var only, no per-call override). The other three knobs accept per-call overrides on the `search` MCP tool.
+
+### `search` MCP tool — new optional parameters
+
+```python
+search(
+    query: str,
+    *,
+    limit: int = 10,
+    mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+    filters: dict[str, str] | None = None,
+    folder: str | None = None,
+    chunks_per_doc: int | None = None,   # NEW — None → server default
+    snippet_words: int | None = None,    # NEW — None → server default; 0 → full chunk
+) -> list[SearchResult]
+```
+
+`SearchResult` shape unchanged; `content` semantics changed (snippet by default — documented in the tool docstring).
+
+### `read` MCP tool — new optional parameter
+
+```python
+read(
+    path: str,
+    *,
+    section: str | None = None,   # NEW — None → whole document; else exact heading match
+) -> NoteContent | AttachmentContent
+```
+
+When `section` is provided:
+- Heading lookup uses exact-match against `sections.heading` for that document.
+- Multiple sections share the same heading? First by `start_line` is returned (deterministic). Documented behavior; rare in practice.
+- Section not found → `ValueError("Section 'X' not found in document Y")`.
+- `section=""` or whitespace-only → `ValueError`.
+- Returned `NoteContent.content` is the chunk content; frontmatter is not synthesized for section-only reads.
+
+### Backwards compatibility
+
+- Existing `search` callers passing no new params get a 200-word snippet in `content`. **This is a default behavior change.** Documented in `CHANGELOG.md` as a `feat:` (default-tightening). Consumers can opt back into full-chunk behavior with `snippet_words=0`.
+- Existing `read` callers passing no new params see identical behavior to today.
+- Existing `SearchResult` consumers reading `content` continue to work (same field, same type, just shorter).
+- **Reindex required** for the chunker change to take effect — the new `documents.chunk_count` column is populated and the adaptive chunker boundaries differ from today's. Call out in release notes; the existing `reindex` MCP tool / startup path handles it.
+
+### Validation
+
+- Numeric params: reject negatives at parameter-binding time.
+- `chunks_per_doc=0` rejected.
+- Other knobs accept `0` (feature-disabled semantics).
+- `section`: empty / whitespace raises `ValueError` at the manager layer.
+
+## Testing strategy
+
+| Test surface | What to cover |
+|---|---|
+| `tests/test_scanner_adaptive_chunking.py` (new) | `max_chunk_words=None` produces today's H1/H2-only behavior. `max_chunk_words=400` recursively splits oversize H1 → H2 sub-chunks. Recursion descends H1→…→H6 and stops when chunk fits. Oversize H6 (or oversize prose with no deeper headings) stays as one chunk. Preamble stays as one chunk regardless of size. Short-doc bypass (≤ 30 lines) still applies. `heading_level` and `start_line` correctly propagated. |
+| `tests/test_search_length_downweight.py` (new) | Fixture vault with one 14-chunk doc + ten 1-chunk docs, all containing a query term. `alpha=0`: long-doc chunks dominate. `alpha=0.25`: they slide down. `alpha=2.0`: they're nearly absent. Run for keyword, semantic, hybrid. |
+| `tests/test_search_chunks_per_doc_cap.py` (new) | Same fixture: with `chunks_per_doc=1`, top-10 results contain ≤ 1 chunk per path. With `chunks_per_doc=2`, ≤ 2 per path. Candidate-widening formula yields `limit` results when enough distinct docs exist; fewer when the vault has fewer matching docs. Per-call override beats env-var default. |
+| `tests/test_search_snippets.py` (new) | `snippet_words=0` → full chunk. `snippet_words=200` on a long chunk → ≤ ~200 words and centered on a query token. FTS5 path: keyword hit produces tokenizer-aware snippet with `…` ellipses. Semantic-only path: word-window scan picks the densest window of query tokens; falls back to first N words on no overlap. Hybrid: keyword-side hit gets FTS5 snippet; semantic-only hit gets Python word-window. Snippet generation runs *after* cap (only `limit` snippets computed). |
+| `tests/test_documents_read_section.py` (new) | `read(path)` → whole file (regression). `read(path, section="Heading")` → just that section's chunk. Unknown / empty / whitespace section → `ValueError`. Multiple sections with the same heading → first by `start_line`. Frontmatter not included in section-only reads. |
+| `tests/test_fts_chunk_count.py` (new) | New `chunk_count` column populated at `upsert_note` and `build_from_notes`. Reindex updates the column when chunk count changes. Migration: an FTS DB created before this PR is upgraded on next index load. |
+| `tests/test_search_pipeline_integration.py` (new) | End-to-end on the diagnostic-style fixture (one 12-section essay + many short notes, query similar to "se-cura etymology"): essay occupies ≤ 2 of top 10 slots; snippet payloads are bounded; other docs get representation. Run for all three modes. |
+| Existing tests | `tests/test_search*.py`, `tests/test_collection_search.py`, etc. — many will break because `content` is now snippet-by-default. Add `snippet_words=0` to existing search calls that assert on full-content equality. The breakage is itself a useful signal that the feature works as advertised. |
+
+### Manual verification checklist (in PR description)
+
+- [ ] `uv run pytest -x -q` — all tests pass.
+- [ ] `uv run mypy src/ tests/` — no errors.
+- [ ] `uv run ruff check --fix .` then `uv run ruff format .` — clean.
+- [ ] Reindex local vault. Run diagnostic queries `"se-cura"` (semantic) and `"se-cura etymology security without care"` (hybrid). Eyeball: ≤ 2 essay slots in top 10, snippets are sentence-scale, other relevant notes appear.
+- [ ] Run with `chunks_per_doc=1, snippet_words=0` — escape-hatch behavior matches expectations.
+- [ ] Run with `length_downweight_alpha=0` — long docs return to dominant ranking (regression-style sanity check).
+
+### Patch coverage
+
+All new code in `scanner.py`, `search.py`, `document.py`, `fts_index.py`, and `config.py` exercised by the suites above. Target ≥ 80% on the diff (project hard gate).
+
+### Performance
+
+- Snippet computation is per-result (10ish per query), not per-candidate (50–100). FTS5 `snippet()` is constant-time SQL. Word-window scan is O(chunk_size) per semantic-only result — negligible.
+- Length downweight adds one log + one division per candidate — negligible.
+- Adaptive chunking adds O(chunks) recursive work at index time, paid once per document.
+
+## Open questions resolved during brainstorming
+
+| Question | Resolution |
+|---|---|
+| Scope of `kind` taxonomy (1c)? | **Out, by principle.** MCP must not require frontmatter conventions on vault content. Captured as non-goal 1. |
+| Per-call override for cap and snippet knobs? | **Yes** for `chunks_per_doc` and `snippet_words`. **No** for `length_downweight_alpha` (operator tuning knob). |
+| Defaults for new knobs? | `chunks_per_doc=2`, `snippet_words=200`, `length_downweight_alpha=0.25`, `max_chunk_words=400`. |
+| Snippet selection strategy? | A1: FTS5 native `snippet()` for keyword/hybrid-keyword + Python word-window for semantic-only + first-N-words-of-chunk-body fallback when query has zero literal overlap. |
+| Backwards compatibility — replace `content` or add `snippet`? | F1: keep `content`, truncate by default, `snippet_words=0` opts out. No SearchResult shape break. |
+| Cap × RRF interaction? | C2: cap *after* RRF on the merged sorted list. Uniform across all three modes. |
+| Length downweight placement? | D1: per-channel, before fusion. Re-rank each channel by adjusted score. |
+| Recovery path for snippet truncation? | B2: extend `read(path)` with optional `section` parameter. Reuses existing `(path, heading)` chunk identity. |
+| Adaptive chunking? | **In scope.** Goal 5. Threshold-driven recursive H-level descent. |
+
+## Risks & mitigations
+
+- **Risk:** default snippet truncation surprises an existing automation that depends on full `content`. **Mitigation:** explicit `feat:` `CHANGELOG.md` entry; `snippet_words=0` escape hatch documented prominently in tool docstring and migration notes.
+- **Risk:** adaptive chunker changes embedding behavior in ways that hurt some queries even as it helps others. **Mitigation:** `max_chunk_words` is tunable; setting it very high reverts to today's behavior. Observe diagnostic queries after deploy.
+- **Risk:** `documents.chunk_count` migration on existing FTS databases. **Mitigation:** `ALTER TABLE ADD COLUMN ... DEFAULT 1` is non-destructive; population happens lazily via the next reindex of each doc, with a guard that recomputes on missing or stale values.
+- **Risk:** word-count chunking threshold doesn't match user expectations on multilingual content (CJK has no whitespace). **Mitigation:** `len(content.split())` is good enough for prose markdown; non-Latin scripts may want a custom threshold via the env var. Document as a known limitation.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -52,8 +52,13 @@ Find documents matching a query using full-text or semantic search.
 | `mode` | string | `"keyword"` | `"keyword"` (FTS5/BM25), `"semantic"` (vector similarity), or `"hybrid"` (reciprocal rank fusion) |
 | `folder` | string | `null` | Restrict to documents under this folder path |
 | `filters` | object | `null` | Filter by indexed frontmatter field values (e.g. `{"tags": "pacing"}`) |
+| `chunks_per_doc` | int | server default (`2`) | Per-document cap on the result list. Overrides `MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC` for this call. `0` is rejected. |
+| `snippet_words` | int | server default (`200`) | Approximate word budget for the `content` field. `0` returns the full chunk. Overrides `MARKDOWN_VAULT_MCP_SNIPPET_WORDS` for this call. |
 
-**Returns:** List of result dicts ranked by relevance. Each contains: `path`, `title`, `folder`, `content` (matched chunk), `score`, `frontmatter`.
+**Returns:** List of result dicts ranked by relevance. Each contains: `path`, `title`, `folder`, `heading`, `content` (snippet by default — see note below), `score`, `frontmatter`, `search_type`.
+
+!!! note "Snippet content and full-chunk recovery"
+    By default, `content` is a snippet of approximately 200 words centered on the query terms — not the full chunk. Pass `snippet_words=0` to receive the complete chunk. To read the full section after receiving a search result, call `read(path=result["path"], section=result["heading"])` — this returns the entire chunk from the index without re-reading the whole document.
 
 !!! tip "Choosing a search mode"
     - Use `mode="hybrid"` when semantic search is available — it combines keyword precision with semantic understanding
@@ -74,13 +79,17 @@ Find documents matching a query using full-text or semantic search.
 
 ### `read`
 
-Read the full content of a document or attachment by path.
+Read the full content of a document or attachment by path. When combined with search, the optional `section` parameter lets you retrieve the full content of a specific chunk without loading the entire document.
 
 **Parameters:**
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string | Relative path to the document or attachment (e.g. `"Journal/note.md"` or `"assets/diagram.pdf"`) |
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | string | required | Relative path to the document or attachment (e.g. `"Journal/note.md"` or `"assets/diagram.pdf"`) |
+| `section` | string | `null` | Optional heading to select a single section chunk. Pass the `heading` field from a `search` result to retrieve the full chunk content. Raises an error if the heading is not found or is empty. |
+
+!!! tip "Recovering full chunks after search"
+    When `search` returns a snippet result, pass `result["heading"]` as the `section` parameter to recover the complete chunk: `read(path=result["path"], section=result["heading"])`. If the document has no sub-headings (preamble content), omit `section` to read the whole document.
 
 **Returns:**
 

--- a/examples/obsidian-readonly.env
+++ b/examples/obsidian-readonly.env
@@ -21,3 +21,17 @@ MARKDOWN_VAULT_MCP_EXCLUDE=.obsidian/**,.trash/**,_templates/**
 MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=ollama
 OLLAMA_HOST=http://localhost:11434
 MARKDOWN_VAULT_MCP_OLLAMA_MODEL=nomic-embed-text
+
+# --- Search ranking and snippet truncation ---
+# Per-document result cap. 0 rejected. Per-call override via search tool.
+# MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC=2
+
+# Snippet word budget. 0 = no truncation, full chunk. Per-call override.
+# MARKDOWN_VAULT_MCP_SNIPPET_WORDS=200
+
+# Length downweight strength. 0 disables. Operator-only (no per-call override).
+# MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA=0.25
+
+# Adaptive chunker word threshold. Reindex required when changed.
+# Set very high (e.g. 100000) to disable adaptive splitting.
+# MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS=400

--- a/examples/obsidian-readwrite.env
+++ b/examples/obsidian-readwrite.env
@@ -31,3 +31,17 @@ MARKDOWN_VAULT_MCP_GIT_TOKEN=ghp_your_token_here
 MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=ollama
 OLLAMA_HOST=http://localhost:11434
 MARKDOWN_VAULT_MCP_OLLAMA_MODEL=nomic-embed-text
+
+# --- Search ranking and snippet truncation ---
+# Per-document result cap. 0 rejected. Per-call override via search tool.
+# MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC=2
+
+# Snippet word budget. 0 = no truncation, full chunk. Per-call override.
+# MARKDOWN_VAULT_MCP_SNIPPET_WORDS=200
+
+# Length downweight strength. 0 disables. Operator-only (no per-call override).
+# MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA=0.25
+
+# Adaptive chunker word threshold. Reindex required when changed.
+# Set very high (e.g. 100000) to disable adaptive splitting.
+# MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS=400

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -195,7 +195,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Returns:
             For .md: dict with path, title, folder, content (markdown body
-            or section text when section= is given), frontmatter (dict),
+            or section text when section= is given), frontmatter (dict —
+            empty {} when section= is provided; call read(path) without
+            section= to get the full document's frontmatter),
             modified_at (Unix timestamp), etag (SHA-256 hex str or null).
             For attachments: dict with path, mime_type (str or null),
             size_bytes (int), content_base64 (str), modified_at (Unix timestamp),

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -168,6 +168,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     )
     async def read(
         path: str,
+        section: str | None = None,
         collection: Collection = Depends(get_collection),
     ) -> dict[str, Any]:
         """Read the full content of a document or attachment by path.
@@ -179,15 +180,22 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Do not guess paths — look them up first via 'search' or 'list_documents'.
 
+        To recover the full text of a specific section returned by 'search',
+        pass section=heading (the value from the result's 'heading' field).
+
         Args:
             path: Relative path to the document or attachment
                 (e.g. "Journal/note.md" or "assets/diagram.pdf").
                 Case-sensitive.
+            section: When provided, return only the content of the heading
+                matching this string (case-insensitive). Useful for recovering
+                full section text after a snippet-truncated search result.
+                Ignored for non-.md paths.
 
         Returns:
-            For .md: dict with path, title, folder, content (markdown body),
-            frontmatter (dict), modified_at (Unix timestamp),
-            etag (SHA-256 hex str or null).
+            For .md: dict with path, title, folder, content (markdown body
+            or section text when section= is given), frontmatter (dict),
+            modified_at (Unix timestamp), etag (SHA-256 hex str or null).
             For attachments: dict with path, mime_type (str or null),
             size_bytes (int), content_base64 (str), modified_at (Unix timestamp),
             etag (SHA-256 hex str or null).
@@ -196,13 +204,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Raises:
             ValueError: If no file exists at the given path, the extension is
-                not in the attachment allowlist, or the file exceeds the size
-                limit.
+                not in the attachment allowlist, the file exceeds the size
+                limit, or the requested section heading is not found.
         """
         if not path.endswith(".md"):
             attachment = await asyncio.to_thread(collection.read_attachment, path)
             return asdict(attachment)
-        note = await asyncio.to_thread(collection.read, path)
+        note = await asyncio.to_thread(collection.read, path, section=section)
         if note is None:
             raise ValueError(f"Document not found: {path}")
         return asdict(note)

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -187,9 +187,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             path: Relative path to the document or attachment
                 (e.g. "Journal/note.md" or "assets/diagram.pdf").
                 Case-sensitive.
-            section: When provided, return only the content of the heading
-                matching this string (case-insensitive). Useful for recovering
-                full section text after a snippet-truncated search result.
+            section: When provided, return only the section whose heading
+                matches *section* exactly (case-sensitive). Pass the ``heading``
+                value from a ``search`` result unchanged for guaranteed match.
+                ``None`` (the default) returns the whole document.
                 Ignored for non-.md paths.
 
         Returns:

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -86,6 +86,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
         folder: str | None = None,
         filters: dict[str, str] | None = None,
+        chunks_per_doc: int | None = None,
+        snippet_words: int | None = None,
         collection: Collection = Depends(get_collection),
     ) -> list[dict[str, Any]]:
         """Find documents matching a query using full-text or semantic search.
@@ -94,6 +96,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         mode="hybrid" when 'stats' shows semantic_search_available=True —
         hybrid fuses keyword and vector results for best quality. Use
         mode="semantic" for pure vector similarity.
+
+        The 'content' field in each result is a snippet by default, not the
+        full document. Use read(path, section=heading) to retrieve the full
+        text of a specific section.
 
         Args:
             query: Natural language or keyword query string.
@@ -110,6 +116,12 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 Multiple filters are ANDed. For list fields (e.g. tags),
                 this checks membership — {"tags": "pacing"} matches any
                 document where "pacing" appears in the tags list.
+            chunks_per_doc: Maximum number of chunks to return per document.
+                Omit to use the server default. Set to 1 to get only the
+                top-ranked chunk per document (deduplicates results by path).
+            snippet_words: Width of the snippet window in words. Omit to use
+                the server default. Set to 0 to return full chunk content.
+                Use read(path, section=heading) for full section recovery.
 
         Returns:
             List of result dicts ranked by relevance. Each contains:
@@ -119,7 +131,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - folder (str): Parent folder path.
             - heading (str | None): Section heading of the matched chunk,
               or null for the document intro.
-            - content (str): Matched chunk text (not the full document).
+            - content (str): Snippet of the matched chunk (truncated by
+              snippet_words). Call read(path, section=heading) for full text.
             - score (float): BM25 relevance score (keyword mode) or cosine
               similarity 0.0-1.0 (semantic/hybrid); higher = better match.
             - search_type (str): "keyword" or "semantic".
@@ -140,6 +153,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             mode=mode,
             folder=folder,
             filters=filters,
+            chunks_per_doc=chunks_per_doc,
+            snippet_words=snippet_words,
         )
         return [asdict(r) for r in results]
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -157,12 +157,10 @@ class Collection:
             )
         else:
             # NOTE: When a caller passes an explicit chunk_strategy instance
-            # (e.g. HeadingChunker(max_chunk_words=None) for legacy
-            # H1/H2-only behaviour), we do NOT override their construction
-            # with the Collection-level max_chunk_words.  The string "heading"
-            # path is the conventional default that picks up Collection's
-            # max_chunk_words; explicit instances are honoured as-is.
-            # See PR #433 review thread for context.
+            # (e.g. HeadingChunker(max_chunk_words=None) for legacy H1/H2-only
+            # behaviour), we honour their construction as-is. The Collection-level
+            # max_chunk_words only takes effect for the conventional default
+            # ("heading" string), so explicit-instance callers retain full control.
             self._chunk_strategy = _resolve_chunk_strategy(chunk_strategy)
         self._on_write = on_write
         self._git_strategy = git_strategy

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -137,6 +137,10 @@ class Collection:
         exclude_patterns: list[str] | None = None,
         attachment_extensions: list[str] | None = None,
         max_attachment_size_mb: float = 10.0,
+        chunks_per_doc: int = 2,
+        snippet_words: int = 200,
+        length_downweight_alpha: float = 0.25,
+        max_chunk_words: int = 400,
     ) -> None:
         self._source_dir = source_dir
         self._index_path = index_path
@@ -145,7 +149,14 @@ class Collection:
         self._read_only = read_only
         self._indexed_frontmatter_fields: list[str] = indexed_frontmatter_fields or []
         self._required_frontmatter = required_frontmatter
-        self._chunk_strategy = _resolve_chunk_strategy(chunk_strategy)
+        # Only inject max_chunk_words when the caller has not provided a
+        # custom ChunkStrategy instance or an explicit string name override.
+        if isinstance(chunk_strategy, str) and chunk_strategy == "heading":
+            self._chunk_strategy: ChunkStrategy = HeadingChunker(
+                max_chunk_words=max_chunk_words
+            )
+        else:
+            self._chunk_strategy = _resolve_chunk_strategy(chunk_strategy)
         self._on_write = on_write
         self._git_strategy = git_strategy
         self._git_pull_interval_s = git_pull_interval_s
@@ -217,6 +228,9 @@ class Collection:
             link_manager=self._link_mgr,
             flush_embeddings=self._index_mgr.flush_dirty_embeddings,
             rebuild_embeddings=lambda: self._index_mgr.build_embeddings(force=True),
+            chunks_per_doc=chunks_per_doc,
+            snippet_words=snippet_words,
+            length_downweight_alpha=length_downweight_alpha,
         )
         # 4. DocumentManager (needs index_mgr callbacks)
         self._doc_mgr = DocumentManager(

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -409,9 +409,11 @@ class Collection:
 
         Args:
             path: Relative document path (e.g. ``"Journal/note.md"``).
-            section: When provided, return only the content of the heading
-                whose text matches *section* (case-insensitive).  Raises
-                :exc:`ValueError` if the section is not found.
+            section: When provided, return only the section whose heading
+                matches *section* exactly (case-sensitive). Pass the
+                ``heading`` value from a ``search`` result unchanged for
+                guaranteed match. ``None`` (the default) returns the whole
+                document. Raises :exc:`ValueError` if the section is not found.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -362,6 +362,8 @@ class Collection:
         mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
         filters: dict[str, str] | None = None,
         folder: str | None = None,
+        chunks_per_doc: int | None = None,
+        snippet_words: int | None = None,
     ) -> list[SearchResult]:
         """Search the collection.
 
@@ -374,6 +376,10 @@ class Collection:
                 Only works for fields in ``indexed_frontmatter_fields``.
             folder: If provided, restrict results to documents in this folder
                 (and its sub-folders).
+            chunks_per_doc: Maximum number of chunks to return per document.
+                ``None`` uses the server default configured at startup.
+            snippet_words: Width of the snippet window in words.  ``0`` returns
+                the full chunk.  ``None`` uses the server default.
 
         Returns:
             List of :class:`~markdown_vault_mcp.types.SearchResult` ordered by
@@ -385,25 +391,34 @@ class Collection:
         """
         self._ensure_initialized()
         return self._search_mgr.search(
-            query, limit=limit, mode=mode, filters=filters, folder=folder
+            query,
+            limit=limit,
+            mode=mode,
+            filters=filters,
+            folder=folder,
+            chunks_per_doc=chunks_per_doc,
+            snippet_words=snippet_words,
         )
 
     # ------------------------------------------------------------------
     # Read / list
     # ------------------------------------------------------------------
 
-    def read(self, path: str) -> NoteContent | None:
+    def read(self, path: str, *, section: str | None = None) -> NoteContent | None:
         """Read the full content of a document from disk.
 
         Args:
             path: Relative document path (e.g. ``"Journal/note.md"``).
+            section: When provided, return only the content of the heading
+                whose text matches *section* (case-insensitive).  Raises
+                :exc:`ValueError` if the section is not found.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``
             if the file does not exist.
         """
         self._ensure_initialized()
-        return self._doc_mgr.read(path)
+        return self._doc_mgr.read(path, section=section)
 
     def list(
         self,

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -156,6 +156,13 @@ class Collection:
                 max_chunk_words=max_chunk_words
             )
         else:
+            # NOTE: When a caller passes an explicit chunk_strategy instance
+            # (e.g. HeadingChunker(max_chunk_words=None) for legacy
+            # H1/H2-only behaviour), we do NOT override their construction
+            # with the Collection-level max_chunk_words.  The string "heading"
+            # path is the conventional default that picks up Collection's
+            # max_chunk_words; explicit instances are honoured as-is.
+            # See PR #433 review thread for context.
             self._chunk_strategy = _resolve_chunk_strategy(chunk_strategy)
         self._on_write = on_write
         self._git_strategy = git_strategy

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -251,6 +251,10 @@ class CollectionConfig:
             "attachment_extensions": self.attachment_extensions,
             "max_attachment_size_mb": self.max_attachment_size_mb,
             "git_pull_interval_s": 0,
+            "chunks_per_doc": self.chunks_per_doc,
+            "snippet_words": self.snippet_words,
+            "length_downweight_alpha": self.length_downweight_alpha,
+            "max_chunk_words": self.max_chunk_words,
         }
 
         # Resolve embedding provider if embeddings_path is configured.

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -697,7 +697,16 @@ def load_config() -> CollectionConfig:
 
     # --- Search ranking and snippet truncation ---
     raw_chunks_per_doc = (_env("CHUNKS_PER_DOC") or "").strip()
-    chunks_per_doc = int(raw_chunks_per_doc) if raw_chunks_per_doc else 2
+    if raw_chunks_per_doc:
+        try:
+            chunks_per_doc = int(raw_chunks_per_doc)
+        except ValueError as exc:
+            raise ValueError(
+                f"MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC must be a positive integer, "
+                f"got {raw_chunks_per_doc!r}"
+            ) from exc
+    else:
+        chunks_per_doc = 2
     if chunks_per_doc < 1:
         raise ValueError(
             f"chunks_per_doc must be >= 1, got {chunks_per_doc}; set "
@@ -706,13 +715,31 @@ def load_config() -> CollectionConfig:
     logger.debug("load_config: chunks_per_doc=%s", chunks_per_doc)
 
     raw_snippet_words = (_env("SNIPPET_WORDS") or "").strip()
-    snippet_words = int(raw_snippet_words) if raw_snippet_words else 200
+    if raw_snippet_words:
+        try:
+            snippet_words = int(raw_snippet_words)
+        except ValueError as exc:
+            raise ValueError(
+                f"MARKDOWN_VAULT_MCP_SNIPPET_WORDS must be a non-negative integer, "
+                f"got {raw_snippet_words!r}"
+            ) from exc
+    else:
+        snippet_words = 200
     if snippet_words < 0:
         raise ValueError(f"snippet_words must be >= 0, got {snippet_words}")
     logger.debug("load_config: snippet_words=%s", snippet_words)
 
     raw_alpha = (_env("LENGTH_DOWNWEIGHT_ALPHA") or "").strip()
-    length_downweight_alpha = float(raw_alpha) if raw_alpha else 0.25
+    if raw_alpha:
+        try:
+            length_downweight_alpha = float(raw_alpha)
+        except ValueError as exc:
+            raise ValueError(
+                f"MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA must be a non-negative "
+                f"float, got {raw_alpha!r}"
+            ) from exc
+    else:
+        length_downweight_alpha = 0.25
     if length_downweight_alpha < 0:
         raise ValueError(
             f"length_downweight_alpha must be >= 0, got {length_downweight_alpha}"
@@ -720,7 +747,16 @@ def load_config() -> CollectionConfig:
     logger.debug("load_config: length_downweight_alpha=%s", length_downweight_alpha)
 
     raw_max_chunk_words = (_env("MAX_CHUNK_WORDS") or "").strip()
-    max_chunk_words = int(raw_max_chunk_words) if raw_max_chunk_words else 400
+    if raw_max_chunk_words:
+        try:
+            max_chunk_words = int(raw_max_chunk_words)
+        except ValueError as exc:
+            raise ValueError(
+                f"MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS must be a positive integer, "
+                f"got {raw_max_chunk_words!r}"
+            ) from exc
+    else:
+        max_chunk_words = 400
     if max_chunk_words < 1:
         raise ValueError(f"max_chunk_words must be >= 1, got {max_chunk_words}")
     logger.debug("load_config: max_chunk_words=%s", max_chunk_words)

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -204,6 +204,12 @@ class CollectionConfig:
     openai_api_key: str | None = None
     fastembed_model: str = "BAAI/bge-small-en-v1.5"
     fastembed_cache_dir: str | None = None
+
+    # Search ranking and snippet truncation
+    chunks_per_doc: int = 2
+    snippet_words: int = 200
+    length_downweight_alpha: float = 0.25
+    max_chunk_words: int = 400
     # CONFIG-FIELDS-END
 
     # Universal server fields delegated to fastmcp_pvl_core.ServerConfig.
@@ -689,6 +695,36 @@ def load_config() -> CollectionConfig:
         "load_config: fastembed_cache_dir=%s", fastembed_cache_dir or "not set"
     )
 
+    # --- Search ranking and snippet truncation ---
+    raw_chunks_per_doc = (_env("CHUNKS_PER_DOC") or "").strip()
+    chunks_per_doc = int(raw_chunks_per_doc) if raw_chunks_per_doc else 2
+    if chunks_per_doc < 1:
+        raise ValueError(
+            f"chunks_per_doc must be >= 1, got {chunks_per_doc}; set "
+            "MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC to a positive integer."
+        )
+    logger.debug("load_config: chunks_per_doc=%s", chunks_per_doc)
+
+    raw_snippet_words = (_env("SNIPPET_WORDS") or "").strip()
+    snippet_words = int(raw_snippet_words) if raw_snippet_words else 200
+    if snippet_words < 0:
+        raise ValueError(f"snippet_words must be >= 0, got {snippet_words}")
+    logger.debug("load_config: snippet_words=%s", snippet_words)
+
+    raw_alpha = (_env("LENGTH_DOWNWEIGHT_ALPHA") or "").strip()
+    length_downweight_alpha = float(raw_alpha) if raw_alpha else 0.25
+    if length_downweight_alpha < 0:
+        raise ValueError(
+            f"length_downweight_alpha must be >= 0, got {length_downweight_alpha}"
+        )
+    logger.debug("load_config: length_downweight_alpha=%s", length_downweight_alpha)
+
+    raw_max_chunk_words = (_env("MAX_CHUNK_WORDS") or "").strip()
+    max_chunk_words = int(raw_max_chunk_words) if raw_max_chunk_words else 400
+    if max_chunk_words < 1:
+        raise ValueError(f"max_chunk_words must be >= 1, got {max_chunk_words}")
+    logger.debug("load_config: max_chunk_words=%s", max_chunk_words)
+
     return CollectionConfig(
         # CONFIG-FROM-ENV-START — domain fields populated from env; kept across copier update
         source_dir=source_dir,
@@ -731,6 +767,10 @@ def load_config() -> CollectionConfig:
         openai_api_key=openai_api_key,
         fastembed_model=fastembed_model,
         fastembed_cache_dir=fastembed_cache_dir,
+        chunks_per_doc=chunks_per_doc,
+        snippet_words=snippet_words,
+        length_downweight_alpha=length_downweight_alpha,
+        max_chunk_words=max_chunk_words,
         # CONFIG-FROM-ENV-END
         server=ServerConfig.from_env(_ENV_PREFIX),
     )

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -575,22 +575,23 @@ class FTSIndex:
         limit: int = 10,
         folder: str | None = None,
         filters: dict[str, str] | None = None,
+        snippet_words: int | None = None,
     ) -> list[FTSResult]:
         """Full-text search using BM25 ranking.
-
-        Optionally filters results by folder prefix and/or frontmatter tag
-        key-value pairs.  Each entry in ``filters`` is ANDed.
 
         Args:
             query: FTS5 query string.
             limit: Maximum number of results to return.
             folder: If provided, only return documents whose ``folder``
                 starts with this string.
-            filters: Dict of ``{tag_key: tag_value}`` pairs.  All pairs must
-                match (AND semantics).
+            filters: Dict of ``{tag_key: tag_value}`` pairs (AND semantics).
+            snippet_words: When set to a positive integer, returned
+                ``content`` is replaced with FTS5's ``snippet()`` of the
+                matched content column, sized to approximately this many
+                tokens. ``None`` or ``0`` returns the full chunk.
 
         Returns:
-            List of :class:`~markdown_vault_mcp.types.FTSResult` objects ordered by
+            List of :class:`~markdown_vault_mcp.types.FTSResult` ordered by
             descending BM25 score.
         """
         # Build tag subquery filters (one per entry, ANDed).
@@ -609,9 +610,6 @@ class FTSIndex:
         folder_clause = ""
         folder_params: list[str] = []
         if folder is not None:
-            # Match exact folder or sub-folders.  Escape LIKE wildcards in the
-            # user-supplied folder value so that literal '%' and '_' characters
-            # are matched as-is rather than treated as SQL wildcards.
             escaped = _escape_like(folder)
             folder_clause = "AND (d.folder = ? OR d.folder LIKE ? ESCAPE '\\')"
             folder_params = [folder, escaped + "/%"]
@@ -620,14 +618,24 @@ class FTSIndex:
         if tag_clauses:
             tag_filter_sql = "AND " + " AND ".join(tag_clauses)
 
+        # column index 4 is the 'content' column in
+        #   notes_fts USING fts5(path, title, folder, heading, content, ...)
+        if snippet_words and snippet_words > 0:
+            content_expr = "snippet(notes_fts, 4, '', '', '…', ?) AS content"
+            snippet_params: list[object] = [snippet_words]
+        else:
+            content_expr = "f.content AS content"
+            snippet_params = []
+
         sql = f"""
             SELECT
                 f.path,
                 d.title,
                 d.folder,
                 f.heading,
-                f.content,
-                ABS(f.rank) AS score
+                {content_expr},
+                ABS(f.rank) AS score,
+                d.chunk_count AS chunk_count
             FROM notes_fts f
             JOIN documents d ON d.path = f.path
             WHERE notes_fts MATCH ?
@@ -640,13 +648,20 @@ class FTSIndex:
         if not query:
             return []
 
-        params: list[object] = [query, *folder_params, *tag_params, limit]
+        params: list[object] = [
+            *snippet_params,
+            query,
+            *folder_params,
+            *tag_params,
+            limit,
+        ]
         logger.debug(
-            "FTS search: query=%r folder=%r filters=%r limit=%d",
+            "FTS search: query=%r folder=%r filters=%r limit=%d snippet_words=%r",
             query,
             folder,
             filters,
             limit,
+            snippet_words,
         )
         try:
             cur = self._conn.execute(sql, params)
@@ -674,6 +689,7 @@ class FTSIndex:
                     heading=row["heading"] or None,
                     content=row["content"],
                     score=row["score"],
+                    chunk_count=row["chunk_count"],
                 )
             )
         return results

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -184,11 +184,21 @@ def _open_connection(db_path: Path | str) -> sqlite3.Connection:
     # columns, so we probe PRAGMA first.
     cols = {r["name"] for r in conn.execute("PRAGMA table_info(documents)").fetchall()}
     if "chunk_count" not in cols:
-        conn.execute(
-            "ALTER TABLE documents ADD COLUMN chunk_count INTEGER NOT NULL DEFAULT 1"
-        )
-        conn.commit()
-        logger.info("fts_index: migrated documents table — added chunk_count column")
+        try:
+            conn.execute(
+                "ALTER TABLE documents ADD COLUMN chunk_count INTEGER NOT NULL DEFAULT 1"
+            )
+            conn.commit()
+            logger.info(
+                "fts_index: migrated documents table — added chunk_count column"
+            )
+        except sqlite3.OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                raise
+            # Another process beat us to it; column now exists.
+            logger.debug(
+                "fts_index: chunk_count column already added by concurrent process"
+            )
     # Ensure foreign_keys stays ON for subsequent statements (executescript
     # does not guarantee this survives across statement boundaries in all
     # SQLite versions).
@@ -1273,6 +1283,75 @@ class FTSIndex:
               AND NOT EXISTS (SELECT 1 FROM links WHERE target_path = d.path)
             """
         )
+
+    def get_chunk_count(self, path: str) -> int:
+        """Return the chunk_count for a single document, defaulting to 1.
+
+        Args:
+            path: Relative document path.
+
+        Returns:
+            The ``chunk_count`` stored in the documents table, or ``1`` if
+            the document is not found.
+        """
+        row = self._conn.execute(
+            "SELECT chunk_count FROM documents WHERE path = ?", (path,)
+        ).fetchone()
+        return int(row["chunk_count"]) if row else 1
+
+    def get_chunk_counts(self, paths: Iterable[str]) -> dict[str, int]:
+        """Return a ``{path: chunk_count}`` map for the given paths.
+
+        Missing paths are omitted; callers should default to ``1``.
+
+        Args:
+            paths: Iterable of relative document paths to look up.
+
+        Returns:
+            Dict mapping each found path to its ``chunk_count`` value.
+        """
+        paths_list = list(paths)
+        if not paths_list:
+            return {}
+        placeholders = ",".join("?" * len(paths_list))
+        rows = self._conn.execute(
+            f"SELECT path, chunk_count FROM documents WHERE path IN ({placeholders})",
+            paths_list,
+        ).fetchall()
+        return {r["path"]: int(r["chunk_count"]) for r in rows}
+
+    def get_section(self, path: str, heading: str) -> dict[str, Any] | None:
+        """Return the first section row for (path, heading), or ``None``.
+
+        Returns a dict with keys ``'content'``, ``'heading'``,
+        ``'heading_level'`` on hit; ``None`` when the heading is not found
+        in the document.  Tie-breaks by ``start_line ASC``.
+
+        Args:
+            path: Relative document path.
+            heading: Exact heading string to match.
+
+        Returns:
+            A dict with section data, or ``None`` when not found.
+        """
+        row = self._conn.execute(
+            """
+            SELECT s.content, s.heading, s.heading_level
+            FROM sections s
+            JOIN documents d ON d.id = s.document_id
+            WHERE d.path = ? AND s.heading = ?
+            ORDER BY s.start_line ASC
+            LIMIT 1
+            """,
+            (path, heading),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "content": row["content"],
+            "heading": row["heading"],
+            "heading_level": row["heading_level"],
+        }
 
     def close(self) -> None:
         """Close the underlying database connection.

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS documents (
     folder TEXT NOT NULL DEFAULT '',
     frontmatter_json TEXT,
     content_hash TEXT NOT NULL,
-    modified_at REAL NOT NULL
+    modified_at REAL NOT NULL,
+    chunk_count INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE TABLE IF NOT EXISTS sections (
@@ -178,6 +179,16 @@ def _open_connection(db_path: Path | str) -> sqlite3.Connection:
         CREATE INDEX IF NOT EXISTS idx_aliases_docid ON document_aliases(document_id);
         """
     )
+    # Migration: chunk_count was added 2026-04-30. ALTER TABLE is a no-op
+    # if the column already exists, but SQLite has no IF NOT EXISTS for
+    # columns, so we probe PRAGMA first.
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(documents)").fetchall()}
+    if "chunk_count" not in cols:
+        conn.execute(
+            "ALTER TABLE documents ADD COLUMN chunk_count INTEGER NOT NULL DEFAULT 1"
+        )
+        conn.commit()
+        logger.info("fts_index: migrated documents table — added chunk_count column")
     # Ensure foreign_keys stays ON for subsequent statements (executescript
     # does not guarantee this survives across statement boundaries in all
     # SQLite versions).
@@ -255,8 +266,8 @@ class FTSIndex:
         cur.execute(
             """
             INSERT INTO documents (path, title, folder, frontmatter_json,
-                                   content_hash, modified_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+                                   content_hash, modified_at, chunk_count)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 note.path,
@@ -265,6 +276,7 @@ class FTSIndex:
                 json.dumps(note.frontmatter, default=_json_default),
                 note.content_hash,
                 note.modified_at,
+                len(note.chunks),
             ),
         )
         if cur.lastrowid is None:

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -233,7 +233,11 @@ class DocumentManager:
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent`, or ``None`` if
-            the file does not exist (whole-document mode).
+            the file does not exist (whole-document mode). When ``section`` is
+            provided, the returned ``NoteContent.frontmatter`` is an empty dict
+            ``{}`` because section reads do not synthesise per-section frontmatter.
+            Call ``read(path)`` without ``section=`` to get the full document's
+            frontmatter.
 
         Raises:
             ValueError: When *section* is provided and is empty / whitespace,

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -222,16 +222,31 @@ class DocumentManager:
     # Read operations
     # ------------------------------------------------------------------
 
-    def read(self, path: str) -> NoteContent | None:
-        """Read the full content of a document from disk.
+    def read(self, path: str, *, section: str | None = None) -> NoteContent | None:
+        """Read a document or a single section from disk.
 
         Args:
             path: Relative document path (e.g. ``"Journal/note.md"``).
+            section: When provided, return only the chunk whose heading
+                matches *section* exactly. ``None`` returns the whole
+                document (today's behaviour).
 
         Returns:
-            A :class:`~markdown_vault_mcp.types.NoteContent` instance, or
-            ``None`` if the file does not exist.
+            A :class:`~markdown_vault_mcp.types.NoteContent`, or ``None`` if
+            the file does not exist (whole-document mode).
+
+        Raises:
+            ValueError: When *section* is provided and is empty / whitespace,
+                or when the document does not contain a chunk with that
+                heading. (Path-not-found also raises in section mode rather
+                than returning ``None``, since "no document" implies "no
+                section".)
         """
+        if section is not None:
+            if not section.strip():
+                raise ValueError("section must be a non-empty heading or None")
+            return self._read_section(path, section.strip())
+
         abs_path = (self._source_dir / path).resolve()
         if not abs_path.is_relative_to(self._source_dir.resolve()):
             return None
@@ -258,6 +273,55 @@ class DocumentManager:
             frontmatter=note.frontmatter,
             modified_at=note.modified_at,
             etag=etag,
+        )
+
+    def _read_section(self, path: str, heading: str) -> NoteContent:
+        """Return a NoteContent containing only the named section's chunk.
+
+        Args:
+            path: Relative document path.
+            heading: Exact heading string to match in the sections table.
+
+        Returns:
+            A :class:`~markdown_vault_mcp.types.NoteContent` with the
+            section's content.
+
+        Raises:
+            ValueError: If the document is not indexed or the heading is
+                not found.
+        """
+        doc_row = self._fts.get_note(path)
+        if doc_row is None:
+            raise ValueError(
+                f"Section '{heading}' not found in document {path}: "
+                "document is not indexed or does not exist"
+            )
+        section_row = self._fts._conn.execute(
+            """
+            SELECT s.content, s.heading, s.heading_level
+            FROM sections s
+            JOIN documents d ON d.id = s.document_id
+            WHERE d.path = ? AND s.heading = ?
+            ORDER BY s.start_line ASC
+            LIMIT 1
+            """,
+            (path, heading),
+        ).fetchone()
+        if section_row is None:
+            raise ValueError(f"Section '{heading}' not found in document {path}")
+
+        folder = str(Path(path).parent)
+        if folder == ".":
+            folder = ""
+
+        return NoteContent(
+            path=path,
+            title=doc_row["title"],
+            folder=folder,
+            content=section_row["content"],
+            frontmatter={},  # section reads do not synthesise frontmatter
+            modified_at=doc_row["modified_at"],
+            etag="",  # ETag is whole-file; not meaningful for a section
         )
 
     def read_attachment(self, path: str) -> AttachmentContent:

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -296,17 +296,7 @@ class DocumentManager:
                 f"Section '{heading}' not found in document {path}: "
                 "document is not indexed or does not exist"
             )
-        section_row = self._fts._conn.execute(
-            """
-            SELECT s.content, s.heading, s.heading_level
-            FROM sections s
-            JOIN documents d ON d.id = s.document_id
-            WHERE d.path = ? AND s.heading = ?
-            ORDER BY s.start_line ASC
-            LIMIT 1
-            """,
-            (path, heading),
-        ).fetchone()
+        section_row = self._fts.get_section(path, heading)
         if section_row is None:
             raise ValueError(f"Section '{heading}' not found in document {path}")
 

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -287,7 +287,10 @@ class DocumentManager:
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent` with the
-            section's content.
+            section's content.  ``frontmatter`` is always ``{}`` because
+            section reads do not synthesise per-section frontmatter; call
+            :meth:`read` without ``section=`` to get the full document's
+            frontmatter.
 
         Raises:
             ValueError: If the document is not indexed or the heading is

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -281,6 +281,9 @@ class DocumentManager:
         Args:
             path: Relative document path.
             heading: Exact heading string to match in the sections table.
+                When a document contains multiple sections with the same
+                heading text (rare in practice), the first occurrence by
+                ``start_line`` is returned.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent` with the

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -12,10 +12,12 @@ import contextlib
 import fnmatch
 import json
 import logging
+import math
 import mimetypes
 import sqlite3
+from dataclasses import replace as _dc_replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from markdown_vault_mcp.types import (
     AttachmentInfo,
@@ -49,6 +51,41 @@ _RRF_K = 60
 
 # Maximum folder peers returned by get_context().
 _CONTEXT_FOLDER_PEERS_LIMIT = 20
+
+_RankT = TypeVar("_RankT")
+
+
+def _apply_length_downweight(rows: list[_RankT], *, alpha: float) -> list[_RankT]:
+    """Re-rank ``rows`` by ``score / (1 + alpha * log(chunk_count))``.
+
+    Each element must expose ``score: float`` and ``chunk_count: int``
+    attributes.  Works for both :class:`FTSResult` and dataclass adapters
+    used by the semantic-channel pipeline.
+
+    Returns a new list sorted by descending adjusted score; input is not
+    mutated.
+    """
+    if alpha <= 0 or not rows:
+        return list(rows)
+
+    adjusted: list[tuple[_RankT, float]] = []
+    for row in rows:
+        chunk_count = max(1, getattr(row, "chunk_count", 1))
+        # log(1) = 0 -> factor = 1 -> no change for single-chunk docs.
+        factor = 1.0 + alpha * math.log(chunk_count)
+        new_score = row.score / factor  # type: ignore[attr-defined]
+        try:
+            new_row = _dc_replace(row, score=new_score)  # type: ignore[type-var]
+        except TypeError:
+            # Not a dataclass: fall back to a shallow copy.
+            import copy as _copy
+
+            new_row = _copy.copy(row)
+            new_row.score = new_score  # type: ignore[attr-defined]
+        adjusted.append((new_row, new_score))
+
+    adjusted.sort(key=lambda t: t[1], reverse=True)
+    return [r for r, _ in adjusted]
 
 
 class SearchManager:

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -138,15 +138,20 @@ def _compute_snippet_for_semantic(
     if len(words) <= snippet_words:
         return content
 
-    # Tokenize the query the same way we normalize content words: split on
-    # whitespace, then keep alphanumeric runs joined per word.  Symmetric
-    # with the per-word normalization below so a user query like
-    # ``"isn't"`` (→ ``"isnt"``) matches a content word ``"isn't"``
-    # (also → ``"isnt"``).
-    query_tokens = {
-        "".join(_QUERY_TOKEN_RE.findall(word)).lower() for word in query.split()
-    }
-    query_tokens.discard("")  # whitespace-only query words after stripping
+    # Tokenize the query into both the joined-per-word form (matches our
+    # content normalization, e.g. "isn't" → "isnt") AND the individual
+    # alphanumeric runs (matches per-token content words, e.g. "se-cura"
+    # → {"se", "cura"} so a chunk that mentions "cura" alone still hits).
+    query_tokens: set[str] = set()
+    for word in query.split():
+        runs = _QUERY_TOKEN_RE.findall(word)
+        if not runs:
+            continue
+        # Joined form: runs concatenated.
+        query_tokens.add("".join(runs).lower())
+        # Individual runs: each alphanumeric span.
+        query_tokens.update(r.lower() for r in runs)
+    query_tokens.discard("")
     if not query_tokens:
         return " ".join(words[:snippet_words]) + "…"
 

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -9,7 +9,6 @@ source directory, and optional collaborators.
 from __future__ import annotations
 
 import contextlib
-import copy
 import fnmatch
 import json
 import logging
@@ -20,7 +19,7 @@ import sqlite3
 from dataclasses import dataclass
 from dataclasses import replace as _dc_replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 
 from markdown_vault_mcp.types import (
     AttachmentInfo,
@@ -59,34 +58,54 @@ _QUERY_TOKEN_RE = _re.compile(r"[A-Za-z0-9]+")
 # Maximum folder peers returned by get_context().
 _CONTEXT_FOLDER_PEERS_LIMIT = 20
 
-_RankT = TypeVar("_RankT")
+
+class _ScorableRow(Protocol):
+    """Row contract consumed by the length-downweight helper.
+
+    Both :class:`~markdown_vault_mcp.types.FTSResult` and the local
+    :class:`_SemanticRow` adapter satisfy this Protocol structurally; no
+    nominal subclassing required.  All callers are dataclasses so
+    :func:`dataclasses.replace` is used to produce adjusted-score copies
+    without mutating the input.
+    """
+
+    score: float
+    chunk_count: int
 
 
-def _apply_length_downweight(rows: list[_RankT], *, alpha: float) -> list[_RankT]:
+class _CappableRow(Protocol):
+    """Row contract consumed by the per-document cap helper."""
+
+    path: str
+
+
+_ScorableT = TypeVar("_ScorableT", bound=_ScorableRow)
+_CappableT = TypeVar("_CappableT", bound=_CappableRow)
+
+
+def _apply_length_downweight(
+    rows: list[_ScorableT], *, alpha: float
+) -> list[_ScorableT]:
     """Re-rank ``rows`` by ``score / (1 + alpha * log(chunk_count))``.
 
-    Each element must expose ``score: float`` and ``chunk_count: int``
-    attributes.  Works for both :class:`FTSResult` and dataclass adapters
-    used by the semantic-channel pipeline.
-
     Returns a new list sorted by descending adjusted score; input is not
-    mutated.
+    mutated.  Callers must pass dataclass instances (every caller in this
+    codebase already does) so :func:`dataclasses.replace` can produce the
+    adjusted-score copies.
     """
     if alpha <= 0 or not rows:
         return list(rows)
 
-    adjusted: list[tuple[_RankT, float]] = []
+    adjusted: list[tuple[_ScorableT, float]] = []
     for row in rows:
-        chunk_count = max(1, getattr(row, "chunk_count", 1))
+        chunk_count = max(1, row.chunk_count)
         # log(1) = 0 -> factor = 1 -> no change for single-chunk docs.
         factor = 1.0 + alpha * math.log(chunk_count)
-        new_score = row.score / factor  # type: ignore[attr-defined]
-        try:
-            new_row = _dc_replace(row, score=new_score)  # type: ignore[type-var]
-        except TypeError:
-            # Not a dataclass: fall back to a shallow copy.
-            new_row = copy.copy(row)
-            new_row.score = new_score  # type: ignore[attr-defined]
+        new_score = row.score / factor
+        # Protocols can't promise __dataclass_fields__; the helper's
+        # contract is "callers pass dataclasses" (FTSResult / _SemanticRow
+        # / _CapRow all are), enforced at runtime by replace() itself.
+        new_row = _dc_replace(row, score=new_score)  # type: ignore[type-var]
         adjusted.append((new_row, new_score))
 
     adjusted.sort(key=lambda t: t[1], reverse=True)
@@ -94,21 +113,21 @@ def _apply_length_downweight(rows: list[_RankT], *, alpha: float) -> list[_RankT
 
 
 def _apply_chunks_per_doc_cap(
-    rows: list[_RankT], *, n: int, limit: int
-) -> list[_RankT]:
+    rows: list[_CappableT], *, n: int, limit: int
+) -> list[_CappableT]:
     """Walk ``rows`` in order; keep at most ``n`` rows per ``path``; stop at ``limit``.
 
-    Each element must expose a ``path`` attribute. Order is preserved.
+    Order is preserved.
 
     Raises:
         ValueError: If ``n`` is less than 1.
     """
     if n < 1:
         raise ValueError(f"chunks_per_doc cap must be >= 1, got {n}")
-    out: list[_RankT] = []
+    out: list[_CappableT] = []
     counts: dict[str, int] = {}
     for row in rows:
-        path = row.path  # type: ignore[attr-defined]
+        path = row.path
         c = counts.get(path, 0)
         if c >= n:
             continue

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -352,21 +352,6 @@ class SearchManager:
             )
             return {}
 
-    def _fts_chunk_count_for(self, path: str) -> int:
-        """Look up parent doc chunk_count from the FTS index, default 1.
-
-        Args:
-            path: Relative document path.
-
-        Returns:
-            The ``chunk_count`` value stored in the documents table, or 1 if
-            the document is not found.
-        """
-        row = self._fts._conn.execute(
-            "SELECT chunk_count FROM documents WHERE path = ?", (path,)
-        ).fetchone()
-        return int(row["chunk_count"]) if row else 1
-
     def _row_matches_filters(self, path: str, filters: dict[str, str]) -> bool:
         """Return ``True`` if the document at *path* satisfies all *filters*.
 
@@ -590,7 +575,8 @@ class SearchManager:
         candidate_limit = max(limit * (chunks_per_doc + 4), 50)
         raw = vectors.search(query, limit=candidate_limit)
 
-        rows: list[_SemanticRow] = []
+        # Filter first, then batch-fetch chunk counts to avoid N+1 queries.
+        filtered: list[dict[str, Any]] = []
         for r in raw:
             if folder is not None:
                 r_folder = r.get("folder", "")
@@ -598,17 +584,21 @@ class SearchManager:
                     continue
             if filters and not self._row_matches_filters(r["path"], filters):
                 continue
-            rows.append(
-                _SemanticRow(
-                    path=r["path"],
-                    title=r["title"],
-                    folder=r["folder"],
-                    heading=r.get("heading"),
-                    content=r["content"],
-                    score=r["score"],
-                    chunk_count=self._fts_chunk_count_for(r["path"]),
-                )
+            filtered.append(r)
+
+        chunk_counts = self._fts.get_chunk_counts({r["path"] for r in filtered})
+        rows: list[_SemanticRow] = [
+            _SemanticRow(
+                path=r["path"],
+                title=r["title"],
+                folder=r["folder"],
+                heading=r.get("heading"),
+                content=r["content"],
+                score=r["score"],
+                chunk_count=chunk_counts.get(r["path"], 1),
             )
+            for r in filtered
+        ]
 
         downweighted = _apply_length_downweight(
             rows, alpha=self._length_downweight_alpha
@@ -666,7 +656,8 @@ class SearchManager:
 
         vectors = self._load_vectors()
         vec_raw = vectors.search(query, limit=candidate_limit)
-        vec_rows: list[_SemanticRow] = []
+        # Filter first, then batch-fetch chunk counts to avoid N+1 queries.
+        vec_filtered: list[dict[str, Any]] = []
         for r in vec_raw:
             if folder is not None:
                 r_folder = r.get("folder", "")
@@ -674,17 +665,21 @@ class SearchManager:
                     continue
             if filters and not self._row_matches_filters(r["path"], filters):
                 continue
-            vec_rows.append(
-                _SemanticRow(
-                    path=r["path"],
-                    title=r["title"],
-                    folder=r["folder"],
-                    heading=r.get("heading"),
-                    content=r["content"],
-                    score=r["score"],
-                    chunk_count=self._fts_chunk_count_for(r["path"]),
-                )
+            vec_filtered.append(r)
+
+        vec_chunk_counts = self._fts.get_chunk_counts({r["path"] for r in vec_filtered})
+        vec_rows: list[_SemanticRow] = [
+            _SemanticRow(
+                path=r["path"],
+                title=r["title"],
+                folder=r["folder"],
+                heading=r.get("heading"),
+                content=r["content"],
+                score=r["score"],
+                chunk_count=vec_chunk_counts.get(r["path"], 1),
             )
+            for r in vec_filtered
+        ]
         vec_rows = _apply_length_downweight(
             vec_rows, alpha=self._length_downweight_alpha
         )
@@ -693,6 +688,7 @@ class SearchManager:
         rrf_scores: dict[tuple[str, str | None], float] = {}
         chunk_meta: dict[tuple[str, str | None], dict[str, Any]] = {}
         keyword_keys: set[tuple[str, str | None]] = set()
+        vec_keys: set[tuple[str, str | None]] = set()
 
         for rank, fr in enumerate(fts_results, start=1):
             key = (fr.path, fr.heading)
@@ -713,6 +709,7 @@ class SearchManager:
         for rank, vr in enumerate(vec_rows, start=1):
             vkey = (vr.path, vr.heading)
             rrf_scores[vkey] = rrf_scores.get(vkey, 0.0) + 1.0 / (_RRF_K + rank)
+            vec_keys.add(vkey)
             chunk_meta.setdefault(
                 vkey,
                 {
@@ -724,6 +721,10 @@ class SearchManager:
                     "search_type": "semantic",
                 },
             )
+
+        # Chunks present in both channels get labelled "hybrid".
+        for key in keyword_keys & vec_keys:
+            chunk_meta[key]["search_type"] = "hybrid"
 
         sorted_keys = sorted(rrf_scores, key=lambda k: rrf_scores[k], reverse=True)
 

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -88,6 +88,31 @@ def _apply_length_downweight(rows: list[_RankT], *, alpha: float) -> list[_RankT
     return [r for r, _ in adjusted]
 
 
+def _apply_chunks_per_doc_cap(
+    rows: list[_RankT], *, n: int, limit: int
+) -> list[_RankT]:
+    """Walk ``rows`` in order; keep at most ``n`` rows per ``path``; stop at ``limit``.
+
+    Each element must expose a ``path`` attribute. Order is preserved.
+
+    Raises:
+        ValueError: If ``n`` is less than 1.
+    """
+    if n < 1:
+        raise ValueError(f"chunks_per_doc cap must be >= 1, got {n}")
+    out: list[_RankT] = []
+    counts: dict[str, int] = {}
+    for row in rows:
+        path = row.path  # type: ignore[attr-defined]
+        if counts.get(path, 0) >= n:
+            continue
+        counts[path] = counts.get(path, 0) + 1
+        out.append(row)
+        if len(out) >= limit:
+            break
+    return out
+
+
 class SearchManager:
     """Manages search, listing, and query operations against the vault.
 

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -9,6 +9,7 @@ source directory, and optional collaborators.
 from __future__ import annotations
 
 import contextlib
+import copy
 import fnmatch
 import json
 import logging
@@ -84,9 +85,7 @@ def _apply_length_downweight(rows: list[_RankT], *, alpha: float) -> list[_RankT
             new_row = _dc_replace(row, score=new_score)  # type: ignore[type-var]
         except TypeError:
             # Not a dataclass: fall back to a shallow copy.
-            import copy as _copy
-
-            new_row = _copy.copy(row)
+            new_row = copy.copy(row)
             new_row.score = new_score  # type: ignore[attr-defined]
         adjusted.append((new_row, new_score))
 
@@ -110,9 +109,10 @@ def _apply_chunks_per_doc_cap(
     counts: dict[str, int] = {}
     for row in rows:
         path = row.path  # type: ignore[attr-defined]
-        if counts.get(path, 0) >= n:
+        c = counts.get(path, 0)
+        if c >= n:
             continue
-        counts[path] = counts.get(path, 0) + 1
+        counts[path] = c + 1
         out.append(row)
         if len(out) >= limit:
             break
@@ -143,8 +143,10 @@ def _compute_snippet_for_semantic(
         return " ".join(words[:snippet_words]) + " …"
 
     # Normalise each word: keep alphanumeric chars, lower-case, fall back to
-    # the lowercased original if the regex strip leaves an empty string.
-    lower_words = [_QUERY_TOKEN_RE.sub("", w).lower() or w.lower() for w in words]
+    # the lowercased original if no alphanumeric chars were found.
+    lower_words = [
+        "".join(_QUERY_TOKEN_RE.findall(w)).lower() or w.lower() for w in words
+    ]
 
     # Sliding window: maintain best_start / best_score, update incrementally.
     best_start = 0
@@ -513,24 +515,42 @@ class SearchManager:
 
         if snippet_words > 0:
             snippets_by_key = self._fetch_snippet_map(
-                query, capped, snippet_words=snippet_words
+                query,
+                capped,
+                snippet_words=snippet_words,
+                folder=folder,
+                filters=filters,
             )
         else:
             snippets_by_key = {}
 
-        return [
-            SearchResult(
-                path=r.path,
-                title=r.title,
-                folder=r.folder,
-                heading=r.heading,
-                content=snippets_by_key.get((r.path, r.heading), r.content),
-                score=r.score,
-                search_type="keyword",
-                frontmatter=self._get_frontmatter(r.path),
+        results: list[SearchResult] = []
+        for r in capped:
+            key = (r.path, r.heading)
+            if key in snippets_by_key:
+                content = snippets_by_key[key]
+            elif snippet_words > 0:
+                # Keyword survivor missing from snippet_map (rare FTS rank
+                # inversion) — apply the word-window helper so payload bounds
+                # hold.
+                content = _compute_snippet_for_semantic(
+                    r.content, query, snippet_words=snippet_words
+                )
+            else:
+                content = r.content
+            results.append(
+                SearchResult(
+                    path=r.path,
+                    title=r.title,
+                    folder=r.folder,
+                    heading=r.heading,
+                    content=content,
+                    score=r.score,
+                    search_type="keyword",
+                    frontmatter=self._get_frontmatter(r.path),
+                )
             )
-            for r in capped
-        ]
+        return results
 
     def _fetch_snippet_map(
         self,
@@ -538,19 +558,27 @@ class SearchManager:
         survivors: list[FTSResult],
         *,
         snippet_words: int,
+        folder: str | None,
+        filters: dict[str, str] | None,
     ) -> dict[tuple[str, str | None], str]:
         """Re-query FTS with snippet projection, restricted to survivor paths.
 
-        Returns a ``{(path, heading): snippet}`` map. Falls back to the
-        survivor's own ``content`` field when an FTS row cannot be located
-        for a given key.
+        Returns a ``{(path, heading): snippet}`` map. Pool is widened with the
+        same floor as the caller's initial fetch (``50``) and scoped via the
+        same ``folder`` / ``filters`` so a narrowly-scoped initial search
+        doesn't fall back to a global re-query.
+
+        The caller falls back to the survivor's own ``content`` when a key is
+        missing from the map (rare FTS rank inversion).
         """
         if not survivors:
             return {}
-        candidate_n = max(len(survivors) * 4, 20)
+        candidate_n = max(len(survivors) * 4, 50)
         rows = self._fts.search(
             query,
             limit=candidate_n,
+            folder=folder,
+            filters=filters,
             snippet_words=snippet_words,
         )
         wanted = {(s.path, s.heading) for s in survivors}
@@ -743,7 +771,11 @@ class SearchManager:
                 if (fts_r.path, fts_r.heading) in survivor_keys
             ]
             snippet_map = self._fetch_snippet_map(
-                query, survivor_fts_rows, snippet_words=snippet_words
+                query,
+                survivor_fts_rows,
+                snippet_words=snippet_words,
+                folder=folder,
+                filters=filters,
             )
 
         out: list[SearchResult] = []

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -138,7 +138,15 @@ def _compute_snippet_for_semantic(
     if len(words) <= snippet_words:
         return content
 
-    query_tokens = {t.lower() for t in _QUERY_TOKEN_RE.findall(query)}
+    # Tokenize the query the same way we normalize content words: split on
+    # whitespace, then keep alphanumeric runs joined per word.  Symmetric
+    # with the per-word normalization below so a user query like
+    # ``"isn't"`` (→ ``"isnt"``) matches a content word ``"isn't"``
+    # (also → ``"isnt"``).
+    query_tokens = {
+        "".join(_QUERY_TOKEN_RE.findall(word)).lower() for word in query.split()
+    }
+    query_tokens.discard("")  # whitespace-only query words after stripping
     if not query_tokens:
         return " ".join(words[:snippet_words]) + " …"
 

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -184,6 +184,15 @@ class _SemanticRow:
     chunk_count: int
 
 
+@dataclass
+class _CapRow:
+    """Adapter row for the post-RRF cap step (only needs .path / .score)."""
+
+    path: str
+    heading: str | None
+    score: float
+
+
 class SearchManager:
     """Manages search, listing, and query operations against the vault.
 
@@ -480,7 +489,14 @@ class SearchManager:
 
         # hybrid
         self._require_vectors()
-        return self._hybrid_search(query, limit=limit, filters=filters, folder=folder)
+        return self._hybrid_search(
+            query,
+            limit=limit,
+            filters=filters,
+            folder=folder,
+            chunks_per_doc=eff_cap,
+            snippet_words=eff_snip,
+        )
 
     def _keyword_search(
         self,
@@ -622,109 +638,138 @@ class SearchManager:
         limit: int,
         filters: dict[str, str] | None,
         folder: str | None,
+        chunks_per_doc: int,
+        snippet_words: int,
     ) -> list[SearchResult]:
         """RRF merge of keyword and semantic results.
 
         Each result set is ranked independently.  Merged score:
         ``1 / (k + rank)`` where k=60.  Results appearing in both sets
-        have their scores summed.  Returns top *limit* by total RRF score.
+        have their scores summed.  Returns top *limit* by total RRF score,
+        after applying per-channel length downweight and a per-doc cap on the
+        merged sorted list.
         """
-        # Fetch more candidates than needed so RRF has enough to rank.
-        candidate_limit = max(limit * 2, 20)
-
-        # Flush deferred embedding updates so results are consistent.
         self._flush_embeddings()
+        candidate_limit = max(limit * (chunks_per_doc + 4), 50)
 
-        fts_results = self._fts.search(
-            query, limit=candidate_limit, filters=filters, folder=folder
+        fts_raw: list[FTSResult] = self._fts.search(
+            query,
+            limit=candidate_limit,
+            filters=filters,
+            folder=folder,
+            snippet_words=None,  # full content; snippet applied later
         )
+        # Apply length downweight inside the keyword channel.
+        fts_results: list[FTSResult] = _apply_length_downweight(
+            fts_raw, alpha=self._length_downweight_alpha
+        )
+
         vectors = self._load_vectors()
-        vec_results = vectors.search(query, limit=candidate_limit)
-
-        # Build a key for deduplication: (path, heading) identifies a chunk.
-        # Use a dict to accumulate RRF scores and store metadata.
-        rrf_scores: dict[tuple[str, str | None], float] = {}
-        # Store the best metadata dict keyed by (path, heading).
-        chunk_meta: dict[tuple[str, str | None], dict[str, Any]] = {}
-
-        for rank, r in enumerate(fts_results, start=1):
-            key = (r.path, r.heading)
-            rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (_RRF_K + rank)
-            if key not in chunk_meta:
-                chunk_meta[key] = {
-                    "path": r.path,
-                    "title": r.title,
-                    "folder": r.folder,
-                    "heading": r.heading,
-                    "content": r.content,
-                    "search_type": "keyword",
-                }
-
-        for rank, vr in enumerate(vec_results, start=1):
-            # Apply folder prefix filter to semantic results.
+        vec_raw = vectors.search(query, limit=candidate_limit)
+        vec_rows: list[_SemanticRow] = []
+        for r in vec_raw:
             if folder is not None:
-                vr_folder = vr.get("folder", "")
-                if vr_folder != folder and not vr_folder.startswith(folder + "/"):
+                r_folder = r.get("folder", "")
+                if r_folder != folder and not r_folder.startswith(folder + "/"):
                     continue
-
-            # Apply tag filters to semantic results via frontmatter lookup.
-            if filters:
-                note_row = self._fts.get_note(vr["path"])
-                if note_row is None:
-                    continue
-                fm_raw = note_row.get("frontmatter_json")
-                fm: dict[str, Any] = {}
-                if fm_raw:
-                    with contextlib.suppress(json.JSONDecodeError, TypeError):
-                        fm = json.loads(fm_raw)
-                skip = False
-                for fk, fv in filters.items():
-                    fm_val = fm.get(fk)
-                    if fm_val is None:
-                        skip = True
-                        break
-                    if isinstance(fm_val, list):
-                        if str(fv) not in [str(v) for v in fm_val]:
-                            skip = True
-                            break
-                    else:
-                        if str(fm_val) != str(fv):
-                            skip = True
-                            break
-                if skip:
-                    continue
-
-            heading = vr.get("heading")
-            vkey = (vr["path"], heading)
-            rrf_scores[vkey] = rrf_scores.get(vkey, 0.0) + 1.0 / (_RRF_K + rank)
-            if vkey not in chunk_meta:
-                chunk_meta[vkey] = {
-                    "path": vr["path"],
-                    "title": vr["title"],
-                    "folder": vr["folder"],
-                    "heading": heading,
-                    "content": vr["content"],
-                    "search_type": "semantic",
-                }
-
-        # Sort by descending RRF score, take top limit.
-        sorted_keys = sorted(rrf_scores, key=lambda k: rrf_scores[k], reverse=True)[
-            :limit
-        ]
-
-        return [
-            SearchResult(
-                path=chunk_meta[k]["path"],
-                title=chunk_meta[k]["title"],
-                folder=chunk_meta[k]["folder"],
-                heading=chunk_meta[k]["heading"],
-                content=chunk_meta[k]["content"],
-                score=rrf_scores[k],
-                search_type=chunk_meta[k]["search_type"],
-                frontmatter=self._get_frontmatter(chunk_meta[k]["path"]),
+            if filters and not self._row_matches_filters(r["path"], filters):
+                continue
+            vec_rows.append(
+                _SemanticRow(
+                    path=r["path"],
+                    title=r["title"],
+                    folder=r["folder"],
+                    heading=r.get("heading"),
+                    content=r["content"],
+                    score=r["score"],
+                    chunk_count=self._fts_chunk_count_for(r["path"]),
+                )
             )
-            for k in sorted_keys
+        vec_rows = _apply_length_downweight(
+            vec_rows, alpha=self._length_downweight_alpha
+        )
+
+        # RRF fusion on adjusted-rank order.
+        rrf_scores: dict[tuple[str, str | None], float] = {}
+        chunk_meta: dict[tuple[str, str | None], dict[str, Any]] = {}
+        keyword_keys: set[tuple[str, str | None]] = set()
+
+        for rank, fr in enumerate(fts_results, start=1):
+            key = (fr.path, fr.heading)
+            rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (_RRF_K + rank)
+            keyword_keys.add(key)
+            chunk_meta.setdefault(
+                key,
+                {
+                    "path": fr.path,
+                    "title": fr.title,
+                    "folder": fr.folder,
+                    "heading": fr.heading,
+                    "content": fr.content,
+                    "search_type": "keyword",
+                },
+            )
+
+        for rank, vr in enumerate(vec_rows, start=1):
+            vkey = (vr.path, vr.heading)
+            rrf_scores[vkey] = rrf_scores.get(vkey, 0.0) + 1.0 / (_RRF_K + rank)
+            chunk_meta.setdefault(
+                vkey,
+                {
+                    "path": vr.path,
+                    "title": vr.title,
+                    "folder": vr.folder,
+                    "heading": vr.heading,
+                    "content": vr.content,
+                    "search_type": "semantic",
+                },
+            )
+
+        sorted_keys = sorted(rrf_scores, key=lambda k: rrf_scores[k], reverse=True)
+
+        cap_input = [
+            _CapRow(path=k[0], heading=k[1], score=rrf_scores[k]) for k in sorted_keys
         ]
+        capped = _apply_chunks_per_doc_cap(cap_input, n=chunks_per_doc, limit=limit)
+
+        keyword_capped = [c for c in capped if (c.path, c.heading) in keyword_keys]
+        snippet_map: dict[tuple[str, str | None], str] = {}
+        if snippet_words > 0 and keyword_capped:
+            survivor_keys = {(c.path, c.heading) for c in keyword_capped}
+            survivor_fts_rows = [
+                fts_r
+                for fts_r in fts_results
+                if (fts_r.path, fts_r.heading) in survivor_keys
+            ]
+            snippet_map = self._fetch_snippet_map(
+                query, survivor_fts_rows, snippet_words=snippet_words
+            )
+
+        out: list[SearchResult] = []
+        for c in capped:
+            key = (c.path, c.heading)
+            meta = chunk_meta[key]
+            if key in snippet_map:
+                content = snippet_map[key]
+            elif key in keyword_keys:
+                content = meta["content"]
+            else:
+                content = _compute_snippet_for_semantic(
+                    meta["content"], query, snippet_words=snippet_words
+                )
+            out.append(
+                SearchResult(
+                    path=meta["path"],
+                    title=meta["title"],
+                    folder=meta["folder"],
+                    heading=meta["heading"],
+                    content=content,
+                    score=rrf_scores[key],
+                    search_type=meta["search_type"],
+                    frontmatter=self._get_frontmatter(meta["path"]),
+                )
+            )
+        return out
 
     # ------------------------------------------------------------------
     # List / enumerate

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -14,6 +14,7 @@ import json
 import logging
 import math
 import mimetypes
+import re as _re
 import sqlite3
 from dataclasses import replace as _dc_replace
 from pathlib import Path
@@ -48,6 +49,9 @@ logger = logging.getLogger(__name__)
 
 # RRF constant — standard value recommended in the original paper.
 _RRF_K = 60
+
+# Regex for extracting query tokens (alphanumeric sequences).
+_QUERY_TOKEN_RE = _re.compile(r"[A-Za-z0-9]+")
 
 # Maximum folder peers returned by get_context().
 _CONTEXT_FOLDER_PEERS_LIMIT = 20
@@ -111,6 +115,58 @@ def _apply_chunks_per_doc_cap(
         if len(out) >= limit:
             break
     return out
+
+
+def _compute_snippet_for_semantic(
+    content: str, query: str, *, snippet_words: int
+) -> str:
+    """Pick a ``snippet_words``-wide window from ``content``.
+
+    Returns the full content when ``snippet_words`` is 0, when the chunk is
+    already shorter, or as a fallback when no query tokens overlap (in which
+    case the first ``snippet_words`` words are returned with a trailing
+    ellipsis).
+
+    Uses simple case-insensitive substring matching on alphanumeric tokens.
+    """
+    if snippet_words <= 0:
+        return content
+
+    words = content.split()
+    if len(words) <= snippet_words:
+        return content
+
+    query_tokens = {t.lower() for t in _QUERY_TOKEN_RE.findall(query)}
+    if not query_tokens:
+        return " ".join(words[:snippet_words]) + " …"
+
+    # Normalise each word: keep alphanumeric chars, lower-case, fall back to
+    # the lowercased original if the regex strip leaves an empty string.
+    lower_words = [_QUERY_TOKEN_RE.sub("", w).lower() or w.lower() for w in words]
+
+    # Sliding window: maintain best_start / best_score, update incrementally.
+    best_start = 0
+    best_score = sum(1 for w in lower_words[:snippet_words] if w in query_tokens)
+    cur_score = best_score
+    for i in range(1, len(words) - snippet_words + 1):
+        if lower_words[i - 1] in query_tokens:
+            cur_score -= 1
+        if lower_words[i + snippet_words - 1] in query_tokens:
+            cur_score += 1
+        if cur_score > best_score:
+            best_score = cur_score
+            best_start = i
+
+    if best_score == 0:
+        # No literal overlap anywhere — fall back to first-N words.
+        return " ".join(words[:snippet_words]) + " …"
+
+    snippet = " ".join(words[best_start : best_start + snippet_words])
+    if best_start > 0:
+        snippet = "… " + snippet
+    if best_start + snippet_words < len(words):
+        snippet = snippet + " …"
+    return snippet
 
 
 class SearchManager:

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -16,6 +16,7 @@ import math
 import mimetypes
 import re as _re
 import sqlite3
+from dataclasses import dataclass
 from dataclasses import replace as _dc_replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
@@ -168,6 +169,19 @@ def _compute_snippet_for_semantic(
     if best_start + snippet_words < len(words):
         snippet = snippet + " …"
     return snippet
+
+
+@dataclass
+class _SemanticRow:
+    """Adapter row for vector search results so they expose .score / .chunk_count."""
+
+    path: str
+    title: str
+    folder: str
+    heading: str | None
+    content: str
+    score: float
+    chunk_count: int
 
 
 class SearchManager:
@@ -329,6 +343,54 @@ class SearchManager:
             )
             return {}
 
+    def _fts_chunk_count_for(self, path: str) -> int:
+        """Look up parent doc chunk_count from the FTS index, default 1.
+
+        Args:
+            path: Relative document path.
+
+        Returns:
+            The ``chunk_count`` value stored in the documents table, or 1 if
+            the document is not found.
+        """
+        row = self._fts._conn.execute(
+            "SELECT chunk_count FROM documents WHERE path = ?", (path,)
+        ).fetchone()
+        return int(row["chunk_count"]) if row else 1
+
+    def _row_matches_filters(self, path: str, filters: dict[str, str]) -> bool:
+        """Return ``True`` if the document at *path* satisfies all *filters*.
+
+        Looks up frontmatter from the FTS index and checks each key/value
+        pair.  List-valued frontmatter fields are matched by membership.
+
+        Args:
+            path: Relative document path.
+            filters: Dict of ``{frontmatter_key: value}`` pairs.
+
+        Returns:
+            ``True`` if the document exists and all filter conditions are met.
+        """
+        note_row = self._fts.get_note(path)
+        if note_row is None:
+            return False
+        fm_raw = note_row.get("frontmatter_json")
+        fm: dict[str, Any] = {}
+        if fm_raw:
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                fm = json.loads(fm_raw)
+        for key, value in filters.items():
+            fm_val = fm.get(key)
+            if fm_val is None:
+                return False
+            if isinstance(fm_val, list):
+                if str(value) not in [str(v) for v in fm_val]:
+                    return False
+            else:
+                if str(fm_val) != str(value):
+                    return False
+        return True
+
     def _effective_attachment_extensions(self) -> frozenset[str]:
         """Return the effective set of allowed attachment extensions.
 
@@ -408,7 +470,12 @@ class SearchManager:
         if mode == "semantic":
             self._require_vectors()
             return self._semantic_search(
-                query, limit=limit, filters=filters, folder=folder
+                query,
+                limit=limit,
+                filters=filters,
+                folder=folder,
+                chunks_per_doc=eff_cap,
+                snippet_words=eff_snip,
             )
 
         # hybrid
@@ -499,66 +566,54 @@ class SearchManager:
         limit: int,
         filters: dict[str, str] | None = None,
         folder: str | None = None,
+        chunks_per_doc: int,
+        snippet_words: int,
     ) -> list[SearchResult]:
-        # Flush deferred embedding updates so results are consistent.
         self._flush_embeddings()
         vectors = self._load_vectors()
-        # Fetch extra candidates so post-filtering still yields *limit* results.
-        candidate_limit = max(limit * 3, 30) if (folder or filters) else limit
+        candidate_limit = max(limit * (chunks_per_doc + 4), 50)
         raw = vectors.search(query, limit=candidate_limit)
 
-        results: list[SearchResult] = []
+        rows: list[_SemanticRow] = []
         for r in raw:
-            if len(results) >= limit:
-                break
-
-            # Apply folder prefix filter.
             if folder is not None:
                 r_folder = r.get("folder", "")
                 if r_folder != folder and not r_folder.startswith(folder + "/"):
                     continue
-
-            # Apply tag filters: check FTS index for each required tag.
-            if filters:
-                note_row = self._fts.get_note(r["path"])
-                if note_row is None:
-                    continue
-                fm_raw = note_row.get("frontmatter_json")
-                fm: dict[str, Any] = {}
-                if fm_raw:
-                    with contextlib.suppress(json.JSONDecodeError, TypeError):
-                        fm = json.loads(fm_raw)
-                match = True
-                for key, value in filters.items():
-                    fm_val = fm.get(key)
-                    if fm_val is None:
-                        match = False
-                        break
-                    # Support both scalar and list values.
-                    if isinstance(fm_val, list):
-                        if str(value) not in [str(v) for v in fm_val]:
-                            match = False
-                            break
-                    else:
-                        if str(fm_val) != str(value):
-                            match = False
-                            break
-                if not match:
-                    continue
-
-            results.append(
-                SearchResult(
+            if filters and not self._row_matches_filters(r["path"], filters):
+                continue
+            rows.append(
+                _SemanticRow(
                     path=r["path"],
                     title=r["title"],
                     folder=r["folder"],
                     heading=r.get("heading"),
                     content=r["content"],
                     score=r["score"],
-                    search_type="semantic",
-                    frontmatter=self._get_frontmatter(r["path"]),
+                    chunk_count=self._fts_chunk_count_for(r["path"]),
                 )
             )
-        return results
+
+        downweighted = _apply_length_downweight(
+            rows, alpha=self._length_downweight_alpha
+        )
+        capped = _apply_chunks_per_doc_cap(downweighted, n=chunks_per_doc, limit=limit)
+
+        return [
+            SearchResult(
+                path=r.path,
+                title=r.title,
+                folder=r.folder,
+                heading=r.heading,
+                content=_compute_snippet_for_semantic(
+                    r.content, query, snippet_words=snippet_words
+                ),
+                score=r.score,
+                search_type="semantic",
+                frontmatter=self._get_frontmatter(r.path),
+            )
+            for r in capped
+        ]
 
     def _hybrid_search(
         self,

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -148,7 +148,7 @@ def _compute_snippet_for_semantic(
     }
     query_tokens.discard("")  # whitespace-only query words after stripping
     if not query_tokens:
-        return " ".join(words[:snippet_words]) + " …"
+        return " ".join(words[:snippet_words]) + "…"
 
     # Normalise each word: keep alphanumeric chars, lower-case, fall back to
     # the lowercased original if no alphanumeric chars were found.
@@ -171,13 +171,13 @@ def _compute_snippet_for_semantic(
 
     if best_score == 0:
         # No literal overlap anywhere — fall back to first-N words.
-        return " ".join(words[:snippet_words]) + " …"
+        return " ".join(words[:snippet_words]) + "…"
 
     snippet = " ".join(words[best_start : best_start + snippet_words])
     if best_start > 0:
-        snippet = "… " + snippet
+        snippet = "…" + snippet
     if best_start + snippet_words < len(words):
-        snippet = snippet + " …"
+        snippet = snippet + "…"
     return snippet
 
 
@@ -528,6 +528,7 @@ class SearchManager:
                 snippet_words=snippet_words,
                 folder=folder,
                 filters=filters,
+                candidate_limit=candidate_limit,
             )
         else:
             snippets_by_key = {}
@@ -568,20 +569,32 @@ class SearchManager:
         snippet_words: int,
         folder: str | None,
         filters: dict[str, str] | None,
+        candidate_limit: int = 50,
     ) -> dict[tuple[str, str | None], str]:
         """Re-query FTS with snippet projection, restricted to survivor paths.
 
-        Returns a ``{(path, heading): snippet}`` map. Pool is widened with the
-        same floor as the caller's initial fetch (``50``) and scoped via the
-        same ``folder`` / ``filters`` so a narrowly-scoped initial search
-        doesn't fall back to a global re-query.
+        Returns a ``{(path, heading): snippet}`` map. Pool is widened to at
+        least the caller's initial ``candidate_limit`` (so the snippet re-query
+        is never narrower than the ranking query) and scoped via the same
+        ``folder`` / ``filters`` so a narrowly-scoped initial search doesn't
+        fall back to a global re-query.
 
         The caller falls back to the survivor's own ``content`` when a key is
         missing from the map (rare FTS rank inversion).
+
+        Args:
+            query: The search query string.
+            survivors: FTS result rows that survived ranking and capping.
+            snippet_words: Width of the FTS5 snippet window.
+            folder: Folder restriction forwarded from the original search.
+            filters: Frontmatter filters forwarded from the original search.
+            candidate_limit: The caller's initial candidate pool size; used as
+                a floor so the snippet re-query is at least as wide as the
+                ranking query.
         """
         if not survivors:
             return {}
-        candidate_n = max(len(survivors) * 4, 50)
+        candidate_n = max(candidate_limit, len(survivors) * 4, 50)
         rows = self._fts.search(
             query,
             limit=candidate_n,
@@ -784,6 +797,7 @@ class SearchManager:
                 snippet_words=snippet_words,
                 folder=folder,
                 filters=filters,
+                candidate_limit=candidate_limit,
             )
 
         out: list[SearchResult] = []

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -569,7 +569,7 @@ class SearchManager:
         snippet_words: int,
         folder: str | None,
         filters: dict[str, str] | None,
-        candidate_limit: int = 50,
+        candidate_limit: int,
     ) -> dict[tuple[str, str | None], str]:
         """Re-query FTS with snippet projection, restricted to survivor paths.
 

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -751,12 +751,16 @@ class SearchManager:
             meta = chunk_meta[key]
             if key in snippet_map:
                 content = snippet_map[key]
-            elif key in keyword_keys:
-                content = meta["content"]
-            else:
+            elif snippet_words > 0:
+                # Keyword survivor missing from snippet_map (rare FTS rank
+                # inversion), or semantic-only hit — apply the word-window
+                # helper as a uniform backstop so payload bounds hold.
                 content = _compute_snippet_for_semantic(
                     meta["content"], query, snippet_words=snippet_words
                 )
+            else:
+                # snippet_words == 0 → caller asked for the full chunk.
+                content = meta["content"]
             out.append(
                 SearchResult(
                     path=meta["path"],

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from markdown_vault_mcp.fts_index import FTSIndex
     from markdown_vault_mcp.managers.link import LinkManager
     from markdown_vault_mcp.providers import EmbeddingProvider
+    from markdown_vault_mcp.types import FTSResult
     from markdown_vault_mcp.vector_index import VectorIndex
 
 logger = logging.getLogger(__name__)
@@ -203,6 +204,9 @@ class SearchManager:
         link_manager: LinkManager | None = None,
         flush_embeddings: Callable[[], None] | None = None,
         rebuild_embeddings: Callable[[], None] | None = None,
+        chunks_per_doc: int = 2,
+        snippet_words: int = 200,
+        length_downweight_alpha: float = 0.25,
     ) -> None:
         self._fts = fts
         self._source_dir = source_dir
@@ -214,6 +218,9 @@ class SearchManager:
         self._link_manager = link_manager
         self._flush_embeddings = flush_embeddings or (lambda: None)
         self._rebuild_embeddings = rebuild_embeddings or (lambda: None)
+        self._chunks_per_doc = chunks_per_doc
+        self._snippet_words = snippet_words
+        self._length_downweight_alpha = length_downweight_alpha
 
         # Vector index is loaded lazily (only if embeddings_path is set).
         self._vectors: VectorIndex | None = None
@@ -355,6 +362,8 @@ class SearchManager:
         mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
         filters: dict[str, str] | None = None,
         folder: str | None = None,
+        chunks_per_doc: int | None = None,
+        snippet_words: int | None = None,
     ) -> list[SearchResult]:
         """Search the collection.
 
@@ -369,6 +378,11 @@ class SearchManager:
                 ``indexed_frontmatter_fields``.
             folder: If provided, restrict results to documents in this
                 folder (and its sub-folders).
+            chunks_per_doc: Maximum number of chunks to return per document.
+                ``None`` uses the instance default (``self._chunks_per_doc``).
+            snippet_words: Width of the FTS5 snippet window in words.
+                ``0`` returns full chunk content.  ``None`` uses the instance
+                default (``self._snippet_words``).
 
         Returns:
             List of :class:`~markdown_vault_mcp.types.SearchResult` ordered
@@ -378,9 +392,17 @@ class SearchManager:
             ValueError: If *mode* is ``"semantic"`` or ``"hybrid"`` but no
                 embedding provider or embeddings path is configured.
         """
+        eff_cap = chunks_per_doc if chunks_per_doc is not None else self._chunks_per_doc
+        eff_snip = snippet_words if snippet_words is not None else self._snippet_words
+
         if mode == "keyword":
             return self._keyword_search(
-                query, limit=limit, filters=filters, folder=folder
+                query,
+                limit=limit,
+                filters=filters,
+                folder=folder,
+                chunks_per_doc=eff_cap,
+                snippet_words=eff_snip,
             )
 
         if mode == "semantic":
@@ -400,23 +422,75 @@ class SearchManager:
         limit: int,
         filters: dict[str, str] | None,
         folder: str | None,
+        chunks_per_doc: int,
+        snippet_words: int,
     ) -> list[SearchResult]:
-        fts_results = self._fts.search(
-            query, limit=limit, filters=filters, folder=folder
+        # Widen candidate pool so the cap doesn't starve us of `limit` rows.
+        candidate_limit = max(limit * (chunks_per_doc + 4), 50)
+
+        # Fetch raw content first (no snippet projection yet) so the length-
+        # downweight has full chunk_count info. Snippet projection runs only
+        # for survivors, via a second FTS query.
+        raw = self._fts.search(
+            query,
+            limit=candidate_limit,
+            filters=filters,
+            folder=folder,
+            snippet_words=None,
         )
+        downweighted = _apply_length_downweight(
+            raw, alpha=self._length_downweight_alpha
+        )
+        capped = _apply_chunks_per_doc_cap(downweighted, n=chunks_per_doc, limit=limit)
+
+        if snippet_words > 0:
+            snippets_by_key = self._fetch_snippet_map(
+                query, capped, snippet_words=snippet_words
+            )
+        else:
+            snippets_by_key = {}
+
         return [
             SearchResult(
                 path=r.path,
                 title=r.title,
                 folder=r.folder,
                 heading=r.heading,
-                content=r.content,
+                content=snippets_by_key.get((r.path, r.heading), r.content),
                 score=r.score,
                 search_type="keyword",
                 frontmatter=self._get_frontmatter(r.path),
             )
-            for r in fts_results
+            for r in capped
         ]
+
+    def _fetch_snippet_map(
+        self,
+        query: str,
+        survivors: list[FTSResult],
+        *,
+        snippet_words: int,
+    ) -> dict[tuple[str, str | None], str]:
+        """Re-query FTS with snippet projection, restricted to survivor paths.
+
+        Returns a ``{(path, heading): snippet}`` map. Falls back to the
+        survivor's own ``content`` field when an FTS row cannot be located
+        for a given key.
+        """
+        if not survivors:
+            return {}
+        candidate_n = max(len(survivors) * 4, 20)
+        rows = self._fts.search(
+            query,
+            limit=candidate_n,
+            snippet_words=snippet_words,
+        )
+        wanted = {(s.path, s.heading) for s in survivors}
+        return {
+            (r.path, r.heading): r.content
+            for r in rows
+            if (r.path, r.heading) in wanted
+        }
 
     def _semantic_search(
         self,

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -74,13 +74,18 @@ class HeadingChunker:
     exceed ``max_chunk_words``.
 
     Default behaviour (``max_chunk_words=None``): split on H1/H2 only — the
-    pre-2026-04 behaviour. With ``max_chunk_words`` set, after the initial
+    pre-2026-04 behaviour.  A document that contains only H3+ headings and no
+    H1/H2 headings returns a **single** ``heading=None`` chunk in legacy mode
+    (same as pre-2026-04).  With ``max_chunk_words`` set, after the initial
     H1/H2 split each chunk that exceeds the threshold is recursively re-split
     at the next heading level (H3, then H4, …, up to H6) until each chunk
-    fits or no headings of the next level exist inside.  Note: the cap is
-    *soft*. A chunk with no deeper headings inside (e.g. a 5000-word section
-    under a single H2) stays at that size — no paragraph- or sentence-level
-    splitting is performed.
+    fits or no headings of the next level exist inside.  In adaptive mode, if
+    H1/H2 yielded nothing the chunker descends H3→H6 to find the shallowest
+    heading level present — so a doc with only H3 headings is still split at
+    H3 rather than dropped into a single chunk.  Note: the cap is *soft*. A
+    chunk with no deeper headings inside (e.g. a 5000-word section under a
+    single H2) stays at that size — no paragraph- or sentence-level splitting
+    is performed.
 
     Short documents (fewer than ``short_doc_lines`` lines) are returned as a
     single chunk without splitting. Preamble (content before the first
@@ -126,12 +131,14 @@ class HeadingChunker:
         # Try the canonical H1+H2 split first.
         chunks = self._split_at_levels(lines, levels=(1, 2), base_line=0)
 
-        # If H1/H2 yielded nothing, descend through H3..H6 to find any
-        # heading-level present in the doc.  This implements the spec's
-        # "single huge prose block ... leave as-is" guarantee — a doc with
-        # only H3 headings becomes chunked at H3 rather than dropped.
+        # In adaptive mode, if H1/H2 yielded nothing, descend through H3..H6
+        # to find any heading-level present in the doc, so the cap/snippet
+        # pipeline still sees per-section chunks.  In legacy mode
+        # (max_chunk_words is None) we preserve the pre-2026-04 H1/H2-only
+        # behaviour: a doc with only deep headings falls through to the
+        # single-chunk-no-heading return below.
         deepest_split_level = 2
-        if not chunks:
+        if not chunks and self.max_chunk_words is not None:
             for level in (3, 4, 5, 6):
                 chunks = self._split_at_levels(lines, levels=(level,), base_line=0)
                 if chunks:

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -28,12 +28,14 @@ _SHORT_DOC_LINES = 30
 class ChunkStrategy(Protocol):
     """Protocol for document chunking strategies."""
 
-    def chunk(self, content: str, metadata: dict[str, Any]) -> list[Chunk]:
+    def chunk(self, content: str, _metadata: dict[str, Any]) -> list[Chunk]:
         """Chunk the markdown body into sections.
 
         Args:
             content: Markdown body after frontmatter has been stripped.
-            metadata: Parsed frontmatter dict (for context, not modification).
+            _metadata: Parsed frontmatter dict (for context, not modification).
+                Underscore prefix marks the parameter as unused-by-default in
+                implementations; callers pass it positionally.
 
         Returns:
             List of Chunk objects.

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -21,9 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Threshold below which a document is not split (single chunk).
-# Kept intentionally small so that multi-section test fixtures with compact
-# word-per-line layout (e.g. 9-line documents) still exercise the split path.
-_SHORT_DOC_LINES = 8
+_SHORT_DOC_LINES = 30
 
 
 @runtime_checkable
@@ -108,18 +106,6 @@ class HeadingChunker:
     def chunk(self, content: str, _metadata: dict[str, Any]) -> list[Chunk]:
         """Split content adaptively on heading boundaries.
 
-        In legacy mode (``max_chunk_words=None``) the short-document bypass
-        fires whenever the document is at or below ``short_doc_lines`` lines.
-
-        In adaptive mode (``max_chunk_words`` set) the bypass fires only when
-        the document is short *and* the total word count does not exceed
-        ``max_chunk_words``; a compact but oversize document is still split so
-        that the adaptive refinement can act on it.
-
-        When no H1/H2 heading exists in the document (adaptive mode), the
-        entire document is returned as a single chunk with the first heading
-        of any level used as chunk metadata.
-
         Args:
             content: Markdown body after frontmatter has been stripped.
             _metadata: Parsed frontmatter dict (unused).
@@ -129,46 +115,30 @@ class HeadingChunker:
         """
         lines = content.splitlines(keepends=True)
 
-        # Short-document bypass.
-        is_short = len(lines) <= self.short_doc_lines
-        if is_short:
-            if self.max_chunk_words is None:
-                # Legacy mode: bypass unconditionally.
-                return [
-                    Chunk(heading=None, heading_level=0, content=content, start_line=0)
-                ]
-            # Adaptive mode: bypass only when total words also fit in one chunk.
-            total_words = len(content.split())
-            if total_words <= self.max_chunk_words:
-                return [
-                    Chunk(heading=None, heading_level=0, content=content, start_line=0)
-                ]
-            # Fall through: short in lines but too many words — still split.
+        if len(lines) <= self.short_doc_lines:
+            return [Chunk(heading=None, heading_level=0, content=content, start_line=0)]
 
+        # Try the canonical H1+H2 split first.
         chunks = self._split_at_levels(lines, levels=(1, 2), base_line=0)
 
-        if not chunks and self.max_chunk_words is not None:
-            # No H1/H2 found in adaptive mode: treat the whole document as one
-            # chunk, extracting the first heading of any level for metadata.
-            heading: str | None = None
-            heading_level = 0
-            for line in lines:
-                m = re.match(r"^(#{1,6})\s+(.+)$", line.rstrip())
-                if m:
-                    heading = m.group(2).strip()
-                    heading_level = len(m.group(1))
+        # If H1/H2 yielded nothing, descend through H3..H6 to find any
+        # heading-level present in the doc.  This implements the spec's
+        # "single huge prose block ... leave as-is" guarantee — a doc with
+        # only H3 headings becomes chunked at H3 rather than dropped.
+        deepest_split_level = 2
+        if not chunks:
+            for level in (3, 4, 5, 6):
+                chunks = self._split_at_levels(lines, levels=(level,), base_line=0)
+                if chunks:
+                    deepest_split_level = level
                     break
-            return [
-                Chunk(
-                    heading=heading,
-                    heading_level=heading_level,
-                    content=content,
-                    start_line=0,
-                )
-            ]
 
-        if chunks and self.max_chunk_words is not None:
-            chunks = self._refine_oversize(chunks, current_level=2)
+        if not chunks:
+            # No headings at all → single chunk with no heading.
+            return [Chunk(heading=None, heading_level=0, content=content, start_line=0)]
+
+        if self.max_chunk_words is not None:
+            chunks = self._refine_oversize(chunks, current_level=deepest_split_level)
         return chunks
 
     # ------------------------------------------------------------------

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -77,7 +77,10 @@ class HeadingChunker:
     pre-2026-04 behaviour. With ``max_chunk_words`` set, after the initial
     H1/H2 split each chunk that exceeds the threshold is recursively re-split
     at the next heading level (H3, then H4, …, up to H6) until each chunk
-    fits or no headings of the next level exist inside.
+    fits or no headings of the next level exist inside.  Note: the cap is
+    *soft*. A chunk with no deeper headings inside (e.g. a 5000-word section
+    under a single H2) stays at that size — no paragraph- or sentence-level
+    splitting is performed.
 
     Short documents (fewer than ``short_doc_lines`` lines) are returned as a
     single chunk without splitting. Preamble (content before the first

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -21,7 +21,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Threshold below which a document is not split (single chunk).
-_SHORT_DOC_LINES = 30
+# Kept intentionally small so that multi-section test fixtures with compact
+# word-per-line layout (e.g. 9-line documents) still exercise the split path.
+_SHORT_DOC_LINES = 8
 
 
 @runtime_checkable
@@ -68,96 +70,162 @@ class WholeDocumentChunker:
 
 
 class HeadingChunker:
-    """Split document on H1/H2 boundaries.
+    """Split document on heading boundaries, descending adaptively when chunks
+    exceed ``max_chunk_words``.
+
+    Default behaviour (``max_chunk_words=None``): split on H1/H2 only — the
+    pre-2026-04 behaviour. With ``max_chunk_words`` set, after the initial
+    H1/H2 split each chunk that exceeds the threshold is recursively re-split
+    at the next heading level (H3, then H4, …, up to H6) until each chunk
+    fits or no headings of the next level exist inside.
 
     Short documents (fewer than ``short_doc_lines`` lines) are returned as a
-    single chunk without splitting. Each chunk receives the heading text and
-    level of the section it starts with; a preamble before the first heading
-    gets ``heading=None`` and ``heading_level=0``.
+    single chunk without splitting. Preamble (content before the first
+    heading) is never refined further regardless of size — there are no
+    deeper headings to split on.
 
     This is the default chunking strategy.
     """
 
-    def __init__(self, short_doc_lines: int = _SHORT_DOC_LINES) -> None:
+    def __init__(
+        self,
+        short_doc_lines: int = _SHORT_DOC_LINES,
+        *,
+        max_chunk_words: int | None = None,
+    ) -> None:
         """Initialise the chunker.
 
         Args:
             short_doc_lines: Line count at or below which the document is
                 returned as a single chunk rather than split on headings.
+            max_chunk_words: Word-count threshold above which a chunk is
+                recursively re-split at the next heading level. ``None``
+                preserves today's H1/H2-only behaviour.
         """
         self.short_doc_lines = short_doc_lines
+        self.max_chunk_words = max_chunk_words
 
     def chunk(self, content: str, _metadata: dict[str, Any]) -> list[Chunk]:
-        """Split content on H1/H2 boundaries.
+        """Split content adaptively on heading boundaries.
+
+        In legacy mode (``max_chunk_words=None``) the short-document bypass
+        fires whenever the document is at or below ``short_doc_lines`` lines.
+
+        In adaptive mode (``max_chunk_words`` set) the bypass fires only when
+        the document is short *and* the total word count does not exceed
+        ``max_chunk_words``; a compact but oversize document is still split so
+        that the adaptive refinement can act on it.
+
+        When no H1/H2 heading exists in the document (adaptive mode), the
+        entire document is returned as a single chunk with the first heading
+        of any level used as chunk metadata.
 
         Args:
             content: Markdown body after frontmatter has been stripped.
-            _metadata: Parsed frontmatter dict (for context, not modification).
+            _metadata: Parsed frontmatter dict (unused).
 
         Returns:
-            List of Chunk objects, one per section. Short documents return a
-            single Chunk.
+            List of :class:`~markdown_vault_mcp.types.Chunk` objects.
         """
         lines = content.splitlines(keepends=True)
 
-        # Short documents: no split.
-        if len(lines) <= self.short_doc_lines:
+        # Short-document bypass.
+        is_short = len(lines) <= self.short_doc_lines
+        if is_short:
+            if self.max_chunk_words is None:
+                # Legacy mode: bypass unconditionally.
+                return [
+                    Chunk(heading=None, heading_level=0, content=content, start_line=0)
+                ]
+            # Adaptive mode: bypass only when total words also fit in one chunk.
+            total_words = len(content.split())
+            if total_words <= self.max_chunk_words:
+                return [
+                    Chunk(heading=None, heading_level=0, content=content, start_line=0)
+                ]
+            # Fall through: short in lines but too many words — still split.
+
+        chunks = self._split_at_levels(lines, levels=(1, 2), base_line=0)
+
+        if not chunks and self.max_chunk_words is not None:
+            # No H1/H2 found in adaptive mode: treat the whole document as one
+            # chunk, extracting the first heading of any level for metadata.
+            heading: str | None = None
+            heading_level = 0
+            for line in lines:
+                m = re.match(r"^(#{1,6})\s+(.+)$", line.rstrip())
+                if m:
+                    heading = m.group(2).strip()
+                    heading_level = len(m.group(1))
+                    break
             return [
                 Chunk(
-                    heading=None,
-                    heading_level=0,
+                    heading=heading,
+                    heading_level=heading_level,
                     content=content,
                     start_line=0,
                 )
             ]
 
-        # Walk lines and record where H1/H2 headings appear.
-        split_points: list[tuple[int, int, str]] = []  # (line_index, level, text)
+        if chunks and self.max_chunk_words is not None:
+            chunks = self._refine_oversize(chunks, current_level=2)
+        return chunks
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _split_at_levels(
+        self,
+        lines: list[str],
+        *,
+        levels: tuple[int, ...],
+        base_line: int,
+    ) -> list[Chunk]:
+        """Split *lines* on any heading whose level is in *levels*.
+
+        ``base_line`` is added to every emitted ``start_line`` so that
+        ``start_line`` always refers to the *original* document, not the
+        sub-slice passed in during recursion.
+
+        Returns an empty list if the slice contains no matching headings.
+        """
+        # Walk and record split points (line index in this slice, level, text).
+        split_points: list[tuple[int, int, str]] = []
+        max_level = max(levels)
+        pat = re.compile(rf"^(#{{1,{max_level}}})\s+(.+)$")
         for idx, line in enumerate(lines):
-            m = re.match(r"^(#{1,2})\s+(.+)$", line.rstrip())
+            m = pat.match(line.rstrip())
             if m:
                 level = len(m.group(1))
-                text = m.group(2).strip()
-                split_points.append((idx, level, text))
+                if level in levels:
+                    split_points.append((idx, level, m.group(2).strip()))
 
-        # No headings found: single chunk.
         if not split_points:
-            return [
-                Chunk(
-                    heading=None,
-                    heading_level=0,
-                    content=content,
-                    start_line=0,
-                )
-            ]
+            return []
 
         chunks: list[Chunk] = []
 
-        # Preamble: content before the first heading.
-        first_heading_line = split_points[0][0]
-        if first_heading_line > 0:
-            preamble = "".join(lines[:first_heading_line])
+        # Preamble: anything before the first split point.
+        first_line = split_points[0][0]
+        if first_line > 0:
+            preamble = "".join(lines[:first_line])
             if preamble.strip():
                 chunks.append(
                     Chunk(
                         heading=None,
                         heading_level=0,
                         content=preamble,
-                        start_line=0,
+                        start_line=base_line,
                     )
                 )
 
-        # Sections between headings.
         for i, (line_idx, level, heading_text) in enumerate(split_points):
-            # Content runs from the line after the heading to the next split.
             content_start = line_idx + 1
-            if i + 1 < len(split_points):
-                content_end = split_points[i + 1][0]
-            else:
-                content_end = len(lines)
-
+            content_end = (
+                split_points[i + 1][0] if i + 1 < len(split_points) else len(lines)
+            )
             section_content = "".join(lines[content_start:content_end])
-            # Skip heading-only sections that have no meaningful body content.
             if not section_content.strip():
                 continue
             chunks.append(
@@ -165,11 +233,44 @@ class HeadingChunker:
                     heading=heading_text,
                     heading_level=level,
                     content=section_content,
-                    start_line=line_idx,
+                    start_line=base_line + line_idx,
                 )
             )
-
         return chunks
+
+    def _refine_oversize(
+        self, chunks: list[Chunk], *, current_level: int
+    ) -> list[Chunk]:
+        """Recursively re-split chunks that exceed ``max_chunk_words``.
+
+        ``current_level`` is the deepest heading level already used as a
+        split point. Refinement attempts ``current_level + 1`` next.
+        """
+        assert self.max_chunk_words is not None  # guarded by caller
+        if current_level >= 6:
+            return chunks
+
+        next_level = current_level + 1
+        out: list[Chunk] = []
+        for chunk in chunks:
+            if chunk.heading is None:
+                # Preamble: no deeper headings exist inside it; keep as-is.
+                out.append(chunk)
+                continue
+            if len(chunk.content.split()) <= self.max_chunk_words:
+                out.append(chunk)
+                continue
+
+            sub_lines = chunk.content.splitlines(keepends=True)
+            sub_chunks = self._split_at_levels(
+                sub_lines, levels=(next_level,), base_line=chunk.start_line + 1
+            )
+            if not sub_chunks:
+                # No headings of next_level inside; cannot split further.
+                out.append(chunk)
+                continue
+            out.extend(self._refine_oversize(sub_chunks, current_level=next_level))
+        return out
 
 
 def _resolve_title(metadata: dict[str, Any], content: str, path: Path) -> str:

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -100,9 +100,12 @@ class FTSResult:
         path: Relative path of the document containing this chunk.
         title: Document title.
         folder: Parent folder path.
-        heading: Section heading this chunk falls under, or ``None`` for the intro.
-        content: Matched chunk text.
+        heading: Section heading this chunk falls under, or ``None``.
+        content: Matched chunk text — full chunk by default; truncated to a
+            tokenizer-aware snippet when ``snippet_words`` is passed to the
+            search call.
         score: BM25 relevance score (higher is better).
+        chunk_count: Total number of chunks belonging to the parent document.
     """
 
     path: str
@@ -111,6 +114,7 @@ class FTSResult:
     heading: str | None
     content: str
     score: float
+    chunk_count: int = 1
 
 
 @dataclass

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -76,7 +76,11 @@ class SearchResult:
         title: Document title.
         folder: Parent folder path.
         heading: Section heading this chunk falls under, or ``None`` for the intro.
-        content: Matched chunk text (not the full document).
+        content: Matched chunk text — a query-relevant snippet by default
+            (≤ ``snippet_words`` words, centred on matched terms). Pass
+            ``snippet_words=0`` to ``search`` for the full chunk verbatim,
+            or recover the full chunk after seeing a snippet via
+            ``read(path, section=heading)``.
         score: Relevance score. Higher is better; not comparable across search types.
         search_type: ``"keyword"`` (BM25) or ``"semantic"`` (cosine similarity).
         frontmatter: Parsed YAML frontmatter of the parent document.

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -77,12 +77,14 @@ class SearchResult:
         folder: Parent folder path.
         heading: Section heading this chunk falls under, or ``None`` for the intro.
         content: Matched chunk text — a query-relevant snippet by default
-            (≤ ``snippet_words`` words, centred on matched terms). Pass
+            (approximately ``snippet_words`` words plus optional leading/trailing
+            ellipsis markers, centred on matched terms). Pass
             ``snippet_words=0`` to ``search`` for the full chunk verbatim,
             or recover the full chunk after seeing a snippet via
             ``read(path, section=heading)``.
         score: Relevance score. Higher is better; not comparable across search types.
-        search_type: ``"keyword"`` (BM25) or ``"semantic"`` (cosine similarity).
+        search_type: ``"keyword"`` (BM25), ``"semantic"`` (cosine similarity),
+            or ``"hybrid"`` (chunk appeared in both keyword and semantic channels).
         frontmatter: Parsed YAML frontmatter of the parent document.
     """
 
@@ -92,7 +94,7 @@ class SearchResult:
     heading: str | None
     content: str
     score: float
-    search_type: Literal["keyword", "semantic"]
+    search_type: Literal["keyword", "semantic", "hybrid"]
     frontmatter: dict[str, Any]
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3917,3 +3917,31 @@ class TestLoggingAuditSilentPaths:
         assert any(
             "_get_frontmatter: invalid JSON" in rec.message for rec in caplog.records
         )
+
+
+def test_collection_constructs_chunker_with_max_chunk_words(tmp_path):
+    """Collection plumbs max_chunk_words into HeadingChunker."""
+    from markdown_vault_mcp.collection import Collection
+    from markdown_vault_mcp.scanner import HeadingChunker
+
+    coll = Collection(source_dir=tmp_path, max_chunk_words=250)
+    assert isinstance(coll._chunk_strategy, HeadingChunker)
+    assert coll._chunk_strategy.max_chunk_words == 250
+
+
+def test_collection_search_honours_default_chunks_per_doc(tmp_path):
+    """A Collection-level search uses chunks_per_doc=2 by default."""
+    from markdown_vault_mcp.collection import Collection
+
+    (tmp_path / "long.md").write_text(
+        "# Top\n## A\nworld a\n## B\nworld b\n## C\nworld c\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "short.md").write_text("# Short\nworld\n", encoding="utf-8")
+    coll = Collection(source_dir=tmp_path)
+    coll.build_index()
+    results = coll.search("world", mode="keyword", limit=10)
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.path] = counts.get(r.path, 0) + 1
+    assert counts.get("long.md", 0) <= 2

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -119,8 +119,9 @@ class TestBuildIndex:
 
         # 9 valid .md files (excludes invalid_utf8.md; malformed_yaml.md skipped).
         assert stats.documents_indexed == 9
-        # All fixtures are short (<= 30 lines) → 1 chunk each.
-        assert stats.chunks_indexed == 9
+        # 12 total chunks: longer fixtures (unicode.md=3, deep_headings.md=2)
+        # are now split; shorter fixtures produce 1 chunk each.
+        assert stats.chunks_indexed == 12
         assert stats.skipped >= 0
 
     def test_build_index_force_rebuild(self, vault_path: Path) -> None:
@@ -130,7 +131,7 @@ class TestBuildIndex:
         stats = col.build_index(force=True)
 
         assert stats.documents_indexed == 9
-        assert stats.chunks_indexed == 9
+        assert stats.chunks_indexed == 12
 
     def test_build_index_idempotent_without_force(self, vault_path: Path) -> None:
         """Calling build_index() twice (no force) does not double-index."""
@@ -172,7 +173,7 @@ class TestBuildIndex:
 
         # One document errored, remaining 8 indexed successfully.
         assert stats.documents_indexed == 8
-        assert stats.chunks_indexed == 8
+        assert stats.chunks_indexed == 10
 
     def test_reindex_continues_on_upsert_error(
         self, tmp_path: Path, vault_path: Path
@@ -668,7 +669,7 @@ class TestStats:
 
         assert isinstance(s, CollectionStats)
         assert s.document_count == 9
-        assert s.chunk_count == 9
+        assert s.chunk_count == 12
         # Folders: "" (root), "subfolder", "subfolder/deep"
         assert s.folder_count == 3
         assert s.semantic_search_available is False
@@ -2770,8 +2771,8 @@ class TestEmbeddingsStatus:
         status = semantic_collection.embeddings_status()
 
         assert status["available"] is True
-        # 9 documents, each one chunk — chunk_count must match.
-        assert status["chunk_count"] == 9
+        # 12 total chunks from 9 documents.
+        assert status["chunk_count"] == 12
 
     def test_status_reads_json_when_vectors_not_loaded(
         self,
@@ -2836,7 +2837,7 @@ class TestBuildEmbeddings:
         )
         col.build_index()
         count1 = col.build_embeddings()
-        assert count1 == 9
+        assert count1 == 12
 
         # Track embed calls to prove no re-embedding happens.
         original_embed = mock_provider.embed
@@ -2883,7 +2884,7 @@ class TestBuildEmbeddings:
 
         # Re-embedding must have occurred.
         assert len(embed_calls) > 0
-        assert count == 9
+        assert count == 12
 
     def test_build_embeddings_uses_bounded_batches(
         self,
@@ -2912,7 +2913,7 @@ class TestBuildEmbeddings:
         mock_provider.embed = tracking_embed  # type: ignore[method-assign]
 
         count = col.build_embeddings(force=True)
-        assert count == 9
+        assert count == 12
 
         # embed() must have been called, and every batch at most _EMBEDDING_BATCH_SIZE.
         assert len(batch_sizes) > 0, "embed() should have been called"

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -119,9 +119,8 @@ class TestBuildIndex:
 
         # 9 valid .md files (excludes invalid_utf8.md; malformed_yaml.md skipped).
         assert stats.documents_indexed == 9
-        # 12 total chunks: longer fixtures (unicode.md=3, deep_headings.md=2)
-        # are now split; shorter fixtures produce 1 chunk each.
-        assert stats.chunks_indexed == 12
+        # All fixtures are short (<= 30 lines) → 1 chunk each.
+        assert stats.chunks_indexed == 9
         assert stats.skipped >= 0
 
     def test_build_index_force_rebuild(self, vault_path: Path) -> None:
@@ -131,7 +130,7 @@ class TestBuildIndex:
         stats = col.build_index(force=True)
 
         assert stats.documents_indexed == 9
-        assert stats.chunks_indexed == 12
+        assert stats.chunks_indexed == 9
 
     def test_build_index_idempotent_without_force(self, vault_path: Path) -> None:
         """Calling build_index() twice (no force) does not double-index."""
@@ -173,7 +172,7 @@ class TestBuildIndex:
 
         # One document errored, remaining 8 indexed successfully.
         assert stats.documents_indexed == 8
-        assert stats.chunks_indexed == 10
+        assert stats.chunks_indexed == 8
 
     def test_reindex_continues_on_upsert_error(
         self, tmp_path: Path, vault_path: Path
@@ -669,7 +668,7 @@ class TestStats:
 
         assert isinstance(s, CollectionStats)
         assert s.document_count == 9
-        assert s.chunk_count == 12
+        assert s.chunk_count == 9
         # Folders: "" (root), "subfolder", "subfolder/deep"
         assert s.folder_count == 3
         assert s.semantic_search_available is False
@@ -2771,8 +2770,8 @@ class TestEmbeddingsStatus:
         status = semantic_collection.embeddings_status()
 
         assert status["available"] is True
-        # 12 total chunks from 9 documents.
-        assert status["chunk_count"] == 12
+        # 9 documents, each one chunk — chunk_count must match.
+        assert status["chunk_count"] == 9
 
     def test_status_reads_json_when_vectors_not_loaded(
         self,
@@ -2837,7 +2836,7 @@ class TestBuildEmbeddings:
         )
         col.build_index()
         count1 = col.build_embeddings()
-        assert count1 == 12
+        assert count1 == 9
 
         # Track embed calls to prove no re-embedding happens.
         original_embed = mock_provider.embed
@@ -2884,7 +2883,7 @@ class TestBuildEmbeddings:
 
         # Re-embedding must have occurred.
         assert len(embed_calls) > 0
-        assert count == 12
+        assert count == 9
 
     def test_build_embeddings_uses_bounded_batches(
         self,
@@ -2913,7 +2912,7 @@ class TestBuildEmbeddings:
         mock_provider.embed = tracking_embed  # type: ignore[method-assign]
 
         count = col.build_embeddings(force=True)
-        assert count == 12
+        assert count == 9
 
         # embed() must have been called, and every batch at most _EMBEDDING_BATCH_SIZE.
         assert len(batch_sizes) > 0, "embed() should have been called"

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -2620,12 +2620,12 @@ class TestHybridSearch:
     def test_hybrid_search_search_type_varies(
         self, semantic_collection: Collection
     ) -> None:
-        """Hybrid results can carry 'keyword' or 'semantic' search_type."""
+        """Hybrid results can carry 'keyword', 'semantic', or 'hybrid' search_type."""
         results = semantic_collection.search("document content", mode="hybrid", limit=9)
 
         types = {r.search_type for r in results}
         # With 9 docs and a broad query, at least one type should appear.
-        assert types.issubset({"keyword", "semantic"})
+        assert types.issubset({"keyword", "semantic", "hybrid"})
         assert len(types) >= 1
 
     def test_hybrid_search_folder_filter(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,55 @@ from markdown_vault_mcp.config import (
 )
 
 
+def test_search_ranking_config_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """New ranking/snippet knobs default to documented values when env unset."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    # Clear any test-runner-leaked overrides.
+    for var in (
+        "MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC",
+        "MARKDOWN_VAULT_MCP_SNIPPET_WORDS",
+        "MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA",
+        "MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = load_config()
+    assert cfg.chunks_per_doc == 2
+    assert cfg.snippet_words == 200
+    assert cfg.length_downweight_alpha == 0.25
+    assert cfg.max_chunk_words == 400
+
+
+def test_search_ranking_config_env_overrides(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Env vars override the defaults."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC", "1")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SNIPPET_WORDS", "0")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA", "0.0")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS", "100000")
+
+    cfg = load_config()
+    assert cfg.chunks_per_doc == 1
+    assert cfg.snippet_words == 0
+    assert cfg.length_downweight_alpha == 0.0
+    assert cfg.max_chunk_words == 100000
+
+
+def test_search_ranking_config_rejects_zero_chunks_per_doc(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """chunks_per_doc=0 is rejected at load_config time (no useful semantics)."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC", "0")
+
+    with pytest.raises(ValueError, match="chunks_per_doc"):
+        load_config()
+
+
 class TestParseHelpers:
     """Test boolean and list parsing edge cases via load_config."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1154,3 +1154,25 @@ class TestServerConfigComposition:
         assert config.server.transport == "http"
         assert config.server.bearer_token == "secret-token"
         assert config.server.base_url == "https://api.example.com"
+
+
+def test_search_ranking_config_rejects_malformed_int(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bad env input names the offending variable in the error message."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC", "foo")
+
+    with pytest.raises(ValueError, match="MARKDOWN_VAULT_MCP_CHUNKS_PER_DOC"):
+        load_config()
+
+
+def test_search_ranking_config_rejects_malformed_float(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bad float env input names the offending variable in the error message."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA", "abc")
+
+    with pytest.raises(ValueError, match="MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA"):
+        load_config()

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -1,0 +1,71 @@
+"""Tests for DocumentManager.read(path, section=...) section retrieval."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.managers.document import DocumentManager
+from markdown_vault_mcp.scanner import HeadingChunker, scan_directory
+
+
+@pytest.fixture()
+def doc_mgr(tmp_path):
+    a = tmp_path / "a.md"
+    # Use multi-line bodies so the doc clears the 30-line short-doc bypass and
+    # actually splits into per-section chunks.
+    body = (
+        "# A\n"
+        + "\n".join(["intro"] * 12)
+        + "\n## Section One\n"
+        + "\n".join(["first body word"] * 12)
+        + "\n## Section Two\n"
+        + "\n".join(["second body word"] * 12)
+        + "\n"
+    )
+    a.write_text(body, encoding="utf-8")
+    fts = FTSIndex(db_path=":memory:")
+    chunker = HeadingChunker()
+    for note in scan_directory(tmp_path, chunk_strategy=chunker):
+        fts.upsert_note(note)
+    return DocumentManager(
+        fts=fts,
+        source_dir=tmp_path,
+        write_lock=threading.RLock(),
+        chunk_strategy=chunker,
+        read_only=False,
+    )
+
+
+def test_read_no_section_returns_full_file(doc_mgr):
+    nc = doc_mgr.read("a.md")
+    assert nc is not None
+    assert "Section One" in nc.content
+    assert "Section Two" in nc.content
+
+
+def test_read_with_section_returns_only_that_chunk(doc_mgr):
+    nc = doc_mgr.read("a.md", section="Section One")
+    assert nc is not None
+    assert "first body word" in nc.content
+    assert "second body word" not in nc.content
+
+
+def test_read_unknown_section_raises(doc_mgr):
+    with pytest.raises(ValueError, match="Section"):
+        doc_mgr.read("a.md", section="No Such Heading")
+
+
+def test_read_empty_section_raises(doc_mgr):
+    with pytest.raises(ValueError):
+        doc_mgr.read("a.md", section="   ")
+
+
+def test_read_returns_none_when_path_unknown(doc_mgr):
+    assert doc_mgr.read("missing.md") is None
+    # With section, missing path also raises (cannot resolve section in
+    # nonexistent doc).
+    with pytest.raises(ValueError):
+        doc_mgr.read("missing.md", section="Anything")

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -69,3 +69,34 @@ def test_read_returns_none_when_path_unknown(doc_mgr):
     # nonexistent doc).
     with pytest.raises(ValueError):
         doc_mgr.read("missing.md", section="Anything")
+
+
+def test_read_section_duplicate_heading_returns_first_by_start_line(tmp_path):
+    """When a heading repeats, _read_section returns the first occurrence."""
+    a = tmp_path / "a.md"
+    # Each section body must be long enough that the total doc exceeds the
+    # 30-line short-doc bypass (HeadingChunker default), so we get per-section
+    # chunks rather than a single whole-document chunk.
+    body = (
+        "# A\n## Repeat\n"
+        + "\n".join(["first occurrence body"] * 16)
+        + "\n## Repeat\n"
+        + "\n".join(["second occurrence body"] * 16)
+        + "\n"
+    )
+    a.write_text(body, encoding="utf-8")
+    fts = FTSIndex(db_path=":memory:")
+    chunker = HeadingChunker()
+    for note in scan_directory(tmp_path, chunk_strategy=chunker):
+        fts.upsert_note(note)
+    mgr = DocumentManager(
+        fts=fts,
+        source_dir=tmp_path,
+        write_lock=threading.RLock(),
+        chunk_strategy=chunker,
+    )
+
+    nc = mgr.read("a.md", section="Repeat")
+    assert nc is not None
+    assert "first occurrence body" in nc.content
+    assert "second occurrence body" not in nc.content

--- a/tests/test_fts_chunk_count.py
+++ b/tests/test_fts_chunk_count.py
@@ -74,6 +74,32 @@ def test_chunk_count_updates_on_reupsert(tmp_path):
     assert v2_count == len(note_v2.chunks)
 
 
+def test_migration_no_crash_when_column_already_added(tmp_path):
+    """If a concurrent process added chunk_count first, our migration is a no-op."""
+    db_path = tmp_path / "race.sqlite3"
+    legacy = sqlite3.connect(db_path)
+    legacy.executescript(
+        """
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY,
+            path TEXT UNIQUE NOT NULL,
+            title TEXT NOT NULL,
+            folder TEXT NOT NULL DEFAULT '',
+            frontmatter_json TEXT,
+            content_hash TEXT NOT NULL,
+            modified_at REAL NOT NULL,
+            chunk_count INTEGER NOT NULL DEFAULT 1
+        );
+        """
+    )
+    legacy.commit()
+    legacy.close()
+
+    # FTSIndex must not crash even though the column already exists.
+    fts = FTSIndex(db_path=db_path)
+    assert fts is not None
+
+
 def test_migration_adds_column_to_pre_existing_db(tmp_path):
     """Opening an FTS DB created without chunk_count adds the column."""
     db_path = tmp_path / "old.sqlite3"

--- a/tests/test_fts_chunk_count.py
+++ b/tests/test_fts_chunk_count.py
@@ -1,0 +1,108 @@
+"""Tests for the chunk_count column on documents and its migration path."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.scanner import HeadingChunker, parse_note
+
+
+def _make_note(tmp_path, name: str, body: str):
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return parse_note(
+        p, tmp_path, HeadingChunker(short_doc_lines=0, max_chunk_words=200)
+    )
+
+
+def test_chunk_count_populated_on_upsert(tmp_path):
+    """upsert_note populates documents.chunk_count from len(note.chunks)."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "\n".join(
+        ["# A", "alpha body " * 10, "## B", "beta body " * 10, "## C", "gamma " * 10]
+    )
+    note = _make_note(tmp_path, "doc.md", body)
+    fts.upsert_note(note)
+
+    row = fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = ?", (note.path,)
+    ).fetchone()
+    assert row is not None
+    assert row["chunk_count"] == len(note.chunks)
+    # Sanity: the helper bypasses the 30-line short-doc rule so this fixture
+    # actually splits.
+    assert len(note.chunks) > 1
+
+
+def test_chunk_count_populated_on_build_from_notes(tmp_path):
+    """build_from_notes populates chunk_count for every note."""
+    fts = FTSIndex(db_path=":memory:")
+    notes = [
+        _make_note(tmp_path, "a.md", "# A\nalpha\n## B\nbeta\n"),
+        _make_note(tmp_path, "b.md", "# A\nonly one chunk\n"),
+    ]
+    fts.build_from_notes(notes)
+
+    counts = dict(
+        fts._conn.execute("SELECT path, chunk_count FROM documents").fetchall()
+    )
+    assert counts["a.md"] == len(notes[0].chunks)
+    assert counts["b.md"] == len(notes[1].chunks)
+
+
+def test_chunk_count_updates_on_reupsert(tmp_path):
+    """When a doc is re-upserted with a different chunk count, the column updates."""
+    fts = FTSIndex(db_path=":memory:")
+    note_v1 = _make_note(tmp_path, "doc.md", "# A\nbody\n")
+    fts.upsert_note(note_v1)
+    v1_count = fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = ?", (note_v1.path,)
+    ).fetchone()["chunk_count"]
+
+    note_v2 = _make_note(
+        tmp_path,
+        "doc.md",
+        "# A\nbody\n## B\nmore\n## C\neven more\n",
+    )
+    fts.upsert_note(note_v2)
+    v2_count = fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = ?", (note_v2.path,)
+    ).fetchone()["chunk_count"]
+
+    assert v2_count != v1_count
+    assert v2_count == len(note_v2.chunks)
+
+
+def test_migration_adds_column_to_pre_existing_db(tmp_path):
+    """Opening an FTS DB created without chunk_count adds the column."""
+    db_path = tmp_path / "old.sqlite3"
+    legacy = sqlite3.connect(db_path)
+    legacy.executescript(
+        """
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY,
+            path TEXT UNIQUE NOT NULL,
+            title TEXT NOT NULL,
+            folder TEXT NOT NULL DEFAULT '',
+            frontmatter_json TEXT,
+            content_hash TEXT NOT NULL,
+            modified_at REAL NOT NULL
+        );
+        INSERT INTO documents (path, title, content_hash, modified_at)
+        VALUES ('legacy.md', 'Legacy', 'x', 0.0);
+        """
+    )
+    legacy.commit()
+    legacy.close()
+
+    fts = FTSIndex(db_path=db_path)
+    cols = [
+        r["name"] for r in fts._conn.execute("PRAGMA table_info(documents)").fetchall()
+    ]
+    assert "chunk_count" in cols
+    # Existing legacy row gets the default value.
+    row = fts._conn.execute(
+        "SELECT chunk_count FROM documents WHERE path = 'legacy.md'"
+    ).fetchone()
+    assert row["chunk_count"] == 1

--- a/tests/test_fts_snippet.py
+++ b/tests/test_fts_snippet.py
@@ -1,0 +1,61 @@
+"""Tests for FTS5 snippet() projection in FTSIndex.search."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.scanner import HeadingChunker, parse_note
+
+
+def _upsert(tmp_path, fts: FTSIndex, name: str, body: str) -> None:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    fts.upsert_note(parse_note(p, tmp_path, HeadingChunker()))
+
+
+def test_snippet_words_zero_returns_full_content(tmp_path):
+    """snippet_words=0 (or None) returns the full chunk content."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "# A\n" + "alpha " * 50 + "needle " + "alpha " * 50 + "\n"
+    _upsert(tmp_path, fts, "doc.md", body)
+
+    [r] = fts.search("needle", limit=10, snippet_words=0)
+    # Full chunk: ~101 words.
+    assert "alpha alpha" in r.content
+    assert len(r.content.split()) > 50
+
+
+def test_snippet_words_caps_returned_text(tmp_path):
+    """snippet_words=20 returns roughly 20 tokens centered on the match."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "# A\n" + "alpha " * 100 + "needle " + "alpha " * 100 + "\n"
+    _upsert(tmp_path, fts, "doc.md", body)
+
+    [r] = fts.search("needle", limit=10, snippet_words=20)
+    assert "needle" in r.content
+    assert len(r.content.split()) <= 30  # 20 + ellipsis slack
+
+
+def test_snippet_includes_ellipsis_marker_when_truncated(tmp_path):
+    """Truncated snippets include the … marker."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "# A\n" + "alpha " * 200 + "needle " + "alpha " * 200 + "\n"
+    _upsert(tmp_path, fts, "doc.md", body)
+
+    [r] = fts.search("needle", limit=10, snippet_words=10)
+    assert "…" in r.content
+
+
+def test_chunk_count_populated_on_fts_result(tmp_path):
+    """FTSResult exposes the parent doc's chunk_count."""
+    fts = FTSIndex(db_path=":memory:")
+    body = "# A\nalpha needle\n## B\nbeta\n## C\ngamma\n"
+    _upsert(tmp_path, fts, "doc.md", body)
+
+    results = fts.search("needle", limit=10)
+    assert results[0].chunk_count >= 1
+    assert (
+        results[0].chunk_count
+        == fts._conn.execute(
+            "SELECT chunk_count FROM documents WHERE path = 'doc.md'"
+        ).fetchone()["chunk_count"]
+    )

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -650,3 +650,32 @@ def test_hybrid_search_labels_both_channel_hits_as_hybrid(
     assert any(r.search_type == "hybrid" for r in results), (
         f"expected at least one 'hybrid' label; got {[r.search_type for r in results]}"
     )
+
+
+def test_fetch_snippet_map_widens_pool_to_match_caller(
+    monkeypatch: pytest.MonkeyPatch,
+    search_mgr: SearchManager,
+) -> None:
+    """_fetch_snippet_map's second FTS query must use a candidate pool at
+    least as wide as the caller's initial candidate_limit, so survivors
+    ranked low in the initial pool aren't dropped from the snippet
+    projection."""
+    captured: list[int] = []
+
+    real_search = search_mgr._fts.search
+
+    def spy(*args, **kwargs):
+        if "snippet_words" in kwargs and (kwargs.get("snippet_words") or 0) > 0:
+            captured.append(int(kwargs.get("limit", 0)))
+        return real_search(*args, **kwargs)
+
+    monkeypatch.setattr(search_mgr._fts, "search", spy)
+
+    # Run a keyword search with a wide candidate_limit (default formula:
+    # max(limit * (chunks_per_doc + 4), 50) → 60 at limit=10, chunks_per_doc=2).
+    search_mgr.search("world", mode="keyword", limit=10)
+
+    assert captured, "snippet re-query did not run"
+    assert captured[0] >= 60, (
+        f"snippet re-query limit {captured[0]} < initial pool floor 60"
+    )

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -544,3 +544,64 @@ def test_keyword_search_returns_snippet(search_mgr: SearchManager) -> None:
         len(s.content.split()) <= len(lg.content.split())
         for s, lg in zip(short_results, long_results, strict=False)
     )
+
+
+@pytest.fixture()
+def search_mgr_with_embeddings(search_vault: Path) -> SearchManager:
+    """Build a SearchManager with a deterministic mock embedding provider."""
+    from markdown_vault_mcp.vector_index import VectorIndex
+    from tests.conftest import MockEmbeddingProvider
+
+    fts = FTSIndex(db_path=":memory:", indexed_frontmatter_fields=["tags"])
+    for note in scan_directory(search_vault):
+        fts.upsert_note(note)
+    fts.resolve_vault_wikilinks()
+    provider = MockEmbeddingProvider()
+    embeddings_path = search_vault / "embeddings"
+    vectors = VectorIndex(provider)
+    for note in scan_directory(search_vault):
+        texts = [c.content for c in note.chunks]
+        from pathlib import Path as _Path
+
+        meta = [
+            {
+                "path": note.path,
+                "title": note.title,
+                "folder": (
+                    ""
+                    if _Path(note.path).parent.as_posix() == "."
+                    else _Path(note.path).parent.as_posix()
+                ),
+                "heading": c.heading,
+                "content": c.content,
+            }
+            for c in note.chunks
+        ]
+        if texts:
+            vectors.add(texts, meta)
+    vectors.save(embeddings_path)
+    mgr = SearchManager(
+        fts=fts,
+        source_dir=search_vault,
+        embeddings_path=embeddings_path,
+        embedding_provider=provider,
+        indexed_frontmatter_fields=["tags"],
+    )
+    mgr._vectors = vectors
+    return mgr
+
+
+def test_semantic_search_applies_chunks_per_doc_cap_and_snippet(
+    search_mgr_with_embeddings: SearchManager,
+) -> None:
+    """Semantic mode honours chunks_per_doc and snippet_words."""
+    results = search_mgr_with_embeddings.search(
+        "world",
+        mode="semantic",
+        chunks_per_doc=1,
+        snippet_words=5,
+        limit=10,
+    )
+    paths = [r.path for r in results]
+    assert len(set(paths)) == len(paths)
+    assert all(len(r.content.split()) <= 10 for r in results)

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -517,3 +517,30 @@ class TestValidatePath:
         """Path traversal raises ValueError."""
         with pytest.raises(ValueError, match="traversal"):
             search_mgr._validate_path("../../etc/passwd.md")
+
+
+# ---------------------------------------------------------------------------
+# keyword pipeline — chunks_per_doc cap + snippet projection
+# ---------------------------------------------------------------------------
+
+
+def test_keyword_search_applies_chunks_per_doc_cap(search_mgr: SearchManager) -> None:
+    """Two chunks from the same doc cannot both occupy the top-N."""
+    # The search_vault fixture has single-chunk docs, so this test asserts
+    # the manager honours the chunks_per_doc parameter without erroring;
+    # the pathology case is exercised in tests/test_search_pipeline_integration.py.
+    results = search_mgr.search("world", mode="keyword", chunks_per_doc=1, limit=10)
+    paths_in_top = [r.path for r in results]
+    assert len(set(paths_in_top)) == len(paths_in_top)
+
+
+def test_keyword_search_returns_snippet(search_mgr: SearchManager) -> None:
+    """When snippet_words is set, content is shorter than (or equal to) the full chunk."""
+    long_results = search_mgr.search("world", mode="keyword", snippet_words=0, limit=10)
+    short_results = search_mgr.search(
+        "world", mode="keyword", snippet_words=3, limit=10
+    )
+    assert all(
+        len(s.content.split()) <= len(lg.content.split())
+        for s, lg in zip(short_results, long_results, strict=False)
+    )

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -633,3 +633,20 @@ def test_hybrid_search_uses_fts_snippet_for_keyword_hits(
         limit=10,
     )
     assert all(len(r.content.split()) <= 8 for r in results)
+
+
+def test_hybrid_search_labels_both_channel_hits_as_hybrid(
+    search_mgr_with_embeddings: SearchManager,
+) -> None:
+    """Chunks present in both channels are labelled 'hybrid'."""
+    results = search_mgr_with_embeddings.search(
+        "world",
+        mode="hybrid",
+        chunks_per_doc=10,
+        snippet_words=0,
+        limit=20,
+    )
+    # At least one result should be 'hybrid' (chunk hit in both channels).
+    assert any(r.search_type == "hybrid" for r in results), (
+        f"expected at least one 'hybrid' label; got {[r.search_type for r in results]}"
+    )

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -605,3 +605,31 @@ def test_semantic_search_applies_chunks_per_doc_cap_and_snippet(
     paths = [r.path for r in results]
     assert len(set(paths)) == len(paths)
     assert all(len(r.content.split()) <= 10 for r in results)
+
+
+def test_hybrid_search_caps_per_doc_after_rrf(
+    search_mgr_with_embeddings: SearchManager,
+) -> None:
+    results = search_mgr_with_embeddings.search(
+        "world",
+        mode="hybrid",
+        chunks_per_doc=1,
+        snippet_words=5,
+        limit=10,
+    )
+    paths = [r.path for r in results]
+    assert len(set(paths)) == len(paths)
+
+
+def test_hybrid_search_uses_fts_snippet_for_keyword_hits(
+    search_mgr_with_embeddings: SearchManager,
+) -> None:
+    """Bound payload size in hybrid mode."""
+    results = search_mgr_with_embeddings.search(
+        "world",
+        mode="hybrid",
+        chunks_per_doc=2,
+        snippet_words=3,
+        limit=10,
+    )
+    assert all(len(r.content.split()) <= 8 for r in results)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -313,10 +313,13 @@ def test_unicode_content(fixtures_path: Path) -> None:
     # Title comes from frontmatter.
     assert note.title == "ユニコード文書"
 
-    full_content = " ".join(c.content for c in note.chunks)
-    assert "日本語テスト" in full_content
-    assert "Ñoño" in full_content
-    assert "🎉" in full_content
+    # Check heading text is present in chunk headings or body content.
+    all_text = " ".join(
+        " ".join(filter(None, [c.heading, c.content])) for c in note.chunks
+    )
+    assert "日本語テスト" in all_text
+    assert "Ñoño" in all_text
+    assert "🎉" in all_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -313,13 +313,10 @@ def test_unicode_content(fixtures_path: Path) -> None:
     # Title comes from frontmatter.
     assert note.title == "ユニコード文書"
 
-    # Check heading text is present in chunk headings or body content.
-    all_text = " ".join(
-        " ".join(filter(None, [c.heading, c.content])) for c in note.chunks
-    )
-    assert "日本語テスト" in all_text
-    assert "Ñoño" in all_text
-    assert "🎉" in all_text
+    full_content = " ".join(c.content for c in note.chunks)
+    assert "日本語テスト" in full_content
+    assert "Ñoño" in full_content
+    assert "🎉" in full_content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scanner_adaptive_chunking.py
+++ b/tests/test_scanner_adaptive_chunking.py
@@ -17,10 +17,14 @@ def _doc(*sections: tuple[int, str, int]) -> str:
 
 def test_max_chunk_words_none_preserves_h1_h2_only_behavior():
     """max_chunk_words=None keeps today's H1/H2-only splitting."""
-    body = _doc(
-        (1, "Top", 50),
-        (2, "Sub A", 50),
-        (3, "Deep", 800),  # H3, would not split today and must not split.
+    # Use one word per line so the fixture clears the 30-line short-doc bypass.
+    top_body = "\n".join(["lorem"] * 15)
+    sub_a_body = "\n".join(["lorem"] * 15)
+    deep_body = "\n".join(["lorem"] * 800)
+    body = (
+        f"# Top\n{top_body}\n"
+        f"## Sub A\n{sub_a_body}\n"
+        f"### Deep\n{deep_body}\n"  # H3, would not split today and must not split.
     )
     chunker = HeadingChunker(max_chunk_words=None)
     chunks = chunker.chunk(body, {})
@@ -32,11 +36,9 @@ def test_max_chunk_words_none_preserves_h1_h2_only_behavior():
 
 def test_oversize_h1_splits_at_h2():
     """An H1 chunk exceeding max_chunk_words is re-split at H2."""
-    body = _doc(
-        (1, "Top", 0),
-        (2, "Sub A", 300),
-        (2, "Sub B", 300),
-    )
+    # Use one word per line so the fixture clears the 30-line short-doc bypass.
+    sub_body = "\n".join(["lorem"] * 300)
+    body = f"# Top\n## Sub A\n{sub_body}\n## Sub B\n{sub_body}\n"
     chunker = HeadingChunker(max_chunk_words=200)
     chunks = chunker.chunk(body, {})
     assert [c.heading for c in chunks] == ["Sub A", "Sub B"]
@@ -45,16 +47,18 @@ def test_oversize_h1_splits_at_h2():
 
 def test_recursion_descends_to_h6():
     """An H1 chunk with deeply nested oversized sub-headings descends to H6."""
-    body = _doc(
-        (1, "L1", 0),
-        (2, "L2", 0),
-        (3, "L3", 0),
-        (4, "L4", 0),
-        (5, "L5", 0),
-        (6, "L6a", 50),
-        (6, "L6b", 50),
+    # Use a long enough body to clear the 30-line short-doc bypass.
+    long_body = "\n".join(["lorem"] * 50)  # 50 lines per body
+    body = (
+        f"# L1\n{long_body}\n"
+        f"## L2\n{long_body}\n"
+        f"### L3\n{long_body}\n"
+        f"#### L4\n{long_body}\n"
+        f"##### L5\n{long_body}\n"
+        "###### L6a\n" + " ".join(["lorem"] * 50) + "\n"
+        "###### L6b\n" + " ".join(["lorem"] * 50) + "\n"
     )
-    chunker = HeadingChunker(max_chunk_words=80)
+    chunker = HeadingChunker(max_chunk_words=40)
     chunks = chunker.chunk(body, {})
     headings = [c.heading for c in chunks]
     assert "L6a" in headings and "L6b" in headings
@@ -62,8 +66,8 @@ def test_recursion_descends_to_h6():
 
 def test_oversize_chunk_with_no_deeper_headings_stays_one_chunk():
     """A 1000-word H6 with no deeper headings stays as one chunk."""
-    body = "###### Solo\n" + " ".join(["lorem"] * 1000) + "\n"
-    chunker = HeadingChunker(max_chunk_words=200)
+    body = "###### Solo\n" + "\n".join(["lorem"] * 100) + "\n"
+    chunker = HeadingChunker(max_chunk_words=50)
     chunks = chunker.chunk(body, {})
     assert len(chunks) == 1
     assert chunks[0].heading == "Solo"
@@ -95,10 +99,9 @@ def test_short_doc_bypass_still_applies():
 
 def test_heading_level_and_start_line_propagated_through_recursion():
     """Refined sub-chunks carry correct heading_level and start_line."""
-    body = _doc(
-        (1, "Top", 0),
-        (2, "Inner", 300),
-    )
+    # Use one word per line so the fixture clears the 30-line short-doc bypass.
+    inner_body = "\n".join(["lorem"] * 300)
+    body = f"# Top\n## Inner\n{inner_body}\n"
     chunker = HeadingChunker(max_chunk_words=200)
     chunks = chunker.chunk(body, {})
     inner = next(c for c in chunks if c.heading == "Inner")

--- a/tests/test_scanner_adaptive_chunking.py
+++ b/tests/test_scanner_adaptive_chunking.py
@@ -1,0 +1,108 @@
+"""Tests for HeadingChunker's adaptive H-level refinement."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.scanner import HeadingChunker
+
+
+def _doc(*sections: tuple[int, str, int]) -> str:
+    """Build a markdown doc from (level, heading, body_word_count) tuples."""
+    parts: list[str] = []
+    for level, heading, words in sections:
+        parts.append("#" * level + " " + heading)
+        parts.append(" ".join(["lorem"] * words))
+        parts.append("")
+    return "\n".join(parts) + "\n"
+
+
+def test_max_chunk_words_none_preserves_h1_h2_only_behavior():
+    """max_chunk_words=None keeps today's H1/H2-only splitting."""
+    body = _doc(
+        (1, "Top", 50),
+        (2, "Sub A", 50),
+        (3, "Deep", 800),  # H3, would not split today and must not split.
+    )
+    chunker = HeadingChunker(max_chunk_words=None)
+    chunks = chunker.chunk(body, {})
+    # H1 + H2 produce 2 chunks; H3 stays inside the H2 chunk.
+    assert len(chunks) == 2
+    headings = [c.heading for c in chunks]
+    assert headings == ["Top", "Sub A"]
+
+
+def test_oversize_h1_splits_at_h2():
+    """An H1 chunk exceeding max_chunk_words is re-split at H2."""
+    body = _doc(
+        (1, "Top", 0),
+        (2, "Sub A", 300),
+        (2, "Sub B", 300),
+    )
+    chunker = HeadingChunker(max_chunk_words=200)
+    chunks = chunker.chunk(body, {})
+    assert [c.heading for c in chunks] == ["Sub A", "Sub B"]
+    assert all(c.heading_level == 2 for c in chunks)
+
+
+def test_recursion_descends_to_h6():
+    """An H1 chunk with deeply nested oversized sub-headings descends to H6."""
+    body = _doc(
+        (1, "L1", 0),
+        (2, "L2", 0),
+        (3, "L3", 0),
+        (4, "L4", 0),
+        (5, "L5", 0),
+        (6, "L6a", 50),
+        (6, "L6b", 50),
+    )
+    chunker = HeadingChunker(max_chunk_words=80)
+    chunks = chunker.chunk(body, {})
+    headings = [c.heading for c in chunks]
+    assert "L6a" in headings and "L6b" in headings
+
+
+def test_oversize_chunk_with_no_deeper_headings_stays_one_chunk():
+    """A 1000-word H6 with no deeper headings stays as one chunk."""
+    body = "###### Solo\n" + " ".join(["lorem"] * 1000) + "\n"
+    chunker = HeadingChunker(max_chunk_words=200)
+    chunks = chunker.chunk(body, {})
+    assert len(chunks) == 1
+    assert chunks[0].heading == "Solo"
+
+
+def test_preamble_stays_one_chunk_regardless_of_size():
+    """Preamble (no heading) is not refined further."""
+    preamble_words = 1000
+    body = (
+        " ".join(["lorem"] * preamble_words)
+        + "\n\n# Heading\n\n"
+        + " ".join(["ipsum"] * 50)
+        + "\n"
+    )
+    chunker = HeadingChunker(max_chunk_words=200)
+    chunks = chunker.chunk(body, {})
+    # First chunk is the oversize preamble (heading=None), preserved.
+    assert chunks[0].heading is None
+    assert len(chunks[0].content.split()) >= preamble_words
+
+
+def test_short_doc_bypass_still_applies():
+    """Documents <= 30 lines return as one chunk."""
+    body = "# A\nbody\n## B\nmore body\n"
+    chunker = HeadingChunker(max_chunk_words=10)
+    chunks = chunker.chunk(body, {})
+    assert len(chunks) == 1
+
+
+def test_heading_level_and_start_line_propagated_through_recursion():
+    """Refined sub-chunks carry correct heading_level and start_line."""
+    body = _doc(
+        (1, "Top", 0),
+        (2, "Inner", 300),
+    )
+    chunker = HeadingChunker(max_chunk_words=200)
+    chunks = chunker.chunk(body, {})
+    inner = next(c for c in chunks if c.heading == "Inner")
+    assert inner.heading_level == 2
+    # start_line points at the H2 line in the document.
+    body_lines = body.splitlines()
+    assert body_lines[inner.start_line].lstrip().startswith("## Inner")

--- a/tests/test_scanner_adaptive_chunking.py
+++ b/tests/test_scanner_adaptive_chunking.py
@@ -109,3 +109,46 @@ def test_heading_level_and_start_line_propagated_through_recursion():
     # start_line points at the H2 line in the document.
     body_lines = body.splitlines()
     assert body_lines[inner.start_line].lstrip().startswith("## Inner")
+
+
+def test_legacy_mode_h3_only_doc_returns_single_chunk_no_heading():
+    """Legacy mode (max_chunk_words=None) preserves pre-PR behaviour:
+    a doc with only H3 headings returns one chunk with heading=None
+    (rather than being split at H3, which is the adaptive-mode behaviour).
+
+    Body uses 20 lines per section (one word per line) to clear the
+    30-line short-doc bypass, so the test exercises the H1/H2-only
+    heading logic rather than the short-doc fast-path.
+    """
+    body = (
+        "### A\n"
+        + "\n".join(["body"] * 20)
+        + "\n### B\n"
+        + "\n".join(["word"] * 20)
+        + "\n"
+    )
+    chunker = HeadingChunker(max_chunk_words=None)
+    chunks = chunker.chunk(body, {})
+    assert len(chunks) == 1
+    assert chunks[0].heading is None
+
+
+def test_adaptive_mode_h3_only_doc_splits_at_h3():
+    """Adaptive mode descends to H3 when H1/H2 are absent.
+
+    Body uses 20 lines per section (one word per line) to clear the
+    30-line short-doc bypass, which would otherwise return a single chunk
+    before the H3-descent code is reached.
+    """
+    body = (
+        "### A\n"
+        + "\n".join(["body"] * 20)
+        + "\n### B\n"
+        + "\n".join(["word"] * 20)
+        + "\n"
+    )
+    chunker = HeadingChunker(max_chunk_words=400)
+    chunks = chunker.chunk(body, {})
+    assert len(chunks) == 2
+    assert {c.heading for c in chunks} == {"A", "B"}
+    assert all(c.heading_level == 3 for c in chunks)

--- a/tests/test_search_chunks_per_doc_cap.py
+++ b/tests/test_search_chunks_per_doc_cap.py
@@ -1,0 +1,56 @@
+"""Tests for the per-document result cap helper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from markdown_vault_mcp.managers.search import _apply_chunks_per_doc_cap
+
+
+@dataclass
+class _Row:
+    path: str
+    score: float
+
+
+def test_cap_one_keeps_first_per_path():
+    rows = [
+        _Row("a.md", 1.0),
+        _Row("a.md", 0.9),
+        _Row("b.md", 0.8),
+        _Row("a.md", 0.7),
+    ]
+    out = _apply_chunks_per_doc_cap(rows, n=1, limit=10)
+    assert [r.path for r in out] == ["a.md", "b.md"]
+
+
+def test_cap_two_keeps_first_two_per_path():
+    rows = [
+        _Row("a.md", 1.0),
+        _Row("a.md", 0.9),
+        _Row("a.md", 0.8),
+        _Row("b.md", 0.7),
+    ]
+    out = _apply_chunks_per_doc_cap(rows, n=2, limit=10)
+    assert [r.path for r in out] == ["a.md", "a.md", "b.md"]
+
+
+def test_cap_truncates_to_limit():
+    rows = [_Row("a.md", 1.0), _Row("b.md", 0.9), _Row("c.md", 0.8)]
+    out = _apply_chunks_per_doc_cap(rows, n=10, limit=2)
+    assert len(out) == 2
+
+
+def test_cap_preserves_order_of_remaining_results():
+    rows = [
+        _Row("a.md", 1.0),
+        _Row("a.md", 0.9),  # dropped
+        _Row("b.md", 0.8),
+        _Row("c.md", 0.7),
+    ]
+    out = _apply_chunks_per_doc_cap(rows, n=1, limit=10)
+    assert [r.score for r in out] == [1.0, 0.8, 0.7]
+
+
+def test_cap_empty_list_returns_empty():
+    assert _apply_chunks_per_doc_cap([], n=2, limit=10) == []

--- a/tests/test_search_length_downweight.py
+++ b/tests/test_search_length_downweight.py
@@ -1,0 +1,56 @@
+"""Tests for the per-channel length-downweight helper."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from markdown_vault_mcp.managers.search import _apply_length_downweight
+
+
+@dataclass
+class _Row:
+    """Stand-in for either an FTSResult or a vector-search dict."""
+
+    path: str
+    score: float
+    chunk_count: int
+
+
+def test_alpha_zero_is_identity():
+    rows = [_Row("a.md", 1.0, 10), _Row("b.md", 0.5, 1)]
+    out = _apply_length_downweight(rows, alpha=0.0)
+    assert [r.path for r in out] == ["a.md", "b.md"]
+    assert out[0].score == 1.0
+
+
+def test_long_doc_slides_down_with_positive_alpha():
+    """A 10-chunk doc and a 1-chunk doc with equal raw scores: 1-chunk wins."""
+    rows = [_Row("long.md", 1.0, 10), _Row("short.md", 1.0, 1)]
+    out = _apply_length_downweight(rows, alpha=0.25)
+    assert [r.path for r in out] == ["short.md", "long.md"]
+    assert out[1].score == 1.0 / (1 + 0.25 * math.log(10))
+
+
+def test_short_doc_unchanged_for_chunk_count_one():
+    """log(1) = 0, so chunk_count=1 is unaffected by any alpha."""
+    rows = [_Row("only.md", 0.7, 1)]
+    out = _apply_length_downweight(rows, alpha=10.0)
+    assert out[0].score == 0.7
+
+
+def test_higher_alpha_pushes_long_doc_further_down():
+    long10 = _Row("L.md", 2.0, 10)
+    short = _Row("S.md", 1.0, 1)
+    out_low = _apply_length_downweight([long10, short], alpha=0.1)
+    out_high = _apply_length_downweight([long10, short], alpha=2.0)
+    # At low alpha, L.md still ranks first; at high alpha, S.md wins.
+    assert out_low[0].path == "L.md"
+    assert out_high[0].path == "S.md"
+
+
+def test_score_recomputation_does_not_mutate_input():
+    rows = [_Row("a.md", 1.0, 10)]
+    _ = _apply_length_downweight(rows, alpha=0.5)
+    # Original list elements are not mutated in place.
+    assert rows[0].score == 1.0

--- a/tests/test_search_pipeline_integration.py
+++ b/tests/test_search_pipeline_integration.py
@@ -1,0 +1,136 @@
+"""End-to-end integration test for the search ranking pipeline.
+
+Mirrors the diagnostic case described in
+docs/superpowers/specs/2026-04-30-search-ranking-and-snippets-design.md:
+one 12-section essay plus many short atomic notes that all mention the
+query terms. The essay must not occupy more than 2 of the top 10 slots,
+result payloads must be bounded, and other notes must get representation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.collection import Collection
+
+from .conftest import MockEmbeddingProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def diagnostic_vault(tmp_path: Path) -> Path:
+    """Build a vault: one 12-section essay + 20 short atomic notes.
+
+    The essay's body is multi-line per section so the doc clears the
+    30-line short-doc bypass and actually splits into 12+ chunks.
+    """
+    sections: list[str] = []
+    for i in range(12):
+        sections.append(f"## Section {i}")
+        sections.extend(
+            [
+                f"On the etymology of secura: this {i} section "
+                "repeats key terms etymology security care."
+            ]
+            * 30
+        )
+    essay = "# Lexicon Essay\n" + "\n".join(sections) + "\n"
+    (tmp_path / "essay.md").write_text(essay, encoding="utf-8")
+
+    # Twenty short atomic notes — each multi-line so they aren't bypassed.
+    for i in range(20):
+        body = (
+            f"# Note {i}\n"
+            + "\n".join(
+                [
+                    f"etymology and secura — note {i} discusses "
+                    "security and care in brief."
+                ]
+                * 8
+            )
+            + "\n"
+        )
+        (tmp_path / f"note_{i:02d}.md").write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def _make_collection(vault: Path, *, with_embeddings: bool = False) -> Collection:
+    """Create a Collection for the diagnostic vault.
+
+    Args:
+        vault: Path to the vault root.
+        with_embeddings: Whether to configure an embedding provider.
+
+    Returns:
+        A configured Collection instance.
+    """
+    kwargs: dict = {
+        "source_dir": vault,
+        "index_path": None,  # in-memory SQLite
+        "read_only": True,
+    }
+    if with_embeddings:
+        provider = MockEmbeddingProvider()
+        kwargs["embedding_provider"] = provider
+        kwargs["embeddings_path"] = vault / ".embeddings"
+    return Collection(**kwargs)
+
+
+def test_essay_capped_in_top_ten_keyword(diagnostic_vault: Path) -> None:
+    """The essay must not occupy more than 2 of the top 10 keyword slots."""
+    coll = _make_collection(diagnostic_vault)
+    coll.build_index()
+
+    results = coll.search("etymology secura security care", mode="keyword", limit=10)
+    essay_slots = sum(1 for r in results if r.path == "essay.md")
+    assert essay_slots <= 2, f"essay.md occupied {essay_slots} of 10 slots (keyword)"
+    # Other docs get representation.
+    other_paths = {r.path for r in results} - {"essay.md"}
+    assert len(other_paths) >= 5, (
+        f"too few other docs in top 10 (keyword): {other_paths}"
+    )
+
+
+def test_essay_capped_in_top_ten_semantic(diagnostic_vault: Path) -> None:
+    """The essay must not occupy more than 2 of the top 10 semantic slots."""
+    coll = _make_collection(diagnostic_vault, with_embeddings=True)
+    coll.build_index()
+    coll.build_embeddings()
+
+    results = coll.search("etymology secura security care", mode="semantic", limit=10)
+    essay_slots = sum(1 for r in results if r.path == "essay.md")
+    assert essay_slots <= 2, f"essay.md occupied {essay_slots} of 10 slots (semantic)"
+    other_paths = {r.path for r in results} - {"essay.md"}
+    assert len(other_paths) >= 5, (
+        f"too few other docs in top 10 (semantic): {other_paths}"
+    )
+
+
+def test_essay_capped_in_top_ten_hybrid(diagnostic_vault: Path) -> None:
+    """The essay must not occupy more than 2 of the top 10 hybrid slots."""
+    coll = _make_collection(diagnostic_vault, with_embeddings=True)
+    coll.build_index()
+    coll.build_embeddings()
+
+    results = coll.search("etymology secura security care", mode="hybrid", limit=10)
+    essay_slots = sum(1 for r in results if r.path == "essay.md")
+    assert essay_slots <= 2, f"essay.md occupied {essay_slots} of 10 slots (hybrid)"
+    other_paths = {r.path for r in results} - {"essay.md"}
+    assert len(other_paths) >= 5, (
+        f"too few other docs in top 10 (hybrid): {other_paths}"
+    )
+
+
+def test_payloads_bounded_by_default(diagnostic_vault: Path) -> None:
+    """Default snippet_words=200; payloads stay below ~220 words."""
+    coll = _make_collection(diagnostic_vault)
+    coll.build_index()
+    results = coll.search("etymology secura", mode="keyword", limit=10)
+    for r in results:
+        assert len(r.content.split()) <= 220, (
+            f"{r.path}: snippet has {len(r.content.split())} words"
+        )

--- a/tests/test_search_snippets.py
+++ b/tests/test_search_snippets.py
@@ -43,3 +43,16 @@ def test_query_tokenization_is_case_insensitive():
     )
     out = _compute_snippet_for_semantic(content, "NEEDLE", snippet_words=10)
     assert "Needle" in out
+
+
+def test_window_matches_words_with_embedded_punctuation():
+    """Words with apostrophes/hyphens normalise to alphanumeric for matching."""
+    content = (
+        " ".join(["filler"] * 20)
+        + " isn't midway test-driven "
+        + " ".join(["filler"] * 20)
+    )
+    out = _compute_snippet_for_semantic(content, "isnt testdriven", snippet_words=10)
+    # The window should include both punctuation-bearing words.
+    assert "isn't" in out or "test-driven" in out
+    assert len(out.split()) <= 12  # 10 + ellipsis slack

--- a/tests/test_search_snippets.py
+++ b/tests/test_search_snippets.py
@@ -62,3 +62,17 @@ def test_window_matches_words_with_embedded_punctuation():
     out = _compute_snippet_for_semantic(content, "isn't test-driven", snippet_words=10)
     assert "isn't" in out or "test-driven" in out
     assert len(out.split()) <= 11  # 10 words; ellipsis is flush ("…word" = 1 token)
+
+
+def test_window_matches_hyphenated_query_against_split_content():
+    """A hyphenated query like 'se-cura' must match content where the parts
+    appear as standalone words (regression: prior symmetric tokenization
+    over-collapsed the query to {"secura"} only)."""
+    content = (
+        " ".join(["filler"] * 20)
+        + " The cura concept is etymologically central. "
+        + " ".join(["filler"] * 20)
+    )
+    out = _compute_snippet_for_semantic(content, "se-cura", snippet_words=10)
+    assert "cura" in out
+    assert len(out.split()) <= 11  # 10 + flush ellipsis

--- a/tests/test_search_snippets.py
+++ b/tests/test_search_snippets.py
@@ -19,7 +19,11 @@ def test_window_centered_on_densest_query_match():
     )
     out = _compute_snippet_for_semantic(content, "needle", snippet_words=10)
     assert "needle" in out
-    assert len(out.split()) <= 12  # 10 + slack for ellipses
+    # Ellipsis is flush with adjacent word ("…word"), so at most 10 words;
+    # allow 11 as slack for the edge case where the window starts at position 0
+    # (no leading ellipsis) but ends before the last word (trailing ellipsis
+    # glued to the last word, still 10 tokens total).
+    assert len(out.split()) <= 11
 
 
 def test_no_overlap_falls_back_to_first_n_words():
@@ -27,8 +31,9 @@ def test_no_overlap_falls_back_to_first_n_words():
     out = _compute_snippet_for_semantic(
         content, "completely-unrelated-token", snippet_words=10
     )
+    # The trailing ellipsis is flush: "word9…" — still 10 tokens from split().
     assert out.split()[0] == "word0"
-    assert len(out.split()) <= 12
+    assert len(out.split()) <= 11
 
 
 def test_short_chunk_returned_intact():
@@ -56,4 +61,4 @@ def test_window_matches_words_with_embedded_punctuation():
     # that also have punctuation.
     out = _compute_snippet_for_semantic(content, "isn't test-driven", snippet_words=10)
     assert "isn't" in out or "test-driven" in out
-    assert len(out.split()) <= 12  # 10 + ellipsis slack
+    assert len(out.split()) <= 11  # 10 words; ellipsis is flush ("…word" = 1 token)

--- a/tests/test_search_snippets.py
+++ b/tests/test_search_snippets.py
@@ -1,0 +1,45 @@
+"""Tests for snippet generation in SearchManager."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.managers.search import _compute_snippet_for_semantic
+
+
+def test_snippet_words_zero_returns_full_content():
+    content = " ".join(f"word{i}" for i in range(50))
+    assert (
+        _compute_snippet_for_semantic(content, "anything", snippet_words=0) == content
+    )
+
+
+def test_window_centered_on_densest_query_match():
+    """Slide a 10-word window; pick the one with most query tokens."""
+    content = (
+        " ".join(["filler"] * 20) + " needle midway needle " + " ".join(["filler"] * 20)
+    )
+    out = _compute_snippet_for_semantic(content, "needle", snippet_words=10)
+    assert "needle" in out
+    assert len(out.split()) <= 12  # 10 + slack for ellipses
+
+
+def test_no_overlap_falls_back_to_first_n_words():
+    content = " ".join(f"word{i}" for i in range(50))
+    out = _compute_snippet_for_semantic(
+        content, "completely-unrelated-token", snippet_words=10
+    )
+    assert out.split()[0] == "word0"
+    assert len(out.split()) <= 12
+
+
+def test_short_chunk_returned_intact():
+    content = "five word chunk only here"
+    out = _compute_snippet_for_semantic(content, "chunk", snippet_words=200)
+    assert out == content
+
+
+def test_query_tokenization_is_case_insensitive():
+    content = (
+        " ".join(["filler"] * 20) + " Needle hit Needle " + " ".join(["filler"] * 20)
+    )
+    out = _compute_snippet_for_semantic(content, "NEEDLE", snippet_words=10)
+    assert "Needle" in out

--- a/tests/test_search_snippets.py
+++ b/tests/test_search_snippets.py
@@ -46,13 +46,14 @@ def test_query_tokenization_is_case_insensitive():
 
 
 def test_window_matches_words_with_embedded_punctuation():
-    """Words with apostrophes/hyphens normalise to alphanumeric for matching."""
+    """Query and content with apostrophes/hyphens normalise symmetrically."""
     content = (
         " ".join(["filler"] * 20)
         + " isn't midway test-driven "
         + " ".join(["filler"] * 20)
     )
-    out = _compute_snippet_for_semantic(content, "isnt testdriven", snippet_words=10)
-    # The window should include both punctuation-bearing words.
+    # User types the literal punctuation form — must match content words
+    # that also have punctuation.
+    out = _compute_snippet_for_semantic(content, "isn't test-driven", snippet_words=10)
     assert "isn't" in out or "test-driven" in out
     assert len(out.split()) <= 12  # 10 + ellipsis slack

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3294,6 +3294,42 @@ async def test_search_tool_accepts_chunks_per_doc_and_snippet_words(
     assert all(len((r["content"] or "").split()) <= 8 for r in results)
 
 
+async def test_read_tool_returns_only_named_section(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The `read` MCP tool accepts section= and returns only that chunk."""
+    # 16 body lines per section: 2 heading + 16 + 2 heading + 16 + 1 = 37 lines
+    # which is above the 30-line short-doc bypass so the doc splits into chunks.
+    body = (
+        "# A\n## One\n"
+        + "\n".join(["first body"] * 16)
+        + "\n## Two\n"
+        + "\n".join(["second body"] * 16)
+        + "\n"
+    )
+    (tmp_path / "a.md").write_text(body, encoding="utf-8")
+
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "true")
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    server = make_server()
+    async with Client(server) as client:
+        whole = await client.call_tool("read", {"path": "a.md"})
+        assert "first body" in whole.data["content"]
+        assert "second body" in whole.data["content"]
+
+        partial = await client.call_tool("read", {"path": "a.md", "section": "One"})
+        assert "first body" in partial.data["content"]
+        assert "second body" not in partial.data["content"]
+
+        with pytest.raises(Exception) as excinfo:
+            await client.call_tool("read", {"path": "a.md", "section": "Nope"})
+        assert "Nope" in str(excinfo.value)
+
+
 class TestGitToolsUntilParam:
     """Tool-level tests for the `until` param on get_history (issue #340)."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3251,6 +3251,49 @@ class TestGetDiffTool:
         assert [c["message"] for c in data] == ["edit v4", "edit v3"]
 
 
+async def test_search_tool_accepts_chunks_per_doc_and_snippet_words(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The `search` MCP tool surfaces chunks_per_doc and snippet_words."""
+    # Multi-line bodies so the docs split (clears the 30-line short-doc bypass).
+    long_body = (
+        "# Top\n"
+        + "\n".join(["world a"] * 12)
+        + "\n## A\n"
+        + "\n".join(["world a"] * 12)
+        + "\n## B\n"
+        + "\n".join(["world b"] * 12)
+        + "\n## C\n"
+        + "\n".join(["world c"] * 12)
+        + "\n"
+    )
+    (tmp_path / "long.md").write_text(long_body, encoding="utf-8")
+    (tmp_path / "short.md").write_text("# S\nworld\n", encoding="utf-8")
+
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "true")
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    server = make_server()
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "search",
+            {
+                "query": "world",
+                "mode": "keyword",
+                "chunks_per_doc": 1,
+                "snippet_words": 5,
+                "limit": 10,
+            },
+        )
+    results = _parse_tool_data(result)
+    paths = [r["path"] for r in results]
+    assert len(set(paths)) == len(paths)
+    assert all(len((r["content"] or "").split()) <= 8 for r in results)
+
+
 class TestGitToolsUntilParam:
     """Tool-level tests for the `until` param on get_history (issue #340)."""
 


### PR DESCRIPTION
Closes #432

## Summary

Implements the four-knob search ranking and snippet truncation system described in `docs/superpowers/specs/2026-04-30-search-ranking-and-snippets-design.md`:

- **Per-doc cap** (`chunks_per_doc`, default 2) — no single document occupies more than N of the top-K result slots.
- **Length downweight** (`length_downweight_alpha`, default 0.25) — `score / (1 + alpha · log(chunk_count))` applied per channel before fusion.
- **Snippet truncation** (`snippet_words`, default 200) — `SearchResult.content` is now a query-relevant snippet by default; `read(path, section=heading)` recovers the full chunk.
- **Adaptive heading-level chunker** (`max_chunk_words`, default 400) — recursively descends H1 → H6 when a chunk exceeds the threshold.

Pipeline order (uniform across keyword/semantic/hybrid):

```
fetch wide candidate pool
  → length downweight per channel
  → fuse (RRF for hybrid only)
  → cap per path on merged sorted list
  → snippet projection (FTS5 native for keyword-side, Python word-window for semantic-only)
```

## What's in this PR

23 commits structured per the implementation plan in `docs/superpowers/plans/2026-04-30-search-ranking-and-snippets.md`:

- 4 config / schema commits (env knobs + validation, chunk_count column + migration, FTS5 snippet projection, Protocol harmonisation)
- 1 chunker commit + 1 revert/correction (adaptive H-level splitting)
- 3 helper commits (length downweight, per-doc cap, semantic word-window snippet)
- 3 pipeline commits (keyword / semantic / hybrid modes)
- 1 read extension (`read(section=)`)
- 1 collection wiring
- 2 MCP tool surface commits (`search` knobs, `read` section)
- 1 end-to-end integration test
- 1 docs commit
- 2 review-fixup commits (local-review primary + second-opinion findings addressed)

## Default-behaviour change

Existing `search` consumers will see shorter `content` (≈ 200-word snippets) after this lands. Pass `snippet_words=0` to recover full-chunk behaviour. Documented in `README.md` and `docs/configuration.md`. Captured in commit messages on `feat(server)` and `docs:` commits.

## Migration

A reindex is required for the adaptive chunker change to take effect (different chunk boundaries → different `sections` rows + different embeddings). The `documents.chunk_count` column is added via `ALTER TABLE ADD COLUMN` (with concurrent-process race tolerance) on the next FTS index open.

## Test plan

- [x] `uv run pytest -x -q` — **1451 tests pass** (was ~1395 pre-PR)
- [x] `uv run mypy src/ tests/` — clean
- [x] `uv run ruff check --fix . && uv run ruff format .` — clean
- [x] Pre-commit hooks pass (ruff, mypy, vendor-SPA, whitespace, gitleaks)
- [x] End-to-end pipeline integration test (`tests/test_search_pipeline_integration.py`) verifies the diagnostic pathology is fixed: essay ≤ 2 of top 10 across all three modes, payloads bounded under ~220 words, other notes get representation
- [x] Local review converged: primary (`pr-review-toolkit:code-reviewer`) + second-opinion (`superpowers:code-reviewer`) both approved after their fix-ups landed
- [ ] CI green
- [ ] `claude-review` LGTM
- [ ] `gemini-code-assist` LGTM (auto-runs on flip-to-ready per repo defaults)
- [ ] Manual smoke: reindex local vault, run diagnostic queries `"se-cura"` and `"se-cura etymology security without care"`, eyeball results
- [ ] Manual smoke: `chunks_per_doc=0` rejected with clear error (actually, value `0` is rejected at config-load; in tool params `None` falls back to default)
- [ ] Manual smoke: `length_downweight_alpha=0` returns long docs to dominant ranking (regression sanity)

## Non-goals (codified in spec, will not creep in later)

- No frontmatter-based ranking — MCP must not require vault-content conventions (no `kind`, `noindex`, `boost`).
- No re-embedding at search time.
- No paragraph-level or fixed-window chunking.
- No new search modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)