### PR TITLE
feat(uploads): adopt register_file_exchange_upload (#443)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,15 +172,27 @@ across `copier update`, so opt-in customisations (`produces=`,
 download-direction `register_file_exchange(...)` call itself) survive
 subsequent template updates.
 
-> **Project-specific override:** unlike the template default, **neither
-> direction is currently wired in markdown-vault-mcp**. The download
-> direction is deferred to #431 because the spec-compliant
-> `create_download_link(origin_id, ttl_seconds)` tool collides on name
-> with MV's existing `create_download_link(path, ttl_seconds)` (registered
-> via `ArtifactStore` in the `DOMAIN-WIRING` block). The upload direction
-> ships fully commented-out and is intended to be uncommented alongside
-> the #431 migration. See [`docs/guides/file-exchange.md`](docs/guides/file-exchange.md)
-> for the wiring pattern.
+> **Project-specific override:** unlike the template default, the two
+> directions are wired asymmetrically.
+>
+> - **Upload direction is wired** as of #443:
+>   `register_file_exchange_upload(...)` is active in
+>   `server.py`, with `_vault_upload_receiver` /
+>   `_validate_upload_target` from `markdown_vault_mcp.uploads` as the
+>   receiver and pre-link validator. The route auto-mounts only when
+>   transport is HTTP/SSE *and* `MARKDOWN_VAULT_MCP_BASE_URL` is set.
+> - **Download direction is still deferred to #431** because the
+>   spec-compliant `create_download_link(origin_id, ttl_seconds)` tool
+>   collides on name with MV's existing
+>   `create_download_link(path, ttl_seconds)` (registered via
+>   `ArtifactStore` in the `DOMAIN-WIRING` block). Do not add
+>   `register_file_exchange(mcp, ...)` to the sentinel block until #431
+>   resolves the collision.
+>
+> See [`docs/guides/file-exchange.md`](docs/guides/file-exchange.md)
+> for the wiring pattern, and the
+> [`create_upload_link` tool entry](docs/tools/index.md) for the
+> agent-facing contract.
 
 ## Shared Infrastructure
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **Attachment support** — read, write, delete, and list non-markdown files (PDFs, images, etc.)
 - **Git integration** — optional auto-commit and push on every write via `GIT_ASKPASS`
 - **OIDC authentication** — optional token-based auth for HTTP deployments (Authelia, Keycloak, etc.)
-- **MCP tools** — 28 LLM-visible tools including search, read, write, edit, delete, rename, git history, and admin operations; plus 6 app-only tools for MCP Apps clients
+- **MCP tools** — 29 LLM-visible tools including search, read, write, edit, delete, rename, git history, file-exchange uploads, and admin operations; plus 6 app-only tools for MCP Apps clients
 - **MCP resources** — 9 resources exposing vault configuration, statistics, tags, folders, document outlines, similar notes, recent notes, and an interactive SPA
 - **MCP prompts** — 6 prompt templates including template-driven note creation
 <!-- DOMAIN-END -->
