### PR TITLE
fix(ci): hotfix copier-update.yml — bare Write for Jobs B/C + revert show_full_output

### DIFF
--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -235,8 +235,12 @@ jobs:
       # Each agent step constrains tool access via `claude_args
       # --allowed-tools` to enforce the spec's per-job tool boundaries
       # (Job A: file read/write + git commit on the working tree; Jobs B/C:
-      # read-only). Without this, a prompt-injection-vulnerable model could
-      # bypass the prose constraints in the prompt body.
+      # read everywhere, plus a bare Write — narrowed to the single output
+      # JSON at /tmp/agent-job-{b,c}.json by prose in each job's prompt).
+      # The path-scoped Write(//tmp/agent-job-b.json) form documented at
+      # code.claude.com/docs/en/permissions empirically doesn't match the
+      # agent's single-slash invocations under the SDK shipped with
+      # claude-code-action@v1, so the prose constraint is what's narrow.
 
       - name: Pre-render Job A prompt
         id: prepare-prompt-a
@@ -304,10 +308,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prepare-prompt-b.outputs.prompt }}
-          # DIAGNOSTIC: remove once issue #451 permission-deny pattern is captured.
-          show_full_output: "true"
           claude_args: |
-            --allowed-tools "Read,Write(//tmp/agent-job-b.json),Bash(cat:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Write,Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Pre-render Job C prompt
         id: prepare-prompt-c
@@ -341,7 +343,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prepare-prompt-c.outputs.prompt }}
           claude_args: |
-            --allowed-tools "Read,Write(//tmp/agent-job-c.json),Bash(cat:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Write,Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

Two-part cleanup superseding #449's path-scoping and reverting #452's diagnostic:

1. **Jobs B and C `--allowed-tools` switch from `Write(//tmp/agent-job-{b,c}.json)` to bare `Write`** (matches Job A's working pattern).
2. **Removes `show_full_output: "true"` and its DIAGNOSTIC comment** (added by #452 to capture verbose Job B output — purpose served).
3. **Updates the lines 235-243 comment block** to mirror the upstream template's corrected text. Identical text on both sides means the next `copier update` will overwrite without conflict.

## Why

#449 added `Write(//tmp/agent-job-{b,c}.json)`, mirroring upstream `pvliesdonk/fastmcp-server-template#123`. The double-slash absolute-path syntax is [documented at code.claude.com/docs/en/permissions](https://code.claude.com/docs/en/permissions) and was verified twice by local reviewers against that doc. Bot reviewers (claude-review) had a soft "double-slash seems suspicious" instinct that I dismissed in a defense-in-writing comment. Bot was right.

The diagnostic run under #452 ([action 25637740422](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/25637740422)) captured:

```
Agent invokes: Write(file_path="/tmp/agent-job-b.json")    ← single slash
SDK denies against rule: Write(//tmp/agent-job-b.json)     ← double slash
Deny message: "Claude requested permissions to write to /tmp/agent-job-b.json,
              but you haven't granted it yet."
```

The path-scoped form documented in the SDK docs simply doesn't match what the agent invokes under the SDK shipping with `claude-code-action@v1`. The defense was illusory.

Bare `Write` matches anything; Job A has used it since this workflow was scaffolded without issues.

## Trade-off

Bare `Write` means Jobs B/C agents have unrestricted file-write within the runner — the same posture Job A has had all along. Narrowing to the single output JSON now lives in prose in each job's prompt body, not mechanically in the allowlist. Blast radius bounded by ephemeral runner + no secrets reachable + the OAuth token isn't on the agent's path.

The new comment block at lines 235-243 documents this explicitly so a future maintainer doesn't "fix" the bare Write back to the broken path-scoped form.

## Mirrors upstream template fix

The same fix is being applied at pvliesdonk/fastmcp-server-template#123 (force-pushed). Once a new template version ships, the next `copier update` will overwrite this workflow file with the (already-fixed) template version — clean no-conflict overwrite because the local comment block matches the template's text exactly.

## Upstream bug to file

The path-scoping discrepancy (docs say `//absolute-path`, SDK actually rejects it) should be reported at `anthropics/claude-code-action` (and possibly `anthropics/claude-code`) so docs or SDK gets reconciled. I'll file that after this hotfix lands.

Closes #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)