### PR TITLE
fix(git): post-#444 polish — sync_once rebase detection, would_apply semantic, commit check, error tests

### DIFF
--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -134,8 +134,8 @@ def _format_pull_dict(result: PullResult, dry_run: bool) -> dict[str, Any]:
     if result.conflict_files:
         pull_dict["conflict_files"] = list(result.conflict_files)
     if dry_run:
-        # Dry-run reports the projected outcome, not actual.
-        pull_dict["would_apply"] = result.commits_pulled > 0
+        # SHA comparison: handles force_pull's up-to-date early-return cleanly.
+        pull_dict["would_apply"] = result.from_sha != result.to_sha
     return pull_dict
 
 

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1838,7 +1838,7 @@ class GitWriteStrategy:
                             if abort_proc.returncode != 0:
                                 logger.error(
                                     "Git pull: failed to abort rebase: %s",
-                                    (abort_proc.stderr or "").strip(),
+                                    self._redact((abort_proc.stderr or "").strip()),
                                 )
                             # After abort, the working tree reverts to the
                             # pre-rebase state (MCP commits), so the original

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1505,10 +1505,18 @@ class GitWriteStrategy:
                     from_sha, PULL_REASON_CONFLICT_RESOLUTION_FAILED
                 )
 
+            # Rebase has already completed via ``git rebase --continue`` — HEAD
+            # has advanced even if the sibling-files commit below fails.
+            actual_head = self._head_sha(git_root)
             written = self._write_conflict_files(git_root, saved, env)
             if written is None:
-                return PullResult.head_unchanged_failure(
-                    from_sha, PULL_REASON_CONFLICT_RESOLUTION_FAILED
+                return PullResult(
+                    applied=False,
+                    fast_forward=False,
+                    commits_pulled=0,
+                    from_sha=from_sha,
+                    to_sha=actual_head,
+                    reason=PULL_REASON_CONFLICT_RESOLUTION_FAILED,
                 )
             for cf in written:
                 logger.warning(

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -888,7 +888,7 @@ class GitWriteStrategy:
             )
         return saved, None
 
-    def _check_rebase_in_progress(
+    def _rebase_in_progress(
         self,
         git_root: Path,
         env: dict[str, str] | None,
@@ -1480,7 +1480,7 @@ class GitWriteStrategy:
             # limit, or exited via ``break`` without completing), abort
             # cleanly so the working tree is consistent before we write
             # conflict files.
-            rebase_in_progress = self._check_rebase_in_progress(git_root, env)
+            rebase_in_progress = self._rebase_in_progress(git_root, env)
 
             if rebase_in_progress:
                 if not self._abort_in_progress_rebase(git_root, env):
@@ -1803,24 +1803,8 @@ class GitWriteStrategy:
                         # saving the MCP version as a conflict file.
                         saved = self._resolve_rebase_conflicts(git_root, env)
 
-                        # Check if a rebase is still in progress (e.g. the
-                        # loop exited via break because no conflicting files
-                        # were found but rebase --continue had returned
-                        # non-zero, or the iteration limit was hit).
-                        rebase_head = subprocess.run(
-                            [
-                                "git",
-                                "-C",
-                                str(git_root),
-                                "rev-parse",
-                                "--verify",
-                                "REBASE_HEAD",
-                            ],
-                            capture_output=True,
-                            text=True,
-                            env=env,
-                        )
-                        rebase_in_progress = rebase_head.returncode == 0
+                        # Directory check (REBASE_HEAD lingers post-continue, #466).
+                        rebase_in_progress = self._rebase_in_progress(git_root, env)
 
                         if rebase_in_progress:
                             # Abort the incomplete rebase before committing

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1068,7 +1068,7 @@ class GitWriteStrategy:
         git_root: Path,
         saved: list[tuple[str, str]],
         env: dict[str, str] | None,
-    ) -> list[str]:
+    ) -> list[str] | None:
         """Write conflict files and add ``conflict_with`` frontmatter to both sides.
 
         For each ``(relative_path, content)`` in *saved*:
@@ -1079,7 +1079,12 @@ class GitWriteStrategy:
            file's existing frontmatter.
 
         Returns:
-            List of conflict file relative paths that were written.
+            List of conflict file relative paths that were written and
+            committed.  Returns ``None`` when the final ``git commit`` step
+            failed (nothing-to-commit, hook failure, signing failure, etc.)
+            so callers can surface ``conflict_resolution_failed`` instead of
+            implying a successful conflict-resolution commit.  Returns an
+            empty list when *saved* is empty (nothing to do).
         """
         root = str(git_root)
         now = datetime.datetime.now(tz=datetime.UTC)
@@ -1170,8 +1175,11 @@ class GitWriteStrategy:
             logger.error(
                 "Git pull: conflict commit failed (rc=%d): %s",
                 commit_result.returncode,
-                (commit_result.stderr or commit_result.stdout or "").strip(),
+                self._redact(
+                    (commit_result.stderr or commit_result.stdout or "").strip()
+                ),
             )
+            return None
 
         return written
 
@@ -1498,6 +1506,10 @@ class GitWriteStrategy:
                 )
 
             written = self._write_conflict_files(git_root, saved, env)