@@ -170,17 +170,19 @@ The server registers a built-in `get_server_info` tool (via `fastmcp_pvl_core.re
 ### File exchange
 
 A `DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel
-block in `server.py` reserves space for the
+block in `server.py` wires the
 [MCP File Exchange](docs/guides/file-exchange.md) helpers from
-`fastmcp-pvl-core`. **Neither direction is currently wired in this
-server** — the download-direction `register_file_exchange(...)` call is
-deferred to #431 (name collision with MV's existing
-`create_download_link` tool registered via `ArtifactStore`); the
-upload-direction `register_file_exchange_upload(...)` ships fully
-commented-out and is intended to be uncommented alongside the #431
-migration. See the guide for producing / consuming / uploading
-patterns, or [`CLAUDE.md`](CLAUDE.md#file-exchange-register_file_exchange--opt-in-upload)
-for the wiring pattern.
+`fastmcp-pvl-core`. The **upload direction is wired** (#443) — agents
+mint a one-time HTTPS POST URL via `create_upload_link(target_id,
+ttl_seconds)` and push bytes outside the MCP context, with the route
+mounted only on HTTP/SSE transports when `MARKDOWN_VAULT_MCP_BASE_URL`
+is set. The **download direction remains deferred to #431** because
+the spec-compliant `create_download_link(origin_id, ttl_seconds)` tool
+collides on name with MV's existing `create_download_link(path,
+ttl_seconds)` registered via `ArtifactStore`. See the guide for the
+upload-flow walkthrough and the producer / consumer patterns waiting on
+#431, or [`CLAUDE.md`](CLAUDE.md#file-exchange-register_file_exchange--opt-in-upload)
+for the wiring overview.
 
 ## Configuration
 
@@ -389,10 +391,11 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `get_diff` | Return a unified diff of a note between a reference commit/timestamp and HEAD (git-backed vaults only) |
 | `fetch` | Download a file from a URL and save it to the vault as a note or attachment (MCP-to-MCP transfer) |
 | `create_download_link` | Generate a one-time download URL for a vault file — enables MCP-to-MCP file transfer (HTTP/SSE transport only; requires `BASE_URL`) |
+| `create_upload_link` | Mint a one-time HTTPS POST URL for pushing bytes into the vault. Bytes flow over HTTP, not through MCP context — use this for any file >100 KB. HTTP/SSE transport only; requires `MARKDOWN_VAULT_MCP_BASE_URL`. |
 | `browse_vault` | Open the vault explorer SPA in a supporting MCP Apps client |
 | `show_context` | Open the Context Card for a specific note in a supporting MCP Apps client |
 
-Write tools (`write`, `edit`, `delete`, `rename`, `fetch`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`.
+Write tools (`write`, `edit`, `delete`, `rename`, `fetch`, `create_upload_link`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`.
 
 `browse_vault` and `show_context` are LLM-visible in all clients; when called in an MCP Apps-capable client they open the interactive SPA. Six additional internal tools (`vault_context`, `vault_list`, `vault_read`, `vault_search`, `vault_graph_neighborhood`, `vault_graph_hubs`) use `visibility="app"` and are used by the SPA only — they are never visible to the LLM.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,15 +33,20 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 
 ## MCP File Exchange
 
-!!! warning "Not wired in markdown-vault-mcp today"
+!!! info "Upload wired (#443); download deferred to #431"
     These env vars come from `fastmcp-pvl-core` 2.1.0+'s
     `register_file_exchange` / `register_file_exchange_upload` helpers.
-    `markdown-vault-mcp` does **not** wire either direction at present
-    (#431) — its existing `create_download_link` tool collides on name
-    with the spec-compliant version, so the helper is intentionally not
-    called in `server.py`.  Setting these vars has no effect until the
-    migration in #431 lands.  Documented here for completeness so the
-    contract is visible.
+    The **upload direction is wired** in `server.py` as of #443: the
+    `MARKDOWN_VAULT_MCP_UPLOAD_*` variables below take effect today and
+    govern the [`create_upload_link`](tools/index.md#create_upload_link)
+    tool plus the `POST /markdown-vault-mcp/uploads/{token}` route. The **download
+    direction is not wired** — `markdown-vault-mcp` has its own
+    `create_download_link(path, ttl_seconds)` tool whose name collides
+    with the pvl-core spec-compliant version, so
+    `register_file_exchange(...)` remains commented out pending the
+    migration in #431. The `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_*`
+    variables are documented here for completeness; setting them has
+    no effect until #431 lands.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -49,7 +54,7 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_PRODUCE` | `true` | Allow this server to mint `FileRef` objects via `handle.publish(...)`. |
 | `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_CONSUME` | `true` | Master toggle for the consumer side. Only effective when `consumer_sink=` is wired in `server.py`. |
 | `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_TTL` | `3600` | Lifetime in seconds for download links and exchange-volume records. |
-| `MARKDOWN_VAULT_MCP_UPLOAD_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch for the upload direction. Only effective when `register_file_exchange_upload(...)` is uncommented in `server.py`; also requires `MARKDOWN_VAULT_MCP_BASE_URL`. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch for the upload direction (wired since #443). Also requires `MARKDOWN_VAULT_MCP_BASE_URL`. Set to `false` to disable the `create_upload_link` tool and `POST /markdown-vault-mcp/uploads/{token}` route. |
 | `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` | `10485760` (10 MiB) | Maximum POST body size for the upload route. Bodies exceeding this return HTTP 413. |
 | `MARKDOWN_VAULT_MCP_UPLOAD_TTL` | `300` | Default lifetime in seconds for upload links. Caller-requested TTL is clamped to `MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX`. |
 | `MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX` | `3600` | Operator ceiling for caller-requested upload-link TTL. |

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -362,3 +362,61 @@ For full details on views, configuration, and architecture, see the [MCP Apps gu
 ### Firing prompts from Claude.ai's `+` menu
 
 This guide covers Claude Desktop. If you also use Claude.ai with the same server, its prompts can be fired from the compose area's `+` menu once the server is added as a connector. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the prompt scaffolded. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts).
+
+---
+
+## Workflows
+
+### Uploading a local file to the vault
+
+For files larger than ~100 KB, route bytes through the upload endpoint
+instead of base64-encoding through the MCP context. This works only
+when the server runs on HTTP/SSE transport with
+`MARKDOWN_VAULT_MCP_BASE_URL` set — `stdio` deployments (the default
+Claude Desktop configuration) cannot mount the upload route.
+
+**Prerequisites:**
+
+- Server reachable on HTTP or SSE transport (typically `markdown-vault-mcp serve --transport http`).
+- `MARKDOWN_VAULT_MCP_BASE_URL` set to the public URL the agent (and curl) can reach (e.g. `https://mcp.example.com`).
+- `MARKDOWN_VAULT_MCP_READ_ONLY=false` — the tool is tagged `write` and hidden in read-only mode.
+
+**Steps:**
+
+1. Ask Claude to mint an upload link:
+
+    > "Use `create_upload_link` to give me a URL for `screenshot.png`."
+
+2. Claude returns a JSON payload like:
+
+    ```json
+    {
+      "upload_url": "https://mcp.example.com/markdown-vault-mcp/uploads/<token>",
+      "expires_in_seconds": 300,
+      "target_id": "screenshot.png"
+    }
+    ```
+
+3. POST the bytes from your shell within the TTL window:
+
+    ```bash
+    curl -X POST --data-binary @screenshot.png "https://mcp.example.com/markdown-vault-mcp/uploads/<token>"
+    ```
+
+4. The server commits the file to the vault and responds with `{"path": "screenshot.png", "size_bytes": 12345}`. Claude can now `read`, `search`, or `get_context` for it by path.
+
+!!! warning "`target_id` must be a single safe filename"
+    `target_id` is a single path segment per pvl-core's
+    `ExchangeURI.validate_segment` rules — slashes, `..`, leading and
+    trailing whitespace, and control bytes are rejected at link
+    creation time. Pass the bare filename (`"screenshot.png"`), not a
+    folder-prefixed path (`"assets/screenshot.png"`). Move the file
+    after upload with `rename` if you need it under a sub-folder.
+
+!!! tip "When to prefer this over `write(content_base64=...)`"
+    Files larger than ~100 KB blow past the LLM's context budget once
+    base64-encoded. The hard ceiling for `write(content_base64=...)`
+    is `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` (default 1 MiB);
+    `create_upload_link` raises that to
+    `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` (default 10 MiB) and keeps
+    the bytes off the MCP transport entirely.

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -415,8 +415,13 @@ Claude Desktop configuration) cannot mount the upload route.
 
 !!! tip "When to prefer this over `write(content_base64=...)`"
     Files larger than ~100 KB blow past the LLM's context budget once
-    base64-encoded. The hard ceiling for `write(content_base64=...)`
-    is `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` (default 1 MiB);
-    `create_upload_link` raises that to
-    `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` (default 10 MiB) and keeps
-    the bytes off the MCP transport entirely.
+    base64-encoded.  `create_upload_link` keeps the bytes off the MCP
+    transport entirely.  The effective size cap differs by extension:
+
+    - **`.md` uploads** are bounded only by
+      `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` (default 10 MiB).
+    - **Non-`.md` (attachment) uploads** ALSO have to clear the
+      in-Collection `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` cap
+      (default **1 MiB** — same as `write(content_base64=...)`).  Raise
+      that env var to allow larger attachments.  See the
+      `create_upload_link` reference for the full discussion.

--- a/docs/guides/file-exchange.md
+++ b/docs/guides/file-exchange.md
@@ -6,10 +6,10 @@ remote clients):
 
 - `register_file_exchange(...)` — download direction. Mints a
   spec-compliant `create_download_link(origin_id, ttl_seconds)` tool
-  and a one-time `GET /uploads/{token}` route.
+  and a one-time `GET /markdown-vault-mcp/uploads/{token}` route.
 - `register_file_exchange_upload(...)` — upload direction. Mints a
   spec-compliant `create_upload_link(target_id, ttl_seconds)` tool and
