### PR TITLE
fix(ci): hotfix copier-update.yml — path-scoped Write for Jobs B and C

### DIFF
--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -305,7 +305,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prepare-prompt-b.outputs.prompt }}
           claude_args: |
-            --allowed-tools "Read,Bash(cat:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Write(//tmp/agent-job-b.json),Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Pre-render Job C prompt
         id: prepare-prompt-c
@@ -339,7 +339,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prepare-prompt-c.outputs.prompt }}
           claude_args: |
-            --allowed-tools "Read,Bash(cat:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Write(//tmp/agent-job-c.json),Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

- Adds path-scoped Write — `Write(//tmp/agent-job-{b,c}.json)` — to the `--allowed-tools` allowlist for Agent Jobs B and C in `.github/workflows/copier-update.yml`.
- Job A's allowlist already had bare Write (it edits arbitrary working-tree files during conflict resolution); Jobs B and C had no Write at all, so their attempts to persist output JSON were denied.

## Why

Each Agent Job's prompt requires writing JSON output that the aggregator step then consumes. With Write missing, every write was denied (`permission_denials_count: 18` in run 25635456782) and the resulting PR body's two enrichment sections rendered as "⚠️ Agent failed". Path-scoping (rather than bare Write) preserves the prompt-injection defense — the agents read attacker-controllable inputs (cloned-template CHANGELOG, diff content) and bare Write would let injection redirect output to clobber other paths.

Closes #448.

## Note: hotfix temporarily diverges from the template

The same fix is being applied upstream in pvliesdonk/fastmcp-server-template#123 (which already closes #122 OIDC and #124 Write together). Once that lands and a new template version is released, the next `copier update` will overwrite this workflow file with the (already-fixed) template version, so no rollback or merge handling is needed.

The stale "Jobs B/C: read-only" comment block in this same workflow file is left untouched here on purpose — it's corrected in the upstream template; updating it here would create extra divergence that copier would re-conflict on.

## Test plan

- [ ] Trigger a manual `Copier Update` run after merge; confirm all three agent enrichment sections populate in the resulting PR body (not just Job A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)