### PR TITLE
chore(copier): update to v1.6.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.5.1
+_commit: v1.6.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown collection MCP server with FTS5 + semantic search

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,11 +162,25 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 
 For services that talk to a remote upstream (e.g. paperless, an HTTP API), wire the upstream version inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/markdown_vault_mcp/server.py`. Pass `upstream_version=` (a zero-arg callable returning a dict / str / None) and optionally `upstream_label="<service>"` (default `"upstream"`). The simplest pattern is a module-level upstream client (typically constructed from env vars at import time) whose version method is referenced from the callable — `CurrentContext()` is a FastMCP DI marker that only resolves inside parameter defaults, so it cannot be called directly from a zero-arg provider. The block is preserved across `copier update`.
 
+## File Exchange (`register_file_exchange` + opt-in upload)
+
+`make_server()` calls `register_file_exchange(...)` inside the
+`DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel in
+`src/markdown_vault_mcp/server.py`. The block is preserved across
+`copier update`, so opt-in customisations (`produces=`, `consumer_sink=`,
+or uncommenting the `register_file_exchange_upload(...)` block for the
+inbound direction) survive subsequent template updates. Download direction
+is wired unconditionally; upload direction is opt-in by uncommenting
+the fully commented `register_file_exchange_upload(...)` call and
+fleshing out `_upload_receiver` / `_validate_upload_target`. See
+[`docs/guides/file-exchange.md`](docs/guides/file-exchange.md) for the
+full pattern.
+
 ## Shared Infrastructure
 
 Shared infrastructure (auth providers, middleware stack, logging bootstrap, event store factory, CLI scaffolding, release pipeline, Docker entrypoint, nfpm packaging, mcpb bundle) lives upstream in two places:
 