-  a one-time `POST /uploads/{token}` route.
+  a one-time `POST /markdown-vault-mcp/uploads/{token}` route.
 
 Both helpers' wiring lives inside the
 `DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel
@@ -18,45 +18,69 @@ across `copier update`.
 
 ## Status in markdown-vault-mcp
 
-!!! warning "Not wired today"
-    **Neither direction is currently wired in this server.** The
-    download-direction `register_file_exchange(...)` call is deferred
-    to [#431](https://github.com/pvliesdonk/markdown-vault-mcp/issues/431)
-    because the spec-compliant `create_download_link(origin_id,
+!!! info "Upload wired, download deferred"
+    **Upload direction is wired** as of
+    [#443](https://github.com/pvliesdonk/markdown-vault-mcp/pull/443) —
+    `register_file_exchange_upload(...)` is active in
+    `src/markdown_vault_mcp/server.py`. The
+    [`create_upload_link`](../tools/index.md#create_upload_link) tool
+    mints a one-time `POST /markdown-vault-mcp/uploads/{token}` URL when the server runs
+    on HTTP or SSE transport with `MARKDOWN_VAULT_MCP_BASE_URL` set;
+    bytes are committed via `Collection.write` (for `.md` filenames) or
+    `Collection.write_attachment` (for binaries).
+
+    **Download direction remains deferred** to
+    [#431](https://github.com/pvliesdonk/markdown-vault-mcp/issues/431).
+    pvl-core's spec-compliant `create_download_link(origin_id,
     ttl_seconds)` tool name collides with MV's existing
-    `create_download_link(path, ttl_seconds)` tool (registered via
+    `create_download_link(path, ttl_seconds)` (registered via
     `ArtifactStore` in the `DOMAIN-WIRING` block). Wiring both would
-    silently shadow one or the other depending on registration order.
-    The upload-direction `register_file_exchange_upload(...)` ships
-    fully commented-out in `server.py` and is intended to be
-    uncommented alongside the #431 migration.
+    silently shadow one or the other depending on registration order,
+    so `register_file_exchange(...)` is intentionally not called in
+    `server.py` until #431 resolves the collision.
 
 ## Today
 
-For inbound file transfers, the existing tools are:
+### Inbound (uploads from agent → vault)
 
-- **`fetch(url, path)`** — server-side download from an HTTP/HTTPS URL
-  into the vault. Useful when the file is publicly accessible by URL.
+The preferred path is the wired upload tool:
+
+- **`create_upload_link(target_id, ttl_seconds)`** — mints a one-time
+  `POST /markdown-vault-mcp/uploads/{token}` URL. The agent (or a local helper) POSTs
+  the raw bytes; the server commits them to the vault via
+  `Collection.write` / `Collection.write_attachment`. Bytes flow over
+  HTTP, not through the MCP context — recommended for any file >100 KB.
+  See the [Claude Desktop workflow](claude-desktop.md#uploading-a-local-file-to-the-vault)
+  for a curl walkthrough and the
+  [tool reference](../tools/index.md#create_upload_link) for the full
+  parameter / error contract. Requires HTTP/SSE transport and
+  `MARKDOWN_VAULT_MCP_BASE_URL`; gated by `MARKDOWN_VAULT_MCP_READ_ONLY=false`.
+
+For deployments that cannot run HTTP/SSE — for example pure stdio
+Claude Desktop setups — two fallbacks remain:
+
+- **`fetch(url, path)`** — server-side download from a publicly
+  reachable HTTP/HTTPS URL into the vault.
 - **`write(path, content_base64)`** — round-trip binary content
   through the LLM context. Bounded by
-  `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` (default 1 MB); not
-  recommended for files larger than ~100 KB because of base64
-  inflation. Once #431 lands and `register_file_exchange_upload(...)`
-  is uncommented, `create_upload_link(target_id)` will be the right
-  alternative.
+  `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` (default 1 MiB); not
+  recommended for files larger than ~100 KB because of base64 inflation.
 
-For outbound file transfers, the existing tool is:
+### Outbound (downloads from vault → agent / peer server)
 
 - **`create_download_link(path, ttl_seconds)`** — mints a one-time
   `GET /artifacts/{token}` URL backed by `ArtifactStore`. This is the
-  tool that conflicts with the spec-compliant version's name.
+  tool that conflicts with the pvl-core spec-compliant version's name;
+  see #431.
 
 ## Configuration
 
 The pvl-core helpers' env-var contract is documented in
 [Configuration > MCP File Exchange](../configuration.md#mcp-file-exchange).
-Setting any of those vars currently has no effect because neither
-helper is called.
+Upload-direction variables (`MARKDOWN_VAULT_MCP_UPLOAD_*`) take effect
+today; download-direction variables
+(`MARKDOWN_VAULT_MCP_FILE_EXCHANGE_*`) remain inert until #431 wires
+`register_file_exchange(...)`.
 
 ## When #431 lands
 
@@ -66,11 +90,8 @@ The migration in #431 will:
 2. Drop the `ArtifactStore` HTTP route in the `DOMAIN-WIRING` block.
 3. Uncomment the `register_file_exchange(...)` call in the
    `DOMAIN-FILE-EXCHANGE` sentinel block.
-4. Optionally uncomment `register_file_exchange_upload(...)` and
-   flesh out `_upload_receiver` / `_validate_upload_target` for the
-   inbound direction.
-5. Update this guide to remove the warning admonition above and
-   document the wired patterns.
+4. Update this guide to retire the "deferred" half of the status
+   admonition and document the wired download patterns.
 
 See [#431](https://github.com/pvliesdonk/markdown-vault-mcp/issues/431)
 for status.

--- a/docs/guides/file-exchange.md
+++ b/docs/guides/file-exchange.md
@@ -6,7 +6,7 @@ remote clients):
 
 - `register_file_exchange(...)` — download direction. Mints a
   spec-compliant `create_download_link(origin_id, ttl_seconds)` tool
-  and a one-time `GET /markdown-vault-mcp/uploads/{token}` route.
+  and a one-time `GET /artifacts/{token}` route.
 - `register_file_exchange_upload(...)` — upload direction. Mints a
   spec-compliant `create_upload_link(target_id, ttl_seconds)` tool and
   a one-time `POST /markdown-vault-mcp/uploads/{token}` route.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -352,10 +352,20 @@ Generate a one-time download URL for a vault file. The link expires after a sing
 
 Mint a one-time HTTPS POST URL for pushing bytes into the vault. The
 agent receives the URL and an expiry hint; the actual file content
-flows over plain HTTP, not through MCP context. Use this for any file
-larger than ~100 KB — base64-encoding through `write(content_base64=...)`
-is bounded by `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` (default 1
-MiB) and inflates payloads ~33% on the wire.
+flows over plain HTTP, not through MCP context, avoiding the ~33% base64
+inflation that `write(content_base64=...)` incurs.
+
+!!! warning "Effective size cap depends on extension"
+    `.md` uploads are bounded only by the network-tier cap
+    (`MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES`, default 10 MiB).  Non-`.md`
+    uploads (attachments) ALSO have to clear the in-Collection
+    `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` cap (default **1 MiB**)
+    when the receiver writes the bytes — the same cap as
+    `write(content_base64=...)`.  Raise
+    `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` to allow larger
+    attachments.  This is tracked as a follow-up in #443's review notes
+    (the cap should arguably be bypassed on the upload path; for now,
+    operator config is the lever).
 
 **Parameters:**
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -398,7 +398,10 @@ creation time; (b) for `.md` filenames, the resolved path stays under
 configured attachment allowlist
 (`MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS`). All three checks raise
 `ValueError` from the tool call so the agent learns about the
-mis-target before wasting a POST.
+mis-target before wasting a POST.  Note: rule (a) is enforced upstream
+by pvl-core's `ExchangeURI.validate_segment` *before* MV's pre-link
+validator runs, so the error message for slash/`..`/whitespace cases
+comes from pvl-core, not MV.
 
 **Errors:**
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -34,6 +34,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`rename`](#rename) | Write | Rename/move a document or attachment |
 | [`fetch`](#fetch) | Write | Download from URL and save to vault |
 | [`create_download_link`](#create_download_link) | Write | Generate a one-time download URL for a vault file |
+| [`create_upload_link`](#create_upload_link) | Write | Mint a one-time HTTPS POST URL for pushing bytes into the vault |
 | [`browse_vault`](#browse_vault) | Apps | Open the vault explorer SPA |
 | [`show_context`](#show_context) | Apps | Open the Context Card for a note |
 
@@ -240,8 +241,8 @@ Create or overwrite a document or attachment.
 
 **Context cost:** the `content` parameter (text) is bounded only by the
 LLM's own output budget.  The `content_base64` parameter (binary) inflates
-by ~33%; for files >100 KB use `create_upload_link()` (when available)
-instead.
+by ~33%; for files >100 KB use [`create_upload_link`](#create_upload_link)
+instead — bytes flow over plain HTTP, not through MCP context.
 
 **Returns:** `{"path": "Journal/note.md", "created": true}`
 
@@ -346,6 +347,71 @@ Generate a one-time download URL for a vault file. The link expires after a sing
 
 !!! note "Requirements"
     Only available with HTTP or SSE transport. Requires `MARKDOWN_VAULT_MCP_BASE_URL` to be set.
+
+### `create_upload_link`
+
+Mint a one-time HTTPS POST URL for pushing bytes into the vault. The
+agent receives the URL and an expiry hint; the actual file content
+flows over plain HTTP, not through MCP context. Use this for any file
+larger than ~100 KB — base64-encoding through `write(content_base64=...)`
+is bounded by `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` (default 1
+MiB) and inflates payloads ~33% on the wire.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `target_id` | string | required | Single safe filename to store the upload as in the vault. Must be one path segment per pvl-core's `ExchangeURI.validate_segment` rules — **no slashes, no `..`, no leading/trailing whitespace, no control bytes**. Use `target_id="screenshot.png"`, not `target_id="assets/screenshot.png"`. Extension determines handling: `.md` → note (UTF-8 decoded), anything else → attachment (raw bytes). |
+| `ttl_seconds` | int | server default (`300`) | Requested link lifetime. Clamped to `[1, MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX]` (default ceiling `3600`). |
+| `max_bytes` | int \| null | server default (`MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES`, default 10 MiB) | Per-link body cap. Pass a smaller value to constrain a specific upload below the operator default; non-positive values fall back to the default. The HTTP route returns `413` when the actual POST body exceeds the cap. |
+| `extra` | dict \| null | `null` | Opaque caller-supplied dict passed verbatim to the receiver. MV's receiver ignores it; useful to record provenance (e.g. `{"source": "claude-desktop"}`) alongside the upload for future receivers. |
+
+**Returns:** `{"upload_url": "https://mcp.example.com/markdown-vault-mcp/uploads/<token>", "expires_in_seconds": 300, "target_id": "screenshot.png"}`
+
+**Usage:**
+
+1. Agent calls `create_upload_link(target_id="screenshot.png")` and receives an `upload_url`.
+2. The agent (or a local helper) POSTs the bytes to the URL:
+
+    ```bash
+    curl -X POST --data-binary @screenshot.png "https://mcp.example.com/markdown-vault-mcp/uploads/<token>"
+    ```
+
+3. The server responds `200 OK` with `{"path": "screenshot.png", "size_bytes": 12345}` once the bytes are committed to the vault.
+4. Subsequent calls (`read`, `search`, `get_context`, etc.) can reference the stored file by `path`.
+
+**Validation:** the pre-link validator enforces (a) `target_id` is a
+single safe filename per pvl-core's segment rules — slashes, `..`,
+leading/trailing whitespace, and control bytes are rejected at link
+creation time; (b) for `.md` filenames, the resolved path stays under
+`source_dir`; (c) for non-`.md` filenames, the extension is in the
+configured attachment allowlist
+(`MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS`). All three checks raise
+`ValueError` from the tool call so the agent learns about the
+mis-target before wasting a POST.
+
+**Errors:**
+
+- `ValueError` at link-creation time — invalid `target_id` (slash, `..`,
+  forbidden segment, disallowed extension, would escape `source_dir`).
+- HTTP `400` on POST — body cannot be read or decoded (e.g. `.md` upload
+  with non-UTF-8 bytes).
+- HTTP `404` on POST — token unknown (already consumed, expired, or
+  wrong server).
+- HTTP `410` on POST — token expired between mint and POST.
+- HTTP `413` on POST — body exceeds `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES`
+  (default 10 MiB).
+- HTTP `415` on POST — unsupported content/encoding combination per the
+  spec.
+- HTTP `500` on POST — receiver raised an unhandled exception.
+
+**Tag:** `write` — hidden when `MARKDOWN_VAULT_MCP_READ_ONLY=true`.
+
+!!! note "Requirements"
+    Only available with HTTP or SSE transport. Requires
+    `MARKDOWN_VAULT_MCP_BASE_URL` to be set so the URL the tool returns
+    is reachable from the caller. The route is auto-mounted by
+    `register_file_exchange_upload(...)` when both conditions are met.
 
 ---
 

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -25,6 +25,47 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_collection_singleton: Collection | None = None
+
+
+def set_collection_singleton(collection: Collection | None) -> None:
+    """Set the module-level :class:`Collection` singleton.
+
+    Called by the lifespan factory on startup with the live Collection,
+    and again on shutdown with ``None`` so a subsequent server in the
+    same process starts from a clean slate.
+
+    Args:
+        collection: The live :class:`Collection`, or ``None`` to clear.
+    """
+    global _collection_singleton
+    _collection_singleton = collection
+
+
+def get_collection_singleton() -> Collection:
+    """Return the module-level :class:`Collection` singleton.
+
+    Used by HTTP route handlers (e.g. the pvl-core file-exchange upload
+    receiver) that run outside FastMCP's ``Depends(get_collection)``
+    injection and therefore cannot resolve the Collection from the
+    lifespan context.
+
+    Returns:
+        The live :class:`Collection` set by the lifespan factory.
+
+    Raises:
+        RuntimeError: If the singleton has not been set yet.
+    """
+    if _collection_singleton is None:
+        msg = (
+            "Collection not initialised — set_collection_singleton was never "
+            "called.  In normal operation the lifespan factory sets it; in "
+            "tests, set explicitly via set_collection_singleton(col)."
+        )
+        raise RuntimeError(msg)
+    return _collection_singleton
+
+
 def make_collection_lifespan(config: CollectionConfig) -> Any:
     """Create a lifespan function that closes over a pre-loaded config.
 
@@ -53,6 +94,7 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
                 type(kwargs["embedding_provider"]).__name__,
             )
         collection = Collection(**kwargs)
+        set_collection_singleton(collection)
 
         # If periodic git pull is enabled, sync before building the initial index so
         # build_index() scans the freshest working tree.
@@ -85,6 +127,10 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         try:
             yield {"collection": collection, "config": config}
         finally:
+            # Clear the singleton before closing so any in-flight HTTP handler
+            # gets a clean RuntimeError instead of touching a Collection
+            # mid-close().
+            set_collection_singleton(None)
             collection.close()
             logger.info("Collection shut down")
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1060,8 +1060,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
                 **Context cost:** base64 encoding inflates by ~33%; even a 1 MB
                 attachment becomes ~1.3 MB of tokens. For files larger than
-                ~100 KB, prefer ``create_upload_link(path)`` (when available)
-                — bytes flow over HTTP POST, not through context.
+                ~100 KB, prefer ``create_upload_link(target_id)`` on HTTP/SSE
+                deployments — bytes flow over HTTP POST, not through context.
             if_match: Optional etag obtained from a previous 'read' call.
                 When provided, the write only proceeds if the file has not
                 been modified since that read (optimistic concurrency).

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -569,10 +569,10 @@ class DocumentManager:
                         f"({size_bytes / 1024 / 1024:.1f} MB), exceeds "
                         f"MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
                         f"({self._max_attachment_size_mb} MB). "
-                        f"Use create_upload_link({path!r}) (when available) "
-                        f"for out-of-band upload, or raise "
-                        f"MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB if you need "
-                        f"to write the bytes through context."
+                        f"This cap applies to all attachment writes "
+                        f"including the create_upload_link receiver path. "
+                        f"Raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
+                        f"to allow larger attachments."
                     )
             created = not abs_path.is_file()
             abs_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -24,6 +24,7 @@ from fastmcp_pvl_core import (
     ArtifactStore,
     ServerConfig,
     build_auth,
+    register_file_exchange_upload,
     register_server_info_tool,
     resolve_auth_mode,
     wire_middleware_stack,
@@ -38,6 +39,10 @@ from fastmcp_pvl_core import (
 from markdown_vault_mcp.config import (
     _ENV_PREFIX,
     load_config,
+)
+from markdown_vault_mcp.uploads import (
+    _validate_upload_target,
+    _vault_upload_receiver,
 )
 
 from ._icons import _SERVER_ICON
@@ -256,10 +261,15 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # across copier update so opt-in customisations (consumer_sink=,
     # produces=, upload receiver) survive subsequent template updates.
     #
-    # NEITHER direction is currently wired in markdown-vault-mcp:
-    # - Download: deferred per #431 (name collision; see NOTE below).
-    # - Upload: not yet wired (the commented-out scaffold below is ready
-    #   for the migration in #431 to flesh out alongside the download fix).
+    # Upload direction IS wired (see register_file_exchange_upload below) —
+    # commits agent-pushed files into the vault via Collection.write /
+    # Collection.write_attachment.  The route mounts only when transport is
+    # HTTP/SSE AND MARKDOWN_VAULT_MCP_BASE_URL is set; sync receivers run in
+    # a thread.  See docs/guides/file-exchange.md for the full pattern and
+    # markdown_vault_mcp.uploads for the receiver / pre-link validator.
+    #
+    # Download direction is NOT wired — deferred per #431 (name collision;
+    # see NOTE below).
     #
     # NOTE: pvl-core 2.1's ``register_file_exchange`` registers a
     # spec-compliant ``create_download_link(origin_id, ttl_seconds)`` tool
@@ -270,48 +280,14 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # add ``register_file_exchange(mcp, ...)`` here without first resolving
     # the name collision.
 
-    # Optional upload direction — uncomment + flesh out the helpers below
-    # to accept agent-pushed files via POST /<namespace>/uploads/{token}.
-    # The route mounts only when transport is HTTP/SSE AND
-    # MARKDOWN_VAULT_MCP_BASE_URL is set; sync receivers run in a thread.
-    # See docs/guides/file-exchange.md for the full pattern. When
-    # uncommenting, move the two ``from`` imports below to the
-    # module-level import block at the top of this file.
-    #
-    # from typing import Any
-    #
-    # from fastmcp_pvl_core import (
-    #     UploadRecord,
-    #     register_file_exchange_upload,
-    # )
-    #
-    # def _validate_upload_target(target_id: str, extra: dict[str, Any] | None) -> None:
-    #     """Pre-link validator: reject obviously bad target_ids in-band.
-    #
-    #     Runs inside create_upload_link before the token is minted, so an
-    #     LLM gets a clean tool error rather than after a wasted upload
-    #     round-trip.
-    #     """
-    #     # Example: reject anything outside the domain's allowlist.
-    #     # raise ValueError(f"target_id not allowed: {target_id}")
-    #     pass
-    #
-    # def _upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
-    #     """Commit the uploaded bytes. Raise ValueError → 400,
-    #     FileExistsError → 409, anything else → 500 (with traceback
-    #     logged). Return value MUST be a dict — non-dict returns are
-    #     treated as receiver bugs (500 + WARNING log)."""
-    #     # TODO: replace with your storage logic.
-    #     return {"path": record.target_id, "size_bytes": len(body)}
-    #
-    # register_file_exchange_upload(
-    #     mcp,
-    #     namespace="markdown-vault-mcp",
-    #     env_prefix=_ENV_PREFIX,
-    #     transport="auto",
-    #     receiver=_upload_receiver,
-    #     pre_link_validator=_validate_upload_target,
-    # )
+    register_file_exchange_upload(
+        mcp,
+        namespace="markdown-vault-mcp",
+        env_prefix=_ENV_PREFIX,
+        transport="auto",
+        receiver=_vault_upload_receiver,
+        pre_link_validator=_validate_upload_target,
+    )
     # DOMAIN-FILE-EXCHANGE-END
 
     # --- Visibility: hide write-tagged components in read-only mode ---

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -280,11 +280,20 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # add ``register_file_exchange(mcp, ...)`` here without first resolving
     # the name collision.
 
+    # We pass ``transport`` explicitly (NOT ``"auto"``) because ``"auto"``
+    # reads env vars (``MARKDOWN_VAULT_MCP_TRANSPORT`` /
+    # ``FASTMCP_TRANSPORT``) that the CLI does not set — leaving ``"auto"``
+    # would silently disable file-exchange-upload in production whenever
+    # the operator runs ``markdown-vault-mcp serve --transport http``
+    # without also exporting one of those env vars.  The CLI knows the
+    # transport from its own ``--transport`` flag and passes it to
+    # ``make_server``, so we have the authoritative value here.
+    fx_transport: str = "http" if transport in ("http", "sse") else "stdio"
     register_file_exchange_upload(
         mcp,
         namespace="markdown-vault-mcp",
         env_prefix=_ENV_PREFIX,
-        transport="auto",
+        transport=fx_transport,  # type: ignore[arg-type]
         receiver=_vault_upload_receiver,
         pre_link_validator=_validate_upload_target,
     )

--- a/src/markdown_vault_mcp/uploads.py
+++ b/src/markdown_vault_mcp/uploads.py
@@ -46,3 +46,40 @@ def _vault_upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
     else:
         collection.write_attachment(record.target_id, body)
     return {"path": record.target_id, "size_bytes": len(body)}
+
+
+def _validate_upload_target(target_id: str, extra: dict[str, Any] | None) -> None:
+    """Reject upload targets that would escape the vault or violate the allowlist.
+
+    Wired as pvl-core's ``register_file_exchange_upload(pre_link_validator=...)``
+    callback so failures surface as ``ValueError`` at ``create_upload_link``
+    call time, in-band to the agent, rather than after a wasted HTTP POST.
+
+    pvl-core's :class:`~fastmcp_pvl_core.ExchangeURI` already enforces that
+    ``target_id`` is a single safe filename (no slashes, no ``..``, no
+    control bytes, no leading/trailing whitespace) before this callback
+    runs.  This function is therefore defense-in-depth for path traversal
+    plus the primary enforcement point for the attachment-extension
+    allowlist.
+
+    Delegates to :meth:`Collection._validate_path` for ``.md`` targets and
+    :meth:`Collection._validate_attachment_path` for everything else, which
+    also re-checks that the resolved path stays under ``source_dir``.
+
+    Args:
+        target_id: The vault-relative filename the agent passed to
+            ``create_upload_link``.
+        extra: Caller-supplied opaque dict from
+            ``create_upload_link(extra=...)``.  Unused — accepted to match
+            pvl-core's ``PreLinkValidator`` callable signature.
+
+    Raises:
+        ValueError: If ``target_id`` would escape the vault or its
+            extension is not in the configured attachment allowlist.
+    """
+    del extra
+    collection = get_collection_singleton()
+    if target_id.endswith(".md"):
+        collection._validate_path(target_id)
+    else:
+        collection._validate_attachment_path(target_id)

--- a/src/markdown_vault_mcp/uploads.py
+++ b/src/markdown_vault_mcp/uploads.py
@@ -1,0 +1,48 @@
+"""MV-side wiring for fastmcp-pvl-core's file-exchange upload helper.
+
+Provides the ``receiver`` callable passed to
+:func:`fastmcp_pvl_core.register_file_exchange_upload` in
+:mod:`markdown_vault_mcp.server`.  The receiver commits uploaded
+bytes to the vault via the existing :class:`~markdown_vault_mcp.collection.Collection`
+write APIs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from markdown_vault_mcp._server_deps import get_collection_singleton
+
+if TYPE_CHECKING:
+    from fastmcp_pvl_core import UploadRecord
+
+
+def _vault_upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
+    """Commit uploaded bytes to the vault.
+
+    Dispatches to :meth:`~markdown_vault_mcp.collection.Collection.write`
+    for ``.md`` filenames or
+    :meth:`~markdown_vault_mcp.collection.Collection.write_attachment`
+    for binaries based on the ``target_id``'s extension.  pvl-core's
+    ``ExchangeURI.validate_segment`` already enforces that ``target_id``
+    is a single safe filename (no slashes, no ``..``, no control bytes),
+    and the MV-side pre-link validator runs additional checks at link
+    creation time, so this function trusts the value.
+
+    Args:
+        record: pvl-core's :class:`~fastmcp_pvl_core.UploadRecord` —
+            ``target_id`` is the vault-relative filename the agent passed
+            to ``create_upload_link``.
+        body: Raw bytes streamed from the POST request, already validated
+            against ``record.max_bytes`` by the HTTP route.
+
+    Returns:
+        Dict serialised as the HTTP 200 response body.  Conventional keys:
+        ``path``, ``size_bytes``.
+    """
+    collection = get_collection_singleton()
+    if record.target_id.endswith(".md"):
+        collection.write(record.target_id, content=body.decode("utf-8"))
+    else:
+        collection.write_attachment(record.target_id, body)
+    return {"path": record.target_id, "size_bytes": len(body)}

--- a/tests/test_server_deps.py
+++ b/tests/test_server_deps.py
@@ -1,0 +1,49 @@
+"""Tests for :mod:`markdown_vault_mcp._server_deps`.
+
+Covers the module-level Collection singleton accessors used by HTTP
+route handlers that run outside FastMCP's ``Depends(get_collection)``
+injection (e.g. the pvl-core file-exchange upload receiver).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp._server_deps import (
+    get_collection_singleton,
+    set_collection_singleton,
+)
+from markdown_vault_mcp.collection import Collection
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestCollectionSingleton:
+    """Module-level Collection accessor mirrors :mod:`artifacts`'s pattern."""
+
+    def test_get_raises_when_unset(self) -> None:
+        """After clearing the singleton, the getter raises RuntimeError."""
+        import markdown_vault_mcp._server_deps as _deps_module
+
+        saved = _deps_module._collection_singleton
+        try:
+            set_collection_singleton(None)
+            with pytest.raises(RuntimeError, match="Collection not initialised"):
+                get_collection_singleton()
+        finally:
+            _deps_module._collection_singleton = saved
+
+    def test_set_then_get_roundtrips(self, tmp_path: Path) -> None:
+        """Setting then getting returns the same Collection instance."""
+        import markdown_vault_mcp._server_deps as _deps_module
+
+        saved = _deps_module._collection_singleton
+        try:
+            col = Collection(source_dir=tmp_path)
+            set_collection_singleton(col)
+            assert get_collection_singleton() is col
+        finally:
+            _deps_module._collection_singleton = saved

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -261,6 +261,38 @@ class TestUploadEndToEnd:
             assert read_data["path"] == "uploaded.md"
             assert read_data["content"] == payload.decode("utf-8")
 
+    async def test_invalid_utf8_md_upload_returns_400(
+        self, _upload_vault: Path
+    ) -> None:
+        """Non-UTF-8 bytes on a ``.md`` upload surface as HTTP 400 to the agent.
+
+        ``_vault_upload_receiver`` calls ``body.decode("utf-8")`` on
+        ``.md`` paths.  Invalid UTF-8 raises ``UnicodeDecodeError``,
+        which is a subclass of ``ValueError``; pvl-core's
+        ``_upload_handler`` maps ``ValueError`` to HTTP 400 with the
+        exception message as body.  This test guards the docs claim at
+        ``docs/tools/index.md`` that decode failures surface as 400 (not
+        500): if pvl-core ever changes the mapping, this test fails and
+        the docs need updating.
+        """
+        server = make_server(transport="http")
+        async with Client(server) as client:
+            mint_result = await client.call_tool(
+                "create_upload_link", {"target_id": "bad.md"}
+            )
+            data = json.loads(mint_result.content[0].text)
+            upload_path = urlsplit(data["upload_url"]).path
+            invalid_utf8 = b"\xff\xfe\xfd not valid utf-8 \xc3\x28"
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=server.http_app()),
+                base_url="http://test.invalid",
+            ) as http:
+                response = await http.post(upload_path, content=invalid_utf8)
+            assert response.status_code == 400, (
+                f"expected 400 for invalid UTF-8 .md upload, "
+                f"got {response.status_code}: {response.text}"
+            )
+
     async def test_create_upload_link_registered_via_make_server_arg(
         self, _upload_vault: Path
     ) -> None:

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -10,16 +10,42 @@ the agent gets ``ValueError`` in-band instead of after a wasted HTTP POST.
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
+import httpx
 import pytest
+from fastmcp import Client
 from fastmcp_pvl_core import UploadRecord
 
 from markdown_vault_mcp import _server_deps, uploads
 from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.server import make_server
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+_CLEAR_VARS = (
+    "MARKDOWN_VAULT_MCP_INDEX_PATH",
+    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
+    "MARKDOWN_VAULT_MCP_STATE_PATH",
+    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
+    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
+    "MARKDOWN_VAULT_MCP_EXCLUDE",
+    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
+    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
+    "MARKDOWN_VAULT_MCP_SERVER_NAME",
+    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
+    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
+    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
+    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
+    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
+    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
+    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
+    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
+)
 
 
 def _make_record(target_id: str) -> UploadRecord:
@@ -141,3 +167,91 @@ class TestValidateUploadTarget:
         finally:
             col.close()
             _server_deps._collection_singleton = saved
+
+
+class TestUploadEndToEnd:
+    """``create_upload_link`` → POST → file in vault → readable via ``read``.
+
+    Catches wiring bugs that the receiver/validator unit tests above
+    cannot — for example, the route not being mounted, the receiver not
+    being supplied to :func:`register_file_exchange_upload`, or the
+    pre-link validator running at the wrong stage.
+
+    Mirrors :class:`tests.test_artifacts.TestCreateServerArtifactRoute`'s
+    end-to-end pattern for the inverse (download) direction.
+    """
+
+    @pytest.fixture
+    def _upload_vault(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Writable vault and upload-enabling env vars for end-to-end tests."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+        # BASE_URL is required by register_file_exchange_upload to mount
+        # the route — without it the helper logs a warning and returns a
+        # disabled handle.
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_BASE_URL", "http://test.invalid")
+        # Transport is read from FASTMCP_TRANSPORT (or
+        # MARKDOWN_VAULT_MCP_TRANSPORT) by pvl-core's _resolve_transport,
+        # not from make_server's argument; the route only mounts when the
+        # resolved transport is HTTP.
+        monkeypatch.setenv("FASTMCP_TRANSPORT", "http")
+        for var in _CLEAR_VARS:
+            monkeypatch.delenv(var, raising=False)
+        return vault
+
+    async def test_md_upload_round_trip(self, _upload_vault: Path) -> None:
+        """Mint URL → POST bytes → file lands in vault → readable via ``read``.
+
+        Uses the FastMCP in-process :class:`Client` to drive the lifespan
+        (which sets the :class:`Collection` singleton the receiver needs)
+        and to call ``create_upload_link`` / ``read``; uses an
+        :class:`httpx.AsyncClient` over :class:`httpx.ASGITransport` to
+        POST against the same FastMCP server's HTTP app.  Both paths
+        share the module-level :class:`UploadStore` singleton captured
+        by the route closure at registration time.
+        """
+        server = make_server(transport="http")
+        async with Client(server) as client:
+            # 1. Mint a one-time upload URL via the MCP tool.  pvl-core's
+            #    ExchangeURI.validate_segment requires target_id to be a
+            #    bare safe filename (no slashes, no ``..``); receivers
+            #    that interpret it as a path build the full path
+            #    themselves from the bare name.
+            mint_result = await client.call_tool(
+                "create_upload_link", {"target_id": "uploaded.md"}
+            )
+            data = json.loads(mint_result.content[0].text)
+            assert data["target_id"] == "uploaded.md"
+            assert data["expires_in_seconds"] > 0
+            assert data["upload_url"].startswith(
+                "http://test.invalid/markdown-vault-mcp/uploads/"
+            )
+
+            # 2. POST raw bytes to the minted URL.  The upload_url is built
+            #    against the configured BASE_URL; strip it down to the path
+            #    component so the in-process ASGI transport handles it.
+            upload_path = urlsplit(data["upload_url"]).path
+            payload = b"# Uploaded\n\nVia HTTP POST.\n"
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=server.http_app()),
+                base_url="http://test.invalid",
+            ) as http:
+                response = await http.post(upload_path, content=payload)
+
+            # 3. Verify the receiver returned the expected JSON shape.
+            assert response.status_code == 200
+            body = response.json()
+            assert body == {"path": "uploaded.md", "size_bytes": len(payload)}
+
+            # 4. Verify the file actually landed in the vault on disk.
+            assert (_upload_vault / "uploaded.md").read_bytes() == payload
+
+            # 5. Verify it is now readable via the ``read`` MCP tool —
+            #    proves the FTS index was updated synchronously by
+            #    Collection.write (not just the filesystem write).
+            read_result = await client.call_tool("read", {"path": "uploaded.md"})
+            read_data = json.loads(read_result.content[0].text)
+            assert read_data["path"] == "uploaded.md"
+            assert read_data["content"] == payload.decode("utf-8")

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -1,0 +1,73 @@
+"""Tests for the MV-side file-exchange upload receiver.
+
+Covers :mod:`markdown_vault_mcp.uploads`, which provides the callable
+passed to pvl-core's ``register_file_exchange_upload(receiver=...)``.
+The receiver dispatches by extension to ``Collection.write`` (for
+``.md`` paths) or ``Collection.write_attachment`` (for binaries).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastmcp_pvl_core import UploadRecord
+
+from markdown_vault_mcp import _server_deps, uploads
+from markdown_vault_mcp.collection import Collection
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_record(target_id: str) -> UploadRecord:
+    """Build an UploadRecord with arbitrary-but-valid runtime guards.
+
+    The receiver only consumes ``target_id`` — ``max_bytes`` and
+    ``expires_at`` are enforced by the HTTP route before dispatch.
+    """
+    return UploadRecord(
+        target_id=target_id,
+        max_bytes=1024 * 1024,
+        extra={},
+        expires_at=1e12,
+    )
+
+
+class TestVaultUploadReceiver:
+    """``_vault_upload_receiver`` dispatches by extension to write or write_attachment."""
+
+    def test_md_path_dispatches_to_write(self, tmp_path: Path) -> None:
+        """A ``.md`` target is decoded as utf-8 and committed via ``Collection.write``."""
+        col = Collection(source_dir=tmp_path, read_only=False)
+        col.build_index()
+        saved = _server_deps._collection_singleton
+        _server_deps.set_collection_singleton(col)
+        try:
+            payload = b"# Note\n\nbody\n"
+            record = _make_record("note.md")
+            result = uploads._vault_upload_receiver(record, payload)
+            assert result == {"path": "note.md", "size_bytes": len(payload)}
+            assert (tmp_path / "note.md").read_text() == "# Note\n\nbody\n"
+        finally:
+            col.close()
+            _server_deps._collection_singleton = saved
+
+    def test_binary_path_dispatches_to_write_attachment(self, tmp_path: Path) -> None:
+        """A non-``.md`` target is committed verbatim via ``Collection.write_attachment``."""
+        col = Collection(
+            source_dir=tmp_path,
+            read_only=False,
+            attachment_extensions=["pdf"],
+        )
+        col.build_index()
+        saved = _server_deps._collection_singleton
+        _server_deps.set_collection_singleton(col)
+        try:
+            payload = b"%PDF-1.4 fake bytes \x00\x01\x02"
+            record = _make_record("doc.pdf")
+            result = uploads._vault_upload_receiver(record, payload)
+            assert result == {"path": "doc.pdf", "size_bytes": len(payload)}
+            assert (tmp_path / "doc.pdf").read_bytes() == payload
+        finally:
+            col.close()
+            _server_deps._collection_singleton = saved

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -1,15 +1,18 @@
 """Tests for the MV-side file-exchange upload receiver.
 
-Covers :mod:`markdown_vault_mcp.uploads`, which provides the callable
-passed to pvl-core's ``register_file_exchange_upload(receiver=...)``.
+Covers :mod:`markdown_vault_mcp.uploads`, which provides the callables
+passed to pvl-core's ``register_file_exchange_upload(receiver=..., pre_link_validator=...)``.
 The receiver dispatches by extension to ``Collection.write`` (for
-``.md`` paths) or ``Collection.write_attachment`` (for binaries).
+``.md`` paths) or ``Collection.write_attachment`` (for binaries).  The
+pre-link validator rejects bad ``target_id``s at link-creation time so
+the agent gets ``ValueError`` in-band instead of after a wasted HTTP POST.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from fastmcp_pvl_core import UploadRecord
 
 from markdown_vault_mcp import _server_deps, uploads
@@ -68,6 +71,73 @@ class TestVaultUploadReceiver:
             result = uploads._vault_upload_receiver(record, payload)
             assert result == {"path": "doc.pdf", "size_bytes": len(payload)}
             assert (tmp_path / "doc.pdf").read_bytes() == payload
+        finally:
+            col.close()
+            _server_deps._collection_singleton = saved
+
+
+class TestValidateUploadTarget:
+    """``_validate_upload_target`` rejects bad paths at link-creation time."""
+
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        """A ``..``-bearing target_id raises ``ValueError`` defensively.
+
+        pvl-core's ``ExchangeURI.validate_segment`` would already block
+        this upstream, but the validator must defend in depth in case the
+        pre-link validator ever runs against an unvalidated source.
+        """
+        col = Collection(source_dir=tmp_path, read_only=False)
+        col.build_index()
+        saved = _server_deps._collection_singleton
+        _server_deps.set_collection_singleton(col)
+        try:
+            with pytest.raises(ValueError):
+                uploads._validate_upload_target("../etc/passwd", None)
+        finally:
+            col.close()
+            _server_deps._collection_singleton = saved
+
+    def test_disallowed_extension_rejected(self, tmp_path: Path) -> None:
+        """An attachment whose extension is not in the allowlist is rejected."""
+        col = Collection(
+            source_dir=tmp_path,
+            read_only=False,
+            attachment_extensions=["pdf"],
+        )
+        col.build_index()
+        saved = _server_deps._collection_singleton
+        _server_deps.set_collection_singleton(col)
+        try:
+            with pytest.raises(ValueError):
+                uploads._validate_upload_target("malware.exe", None)
+        finally:
+            col.close()
+            _server_deps._collection_singleton = saved
+
+    def test_md_path_accepted(self, tmp_path: Path) -> None:
+        """A bare ``.md`` filename passes validation without raising."""
+        col = Collection(source_dir=tmp_path, read_only=False)
+        col.build_index()
+        saved = _server_deps._collection_singleton
+        _server_deps.set_collection_singleton(col)
+        try:
+            uploads._validate_upload_target("note.md", None)
+        finally:
+            col.close()
+            _server_deps._collection_singleton = saved
+
+    def test_allowed_attachment_accepted(self, tmp_path: Path) -> None:
+        """An attachment whose extension is in the allowlist passes validation."""
+        col = Collection(
+            source_dir=tmp_path,
+            read_only=False,
+            attachment_extensions=["pdf"],
+        )
+        col.build_index()
+        saved = _server_deps._collection_singleton
+        _server_deps.set_collection_singleton(col)
+        try:
+            uploads._validate_upload_target("file.pdf", None)
         finally:
             col.close()
             _server_deps._collection_singleton = saved

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -45,6 +45,11 @@ _CLEAR_VARS = (
     "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
     "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
     "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
+    # Pollution from these would let the wiring "work" even if make_server
+    # regressed back to transport="auto".  Cleared so transport-arg tests
+    # exercise the explicit pass-through.
+    "MARKDOWN_VAULT_MCP_TRANSPORT",
+    "FASTMCP_TRANSPORT",
 )
 
 
@@ -192,11 +197,11 @@ class TestUploadEndToEnd:
         # the route — without it the helper logs a warning and returns a
         # disabled handle.
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_BASE_URL", "http://test.invalid")
-        # Transport is read from FASTMCP_TRANSPORT (or
-        # MARKDOWN_VAULT_MCP_TRANSPORT) by pvl-core's _resolve_transport,
-        # not from make_server's argument; the route only mounts when the
-        # resolved transport is HTTP.
-        monkeypatch.setenv("FASTMCP_TRANSPORT", "http")
+        # ``make_server`` derives ``fx_transport`` from its own ``transport``
+        # arg and passes it to ``register_file_exchange_upload`` — no
+        # TRANSPORT env var needed.  ``_CLEAR_VARS`` already strips
+        # ``MARKDOWN_VAULT_MCP_TRANSPORT`` and ``FASTMCP_TRANSPORT`` to
+        # make sure the test exercises the arg-driven path.
         for var in _CLEAR_VARS:
             monkeypatch.delenv(var, raising=False)
         return vault
@@ -255,3 +260,30 @@ class TestUploadEndToEnd:
             read_data = json.loads(read_result.content[0].text)
             assert read_data["path"] == "uploaded.md"
             assert read_data["content"] == payload.decode("utf-8")
+
+    async def test_create_upload_link_registered_via_make_server_arg(
+        self, _upload_vault: Path
+    ) -> None:
+        """``create_upload_link`` is registered when ``make_server`` gets ``transport="http"``.
+
+        Regression test for the ``transport="auto"`` footgun: pvl-core's
+        ``register_file_exchange_upload(transport="auto")`` reads
+        ``MARKDOWN_VAULT_MCP_TRANSPORT`` / ``FASTMCP_TRANSPORT`` env vars
+        — neither of which the CLI sets when the operator runs
+        ``markdown-vault-mcp serve --transport http``.  Leaving ``"auto"``
+        would silently disable upload in production.  ``make_server`` must
+        derive ``fx_transport`` from its own ``transport`` arg and pass it
+        through explicitly.
+
+        ``_upload_vault`` clears both env vars (see ``_CLEAR_VARS``) so
+        this test fails if ``make_server`` ever regresses to passing
+        ``"auto"``.
+        """
+        server = make_server(transport="http")
+        async with Client(server) as client:
+            tools = await client.list_tools()
+            tool_names = {tool.name for tool in tools}
+            assert "create_upload_link" in tool_names, (
+                f"create_upload_link not registered (transport wiring regression?). "
+                f"Registered tools: {sorted(tool_names)}"
+            )


### PR DESCRIPTION
Closes #443.

Adopts `fastmcp-pvl-core` 2.1.0's `register_file_exchange_upload` via the v1.6.1 template scaffold (landed in #455). Gives a local agent a one-time HTTPS POST URL (`create_upload_link`) for pushing files into the vault without round-tripping bytes through MCP context.

## Summary

- **New tool `create_upload_link(target_id, ttl_seconds)`** — mints a one-time `POST /markdown-vault-mcp/uploads/{token}` URL (HTTP/SSE only; requires `MARKDOWN_VAULT_MCP_BASE_URL`). Tagged `write` — hidden in read-only mode.
- **New `_vault_upload_receiver`** in `markdown_vault_mcp.uploads` — extension-dispatched commit: `.md` → `Collection.write` (utf-8 decoded), other → `Collection.write_attachment` (raw bytes).
- **New `_validate_upload_target`** in same module — runs as `pre_link_validator=` so path-traversal attempts and disallowed extensions raise `ValueError` at `create_upload_link` call time, not after a wasted POST.
- **New `get_collection_singleton` accessor** in `_server_deps.py` — the HTTP route handler runs outside FastMCP's `Depends(get_collection)` injection; same pattern as `artifacts.py`'s singleton.
- **End-to-end test**: mint URL → POST bytes via httpx → file lands → readable via `read`.
- **Regression test** for the `transport=\"auto\"` footgun (mirrors image-gen-mcp's pattern: derive `fx_transport` from `make_server`'s arg and pass explicitly, since `\"auto\"` reads env vars the CLI doesn't set).
- **Docs**: `create_upload_link` row in README + full entry in `docs/tools/index.md` with curl example, validation details, and an admonition about the per-extension size cap; new \"Uploading a local file to the vault\" workflow in `docs/guides/claude-desktop.md`; updated `CLAUDE.md`/`README.md`/`docs/configuration.md`/`docs/guides/file-exchange.md` to reflect that upload IS now wired (download still deferred to #431).

## Test plan

- [x] \`uv run pytest -x -q\` — 1485/1485 green (8 new tests in \`test_uploads.py\` + 2 in \`test_server_deps.py\`)
- [x] \`uv run mypy src/ tests/\` clean
- [x] \`uv run pre-commit run --all-files\` clean
- [x] \`diff-cover ... --fail-under=80\` — 100% on patch
- [x] Local review circus (3 rounds, 6 dispatches): both \`pr-review-toolkit:code-reviewer\` and \`pr-review-toolkit:silent-failure-hunter\` APPROVED on \`49adfa8\`
- [x] Regression-test sanity-check: temporarily reverted server.py to confirm the new \`test_create_upload_link_registered_via_make_server_arg\` test FAILS on the old wiring, PASSES on the new
- [ ] CI green
- [ ] Bot reviewers LGTM

## Follow-ups deferred to separate issues

- #458 — Bypass the in-Collection \`MAX_ATTACHMENT_SIZE_MB\` cap for non-\`.md\` uploads. Currently both \`write(content_base64=...)\` and \`create_upload_link\` for attachments are bounded by the same 1-MiB default, defeating the upload path's intent for large binaries.
- #459 — Widen the \`fx_transport\` mapping to include \`\"streamable-http\"\` (or fail loudly on unknown transport values). CLI argparse \`choices\` make this unreachable in production today.