### PR TITLE
fix(uploads,server): #443 follow-ups — bypass attachment size cap on upload route, widen fx_transport

### DIFF
--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -416,12 +416,7 @@ Claude Desktop configuration) cannot mount the upload route.
 !!! tip "When to prefer this over `write(content_base64=...)`"
     Files larger than ~100 KB blow past the LLM's context budget once
     base64-encoded.  `create_upload_link` keeps the bytes off the MCP
-    transport entirely.  The effective size cap differs by extension:
-
-    - **`.md` uploads** are bounded only by
-      `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` (default 10 MiB).
-    - **Non-`.md` (attachment) uploads** ALSO have to clear the
-      in-Collection `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` cap
-      (default **1 MiB** — same as `write(content_base64=...)`).  Raise
-      that env var to allow larger attachments.  See the
-      `create_upload_link` reference for the full discussion.
+    transport entirely, and uploads on either extension are bounded
+    only by `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` (default 10 MiB) —
+    the in-Collection `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` cap
+    does not apply on the upload path.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -359,17 +359,13 @@ agent receives the URL and an expiry hint; the actual file content
 flows over plain HTTP, not through MCP context, avoiding the ~33% base64
 inflation that `write(content_base64=...)` incurs.
 
-!!! warning "Effective size cap depends on extension"
-    `.md` uploads are bounded only by the network-tier cap
-    (`MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES`, default 10 MiB).  Non-`.md`
-    uploads (attachments) ALSO have to clear the in-Collection
-    `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` cap (default **1 MiB**)
-    when the receiver writes the bytes — the same cap as
-    `write(content_base64=...)`.  Raise
-    `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` to allow larger
-    attachments.  This is tracked as a follow-up in #443's review notes
-    (the cap should arguably be bypassed on the upload path; for now,
-    operator config is the lever).
+!!! info "Effective size cap"
+    Uploads are bounded only by the network-tier cap
+    (`MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES`, default 10 MiB).  The
+    in-Collection `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` cap that
+    applies to `write(content_base64=...)` is bypassed on the upload
+    path — those bytes flow over HTTP and never touch LLM context, so
+    the context-budget cap is the wrong gate here.
 
 **Parameters:**
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -989,14 +989,25 @@ class Collection:
         return self._doc_mgr.read_attachment(path)
 
     def write_attachment(
-        self, path: str, content: bytes, if_match: str | None = None
+        self,
+        path: str,
+        content: bytes,
+        if_match: str | None = None,
+        *,
+        skip_size_cap: bool = False,
     ) -> WriteResult:
         """Create or overwrite a non-.md attachment.
 
-        Delegates to :meth:`DocumentManager.write_attachment`.
+        Delegates to :meth:`DocumentManager.write_attachment`.  Pass
+        ``skip_size_cap=True`` from callers that have their own size
+        gate (e.g. the ``create_upload_link`` receiver path, which has
+        already validated against ``MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES``);
+        leave ``False`` for base64 callers of the MCP ``write`` tool.
         """
         self._ensure_initialized()
-        return self._doc_mgr.write_attachment(path, content, if_match=if_match)
+        return self._doc_mgr.write_attachment(
+            path, content, if_match=if_match, skip_size_cap=skip_size_cap
+        )
 
     def write(
         self,

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -384,7 +384,7 @@ class DocumentManager:
                     f"MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
                     f"({self._max_attachment_size_mb} MB). "
                     f"Use create_download_link({path!r}) for HTTP transfer, "
-                    f"or raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB if "
+                    f"or increase MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB if "
                     f"you need the bytes in context."
                 )
 
@@ -585,7 +585,7 @@ class DocumentManager:
                         f"({self._max_attachment_size_mb} MB). "
                         f"Use create_upload_link({path!r}) to push the "
                         f"bytes over HTTP without inflating LLM context, "
-                        f"or raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
+                        f"or increase MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
                         f"if you need the bytes in context."
                     )
             created = not abs_path.is_file()

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -521,7 +521,12 @@ class DocumentManager:
         return result
 
     def write_attachment(
-        self, path: str, content: bytes, if_match: str | None = None
+        self,
+        path: str,
+        content: bytes,
+        if_match: str | None = None,
+        *,
+        skip_size_cap: bool = False,
     ) -> WriteResult:
         """Create or overwrite a non-.md attachment.
 
@@ -533,6 +538,15 @@ class DocumentManager:
                 current file hash matches this value, preventing overwrites
                 of concurrent modifications. Pass ``None`` (default) to skip
                 the check.
+            skip_size_cap: When ``False`` (default), enforces
+                ``MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB`` to protect LLM
+                context for base64 callers of the MCP ``write`` tool.  Pass
+                ``True`` from the ``create_upload_link`` receiver path —
+                bytes there flow over HTTP, never touch LLM context, and
+                the route already validated against
+                ``MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES``.  Direct library
+                callers should leave it ``False`` unless they have their
+                own size gate.
 
         Returns:
             :class:`~markdown_vault_mcp.types.WriteResult`.
@@ -543,7 +557,7 @@ class DocumentManager:
                 not match the current file hash.
             ValueError: If the path escapes the source directory, has an
                 extension not in the allowlist, or the content exceeds the
-                size limit.
+                size limit (when *skip_size_cap* is ``False``).
         """
         self._check_writable()
         with self._write_lock:
