### PR TITLE
chore(copier): update to v1.6.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.5.1
+_commit: v1.6.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown collection MCP server with FTS5 + semantic search

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,11 +162,31 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 
 For services that talk to a remote upstream (e.g. paperless, an HTTP API), wire the upstream version inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/markdown_vault_mcp/server.py`. Pass `upstream_version=` (a zero-arg callable returning a dict / str / None) and optionally `upstream_label="<service>"` (default `"upstream"`). The simplest pattern is a module-level upstream client (typically constructed from env vars at import time) whose version method is referenced from the callable — `CurrentContext()` is a FastMCP DI marker that only resolves inside parameter defaults, so it cannot be called directly from a zero-arg provider. The block is preserved across `copier update`.
 
+## File Exchange (`register_file_exchange` + opt-in upload)
+
+`make_server()` reserves a `DOMAIN-FILE-EXCHANGE-START` /
+`DOMAIN-FILE-EXCHANGE-END` sentinel in `src/markdown_vault_mcp/server.py`
+for the `fastmcp-pvl-core` file-exchange helpers. The block is preserved
+across `copier update`, so opt-in customisations (`produces=`,
+`consumer_sink=`, the upload receiver, or — once #431 lands — the
+download-direction `register_file_exchange(...)` call itself) survive
+subsequent template updates.
+
+> **Project-specific override:** unlike the template default, **neither
+> direction is currently wired in markdown-vault-mcp**. The download
+> direction is deferred to #431 because the spec-compliant
+> `create_download_link(origin_id, ttl_seconds)` tool collides on name
+> with MV's existing `create_download_link(path, ttl_seconds)` (registered
+> via `ArtifactStore` in the `DOMAIN-WIRING` block). The upload direction
+> ships fully commented-out and is intended to be uncommented alongside
+> the #431 migration. See [`docs/guides/file-exchange.md`](docs/guides/file-exchange.md)
+> for the wiring pattern.
+
 ## Shared Infrastructure
 
 Shared infrastructure (auth providers, middleware stack, logging bootstrap, event store factory, CLI scaffolding, release pipeline, Docker entrypoint, nfpm packaging, mcpb bundle) lives upstream in two places:
 
-- [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, MCP File Exchange (`register_file_exchange`), and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
+- [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, MCP File Exchange (`register_file_exchange` + `register_file_exchange_upload`), and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
 - [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, `.gemini/config.yaml` (gemini-code-assist scope control), and this very section of CLAUDE.md.
 
 Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `README.md`, `CHANGELOG.md`, `LICENSE`, `.env.example`) are written once and require manual reconciliation on template updates — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` and `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels) stays in this repo.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ For reverse proxy (Traefik) and deployment setup, see [`docs/deployment.md`](doc
 
 The server registers a built-in `get_server_info` tool (via `fastmcp_pvl_core.register_server_info_tool`) so operators can confirm the deployed version with a single MCP call. The response carries `server_name`, `server_version`, and `core_version`. Wire upstream version reporting (when applicable) inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/markdown_vault_mcp/server.py`.
 
+### File exchange
+
+A `DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel
+block in `server.py` reserves space for the
+[MCP File Exchange](docs/guides/file-exchange.md) helpers from
+`fastmcp-pvl-core`. **Neither direction is currently wired in this
+server** — the download-direction `register_file_exchange(...)` call is
+deferred to #431 (name collision with MV's existing
+`create_download_link` tool registered via `ArtifactStore`); the
+upload-direction `register_file_exchange_upload(...)` ships fully
+commented-out and is intended to be uncommented alongside the #431
+migration. See the guide for producing / consuming / uploading
+patterns, or [`CLAUDE.md`](CLAUDE.md#file-exchange-register_file_exchange--opt-in-upload)
+for the wiring pattern.
+
 ## Configuration
 
 All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` prefix (except embedding provider settings, which use their own conventions).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,34 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `FASTMCP_LOG_LEVEL` | string | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `-v` CLI flag overrides both app and FastMCP loggers to `DEBUG` |
 | `FASTMCP_ENABLE_RICH_LOGGING` | bool | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output |
 
