### PR TITLE
fix(ci): hotfix copier-update.yml — add id-token: write for claude-code-action OIDC

### DIFF
--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -27,6 +27,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Required by anthropics/claude-code-action@v1: setupGitHubToken() mints
+      # a Claude-app GitHub token via OIDC token exchange, which needs
+      # id-token: write at the job level. Without it the agent steps retry
+      # 3x then abort on "Could not fetch an OIDC token".
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Adds `id-token: write` to the `update` job's `permissions:` block in `.github/workflows/copier-update.yml`
- 4-line explanatory comment names the upstream action, function, and failure symptom

## Why

The three `Agent Job *` steps invoke `anthropics/claude-code-action@v1`. The action's `setupGitHubToken()` calls `getOidcToken()` to mint a Claude-app GitHub token via OIDC token exchange. Without `id-token: write` at the job level the OIDC call aborts the action after 3 retries with `Could not fetch an OIDC token`. `continue-on-error: true` swallowed the failure but the PR body's three analysis sections rendered as `⚠️ Agent failed`.

Evidence:
- Run: https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/25634333290
- Resulting PR: #434 (still open with conflict markers + Agent-failed sections)

Closes #446.

## Note: this hotfix temporarily diverges from the template

The same fix is being applied upstream in pvliesdonk/fastmcp-server-template#123. Once that lands and a new template version is released, the next `copier update` will overwrite this workflow file with the (already-fixed) template version, so no rollback or merge handling is needed. The CI workflows are template-managed (not in `_skip_if_exists`), so divergence self-heals automatically.

## Test plan

- [ ] Trigger a manual `Copier Update` run after merge; confirm the agent steps no longer abort on OIDC.
- [ ] Existing PR #434 still shows `Agent failed` sections (because the broken workflow already produced it); requires a fresh run after this hotfix merges to refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)