### PR TITLE
chore(mcp-apps): polish series — graph perf, test dedup, conformance

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1511,7 +1511,11 @@ MCP Apps are browser-based views that MCP clients supporting the protocol can re
 | `_vault_graph_hubs` | Returns `{nodes, edges}` for the most-linked hub notes |
 | `_vault_list` | Returns `{folders, notes}` for a vault directory |
 | `_vault_read` | Returns note content, frontmatter, and metadata |
-| `_vault_search` | Returns keyword search results with snippets |
+| `_vault_search` | Returns search results with snippets (default mode `hybrid`) |
+
+**View navigation behavior**: backlinks, outlinks, and similar-note items rendered inside the Context Card are clickable, and a click loads that note's context **in the same Context Card view** rather than switching the active view. A dedicated "Open in Browser" button (`ctx-browse-btn`) is the only path that calls `navigateTo('browse', {path})` to switch into the Vault Browser. This supersedes any earlier wording that suggested item clicks themselves perform cross-view navigation — keeping the click in-view preserves an exploration flow without losing scroll position or the surrounding dossier.
+
+**Host context updates**: the Graph Explorer calls `app.updateContext(...)` whenever the active note or the visible neighborhood changes, supplying the active path, title, visible node count, and visible link count. The exact wording of the string is an implementation detail of the SPA; clients should read the structured fields (path/title/counts) rather than parse the string.
 
 **Vendored dependencies** (bundled inline at build time via `scripts/vendor_spa.py`):
 - `vis-network` — force-directed graph rendering for Graph Explorer

--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -21,7 +21,7 @@ Click any linked note to navigate to its context card.
 
 Interactive force-directed link graph of the vault, powered by vis-network. Two modes:
 
-- **Neighborhood** — shows a note and its direct connections (configurable depth)
+- **Neighborhood** — shows a note and its direct connections (configurable depth, soft-capped at `max_nodes=200` by default; the response carries `truncated=true` when the BFS hit the cap so the SPA can warn the user)
 - **Hubs** — shows the most-linked notes in the vault and their connections
 
 Click a node to view that note's context card. Toggle semantic similarity edges when embeddings are available.

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -409,6 +409,7 @@ def register_apps(mcp: FastMCP) -> None:
         path: str,
         depth: int = 1,
         include_semantic: bool = False,
+        max_nodes: int = 200,
         collection: Collection = Depends(get_collection),
     ) -> dict[str, Any]:
         """Return the link neighborhood of a note as a node/edge graph (app-only).
@@ -422,6 +423,10 @@ def register_apps(mcp: FastMCP) -> None:
             include_semantic: When True, add dashed semantic-similarity edges
                 for each interior node (requires embeddings to be configured;
                 silently omitted when unavailable).
+            max_nodes: Soft cap on returned node count (default 200). BFS
+                stops once the cap is hit; the response sets
+                ``truncated=True``. Bounds dense-vault depth=2 traversals
+                that would otherwise bog down vis-network.
 
         Returns:
             Dict with:
@@ -439,13 +444,19 @@ def register_apps(mcp: FastMCP) -> None:
               - from (str): Source node ID.
               - to (str): Target node ID.
               - type (str): "markdown", "wikilink", "reference", or "semantic".
+
+            - truncated (bool): True when BFS hit the ``max_nodes`` cap.
         """
         nodes: dict[str, dict[str, Any]] = {}
         edges: list[dict[str, Any]] = []
         visited: set[str] = set()
         queue: collections.deque[tuple[str, int]] = collections.deque([(path, 0)])
+        truncated = False
 
         while queue:
+            if len(nodes) >= max_nodes:
+                truncated = True
+                break
             current, d = queue.popleft()
             if current in visited:
                 continue
@@ -565,7 +576,11 @@ def register_apps(mcp: FastMCP) -> None:
                         {"from": node_path, "to": sr.path, "type": "semantic"}
                     )
 