+## MCP File Exchange
+
+!!! warning "Not wired in markdown-vault-mcp today"
+    These env vars come from `fastmcp-pvl-core` 2.1.0+'s
+    `register_file_exchange` / `register_file_exchange_upload` helpers.
+    `markdown-vault-mcp` does **not** wire either direction at present
+    (#431) — its existing `create_download_link` tool collides on name
+    with the spec-compliant version, so the helper is intentionally not
+    called in `server.py`.  Setting these vars has no effect until the
+    migration in #431 lands.  Documented here for completeness so the
+    contract is visible.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch for the download direction. |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_PRODUCE` | `true` | Allow this server to mint `FileRef` objects via `handle.publish(...)`. |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_CONSUME` | `true` | Master toggle for the consumer side. Only effective when `consumer_sink=` is wired in `server.py`. |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_TTL` | `3600` | Lifetime in seconds for download links and exchange-volume records. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch for the upload direction. Only effective when `register_file_exchange_upload(...)` is uncommented in `server.py`; also requires `MARKDOWN_VAULT_MCP_BASE_URL`. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` | `10485760` (10 MiB) | Maximum POST body size for the upload route. Bodies exceeding this return HTTP 413. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_TTL` | `300` | Default lifetime in seconds for upload links. Caller-requested TTL is clamped to `MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX`. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX` | `3600` | Operator ceiling for caller-requested upload-link TTL. |
+
+Upload-direction variables are namespaced under `_UPLOAD_*` (not
+`_FILE_EXCHANGE_UPLOAD_*`) per the upstream `fastmcp-pvl-core` 2.1.0
+contract. Download-direction variables keep the historical
+`_FILE_EXCHANGE_*` namespace.
+
 ## Search Ranking and Snippet Truncation
 
 | Env var | Default | Type | Notes |

--- a/docs/guides/file-exchange.md
+++ b/docs/guides/file-exchange.md
@@ -1,0 +1,76 @@
+# MCP File Exchange
+
+`fastmcp-pvl-core` 2.1.0+ ships two helpers for spec-compliant out-of-band
+file transfer between co-deployed MCP servers (and HTTP fallback for
+remote clients):
+
+- `register_file_exchange(...)` — download direction. Mints a
+  spec-compliant `create_download_link(origin_id, ttl_seconds)` tool
+  and a one-time `GET /uploads/{token}` route.
+- `register_file_exchange_upload(...)` — upload direction. Mints a
+  spec-compliant `create_upload_link(target_id, ttl_seconds)` tool and
+  a one-time `POST /uploads/{token}` route.
+
+Both helpers' wiring lives inside the
+`DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel
+block in `src/markdown_vault_mcp/server.py`. The block is preserved
+across `copier update`.
+
+## Status in markdown-vault-mcp
+
+!!! warning "Not wired today"
+    **Neither direction is currently wired in this server.** The
+    download-direction `register_file_exchange(...)` call is deferred
+    to [#431](https://github.com/pvliesdonk/markdown-vault-mcp/issues/431)
+    because the spec-compliant `create_download_link(origin_id,
+    ttl_seconds)` tool name collides with MV's existing
+    `create_download_link(path, ttl_seconds)` tool (registered via
+    `ArtifactStore` in the `DOMAIN-WIRING` block). Wiring both would
+    silently shadow one or the other depending on registration order.
+    The upload-direction `register_file_exchange_upload(...)` ships
+    fully commented-out in `server.py` and is intended to be
+    uncommented alongside the #431 migration.
+
+## Today
+
+For inbound file transfers, the existing tools are:
+
+- **`fetch(url, path)`** — server-side download from an HTTP/HTTPS URL
+  into the vault. Useful when the file is publicly accessible by URL.
+- **`write(path, content_base64)`** — round-trip binary content
+  through the LLM context. Bounded by
+  `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` (default 1 MB); not
+  recommended for files larger than ~100 KB because of base64
+  inflation. Once #431 lands and `register_file_exchange_upload(...)`
+  is uncommented, `create_upload_link(target_id)` will be the right
+  alternative.
+
+For outbound file transfers, the existing tool is:
+
+- **`create_download_link(path, ttl_seconds)`** — mints a one-time
+  `GET /artifacts/{token}` URL backed by `ArtifactStore`. This is the
+  tool that conflicts with the spec-compliant version's name.
+
+## Configuration
+
+The pvl-core helpers' env-var contract is documented in
+[Configuration > MCP File Exchange](../configuration.md#mcp-file-exchange).
+Setting any of those vars currently has no effect because neither
+helper is called.
+
+## When #431 lands
+
+The migration in #431 will:
+
+1. Drop MV's bespoke `create_download_link` tool registration.
+2. Drop the `ArtifactStore` HTTP route in the `DOMAIN-WIRING` block.
+3. Uncomment the `register_file_exchange(...)` call in the
+   `DOMAIN-FILE-EXCHANGE` sentinel block.
+4. Optionally uncomment `register_file_exchange_upload(...)` and
+   flesh out `_upload_receiver` / `_validate_upload_target` for the
+   inbound direction.
+5. Update this guide to remove the warning admonition above and
+   document the wired patterns.
+
+See [#431](https://github.com/pvliesdonk/markdown-vault-mcp/issues/431)
+for status.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ plugins:
           - guides/para.md: PARA workflow (Projects/Areas/Resources/Archive with triage, kickoff, and weekly review prompts)
           - guides/mcp-apps.md: MCP Apps — Context Card, Graph Explorer, Vault Browser, and Note Preview views
           - guides/claude-code-plugin.md: Claude Code plugin — install via /plugin marketplace
+          - guides/file-exchange.md: MCP File Exchange — out-of-band file transfer (status, fetch/write/create_download_link today, #431 migration)
         MCP Interface:
           - tools/index.md: MCP tools with parameters and examples (search, read, write, link graph, MCP Apps)
           - resources.md: MCP resources with URI patterns (config, stats, tags, folders, toc, similar, recent, ui)
@@ -147,6 +148,7 @@ nav:
       - PARA: guides/para.md
       - MCP Apps: guides/mcp-apps.md
       - Claude Code Plugin: guides/claude-code-plugin.md
+      - File Exchange: guides/file-exchange.md
   - MCP Interface:
       - Tools: tools/index.md
       - Resources: resources.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "fastmcp-pvl-core>=2.0.0,<3",
+    "fastmcp-pvl-core>=2.1.0,<3",
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update
     "python-frontmatter>=1.0",
     "requests>=2.33.0",

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -252,13 +252,67 @@ def make_server(transport: str = "stdio") -> FastMCP:
         ArtifactStore.register_route(mcp, artifact_store)
     # DOMAIN-WIRING-END
 
-    # NOTE: pvl-core 2.0's ``register_file_exchange`` registers a
-    # spec-compliant ``create_download_link(origin_id, ttl_seconds)``
-    # tool that collides with MV's existing ``create_download_link(path,
-    # ttl_seconds)`` tool above.  Wiring both silently shadows one or the
-    # other depending on registration order.  Migration tracked in #431;
-    # do NOT add ``register_file_exchange(mcp, ...)`` here without first
-    # resolving the name collision.
+    # DOMAIN-FILE-EXCHANGE-START — file-exchange wiring sentinel.  Kept
+    # across copier update so opt-in customisations (consumer_sink=,
+    # produces=, upload receiver) survive subsequent template updates.
+    #
+    # NEITHER direction is currently wired in markdown-vault-mcp:
+    # - Download: deferred per #431 (name collision; see NOTE below).
+    # - Upload: not yet wired (the commented-out scaffold below is ready
+    #   for the migration in #431 to flesh out alongside the download fix).
+    #
+    # NOTE: pvl-core 2.1's ``register_file_exchange`` registers a
+    # spec-compliant ``create_download_link(origin_id, ttl_seconds)`` tool
+    # that collides with MV's existing ``create_download_link(path,
+    # ttl_seconds)`` tool above (registered via ArtifactStore in the
+    # DOMAIN-WIRING block).  Wiring both silently shadows one or the other
+    # depending on registration order.  Migration tracked in #431; do NOT
+    # add ``register_file_exchange(mcp, ...)`` here without first resolving
+    # the name collision.
+
+    # Optional upload direction — uncomment + flesh out the helpers below
+    # to accept agent-pushed files via POST /<namespace>/uploads/{token}.
+    # The route mounts only when transport is HTTP/SSE AND
+    # MARKDOWN_VAULT_MCP_BASE_URL is set; sync receivers run in a thread.
+    # See docs/guides/file-exchange.md for the full pattern. When
+    # uncommenting, move the two ``from`` imports below to the
+    # module-level import block at the top of this file.
+    #
+    # from typing import Any
+    #
+    # from fastmcp_pvl_core import (
+    #     UploadRecord,
+    #     register_file_exchange_upload,
+    # )
+    #
+    # def _validate_upload_target(target_id: str, extra: dict[str, Any] | None) -> None:
+    #     """Pre-link validator: reject obviously bad target_ids in-band.
+    #
+    #     Runs inside create_upload_link before the token is minted, so an
+    #     LLM gets a clean tool error rather than after a wasted upload
+    #     round-trip.
+    #     """
+    #     # Example: reject anything outside the domain's allowlist.
+    #     # raise ValueError(f"target_id not allowed: {target_id}")
+    #     pass
+    #
+    # def _upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
+    #     """Commit the uploaded bytes. Raise ValueError → 400,
+    #     FileExistsError → 409, anything else → 500 (with traceback
+    #     logged). Return value MUST be a dict — non-dict returns are
+    #     treated as receiver bugs (500 + WARNING log)."""
+    #     # TODO: replace with your storage logic.
+    #     return {"path": record.target_id, "size_bytes": len(body)}
+    #
+    # register_file_exchange_upload(
+    #     mcp,
+    #     namespace="markdown-vault-mcp",
+    #     env_prefix=_ENV_PREFIX,
+    #     transport="auto",
+    #     receiver=_upload_receiver,
+    #     pre_link_validator=_validate_upload_target,
+    # )
+    # DOMAIN-FILE-EXCHANGE-END
 
     # --- Visibility: hide write-tagged components in read-only mode ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -761,15 +761,15 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/ee/1493ad2dafe3defe69823cac0c2b78c6251698b44b72cce131018fa45126/fastmcp_pvl_core-2.0.0.tar.gz", hash = "sha256:2d95c4936311a70c31147c422d376865fb2b84420ea7c2d39a919bf25750e871", size = 276393, upload-time = "2026-05-06T18:15:19.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/4a/161f08dd9ce9feec3ef72687bb4112f377cd7afaa45b81add3e6281b2ff1/fastmcp_pvl_core-2.1.0.tar.gz", hash = "sha256:46bf41e032c15d4533fbd032cb4d9dbadf852f0509973b9e0b23c1cbbe7b49ca", size = 333983, upload-time = "2026-05-10T09:06:02.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/f9/0c00b4dc455b376224a7e5b935db8ca6aff331cb72ee6f070a1e7049602c/fastmcp_pvl_core-2.0.0-py3-none-any.whl", hash = "sha256:048f198a3da3259d46738aafec4e886522abbebe4b4181a33f882d099fc0d4ab", size = 73450, upload-time = "2026-05-06T18:15:18.118Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/2918c68e3423dc7562f0d6df48cd99f23cd322f8a7db9be1292b5e8d4368/fastmcp_pvl_core-2.1.0-py3-none-any.whl", hash = "sha256:d5baf34f6f1cf425d6e4e104fbe8a584d9d97dd2035561bb5a4e9bc85d6ac53f", size = 89834, upload-time = "2026-05-10T09:06:00.755Z" },
 ]
 
 [package.optional-dependencies]
@@ -1261,7 +1261,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.3" },
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "fastmcp-pvl-core", specifier = ">=2.0.0,<3" },
+    { name = "fastmcp-pvl-core", specifier = ">=2.1.0,<3" },
     { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25" },
     { name = "httpx", marker = "extra == 'embeddings-api'", specifier = ">=0.25" },


### PR DESCRIPTION
## Template update: `v1.5.1` → `v1.6.1`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v1.5.1...v1.6.1)

<details><summary>Release notes (v1.6.1)</summary>

- #123 fix(copier-update): OIDC permission + bare Write for Jobs B/C

</details>

<details><summary>Files changed (6)</summary>

```
 .copier-answers.yml              |  2 +-
 CLAUDE.md                        | 16 +++++++++-
 README.md                        | 10 +++++++
 docs/configuration.md            | 19 ++++++++++++
 pyproject.toml                   |  2 +-
 src/markdown_vault_mcp/server.py | 63 ++++++++++++++++++++++++++++++++++++++++
 6 files changed, 109 insertions(+), 3 deletions(-)
```

</details>

### ⚠️ 3 file(s) with unresolved conflict markers

The `<<<<<<< before updating` markers **are committed to this branch** — resolve them before merging:

- `docs/configuration.md`
- `pyproject.toml`
- `src/markdown_vault_mcp/server.py`

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

---

## Agent analysis

### 🔧 Conflict resolutions

**Auto-committed by claude-code** — VERIFY before merging:

- `pyproject.toml` (commit STAGED_NOT_COMMITTED): _Accepted the template's bump of fastmcp-pvl-core from >=2.0.0 to >=2.1.0 (the only template change in this diff); the typer>=0.12 line is excluded because the downstream had intentionally dropped it from the template-owned section and the template-vs-template delta did not add it (it existed at v1.5.1 already). NOTE: git commit was blocked because docs/configuration.md and src/markdown_vault_mcp/server.py remain in UU (unmerged) state; the edit is staged (M pyproject.toml) and will be committed once the remaining conflicts are resolved._

**Needs review** — conflict markers remain, operator must resolve:

- `docs/configuration.md`: The conflict falls entirely inside the <!-- DOMAIN-CONFIG-VARS-START --> / <!-- DOMAIN-CONFIG-VARS-END --> block (L20–L168), which is downstream-owned by contract. The copier 3-way merge injected the template's new upload-direction variable rows at this location because the downstream's configuration.md diverges structurally from the template: the downstream expanded the DOMAIN-CONFIG-VARS block to hold all project configuration rather than keeping the template's MCP File Exchange section above the sentinel. The correct resolution requires (a) taking the downstream side for the conflict marker, and (b) manually placing the new file-exchange upload documentation in the appropriate template-owned section above the sentinel — a two-step operation spanning different parts of the file that cannot be articulated as one unambiguous transformation.
  Recommended approach: Take the downstream (before) side: keep '## Search Ranking and Snippet Truncation' and its table (L55-L62), which is inside the downstream-owned <!-- DOMAIN-CONFIG-VARS-START --> block. The template was trying to inject the new upload-direction variable rows (UPLOAD_ENABLED, UPLOAD_MAX_BYTES, UPLOAD_TTL, UPLOAD_TTL_MAX, the updated BASE_URL row, and the note about the _UPLOAD_* namespace) into what it computed as the ## MCP File Exchange section location, but that landed inside the downstream's sentinel block instead. After resolving this conflict by keeping the before side, manually insert a new '## MCP File Exchange' section into the downstream's configuration.md — above the <!-- DOMAIN-CONFIG-VARS-START --> marker at L20 — containing the upload-direction variable table from the template's v1.6.1 docs/configuration.md.jinja, with env vars resolved to the MARKDOWN_VAULT_MCP_ prefix. Skip the BASE_URL row in that new section since it is already documented in the Server Identity table (L28). If upload is not wired (register_file_exchange_upload is commented out in server.py), that section can be annotated as opt-in only.
- `src/markdown_vault_mcp/server.py`: The before side has two distinct pieces: (1) a NOTE comment explaining that register_file_exchange could not be wired due to a name collision with the downstream's custom create_download_link tool (tracked in issue #431), and (2) 'if is_read_only: mcp.disable(tags={"write"})' which is critical downstream business logic documented in make_server()'s own docstring. The template's after side replaces both with just the DOMAIN-FILE-EXCHANGE-START sentinel and register_file_exchange call — it does not carry the mcp.disable call at all (the template never had it). A correct resolution must (a) accept the template's register_file_exchange wiring (the name collision is presumably resolved in pvl-core 2.1.0), (b) preserve the mcp.disable business logic by relocating it after DOMAIN-FILE-EXCHANGE-END, and (c) add the missing register_file_exchange import to the module-level import block — three coordinated edits across two regions of the file that cannot be safely expressed as a single unambiguous sentence.
  Recommended approach: Take the template's after side (DOMAIN-FILE-EXCHANGE-START + register_file_exchange call), drop the obsolete name-collision NOTE comment, and preserve the downstream's 'if is_read_only: mcp.disable(tags={"write"})' by inserting it after the DOMAIN-FILE-EXCHANGE-END sentinel (L329) and before 'return mcp' (L331). Additionally add 'register_file_exchange' to the fastmcp_pvl_core import block at the top of server.py (it is currently absent — the downstream's import block has ArtifactStore, ServerConfig, build_auth, register_server_info_tool, resolve_auth_mode, and wire_middleware_stack but not register_file_exchange). The resolved make_server() tail should read: DOMAIN-FILE-EXCHANGE-START, register_file_exchange(...), [upload direction commented-out block], DOMAIN-FILE-EXCHANGE-END, blank line, if is_read_only: mcp.disable(tags={'write'}), blank line, return mcp.

### ✨ New features in this update

**Needs your attention** (action-required):

- #121 feat(file-exchange): scaffold register_file_exchange_upload + DOMAIN-FILE-EXCHANGE sentinel — needs opt-in.
  Two related changes ship together. First, the existing `register_file_exchange(...)` call in `server.py.jinja` is now wrapped in a `DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel so opt-in kwargs (`produces=`, `consumer_sink=`) survive future copier updates — this structural change ships automatically via the 3-way merge on `server.py`. Second, a fully-commented `register_file_exchange_upload(...)` block with stub `_upload_receiver` / `_validate_upload_target` is added inside that sentinel; the upload direction stays disabled by default and requires deliberate opt-in (uncomment the block, implement the two stubs, and set `UPLOAD_ENABLED=true`). Documentation for the upload env vars (`UPLOAD_ENABLED`, `UPLOAD_MAX_BYTES`, `UPLOAD_TTL`, `UPLOAD_TTL_MAX`) lands in `docs/configuration.md`, `docs/guides/file-exchange.md`, `README.md`, and `CLAUDE.md` — all template-owned, so they ship automatically. `pyproject.toml` minimum for `fastmcp-pvl-core` is bumped to `2.1.0` (required for `register_file_exchange_upload` + `UploadRecord`). Note: `server.py` shows as a merge conflict (`UU`) in this update — resolve it by accepting the new sentinel structure and preserving any existing domain customisations inside the block.

**Ships through automatically** (informational):

- #123 fix(copier-update): OIDC permission + bare Write for Jobs B/C — applied this run