@@ -560,7 +574,7 @@ class DocumentManager:
                     raise ConcurrentModificationError(
                         path, expected=if_match, actual=current_hash
                     )
-            if self._max_attachment_size_mb > 0:
+            if not skip_size_cap and self._max_attachment_size_mb > 0:
                 limit_bytes = int(self._max_attachment_size_mb * 1024 * 1024)
                 if len(content) > limit_bytes:
                     size_bytes = len(content)
@@ -569,10 +583,10 @@ class DocumentManager:
                         f"({size_bytes / 1024 / 1024:.1f} MB), exceeds "
                         f"MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
                         f"({self._max_attachment_size_mb} MB). "
-                        f"This cap applies to all attachment writes "
-                        f"including the create_upload_link receiver path. "
-                        f"Raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
-                        f"to allow larger attachments."
+                        f"Use create_upload_link({path!r}) to push the "
+                        f"bytes over HTTP without inflating LLM context, "
+                        f"or raise MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
+                        f"if you need the bytes in context."
                     )
             created = not abs_path.is_file()
             abs_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -136,9 +136,9 @@ def make_server(transport: str = "stdio") -> FastMCP:
       built-in.  Default: disabled.
 
     Args:
-        transport: ``"stdio"`` / ``"http"`` / ``"sse"``.  Used for the
-            ``ArtifactStore`` route guard (HTTP-only) and as ``transport=%s``
-            in the startup log.
+        transport: ``"stdio"`` / ``"http"`` / ``"sse"`` / ``"streamable-http"``.
+            Used for the ``ArtifactStore`` route guard (HTTP-only) and as
+            ``transport=%s`` in the startup log.
 
     Returns:
         A fully configured :class:`~fastmcp.FastMCP` instance ready to run.

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -288,7 +288,9 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # without also exporting one of those env vars.  The CLI knows the
     # transport from its own ``--transport`` flag and passes it to
     # ``make_server``, so we have the authoritative value here.