+            if written is None:
+                return PullResult.head_unchanged_failure(
+                    from_sha, PULL_REASON_CONFLICT_RESOLUTION_FAILED
+                )
             for cf in written:
                 logger.warning(
                     "Git force_pull: conflict resolved, saved MCP version as %s",
@@ -1843,6 +1855,11 @@ class GitWriteStrategy:
 
                         if saved:
                             written = self._write_conflict_files(git_root, saved, env)
+                            if written is None:
+                                logger.warning(
+                                    "Git pull: conflict commit failed, skipping"
+                                )
+                                return False
                             for cf in written:
                                 logger.warning(
                                     "Git pull: conflict resolved, saved MCP version as %s",

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -1343,7 +1343,7 @@ class GitWriteStrategy:
                         )
 
                 if remote_sha == from_sha:
-                    # Already up to date — successful no-op.
+                    # Already up to date — successful no-op (applied=True even on dry_run).
                     return PullResult(
                         applied=True,
                         fast_forward=True,

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1648,6 +1648,117 @@ class TestGitSyncOnce:
         conflict_files = list(work.glob("README.conflict-mcp-*.md"))
         assert len(conflict_files) == 1
 
+    def test_sync_once_conflict_commit_failure_returns_false(
+        self,
+        tmp_path: Path,
+        git_repo_with_remote: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """sync_once returns False + WARNING when _write_conflict_files commit fails.
+
+        Mirrors test_force_pull_conflict_commit_failure_surfaces_resolution_failed
+        on the force_pull side; covers the sync_once None-return path added in #462.
+        The rebase --continue succeeds (so HEAD moves) before the conflict-commit
+        fails, so we also assert HEAD actually advanced.
+        """
+        import subprocess as _real_subprocess
+
+        from markdown_vault_mcp.git import subprocess as git_subprocess
+
+        work, bare = git_repo_with_remote
+
+        # Local-only divergent commit on README.md.
+        (work / "README.md").write_text("# Local diverge\n")
+        subprocess.run(
+            ["git", "-C", str(work), "add", "."],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(work), "commit", "-m", "local diverge"],
+            check=True,
+            capture_output=True,
+        )
+
+        # Advance remote via sibling clone, conflicting on the same file.
+        other = tmp_path / "other"
+        subprocess.run(
+            ["git", "clone", str(bare), str(other)],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(other), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(other), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        (other / "README.md").write_text("# Remote diverge\n")
+        subprocess.run(
+            ["git", "-C", str(other), "add", "."],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(other), "commit", "-m", "remote diverge"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(other), "push"],
+            check=True,
+            capture_output=True,
+        )
+
+        real_run = _real_subprocess.run
+
+        def _patched_run(args: list[str], **kwargs: object) -> object:
+            # Fail only the conflict-files commit; let everything else run.
+            if (
+                isinstance(args, list)
+                and "commit" in args
+                and any(isinstance(a, str) and a.startswith("conflict:") for a in args)
+            ):
+                return _real_subprocess.CompletedProcess(
+                    args=args,
+                    returncode=1,
+                    stdout="",
+                    stderr="error: pre-commit hook rejected the commit",
+                )
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(git_subprocess, "run", _patched_run)
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        head_before = subprocess.run(
+            ["git", "-C", str(work), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"):
+            did_advance = strategy.sync_once(work)
+        head_after = subprocess.run(
+            ["git", "-C", str(work), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        # Commit failed → sync_once reports no advance to the caller.
+        assert did_advance is False
+        # WARNING surfaced for operator visibility.
+        assert any(
+            "conflict commit failed, skipping" in r.message for r in caplog.records
+        )
+        # The rebase --continue ran before the failing commit, so HEAD did move.
+        assert head_after != head_before
+
     def test_resolve_rebase_conflicts_max_iterations_returns_saved(
         self,
         tmp_path: Path,

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1769,6 +1769,37 @@ class TestGitSyncOnce:
         assert len(warnings) >= 1
 
 
+class TestRebaseInProgress:
+    """Tests for the _rebase_in_progress helper (refs #466)."""
+
+    def test_returns_false_on_clean_repo(self, git_repo: Path) -> None:
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        assert strategy._rebase_in_progress(git_repo, env=None) is False
+
+    def test_detects_rebase_merge_directory(self, git_repo: Path) -> None:
+        (git_repo / ".git" / "rebase-merge").mkdir()
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        assert strategy._rebase_in_progress(git_repo, env=None) is True
+
+    def test_detects_rebase_apply_directory(self, git_repo: Path) -> None:
+        (git_repo / ".git" / "rebase-apply").mkdir()
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        assert strategy._rebase_in_progress(git_repo, env=None) is True
+
+    def test_ignores_stale_rebase_head_ref(self, git_repo: Path) -> None:
+        """Stale REBASE_HEAD ref must not trip the in-progress check (refs #466)."""
+        head_sha = subprocess.run(
+            ["git", "-C", str(git_repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        (git_repo / ".git" / "REBASE_HEAD").write_text(head_sha + "\n")
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        assert strategy._rebase_in_progress(git_repo, env=None) is False
+
+
 class TestGitPullLoop:
     def test_start_runs_tick_with_pause_and_on_pull(
         self,

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1691,12 +1691,12 @@ class TestGitSyncOnce:
         assert len(result) == 1
         assert result[0] == ("README.md", "# MCP content\n")
 
-    def test_write_conflict_files_commit_failure_is_logged(
+    def test_write_conflict_files_commit_failure_returns_none(
         self,
         git_repo: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """_write_conflict_files logs ERROR when git commit fails but does not raise."""
+        """_write_conflict_files returns None and logs ERROR when git commit fails."""
         strategy = GitWriteStrategy(token=None, push_delay_s=0)
 
         # Create a real file for the original path.
@@ -1728,10 +1728,50 @@ class TestGitSyncOnce:
         ):
             written = strategy._write_conflict_files(git_repo, saved, env=None)
 
-        # The method still returns the written conflict file paths.
-        assert len(written) == 1
+        # Commit failed: helper signals failure to its caller via None.
+        assert written is None
         # The ERROR was logged.
         assert any("conflict commit failed" in r.message for r in caplog.records)
+
+    def test_write_conflict_files_commit_failure_redacts_token(
+        self,
+        git_repo: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Commit-failure stderr passes through _redact before being logged."""
+        strategy = GitWriteStrategy(token="secret-pat-xyz", push_delay_s=0)
+
+        (git_repo / "note.md").write_text("# Original\n")
+        saved = [("note.md", "# MCP version\n")]
+
+        import subprocess as sp
+
+        real_run = sp.run
+
+        def patched_run(cmd: list[str], **kwargs: object) -> object:
+            if isinstance(cmd, list) and "commit" in cmd:
+                from types import SimpleNamespace
+
+                return SimpleNamespace(
+                    returncode=1,
+                    stdout="",
+                    stderr="fatal: auth failed for secret-pat-xyz@host",
+                )
+            return real_run(cmd, **kwargs)
+
+        import unittest.mock as mock
+
+        with (
+            mock.patch(
+                "markdown_vault_mcp.git.subprocess.run", side_effect=patched_run
+            ),
+            caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._write_conflict_files(git_repo, saved, env=None)
+
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "secret-pat-xyz" not in joined
+        assert "***" in joined
 
     def test_write_conflict_files_invalid_frontmatter_logs_warning(
         self,

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -619,6 +619,127 @@ class TestForceMethodsErrorBranches:
         assert result.to_sha == head_before
         assert result.conflict_files == ()
 
+    def test_force_pull_rebase_loop_hits_max_iterations(
+        self,
+        git_repo_pair: GitRepoPair,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """_resolve_rebase_conflicts cap exhaustion logs ERROR + returns partial saved (#468)."""
+        import logging
+        import subprocess as _real_subprocess
+
+        from markdown_vault_mcp.git import GitWriteStrategy
+        from markdown_vault_mcp.git import subprocess as git_subprocess
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+
+        real_run = _real_subprocess.run
+
+        def _patched_run(args: list[str], **kwargs: object) -> object:
+            if not isinstance(args, list):
+                return real_run(args, **kwargs)
+            if "diff" in args and "--diff-filter=U" in args:
+                return _real_subprocess.CompletedProcess(
+                    args=args, returncode=0, stdout="README.md\n", stderr=""
+                )
+            if "show" in args and any(
+                isinstance(a, str) and a.startswith("REBASE_HEAD:") for a in args
+            ):
+                return _real_subprocess.CompletedProcess(
+                    args=args, returncode=0, stdout="# local\n", stderr=""
+                )
+            if "checkout" in args and "--ours" in args:
+                return _real_subprocess.CompletedProcess(
+                    args=args, returncode=0, stdout="", stderr=""
+                )
+            if "add" in args and "--" in args:
+                return _real_subprocess.CompletedProcess(
+                    args=args, returncode=0, stdout="", stderr=""
+                )
+            if "rebase" in args and "--continue" in args:
+                return _real_subprocess.CompletedProcess(
+                    args=args,
+                    returncode=1,
+                    stdout="",
+                    stderr="CONFLICT (content): merge conflict in README.md",
+                )
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(git_subprocess, "run", _patched_run)
+
+        with caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"):
+            saved = strategy._resolve_rebase_conflicts(
+                git_repo_pair.local_path, env=None
+            )
+
+        # README.md was "saved" on every iteration; dict dedup leaves one entry.
+        assert saved == [("README.md", "# local\n")]
+        log_messages = [r.getMessage() for r in caplog.records]
+        assert any("exceeded 50 iterations" in msg for msg in log_messages), (
+            f"expected max_iterations ERROR log; got: {log_messages}"
+        )
+
+    def test_force_pull_non_fast_forward_with_conflicts_when_abort_fails(
+        self, git_repo_pair: GitRepoPair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rebase-in-progress + abort failure surfaces non_fast_forward_with_conflicts (#468)."""
+        import subprocess as _real_subprocess
+
+        from markdown_vault_mcp.git import (
+            PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS,
+            GitWriteStrategy,
+        )
+        from markdown_vault_mcp.git import subprocess as git_subprocess
+
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_nffwc",
+            file_name="README.md",
+            body="# remote\n",
+        )
+        (git_repo_pair.local_path / "README.md").write_text("# local\n")
+        _run_git(git_repo_pair.local_path, "add", "README.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local edit")
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+
+        # Stub the helper: claim a save but DO NOT finish the rebase, so
+        # _rebase_in_progress reports True.
+        def _stub_resolve(*_args: object, **_kwargs: object) -> list[tuple[str, str]]:
+            return [("README.md", "# local\n")]
+
+        monkeypatch.setattr(strategy, "_resolve_rebase_conflicts", _stub_resolve)
+
+        real_run = _real_subprocess.run
+
+        def _patched_run(args: list[str], **kwargs: object) -> object:
+            if isinstance(args, list) and "rebase" in args and "--abort" in args:
+                return _real_subprocess.CompletedProcess(
+                    args=args,
+                    returncode=1,
+                    stdout="",
+                    stderr="fatal: simulated abort failure",
+                )
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(git_subprocess, "run", _patched_run)
+
+        head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        result = strategy.force_pull()
+
+        assert result.applied is False
+        assert result.reason == PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS
+        assert result.from_sha == result.to_sha == head_before
+
     def test_force_push_to_unreachable_remote_returns_push_failed(
         self, git_repo_pair: GitRepoPair
     ) -> None:

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -612,11 +612,17 @@ class TestForceMethodsErrorBranches:
 
         head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
         result = strategy.force_pull()
+        head_after = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
 
         assert result.applied is False
         assert result.reason == PULL_REASON_CONFLICT_RESOLUTION_FAILED
+        # ``from_sha`` is the pre-rebase HEAD; ``to_sha`` reflects the actual
+        # post-rebase HEAD because the rebase completed before the sibling
+        # commit failed.
         assert result.from_sha == head_before
-        assert result.to_sha == head_before
+        assert head_after != head_before
+        assert result.to_sha == head_after
+        assert result.to_sha != result.from_sha
         assert result.conflict_files == ()
 
     def test_force_pull_rebase_loop_hits_max_iterations(

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -564,6 +564,61 @@ class TestForceMethodsErrorBranches:
         assert not (git_repo_pair.local_path / ".git" / "rebase-merge").exists()
         assert not (git_repo_pair.local_path / ".git" / "rebase-apply").exists()
 
+    def test_force_pull_conflict_commit_failure_surfaces_resolution_failed(
+        self, git_repo_pair: GitRepoPair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Conflict-resolution commit failure → reason=conflict_resolution_failed (#462)."""
+        import subprocess as _real_subprocess
+
+        from markdown_vault_mcp.git import (
+            PULL_REASON_CONFLICT_RESOLUTION_FAILED,
+            GitWriteStrategy,
+        )
+        from markdown_vault_mcp.git import subprocess as git_subprocess
+
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_commit_fail",
+            file_name="README.md",
+            body="# remote\n",
+        )
+        (git_repo_pair.local_path / "README.md").write_text("# local\n")
+        _run_git(git_repo_pair.local_path, "add", "README.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local edit")
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+
+        real_run = _real_subprocess.run
+
+        def _patched_run(args: list[str], **kwargs: object) -> object:
+            if (
+                isinstance(args, list)
+                and "commit" in args
+                and any(isinstance(a, str) and a.startswith("conflict:") for a in args)
+            ):
+                return _real_subprocess.CompletedProcess(
+                    args=args,
+                    returncode=1,
+                    stdout="",
+                    stderr="error: pre-commit hook rejected the commit",
+                )
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(git_subprocess, "run", _patched_run)
+
+        head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        result = strategy.force_pull()
+
+        assert result.applied is False
+        assert result.reason == PULL_REASON_CONFLICT_RESOLUTION_FAILED
+        assert result.from_sha == head_before
+        assert result.to_sha == head_before
+        assert result.conflict_files == ()
+
     def test_force_push_to_unreachable_remote_returns_push_failed(
         self, git_repo_pair: GitRepoPair
     ) -> None:

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -190,6 +190,28 @@ class TestGitSync:
         assert payload["pull"]["commits_pulled"] == 1
         assert not (git_repo_pair.local_path / "dryseed.md").exists()
 
+    async def test_dry_run_pull_already_up_to_date_would_apply_false(
+        self, _git_managed_env: Path
+    ) -> None:
+        """Refs #467: dry-run pull on an up-to-date clone reports would_apply=False."""
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "git_sync", {"direction": "pull", "dry_run": True}
+            )
+
+        payload = _parse_tool_data(result)
+
+        assert payload["dry_run"] is True
+        assert payload["pull"] is not None
+        # force_pull early-returns applied=True for an already-up-to-date
+        # clone regardless of dry_run; would_apply must be False because
+        # from_sha == to_sha (no commits to apply).
+        assert payload["pull"]["applied"] is True
+        assert payload["pull"]["would_apply"] is False
+        assert payload["pull"]["commits_pulled"] == 0
+        assert payload["pull"]["from_sha"] == payload["pull"]["to_sha"]
+
     async def test_dry_run_both_reports_push_dry_run_unsupported(
         self, git_repo_pair: GitRepoPair, _git_managed_env: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Bundle of four PR #444/#465 follow-ups surfaced during local circus. All scoped to `git.py` + `_server_tools.py:git_sync` + adjacent tests. Five commits (4 issue fixes + 1 second-opinion correction).

| Commit | Closes | Scope |
|---|---|---|
| `8465a78` | #466 | Replace unreliable `REBASE_HEAD` check in `sync_once` with directory-existence check; hoist `_rebase_in_progress` helper |
| `5b008dc` | #467 | `would_apply = from_sha != to_sha` (was `commits_pulled > 0` — surprising on up-to-date dry-run) |
| `022ce1e` | #462 | `_write_conflict_files` returns `list[str] \| None`; propagate failure via `PullResult.reason='conflict_resolution_failed'` instead of silent commit drop |
| `d068ad9` | #468 | Tests for `_force_pull_rebase_fallback` error branches (max_iterations exhaustion, non_fast_forward_with_conflicts) |
| `65124ee` | — | Local-circus correction: report actual rebased HEAD as `to_sha` when conflict-commit fails (was lying with `from_sha` via `head_unchanged_failure`) |

## Test plan

- [x] `uv run pytest -x -q` — 1536 tests pass
- [x] `uv run mypy src/ tests/` — clean (79 files)
- [x] `uv run ruff check` + `format --check` — clean
- [x] `uv run diff-cover --compare-branch origin/main` — 80% (gate ≥80%)
- [x] Local-review circus: pr-review-toolkit (primary) + feature-dev (second-opinion) both clean after the `65124ee` fix
- [x] Token redaction on the new ERROR log path verified by `test_write_conflict_files_commit_failure_redacts_token`

## Notable correction during local review

Second-opinion reviewer caught that the original `#462` fix used `head_unchanged_failure(from_sha, ...)` on the `conflict_resolution_failed` path, but that path runs AFTER `git rebase --continue` has already succeeded — so HEAD has actually advanced and the factory's "HEAD did not move" contract was violated. Commit `65124ee` captures actual HEAD before `_write_conflict_files` and surfaces it as `to_sha` on the failure return. The test now asserts real HEAD movement.

Closes #466, closes #467, closes #462, closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)