-        return {"nodes": list(nodes.values()), "edges": unique_edges}
+        return {
+            "nodes": list(nodes.values()),
+            "edges": unique_edges,
+            "truncated": truncated,
+        }
 
     @mcp.tool(
         icons=_TOOL_ICONS["vault_graph_hubs"],

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -424,9 +424,9 @@ def register_apps(mcp: FastMCP) -> None:
                 for each interior node (requires embeddings to be configured;
                 silently omitted when unavailable).
             max_nodes: Soft cap on returned node count (default 200). BFS
-                stops once the cap is hit; the response sets
-                ``truncated=True``. Bounds dense-vault depth=2 traversals
-                that would otherwise bog down vis-network.
+                and any semantic expansion both stop once the cap is hit;
+                the response sets ``truncated=True``. Bounds dense-vault
+                depth=2 traversals that would otherwise bog down vis-network.
 
         Returns:
             Dict with:
@@ -536,6 +536,9 @@ def register_apps(mcp: FastMCP) -> None:
         if include_semantic:
             sem_seen: set[frozenset[str]] = set()
             for node_path in list(nodes.keys()):
+                if len(nodes) >= max_nodes:
+                    truncated = True
+                    break
                 try:
                     similar = await asyncio.to_thread(
                         collection.get_similar, node_path, limit=5
@@ -558,6 +561,9 @@ def register_apps(mcp: FastMCP) -> None:
                         continue
                     sem_seen.add(pair)
                     if sr.path not in nodes:
+                        if len(nodes) >= max_nodes:
+                            truncated = True
+                            break
                         sim_note = await asyncio.to_thread(collection.read, sr.path)
                         sim_label = (
                             sim_note.title

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -613,15 +613,12 @@ def register_apps(mcp: FastMCP) -> None:
         seen_edges: set[tuple[str, str]] = set()
 
         for hub in hubs:
-            # TODO: extend get_most_linked to return folder, eliminating this per-hub read
-            hub_note = await asyncio.to_thread(collection.read, hub.path)
-            hub_folder = hub_note.folder if hub_note else ""
             nodes[hub.path] = {
                 "id": hub.path,
                 "label": hub.title,
                 "group": "hub",
                 "backlink_count": hub.backlink_count,
-                "folder": hub_folder,
+                "folder": hub.folder,
             }
 
             # Get immediate connections for each hub

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -1152,17 +1152,18 @@ class FTSIndex:
             limit: Maximum number of results to return.
 
         Returns:
-            List of dicts with keys ``path``, ``title``, ``backlink_count``,
-            ordered by backlink_count descending.
+            List of dicts with keys ``path``, ``title``, ``folder``,
+            ``backlink_count``, ordered by backlink_count descending.
         """
         cur = self._conn.execute(
             """
             SELECT d.path,
                    d.title,
+                   d.folder,
                    COUNT(DISTINCT l.source_id) AS backlink_count
             FROM links l
             JOIN documents d ON d.path = l.target_path
-            GROUP BY d.path, d.title
+            GROUP BY d.path, d.title, d.folder
             ORDER BY backlink_count DESC
             LIMIT ?
             """,

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -387,7 +387,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
   }
 </style>
-<!-- vendor-spa-source-sha256:7959dd094b0e71d5391719c2da490122fb7cd14d6ee2a32db6bd0d56be30852b -->
+<!-- vendor-spa-source-sha256:44d3a8d9966af461479c0d78b8467c3a6b2735ea3fe80eda0f5ab989295366b2 -->
 </head>
 <body>
 <div class="app-container">
@@ -990,8 +990,9 @@ app.onteardown = () => {
       const data = parseToolResult(result);
       if (!data) return;
       addGraphData(data);
+      const truncSuffix = data.truncated ? ' (truncated — zoom in for more)' : '';
       window.updateContext('graph explorer', path, nodesDS.get(path)?.label,
-        'Visible: ' + nodesDS.length + ' notes, ' + edgesDS.length + ' links');
+        'Visible: ' + nodesDS.length + ' notes, ' + edgesDS.length + ' links' + truncSuffix);
     } catch (err) {
       console.warn('Graph expand failed:', err);
     }

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -387,7 +387,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
   }
 </style>
-<!-- vendor-spa-source-sha256:36e5b23914e3f7451e50e5f1968d9cbbdbf22c54eb8ddd58a530ace0c722e252 -->
+<!-- vendor-spa-source-sha256:7959dd094b0e71d5391719c2da490122fb7cd14d6ee2a32db6bd0d56be30852b -->
 </head>
 <body>
 <div class="app-container">
@@ -1298,7 +1298,7 @@ app.onteardown = () => {
     searchClear.style.display = '';
     try {
       const result = await app.callServerTool({
-        name: 'vault___vault_search', arguments: { query, mode: 'keyword', limit: 20 }
+        name: 'vault___vault_search', arguments: { query, mode: 'hybrid', limit: 20 }
       });
       const data = parseToolResult(result) || [];
       treeEl.innerHTML = '';

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -872,8 +872,9 @@ app.onteardown = () => {
       const data = parseToolResult(result);
       if (!data) return;
       addGraphData(data);
+      const truncSuffix = data.truncated ? ' (truncated — zoom in for more)' : '';
       window.updateContext('graph explorer', path, nodesDS.get(path)?.label,
-        'Visible: ' + nodesDS.length + ' notes, ' + edgesDS.length + ' links');
+        'Visible: ' + nodesDS.length + ' notes, ' + edgesDS.length + ' links' + truncSuffix);
     } catch (err) {
       console.warn('Graph expand failed:', err);
     }

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1180,7 +1180,7 @@ app.onteardown = () => {
     searchClear.style.display = '';
     try {
       const result = await app.callServerTool({
-        name: 'vault___vault_search', arguments: { query, mode: 'keyword', limit: 20 }
+        name: 'vault___vault_search', arguments: { query, mode: 'hybrid', limit: 20 }
       });
       const data = parseToolResult(result) || [];
       treeEl.innerHTML = '';

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -459,11 +459,13 @@ class MostLinkedNote:
     Attributes:
         path: Relative path from the vault root.
         title: Document title.
+        folder: Parent folder path (empty string for root-level documents).
         backlink_count: Number of other documents that link to this document.
     """
 
     path: str
     title: str
+    folder: str
     backlink_count: int
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,41 @@ async def get_app_html() -> str:
         return resource[0].text if hasattr(resource[0], "text") else str(resource[0])
 
 
+# Shared env-var hygiene for MCP Apps tests — keep make_server() reads
+# deterministic by stripping host-leaked configuration.
+_CLEAR_VARS = (
+    "MARKDOWN_VAULT_MCP_INDEX_PATH",
+    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
+    "MARKDOWN_VAULT_MCP_STATE_PATH",
+    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
+    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
+    "MARKDOWN_VAULT_MCP_EXCLUDE",
+    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
+    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
+    "MARKDOWN_VAULT_MCP_SERVER_NAME",
+    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
+    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
+    "MARKDOWN_VAULT_MCP_AUTH_MODE",
+    "MARKDOWN_VAULT_MCP_BASE_URL",
+    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
+    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
+    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
+    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
+    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
+    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
+    "MARKDOWN_VAULT_MCP_APP_DOMAIN",
+)
+
+
+@pytest.fixture
+def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set minimal env vars for make_server()."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+    monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture
 def vault_path(tmp_path: Path, fixtures_path: Path) -> Path:
     """Copy fixtures into a temp directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,18 @@ def populated_collection(tmp_path: Path):
     return col
 
 
+async def get_app_html() -> str:
+    """Spin up a fresh server and fetch the SPA HTML resource."""
+    from fastmcp import Client
+
+    from markdown_vault_mcp.server import make_server
+
+    server = make_server()
+    async with Client(server) as client:
+        resource = await client.read_resource("ui://vault/app.html")
+        return resource[0].text if hasattr(resource[0], "text") else str(resource[0])
+
+
 @pytest.fixture
 def vault_path(tmp_path: Path, fixtures_path: Path) -> Path:
     """Copy fixtures into a temp directory.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -202,22 +202,25 @@ class TestFTSGetMostLinked:
         assert idx.get_most_linked() == []
 
     def test_most_linked_row_keys(self) -> None:
-        """Each row contains path, title, backlink_count."""
+        """Each row contains path, title, folder, backlink_count."""
         idx = FTSIndex(":memory:")
-        idx.upsert_note(make_note("target.md", title="Target Note"))
+        idx.upsert_note(make_note("notes/target.md", title="Target Note"))
         idx.upsert_note(
             make_note(
                 "src.md",
                 links=[
                     LinkInfo(
-                        target_path="target.md", link_text="T", link_type="markdown"
+                        target_path="notes/target.md",
+                        link_text="T",
+                        link_type="markdown",
                     )
                 ],
             )
         )
         rows = idx.get_most_linked()
-        assert rows[0]["path"] == "target.md"
+        assert rows[0]["path"] == "notes/target.md"
         assert rows[0]["title"] == "Target Note"
+        assert rows[0]["folder"] == "notes"
         assert "backlink_count" in rows[0]
 
 
@@ -289,6 +292,14 @@ class TestCollectionOrphanAndHub:
         col.build_index()
         results = col.get_most_linked(limit=1)
         assert len(results) == 1
+
+    def test_get_most_linked_includes_folder(self, graph_vault: Path) -> None:
+        """MostLinkedNote.folder is populated from the documents table."""
+        col = Collection(source_dir=graph_vault)
+        col.build_index()
+        results = col.get_most_linked()
+        hub = next(r for r in results if r.path == "hub.md")
+        assert hub.folder == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_apps_browser.py
+++ b/tests/test_mcp_apps_browser.py
@@ -14,6 +14,7 @@ from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
+from tests.conftest import get_app_html
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -68,78 +69,70 @@ def _parse_tool_data(result: Any) -> Any:
 class TestBrowserHTML:
     """Verify browser elements exist in the SPA HTML."""
 
-    async def _get_html(self) -> str:
-        server = make_server()
-        async with Client(server) as client:
-            resource = await client.read_resource("ui://vault/app.html")
-            return (
-                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
-            )
-
     async def test_marked_js_vendored(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "marked@" in html
         assert "(vendored)" in html
 
     async def test_dompurify_vendored(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "dompurify@" in html
         assert "(vendored)" in html
         assert "DOMPurify.sanitize" in html
 
     async def test_browser_layout(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "browser-layout" in html
         assert "browser-sidebar" in html
         assert "browser-preview" in html
 
     async def test_folder_tree(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="browser-tree"' in html
         assert "tree-folder" in html
         assert "tree-note" in html
 
     async def test_search_input(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="browser-search-input"' in html
         assert "Search vault" in html
 
     async def test_search_clear_button(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="browser-search-clear"' in html
 
     async def test_preview_panel(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="browser-preview"' in html
         assert "preview-content" in html
 
     async def test_disabled_edit_button(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "edit-btn-disabled" in html
         assert "Coming soon" in html
 
     async def test_send_to_claude_in_preview(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "preview-send-btn" in html
 
     async def test_context_button_in_preview(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "preview-ctx-btn" in html
 
     async def test_graph_button_in_preview(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "preview-graph-btn" in html
 
     async def test_marked_parse_call(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "marked.parse" in html
 
     async def test_host_font_inheritance(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "font-family: inherit" in html or "--font-sans" in html
 
     async def test_update_model_context(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "'browser'" in html
         assert "updateContext" in html
 

--- a/tests/test_mcp_apps_browser.py
+++ b/tests/test_mcp_apps_browser.py
@@ -7,7 +7,7 @@ tools, and HTML browser view content.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 from fastmcp import Client
@@ -15,41 +15,6 @@ from fastmcp import Client
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
 from tests.conftest import get_app_html
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-
-_CLEAR_VARS = (
-    "MARKDOWN_VAULT_MCP_INDEX_PATH",
-    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
-    "MARKDOWN_VAULT_MCP_STATE_PATH",
-    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
-    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
-    "MARKDOWN_VAULT_MCP_EXCLUDE",
-    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
-    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
-    "MARKDOWN_VAULT_MCP_SERVER_NAME",
-    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
-    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
-    "MARKDOWN_VAULT_MCP_AUTH_MODE",
-    "MARKDOWN_VAULT_MCP_BASE_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
-    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
-    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
-    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
-    "MARKDOWN_VAULT_MCP_APP_DOMAIN",
-)
-
-
-@pytest.fixture
-def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
-    monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
-    for var in _CLEAR_VARS:
-        monkeypatch.delenv(var, raising=False)
 
 
 def _parse_tool_data(result: Any) -> Any:

--- a/tests/test_mcp_apps_context.py
+++ b/tests/test_mcp_apps_context.py
@@ -7,7 +7,7 @@ HTML context card rendering.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 from fastmcp import Client
@@ -15,41 +15,6 @@ from fastmcp import Client
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
 from tests.conftest import get_app_html
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-
-_CLEAR_VARS = (
-    "MARKDOWN_VAULT_MCP_INDEX_PATH",
-    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
-    "MARKDOWN_VAULT_MCP_STATE_PATH",
-    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
-    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
-    "MARKDOWN_VAULT_MCP_EXCLUDE",
-    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
-    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
-    "MARKDOWN_VAULT_MCP_SERVER_NAME",
-    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
-    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
-    "MARKDOWN_VAULT_MCP_AUTH_MODE",
-    "MARKDOWN_VAULT_MCP_BASE_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
-    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
-    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
-    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
-    "MARKDOWN_VAULT_MCP_APP_DOMAIN",
-)
-
-
-@pytest.fixture
-def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
-    monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
-    for var in _CLEAR_VARS:
-        monkeypatch.delenv(var, raising=False)
 
 
 def _parse_tool_data(result: Any) -> Any:

--- a/tests/test_mcp_apps_context.py
+++ b/tests/test_mcp_apps_context.py
@@ -14,6 +14,7 @@ from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
+from tests.conftest import get_app_html
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -68,26 +69,18 @@ def _parse_tool_data(result: Any) -> Any:
 class TestContextCardHTML:
     """Verify context card sections exist in the SPA HTML."""
 
-    async def _get_html(self) -> str:
-        server = make_server()
-        async with Client(server) as client:
-            resource = await client.read_resource("ui://vault/app.html")
-            return (
-                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
-            )
-
     async def test_context_card_container(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="context-card"' in html
 
     async def test_context_header_elements(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="ctx-title"' in html
         assert 'id="ctx-path"' in html
         assert 'id="ctx-folder"' in html
 
     async def test_collapsible_sections(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         for section_id in [
             "ctx-frontmatter",
             "ctx-tags",
@@ -99,45 +92,45 @@ class TestContextCardHTML:
             assert f'id="{section_id}"' in html
 
     async def test_send_to_claude_button(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="ctx-send-btn"' in html
         assert "sendToLLM" in html
 
     async def test_call_server_tool_for_context(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "callServerTool" in html
         assert _hashed("vault_context") in html
 
     async def test_clickable_link_items(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "link-item" in html
         assert "data-path" in html
 
     async def test_host_css_variables(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "var(--color-text-info" in html
         assert "var(--color-border-primary" in html
         assert "var(--color-text-secondary" in html
 
     async def test_update_model_context_on_view(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "updateContext" in html
         assert "'context card'" in html
 
     async def test_link_type_badges(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "link-type-badge" in html
 
     async def test_similar_score_bar(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "similar-score-fill" in html
 
     async def test_tag_pills(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "tag-pill" in html
 
     async def test_frontmatter_table(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "fm-table" in html
 
 
@@ -234,22 +227,14 @@ class TestShowContextTool:
 class TestNoHardcodedColors:
     """Verify context card CSS uses variables instead of hardcoded hex colours."""
 
-    async def _get_html(self) -> str:
-        server = make_server()
-        async with Client(server) as client:
-            resource = await client.read_resource("ui://vault/app.html")
-            return (
-                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
-            )
-
     async def test_success_color_is_variable(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "var(--color-text-success" in html
 
     async def test_error_color_is_variable(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "var(--color-text-danger" in html
 
     async def test_accent_fg_color_is_variable(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "var(--color-text-inverse" in html

--- a/tests/test_mcp_apps_foundation.py
+++ b/tests/test_mcp_apps_foundation.py
@@ -20,42 +20,10 @@ from markdown_vault_mcp._server_apps import (
     _rewrite_spa_app_tool_calls,
 )
 from markdown_vault_mcp.server import make_server
+from tests.conftest import _CLEAR_VARS
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-_CLEAR_VARS = (
-    "MARKDOWN_VAULT_MCP_INDEX_PATH",
-    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
-    "MARKDOWN_VAULT_MCP_STATE_PATH",
-    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
-    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
-    "MARKDOWN_VAULT_MCP_EXCLUDE",
-    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
-    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
-    "MARKDOWN_VAULT_MCP_SERVER_NAME",
-    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
-    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
-    "MARKDOWN_VAULT_MCP_AUTH_MODE",
-    "MARKDOWN_VAULT_MCP_BASE_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
-    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
-    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
-    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
-    "MARKDOWN_VAULT_MCP_APP_DOMAIN",
-)
-
-
-@pytest.fixture
-def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Set minimal env vars for make_server."""
-    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
-    monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
-    for var in _CLEAR_VARS:
-        monkeypatch.delenv(var, raising=False)
 
 
 def _parse_tool_data(result: Any) -> Any:

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -15,6 +15,7 @@ from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
+from tests.conftest import get_app_html
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -69,55 +70,47 @@ def _parse_tool_data(result: Any) -> Any:
 class TestGraphExplorerHTML:
     """Verify graph explorer elements exist in the SPA HTML."""
 
-    async def _get_html(self) -> str:
-        server = make_server()
-        async with Client(server) as client:
-            resource = await client.read_resource("ui://vault/app.html")
-            return (
-                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
-            )
-
     async def test_vis_network_vendored(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "vis-network@" in html
         assert "(vendored)" in html
 
     async def test_graph_container(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="graph-container"' in html
 
     async def test_vis_network_initialization(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "vis.Network" in html
         assert "vis.DataSet" in html
 
     async def test_click_handler(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "network.on('click'" in html
 
     async def test_hover_tooltip(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         # Tooltip via node.title property
         assert "tooltipDelay" in html
 
     async def test_double_click_handler(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "doubleClick" in html
         # Double-click triggers focus mode (clear + reload for this node only)
         assert "loadGraph(nodeId)" in html
 
     async def test_dynamic_expansion(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "expandNode" in html
         assert _hashed("vault_graph_neighborhood") in html
 
     async def test_hub_view(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert _hashed("vault_graph_hubs") in html
         assert "loadHubs" in html
 
     async def test_node_visual_encoding(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         # Node size proportional to backlink_count via value
         assert "backlink_count" in html
         # Edge color by type
@@ -126,31 +119,31 @@ class TestGraphExplorerHTML:
         assert "borderDashes" in html
 
     async def test_send_to_claude_button(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="graph-send-btn"' in html
 
     async def test_fullscreen_button(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="graph-fullscreen-btn"' in html
 
     async def test_mini_context_card(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="graph-mini-card"' in html
         assert "showMiniCard" in html
         assert "Full Context" in html
         assert "Open in Browser" in html
 
     async def test_xss_protection_eschtml(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "escHtml" in html
 
     async def test_cdn_crash_guard(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         # loadGraph must check nodesDS before calling clear()
         assert "vis CDN failed" in html or "!nodesDS" in html
 
     async def test_host_css_variables_in_graph(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "getColors" in html
         assert "--color-text-info" in html
 
@@ -298,40 +291,32 @@ class TestGraphDataTools:
 class TestSemanticGraphHTML:
     """Verify semantic similarity graph features in the SPA HTML."""
 
-    async def _get_html(self) -> str:
-        server = make_server()
-        async with Client(server) as client:
-            resource = await client.read_resource("ui://vault/app.html")
-            return (
-                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
-            )
-
     async def test_semantic_toggle_button(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert 'id="graph-semantic-btn"' in html
 
     async def test_include_semantic_passed_to_tool(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "include_semantic" in html
         assert "semanticEnabled" in html
 
     async def test_semantic_edge_color_constant(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "_SEMANTIC_EDGE_COLOR" in html
 
     async def test_semantic_edge_dashed(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         # Semantic edges rendered as dashed lines
         assert "isSemantic" in html
         assert "dashes" in html
 
     async def test_folder_color_palette(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "_FOLDER_COLORS" in html
         assert "_folderColor" in html
 
     async def test_cross_view_currentpath(self) -> None:
-        html = await self._get_html()
+        html = await get_app_html()
         assert "currentPath" in html
 
 

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -204,6 +204,30 @@ class TestGraphDataTools:
             assert "nodes" in data
             assert "edges" in data
 
+    async def test_hubs_does_not_read_hub_documents(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """vault_graph_hubs uses MostLinkedNote.folder, not per-hub collection.read."""
+        from markdown_vault_mcp.collection import Collection
+
+        original_read = Collection.read
+        read_paths: list[str] = []
+
+        def _spy(self: Collection, path: str) -> Any:
+            read_paths.append(path)
+            return original_read(self, path)
+
+        monkeypatch.setattr(Collection, "read", _spy)
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(_hashed("vault_graph_hubs"), {})
+            data = _parse_tool_data(result)
+        hub_paths = {n["id"] for n in data["nodes"] if n["group"] == "hub"}
+        assert hub_paths, "fixture should produce at least one hub"
+        assert not (hub_paths & set(read_paths)), (
+            f"hub documents should not be read directly; read={read_paths}"
+        )
+
     async def test_edges_have_type(self) -> None:
         server = make_server()
         async with Client(server) as client:

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -491,3 +491,65 @@ class TestIncludeSemanticEdges:
         assert "edges" in data
         semantic_edges = [e for e in data["edges"] if e.get("type") == "semantic"]
         assert semantic_edges == []
+
+
+# ---------------------------------------------------------------------------
+# max_nodes BFS cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _star_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    # Star-pattern vault: hub.md links to 20 spokes; each spoke links back.
+    vault = tmp_path / "star_vault"
+    vault.mkdir()
+    spokes = "\n".join(f"- [s{i}](spoke{i}.md)" for i in range(20))
+    (vault / "hub.md").write_text(f"# Hub\n\n{spokes}\n")
+    for i in range(20):
+        (vault / f"spoke{i}.md").write_text(f"# Spoke {i}\n\n[hub](hub.md)\n")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return vault
+
+
+class TestGraphNeighborhoodMaxNodes:
+    """Verify max_nodes caps BFS output and sets the truncated flag."""
+
+    async def test_max_nodes_caps_node_count(self, _star_vault: Path) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                _hashed("vault_graph_neighborhood"),
+                {"path": "hub.md", "depth": 2, "max_nodes": 5},
+            )
+        data = _parse_tool_data(result)
+        assert len(data["nodes"]) <= 5
+        assert data["truncated"] is True
+
+    async def test_truncated_false_when_under_cap(self, _star_vault: Path) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                _hashed("vault_graph_neighborhood"),
+                {"path": "hub.md", "depth": 2, "max_nodes": 500},
+            )
+        data = _parse_tool_data(result)
+        assert data["truncated"] is False
+
+
+@pytest.mark.usefixtures("_mcp_env")
+class TestGraphNeighborhoodMaxNodesDefault:
+    """Default max_nodes preserves prior behavior on small fixture vault."""
+
+    async def test_default_does_not_truncate_small_vault(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                _hashed("vault_graph_neighborhood"),
+                {"path": "simple.md", "depth": 2},
+            )
+        data = _parse_tool_data(result)
+        assert data["truncated"] is False
+        assert len(data["nodes"]) < 200

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -15,42 +15,10 @@ from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
-from tests.conftest import get_app_html
+from tests.conftest import _CLEAR_VARS, get_app_html
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-_CLEAR_VARS = (
-    "MARKDOWN_VAULT_MCP_INDEX_PATH",
-    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
-    "MARKDOWN_VAULT_MCP_STATE_PATH",
-    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
-    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
-    "MARKDOWN_VAULT_MCP_EXCLUDE",
-    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
-    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
-    "MARKDOWN_VAULT_MCP_SERVER_NAME",
-    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
-    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
-    "MARKDOWN_VAULT_MCP_AUTH_MODE",
-    "MARKDOWN_VAULT_MCP_BASE_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
-    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
-    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
-    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
-    "MARKDOWN_VAULT_MCP_APP_DOMAIN",
-)
-
-
-@pytest.fixture
-def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
-    monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
-    for var in _CLEAR_VARS:
-        monkeypatch.delenv(var, raising=False)
 
 
 def _parse_tool_data(result: Any) -> Any:
@@ -537,6 +505,49 @@ class TestGraphNeighborhoodMaxNodes:
             )
         data = _parse_tool_data(result)
         assert data["truncated"] is False
+
+    async def test_max_nodes_caps_semantic_expansion(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """max_nodes also bounds the semantic-expansion phase, not just BFS."""
+        from .conftest import MockEmbeddingProvider
+
+        # Star vault: forces BFS to hit the cap; semantic phase must not bypass it
+        vault = tmp_path / "sem_star"
+        vault.mkdir()
+        spokes = "\n".join(f"- [s{i}](spoke{i}.md)" for i in range(20))
+        (vault / "hub.md").write_text(f"# Hub\n\n{spokes}\n")
+        for i in range(20):
+            (vault / f"spoke{i}.md").write_text(f"# Spoke {i}\n\n[hub](hub.md)\n")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH", str(tmp_path / "embeddings")
+        )
+        for var in _CLEAR_VARS:
+            if var != "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH":
+                monkeypatch.delenv(var, raising=False)
+
+        mock_prov = MockEmbeddingProvider()
+        with patch(
+            "markdown_vault_mcp.providers.get_embedding_provider",
+            return_value=mock_prov,
+        ):
+            server = make_server()
+            async with Client(server) as client:
+                result = await client.call_tool(
+                    _hashed("vault_graph_neighborhood"),
+                    {
+                        "path": "hub.md",
+                        "depth": 2,
+                        "max_nodes": 5,
+                        "include_semantic": True,
+                    },
+                )
+        data = _parse_tool_data(result)
+        assert len(data["nodes"]) <= 5
+        assert data["truncated"] is True
 
 
 @pytest.mark.usefixtures("_mcp_env")

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -549,6 +549,66 @@ class TestGraphNeighborhoodMaxNodes:
         assert len(data["nodes"]) <= 5
         assert data["truncated"] is True
 
+    async def test_max_nodes_caps_semantic_inner_branch(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Inner semantic-cap fires when expansion fills the cap mid-iteration (PR #478)."""
+        from .conftest import MockEmbeddingProvider
+
+        # Vault forces the *inner* cap branch in _vault_graph_neighborhood:
+        # BFS from center returns {center, B} = 2 nodes (below cap=4).
+        # Semantic expansion for `center` then adds enough fresh candidates
+        # to reach the cap mid-loop; the next non-member candidate must
+        # trigger the inner ``len(nodes) >= max_nodes`` guard (lines 564-566).
+        vault = tmp_path / "sem_inner"
+        vault.mkdir()
+        # center links only to B (BFS yields exactly {center, B} at depth=1)
+        (vault / "center.md").write_text("# Center\n\n[B](B.md)\n")
+        (vault / "B.md").write_text("# B\n\n[center](center.md)\n")
+        # Four semantic-only notes (unlinked from center/B). With max_nodes=4
+        # and nodes already at 2, the loop adds two and the third trips the
+        # inner cap regardless of MockEmbeddingProvider's similarity ordering.
+        for label in ("C", "D", "E", "F"):
+            (vault / f"{label}.md").write_text(
+                f"# {label}\n\nstandalone note {label}\n"
+            )
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH", str(tmp_path / "embeddings")
+        )
+        for var in _CLEAR_VARS:
+            if var != "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH":
+                monkeypatch.delenv(var, raising=False)
+
+        mock_prov = MockEmbeddingProvider()
+        with patch(
+            "markdown_vault_mcp.providers.get_embedding_provider",
+            return_value=mock_prov,
+        ):
+            server = make_server()
+            async with Client(server) as client:
+                result = await client.call_tool(
+                    _hashed("vault_graph_neighborhood"),
+                    {
+                        "path": "center.md",
+                        "depth": 1,
+                        "max_nodes": 4,
+                        "include_semantic": True,
+                    },
+                )
+        data = _parse_tool_data(result)
+        assert len(data["nodes"]) == 4
+        assert data["truncated"] is True
+        # Inner branch fired: at least one semantic candidate was rejected
+        # because the cap was reached mid-loop, so not every standalone
+        # note (C/D/E/F) ended up in the result set.
+        node_ids = {n["id"] for n in data["nodes"]}
+        standalone = {"C.md", "D.md", "E.md", "F.md"}
+        assert len(standalone & node_ids) < len(standalone)
+
 
 @pytest.mark.usefixtures("_mcp_env")
 class TestGraphNeighborhoodMaxNodesDefault:

--- a/tests/test_mcp_apps_navigation.py
+++ b/tests/test_mcp_apps_navigation.py
@@ -6,46 +6,9 @@ sendToLLM, updateContext, and toast confirmation.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 from tests.conftest import get_app_html
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-
-_CLEAR_VARS = (
-    "MARKDOWN_VAULT_MCP_INDEX_PATH",
-    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
-    "MARKDOWN_VAULT_MCP_STATE_PATH",
-    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
-    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
-    "MARKDOWN_VAULT_MCP_EXCLUDE",
-    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
-    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
-    "MARKDOWN_VAULT_MCP_SERVER_NAME",
-    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
-    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
-    "MARKDOWN_VAULT_MCP_AUTH_MODE",
-    "MARKDOWN_VAULT_MCP_BASE_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
-    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
-    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
-    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
-    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
-    "MARKDOWN_VAULT_MCP_APP_DOMAIN",
-)
-
-
-@pytest.fixture
-def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
-    monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
-    for var in _CLEAR_VARS:
-        monkeypatch.delenv(var, raising=False)
 
 
 @pytest.mark.usefixtures("_mcp_env")

--- a/tests/test_mcp_apps_navigation.py
+++ b/tests/test_mcp_apps_navigation.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from fastmcp import Client
 
-from markdown_vault_mcp.server import make_server
+from tests.conftest import get_app_html
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -49,28 +48,20 @@ def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(var, raising=False)
 
 
-async def _fetch_app_html() -> str:
-    """Create a server and fetch the app HTML resource."""
-    server = make_server()
-    async with Client(server) as client:
-        resource = await client.read_resource("ui://vault/app.html")
-        return resource[0].text if hasattr(resource[0], "text") else str(resource[0])
-
-
 @pytest.mark.usefixtures("_mcp_env")
 class TestCrossViewNavigation:
     """Verify all cross-view navigation paths are wired in the HTML."""
 
     # AC #1: navigateTo function
     async def test_navigate_to_function_exists(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "window.navigateTo" in html
         assert "function navigateTo" in html
         assert "switchTab" in html
 
     # AC #2: Graph double-click → focus mode (clear + reload for this node)
     async def test_graph_to_context_on_dblclick(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "doubleClick" in html
         # Double-click now triggers focus mode via loadGraph(nodeId)
         assert "loadGraph(nodeId)" in html
@@ -79,41 +70,41 @@ class TestCrossViewNavigation:
 
     # AC #3: Graph → Browser (mini card button)
     async def test_graph_to_browser_mini_card(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "Open in Browser" in html
         assert "mini-open-browser" in html
         assert "navigateTo('browse'" in html
 
     # AC #4: Context → Graph (button)
     async def test_context_to_graph_button(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert 'id="ctx-graph-btn"' in html
         assert "navigateTo('graph'" in html
 
     # AC #5: Context → Browser (backlink/outlink clicks)
     async def test_context_to_browser_button(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert 'id="ctx-browse-btn"' in html
 
     # AC #6: Browser → Context (button in preview)
     async def test_browser_to_context_button(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "preview-ctx-btn" in html
 
     # AC #7: Browser → Graph (button in preview)
     async def test_browser_to_graph_button(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "preview-graph-btn" in html
 
     # AC #8: Mini context card on graph single click
     async def test_graph_mini_card_exists(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "graph-mini-card" in html
         assert "showMiniCard" in html
 
     # AC #9: Mini card has Full Context + Open in Browser
     async def test_mini_card_buttons(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "Full Context" in html
         assert "mini-full-ctx" in html
 
@@ -124,19 +115,19 @@ class TestSendToLLM:
 
     # AC #10: Shared sendToLLM function
     async def test_send_to_llm_function(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "window.sendToLLM" in html
         assert "app.sendMessage" in html
 
     # AC #11: Content truncation
     async def test_truncation_at_4000_chars(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "4000" in html
         assert "truncated" in html
 
     # AC #12: Send button in all views
     async def test_send_buttons_across_views(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         # Context view
         assert "ctx-send-btn" in html
         # Graph view
@@ -146,7 +137,7 @@ class TestSendToLLM:
 
     # AC #13: Toast confirmation
     async def test_toast_after_send(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "showToast" in html
         assert "Sent to Claude" in html
         assert 'class="toast"' in html
@@ -158,18 +149,18 @@ class TestAmbientContext:
 
     # AC #14: Shared updateContext function
     async def test_update_context_function(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "window.updateContext" in html
         assert "updateModelContext" in html
 
     async def test_context_view_calls_update(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "'context card'" in html
 
     async def test_graph_view_calls_update(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "'graph explorer'" in html
 
     async def test_browser_view_calls_update(self) -> None:
-        html = await _fetch_app_html()
+        html = await get_app_html()
         assert "'browser'" in html


### PR DESCRIPTION
## Summary

Bundle of four MCP-Apps follow-ups from the #280-#284 epic. All touch `_server_apps.py` / `static/app.src.html` / MCP-apps tests. Five commits.

| Commit | Closes | Scope |
|---|---|---|
| `12b00f1` | #286 (part) | `get_most_linked` SELECT extended with `d.folder`; `_vault_graph_hubs` reads `hub.folder` directly — eliminates 20-per-call `Collection.read` N+1 |
| `7839951` | #286 (part) | Dedup `_get_html()` helper across 4 MCP-Apps test files → `tests/conftest.py::get_app_html` |
| `ca30584` | #440, #285 (part) | `_vault_graph_neighborhood` gets `max_nodes: int = 200` cap with `truncated: bool` return signal (bounds dense-vault BFS for vis-network rendering) |
| `a8bb459` | #287 | Conformance polish: SPA browser search mode `'keyword'` → `'hybrid'` (#276 AC4); `docs/design.md` resolves #277 AC5 vs #274 AC4 link-click conflict + aligns updateModelContext format |
| `1ef4045` | (local review fixes) | (1) SPA surfaces `truncated` in the context-line status. (2) Semantic expansion phase now respects `max_nodes`. (3) Dedup `_CLEAR_VARS` + `_mcp_env` fixture into `conftest.py` (closes the rest of #286's dedup scope). |

## Test plan

- [x] `uv run pytest -x -q` — 1551 tests pass (+4 new)
- [x] `uv run mypy src/ tests/` — clean (79 files)
- [x] `uv run ruff check` + `format --check` — clean
- [x] diff-cover — 100% on patch lines
- [x] `vendor_spa.py --check` — `app.html` matches `app.src.html`
- [x] Local-review circus: pr-review-toolkit (primary) + feature-dev (second-opinion) both clean after `1ef4045` corrections

## Not closed in this PR

- **#285 asyncio.gather for graph BFS/hubs reads**: deferred. The optimization was reverted in `ca30584` after empirical reproduction of an SQLite concurrency race on the shared `FTSIndex._conn` (under `pytest --cov` the race window widens and `SQLITE_MISUSE` fires deterministically). The fix needs a read-lock or pool — filed as new issue #477 as a prerequisite. The remaining sub-items of #285 (CDN pin, max_nodes guard) are addressed.
- **#285 SDK CDN version pinning**: already done by PR #303 (deps vendored inline).

Closes #286, closes #287, closes #440. Refs #285 (partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)