### PR TITLE
fix: sync_once uses reliable rebase-in-progress check (#466)

### DIFF
--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1807,20 +1807,9 @@ class GitWriteStrategy:
                         # loop exited via break because no conflicting files
                         # were found but rebase --continue had returned
                         # non-zero, or the iteration limit was hit).
-                        rebase_head = subprocess.run(
-                            [
-                                "git",
-                                "-C",
-                                str(git_root),
-                                "rev-parse",
-                                "--verify",
-                                "REBASE_HEAD",
-                            ],
-                            capture_output=True,
-                            text=True,
-                            env=env,
+                        rebase_in_progress = self._check_rebase_in_progress(
+                            git_root, env
                         )
-                        rebase_in_progress = rebase_head.returncode == 0
 
                         if rebase_in_progress:
                             # Abort the incomplete rebase before committing


### PR DESCRIPTION
## Summary
Replace the unreliable `REBASE_HEAD` check in `sync_once` with the reliable `_check_rebase_in_progress` helper that checks for `.git/rebase-merge` / `.git/rebase-apply` directory existence.

## Root cause
`sync_once` used `git rev-parse --verify REBASE_HEAD` to detect an in-progress rebase after a failed `rebase --continue`. However, `REBASE_HEAD` is unreliable — git retains it after a successful `rebase --continue` as a backup reference, so its existence does not mean a rebase is currently in flight.

The `_force_pull_rebase_fallback` path (used by `force_pull`) already had a reliable `_check_rebase_in_progress` method that checks for `.git/rebase-merge` or `.git/rebase-apply` directory existence.

## Fix
Replace the inline `REBASE_HEAD` check in `sync_once` with a call to `self._check_rebase_in_progress(git_root, env)`, which uses the same reliable directory-existence approach. This makes rebase-in-progress detection consistent across both `sync_once` and `force_pull`.

## Validation
- All 100 tests in `tests/test_git.py` pass
- `uv run ruff check --fix .` — all checks passed
- `uv run ruff format .` — 84 files left unchanged
- `uv run mypy src/ tests/` — Success: no issues found in 79 source files

## Before
`sync_once` could call `git rebase --abort` on a working tree with no in-progress rebase (because `REBASE_HEAD` persisted after a successful rebase), or fail to abort a *different* rebase started in the brief window between detection and call.

## After
`sync_once` uses the same reliable rebase-in-progress detection as `_force_pull_rebase_fallback`: checks for `.git/rebase-merge` or `.git/rebase-apply` directory existence via `git rev-parse --git-dir`, which is the authoritative signal.

Fixes #466