-    fx_transport: str = "http" if transport in ("http", "sse") else "stdio"
+    fx_transport: str = (
+        "http" if transport in ("http", "sse", "streamable-http") else "stdio"
+    )
     register_file_exchange_upload(
         mcp,
         namespace="markdown-vault-mcp",

--- a/src/markdown_vault_mcp/uploads.py
+++ b/src/markdown_vault_mcp/uploads.py
@@ -29,6 +29,13 @@ def _vault_upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
     and the MV-side pre-link validator runs additional checks at link
     creation time, so this function trusts the value.
 
+    Passes ``skip_size_cap=True`` to ``write_attachment`` because the
+    HTTP route already enforced ``MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES``
+    against the request body, and these bytes never touch LLM context —
+    the inner ``MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB`` cap exists
+    only to protect context budget for base64 callers of the MCP
+    ``write`` tool.
+
     Args:
         record: pvl-core's :class:`~fastmcp_pvl_core.UploadRecord` —
             ``target_id`` is the vault-relative filename the agent passed
@@ -44,7 +51,7 @@ def _vault_upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
     if record.target_id.endswith(".md"):
         collection.write(record.target_id, content=body.decode("utf-8"))
     else:
-        collection.write_attachment(record.target_id, body)
+        collection.write_attachment(record.target_id, body, skip_size_cap=True)
     return {"path": record.target_id, "size_bytes": len(body)}
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -2145,6 +2145,20 @@ class TestWriteAttachment:
         with pytest.raises(ValueError, match="exceeds"):
             col.write_attachment("assets/big.pdf", b"a" * 100)
 
+    def test_write_attachment_skip_size_cap_bypasses_limit(
+        self, vault_with_attachment: Path
+    ) -> None:
+        """write_attachment(..., skip_size_cap=True) accepts content > MAX_ATTACHMENT_SIZE_MB."""
+        col = Collection(
+            source_dir=vault_with_attachment,
+            read_only=False,
+            max_attachment_size_mb=0.000001,
+        )
+        raw = b"a" * 100
+        result = col.write_attachment("assets/big.pdf", raw, skip_size_cap=True)
+        assert result.created is True
+        assert (vault_with_attachment / "assets" / "big.pdf").read_bytes() == raw
+
     def test_write_attachment_disallowed_extension_raises(
         self, vault_with_attachment: Path
     ) -> None:

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -497,6 +497,44 @@ class TestWriteAttachmentErrorMessage:
             mgr.write_attachment("big.bin", big_content)
 
 
+class TestWriteAttachmentSkipSizeCap:
+    """write_attachment(..., skip_size_cap=True) bypasses MAX_ATTACHMENT_SIZE_MB."""
+
+    def _mgr(self, doc_vault: Path) -> DocumentManager:
+        return DocumentManager(
+            fts=FTSIndex(db_path=":memory:"),
+            source_dir=doc_vault,
+            write_lock=threading.RLock(),
+            chunk_strategy=HeadingChunker(),
+            attachment_extensions=["bin"],
+            max_attachment_size_mb=1.0,
+            read_only=False,
+        )
+
+    def test_default_enforces_cap(self, doc_vault: Path) -> None:
+        big = b"x" * (2 * 1024 * 1024)
+        with pytest.raises(ValueError, match="exceeds"):
+            self._mgr(doc_vault).write_attachment("big.bin", big)
+
+    def test_default_explicit_false_enforces_cap(self, doc_vault: Path) -> None:
+        big = b"x" * (2 * 1024 * 1024)
+        with pytest.raises(ValueError, match="exceeds"):
+            self._mgr(doc_vault).write_attachment("big.bin", big, skip_size_cap=False)
+
+    def test_skip_size_cap_true_allows_oversize_write(self, doc_vault: Path) -> None:
+        big = b"x" * (2 * 1024 * 1024)
+        result = self._mgr(doc_vault).write_attachment(
+            "big.bin", big, skip_size_cap=True
+        )
+        assert result.created is True
+        assert (doc_vault / "big.bin").read_bytes() == big
+
+    def test_skip_size_cap_keyword_only(self, doc_vault: Path) -> None:
+        big = b"x" * (2 * 1024 * 1024)
+        with pytest.raises(TypeError):
+            self._mgr(doc_vault).write_attachment("big.bin", big, None, True)  # type: ignore[misc]
+
+
 # ---------------------------------------------------------------------------
 # Note read size-cap tests
 # ---------------------------------------------------------------------------

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -106,6 +106,34 @@ class TestVaultUploadReceiver:
             col.close()
             _server_deps._collection_singleton = saved
 
+    def test_attachment_upload_bypasses_max_attachment_size_mb(
+        self, tmp_path: Path
+    ) -> None:
+        """Receiver path commits attachments over MAX_ATTACHMENT_SIZE_MB.
+
+        The cap protects LLM context for base64 callers of the MCP write
+        tool.  Upload-link uploads flow over HTTP and are gated by
+        UPLOAD_MAX_BYTES, so the inner cap must NOT apply here.
+        """
+        col = Collection(
+            source_dir=tmp_path,
+            read_only=False,
+            attachment_extensions=["pdf"],
+            max_attachment_size_mb=0.000001,
+        )
+        col.build_index()
+        saved = _server_deps._collection_singleton
+        _server_deps.set_collection_singleton(col)
+        try:
+            payload = b"%PDF-1.4 " + b"\x00" * 1024
+            record = _make_record("big.pdf")
+            result = uploads._vault_upload_receiver(record, payload)
+            assert result == {"path": "big.pdf", "size_bytes": len(payload)}
+            assert (tmp_path / "big.pdf").read_bytes() == payload
+        finally:
+            col.close()
+            _server_deps._collection_singleton = saved
+
 
 class TestValidateUploadTarget:
     """``_validate_upload_target`` rejects bad paths at link-creation time."""

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -281,13 +281,24 @@ class TestUploadEndToEnd:
             # 4. Verify the file actually landed in the vault on disk.
             assert (_upload_vault / "uploaded.md").read_bytes() == payload
 
-            # 5. Verify it is now readable via the ``read`` MCP tool —
-            #    proves the FTS index was updated synchronously by
-            #    Collection.write (not just the filesystem write).
+            # 5. Verify it is now readable via the ``read`` MCP tool.
+            #    ``read`` for a whole-document .md reads disk directly,
+            #    so this only proves the file landed on disk.
             read_result = await client.call_tool("read", {"path": "uploaded.md"})
             read_data = json.loads(read_result.content[0].text)
             assert read_data["path"] == "uploaded.md"
             assert read_data["content"] == payload.decode("utf-8")
+
+            # 6. Verify the upload is searchable — proves Collection.write
+            #    upserted the FTS index synchronously.  A regression that
+            #    drops ``self._fts.upsert_note(note)`` would fail this.
+            search_result = await client.call_tool("search", {"query": "Uploaded"})
+            search_data = json.loads(search_result.content[0].text)
+            assert isinstance(search_data, list)
+            search_paths = {r["path"] for r in search_data}
+            assert "uploaded.md" in search_paths, (
+                f"uploaded.md should be searchable after upload; got {search_paths}"
+            )
 
     async def test_invalid_utf8_md_upload_returns_400(
         self, _upload_vault: Path

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -321,10 +321,11 @@ class TestUploadEndToEnd:
                 f"got {response.status_code}: {response.text}"
             )
 
+    @pytest.mark.parametrize("http_transport", ["http", "sse", "streamable-http"])
     async def test_create_upload_link_registered_via_make_server_arg(
-        self, _upload_vault: Path
+        self, _upload_vault: Path, http_transport: str
     ) -> None:
-        """``create_upload_link`` is registered when ``make_server`` gets ``transport="http"``.
+        """``create_upload_link`` is registered for every HTTP-flavoured transport.
 
         Regression test for the ``transport="auto"`` footgun: pvl-core's
         ``register_file_exchange_upload(transport="auto")`` reads
@@ -335,15 +336,20 @@ class TestUploadEndToEnd:
         derive ``fx_transport`` from its own ``transport`` arg and pass it
         through explicitly.
 
+        Also a regression test for #459: ``"streamable-http"`` previously
+        fell through to ``fx_transport="stdio"`` and disabled the upload
+        route silently for third-party embedders calling ``make_server``
+        with that value.
+
         ``_upload_vault`` clears both env vars (see ``_CLEAR_VARS``) so
         this test fails if ``make_server`` ever regresses to passing
         ``"auto"``.
         """
-        server = make_server(transport="http")
+        server = make_server(transport=http_transport)
         async with Client(server) as client:
             tools = await client.list_tools()
             tool_names = {tool.name for tool in tools}
             assert "create_upload_link" in tool_names, (
-                f"create_upload_link not registered (transport wiring regression?). "
+                f"create_upload_link not registered for transport={http_transport!r}. "
                 f"Registered tools: {sorted(tool_names)}"
             )


### PR DESCRIPTION
## Summary

Two PR #443 follow-ups surfaced during local review:

| Commit | Closes | Scope |
|---|---|---|
| `e208e54` | #458 | `Collection.write_attachment(skip_size_cap=False)` keyword-only param; receiver passes `True`. The MAX_ATTACHMENT_SIZE_MB cap exists to protect LLM context budget for base64 payloads — uploads via `create_upload_link` flow over HTTP and never touch context, so the inner cap is the wrong gate (UPLOAD_MAX_BYTES is the right one). |
| `2d23ce9` | #459 | Widen `fx_transport` tuple to include `"streamable-http"`. Was silently mapping to `"stdio"` and disabling `register_file_exchange_upload`. |
| `2d76c5f` | — | Local-circus second-opinion corrections: (a) `test_md_upload_round_trip` now asserts the upload is searchable via `search` tool (the prior `read` assertion proved file-on-disk, not FTS update). (b) `make_server` docstring lists `"streamable-http"` as a valid transport. |

## Test plan

- [x] `uv run pytest -x -q` — 1535 tests pass (+10 new for #458/#459 + receiver integration + search regression)
- [x] `uv run mypy src/ tests/` — clean (79 files)
- [x] `uv run ruff check` + `format --check` — clean
- [x] diff-cover on patch — 100% on changed lines (primary reviewer verified)
- [x] Local-review circus: pr-review-toolkit (primary) + feature-dev (second-opinion) both clean after `2d76c5f` corrections
- [x] `skip_size_cap` keyword-only contract pinned by `test_skip_size_cap_keyword_only`
- [x] `"streamable-http"` transport exercised by parametrized regression test

## Notable

- `MAX_ATTACHMENT_SIZE_MB=0` (unlimited) semantic preserved.
- MCP `write` tool and `fetch` tool callers leave `skip_size_cap=False` — the cap continues to apply on those paths.
- Receiver's bypass is safe because pvl-core's `register_upload_route` enforces `UPLOAD_MAX_BYTES` upstream (Content-Length precheck + running-total cap in `_bounded_chunks()`).
- Docs updated: `docs/tools/index.md` admonition simplified; `docs/guides/claude-desktop.md` caveat dropped.

Closes #458, closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)