-- [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, MCP File Exchange (`register_file_exchange`), and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
+- [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, MCP File Exchange (`register_file_exchange` + `register_file_exchange_upload`), and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
 - [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, `.gemini/config.yaml` (gemini-code-assist scope control), and this very section of CLAUDE.md.
 
 Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `README.md`, `CHANGELOG.md`, `LICENSE`, `.env.example`) are written once and require manual reconciliation on template updates — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` and `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels) stays in this repo.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ For reverse proxy (Traefik) and deployment setup, see [`docs/deployment.md`](doc
 
 The server registers a built-in `get_server_info` tool (via `fastmcp_pvl_core.register_server_info_tool`) so operators can confirm the deployed version with a single MCP call. The response carries `server_name`, `server_version`, and `core_version`. Wire upstream version reporting (when applicable) inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/markdown_vault_mcp/server.py`.
 
+### File exchange
+
+The server scaffolds [MCP File Exchange](docs/guides/file-exchange.md)
+wiring — download direction is registered by default (on for HTTP/SSE,
+off for stdio); an upload direction ships fully commented-out for
+opt-in via `register_file_exchange_upload(...)`. See the guide for
+producing / consuming / uploading patterns and the env-var matrix, or
+[`CLAUDE.md`](CLAUDE.md#file-exchange-register_file_exchange--opt-in-upload)
+for the wiring pattern.
+
 ## Configuration
 
 All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` prefix (except embedding provider settings, which use their own conventions).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,26 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `FASTMCP_LOG_LEVEL` | string | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `-v` CLI flag overrides both app and FastMCP loggers to `DEBUG` |
 | `FASTMCP_ENABLE_RICH_LOGGING` | bool | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output |
 
+<<<<<<< before updating
 ## Search Ranking and Snippet Truncation
+=======
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch. Set `false` to opt out entirely. |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_PRODUCE` | `true` | Allow this server to mint `FileRef` objects via `handle.publish(...)`. |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_CONSUME` | `true` | Master toggle for the consumer side. **Only effective when `consumer_sink=` is wired in `server.py`** — without that argument, `fetch_file` is never registered no matter how this var is set. See [the guide](guides/file-exchange.md#consuming-files-consumer_sink). |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_TTL` | `3600` | Lifetime in seconds for download links and exchange-volume records. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch for the upload direction. **Only effective when `register_file_exchange_upload(...)` is uncommented in `server.py`** — without that call, no upload route is mounted regardless of this var. Also requires `MARKDOWN_VAULT_MCP_BASE_URL` to be set so `create_upload_link` can mint usable URLs. See [the guide](guides/file-exchange.md#uploading-files-receiver). |
+| `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` | `10485760` (10 MiB) | Maximum POST body size for the upload route. Bodies exceeding this return HTTP 413. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_TTL` | `300` | Default lifetime in seconds for upload links. Caller-requested TTL is clamped to `MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX`. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX` | `3600` | Operator ceiling for caller-requested upload-link TTL. |
+| `MARKDOWN_VAULT_MCP_BASE_URL` | unset | Public base URL of this server. Required for the `http` transfer method — the `create_download_link` tool and (when upload is wired) the `create_upload_link` tool both build URLs against it. Also referenced by the OIDC guide and the universal-variables list above — set it once and every consumer picks it up. |
+
+Note the upload-direction variables are namespaced under `_UPLOAD_*`,
+not `_FILE_EXCHANGE_UPLOAD_*` — this matches the upstream
+`fastmcp-pvl-core` 2.1.0 contract. The download-direction variables
+keep the historical `_FILE_EXCHANGE_*` namespace.
+>>>>>>> after updating
 
 | Env var | Default | Type | Notes |
 |---|---|---|---|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "fastmcp-pvl-core>=2.0.0,<3",
+    "fastmcp-pvl-core>=2.1.0,<3",
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update
     "python-frontmatter>=1.0",
     "requests>=2.33.0",

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -252,6 +252,7 @@ def make_server(transport: str = "stdio") -> FastMCP:
         ArtifactStore.register_route(mcp, artifact_store)
     # DOMAIN-WIRING-END
 
+<<<<<<< before updating
     # NOTE: pvl-core 2.0's ``register_file_exchange`` registers a
     # spec-compliant ``create_download_link(origin_id, ttl_seconds)``
     # tool that collides with MV's existing ``create_download_link(path,
@@ -264,5 +265,67 @@ def make_server(transport: str = "stdio") -> FastMCP:
 
     if is_read_only:
         mcp.disable(tags={"write"})
+=======
+    # DOMAIN-FILE-EXCHANGE-START — file-exchange wiring (download direction
+    # always; upload direction opt-in by uncommenting). Kept across copier
+    # update so opt-in customisations (consumer_sink=, produces=, upload
+    # receiver) survive subsequent template updates.
+    #
+    # To publish files from a tool body, capture the returned handle
+    # — see docs/guides/file-exchange.md for the module-level singleton
+    # pattern (e.g. ``_file_exchange = register_file_exchange(...)``).
+    register_file_exchange(
+        mcp,
+        namespace="markdown-vault-mcp",
+        env_prefix=_ENV_PREFIX,
+        transport="auto",
+        # produces=("application/octet-stream",),  # uncomment + customise per project
+        # consumer_sink=_my_sink,                  # uncomment if this server consumes file_refs
+    )
+>>>>>>> after updating
+
+    # Optional upload direction — uncomment + flesh out the helpers below
+    # to accept agent-pushed files via POST /<namespace>/uploads/{token}.
+    # The route mounts only when transport is HTTP/SSE AND
+    # MARKDOWN_VAULT_MCP_BASE_URL is set; sync receivers run in a thread.
+    # See docs/guides/file-exchange.md for the full pattern. When
+    # uncommenting, move the two ``from`` imports below to the
+    # module-level import block at the top of this file.
+    #
+    # from typing import Any
+    #
+    # from fastmcp_pvl_core import (
+    #     UploadRecord,
+    #     register_file_exchange_upload,
+    # )
+    #
+    # def _validate_upload_target(target_id: str, extra: dict[str, Any] | None) -> None:
+    #     """Pre-link validator: reject obviously bad target_ids in-band.
+    #
+    #     Runs inside create_upload_link before the token is minted, so an
+    #     LLM gets a clean tool error rather than after a wasted upload
+    #     round-trip.
+    #     """
+    #     # Example: reject anything outside the domain's allowlist.
+    #     # raise ValueError(f"target_id not allowed: {target_id}")
+    #     pass
+    #
+    # def _upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
+    #     """Commit the uploaded bytes. Raise ValueError → 400,
+    #     FileExistsError → 409, anything else → 500 (with traceback
+    #     logged). Return value MUST be a dict — non-dict returns are
+    #     treated as receiver bugs (500 + WARNING log)."""
+    #     # TODO: replace with your storage logic.
+    #     return {"path": record.target_id, "size_bytes": len(body)}
+    #
+    # register_file_exchange_upload(
+    #     mcp,
+    #     namespace="markdown-vault-mcp",
+    #     env_prefix=_ENV_PREFIX,
+    #     transport="auto",
+    #     receiver=_upload_receiver,
+    #     pre_link_validator=_validate_upload_target,
+    # )
+    # DOMAIN-FILE-EXCHANGE-END
 
     return mcp


### PR DESCRIPTION
## Template update: `v1.5.1` → `v1.6.0`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v1.5.1...v1.6.0)

<details><summary>Release notes (v1.6.0)</summary>

- #121 feat(file-exchange): scaffold register_file_exchange_upload + DOMAIN-FILE-EXCHANGE sentinel

</details>

<details><summary>Files changed (6)</summary>

```
 .copier-answers.yml              |  2 +-
 CLAUDE.md                        | 16 +++++++++-
 README.md                        | 10 +++++++
 docs/configuration.md            | 19 ++++++++++++
 pyproject.toml                   |  2 +-
 src/markdown_vault_mcp/server.py | 63 ++++++++++++++++++++++++++++++++++++++++
 6 files changed, 109 insertions(+), 3 deletions(-)
```

</details>

### ⚠️ 3 file(s) with unresolved conflict markers

The `<<<<<<< before updating` markers **are committed to this branch** — resolve them before merging:

- `docs/configuration.md`
- `pyproject.toml`
- `src/markdown_vault_mcp/server.py`

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

---

## Agent analysis

### 🔧 Conflict resolutions

**Auto-committed by claude-code** — VERIFY before merging:

- `pyproject.toml` (commit dcda5e90a26bb71bd2e524cc55420beb5780ee9e): _Accept the template's fastmcp-pvl-core version bump from >=2.0.0,<3 to >=2.1.0,<3 while preserving the downstream's intentional removal of typer>=0.12 — the downstream CLI (cli.py → _cli_impl.py) uses argparse, not typer, so the removal was deliberate._

**Needs review** — conflict markers remain, operator must resolve:

- `docs/configuration.md`: The conflict is inside the downstream-owned DOMAIN-CONFIG-VARS-START/END block. The 'before updating' side contains the '## Search Ranking and Snippet Truncation' heading, which is required by the orphaned search ranking table beginning at line 55 — taking the 'after updating' side alone would leave that table with no section heading. Conversely, taking the 'before updating' side alone omits the four new UPLOAD_* env-var rows introduced in v1.6.0. No single side is sufficient; the correct resolution merges content from both sides (new table rows from 'after' + preserved heading from 'before'), which cannot be expressed as a single-side selection and therefore cannot be auto-resolved.
  Recommended approach: Accept the template's 'after updating' content (the MCP File Exchange + Upload table and Note paragraph), then immediately follow with the downstream's '## Search Ranking and Snippet Truncation' heading from the 'before updating' side. The resulting block would be: the `| Variable | Default | Description |` table header + FILE_EXCHANGE_ENABLED/PRODUCE/CONSUME/TTL rows + the four new UPLOAD_* rows + the updated BASE_URL row + the Note paragraph, then the `## Search Ranking and Snippet Truncation` heading to restore the orphaned table at line 55. Note: BASE_URL will then appear twice (in the Server Identity table at line 28 and in the File Exchange table) — the duplicate in Server Identity can be removed at operator discretion.
- `src/markdown_vault_mcp/server.py`: The 'before updating' side contains two critical downstream elements that must not be lost: (1) a NOTE explaining that register_file_exchange cannot be called because pvl-core 2.0's register_file_exchange registers its own create_download_link(origin_id, ttl_seconds) tool, which silently shadows the project's existing create_download_link(path, ttl_seconds) tool (tracked in issue #431); and (2) the `if is_read_only: mcp.disable(tags={"write"})` call, which is the sole mechanism that hides write tools when READ_ONLY=true — dropping it would silently break read-only mode. The 'after updating' side introduces the DOMAIN-FILE-EXCHANGE-START sentinel (needed for future copier updates to preserve opt-in customisations) but also includes a bare register_file_exchange() call that would re-introduce the known name collision. The correct resolution must accept the sentinel structure while keeping register_file_exchange commented out and restoring the mcp.disable call — this cannot be expressed as taking either side verbatim.
  Recommended approach: Replace the conflict region with: (1) the DOMAIN-FILE-EXCHANGE-START sentinel comment from the 'after updating' side, (2) the downstream's NOTE comment explaining the name collision between pvl-core's register_file_exchange create_download_link tool and the project's own ArtifactStore-based create_download_link tool (or remove it if issue #431 is now resolved), (3) keep register_file_exchange commented out until #431 is resolved, and (4) re-add the downstream's `if is_read_only: mcp.disable(tags={"write"})` call (which was in the 'before' side and must be preserved to hide write tools in read-only mode). The upload scaffold (lines 287-329) and DOMAIN-FILE-EXCHANGE-END are already correctly placed after the conflict region.

### ✨ New features in this update

**Needs your attention** (action-required):

- #121 feat(file-exchange): scaffold register_file_exchange_upload + DOMAIN-FILE-EXCHANGE sentinel — needs opt-in.
  The template wraps the existing register_file_exchange(...) call in a new DOMAIN-FILE-EXCHANGE-START / DOMAIN-FILE-EXCHANGE-END sentinel inside server.py.jinja, and adds a fully-commented register_file_exchange_upload(...) block with stub _upload_receiver / _validate_upload_target functions inside that same sentinel. The sentinel protection ships automatically (template-owned server.py.jinja is not in _skip_if_exists), meaning existing opt-in kwargs already added to register_file_exchange(...) will now survive future copier updates without conflict. The upload capability itself is opt-in: to enable inbound file uploads, uncomment the register_file_exchange_upload(...) block and flesh out the two stub bodies. This also bumps the fastmcp-pvl-core minimum to 2.1.0 (required for register_file_exchange_upload + UploadRecord) — that version bump ships automatically via pyproject.toml.jinja. Accompanying docs changes (docs/guides/file-exchange.md.jinja, docs/configuration.md.jinja, CLAUDE.md.jinja, README.md.jinja) all ship automatically. Action required: review the new DOMAIN-FILE-EXCHANGE sentinel block in your rendered server.py after this copier update lands; if you want upload support, uncomment and implement the receiver. See the File Exchange section in CLAUDE.md and docs/guides/file-exchange.md for the full pattern.

