### PR TITLE
feat(git): git_sync MCP tool + GitWriteStrategy.force_pull/force_push (#444)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **Attachment support** — read, write, delete, and list non-markdown files (PDFs, images, etc.)
 - **Git integration** — optional auto-commit and push on every write via `GIT_ASKPASS`
 - **OIDC authentication** — optional token-based auth for HTTP deployments (Authelia, Keycloak, etc.)
-- **MCP tools** — 29 LLM-visible tools including search, read, write, edit, delete, rename, git history, file-exchange uploads, and admin operations; plus 6 app-only tools for MCP Apps clients
+- **MCP tools** — 30 LLM-visible tools including search, read, write, edit, delete, rename, git history, manual git sync, file-exchange uploads, and admin operations; plus 6 app-only tools for MCP Apps clients
 - **MCP resources** — 9 resources exposing vault configuration, statistics, tags, folders, document outlines, similar notes, recent notes, and an interactive SPA
 - **MCP prompts** — 6 prompt templates including template-driven note creation
 <!-- DOMAIN-END -->
@@ -389,13 +389,14 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `get_connection_path` | Find the shortest path between two notes via BFS on the undirected link graph (max 10 hops) |
 | `get_history` | List commits that touched a note or the whole vault (git-backed vaults only) |
 | `get_diff` | Return a unified diff of a note between a reference commit/timestamp and HEAD (git-backed vaults only) |
+| `git_sync` | Force an immediate git pull / push / both, bypassing the periodic loops. Returns structured state (SHAs, commit counts, Syncthing-style conflict file paths if any). Hidden when `MARKDOWN_VAULT_MCP_GIT_REPO_URL` isn't set or `READ_ONLY=true`. |
 | `fetch` | Download a file from a URL and save it to the vault as a note or attachment (MCP-to-MCP transfer) |
 | `create_download_link` | Generate a one-time download URL for a vault file — enables MCP-to-MCP file transfer (HTTP/SSE transport only; requires `BASE_URL`) |
 | `create_upload_link` | Mint a one-time HTTPS POST URL for pushing bytes into the vault. Bytes flow over HTTP, not through MCP context — use this for any file >100 KB. HTTP/SSE transport only; requires `MARKDOWN_VAULT_MCP_BASE_URL`. |
 | `browse_vault` | Open the vault explorer SPA in a supporting MCP Apps client |
 | `show_context` | Open the Context Card for a specific note in a supporting MCP Apps client |
 
-Write tools (`write`, `edit`, `delete`, `rename`, `fetch`, `create_upload_link`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`.
+Write tools (`write`, `edit`, `delete`, `rename`, `fetch`, `create_upload_link`, `git_sync`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`. `git_sync` additionally requires managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` set).
 
 `browse_vault` and `show_context` are LLM-visible in all clients; when called in an MCP Apps-capable client they open the interactive SPA. Six additional internal tools (`vault_context`, `vault_list`, `vault_read`, `vault_search`, `vault_graph_neighborhood`, `vault_graph_hubs`) use `visibility="app"` and are used by the SPA only — they are never visible to the LLM.
 

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -32,6 +32,59 @@ Behavior:
 - Writes are committed and pushed after the configured idle delay.
 - Periodic pull uses fast-forward-only updates.
 
+## Manual sync — `git_sync` tool
+
+The periodic loops are time-based: pull every
+`MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S` seconds (default 600), push
+`MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S` seconds after the last write
+(default 30). For workflows where the LLM needs to confirm "your changes
+are now on the remote" before telling the user to check another device —
+or wants to pull in remote edits *right now* before continuing the
+conversation — call `git_sync` directly:
+
+```
+git_sync(direction="both")
+```
+
+Use `direction="pull"` or `direction="push"` to skip a leg. In
+`direction="both"` mode the push leg only runs when the pull leg
+succeeded; otherwise `push` stays `null` and the LLM should inspect
+`pull.reason` (and `pull.conflict_files`) before retrying.
+
+`dry_run=true` previews what a pull *would* do — useful for "is there
+anything new on origin?" without risking an in-conversation conflict.
+The push leg has no safe local "would this be accepted" probe, so a
+dry-run push always returns `applied=false` with
+`reason="dry_run_unsupported"`.
+
+!!! info "Conflict outcome — Syncthing-style sibling resolution"
+    When the pull would otherwise need an interactive merge, the server
+    follows the [#232](https://github.com/pvliesdonk/markdown-vault-mcp/issues/232)
+    Syncthing-style flow:
+
+    - The pull **succeeds** (`pull.applied=true`,
+      `pull.reason="conflicts_resolved_with_siblings"`).
+    - HEAD advances to the remote tip — the canonical path now reflects
+      the remote (remote wins).
+    - The local versions that conflicted are preserved as
+      `<basename>.conflict-mcp-<timestamp>.md` siblings on the same
+      path; their vault-relative paths are listed in
+      `pull.conflict_files`.
+    - `pull.commits_pulled` is `0` on this path because the rebase
+      replays your local commits *on top of* the remote tip — the
+      counting model only reports linear-history catch-ups.
+
+    The LLM (or a downstream agent) is expected to read the listed
+    sibling(s), reconcile the local content against the remote, and
+    `delete` the sibling once merged.
+
+The full enumeration of `pull.reason` and `push.reason` values lives in
+the [`git_sync` tool reference](../tools/index.md#git_sync).
+
+`git_sync` is hidden when the deployment isn't in managed git mode (no
+`MARKDOWN_VAULT_MCP_GIT_REPO_URL` set) or when
+`MARKDOWN_VAULT_MCP_READ_ONLY=true`.
+
 ## Unmanaged / Commit-Only Mode
 
 Use unmanaged mode when another process controls pull/push, but you still want MCP writes committed locally.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -454,6 +454,11 @@ history before continuing the conversation.
   `direction="push"`. Fields: `applied`, `fast_forward`,
   `commits_pulled`, `from_sha`, `to_sha`; optional `reason`,
   `conflict_files`; `would_apply` (only in `dry_run` mode).
+  `commits_pulled` is reliable on the fast-forward path. On
+  `reason="rebased"` and `reason="conflicts_resolved_with_siblings"` it
+  is `0` even when HEAD advanced — the rebase replays local commits *on
+  top of* the upstream rather than fast-forwarding, so inspect
+  `from_sha != to_sha` to detect the actual change.
 - `push` (dict | null) — payload from the push leg, or `null` when
   `direction="pull"` or when the pull leg failed in
   `direction="both"`. Fields: `applied`, `commits_pushed`,
@@ -528,7 +533,7 @@ Push rejected as non-fast-forward:
     "remote_sha_before": "9999999",
     "remote_sha_after": "9999999",
     "reason": "non_fast_forward",
-    "hint": "Run git_sync(direction='pull') first to integrate remote commits, then retry git_sync(direction='push')."
+    "hint": "Remote has commits the local clone has not seen.  Run git_sync(direction='pull') to reconcile (fast-forward when possible, Syncthing-style siblings on real conflict), then retry git_sync(direction='push')."
   }
 }
 ```

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -35,6 +35,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`fetch`](#fetch) | Write | Download from URL and save to vault |
 | [`create_download_link`](#create_download_link) | Write | Generate a one-time download URL for a vault file |
 | [`create_upload_link`](#create_upload_link) | Write | Mint a one-time HTTPS POST URL for pushing bytes into the vault |
+| [`git_sync`](#git_sync) | Write (git) | Force an immediate git pull / push / both, bypassing the periodic loops |
 | [`browse_vault`](#browse_vault) | Apps | Open the vault explorer SPA |
 | [`show_context`](#show_context) | Apps | Open the Context Card for a note |
 
@@ -425,6 +426,155 @@ comes from pvl-core, not MV.
     `MARKDOWN_VAULT_MCP_BASE_URL` to be set so the URL the tool returns
     is reachable from the caller. The route is auto-mounted by
     `register_file_exchange_upload(...)` when both conditions are met.
+
+---
+
+### `git_sync`
+
+Force an immediate `git pull` / `git push` / both, bypassing the periodic
+pull interval and write-idle push delay. Returns a structured payload
+with the local HEAD SHA, branch, and per-leg results so an LLM agent can
+confirm "your changes are now on the remote" or recover from a divergent
+history before continuing the conversation.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `direction` | `"pull"` \| `"push"` \| `"both"` | `"both"` | Which leg(s) to run. `"both"` runs pull first, then push; if pull fails (`pull.applied=false`) the push leg is skipped and `push` stays `null` so a callable can inspect `pull.reason` before retrying. |
+| `dry_run` | bool | `false` | When `true`, the pull leg runs `git fetch` and reports what *would* happen (`would_apply: bool`, projected `to_sha`) without moving HEAD. The push leg has no safe local probe for "would the remote accept this", so a dry-run push is a no-op that returns `applied=false` with `reason="dry_run_unsupported"`. |
+
+**Returns:** Dict with the following fields:
+
+- `direction` (str) — the requested direction, echoed back.
+- `head_sha` (str) — local HEAD SHA after the operation. Differs from
+  the pre-call HEAD when the pull leg advanced the branch.
+- `branch` (str) — current branch name (or `"HEAD"` on detached HEAD).
+- `pull` (dict | null) — payload from the pull leg, or `null` when
+  `direction="push"`. Fields: `applied`, `fast_forward`,
+  `commits_pulled`, `from_sha`, `to_sha`; optional `reason`,
+  `conflict_files`; `would_apply` (only in `dry_run` mode).
+- `push` (dict | null) — payload from the push leg, or `null` when
+  `direction="pull"` or when the pull leg failed in
+  `direction="both"`. Fields: `applied`, `commits_pushed`,
+  `remote_sha_before`, `remote_sha_after`; optional `reason`, `hint`.
+- `dry_run` (bool) — present only when `dry_run=true` was passed.
+
+**Examples:**
+
+Successful both-direction sync (clean fast-forward + clean push):
+
+```json
+{
+  "direction": "both",
+  "head_sha": "abc1234",
+  "branch": "main",
+  "pull": {
+    "applied": true,
+    "fast_forward": true,
+    "commits_pulled": 3,
+    "from_sha": "9999999",
+    "to_sha": "abc1234"
+  },
+  "push": {
+    "applied": true,
+    "commits_pushed": 5,
+    "remote_sha_before": "8888888",
+    "remote_sha_after": "abc1234"
+  }
+}
+```
+
+Pull with conflict (Syncthing-style sibling resolution per
+[#232](https://github.com/pvliesdonk/markdown-vault-mcp/issues/232)):
+
+```json
+{
+  "direction": "pull",
+  "head_sha": "abc1234",
+  "branch": "main",
+  "pull": {
+    "applied": true,
+    "fast_forward": false,
+    "commits_pulled": 0,
+    "from_sha": "9999999",
+    "to_sha": "abc1234",
+    "reason": "conflicts_resolved_with_siblings",
+    "conflict_files": ["Notes/2026-05-09.conflict-mcp-20260511-114203.md"]
+  },
+  "push": null
+}
+```
+
+The pull *succeeded* (`applied=true`): HEAD now points at the remote tip
+and the local edits that conflicted with the remote were preserved as
+`.conflict-mcp-<timestamp>.md` siblings on the same path. The remote
+version wins on the canonical path; the LLM should read the listed
+sibling(s) and propose how to merge the local content back in.
+`commits_pulled` is `0` on this path because the rebase replays local
+commits *on top of* the remote — the remote commits are reconciled, not
+"pulled forward" in the linear-history sense.
+
+Push rejected as non-fast-forward:
+
+```json
+{
+  "direction": "push",
+  "head_sha": "abc1234",
+  "branch": "main",
+  "push": {
+    "applied": false,
+    "commits_pushed": 0,
+    "remote_sha_before": "9999999",
+    "remote_sha_after": "9999999",
+    "reason": "non_fast_forward",
+    "hint": "Run git_sync(direction='pull') first to integrate remote commits, then retry git_sync(direction='push')."
+  }
+}
+```
+
+**`pull.reason` values** (set on every non-fast-forward outcome and on
+failures; `null` for clean fast-forwards and dry-runs):
+
+| Reason | Meaning | `applied` |
+|--------|---------|-----------|
+| `"fetch_failed"` | `git fetch origin` exited non-zero (network / auth / proxy). HEAD did not move. | `false` |
+| `"no_remote"` | Neither `@{upstream}` nor `origin/HEAD` could be resolved on the local clone. | `false` |
+| `"rebased"` | Local and remote diverged but `git rebase @{upstream}` replayed local commits cleanly. `conflict_files` empty. | `true` |
+| `"conflicts_resolved_with_siblings"` | Rebase hit real conflicts; resolved by accepting upstream and writing local versions as `.conflict-mcp-*` siblings (#232). `conflict_files` populated. | `true` |
+| `"conflict_resolution_failed"` | The conflict-resolution loop could not produce a recoverable working tree; rebase was aborted. HEAD did not move. | `false` |
+| `"non_fast_forward_with_conflicts"` | Rare catastrophic fallback when even the conflict-resolution path could not stabilise the working tree. HEAD did not move. | `false` |
+
+**`push.reason` values** (`null` on success including the
+already-up-to-date no-op):
+
+| Reason | Meaning | `applied` |
+|--------|---------|-----------|
+| `"dry_run_unsupported"` | Caller passed `dry_run=true`. Git has no safe local probe for "would the remote accept this", so the push leg is a deliberate no-op. | `false` |
+| `"no_remote"` | Upstream tracking branch could not be resolved (no `@{upstream}` and no `origin/HEAD`). Push not attempted. | `false` |
+| `"non_fast_forward"` | Remote rejected the push because the local branch is not a strict descendant of the remote tip. `hint` points at `git_sync(direction='pull')` to reconcile first. | `false` |
+| `"push_failed"` | `git push origin` exited non-zero for any other reason (network, auth, server-side hook). `hint` carries the truncated stderr. | `false` |
+
+**Context cost:** small — structured dict only, no file bytes.
+
+**Tag:** `{write, git-managed}`. Hidden when
+`MARKDOWN_VAULT_MCP_READ_ONLY=true` or when the deployment is not in
+managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` not set).
+
+**Errors:**
+
+- `ValueError` — raised at call time when the underlying strategy is
+  not a managed `GitWriteStrategy` (i.e. `MARKDOWN_VAULT_MCP_GIT_REPO_URL`
+  is unset). The visibility tag normally hides the tool in that case;
+  this error guards the path where a client invokes the tool by name
+  despite it not being advertised.
+
+!!! note "Requirements"
+    Only available in managed git mode. Set
+    `MARKDOWN_VAULT_MCP_GIT_REPO_URL` and a working
+    `MARKDOWN_VAULT_MCP_GIT_TOKEN` (with the
+    `MARKDOWN_VAULT_MCP_GIT_USERNAME` appropriate for your provider —
+    see the [Git Integration guide](../guides/git-integration.md#provider-username-reference)).
 
 ---
 

--- a/src/markdown_vault_mcp/_icons.py
+++ b/src/markdown_vault_mcp/_icons.py
@@ -59,6 +59,7 @@ _TOOL_ICONS: dict[str, list[Icon]] = {
         "create_download_link",
         "get_history",
         "get_diff",
+        "git_sync",
         "vault_graph_neighborhood",
         "vault_graph_hubs",
     ]

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -12,7 +12,7 @@ import ipaddress
 import logging
 import subprocess
 from dataclasses import asdict
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse, urlunparse
 
 from fastmcp import FastMCP
@@ -21,7 +21,10 @@ from fastmcp.exceptions import ToolError
 
 from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.exceptions import EditConflictError
-from markdown_vault_mcp.git import GitWriteStrategy
+from markdown_vault_mcp.git import GitWriteStrategy, PullResult, PushResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from ._icons import _TOOL_ICONS
 from ._server_deps import get_collection
@@ -60,6 +63,180 @@ def _is_private_url(url: str) -> bool:
     except ValueError:
         # Not an IP literal — allow (could be a public hostname).
         return False
+
+
+# ---------------------------------------------------------------------------
+# git_sync helpers
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_managed_strategy(collection: Collection) -> GitWriteStrategy:
+    """Resolve and validate the managed-mode git strategy from a Collection.
+
+    Returns:
+        The Collection's :class:`GitWriteStrategy` if it's in managed mode.
+
+    Raises:
+        ValueError: If the deployment isn't wired with a managed git
+            strategy (no ``MARKDOWN_VAULT_MCP_GIT_REPO_URL`` env var).
+    """
+    # The MCP layer is a trusted consumer of Collection internals — adding
+    # a public accessor for this single tool would be scope creep.
+    strategy = collection._git_strategy
+    if not isinstance(strategy, GitWriteStrategy) or not strategy._managed:
+        raise ValueError(
+            "git_sync requires a managed git deployment.  Set "
+            "MARKDOWN_VAULT_MCP_GIT_REPO_URL to enable it."
+        )
+    return strategy
+
+
+async def _get_branch_name(strategy: GitWriteStrategy, git_root: Path) -> str:
+    """Return the current branch name, falling back to ``"HEAD"`` on failure.
+
+    Used by :func:`git_sync` to populate the ``branch`` field of the
+    response.  Detached-HEAD checkouts produce a clean ``"HEAD"`` from
+    git itself; this helper's fallback covers the rarer cases where
+    git invocation fails entirely (binary missing, transient FS error).
+    """
+
+    def _read_branch() -> str:
+        return strategy._git(git_root, "rev-parse", "--abbrev-ref", "HEAD").strip()
+
+    try:
+        return await asyncio.to_thread(_read_branch)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Narrow the catch per CLAUDE.md's logging standard so a real bug
+        # (e.g. AttributeError) still propagates.
+        logger.warning(
+            "git_sync: failed to read branch name, using 'HEAD' fallback",
+            exc_info=True,
+        )
+        return "HEAD"
+
+
+def _format_pull_dict(result: PullResult, dry_run: bool) -> dict[str, Any]:
+    """Project a :class:`PullResult` into the response dict shape.
+
+    Pure transformation — no side effects.  Adds optional ``reason``,
+    ``conflict_files``, and (in dry-run) ``would_apply`` fields when
+    relevant.
+    """
+    pull_dict: dict[str, Any] = {
+        "applied": result.applied,
+        "fast_forward": result.fast_forward,
+        "commits_pulled": result.commits_pulled,
+        "from_sha": result.from_sha,
+        "to_sha": result.to_sha,
+    }
+    if result.reason is not None:
+        pull_dict["reason"] = result.reason
+    if result.conflict_files:
+        pull_dict["conflict_files"] = list(result.conflict_files)
+    if dry_run:
+        # Dry-run reports the projected outcome, not actual.
+        pull_dict["would_apply"] = result.commits_pulled > 0
+    return pull_dict
+
+
+def _format_push_dict(result: PushResult) -> dict[str, Any]:
+    """Project a :class:`PushResult` into the response dict shape.
+
+    Pure transformation — no side effects.  Adds optional ``reason``
+    and ``hint`` fields when present.
+    """
+    push_dict: dict[str, Any] = {
+        "applied": result.applied,
+        "commits_pushed": result.commits_pushed,
+        "remote_sha_before": result.remote_sha_before,
+        "remote_sha_after": result.remote_sha_after,
+    }
+    if result.reason is not None:
+        push_dict["reason"] = result.reason
+    if result.hint is not None:
+        push_dict["hint"] = result.hint
+    return push_dict
+
+
+async def _reindex_after_pull(
+    collection: Collection, pull_dict: dict[str, Any]
+) -> None:
+    """Refresh the FTS index after a pull that moved HEAD.
+
+    ``force_pull`` only mutates the working tree; without this call,
+    ``search`` / ``list_documents`` / ``get_context`` would serve stale
+    data until the next write.  Mirrors the periodic pull loop's
+    ``on_pull`` callback in :meth:`GitWriteStrategy._pull_loop` —
+    same ``pause_writes()`` + ``reindex()`` pattern.
+
+    On reindex failure: the pull side-effect already happened (HEAD
+    moved, files on disk), so failing the whole tool would hide the
+    successful pull from the caller.  Surfaces ``reindex_failed=True``
+    + ``reindex_hint`` on the pull payload instead so the agent knows
+    the index is stale and can decide whether to retry via the
+    ``reindex`` tool.
+
+    Mutates ``pull_dict`` in place on failure.
+    """
+
+    def _pause_and_reindex() -> None:
+        with collection.pause_writes():
+            collection.reindex()
+
+    try:
+        await asyncio.to_thread(_pause_and_reindex)
+    except Exception:
+        logger.exception(
+            "git_sync: reindex after pull failed — FTS index "
+            "is stale until the next reindex / write tick"
+        )
+        pull_dict["reindex_failed"] = True
+        pull_dict["reindex_hint"] = (
+            "Pull succeeded but the FTS index could not be "
+            "refreshed.  search / list_documents / get_context "
+            "will serve stale data until the next call to the "
+            "reindex tool or the next write."
+        )
+
+
+async def _run_pull_leg(
+    strategy: GitWriteStrategy,
+    collection: Collection,
+    *,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Run the pull leg of ``git_sync`` and return its response dict.
+
+    Calls :meth:`GitWriteStrategy.force_pull`, projects the result,
+    and triggers a reindex when HEAD actually moved (skipped on
+    dry-run and on failure).  The reindex's own failure is surfaced
+    on the returned dict, not raised.
+
+    Args:
+        strategy: Resolved managed-mode strategy.
+        collection: Collection used for the post-pull reindex.
+        dry_run: Forwarded to ``force_pull`` and to
+            :func:`_format_pull_dict`.
+
+    Returns:
+        The pull-leg payload dict (caller assigns to
+        ``result["pull"]``).
+    """
+    pull_result = await asyncio.to_thread(strategy.force_pull, dry_run=dry_run)
+    pull_dict = _format_pull_dict(pull_result, dry_run)
+    if (
+        not dry_run
+        and pull_result.applied
+        and pull_result.from_sha != pull_result.to_sha
+    ):
+        await _reindex_after_pull(collection, pull_dict)
+    return pull_dict
+
+
+async def _run_push_leg(strategy: GitWriteStrategy, *, dry_run: bool) -> dict[str, Any]:
+    """Run the push leg of ``git_sync`` and return its response dict."""
+    push_result = await asyncio.to_thread(strategy.force_push, dry_run=dry_run)
+    return _format_push_dict(push_result)
 
 
 def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1436,7 +1436,26 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                     with collection.pause_writes():
                         collection.reindex()
 
-                await asyncio.to_thread(_pause_and_reindex)
+                try:
+                    await asyncio.to_thread(_pause_and_reindex)
+                except Exception:
+                    # Pull side-effect already happened (HEAD moved, files
+                    # on disk).  Failing the whole tool would hide the
+                    # successful pull from the caller.  Surface the
+                    # bookkeeping failure on the pull payload instead so
+                    # the agent knows the index is stale and can decide
+                    # whether to retry via the ``reindex`` tool.
+                    logger.exception(
+                        "git_sync: reindex after pull failed — FTS index "
+                        "is stale until the next reindex / write tick"
+                    )
+                    pull_dict["reindex_failed"] = True
+                    pull_dict["reindex_hint"] = (
+                        "Pull succeeded but the FTS index could not be "
+                        "refreshed.  search / list_documents / get_context "
+                        "will serve stale data until the next call to the "
+                        "reindex tool or the next write."
+                    )
 
             # Short-circuit the push leg when the pull failed in 'both' mode
             # so we don't push on top of an unreconciled local clone.

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -20,6 +20,7 @@ from fastmcp.exceptions import ToolError
 
 from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.exceptions import EditConflictError
+from markdown_vault_mcp.git import GitWriteStrategy
 
 from ._icons import _TOOL_ICONS
 from ._server_deps import get_collection
@@ -1287,6 +1288,165 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             update_links=update_links,
         )
         return asdict(result)
+
+    @mcp.tool(
+        tags={"write", "git-managed"},
+        icons=_TOOL_ICONS["git_sync"],
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": False,
+        },
+    )
+    async def git_sync(
+        direction: Literal["pull", "push", "both"] = "both",
+        dry_run: bool = False,
+        collection: Collection = Depends(get_collection),
+    ) -> dict[str, Any]:
+        """Synchronously reconcile the local clone with ``origin``.
+
+        Composes :meth:`GitWriteStrategy.force_pull` and
+        :meth:`GitWriteStrategy.force_push` behind a single tool call so
+        an operator can request "pull then push" with one round-trip.
+        Only available on managed git deployments
+        (``MARKDOWN_VAULT_MCP_GIT_REPO_URL`` set).
+
+        ``direction='pull'`` runs only the pull leg; ``'push'`` only the
+        push leg; ``'both'`` runs pull first, then push.  When pull fails
+        in ``'both'`` mode the push leg is skipped — the failure surfaces
+        in the ``pull`` payload and the caller is expected to inspect
+        ``pull.reason`` (and ``pull.conflict_files`` for conflict
+        resolution) before retrying.
+
+        ``dry_run=True`` projects the would-be pull without moving HEAD.
+        Push has no safe dry-run (git provides no local probe for
+        "would the remote accept this"), so the push leg returns
+        ``applied=False`` with ``reason='dry_run_unsupported'``.
+
+        Args:
+            direction: ``"pull"``, ``"push"``, or ``"both"`` (default).
+            dry_run: When ``True``, projects pull without moving HEAD.
+                See :meth:`GitWriteStrategy.force_push` for why this is
+                a no-op on the push leg.
+
+        Returns:
+            Dict with the following fields:
+
+            - direction (str): The requested direction, echoed back.
+            - head_sha (str): Local HEAD SHA after the operation.  May
+              differ from the pre-call HEAD when the pull leg advanced
+              the branch.
+            - branch (str): Current branch name (from
+              ``git rev-parse --abbrev-ref HEAD``).
+            - pull (dict | None): Payload from the pull leg, or ``None``
+              when ``direction='push'``.  Contains ``applied``,
+              ``fast_forward``, ``commits_pulled``, ``from_sha``,
+              ``to_sha``, optional ``reason`` and ``conflict_files``.
+              In ``dry_run`` mode also includes
+              ``would_apply: bool``.
+            - push (dict | None): Payload from the push leg, or ``None``
+              when ``direction='pull'`` or when the pull leg failed in
+              ``direction='both'``.  Contains ``applied``,
+              ``commits_pushed``, ``remote_sha_before``,
+              ``remote_sha_after``, optional ``reason`` and ``hint``.
+            - dry_run (bool): Only present when ``dry_run=True`` was
+              passed.
+
+        Raises:
+            ValueError: When the underlying strategy is not a managed
+                :class:`GitWriteStrategy` (i.e. the deployment is not
+                wired with ``MARKDOWN_VAULT_MCP_GIT_REPO_URL``).
+        """
+        # Reach the strategy through the Collection.  The MCP layer is a
+        # trusted consumer of Collection internals — there is no public
+        # accessor and adding one for this single tool would be scope
+        # creep.
+        strategy = collection._git_strategy
+        if not isinstance(strategy, GitWriteStrategy) or not strategy._managed:
+            raise ValueError(
+                "git_sync requires a managed git deployment.  Set "
+                "MARKDOWN_VAULT_MCP_GIT_REPO_URL to enable it."
+            )
+
+        # Resolve the working tree once — both legs need it for SHA / branch
+        # readback.  The strategy owns the validation (raises RuntimeError if
+        # the constructor was not given a repo_path), but in managed mode the
+        # path is set unconditionally so this should never raise here.
+        git_root = strategy._resolve_force_repo()
+
+        def _branch_name() -> str:
+            """Return the current branch name, or ``"HEAD"`` on detached HEAD."""
+            try:
+                return strategy._git(
+                    git_root, "rev-parse", "--abbrev-ref", "HEAD"
+                ).strip()
+            except Exception:
+                # Detached HEAD or transient git failure — fall back to a
+                # well-known sentinel rather than blowing up the whole tool.
+                return "HEAD"
+
+        result: dict[str, Any] = {
+            "direction": direction,
+            "head_sha": await asyncio.to_thread(strategy._head_sha, git_root),
+            "branch": await asyncio.to_thread(_branch_name),
+            "pull": None,
+            "push": None,
+        }
+        if dry_run:
+            result["dry_run"] = True
+
+        if direction in ("pull", "both"):
+            pull_result = await asyncio.to_thread(strategy.force_pull, dry_run=dry_run)
+            pull_dict: dict[str, Any] = {
+                "applied": pull_result.applied,
+                "fast_forward": pull_result.fast_forward,
+                "commits_pulled": pull_result.commits_pulled,
+                "from_sha": pull_result.from_sha,
+                "to_sha": pull_result.to_sha,
+            }
+            if pull_result.reason is not None:
+                pull_dict["reason"] = pull_result.reason
+            if pull_result.conflict_files:
+                pull_dict["conflict_files"] = list(pull_result.conflict_files)
+            if dry_run:
+                # Dry-run reports the projected outcome, not actual.
+                pull_dict["would_apply"] = pull_result.commits_pulled > 0
+            result["pull"] = pull_dict
+
+            # Short-circuit the push leg when the pull failed in 'both' mode
+            # so we don't push on top of an unreconciled local clone.
+            if direction == "both" and not pull_result.applied:
+                # Refresh head_sha — the pull may have moved it even on
+                # partial failure paths (defensive; today's force_pull leaves
+                # HEAD in place on failure).
+                result["head_sha"] = await asyncio.to_thread(
+                    strategy._head_sha,
+                    git_root,
+                )
+                return result
+
+        if direction in ("push", "both"):
+            push_result = await asyncio.to_thread(strategy.force_push, dry_run=dry_run)
+            push_dict: dict[str, Any] = {
+                "applied": push_result.applied,
+                "commits_pushed": push_result.commits_pushed,
+                "remote_sha_before": push_result.remote_sha_before,
+                "remote_sha_after": push_result.remote_sha_after,
+            }
+            if push_result.reason is not None:
+                push_dict["reason"] = push_result.reason
+            if push_result.hint is not None:
+                push_dict["hint"] = push_result.hint
+            result["push"] = push_dict
+
+        # HEAD may have moved (pull leg advanced it).  Refresh once at the
+        # end so the caller sees the post-sync state regardless of which
+        # legs ran.
+        result["head_sha"] = await asyncio.to_thread(
+            strategy._head_sha,
+            git_root,
+        )
+        return result
 
     @mcp.tool(
         tags={"write"},

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -10,6 +10,7 @@ import asyncio
 import base64
 import ipaddress
 import logging
+import subprocess
 from dataclasses import asdict
 from typing import Any, Literal
 from urllib.parse import urlparse, urlunparse
@@ -1380,9 +1381,15 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 return strategy._git(
                     git_root, "rev-parse", "--abbrev-ref", "HEAD"
                 ).strip()
-            except Exception:
-                # Detached HEAD or transient git failure — fall back to a
-                # well-known sentinel rather than blowing up the whole tool.
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                # Detached HEAD, missing git binary, or transient git failure —
+                # fall back to a well-known sentinel rather than blowing up the
+                # whole tool.  Narrow the catch per CLAUDE.md's logging
+                # standard so a real bug (e.g. AttributeError) still propagates.
+                logger.warning(
+                    "git_sync: failed to read branch name, using 'HEAD' fallback",
+                    exc_info=True,
+                )
                 return "HEAD"
 
         result: dict[str, Any] = {
@@ -1413,9 +1420,32 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 pull_dict["would_apply"] = pull_result.commits_pulled > 0
             result["pull"] = pull_dict
 
+            # Refresh the FTS index when the pull leg actually advanced HEAD.
+            # ``force_pull`` only mutates the working tree; without this call
+            # search/list/get_context would serve stale data until the next
+            # write.  Mirrors the periodic pull loop's ``on_pull`` callback
+            # in ``GitWriteStrategy._pull_loop`` — same pause-then-reindex
+            # pattern, same ``Collection.pause_writes`` context manager.
+            if (
+                not dry_run
+                and pull_result.applied
+                and pull_result.from_sha != pull_result.to_sha
+            ):
+
+                def _pause_and_reindex() -> None:
+                    with collection.pause_writes():
+                        collection.reindex()
+
+                await asyncio.to_thread(_pause_and_reindex)
+
             # Short-circuit the push leg when the pull failed in 'both' mode
             # so we don't push on top of an unreconciled local clone.
-            if direction == "both" and not pull_result.applied:
+            # Excludes ``dry_run``: in dry-run mode ``applied`` is always
+            # ``False`` even on a healthy projection, so falling through is
+            # correct — the push leg's ``dry_run_unsupported`` reason then
+            # surfaces in the response, distinguishing a preview from a
+            # real-pull-failed-push-skipped result.
+            if direction == "both" and not pull_result.applied and not dry_run:
                 # Refresh head_sha — the pull may have moved it even on
                 # partial failure paths (defensive; today's force_pull leaves
                 # HEAD in place on failure).

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -70,7 +70,7 @@ def _is_private_url(url: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-async def _resolve_managed_strategy(collection: Collection) -> GitWriteStrategy:
+def _resolve_managed_strategy(collection: Collection) -> GitWriteStrategy:
     """Resolve and validate the managed-mode git strategy from a Collection.
 
     Returns:
@@ -1535,7 +1535,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 :class:`GitWriteStrategy` (i.e. the deployment is not
                 wired with ``MARKDOWN_VAULT_MCP_GIT_REPO_URL``).
         """
-        strategy = await _resolve_managed_strategy(collection)
+        strategy = _resolve_managed_strategy(collection)
         git_root = strategy._resolve_force_repo()
 
         result: dict[str, Any] = {

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1535,44 +1535,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 :class:`GitWriteStrategy` (i.e. the deployment is not
                 wired with ``MARKDOWN_VAULT_MCP_GIT_REPO_URL``).
         """
-        # Reach the strategy through the Collection.  The MCP layer is a
-        # trusted consumer of Collection internals — there is no public
-        # accessor and adding one for this single tool would be scope
-        # creep.
-        strategy = collection._git_strategy
-        if not isinstance(strategy, GitWriteStrategy) or not strategy._managed:
-            raise ValueError(
-                "git_sync requires a managed git deployment.  Set "
-                "MARKDOWN_VAULT_MCP_GIT_REPO_URL to enable it."
-            )
-
-        # Resolve the working tree once — both legs need it for SHA / branch
-        # readback.  The strategy owns the validation (raises RuntimeError if
-        # the constructor was not given a repo_path), but in managed mode the
-        # path is set unconditionally so this should never raise here.
+        strategy = await _resolve_managed_strategy(collection)
         git_root = strategy._resolve_force_repo()
-
-        def _branch_name() -> str:
-            """Return the current branch name, or ``"HEAD"`` on detached HEAD."""
-            try:
-                return strategy._git(
-                    git_root, "rev-parse", "--abbrev-ref", "HEAD"
-                ).strip()
-            except (subprocess.CalledProcessError, FileNotFoundError):
-                # Detached HEAD, missing git binary, or transient git failure —
-                # fall back to a well-known sentinel rather than blowing up the
-                # whole tool.  Narrow the catch per CLAUDE.md's logging
-                # standard so a real bug (e.g. AttributeError) still propagates.
-                logger.warning(
-                    "git_sync: failed to read branch name, using 'HEAD' fallback",
-                    exc_info=True,
-                )
-                return "HEAD"
 
         result: dict[str, Any] = {
             "direction": direction,
             "head_sha": await asyncio.to_thread(strategy._head_sha, git_root),
-            "branch": await asyncio.to_thread(_branch_name),
+            "branch": await _get_branch_name(strategy, git_root),
             "pull": None,
             "push": None,
         }
@@ -1580,59 +1549,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             result["dry_run"] = True
 
         if direction in ("pull", "both"):
-            pull_result = await asyncio.to_thread(strategy.force_pull, dry_run=dry_run)
-            pull_dict: dict[str, Any] = {
-                "applied": pull_result.applied,
-                "fast_forward": pull_result.fast_forward,
-                "commits_pulled": pull_result.commits_pulled,
-                "from_sha": pull_result.from_sha,
-                "to_sha": pull_result.to_sha,
-            }
-            if pull_result.reason is not None:
-                pull_dict["reason"] = pull_result.reason
-            if pull_result.conflict_files:
-                pull_dict["conflict_files"] = list(pull_result.conflict_files)
-            if dry_run:
-                # Dry-run reports the projected outcome, not actual.
-                pull_dict["would_apply"] = pull_result.commits_pulled > 0
+            pull_dict = await _run_pull_leg(strategy, collection, dry_run=dry_run)
             result["pull"] = pull_dict
-
-            # Refresh the FTS index when the pull leg actually advanced HEAD.
-            # ``force_pull`` only mutates the working tree; without this call
-            # search/list/get_context would serve stale data until the next
-            # write.  Mirrors the periodic pull loop's ``on_pull`` callback
-            # in ``GitWriteStrategy._pull_loop`` — same pause-then-reindex
-            # pattern, same ``Collection.pause_writes`` context manager.
-            if (
-                not dry_run
-                and pull_result.applied
-                and pull_result.from_sha != pull_result.to_sha
-            ):
-
-                def _pause_and_reindex() -> None:
-                    with collection.pause_writes():
-                        collection.reindex()
-
-                try:
-                    await asyncio.to_thread(_pause_and_reindex)
-                except Exception:
-                    # Pull side-effect already happened (HEAD moved, files
-                    # on disk).  Failing the whole tool would hide the
-                    # successful pull from the caller.  Surface the
-                    # bookkeeping failure on the pull payload instead so
-                    # the agent knows the index is stale and can decide
-                    # whether to retry via the ``reindex`` tool.
-                    logger.exception(
-                        "git_sync: reindex after pull failed — FTS index "
-                        "is stale until the next reindex / write tick"
-                    )
-                    pull_dict["reindex_failed"] = True
-                    pull_dict["reindex_hint"] = (
-                        "Pull succeeded but the FTS index could not be "
-                        "refreshed.  search / list_documents / get_context "
-                        "will serve stale data until the next call to the "
-                        "reindex tool or the next write."
-                    )
 
             # Short-circuit the push leg when the pull failed in 'both' mode
             # so we don't push on top of an unreconciled local clone.
@@ -1641,37 +1559,21 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             # correct — the push leg's ``dry_run_unsupported`` reason then
             # surfaces in the response, distinguishing a preview from a
             # real-pull-failed-push-skipped result.
-            if direction == "both" and not pull_result.applied and not dry_run:
-                # Refresh head_sha — the pull may have moved it even on
-                # partial failure paths (defensive; today's force_pull leaves
-                # HEAD in place on failure).
+            if direction == "both" and not pull_dict["applied"] and not dry_run:
+                # Refresh head_sha defensively (today's force_pull leaves
+                # HEAD in place on failure, but allowed to move).
                 result["head_sha"] = await asyncio.to_thread(
-                    strategy._head_sha,
-                    git_root,
+                    strategy._head_sha, git_root
                 )
                 return result
 
         if direction in ("push", "both"):
-            push_result = await asyncio.to_thread(strategy.force_push, dry_run=dry_run)
-            push_dict: dict[str, Any] = {
-                "applied": push_result.applied,
-                "commits_pushed": push_result.commits_pushed,
-                "remote_sha_before": push_result.remote_sha_before,
-                "remote_sha_after": push_result.remote_sha_after,
-            }
-            if push_result.reason is not None:
-                push_dict["reason"] = push_result.reason
-            if push_result.hint is not None:
-                push_dict["hint"] = push_result.hint
-            result["push"] = push_dict
+            result["push"] = await _run_push_leg(strategy, dry_run=dry_run)
 
         # HEAD may have moved (pull leg advanced it).  Refresh once at the
         # end so the caller sees the post-sync state regardless of which
         # legs ran.
-        result["head_sha"] = await asyncio.to_thread(
-            strategy._head_sha,
-            git_root,
-        )
+        result["head_sha"] = await asyncio.to_thread(strategy._head_sha, git_root)
         return result
 
     @mcp.tool(

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1186,14 +1186,27 @@ class GitWriteStrategy:
                     "Git force_pull: conflict resolution raised — aborting rebase",
                     exc_info=True,
                 )
-                # Defensive abort: swallow its own errors so the original
-                # exception's diagnostic value is preserved in the logs.
-                subprocess.run(
+                # Defensive abort: don't let abort failure mask the
+                # original exception (already logged at ERROR above), but
+                # log abort failures at WARNING so an operator debugging a
+                # stuck rebase-merge/ directory can tell whether the
+                # defensive abort fired and whether it succeeded.  Mirrors
+                # the in-progress-rebase abort path further below.
+                abort_proc = subprocess.run(
                     ["git", "-C", str(git_root), "rebase", "--abort"],
                     capture_output=True,
                     text=True,
                     env=env,
                 )
+                if abort_proc.returncode != 0:
+                    abort_stderr = (abort_proc.stderr or "").strip()
+                    if self._token and self._token in abort_stderr:
+                        abort_stderr = abort_stderr.replace(self._token, "***")
+                    logger.warning(
+                        "Git force_pull: defensive `git rebase --abort` "
+                        "after conflict-resolution failure also failed: %s",
+                        abort_stderr,
+                    )
                 return PullResult(
                     applied=False,
                     fast_forward=False,

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -912,6 +912,87 @@ class GitWriteStrategy:
             git_dir / "rebase-apply"
         ).is_dir()
 
+    def _abort_in_progress_rebase(
+        self,
+        git_root: Path,
+        env: dict[str, str] | None,
+    ) -> bool:
+        """Run ``git rebase --abort`` synchronously.
+
+        Args:
+            git_root: Working-tree root.
+            env: Optional GIT_ASKPASS environment.
+
+        Returns:
+            ``True`` if abort succeeded; ``False`` if abort itself failed
+            (in which case the caller should bail out — the working tree
+            may be inconsistent).  Failure is logged at ERROR with
+            token-redacted stderr.
+        """
+        abort_proc = self._run_git_capturing(git_root, "rebase", "--abort", env=env)
+        if abort_proc.returncode != 0:
+            logger.error(
+                "Git force_pull: failed to abort rebase: %s",
+                self._redact((abort_proc.stderr or "").strip()),
+            )
+            return False
+        return True
+
+    def _restore_upstream_paths(
+        self,
+        git_root: Path,
+        env: dict[str, str] | None,
+        saved: list[tuple[str, str]],
+    ) -> list[tuple[str, str]]:
+        """Restore upstream content for each conflict path after rebase abort.
+
+        After ``git rebase --abort`` the working tree reverts to the
+        pre-rebase MCP state — every file in ``saved`` again contains the
+        MCP version, not the upstream version.  For each path we run
+        ``git checkout @{upstream} -- <path>`` to bring back the upstream
+        bytes so :meth:`_write_conflict_files` reads the right side
+        (canonical = upstream, sibling = MCP).
+
+        On per-path checkout failure (file deleted upstream, permission
+        error, etc.), the path is DROPPED from the returned list — writing
+        a sibling that contains the same MCP bytes as the canonical path
+        would defeat the "remote wins, local preserved" invariant.  Each
+        drop is logged at ERROR with the path name and token-redacted
+        stderr so an operator can investigate.
+
+        Args:
+            git_root: Working-tree root.
+            env: Optional GIT_ASKPASS environment.
+            saved: List of ``(rel_path, mcp_content)`` tuples returned by
+                :meth:`_resolve_conflicts_safely`.
+
+        Returns:
+            Subset of ``saved`` whose upstream restore succeeded.  May be
+            empty if every checkout failed.
+        """
+        restored: list[tuple[str, str]] = []
+        for rel_path, mcp_content in saved:
+            checkout_proc = self._run_git_capturing(
+                git_root,
+                "checkout",
+                "@{upstream}",
+                "--",
+                rel_path,
+                env=env,
+            )
+            if checkout_proc.returncode != 0:
+                logger.error(
+                    "Git force_pull: failed to restore upstream "
+                    "version of %r after rebase abort; dropping it "
+                    "from conflict siblings to avoid duplicate MCP "
+                    "content: %s",
+                    rel_path,
+                    self._redact((checkout_proc.stderr or "").strip()),
+                )
+                continue
+            restored.append((rel_path, mcp_content))
+        return restored
+
     def _write_conflict_files(
         self,
         git_root: Path,
@@ -1342,15 +1423,7 @@ class GitWriteStrategy:
             rebase_in_progress = self._check_rebase_in_progress(git_root, env)
 
             if rebase_in_progress:
-                abort_proc = self._run_git_capturing(
-                    git_root, "rebase", "--abort", env=env
-                )
-                if abort_proc.returncode != 0:
-                    abort_stderr = self._redact((abort_proc.stderr or "").strip())
-                    logger.error(
-                        "Git force_pull: failed to abort rebase: %s",
-                        abort_stderr,
-                    )
+                if not self._abort_in_progress_rebase(git_root, env):
                     return PullResult(
                         applied=False,
                         fast_forward=False,
@@ -1359,41 +1432,7 @@ class GitWriteStrategy:
                         to_sha=from_sha,
                         reason=PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS,
                     )
-                # After abort, the working tree reverts to the pre-rebase
-                # state (MCP commits), so the original files contain MCP
-                # content, not upstream content.  Restore the upstream
-                # version for each conflicting file so _write_conflict_files
-                # reads the right side.  If checkout fails for a given
-                # path (deleted upstream, permission error, etc.), DROP it
-                # from `saved` — otherwise _write_conflict_files would
-                # produce a sibling that contains the same MCP bytes as the
-                # canonical path, defeating the "remote wins, local saved
-                # as sibling" invariant.
-                restored: list[tuple[str, str]] = []
-                for rel_path, mcp_content in saved:
-                    checkout_proc = self._run_git_capturing(
-                        git_root,
-                        "checkout",
-                        "@{upstream}",
-                        "--",
-                        rel_path,
-                        env=env,
-                    )
-                    if checkout_proc.returncode != 0:
-                        checkout_stderr = self._redact(
-                            (checkout_proc.stderr or "").strip()
-                        )
-                        logger.error(
-                            "Git force_pull: failed to restore upstream "
-                            "version of %r after rebase abort; dropping it "
-                            "from conflict siblings to avoid duplicate MCP "
-                            "content: %s",
-                            rel_path,
-                            checkout_stderr,
-                        )
-                        continue
-                    restored.append((rel_path, mcp_content))
-                saved = restored
+                saved = self._restore_upstream_paths(git_root, env, saved)
 
             if not saved:
                 logger.warning(

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -808,6 +808,61 @@ class GitWriteStrategy:
         )
         return list(saved.items())
 
+    def _resolve_conflicts_safely(
+        self,
+        git_root: Path,
+        env: dict[str, str] | None,
+        from_sha: str,
+    ) -> tuple[list[tuple[str, str]] | None, PullResult | None]:
+        """Defensive wrapper around :meth:`_resolve_rebase_conflicts`.
+
+        Catches the case where conflict resolution itself raises mid-loop,
+        leaving the repository in a half-rebased state.  On exception:
+        logs at ERROR with traceback, runs ``git rebase --abort`` defensively
+        (logging WARNING if the abort itself fails — but not failing the
+        overall recovery), and returns an early-exit ``PullResult`` so the
+        caller can surface ``conflict_resolution_failed`` without a leftover
+        ``rebase-merge`` directory.
+
+        Args:
+            git_root: Working-tree root.
+            env: Optional GIT_ASKPASS environment.
+            from_sha: HEAD SHA captured by the caller before the rebase
+                attempt; reused on the failure path so the returned result
+                has consistent ``from_sha == to_sha`` semantics.
+
+        Returns:
+            ``(saved, None)`` on success — ``saved`` is the list of
+            ``(rel_path, mcp_content)`` tuples from
+            :meth:`_resolve_rebase_conflicts`.
+
+            ``(None, PullResult)`` on failure — caller should return the
+            ``PullResult`` immediately.
+        """
+        try:
+            saved = self._resolve_rebase_conflicts(git_root, env)
+        except Exception:
+            logger.error(
+                "Git force_pull: conflict resolution raised — aborting rebase",
+                exc_info=True,
+            )
+            abort_proc = self._run_git_capturing(git_root, "rebase", "--abort", env=env)
+            if abort_proc.returncode != 0:
+                logger.warning(
+                    "Git force_pull: defensive `git rebase --abort` "
+                    "after conflict-resolution failure also failed: %s",
+                    self._redact((abort_proc.stderr or "").strip()),
+                )
+            return None, PullResult(
+                applied=False,
+                fast_forward=False,
+                commits_pulled=0,
+                from_sha=from_sha,
+                to_sha=from_sha,
+                reason=PULL_REASON_CONFLICT_RESOLUTION_FAILED,
+            )
+        return saved, None
+
     def _write_conflict_files(
         self,
         git_root: Path,
@@ -1218,41 +1273,18 @@ class GitWriteStrategy:
             #
             # ``_resolve_rebase_conflicts`` runs ``git checkout --ours`` and
             # ``git add`` with ``check=True``; if either raises mid-loop the
-            # repository is left in a half-rebased state.  Wrap in a guard
-            # that defensively aborts the rebase before propagating, so a
-            # subsequent ``force_pull`` (or any per-write commit path) does
-            # not trip over the leftover ``rebase-merge`` directory.
-            try:
-                saved = self._resolve_rebase_conflicts(git_root, env)
-            except Exception:
-                logger.error(
-                    "Git force_pull: conflict resolution raised — aborting rebase",
-                    exc_info=True,
-                )
-                # Defensive abort: don't let abort failure mask the
-                # original exception (already logged at ERROR above), but
-                # log abort failures at WARNING so an operator debugging a
-                # stuck rebase-merge/ directory can tell whether the
-                # defensive abort fired and whether it succeeded.  Mirrors
-                # the in-progress-rebase abort path further below.
-                abort_proc = self._run_git_capturing(
-                    git_root, "rebase", "--abort", env=env
-                )
-                if abort_proc.returncode != 0:
-                    abort_stderr = self._redact((abort_proc.stderr or "").strip())
-                    logger.warning(
-                        "Git force_pull: defensive `git rebase --abort` "
-                        "after conflict-resolution failure also failed: %s",
-                        abort_stderr,
-                    )
-                return PullResult(
-                    applied=False,
-                    fast_forward=False,
-                    commits_pulled=0,
-                    from_sha=from_sha,
-                    to_sha=from_sha,
-                    reason=PULL_REASON_CONFLICT_RESOLUTION_FAILED,
-                )
+            # repository is left in a half-rebased state.
+            # ``_resolve_conflicts_safely`` wraps that in a defensive abort
+            # so a subsequent ``force_pull`` (or any per-write commit path)
+            # does not trip over the leftover ``rebase-merge`` directory.
+            saved, early_exit = self._resolve_conflicts_safely(git_root, env, from_sha)
+            if early_exit is not None:
+                return early_exit
+            # ``_resolve_conflicts_safely`` returns ``(saved, None)`` on
+            # success and ``(None, PullResult)`` on failure — exactly one
+            # is non-None.  After the early-exit guard above, ``saved`` is
+            # guaranteed non-None; assert so mypy can narrow.
+            assert saved is not None
 
             # If a rebase is still in progress (loop hit its iteration
             # limit, or exited via ``break`` without completing), abort

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -123,8 +123,15 @@ class PullResult:
             failed.  Inspect ``reason`` and ``conflict_files`` to
             distinguish "applied via conflict resolution" from outright
             failure.
-        commits_pulled: Count of commits brought in.  In ``dry_run`` mode
-            this is the count that *would* have been pulled.
+        commits_pulled: Count of commits brought in.  Reliable on the
+            fast-forward path (``reason is None`` and ``fast_forward=True``).
+            On ``"rebased"`` and ``"conflicts_resolved_with_siblings"`` this
+            is ``0`` even when HEAD advanced — the rebase replays local
+            commits *on top of* the upstream rather than fast-forwarding,
+            so the linear-history "commits pulled" count is not meaningful.
+            Inspect ``from_sha != to_sha`` to detect that HEAD actually
+            moved on those paths.  In ``dry_run`` mode this is the count
+            that *would* have been pulled.
         from_sha: HEAD SHA before the pull.
         to_sha: HEAD SHA after the pull.  In ``dry_run`` mode this is the
             SHA HEAD would have moved to.  When the pull failed and HEAD
@@ -1005,9 +1012,17 @@ class GitWriteStrategy:
                 try:
                     self._git(git_root, "fetch", "origin", env=env)
                 except subprocess.CalledProcessError as exc:
+                    # Sanitise the token before logging — fetch is the
+                    # network-touching subprocess in this method, and git
+                    # error messages can echo the URL with credentials
+                    # back at the user.  Mirrors the redaction pattern
+                    # already used in ``_do_push_safe`` and ``force_push``.
+                    stderr = (exc.stderr or "").strip()
+                    if self._token and self._token in stderr:
+                        stderr = stderr.replace(self._token, "***")
                     logger.warning(
                         "Git force_pull: fetch failed: %s",
-                        (exc.stderr or "").strip(),
+                        stderr,
                     )
                     return PullResult(
                         applied=False,
@@ -1157,7 +1172,36 @@ class GitWriteStrategy:
         except subprocess.CalledProcessError:
             # Real conflicts during rebase — resolve by accepting upstream
             # and saving the local MCP versions as Syncthing-style siblings.
-            saved = self._resolve_rebase_conflicts(git_root, env)
+            #
+            # ``_resolve_rebase_conflicts`` runs ``git checkout --ours`` and
+            # ``git add`` with ``check=True``; if either raises mid-loop the
+            # repository is left in a half-rebased state.  Wrap in a guard
+            # that defensively aborts the rebase before propagating, so a
+            # subsequent ``force_pull`` (or any per-write commit path) does
+            # not trip over the leftover ``rebase-merge`` directory.
+            try:
+                saved = self._resolve_rebase_conflicts(git_root, env)
+            except Exception:
+                logger.error(
+                    "Git force_pull: conflict resolution raised — aborting rebase",
+                    exc_info=True,
+                )
+                # Defensive abort: swallow its own errors so the original
+                # exception's diagnostic value is preserved in the logs.
+                subprocess.run(
+                    ["git", "-C", str(git_root), "rebase", "--abort"],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
+                return PullResult(
+                    applied=False,
+                    fast_forward=False,
+                    commits_pulled=0,
+                    from_sha=from_sha,
+                    to_sha=from_sha,
+                    reason=PULL_REASON_CONFLICT_RESOLUTION_FAILED,
+                )
 
             # If a rebase is still in progress (loop hit its iteration
             # limit, or exited via ``break`` without completing), abort

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1242,9 +1242,22 @@ class GitWriteStrategy:
                     git_dir / "rebase-apply"
                 ).is_dir()
             else:
-                # Fall back to assuming no rebase in progress — the worst
-                # case is a missed abort, not a corrupted repo.
-                rebase_in_progress = False
+                # `rev-parse --git-dir` failure means we cannot tell whether
+                # a rebase is in progress.  Conservatively assume one IS in
+                # progress so the abort runs — abort on a clean tree fails
+                # loudly and is logged below; failing to abort a real
+                # in-progress rebase would leave the repo wedged for every
+                # subsequent force_pull.  Log the underlying failure with
+                # token-redacted stderr for the operator.
+                git_dir_stderr = (git_dir_proc.stderr or "").strip()
+                if self._token and self._token in git_dir_stderr:
+                    git_dir_stderr = git_dir_stderr.replace(self._token, "***")
+                logger.error(
+                    "Git force_pull: `git rev-parse --git-dir` failed; "
+                    "conservatively assuming rebase is in progress: %s",
+                    git_dir_stderr,
+                )
+                rebase_in_progress = True
 
             if rebase_in_progress:
                 abort_proc = subprocess.run(
@@ -1270,9 +1283,15 @@ class GitWriteStrategy:
                 # state (MCP commits), so the original files contain MCP
                 # content, not upstream content.  Restore the upstream
                 # version for each conflicting file so _write_conflict_files
-                # reads the right side.
-                for rel_path, _ in saved:
-                    subprocess.run(
+                # reads the right side.  If checkout fails for a given
+                # path (deleted upstream, permission error, etc.), DROP it
+                # from `saved` — otherwise _write_conflict_files would
+                # produce a sibling that contains the same MCP bytes as the
+                # canonical path, defeating the "remote wins, local saved
+                # as sibling" invariant.
+                restored: list[tuple[str, str]] = []
+                for rel_path, mcp_content in saved:
+                    checkout_proc = subprocess.run(
                         [
                             "git",
                             "-C",
@@ -1286,6 +1305,23 @@ class GitWriteStrategy:
                         text=True,
                         env=env,
                     )
+                    if checkout_proc.returncode != 0:
+                        checkout_stderr = (checkout_proc.stderr or "").strip()
+                        if self._token and self._token in checkout_stderr:
+                            checkout_stderr = checkout_stderr.replace(
+                                self._token, "***"
+                            )
+                        logger.error(
+                            "Git force_pull: failed to restore upstream "
+                            "version of %r after rebase abort; dropping it "
+                            "from conflict siblings to avoid duplicate MCP "
+                            "content: %s",
+                            rel_path,
+                            checkout_stderr,
+                        )
+                        continue
+                    restored.append((rel_path, mcp_content))
+                saved = restored
 
             if not saved:
                 logger.warning(

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -15,6 +15,7 @@ import stat
 import subprocess
 import tempfile
 import threading
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -27,6 +28,16 @@ from markdown_vault_mcp.exceptions import ConfigurationError
 from markdown_vault_mcp.types import CommitDiff, HistoryEntry
 
 logger = logging.getLogger(__name__)
+
+# Reason codes returned in :class:`PullResult.reason` and
+# :class:`PushResult.reason`.  Defined as module-level constants so callers
+# (and tests) can refer to them by name rather than re-typing string literals.
+PULL_REASON_FETCH_FAILED = "fetch_failed"
+PULL_REASON_NO_REMOTE = "no_remote"
+PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS = "non_fast_forward_with_conflicts"
+PULL_REASON_REBASED = "rebased"
+PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS = "conflicts_resolved_with_siblings"
+PULL_REASON_CONFLICT_RESOLUTION_FAILED = "conflict_resolution_failed"
 
 
 def _is_ssh_remote(url: str) -> bool:
@@ -86,6 +97,102 @@ def _find_git_root(path: Path) -> Path | None:
         return Path(result.stdout.strip())
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
+
+
+@dataclass(frozen=True)
+class PullResult:
+    """Result of a :meth:`GitWriteStrategy.force_pull` invocation.
+
+    Attributes:
+        applied: ``True`` when the pull was actually executed and HEAD was
+            moved (or was already up-to-date and required no work).
+            Also ``True`` when divergent history was resolved via the
+            Syncthing-style sibling write — HEAD advanced to the remote
+            and the local MCP versions were preserved as
+            ``.conflict-mcp-*`` siblings (see ``conflict_files``).
+            ``False`` for ``dry_run`` calls and for failures that left
+            HEAD unchanged.
+        fast_forward: ``True`` when the pull was (or would have been) a
+            clean fast-forward.  ``False`` when divergent history
+            required rebase + sibling writes, or when the operation
+            failed.  Inspect ``reason`` and ``conflict_files`` to
+            distinguish "applied via conflict resolution" from outright
+            failure.
+        commits_pulled: Count of commits brought in.  In ``dry_run`` mode
+            this is the count that *would* have been pulled.
+        from_sha: HEAD SHA before the pull.
+        to_sha: HEAD SHA after the pull.  In ``dry_run`` mode this is the
+            SHA HEAD would have moved to.  When the pull failed and HEAD
+            did not move this equals ``from_sha``.
+        reason: Diagnostic code describing the outcome.  ``None`` for
+            clean fast-forward pulls and dry-runs.  Otherwise one of:
+
+            * ``"fetch_failed"`` — ``git fetch origin`` exited non-zero
+              (network error, auth failure, etc.); HEAD did not move.
+            * ``"no_remote"`` — neither ``@{upstream}`` nor
+              ``origin/HEAD`` could be resolved on the local clone.
+            * ``"non_fast_forward_with_conflicts"`` — local and remote
+              histories diverged and the conflict-resolution path
+              failed to produce a usable result; HEAD did not move.
+            * ``"rebased"`` — local and remote histories diverged but
+              ``git rebase @{upstream}`` replayed local commits cleanly
+              on top of the upstream with no manual intervention.
+              ``applied`` is ``True``; ``conflict_files`` is empty.
+            * ``"conflicts_resolved_with_siblings"`` — local and remote
+              histories diverged AND rebase hit real conflicts, which
+              were resolved by accepting upstream and saving the local
+              MCP versions as ``.conflict-mcp-*`` siblings (see #232).
+              HEAD advanced; ``applied`` is ``True`` and
+              ``conflict_files`` is populated.
+            * ``"conflict_resolution_failed"`` — rebase produced no
+              recoverable saved files and the working tree was
+              restored; HEAD did not move.
+
+            See module-level ``PULL_REASON_*`` constants for the
+            string values.
+        conflict_files: Vault-relative paths of Syncthing-style
+            ``.conflict-mcp-*`` siblings written when the pull resolved
+            divergent history (see #232 and the
+            ``"conflicts_resolved_with_siblings"`` reason above).
+            Empty for clean fast-forwards, dry-runs, and failure paths
+            that did not write any siblings.
+    """
+
+    applied: bool
+    fast_forward: bool
+    commits_pulled: int
+    from_sha: str
+    to_sha: str
+    reason: str | None = None
+    conflict_files: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class PushResult:
+    """Result of a :meth:`GitWriteStrategy.force_push` invocation.
+
+    Attributes:
+        applied: ``True`` when the push succeeded (or was a no-op because
+            the remote already had every local commit).  ``False`` when the
+            push was rejected or failed.
+        commits_pushed: Count of commits sent to the remote.  ``0`` when
+            there was nothing to push.
+        remote_sha_before: Remote ref SHA before the push.
+        remote_sha_after: Remote ref SHA after the push.  Equals the local
+            HEAD on success and ``remote_sha_before`` on failure.
+        reason: Set when ``applied=False`` — e.g. ``"non_fast_forward"``
+            or ``"network_error"``.  ``None`` on success.
+        hint: Operator-facing remediation suggestion when ``applied=False``.
+            Surfaced verbatim in the MCP tool response so the caller can
+            see exactly what to do next.
+    """
+
+    applied: bool
+    commits_pushed: int
+    remote_sha_before: str
+    remote_sha_after: str
+    reason: str | None = None
+    hint: str | None = None
 
 
 class GitWriteStrategy:
@@ -168,6 +275,11 @@ class GitWriteStrategy:
         self._commit_name = commit_name or self.DEFAULT_COMMIT_NAME
         self._commit_email = commit_email or self.DEFAULT_COMMIT_EMAIL
         self._git_lfs = git_lfs
+        # Retain the configured repo_path so methods invoked after construction
+        # (e.g. force_pull / force_push) can reach the working tree without
+        # the caller re-passing it.  Distinct from ``_pull_repo_path`` which
+        # is only set when the periodic pull loop is started via ``start()``.
+        self._repo_path: Path | None = repo_path
         self._git_root: Path | None = None
         self._git_root_checked = False
         self._write_init_done = False
@@ -764,6 +876,383 @@ class GitWriteStrategy:
             )
 
         return written
+
+    # ------------------------------------------------------------------
+    # Synchronous force-trigger helpers (used by the ``git_sync`` MCP tool)
+    # ------------------------------------------------------------------
+
+    def _resolve_force_repo(self) -> Path:
+        """Return the working tree path used by ``force_*`` methods.
+
+        Raises:
+            RuntimeError: When no ``repo_path`` was configured at
+                construction time.  The ``force_*`` methods require an
+                explicit working tree because they cannot infer one from
+                a per-write callback path.
+        """
+        if self._repo_path is None:
+            raise RuntimeError(
+                "GitWriteStrategy.force_* requires repo_path to be set at "
+                "construction time."
+            )
+        return self._repo_path
+
+    def _head_sha(self, git_root: Path) -> str:
+        """Return the current HEAD SHA of *git_root*."""
+        return self._git(git_root, "rev-parse", "HEAD").strip()
+
+    def _git(
+        self,
+        git_root: Path,
+        *args: str,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        """Run ``git -C <git_root> <args>`` and return stdout.
+
+        Thin wrapper used by the ``force_*`` helpers — keeps subprocess
+        boilerplate (capture, text mode, check=True) in one place.
+
+        Raises:
+            subprocess.CalledProcessError: If git exits non-zero.  Callers
+                handle this for branches that can legitimately fail
+                (e.g. ``merge --ff-only``).
+        """
+        result = subprocess.run(
+            ["git", "-C", str(git_root), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+        return result.stdout
+
+    def force_pull(self, *, dry_run: bool = False) -> PullResult:
+        """Pull from ``origin`` synchronously and return a structured result.
+
+        The remote-tracking branch is identified by reading the upstream of
+        the current branch (``@{upstream}``) so this method works even when
+        ``origin/HEAD`` has not been set on the local clone.
+
+        Acquires :attr:`_lock` for the duration so the periodic pull loop
+        and the per-write commit path cannot race against the fetch /
+        merge / rebase pipeline.  This blocks writes for the network
+        round-trip; that is acceptable for the interactive ``git_sync``
+        tool and mirrors what :meth:`sync_once` already does.
+
+        On ``ff-only`` failure (divergent history) the implementation
+        falls through to the same rebase + Syncthing-style sibling write
+        path used by :meth:`sync_once` (see :meth:`_resolve_rebase_conflicts`
+        and :meth:`_write_conflict_files`).  When the conflict-resolution
+        path produces sibling files HEAD has advanced to the remote and
+        :attr:`PullResult.applied` is ``True`` with
+        :attr:`PullResult.reason` set to
+        ``"conflicts_resolved_with_siblings"``.
+
+        After a successful HEAD advance — fast-forward or sibling
+        resolution — :meth:`_lfs_pull` runs so any LFS pointers in the
+        new commits are materialised before the caller sees the working
+        tree.
+
+        Args:
+            dry_run: When ``True``, runs ``git fetch`` and computes the
+                would-be pull without modifying HEAD.  Returns
+                ``applied=False`` with ``commits_pulled`` set to the count
+                that *would* have been pulled.
+
+        Returns:
+            :class:`PullResult` describing the operation.  See the
+            ``reason`` field for the full enumeration of outcomes.
+
+        Raises:
+            RuntimeError: When the strategy was constructed without
+                ``repo_path``.
+        """
+        git_root = self._resolve_force_repo()
+        env = self._git_env()
+        try:
+            with self._lock:
+                from_sha = self._head_sha(git_root)
+
+                # Always fetch first — both dry-run and real-pull need the
+                # remote-tracking ref refreshed before comparing SHAs.
+                try:
+                    self._git(git_root, "fetch", "origin", env=env)
+                except subprocess.CalledProcessError as exc:
+                    logger.warning(
+                        "Git force_pull: fetch failed: %s",
+                        (exc.stderr or "").strip(),
+                    )
+                    return PullResult(
+                        applied=False,
+                        fast_forward=False,
+                        commits_pulled=0,
+                        from_sha=from_sha,
+                        to_sha=from_sha,
+                        reason=PULL_REASON_FETCH_FAILED,
+                    )
+
+                # Resolve the upstream-tracking branch.  Falls back to
+                # ``origin/HEAD`` so callers with a non-tracking checkout
+                # still get a reasonable answer; both yield the remote-side
+                # SHA.
+                try:
+                    remote_sha = self._git(
+                        git_root, "rev-parse", "@{upstream}", env=env
+                    ).strip()
+                except subprocess.CalledProcessError:
+                    try:
+                        remote_sha = self._git(
+                            git_root, "rev-parse", "origin/HEAD", env=env
+                        ).strip()
+                    except subprocess.CalledProcessError:
+                        return PullResult(
+                            applied=False,
+                            fast_forward=False,
+                            commits_pulled=0,
+                            from_sha=from_sha,
+                            to_sha=from_sha,
+                            reason=PULL_REASON_NO_REMOTE,
+                        )
+
+                if remote_sha == from_sha:
+                    # Already up to date — successful no-op.
+                    return PullResult(
+                        applied=True,
+                        fast_forward=True,
+                        commits_pulled=0,
+                        from_sha=from_sha,
+                        to_sha=from_sha,
+                    )
+
+                # Count commits between local and remote.  When the local
+                # branch is behind the remote this is the number of commits
+                # ``merge --ff-only`` would apply.
+                commits_ahead = self._git(
+                    git_root,
+                    "rev-list",
+                    "--count",
+                    f"{from_sha}..{remote_sha}",
+                    env=env,
+                ).strip()
+                try:
+                    commits_pulled = int(commits_ahead)
+                except ValueError:
+                    # ``rev-list --count`` is documented to print a single
+                    # integer; if parsing fails, the underlying git call is
+                    # broken in a way we should surface rather than silently
+                    # report 0 commits.  Fall back to 0 but log loudly.
+                    logger.warning(
+                        "Git force_pull: could not parse commit count %r "
+                        "from `git rev-list --count %s..%s`",
+                        commits_ahead,
+                        from_sha,
+                        remote_sha,
+                    )
+                    commits_pulled = 0
+
+                if dry_run:
+                    # Heuristic: assume fast-forward.  Actual ff-ness is
+                    # only known after attempting the merge; the conflict
+                    # path below corrects this for non-dry-run calls.
+                    return PullResult(
+                        applied=False,
+                        fast_forward=True,
+                        commits_pulled=commits_pulled,
+                        from_sha=from_sha,
+                        to_sha=remote_sha,
+                    )
+
+                # Attempt fast-forward merge first.  On divergence fall
+                # through to rebase + Syncthing-style sibling resolution,
+                # mirroring :meth:`sync_once`.
+                try:
+                    self._git(git_root, "merge", "--ff-only", remote_sha, env=env)
+                except subprocess.CalledProcessError as ff_exc:
+                    logger.debug(
+                        "Git force_pull: ff-only merge failed, attempting rebase: %s",
+                        (ff_exc.stderr or "").strip(),
+                    )
+                    return self._force_pull_rebase_fallback(
+                        git_root=git_root,
+                        env=env,
+                        from_sha=from_sha,
+                    )
+
+                # Fast-forward succeeded.  ``remote_sha`` is the new HEAD —
+                # no need to re-read it via ``_head_sha``.
+                self._lfs_pull(env=env)
+                return PullResult(
+                    applied=True,
+                    fast_forward=True,
+                    commits_pulled=commits_pulled,
+                    from_sha=from_sha,
+                    to_sha=remote_sha,
+                )
+        finally:
+            self._cleanup_git_env(env)
+
+    def _force_pull_rebase_fallback(
+        self,
+        *,
+        git_root: Path,
+        env: dict[str, str] | None,
+        from_sha: str,
+    ) -> PullResult:
+        """Attempt rebase + Syncthing-style sibling resolution.
+
+        Called by :meth:`force_pull` when ``merge --ff-only`` failed
+        because local and remote histories diverged.  Mirrors the
+        rebase / conflict-resolution branch in :meth:`sync_once` but
+        returns a structured :class:`PullResult` rather than a bool.
+
+        Must be called with :attr:`_lock` already held — it issues
+        further git commands against the same working tree.
+
+        Args:
+            git_root: Working-tree root used for git ``-C``.
+            env: Optional GIT_ASKPASS environment for token auth.
+            from_sha: HEAD SHA captured before the fetch.
+
+        Returns:
+            :class:`PullResult` whose ``reason`` is one of
+            ``"conflicts_resolved_with_siblings"`` (HEAD advanced,
+            siblings written, ``applied=True``),
+            ``"conflict_resolution_failed"`` (HEAD unchanged,
+            ``applied=False``), or
+            ``"non_fast_forward_with_conflicts"`` (rebase started but
+            could not be cleanly resolved or aborted, ``applied=False``).
+        """
+        # First try a plain rebase — this handles the common case where
+        # local commits touch *different* files than the upstream commits
+        # and replay cleanly with no manual intervention.
+        try:
+            self._git(git_root, "rebase", "@{upstream}", env=env)
+        except subprocess.CalledProcessError:
+            # Real conflicts during rebase — resolve by accepting upstream
+            # and saving the local MCP versions as Syncthing-style siblings.
+            saved = self._resolve_rebase_conflicts(git_root, env)
+
+            # If a rebase is still in progress (loop hit its iteration
+            # limit, or exited via ``break`` without completing), abort
+            # cleanly so the working tree is consistent before we write
+            # conflict files.
+            #
+            # Reliable signal: ``.git/rebase-merge`` and ``.git/rebase-apply``
+            # directories.  ``REBASE_HEAD`` ref is NOT reliable — git keeps
+            # it around after a successful ``rebase --continue`` for use as
+            # a backup reference, so its mere existence does not mean a
+            # rebase is in flight.  Resolve ``GIT_DIR`` via ``rev-parse``
+            # so this works inside worktrees and submodules where the dir
+            # is not the repo's literal ``.git``.
+            git_dir_proc = subprocess.run(
+                ["git", "-C", str(git_root), "rev-parse", "--git-dir"],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            if git_dir_proc.returncode == 0:
+                git_dir = Path(git_dir_proc.stdout.strip())
+                if not git_dir.is_absolute():
+                    git_dir = git_root / git_dir
+                rebase_in_progress = (git_dir / "rebase-merge").is_dir() or (
+                    git_dir / "rebase-apply"
+                ).is_dir()
+            else:
+                # Fall back to assuming no rebase in progress — the worst
+                # case is a missed abort, not a corrupted repo.
+                rebase_in_progress = False
+
+            if rebase_in_progress:
+                abort_proc = subprocess.run(
+                    ["git", "-C", str(git_root), "rebase", "--abort"],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
+                if abort_proc.returncode != 0:
+                    logger.error(
+                        "Git force_pull: failed to abort rebase: %s",
+                        (abort_proc.stderr or "").strip(),
+                    )
+                    return PullResult(
+                        applied=False,
+                        fast_forward=False,
+                        commits_pulled=0,
+                        from_sha=from_sha,
+                        to_sha=from_sha,
+                        reason=PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS,
+                    )
+                # After abort, the working tree reverts to the pre-rebase
+                # state (MCP commits), so the original files contain MCP
+                # content, not upstream content.  Restore the upstream
+                # version for each conflicting file so _write_conflict_files
+                # reads the right side.
+                for rel_path, _ in saved:
+                    subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(git_root),
+                            "checkout",
+                            "@{upstream}",
+                            "--",
+                            rel_path,
+                        ],
+                        capture_output=True,
+                        text=True,
+                        env=env,
+                    )
+
+            if not saved:
+                logger.warning(
+                    "Git force_pull: conflict resolution failed, leaving HEAD unchanged"
+                )
+                return PullResult(
+                    applied=False,
+                    fast_forward=False,
+                    commits_pulled=0,
+                    from_sha=from_sha,
+                    to_sha=from_sha,
+                    reason=PULL_REASON_CONFLICT_RESOLUTION_FAILED,
+                )
+
+            written = self._write_conflict_files(git_root, saved, env)
+            for cf in written:
+                logger.warning(
+                    "Git force_pull: conflict resolved, saved MCP version as %s",
+                    cf,
+                )
+            logger.info(
+                "Git force_pull: rebase completed with %d conflict file(s)",
+                len(written),
+            )
+            new_head = self._head_sha(git_root)
+            self._lfs_pull(env=env)
+            # HEAD has advanced past the upstream because conflict
+            # resolution itself produced a new commit on top.  Use the
+            # actual new HEAD rather than ``remote_sha``.
+            return PullResult(
+                applied=True,
+                fast_forward=False,
+                commits_pulled=0,
+                from_sha=from_sha,
+                to_sha=new_head,
+                reason=PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS,
+                conflict_files=tuple(written),
+            )
+
+        # Plain rebase succeeded — local commits replayed cleanly on top
+        # of the upstream.  HEAD has advanced.
+        new_head = self._head_sha(git_root)
+        self._lfs_pull(env=env)
+        return PullResult(
+            applied=True,
+            fast_forward=False,
+            commits_pulled=0,
+            from_sha=from_sha,
+            to_sha=new_head,
+            reason=PULL_REASON_REBASED,
+        )
 
     def sync_once(self, repo_path: Path) -> bool:
         """Fetch and update once, returning True if HEAD advanced.

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1267,9 +1267,12 @@ class GitWriteStrategy:
                     env=env,
                 )
                 if abort_proc.returncode != 0:
+                    abort_stderr = (abort_proc.stderr or "").strip()
+                    if self._token and self._token in abort_stderr:
+                        abort_stderr = abort_stderr.replace(self._token, "***")
                     logger.error(
                         "Git force_pull: failed to abort rebase: %s",
-                        (abort_proc.stderr or "").strip(),
+                        abort_stderr,
                     )
                     return PullResult(
                         applied=False,

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -178,6 +178,36 @@ class PullResult:
     reason: str | None = None
     conflict_files: tuple[str, ...] = field(default_factory=tuple)
 
+    @classmethod
+    def head_unchanged_failure(cls, from_sha: str, reason: str) -> PullResult:
+        """Construct a ``PullResult`` for a failure path where HEAD did not move.
+
+        The 5 failure paths in :meth:`GitWriteStrategy.force_pull` and its
+        helpers (``no_remote``, ``non_fast_forward``,
+        ``conflict_resolution_failed``, ``non_fast_forward_with_conflicts``,
+        ``fetch_failed``) all share the same shape: ``applied=False``,
+        ``fast_forward=False``, ``commits_pulled=0``, and
+        ``to_sha == from_sha`` (HEAD unchanged).  This factory reduces the
+        repetition.
+
+        Args:
+            from_sha: HEAD SHA before the failed operation.  Used for both
+                ``from_sha`` and ``to_sha`` since HEAD did not move.
+            reason: One of the ``PULL_REASON_*`` constants.
+
+        Returns:
+            A ``PullResult`` with the failure-shape fields set and the
+            provided ``reason``.
+        """
+        return cls(
+            applied=False,
+            fast_forward=False,
+            commits_pulled=0,
+            from_sha=from_sha,
+            to_sha=from_sha,
+            reason=reason,
+        )
+
 
 @dataclass(frozen=True)
 class PushResult:
@@ -853,13 +883,8 @@ class GitWriteStrategy:
                     "after conflict-resolution failure also failed: %s",
                     self._redact((abort_proc.stderr or "").strip()),
                 )
-            return None, PullResult(
-                applied=False,
-                fast_forward=False,
-                commits_pulled=0,
-                from_sha=from_sha,
-                to_sha=from_sha,
-                reason=PULL_REASON_CONFLICT_RESOLUTION_FAILED,
+            return None, PullResult.head_unchanged_failure(
+                from_sha, PULL_REASON_CONFLICT_RESOLUTION_FAILED
             )
         return saved, None
 
@@ -992,6 +1017,51 @@ class GitWriteStrategy:
                 continue
             restored.append((rel_path, mcp_content))
         return restored
+
+    def _build_pull_result_advanced(
+        self,
+        git_root: Path,
+        env: dict[str, str] | None,
+        *,
+        from_sha: str,
+        reason: str,
+        conflict_files: tuple[str, ...] = (),
+    ) -> PullResult:
+        """Build a successful PullResult after HEAD has advanced.
+
+        Captures the post-pull HEAD SHA and runs ``git lfs pull`` so any
+        LFS pointers brought in by the merge/rebase are resolved before
+        callers continue.  Used by both the plain-rebase success path and
+        the conflicts-resolved-with-siblings success path in
+        :meth:`force_pull` / :meth:`_force_pull_rebase_fallback`.
+
+        Args:
+            git_root: Working-tree root.
+            env: Optional GIT_ASKPASS environment.
+            from_sha: HEAD SHA captured before the operation.
+            reason: One of the ``PULL_REASON_*`` constants for the success
+                shape (typically ``REBASED`` or
+                ``CONFLICTS_RESOLVED_WITH_SIBLINGS``).
+            conflict_files: Tuple of Syncthing-style sibling paths written
+                during conflict resolution.  Empty for the plain-rebase
+                path.
+
+        Returns:
+            A ``PullResult`` with ``applied=True``, ``fast_forward=False``,
+            ``commits_pulled=0``, ``to_sha`` set to the post-operation
+            HEAD, and the provided ``reason`` / ``conflict_files``.
+        """
+        new_head = self._head_sha(git_root)
+        self._lfs_pull(env=env)
+        return PullResult(
+            applied=True,
+            fast_forward=False,
+            commits_pulled=0,
+            from_sha=from_sha,
+            to_sha=new_head,
+            reason=reason,
+            conflict_files=conflict_files,
+        )
 
     def _write_conflict_files(
         self,
@@ -1250,13 +1320,8 @@ class GitWriteStrategy:
                         "Git force_pull: fetch failed: %s",
                         stderr,
                     )
-                    return PullResult(
-                        applied=False,
-                        fast_forward=False,
-                        commits_pulled=0,
-                        from_sha=from_sha,
-                        to_sha=from_sha,
-                        reason=PULL_REASON_FETCH_FAILED,
+                    return PullResult.head_unchanged_failure(
+                        from_sha, PULL_REASON_FETCH_FAILED
                     )
 
                 # Resolve the upstream-tracking branch.  Falls back to
@@ -1273,13 +1338,8 @@ class GitWriteStrategy:
                             git_root, "rev-parse", "origin/HEAD", env=env
                         ).strip()
                     except subprocess.CalledProcessError:
-                        return PullResult(
-                            applied=False,
-                            fast_forward=False,
-                            commits_pulled=0,
-                            from_sha=from_sha,
-                            to_sha=from_sha,
-                            reason=PULL_REASON_NO_REMOTE,
+                        return PullResult.head_unchanged_failure(
+                            from_sha, PULL_REASON_NO_REMOTE
                         )
 
                 if remote_sha == from_sha:
@@ -1424,13 +1484,8 @@ class GitWriteStrategy:
 
             if rebase_in_progress:
                 if not self._abort_in_progress_rebase(git_root, env):
-                    return PullResult(
-                        applied=False,
-                        fast_forward=False,
-                        commits_pulled=0,
-                        from_sha=from_sha,
-                        to_sha=from_sha,
-                        reason=PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS,
+                    return PullResult.head_unchanged_failure(
+                        from_sha, PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS
                     )
                 saved = self._restore_upstream_paths(git_root, env, saved)
 
@@ -1438,13 +1493,8 @@ class GitWriteStrategy:
                 logger.warning(
                     "Git force_pull: conflict resolution failed, leaving HEAD unchanged"
                 )
-                return PullResult(
-                    applied=False,
-                    fast_forward=False,
-                    commits_pulled=0,
-                    from_sha=from_sha,
-                    to_sha=from_sha,
-                    reason=PULL_REASON_CONFLICT_RESOLUTION_FAILED,
+                return PullResult.head_unchanged_failure(
+                    from_sha, PULL_REASON_CONFLICT_RESOLUTION_FAILED
                 )
 
             written = self._write_conflict_files(git_root, saved, env)
@@ -1457,31 +1507,23 @@ class GitWriteStrategy:
                 "Git force_pull: rebase completed with %d conflict file(s)",
                 len(written),
             )
-            new_head = self._head_sha(git_root)
-            self._lfs_pull(env=env)
             # HEAD has advanced past the upstream because conflict
-            # resolution itself produced a new commit on top.  Use the
-            # actual new HEAD rather than ``remote_sha``.
-            return PullResult(
-                applied=True,
-                fast_forward=False,
-                commits_pulled=0,
+            # resolution itself produced a new commit on top.  The helper
+            # captures the actual new HEAD rather than ``remote_sha``.
+            return self._build_pull_result_advanced(
+                git_root,
+                env,
                 from_sha=from_sha,
-                to_sha=new_head,
                 reason=PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS,
                 conflict_files=tuple(written),
             )
 
         # Plain rebase succeeded — local commits replayed cleanly on top
         # of the upstream.  HEAD has advanced.
-        new_head = self._head_sha(git_root)
-        self._lfs_pull(env=env)
-        return PullResult(
-            applied=True,
-            fast_forward=False,
-            commits_pulled=0,
+        return self._build_pull_result_advanced(
+            git_root,
+            env,
             from_sha=from_sha,
-            to_sha=new_head,
             reason=PULL_REASON_REBASED,
         )
 

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1157,6 +1157,8 @@ class GitWriteStrategy:
 
         Returns:
             :class:`PullResult` whose ``reason`` is one of
+            ``"rebased"`` (plain rebase succeeded, HEAD advanced,
+            ``applied=True``),
             ``"conflicts_resolved_with_siblings"`` (HEAD advanced,
             siblings written, ``applied=True``),
             ``"conflict_resolution_failed"`` (HEAD unchanged,

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -39,6 +39,11 @@ PULL_REASON_REBASED = "rebased"
 PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS = "conflicts_resolved_with_siblings"
 PULL_REASON_CONFLICT_RESOLUTION_FAILED = "conflict_resolution_failed"
 
+PUSH_REASON_DRY_RUN_UNSUPPORTED = "dry_run_unsupported"
+PUSH_REASON_NO_REMOTE = "no_remote"
+PUSH_REASON_NON_FAST_FORWARD = "non_fast_forward"
+PUSH_REASON_PUSH_FAILED = "push_failed"
+
 
 def _is_ssh_remote(url: str) -> bool:
     return url.startswith("git@") or url.startswith("ssh://")
@@ -173,15 +178,37 @@ class PushResult:
 
     Attributes:
         applied: ``True`` when the push succeeded (or was a no-op because
-            the remote already had every local commit).  ``False`` when the
-            push was rejected or failed.
+            the remote already had every local commit).  ``False`` for
+            ``dry_run`` calls and for push attempts that were rejected or
+            failed.
         commits_pushed: Count of commits sent to the remote.  ``0`` when
             there was nothing to push.
-        remote_sha_before: Remote ref SHA before the push.
+        remote_sha_before: Remote ref SHA before the push.  Equals
+            ``remote_sha_after`` on no-op and on failure.
         remote_sha_after: Remote ref SHA after the push.  Equals the local
             HEAD on success and ``remote_sha_before`` on failure.
-        reason: Set when ``applied=False`` — e.g. ``"non_fast_forward"``
-            or ``"network_error"``.  ``None`` on success.
+        reason: Diagnostic code describing the outcome.  ``None`` for
+            successful pushes (including the no-op already-up-to-date
+            case).  Otherwise one of:
+
+            * ``"dry_run_unsupported"`` — the caller passed
+              ``dry_run=True``; git has no safe local probe for "would
+              this push be accepted by the remote", so the call is a
+              no-op that sets this code.  HEAD and the remote are not
+              touched.
+            * ``"no_remote"`` — the upstream tracking branch could not
+              be resolved (no ``@{upstream}`` and no ``origin/HEAD``);
+              the push was not attempted.
+            * ``"non_fast_forward"`` — the remote rejected the push
+              because the local branch is not a strict descendant of
+              the remote tip.  ``hint`` points the caller at
+              ``git_sync(direction='pull')`` to reconcile first.
+            * ``"push_failed"`` — ``git push origin`` exited non-zero
+              for any other reason (network error, auth failure, hook
+              rejection).  ``hint`` carries the truncated stderr.
+
+            See module-level ``PUSH_REASON_*`` constants for the
+            string values.
         hint: Operator-facing remediation suggestion when ``applied=False``.
             Surfaced verbatim in the MCP tool response so the caller can
             see exactly what to do next.
@@ -1253,6 +1280,187 @@ class GitWriteStrategy:
             to_sha=new_head,
             reason=PULL_REASON_REBASED,
         )
+
+    def force_push(self, *, dry_run: bool = False) -> PushResult:
+        """Push local commits to ``origin`` synchronously.
+
+        Never force-pushes — the underlying ``git push origin`` is a plain
+        fast-forward push.  When the remote has commits the local clone
+        has not seen, the push is rejected and the returned
+        :class:`PushResult` carries ``reason="non_fast_forward"`` plus a
+        hint pointing at ``git_sync(direction='pull')``.  The caller is
+        expected to reconcile via the pull path and then retry.
+
+        Acquires :attr:`_lock` for the duration so the periodic pull loop
+        and the per-write commit + deferred-push pipeline cannot race
+        against the synchronous push.  This blocks writes for the network
+        round-trip; that is acceptable for the interactive ``git_sync``
+        tool and mirrors :meth:`force_pull`.
+
+        ``dry_run`` is a no-op.  Git has no safe local probe for "would
+        this push be accepted by the remote": the only authoritative
+        check is to actually attempt the push.  Rather than silently
+        substitute a misleading approximation, we surface this with
+        ``reason="dry_run_unsupported"`` so callers can document the
+        limitation.
+
+        Args:
+            dry_run: When ``True``, returns immediately without contacting
+                the remote.  See above for the rationale.
+
+        Returns:
+            :class:`PushResult` describing the operation.  See the
+            ``reason`` field for the full enumeration of outcomes.
+
+        Raises:
+            RuntimeError: When the strategy was constructed without
+                ``repo_path``.
+        """
+        git_root = self._resolve_force_repo()
+
+        with self._lock:
+            local_head = self._head_sha(git_root)
+
+            # Resolve the remote-tracking SHA before the push.  Mirrors
+            # :meth:`force_pull` — prefer ``@{upstream}`` (set when the
+            # branch was created via ``git push -u``), fall back to
+            # ``origin/HEAD`` for non-tracking checkouts.  ``origin/HEAD``
+            # alone is unreliable on freshly-pushed clones, hence the
+            # two-step lookup.
+            try:
+                remote_sha_before = self._git(
+                    git_root, "rev-parse", "@{upstream}"
+                ).strip()
+            except subprocess.CalledProcessError:
+                try:
+                    remote_sha_before = self._git(
+                        git_root, "rev-parse", "origin/HEAD"
+                    ).strip()
+                except subprocess.CalledProcessError:
+                    return PushResult(
+                        applied=False,
+                        commits_pushed=0,
+                        remote_sha_before="",
+                        remote_sha_after="",
+                        reason=PUSH_REASON_NO_REMOTE,
+                        hint=(
+                            "No upstream tracking branch is configured for the "
+                            "current branch.  Run `git push -u origin <branch>` "
+                            "from the working tree once to establish tracking."
+                        ),
+                    )
+
+            if dry_run:
+                # Document the limitation rather than fake a result.
+                return PushResult(
+                    applied=False,
+                    commits_pushed=0,
+                    remote_sha_before=remote_sha_before,
+                    remote_sha_after=remote_sha_before,
+                    reason=PUSH_REASON_DRY_RUN_UNSUPPORTED,
+                    hint=(
+                        "force_push has no dry_run mode: git provides no safe "
+                        "local probe for whether the remote will accept a push. "
+                        "Re-invoke with dry_run=False to actually push."
+                    ),
+                )
+
+            # No-op: local already matches the remote-tracking SHA.  We
+            # could let `git push` short-circuit on its own, but returning
+            # early avoids a subprocess + reads more clearly in logs.
+            if remote_sha_before == local_head:
+                return PushResult(
+                    applied=True,
+                    commits_pushed=0,
+                    remote_sha_before=remote_sha_before,
+                    remote_sha_after=remote_sha_before,
+                )
+
+            # Count commits between remote and local.  When the local
+            # branch is strictly ahead this is the count `git push` will
+            # send; when histories diverge `git push` would reject the
+            # push as non-fast-forward and the count is best-effort.
+            commits_ahead_str = self._git(
+                git_root,
+                "rev-list",
+                "--count",
+                f"{remote_sha_before}..{local_head}",
+            ).strip()
+            try:
+                commits_pushed = int(commits_ahead_str)
+            except ValueError:
+                logger.warning(
+                    "Git force_push: could not parse commit count %r "
+                    "from `git rev-list --count %s..%s`",
+                    commits_ahead_str,
+                    remote_sha_before,
+                    local_head,
+                )
+                commits_pushed = 0
+
+            # Use the strategy's git env so token-based HTTPS auth works
+            # through the same GIT_ASKPASS mechanism the deferred-push
+            # path uses.  Cleaned up in the finally block below.
+            env = self._git_env()
+            try:
+                try:
+                    self._git(git_root, "push", "origin", env=env)
+                except subprocess.CalledProcessError as exc:
+                    stderr = (exc.stderr or "").strip()
+                    # Redact token if it leaked into stderr.  Mirrors the
+                    # sanitisation in :meth:`_do_push_safe`.
+                    if self._token and self._token in stderr:
+                        stderr = stderr.replace(self._token, "***")
+
+                    # Detect the specific non-fast-forward case so the
+                    # caller can route to git_sync(direction='pull').
+                    # Git's wording is stable: "non-fast-forward" appears
+                    # both in the rejection line and the hint paragraph.
+                    if "non-fast-forward" in stderr or "fetch first" in stderr:
+                        logger.warning(
+                            "Git force_push: rejected as non-fast-forward "
+                            "(local %s vs remote %s)",
+                            local_head,
+                            remote_sha_before,
+                        )
+                        return PushResult(
+                            applied=False,
+                            commits_pushed=0,
+                            remote_sha_before=remote_sha_before,
+                            remote_sha_after=remote_sha_before,
+                            reason=PUSH_REASON_NON_FAST_FORWARD,
+                            hint=(
+                                "Remote has commits the local clone has not "
+                                "seen.  Run git_sync(direction='pull') to "
+                                "reconcile (fast-forward when possible, "
+                                "Syncthing-style siblings on real conflict), "
+                                "then retry git_sync(direction='push')."
+                            ),
+                        )
+
+                    logger.error(
+                        "Git force_push: push failed: %s",
+                        stderr,
+                    )
+                    truncated = stderr[:200]
+                    return PushResult(
+                        applied=False,
+                        commits_pushed=0,
+                        remote_sha_before=remote_sha_before,
+                        remote_sha_after=remote_sha_before,
+                        reason=PUSH_REASON_PUSH_FAILED,
+                        hint=truncated or "git push exited non-zero",
+                    )
+            finally:
+                self._cleanup_git_env(env)
+
+            # Push succeeded — remote now matches local HEAD.
+            return PushResult(
+                applied=True,
+                commits_pushed=commits_pushed,
+                remote_sha_before=remote_sha_before,
+                remote_sha_after=local_head,
+            )
 
     def sync_once(self, repo_path: Path) -> bool:
         """Fetch and update once, returning True if HEAD advanced.

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -863,6 +863,55 @@ class GitWriteStrategy:
             )
         return saved, None
 
+    def _check_rebase_in_progress(
+        self,
+        git_root: Path,
+        env: dict[str, str] | None,
+    ) -> bool:
+        """Return True if a rebase is in progress in this working tree.
+
+        Reliable signal: the existence of ``.git/rebase-merge`` or
+        ``.git/rebase-apply`` directories.  ``REBASE_HEAD`` ref is NOT
+        reliable — git keeps it around after a successful ``rebase
+        --continue`` for use as a backup reference, so its mere existence
+        does not mean a rebase is in flight.  Resolves ``GIT_DIR`` via
+        ``rev-parse`` so this works inside worktrees and submodules where
+        the directory is not the repo's literal ``.git``.
+
+        On ``rev-parse --git-dir`` failure (which means we genuinely cannot
+        tell), this conservatively returns ``True`` so the caller's abort
+        runs — abort on a clean tree fails loudly (and is logged), but
+        failing to abort a real in-progress rebase would leave the repo
+        wedged for every subsequent ``force_pull``.  The underlying
+        rev-parse failure is logged at ERROR with token-redacted stderr.
+
+        Args:
+            git_root: Working-tree root.
+            env: Optional GIT_ASKPASS environment.
+
+        Returns:
+            ``True`` if a rebase appears to be in progress (or if we cannot
+            tell); ``False`` only when ``rev-parse --git-dir`` succeeded
+            AND no ``rebase-merge`` / ``rebase-apply`` directory exists.
+        """
+        git_dir_proc = self._run_git_capturing(
+            git_root, "rev-parse", "--git-dir", env=env
+        )
+        if git_dir_proc.returncode != 0:
+            logger.error(
+                "Git force_pull: `git rev-parse --git-dir` failed; "
+                "conservatively assuming rebase is in progress: %s",
+                self._redact((git_dir_proc.stderr or "").strip()),
+            )
+            return True
+
+        git_dir = Path(git_dir_proc.stdout.strip())
+        if not git_dir.is_absolute():
+            git_dir = git_root / git_dir
+        return (git_dir / "rebase-merge").is_dir() or (
+            git_dir / "rebase-apply"
+        ).is_dir()
+
     def _write_conflict_files(
         self,
         git_root: Path,
@@ -1290,39 +1339,7 @@ class GitWriteStrategy:
             # limit, or exited via ``break`` without completing), abort
             # cleanly so the working tree is consistent before we write
             # conflict files.
-            #
-            # Reliable signal: ``.git/rebase-merge`` and ``.git/rebase-apply``
-            # directories.  ``REBASE_HEAD`` ref is NOT reliable — git keeps
-            # it around after a successful ``rebase --continue`` for use as
-            # a backup reference, so its mere existence does not mean a
-            # rebase is in flight.  Resolve ``GIT_DIR`` via ``rev-parse``
-            # so this works inside worktrees and submodules where the dir
-            # is not the repo's literal ``.git``.
-            git_dir_proc = self._run_git_capturing(
-                git_root, "rev-parse", "--git-dir", env=env
-            )
-            if git_dir_proc.returncode == 0:
-                git_dir = Path(git_dir_proc.stdout.strip())
-                if not git_dir.is_absolute():
-                    git_dir = git_root / git_dir
-                rebase_in_progress = (git_dir / "rebase-merge").is_dir() or (
-                    git_dir / "rebase-apply"
-                ).is_dir()
-            else:
-                # `rev-parse --git-dir` failure means we cannot tell whether
-                # a rebase is in progress.  Conservatively assume one IS in
-                # progress so the abort runs — abort on a clean tree fails
-                # loudly and is logged below; failing to abort a real
-                # in-progress rebase would leave the repo wedged for every
-                # subsequent force_pull.  Log the underlying failure with
-                # token-redacted stderr for the operator.
-                git_dir_stderr = self._redact((git_dir_proc.stderr or "").strip())
-                logger.error(
-                    "Git force_pull: `git rev-parse --git-dir` failed; "
-                    "conservatively assuming rebase is in progress: %s",
-                    git_dir_stderr,
-                )
-                rebase_in_progress = True
+            rebase_in_progress = self._check_rebase_in_progress(git_root, env)
 
             if rebase_in_progress:
                 abort_proc = self._run_git_capturing(

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -969,6 +969,40 @@ class GitWriteStrategy:
         )
         return result.stdout
 
+    def _run_git_capturing(
+        self,
+        git_root: Path,
+        *args: str,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a git command and return the completed process without raising.
+
+        Sister of :meth:`_git` for paths that need to inspect ``returncode``
+        and ``stderr`` instead of letting :class:`subprocess.CalledProcessError`
+        propagate.  Used in :meth:`_force_pull_rebase_fallback` where we need
+        to make recovery decisions based on whether ``git rebase --abort``
+        succeeded, whether the working tree has an in-progress rebase, etc.
+
+        Args:
+            git_root: Working-tree root used for ``git -C``.
+            *args: Git subcommand and arguments (without the leading ``git``).
+            env: Optional environment, typically ``self._git_env()`` for
+                token-bearing operations.  ``None`` inherits the parent process
+                environment.
+
+        Returns:
+            :class:`subprocess.CompletedProcess` with ``returncode``, ``stdout``,
+            and ``stderr`` populated.  Stderr will need to be passed through
+            :meth:`_redact` before logging or surfacing to callers.
+        """
+        return subprocess.run(
+            ["git", "-C", str(git_root), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,  # explicit — caller inspects returncode
+        )
+
     def force_pull(self, *, dry_run: bool = False) -> PullResult:
         """Pull from ``origin`` synchronously and return a structured result.
 
@@ -1201,11 +1235,8 @@ class GitWriteStrategy:
                 # stuck rebase-merge/ directory can tell whether the
                 # defensive abort fired and whether it succeeded.  Mirrors
                 # the in-progress-rebase abort path further below.
-                abort_proc = subprocess.run(
-                    ["git", "-C", str(git_root), "rebase", "--abort"],
-                    capture_output=True,
-                    text=True,
-                    env=env,
+                abort_proc = self._run_git_capturing(
+                    git_root, "rebase", "--abort", env=env
                 )
                 if abort_proc.returncode != 0:
                     abort_stderr = self._redact((abort_proc.stderr or "").strip())
@@ -1235,11 +1266,8 @@ class GitWriteStrategy:
             # rebase is in flight.  Resolve ``GIT_DIR`` via ``rev-parse``
             # so this works inside worktrees and submodules where the dir
             # is not the repo's literal ``.git``.
-            git_dir_proc = subprocess.run(
-                ["git", "-C", str(git_root), "rev-parse", "--git-dir"],
-                capture_output=True,
-                text=True,
-                env=env,
+            git_dir_proc = self._run_git_capturing(
+                git_root, "rev-parse", "--git-dir", env=env
             )
             if git_dir_proc.returncode == 0:
                 git_dir = Path(git_dir_proc.stdout.strip())
@@ -1265,11 +1293,8 @@ class GitWriteStrategy:
                 rebase_in_progress = True
 
             if rebase_in_progress:
-                abort_proc = subprocess.run(
-                    ["git", "-C", str(git_root), "rebase", "--abort"],
-                    capture_output=True,
-                    text=True,
-                    env=env,
+                abort_proc = self._run_git_capturing(
+                    git_root, "rebase", "--abort", env=env
                 )
                 if abort_proc.returncode != 0:
                     abort_stderr = self._redact((abort_proc.stderr or "").strip())
@@ -1297,18 +1322,12 @@ class GitWriteStrategy:
                 # as sibling" invariant.
                 restored: list[tuple[str, str]] = []
                 for rel_path, mcp_content in saved:
-                    checkout_proc = subprocess.run(
-                        [
-                            "git",
-                            "-C",
-                            str(git_root),
-                            "checkout",
-                            "@{upstream}",
-                            "--",
-                            rel_path,
-                        ],
-                        capture_output=True,
-                        text=True,
+                    checkout_proc = self._run_git_capturing(
+                        git_root,
+                        "checkout",
+                        "@{upstream}",
+                        "--",
+                        rel_path,
                         env=env,
                     )
                     if checkout_proc.returncode != 0:

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -357,6 +357,21 @@ class GitWriteStrategy:
         with contextlib.suppress(OSError):
             Path(script_path_str).unlink()
 
+    def _redact(self, text: str) -> str:
+        """Replace the configured PAT with ``***`` so it never reaches logs/responses.
+
+        Args:
+            text: Raw stderr / message text that may contain ``self._token``.
+
+        Returns:
+            The same text with every occurrence of ``self._token`` replaced by
+            ``"***"``.  Returns ``text`` unchanged when no token is configured
+            or the text doesn't contain it (cheap no-op for the common case).
+        """
+        if self._token and self._token in text:
+            return text.replace(self._token, "***")
+        return text
+
     def _ensure_git_root(self, repo_path: Path) -> Path | None:
         if self._git_root_checked:
             return self._git_root
@@ -537,9 +552,7 @@ class GitWriteStrategy:
             if self._enable_push:
                 self._schedule_push()
         except subprocess.CalledProcessError as exc:
-            sanitized_stderr = exc.stderr or ""
-            if self._token and self._token in sanitized_stderr:
-                sanitized_stderr = sanitized_stderr.replace(self._token, "***")
+            sanitized_stderr = self._redact(exc.stderr or "")
             logger.error(
                 "Git operation failed for %s (%s): command %s returned %d\n%s",
                 path,
@@ -572,9 +585,7 @@ class GitWriteStrategy:
         try:
             self._do_push()
         except subprocess.CalledProcessError as exc:
-            sanitized_stderr = exc.stderr or ""
-            if self._token and self._token in sanitized_stderr:
-                sanitized_stderr = sanitized_stderr.replace(self._token, "***")
+            sanitized_stderr = self._redact(exc.stderr or "")
             logger.error(
                 "Git push failed: command %s returned %d\n%s",
                 exc.cmd,
@@ -663,9 +674,7 @@ class GitWriteStrategy:
             try:
                 _push(self._git_root, self._token, self._username)
             except subprocess.CalledProcessError as exc:
-                sanitized_stderr = exc.stderr or ""
-                if self._token and self._token in sanitized_stderr:
-                    sanitized_stderr = sanitized_stderr.replace(self._token, "***")
+                sanitized_stderr = self._redact(exc.stderr or "")
                 logger.error(
                     "Git startup push failed: command %s returned %d\n%s",
                     exc.cmd,
@@ -1017,9 +1026,7 @@ class GitWriteStrategy:
                     # error messages can echo the URL with credentials
                     # back at the user.  Mirrors the redaction pattern
                     # already used in ``_do_push_safe`` and ``force_push``.
-                    stderr = (exc.stderr or "").strip()
-                    if self._token and self._token in stderr:
-                        stderr = stderr.replace(self._token, "***")
+                    stderr = self._redact((exc.stderr or "").strip())
                     logger.warning(
                         "Git force_pull: fetch failed: %s",
                         stderr,
@@ -1201,9 +1208,7 @@ class GitWriteStrategy:
                     env=env,
                 )
                 if abort_proc.returncode != 0:
-                    abort_stderr = (abort_proc.stderr or "").strip()
-                    if self._token and self._token in abort_stderr:
-                        abort_stderr = abort_stderr.replace(self._token, "***")
+                    abort_stderr = self._redact((abort_proc.stderr or "").strip())
                     logger.warning(
                         "Git force_pull: defensive `git rebase --abort` "
                         "after conflict-resolution failure also failed: %s",
@@ -1251,9 +1256,7 @@ class GitWriteStrategy:
                 # in-progress rebase would leave the repo wedged for every
                 # subsequent force_pull.  Log the underlying failure with
                 # token-redacted stderr for the operator.
-                git_dir_stderr = (git_dir_proc.stderr or "").strip()
-                if self._token and self._token in git_dir_stderr:
-                    git_dir_stderr = git_dir_stderr.replace(self._token, "***")
+                git_dir_stderr = self._redact((git_dir_proc.stderr or "").strip())
                 logger.error(
                     "Git force_pull: `git rev-parse --git-dir` failed; "
                     "conservatively assuming rebase is in progress: %s",
@@ -1269,9 +1272,7 @@ class GitWriteStrategy:
                     env=env,
                 )
                 if abort_proc.returncode != 0:
-                    abort_stderr = (abort_proc.stderr or "").strip()
-                    if self._token and self._token in abort_stderr:
-                        abort_stderr = abort_stderr.replace(self._token, "***")
+                    abort_stderr = self._redact((abort_proc.stderr or "").strip())
                     logger.error(
                         "Git force_pull: failed to abort rebase: %s",
                         abort_stderr,
@@ -1311,11 +1312,9 @@ class GitWriteStrategy:
                         env=env,
                     )
                     if checkout_proc.returncode != 0:
-                        checkout_stderr = (checkout_proc.stderr or "").strip()
-                        if self._token and self._token in checkout_stderr:
-                            checkout_stderr = checkout_stderr.replace(
-                                self._token, "***"
-                            )
+                        checkout_stderr = self._redact(
+                            (checkout_proc.stderr or "").strip()
+                        )
                         logger.error(
                             "Git force_pull: failed to restore upstream "
                             "version of %r after rebase abort; dropping it "
@@ -1504,11 +1503,9 @@ class GitWriteStrategy:
                 try:
                     self._git(git_root, "push", "origin", env=env)
                 except subprocess.CalledProcessError as exc:
-                    stderr = (exc.stderr or "").strip()
                     # Redact token if it leaked into stderr.  Mirrors the
                     # sanitisation in :meth:`_do_push_safe`.
-                    if self._token and self._token in stderr:
-                        stderr = stderr.replace(self._token, "***")
+                    stderr = self._redact((exc.stderr or "").strip())
 
                     # Detect the specific non-fast-forward case so the
                     # caller can route to git_sync(direction='pull').

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -304,4 +304,14 @@ def make_server(transport: str = "stdio") -> FastMCP:
     if is_read_only:
         mcp.disable(tags={"write"})
 
+    # Hide git-managed tools (e.g. git_sync) when not in managed git mode.
+    # The two disable passes compose: a tool tagged {"write", "git-managed"}
+    # is hidden if either condition fires (set-union on disabled tags).
+    # ``_managed`` is private but the MCP layer is a trusted consumer of
+    # GitWriteStrategy internals — the same pattern used by the git_sync
+    # tool itself in _server_tools.py.
+    git_strategy = config.to_collection_kwargs().get("git_strategy")
+    if git_strategy is None or not getattr(git_strategy, "_managed", False):
+        mcp.disable(tags={"git-managed"})
+
     return mcp

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -307,11 +307,16 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # Hide git-managed tools (e.g. git_sync) when not in managed git mode.
     # The two disable passes compose: a tool tagged {"write", "git-managed"}
     # is hidden if either condition fires (set-union on disabled tags).
-    # ``_managed`` is private but the MCP layer is a trusted consumer of
-    # GitWriteStrategy internals — the same pattern used by the git_sync
-    # tool itself in _server_tools.py.
-    git_strategy = config.to_collection_kwargs().get("git_strategy")
-    if git_strategy is None or not getattr(git_strategy, "_managed", False):
+    #
+    # Check the config directly rather than constructing a strategy via
+    # ``config.to_collection_kwargs()`` — that call builds an embedding
+    # provider (slow, GBs of memory) and may run ``git clone`` as a side
+    # effect.  The runtime check inside the ``git_sync`` tool body
+    # (``isinstance(strategy, GitWriteStrategy) and strategy._managed``)
+    # stays aligned with this gate via the same ``git_repo_url`` config
+    # value: managed mode requires an explicit remote URL.  See #220 for
+    # the broader cleanup of duplicate ``to_collection_kwargs`` calls.
+    if config.git_repo_url is None:
         mcp.disable(tags={"git-managed"})
 
     return mcp

--- a/src/markdown_vault_mcp/static/icons/git_sync.svg
+++ b/src/markdown_vault_mcp/static/icons/git_sync.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M21 12a9 9 0 0 0-9-9a9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9a9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 16h5v5"/></g></svg>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,11 @@ import pytest
 
 from markdown_vault_mcp.providers import EmbeddingProvider
 
+# Re-export reusable fixtures so they are auto-discovered by pytest in any
+# test module without requiring a per-file import (which would trip ruff's
+# F811 redefinition check on the parameter shadowing).
+from tests.fixtures.git import git_repo_pair  # noqa: F401
+
 
 class MockEmbeddingProvider(EmbeddingProvider):
     """Deterministic provider for testing. Returns hash-based vectors."""

--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -1,0 +1,92 @@
+"""Pytest fixtures for tests that need a real git repository.
+
+Provides:
+- :class:`GitRepoPair`: a small named tuple bundling the bare-remote and
+  local-clone paths produced by :func:`git_repo_pair`.
+- :func:`git_repo_pair`: a function-scoped fixture creating a fresh bare
+  "remote" + local clone with one initial commit on ``main``.
+
+Both pieces are intentionally minimal so they can be reused for any future
+git-tool tests (force-pull, force-push, conflict resolution, etc.).  Every
+invocation gets its own ``tmp_path`` so tests do not pollute each other.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, NamedTuple
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class GitRepoPair(NamedTuple):
+    """A bare 'remote' repo plus a local clone of it.
+
+    Attributes:
+        remote_path: Filesystem path to the bare repository acting as the
+            upstream.  Pass this as ``origin`` when constructing additional
+            clones in tests.
+        local_path: Filesystem path to the local working clone.  Has one
+            initial commit on ``main`` already pushed to ``origin``.
+    """
+
+    remote_path: Path
+    local_path: Path
+
+
+def _run_git(cwd: Path, *args: str) -> str:
+    """Run a git command synchronously and return stdout.
+
+    Args:
+        cwd: Working directory for the git command.
+        *args: Arguments passed to ``git`` (do not include the ``git``
+            executable itself).
+
+    Returns:
+        Captured stdout from the git command.
+
+    Raises:
+        subprocess.CalledProcessError: If the command exits non-zero.
+    """
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+@pytest.fixture
+def git_repo_pair(tmp_path: Path) -> GitRepoPair:
+    """Set up a bare 'remote' + local clone with one initial commit on main.
+
+    The local clone has ``origin`` pointing at the bare remote and an
+    upstream tracking branch (``main`` → ``origin/main``) established via
+    ``git push -u``.
+
+    Returns:
+        :class:`GitRepoPair` with both paths populated.
+    """
+    remote = tmp_path / "remote.git"
+    local = tmp_path / "local"
+    remote.mkdir()
+    _run_git(remote, "init", "--bare", "--initial-branch=main")
+
+    local.mkdir()
+    _run_git(local, "init", "--initial-branch=main")
+    _run_git(local, "config", "user.email", "test@example.com")
+    _run_git(local, "config", "user.name", "Test User")
+    _run_git(local, "remote", "add", "origin", str(remote))
+
+    # Initial commit so HEAD exists on both sides.
+    (local / "README.md").write_text("# Test\n")
+    _run_git(local, "add", "README.md")
+    _run_git(local, "commit", "-m", "initial")
+    _run_git(local, "push", "-u", "origin", "main")
+
+    return GitRepoPair(remote_path=remote, local_path=local)

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -1,0 +1,108 @@
+"""Unit tests for :meth:`GitWriteStrategy.force_pull` (added in #444).
+
+The bare-remote + local-clone fixture lives in :mod:`tests.fixtures.git`
+so the same setup can be reused by future tests for ``force_push`` and
+the higher-level ``git_sync`` MCP tool.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.fixtures.git import _run_git
+
+if TYPE_CHECKING:
+    from tests.fixtures.git import GitRepoPair
+
+
+def _seed_remote_commit(
+    pair: GitRepoPair, *, clone_name: str, file_name: str, body: str
+) -> None:
+    """Push one new commit to the bare remote from a sibling clone.
+
+    This simulates an out-of-band update to the upstream that the local
+    clone in *pair* has not yet seen.
+    """
+    sibling = pair.remote_path.parent / clone_name
+    sibling.mkdir()
+    _run_git(sibling, "init", "--initial-branch=main")
+    _run_git(sibling, "config", "user.email", "other@example.com")
+    _run_git(sibling, "config", "user.name", "Other")
+    _run_git(sibling, "remote", "add", "origin", str(pair.remote_path))
+    _run_git(sibling, "pull", "origin", "main")
+    (sibling / file_name).write_text(body)
+    _run_git(sibling, "add", file_name)
+    _run_git(sibling, "commit", "-m", f"remote commit: {file_name}")
+    _run_git(sibling, "push", "origin", "main")
+
+
+class TestForcePull:
+    """:meth:`GitWriteStrategy.force_pull` pulls from origin synchronously."""
+
+    def test_clean_fast_forward_returns_applied(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """A simple ff-only pull reports applied=True with the new commit count."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone2",
+            file_name="new.md",
+            body="from remote\n",
+        )
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_pull()
+
+        assert result.applied is True
+        assert result.fast_forward is True
+        assert result.commits_pulled == 1
+        assert (git_repo_pair.local_path / "new.md").exists()
+        assert result.from_sha != result.to_sha
+
+    def test_already_up_to_date_returns_zero_commits(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """No upstream changes → applied=True, commits_pulled=0, no SHA move."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_pull()
+
+        assert result.applied is True
+        assert result.commits_pulled == 0
+        assert result.from_sha == result.to_sha
+
+    def test_dry_run_does_not_modify_head(self, git_repo_pair: GitRepoPair) -> None:
+        """dry_run=True predicts the would-be pull without moving HEAD."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone2dry",
+            file_name="drynew.md",
+            body="dry\n",
+        )
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+        head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        result = strategy.force_pull(dry_run=True)
+        head_after = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+
+        assert head_before == head_after
+        assert result.applied is False  # dry-run reports prediction only
+        assert result.commits_pulled == 1  # would pull 1 commit
+        assert not (git_repo_pair.local_path / "drynew.md").exists()

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from tests.fixtures.git import _run_git
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tests.fixtures.git import GitRepoPair
 
 
@@ -208,3 +212,244 @@ class TestForcePush:
         assert result.hint is not None
         # Dry-run must not touch the remote.
         assert result.remote_sha_before == result.remote_sha_after
+
+
+class TestForceMethodsErrorBranches:
+    """Error-path coverage for ``force_pull`` / ``force_push``.
+
+    These tests target the branches the happy-path tests do not exercise:
+
+    * ``_resolve_force_repo`` raising when constructed without ``repo_path``
+    * ``force_pull`` ``fetch_failed`` (remote URL unreachable)
+    * ``force_pull`` ``no_remote`` (no upstream and no ``origin/HEAD``)
+    * ``force_pull`` ``rebased`` (divergent histories on different files)
+    * ``force_push`` ``no_remote`` (same upstream-resolution failure)
+    * ``force_push`` ``push_failed`` (generic remote rejection, not non-ff)
+
+    Together they take the ``git.py`` diff coverage from ~75% to >=80%.
+    """
+
+    def test_force_pull_without_repo_path_raises_runtime_error(self) -> None:
+        """``force_pull`` requires ``repo_path`` set at construction time."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        strategy = GitWriteStrategy(enable_pull=True, enable_push=False)
+        with pytest.raises(RuntimeError, match="repo_path"):
+            strategy.force_pull()
+
+    def test_force_push_without_repo_path_raises_runtime_error(self) -> None:
+        """``force_push`` requires ``repo_path`` set at construction time."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        strategy = GitWriteStrategy(enable_pull=False, enable_push=True)
+        with pytest.raises(RuntimeError, match="repo_path"):
+            strategy.force_push()
+
+    def test_force_pull_fetch_failed_when_remote_unreachable(
+        self, tmp_path: Path
+    ) -> None:
+        """Unreachable origin URL → ``applied=False`` with ``reason='fetch_failed'``."""
+        from markdown_vault_mcp.git import (
+            PULL_REASON_FETCH_FAILED,
+            GitWriteStrategy,
+        )
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _run_git(repo, "init", "--initial-branch=main")
+        _run_git(repo, "config", "user.email", "x@example.com")
+        _run_git(repo, "config", "user.name", "X")
+        # Point origin at a path that does not exist — ``git fetch`` exits non-zero.
+        _run_git(
+            repo, "remote", "add", "origin", str(tmp_path / "definitely-not-a-repo")
+        )
+        (repo / "f.md").write_text("hi\n")
+        _run_git(repo, "add", "f.md")
+        _run_git(repo, "commit", "-m", "initial")
+
+        strategy = GitWriteStrategy(enable_pull=True, enable_push=False, repo_path=repo)
+        head_before = _run_git(repo, "rev-parse", "HEAD").strip()
+        result = strategy.force_pull()
+
+        assert result.applied is False
+        assert result.reason == PULL_REASON_FETCH_FAILED
+        assert result.commits_pulled == 0
+        # HEAD did not move on the failed fetch.
+        assert result.from_sha == head_before
+        assert result.to_sha == head_before
+
+    def test_force_pull_no_remote_when_upstream_and_origin_head_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """No tracking branch and no ``origin/HEAD`` → ``reason='no_remote'``.
+
+        Builds a clone where:
+
+        * ``git fetch origin`` succeeds (the bare remote exists, just has
+          no commits to fetch),
+        * ``rev-parse @{upstream}`` fails (no upstream set — we never ran
+          ``git push -u``),
+        * ``rev-parse origin/HEAD`` fails (the empty bare remote has no
+          ``HEAD`` symbolic ref to populate ``origin/HEAD``).
+
+        That triple condition exercises the ``no_remote`` return inside
+        ``force_pull`` (lines 1029-1042).
+        """
+        from markdown_vault_mcp.git import (
+            PULL_REASON_NO_REMOTE,
+            GitWriteStrategy,
+        )
+
+        # Empty bare remote — fetch will succeed but produce no refs.
+        empty_remote = tmp_path / "empty.git"
+        empty_remote.mkdir()
+        _run_git(empty_remote, "init", "--bare", "--initial-branch=main")
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _run_git(repo, "init", "--initial-branch=main")
+        _run_git(repo, "config", "user.email", "x@example.com")
+        _run_git(repo, "config", "user.name", "X")
+        _run_git(repo, "remote", "add", "origin", str(empty_remote))
+        (repo / "f.md").write_text("hi\n")
+        _run_git(repo, "add", "f.md")
+        _run_git(repo, "commit", "-m", "initial")
+        # Note: no ``git push -u`` — upstream tracking is intentionally absent.
+
+        strategy = GitWriteStrategy(enable_pull=True, enable_push=False, repo_path=repo)
+        result = strategy.force_pull()
+
+        assert result.applied is False
+        assert result.reason == PULL_REASON_NO_REMOTE
+        assert result.commits_pulled == 0
+
+    def test_force_pull_rebased_when_divergent_on_different_files(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """Divergent commits touching different files → plain rebase succeeds.
+
+        Covers the ``PULL_REASON_REBASED`` success path (lines 1273-1282)
+        which is not exercised by the conflict-resolution test in
+        ``test_git_sync.py`` (that path edits the same file on both sides
+        and ends up in the sibling-resolution branch).
+        """
+        from markdown_vault_mcp.git import (
+            PULL_REASON_REBASED,
+            GitWriteStrategy,
+        )
+
+        # Remote advances on file A.
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_rebased",
+            file_name="remote_only.md",
+            body="remote\n",
+        )
+
+        # Local commits a different file B — divergent histories, no overlap.
+        (git_repo_pair.local_path / "local_only.md").write_text("local\n")
+        _run_git(git_repo_pair.local_path, "add", "local_only.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local divergent")
+
+        head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_pull()
+
+        assert result.applied is True
+        assert result.fast_forward is False
+        assert result.reason == PULL_REASON_REBASED
+        # HEAD has moved past the original local commit (rebase replays on top).
+        assert result.from_sha == head_before
+        assert result.to_sha != head_before
+        # Both files exist after the rebase.
+        assert (git_repo_pair.local_path / "remote_only.md").exists()
+        assert (git_repo_pair.local_path / "local_only.md").exists()
+
+    def test_force_push_no_remote_when_upstream_and_origin_head_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """No tracking branch and no ``origin/HEAD`` → ``reason='no_remote'``.
+
+        Mirrors the ``force_pull`` ``no_remote`` test for the push side
+        (lines 1334-1351).  ``force_push`` does not call ``git fetch``, so
+        an empty bare remote is enough to make both upstream lookups fail.
+        """
+        from markdown_vault_mcp.git import (
+            PUSH_REASON_NO_REMOTE,
+            GitWriteStrategy,
+        )
+
+        empty_remote = tmp_path / "empty.git"
+        empty_remote.mkdir()
+        _run_git(empty_remote, "init", "--bare", "--initial-branch=main")
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _run_git(repo, "init", "--initial-branch=main")
+        _run_git(repo, "config", "user.email", "x@example.com")
+        _run_git(repo, "config", "user.name", "X")
+        _run_git(repo, "remote", "add", "origin", str(empty_remote))
+        (repo / "f.md").write_text("hi\n")
+        _run_git(repo, "add", "f.md")
+        _run_git(repo, "commit", "-m", "initial")
+        # No ``git push -u`` — upstream tracking is intentionally absent.
+
+        strategy = GitWriteStrategy(enable_pull=False, enable_push=True, repo_path=repo)
+        result = strategy.force_push()
+
+        assert result.applied is False
+        assert result.reason == PUSH_REASON_NO_REMOTE
+        assert result.commits_pushed == 0
+        assert result.hint is not None
+        assert "git push -u" in result.hint
+
+    def test_force_push_to_unreachable_remote_returns_push_failed(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """Generic push failure (not non-ff) → ``reason='push_failed'`` + truncated hint.
+
+        Repoint origin at a non-existent path so ``git push`` fails with a
+        connection / lookup error rather than the well-known non-fast-forward
+        message.  Covers the error-handling tail of ``force_push`` (lines
+        1441-1453).
+        """
+        from markdown_vault_mcp.git import (
+            PUSH_REASON_PUSH_FAILED,
+            GitWriteStrategy,
+        )
+
+        # Stage a local commit so there's actually something to push.
+        (git_repo_pair.local_path / "to_push.md").write_text("payload\n")
+        _run_git(git_repo_pair.local_path, "add", "to_push.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "to push")
+
+        # Re-point origin at a bogus path — ``rev-parse @{upstream}`` still
+        # works (tracking metadata remains), but ``git push`` fails.
+        _run_git(
+            git_repo_pair.local_path,
+            "remote",
+            "set-url",
+            "origin",
+            str(git_repo_pair.local_path.parent / "definitely-not-a-repo"),
+        )
+
+        strategy = GitWriteStrategy(
+            enable_pull=False,
+            enable_push=True,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_push()
+
+        assert result.applied is False
+        assert result.reason == PUSH_REASON_PUSH_FAILED
+        assert result.commits_pushed == 0
+        # Hint is a (truncated) excerpt of git's stderr — non-empty.
+        assert result.hint is not None
+        assert len(result.hint) > 0
+        # Hint must not contain the full original (non-truncated) marker if stderr
+        # was longer than the cap, but we accept a short stderr too.
+        assert len(result.hint) <= 200

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -1,8 +1,9 @@
-"""Unit tests for :meth:`GitWriteStrategy.force_pull` (added in #444).
+"""Unit tests for :meth:`GitWriteStrategy.force_pull` and
+:meth:`GitWriteStrategy.force_push` (added in #444).
 
 The bare-remote + local-clone fixture lives in :mod:`tests.fixtures.git`
-so the same setup can be reused by future tests for ``force_push`` and
-the higher-level ``git_sync`` MCP tool.
+so the same setup can be reused by future tests for the higher-level
+``git_sync`` MCP tool.
 """
 
 from __future__ import annotations
@@ -106,3 +107,104 @@ class TestForcePull:
         assert result.applied is False  # dry-run reports prediction only
         assert result.commits_pulled == 1  # would pull 1 commit
         assert not (git_repo_pair.local_path / "drynew.md").exists()
+
+
+class TestForcePush:
+    """:meth:`GitWriteStrategy.force_push` pushes to origin synchronously."""
+
+    def test_clean_push_returns_applied(self, git_repo_pair: GitRepoPair) -> None:
+        """One local commit ahead → push → applied=True, commits_pushed=1."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        # Create a local commit not yet on origin.
+        (git_repo_pair.local_path / "local.md").write_text("local change\n")
+        _run_git(git_repo_pair.local_path, "add", "local.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local commit")
+
+        local_head = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        remote_before = _run_git(
+            git_repo_pair.local_path, "rev-parse", "@{upstream}"
+        ).strip()
+        assert local_head != remote_before
+
+        strategy = GitWriteStrategy(
+            enable_pull=False,
+            enable_push=True,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_push()
+
+        assert result.applied is True
+        assert result.commits_pushed == 1
+        assert result.remote_sha_before == remote_before
+        assert result.remote_sha_after == local_head
+
+    def test_nothing_to_push_returns_zero(self, git_repo_pair: GitRepoPair) -> None:
+        """No local commits ahead → applied=True, commits_pushed=0."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        strategy = GitWriteStrategy(
+            enable_pull=False,
+            enable_push=True,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_push()
+
+        assert result.applied is True
+        assert result.commits_pushed == 0
+        assert result.remote_sha_before == result.remote_sha_after
+
+    def test_non_fast_forward_returns_hint(self, git_repo_pair: GitRepoPair) -> None:
+        """Remote moves ahead + local diverges → push fails non-fast-forward."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        # Sibling clone advances the remote so origin/main has a commit
+        # the local clone has never seen.
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone2nff",
+            file_name="remote_only.md",
+            body="remote\n",
+        )
+
+        # Local makes a divergent commit (not based on the new remote tip).
+        (git_repo_pair.local_path / "local_only.md").write_text("local\n")
+        _run_git(git_repo_pair.local_path, "add", "local_only.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local divergent")
+
+        strategy = GitWriteStrategy(
+            enable_pull=False,
+            enable_push=True,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_push()
+
+        assert result.applied is False
+        assert result.reason == "non_fast_forward"
+        assert result.hint is not None
+        assert "git_sync" in result.hint
+        # HEAD on remote did not move.
+        assert result.remote_sha_before == result.remote_sha_after
+
+    def test_dry_run_returns_unsupported(self, git_repo_pair: GitRepoPair) -> None:
+        """``dry_run=True`` is a no-op — git has no safe remote-acceptance probe."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        # Stage a local commit so we know there's something that *would* push.
+        (git_repo_pair.local_path / "dryrun.md").write_text("dry-run\n")
+        _run_git(git_repo_pair.local_path, "add", "dryrun.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "dry-run commit")
+
+        strategy = GitWriteStrategy(
+            enable_pull=False,
+            enable_push=True,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_push(dry_run=True)
+
+        assert result.applied is False
+        assert result.commits_pushed == 0
+        assert result.reason == "dry_run_unsupported"
+        assert result.hint is not None
+        # Dry-run must not touch the remote.
+        assert result.remote_sha_before == result.remote_sha_after

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -407,6 +407,163 @@ class TestForceMethodsErrorBranches:
         assert result.hint is not None
         assert "git push -u" in result.hint
 
+    def test_force_pull_resolve_rebase_conflicts_raises_aborts_defensively(
+        self, git_repo_pair: GitRepoPair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If ``_resolve_rebase_conflicts`` raises, force_pull aborts the rebase.
+
+        The defensive try/except around ``_resolve_rebase_conflicts`` (added
+        in ``fb524e8``) wraps the conflict-resolution helper so a half-rebased
+        ``rebase-merge/`` directory cannot leak into the next pull.  Without
+        this fallback the repo would be wedged: subsequent pulls would
+        bail before they even start.
+
+        Drives a real two-clone conflict (so ``git rebase`` actually halts
+        with conflicts), then monkey-patches the conflict-resolution helper
+        to raise.  Asserts:
+
+        * the tool returns ``conflict_resolution_failed``,
+        * the rebase has been aborted (no ``rebase-merge`` directory left),
+        * HEAD is back at the pre-rebase commit (working tree consistent).
+
+        Covers the ``except Exception`` block in
+        ``_force_pull_rebase_fallback`` (lines 1186-1212 of ``git.py``).
+        """
+        from markdown_vault_mcp.git import (
+            PULL_REASON_CONFLICT_RESOLUTION_FAILED,
+            GitWriteStrategy,
+        )
+
+        # Two-clone conflict on the same file → real rebase halt.
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_resolve_raise",
+            file_name="README.md",
+            body="# remote\n",
+        )
+        (git_repo_pair.local_path / "README.md").write_text("# local\n")
+        _run_git(git_repo_pair.local_path, "add", "README.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local edit")
+        head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+
+        def _raising_resolve(*_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("simulated conflict resolution failure")
+
+        monkeypatch.setattr(strategy, "_resolve_rebase_conflicts", _raising_resolve)
+
+        result = strategy.force_pull()
+
+        assert result.applied is False
+        assert result.reason == PULL_REASON_CONFLICT_RESOLUTION_FAILED
+        # Defensive abort fired: no in-progress rebase directory left behind.
+        assert not (git_repo_pair.local_path / ".git" / "rebase-merge").exists()
+        assert not (git_repo_pair.local_path / ".git" / "rebase-apply").exists()
+        # HEAD reverted to pre-rebase state.
+        head_after = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        assert head_after == head_before
+
+    def test_force_pull_checkout_failure_drops_path_from_siblings(
+        self, git_repo_pair: GitRepoPair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failed ``git checkout @{upstream} -- <path>`` drops the path from siblings.
+
+        After the rebase-in-progress check trips the defensive abort, the
+        working tree reverts to the pre-rebase MCP content.
+        ``_force_pull_rebase_fallback`` then checks out the upstream
+        version of each conflicting file so the canonical path holds
+        upstream bytes and the saved-MCP version is written as a sibling.
+        If the checkout fails for a given path, we MUST drop it from the
+        saved list — otherwise the sibling would carry the same MCP bytes
+        as the canonical path, defeating the "remote wins, local saved as
+        sibling" invariant.
+
+        Drives a two-clone conflict, then:
+
+        * stubs ``_resolve_rebase_conflicts`` to return saved items WITHOUT
+          calling ``git rebase --continue`` (so the next ``rebase_in_progress``
+          probe returns True and the abort + restored loop both fire);
+        * stubs ``subprocess.run`` to fail specifically on the
+          ``checkout @{upstream}`` invocation that the restored loop runs.
+
+        With every checkout failing, the saved list ends up empty and
+        ``_force_pull_rebase_fallback`` surfaces ``conflict_resolution_failed``
+        (HEAD unchanged).
+
+        Covers the checkout-failure branch (lines 1313-1329 of ``git.py``).
+        """
+        import subprocess as _real_subprocess
+
+        from markdown_vault_mcp.git import (
+            PULL_REASON_CONFLICT_RESOLUTION_FAILED,
+            GitWriteStrategy,
+        )
+        from markdown_vault_mcp.git import subprocess as git_subprocess
+
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_checkout_fail",
+            file_name="README.md",
+            body="# remote\n",
+        )
+        (git_repo_pair.local_path / "README.md").write_text("# local\n")
+        _run_git(git_repo_pair.local_path, "add", "README.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local edit")
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+
+        # Stub the conflict-resolution helper: claim the README conflict
+        # was "saved" but DO NOT run the checkout/add/--continue dance, so
+        # the rebase remains in progress when control returns to
+        # ``_force_pull_rebase_fallback``.
+        def _stub_resolve(*_args: object, **_kwargs: object) -> list[tuple[str, str]]:
+            return [("README.md", "# local\n")]
+
+        monkeypatch.setattr(strategy, "_resolve_rebase_conflicts", _stub_resolve)
+
+        # Patch subprocess.run on the git module to fail the checkout
+        # ``@{upstream}`` call.  All other subprocess.run calls (including
+        # the rebase --abort the fallback runs) pass through to the real
+        # implementation.
+        real_run = _real_subprocess.run
+
+        def _patched_run(args: list[str], **kwargs: object) -> object:
+            if isinstance(args, list) and "checkout" in args and "@{upstream}" in args:
+                return _real_subprocess.CompletedProcess(
+                    args=args,
+                    returncode=1,
+                    stdout="",
+                    stderr="error: simulated checkout failure",
+                )
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(git_subprocess, "run", _patched_run)
+
+        head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        result = strategy.force_pull()
+
+        # Every saved path was dropped → empty saved list → reason is
+        # conflict_resolution_failed (HEAD unchanged), not "resolved with
+        # siblings" (which would imply at least one sibling was written).
+        assert result.applied is False
+        assert result.reason == PULL_REASON_CONFLICT_RESOLUTION_FAILED
+        # HEAD did not advance.
+        head_after = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        assert head_after == head_before
+        assert result.from_sha == result.to_sha
+        # No leftover rebase directory — defensive abort fired and succeeded.
+        assert not (git_repo_pair.local_path / ".git" / "rebase-merge").exists()
+        assert not (git_repo_pair.local_path / ".git" / "rebase-apply").exists()
+
     def test_force_push_to_unreachable_remote_returns_push_failed(
         self, git_repo_pair: GitRepoPair
     ) -> None:

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -1,0 +1,190 @@
+"""End-to-end tests for the ``git_sync`` MCP tool (added in #444).
+
+The tool composes :meth:`GitWriteStrategy.force_pull` and
+:meth:`GitWriteStrategy.force_push` behind a single MCP call.  These
+tests drive the tool through the in-memory :class:`fastmcp.Client` so we
+verify both the registered shape and the wire-level response.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastmcp import Client
+
+from markdown_vault_mcp.server import make_server
+from tests.fixtures.git import _run_git
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.fixtures.git import GitRepoPair
+
+
+_CLEAR_VARS = (
+    "MARKDOWN_VAULT_MCP_INDEX_PATH",
+    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
+    "MARKDOWN_VAULT_MCP_STATE_PATH",
+    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
+    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
+    "MARKDOWN_VAULT_MCP_EXCLUDE",
+    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
+    "MARKDOWN_VAULT_MCP_GIT_REPO_URL",
+    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
+    "MARKDOWN_VAULT_MCP_SERVER_NAME",
+    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
+    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
+    "MARKDOWN_VAULT_MCP_AUTH_MODE",
+    "MARKDOWN_VAULT_MCP_BASE_URL",
+    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
+    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
+    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
+    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
+    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
+    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
+)
+
+
+@pytest.fixture
+def _git_managed_env(
+    git_repo_pair: GitRepoPair, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Wire ``make_server`` to the bare-remote + local-clone fixture in managed mode.
+
+    Sets ``READ_ONLY=false`` (write tools must be visible) and disables
+    the periodic pull loop (the test drives sync explicitly via the
+    tool).  Returns the local clone path so tests can stage commits
+    against the working tree.
+    """
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(git_repo_pair.local_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+    monkeypatch.setenv(
+        "MARKDOWN_VAULT_MCP_GIT_REPO_URL", str(git_repo_pair.remote_path)
+    )
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S", "0")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S", "0")
+    return git_repo_pair.local_path
+
+
+def _seed_remote_commit(
+    pair: GitRepoPair, *, clone_name: str, file_name: str, body: str
+) -> None:
+    """Push one new commit to the bare remote from a sibling clone.
+
+    Mirrors the helper in ``test_git_force_methods.py`` so this module is
+    self-contained — both modules use the same bare-remote fixture but
+    test different layers (strategy unit tests vs. MCP tool integration).
+    """
+    sibling = pair.remote_path.parent / clone_name
+    sibling.mkdir()
+    _run_git(sibling, "init", "--initial-branch=main")
+    _run_git(sibling, "config", "user.email", "other@example.com")
+    _run_git(sibling, "config", "user.name", "Other")
+    _run_git(sibling, "remote", "add", "origin", str(pair.remote_path))
+    _run_git(sibling, "pull", "origin", "main")
+    (sibling / file_name).write_text(body)
+    _run_git(sibling, "add", file_name)
+    _run_git(sibling, "commit", "-m", f"remote commit: {file_name}")
+    _run_git(sibling, "push", "origin", "main")
+
+
+def _parse_tool_data(result: Any) -> Any:
+    """Extract the tool's structured payload from a ``CallToolResult``.
+
+    FastMCP v2 returns dicts directly via ``result.data``; this helper
+    falls back to parsing the raw text content when the typed accessor
+    cannot resolve the shape.
+    """
+    data = result.data
+    if isinstance(data, dict):
+        return data
+    raw = result.content[0].text if result.content else "{}"
+    return json.loads(raw)
+
+
+class TestGitSync:
+    """:tool:`git_sync` integration tests through the in-memory MCP client."""
+
+    async def test_clean_both_direction_pulls_and_pushes(
+        self, git_repo_pair: GitRepoPair, _git_managed_env: Path
+    ) -> None:
+        """direction='both' on a clean clone runs both legs and reports applied=True."""
+        # Stage one local commit so the push leg has something to send.
+        (git_repo_pair.local_path / "local.md").write_text("local\n")
+        _run_git(git_repo_pair.local_path, "add", "local.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local commit")
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool("git_sync", {"direction": "both"})
+
+        payload = _parse_tool_data(result)
+
+        assert payload["direction"] == "both"
+        assert "head_sha" in payload and len(payload["head_sha"]) == 40
+        assert "branch" in payload
+        assert payload["pull"] is not None
+        assert payload["pull"]["applied"] is True
+        assert payload["push"] is not None
+        assert payload["push"]["applied"] is True
+        assert payload["push"]["commits_pushed"] == 1
+        # dry_run key is only present when the caller passed dry_run=True.
+        assert "dry_run" not in payload
+
+    async def test_pull_only_direction_skips_push(
+        self, git_repo_pair: GitRepoPair, _git_managed_env: Path
+    ) -> None:
+        """direction='pull' fast-forwards the local clone and leaves push untouched."""
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_pull_only",
+            file_name="seeded.md",
+            body="seeded\n",
+        )
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool("git_sync", {"direction": "pull"})
+
+        payload = _parse_tool_data(result)
+
+        assert payload["direction"] == "pull"
+        assert payload["pull"] is not None
+        assert payload["pull"]["applied"] is True
+        assert payload["pull"]["commits_pulled"] == 1
+        assert payload["push"] is None  # push leg not invoked
+
+    async def test_dry_run_pull_does_not_modify_head(
+        self, git_repo_pair: GitRepoPair, _git_managed_env: Path
+    ) -> None:
+        """dry_run=True predicts the would-be pull without moving HEAD."""
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_dry",
+            file_name="dryseed.md",
+            body="dry\n",
+        )
+
+        head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "git_sync", {"direction": "pull", "dry_run": True}
+            )
+
+        head_after = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        payload = _parse_tool_data(result)
+
+        assert head_before == head_after  # HEAD did not move
+        assert payload["dry_run"] is True
+        assert payload["pull"] is not None
+        # In dry-run mode the response carries the projection, not actual.
+        assert payload["pull"]["applied"] is False
+        assert payload["pull"]["would_apply"] is True
+        assert payload["pull"]["commits_pulled"] == 1
+        assert not (git_repo_pair.local_path / "dryseed.md").exists()

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from fastmcp import Client
 
+from markdown_vault_mcp import _server_deps
 from markdown_vault_mcp.server import make_server
 from tests.fixtures.git import _run_git
 
@@ -290,6 +291,131 @@ class TestGitSync:
         # Sibling file actually exists on disk (rebase landed, files written).
         for rel in conflict_files:
             assert (git_repo_pair.local_path / rel).exists(), rel
+
+    async def test_pull_reindex_failure_surfaces_on_payload(
+        self,
+        git_repo_pair: GitRepoPair,
+        _git_managed_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Failed reindex after a successful pull surfaces ``reindex_failed=True``.
+
+        Regression for ``fb524e8``: when ``Collection.reindex()`` raises
+        after the pull leg has already moved HEAD, the tool must not fail —
+        the side-effect on disk is real and the agent needs to see it.
+        Instead, the bookkeeping failure is surfaced on the pull payload as
+        ``reindex_failed=True`` + ``reindex_hint`` so the caller knows the
+        FTS index is stale and can recover via the standalone ``reindex``
+        tool.
+
+        The reindex callable is monkey-patched on the singleton Collection
+        AFTER the lifespan has constructed it (the singleton accessor is
+        the only seam that exposes the live instance to tests; FastMCP's
+        ``Depends(get_collection)`` resolves through the lifespan context).
+        """
+        # Seed a remote commit so ``force_pull`` actually moves HEAD —
+        # without it the pull short-circuits as "already up to date" and
+        # the post-pull reindex branch never fires.
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_reindex_fail",
+            file_name="reindex_seed.md",
+            body="seed\n",
+        )
+
+        server = make_server()
+        async with Client(server) as client:
+            # Lifespan has set the singleton; monkey-patch reindex BEFORE
+            # the tool call so the post-pull bookkeeping path raises.
+            collection = _server_deps.get_collection_singleton()
+
+            def _failing_reindex() -> None:
+                raise RuntimeError("simulated reindex failure")
+
+            monkeypatch.setattr(collection, "reindex", _failing_reindex)
+
+            result = await client.call_tool("git_sync", {"direction": "pull"})
+
+        payload = _parse_tool_data(result)
+
+        # Pull side-effect is real — HEAD moved, files on disk.
+        assert payload["pull"] is not None, payload
+        assert payload["pull"]["applied"] is True, payload["pull"]
+        assert payload["pull"]["commits_pulled"] == 1, payload["pull"]
+        # And the bookkeeping failure surfaces on the same payload.
+        assert payload["pull"]["reindex_failed"] is True, payload["pull"]
+        assert "reindex_hint" in payload["pull"], payload["pull"]
+        assert "stale" in payload["pull"]["reindex_hint"].lower()
+        # The seeded file landed on disk despite the reindex blow-up.
+        assert (git_repo_pair.local_path / "reindex_seed.md").exists()
+
+    async def test_both_direction_skips_push_when_pull_fails(
+        self,
+        git_repo_pair: GitRepoPair,
+        _git_managed_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """direction='both' with a real (non-dry-run) pull failure short-circuits push.
+
+        Monkey-patches ``force_pull`` after lifespan startup to return a
+        ``PullResult`` with ``applied=False`` (the strategy's managed-mode
+        startup probe rejects mismatched remote URLs, so we cannot break
+        ``origin`` ahead of time).  The tool must then:
+
+        * skip the push leg entirely (``payload["push"] is None``) — pushing
+          on top of an unreconciled clone would risk overwriting upstream;
+        * still refresh ``head_sha`` on the response so the caller sees the
+          post-sync state.
+
+        This exercises the ``direction == 'both' and not pull_result.applied
+        and not dry_run`` short-circuit (lines 1471-1475 of ``_server_tools``).
+        """
+        from markdown_vault_mcp.git import PullResult
+
+        # Stage a local commit so push has *something* it could send if the
+        # short-circuit didn't fire — makes the assertion meaningful.
+        (git_repo_pair.local_path / "would_push.md").write_text("x\n")
+        _run_git(git_repo_pair.local_path, "add", "would_push.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "would push")
+
+        server = make_server()
+        async with Client(server) as client:
+            collection = _server_deps.get_collection_singleton()
+            strategy = collection._git_strategy
+
+            push_called = {"count": 0}
+
+            def _failing_pull(*_args: object, **_kwargs: object) -> PullResult:
+                head = strategy._head_sha(strategy._resolve_force_repo())
+                return PullResult(
+                    applied=False,
+                    fast_forward=False,
+                    commits_pulled=0,
+                    from_sha=head,
+                    to_sha=head,
+                    reason="fetch_failed",
+                )
+
+            def _spy_push(*_args: object, **_kwargs: object) -> object:
+                push_called["count"] += 1
+                raise AssertionError("push leg must be short-circuited")
+
+            monkeypatch.setattr(strategy, "force_pull", _failing_pull)
+            monkeypatch.setattr(strategy, "force_push", _spy_push)
+
+            result = await client.call_tool("git_sync", {"direction": "both"})
+
+        payload = _parse_tool_data(result)
+
+        # Pull leg ran and failed.
+        assert payload["pull"] is not None, payload
+        assert payload["pull"]["applied"] is False, payload["pull"]
+        assert payload["pull"]["reason"] == "fetch_failed", payload["pull"]
+        # Push leg short-circuited — never reached the strategy.force_push call.
+        assert payload["push"] is None, payload
+        assert push_called["count"] == 0
+        # head_sha refreshed at the short-circuit, not at the function tail.
+        assert "head_sha" in payload and len(payload["head_sha"]) == 40
 
 
 class TestGitSyncVisibility:

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -189,6 +189,63 @@ class TestGitSync:
         assert payload["pull"]["commits_pulled"] == 1
         assert not (git_repo_pair.local_path / "dryseed.md").exists()
 
+    async def test_pull_conflict_returns_conflict_files(
+        self, git_repo_pair: GitRepoPair, _git_managed_env: Path
+    ) -> None:
+        """Real two-clone conflict surfaces Syncthing-style sibling paths.
+
+        Edits ``README.md`` differently on the local clone and on a sibling
+        clone (which pushes first), then drives ``git_sync`` and asserts
+        the tool reports the #232 conflict-resolution outcome:
+
+        * ``applied=True``  — HEAD did move (rebase resolved on top of remote)
+        * ``fast_forward=False`` — divergent history required rebase
+        * ``reason="conflicts_resolved_with_siblings"`` — local MCP version
+          was preserved as a ``.conflict-mcp-<timestamp>.md`` sibling
+          rather than discarded.
+        * ``conflict_files`` — non-empty, contains the README-derived sibling
+          path written by ``_write_conflict_files``.
+        """
+        # --- Remote side: seed one commit via a sibling clone. ---
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_conflict_remote",
+            file_name="README.md",
+            body="# remote-edited\n",
+        )
+
+        # --- Local side: edit the same file differently and commit. ---
+        (git_repo_pair.local_path / "README.md").write_text("# local-edited\n")
+        _run_git(git_repo_pair.local_path, "add", "README.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local edit")
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool("git_sync", {"direction": "pull"})
+
+        payload = _parse_tool_data(result)
+
+        assert payload["pull"] is not None, payload
+        # Per #232 Syncthing-style resolution: rebase succeeds on top of the
+        # remote, and the local version is saved as a sibling — so the pull
+        # IS applied, just not as a fast-forward.
+        assert payload["pull"]["applied"] is True, payload["pull"]
+        assert payload["pull"]["fast_forward"] is False, payload["pull"]
+        assert payload["pull"]["reason"] == "conflicts_resolved_with_siblings", payload[
+            "pull"
+        ]
+
+        conflict_files = payload["pull"].get("conflict_files", [])
+        # Sibling format is ``<stem>.conflict-mcp-<timestamp><ext>`` per
+        # ``_write_conflict_files`` — match either the original name or the
+        # Syncthing-style ``.conflict-mcp-`` marker.
+        assert any("README" in f or "conflict-mcp-" in f for f in conflict_files), (
+            conflict_files
+        )
+        # Sibling file actually exists on disk (rebase landed, files written).
+        for rel in conflict_files:
+            assert (git_repo_pair.local_path / rel).exists(), rel
+
 
 class TestGitSyncVisibility:
     """Verify the ``git_sync`` tool is hidden when the deployment isn't managed.

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -188,3 +188,65 @@ class TestGitSync:
         assert payload["pull"]["would_apply"] is True
         assert payload["pull"]["commits_pulled"] == 1
         assert not (git_repo_pair.local_path / "dryseed.md").exists()
+
+
+class TestGitSyncVisibility:
+    """Verify the ``git_sync`` tool is hidden when the deployment isn't managed.
+
+    Composition contract: the tool is tagged ``{"write", "git-managed"}``.
+    ``make_server`` runs two independent ``mcp.disable`` passes — one for
+    ``"write"`` (hides on read-only) and one for ``"git-managed"`` (hides
+    when the strategy is unmanaged).  The tool surfaces only when *both*
+    conditions are absent (managed git mode + read-write).
+    """
+
+    async def test_visible_in_managed_mode(self, _git_managed_env: Path) -> None:
+        """git_sync IS listed in managed git + read-write mode."""
+        server = make_server()
+        async with Client(server) as client:
+            tools = await client.list_tools()
+        names = [t.name for t in tools]
+        assert "git_sync" in names
+
+    async def test_hidden_when_no_git_repo_url(
+        self, vault_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """git_sync is NOT listed when no GIT_REPO_URL is wired (unmanaged mode)."""
+        for var in _CLEAR_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+        # No GIT_REPO_URL → to_collection_kwargs() falls into the unmanaged
+        # commit-only branch, which builds a strategy with managed=False.
+
+        server = make_server()
+        async with Client(server) as client:
+            tools = await client.list_tools()
+        names = [t.name for t in tools]
+        assert "git_sync" not in names
+
+    async def test_hidden_in_read_only_mode(
+        self, git_repo_pair: GitRepoPair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """git_sync is NOT listed in managed mode when READ_ONLY=true.
+
+        The ``"write"`` tag alone already hides the tool; this confirms
+        the two disable passes compose without one masking the other.
+        """
+        for var in _CLEAR_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_SOURCE_DIR", str(git_repo_pair.local_path)
+        )
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "true")
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_GIT_REPO_URL", str(git_repo_pair.remote_path)
+        )
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S", "0")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S", "0")
+
+        server = make_server()
+        async with Client(server) as client:
+            tools = await client.list_tools()
+        names = [t.name for t in tools]
+        assert "git_sync" not in names

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -189,6 +189,51 @@ class TestGitSync:
         assert payload["pull"]["commits_pulled"] == 1
         assert not (git_repo_pair.local_path / "dryseed.md").exists()
 
+    async def test_dry_run_both_reports_push_dry_run_unsupported(
+        self, git_repo_pair: GitRepoPair, _git_managed_env: Path
+    ) -> None:
+        """direction='both' + dry_run=True reports push.reason='dry_run_unsupported'.
+
+        Regression for the local-circus finding: in dry-run mode the pull
+        leg returns ``applied=False`` (HEAD didn't move) which used to fire
+        the "skip push when pull failed" short-circuit and return
+        ``push: null``.  That made a healthy dry-run preview indistinguishable
+        from a real-pull-failed-push-skipped result.  The fix excludes
+        dry-run from the short-circuit so the push leg's
+        ``dry_run_unsupported`` reason is preserved in the response.
+        """
+        # Seed one remote commit so the dry-run pull projection produces
+        # ``applied=False`` for a non-trivial reason (HEAD would move on a
+        # real pull, but doesn't move in dry-run mode).  Without a seeded
+        # commit ``force_pull`` short-circuits with "already up to date"
+        # and ``applied=True``, which doesn't exercise the regression path.
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_dry_both",
+            file_name="dry_both_seed.md",
+            body="dry-both\n",
+        )
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "git_sync", {"direction": "both", "dry_run": True}
+            )
+
+        payload = _parse_tool_data(result)
+
+        assert payload["dry_run"] is True
+        assert payload["pull"] is not None
+        # Pull leg ran; ``applied`` is False because dry-run never moves HEAD
+        # (even though ``would_apply=True``).
+        assert payload["pull"]["applied"] is False
+        assert payload["pull"]["would_apply"] is True
+        # Push leg MUST surface even though the pull leg "failed" by the
+        # applied=False signal — dry-run is special-cased.
+        assert payload["push"] is not None, payload
+        assert payload["push"]["applied"] is False
+        assert payload["push"]["reason"] == "dry_run_unsupported", payload["push"]
+
     async def test_pull_conflict_returns_conflict_files(
         self, git_repo_pair: GitRepoPair, _git_managed_env: Path
     ) -> None:


### PR DESCRIPTION
Closes #444.

Adds a synchronous \`git_sync(direction, dry_run)\` MCP tool that runs an immediate pull / push / both cycle, bypassing the periodic loops. Backed by new \`force_pull\` / \`force_push\` methods on \`GitWriteStrategy\` returning \`PullResult\` / \`PushResult\` dataclasses.

## Summary

- **\`git_sync(direction=\"pull\"|\"push\"|\"both\", dry_run=False)\`** MCP tool — composes the new force methods behind a single tool. Returns structured dict with \`head_sha\`, \`branch\`, per-direction \`pull\` / \`push\` results, and \`dry_run\` marker.
- **\`GitWriteStrategy.force_pull(dry_run=False)\` → \`PullResult\`** — fetch + ff-only first; on failure, falls through to rebase + Syncthing-style sibling resolution (per #232). Returns \`applied=True, reason=\"conflicts_resolved_with_siblings\", conflict_files=[...]\` on the conflict path. Reindex callback fires post-pull (so search/list/get_context aren't stale).
- **\`GitWriteStrategy.force_push(dry_run=False)\` → \`PushResult\`** — never force-pushes. On non-fast-forward, returns \`applied=False, reason=\"non_fast_forward\"\` with a hint pointing at \`git_sync(direction='pull')\`. Token-redacted stderr in failure responses.
- **Visibility gate**: tool tagged \`{\"write\", \"git-managed\"}\`. Hidden when \`MARKDOWN_VAULT_MCP_GIT_REPO_URL\` isn't set OR \`READ_ONLY=true\`. Visibility check uses \`config.git_repo_url\` directly to avoid re-running the embedding-provider construction at startup.
- **Reusable bare-repo pytest fixture** at \`tests/fixtures/git.py\` for any future git-related tests.
- **Module-level reason constants** (\`PULL_REASON_*\`, \`PUSH_REASON_*\`) for callers checking \`PullResult.reason\` / \`PushResult.reason\` against a known set.

## Test plan

- [x] \`uv run pytest -x -q\` — 1508/1508 green (22 new tests across \`test_git_force_methods.py\` + \`test_git_sync.py\` + reused fixture)
- [x] \`uv run mypy src/ tests/\` clean
- [x] \`uv run pre-commit run --all-files\` clean
- [x] \`diff-cover ... --fail-under=80\` — 86% on patch
- [x] \`mkdocs build --strict\` no NEW warnings
- [x] Local review circus (3 rounds, 6 dispatches): both \`pr-review-toolkit:code-reviewer\` and \`pr-review-toolkit:silent-failure-hunter\` APPROVED on \`fb524e8\`
- [ ] CI green
- [ ] Bot reviewers LGTM

## Follow-ups deferred to separate issues

- #462 — \`_write_conflict_files\` commit lacks \`check=True\` (pre-existing in \`sync_once\` flow, elevated by this PR)
- #463 — \`_force_pull_rebase_fallback\`'s \`git checkout @{upstream} -- <path>\` ignores return code
- #464 — \`rev-parse --git-dir\` failure path silently assumes no rebase in progress
- #220 (existing) — third call to \`to_collection_kwargs()\` at server-build time; visibility gate now sidesteps it via \`config.git_repo_url\` direct read