### PR TITLE
refactor(git-tools): wrap get_history / get_diff(per_commit=True) responses in {commits, total} envelope

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1669,6 +1669,8 @@ Safety branch mode for push failures is tracked separately (see #119).
 
 Both methods use the existing `_git_env()` / `_cleanup_git_env()` pattern for credential forwarding and cleanup. Path arguments are always validated via `Collection._validate_path()` before being passed to the git layer. No shell injection is possible because all subprocess calls use list arguments with `shell=False`.
 
+**MCP response envelope**: the MCP wrappers for `get_history` and `get_diff(per_commit=True)` return a `{"commits": [...], "total": N}` envelope rather than a bare list, so the structured payload is self-describing on the wire. FastMCP otherwise auto-wraps list-typed tool returns under a synthetic `"result"` key (`x-fastmcp-wrap-result: true` in the output schema), which forces clients re-reading persisted MCP content to know FastMCP's wrapping convention to find the data. The Python facade (`Collection.get_history`, `Collection.get_diff`) stays list-returning — only the MCP-tool wrapper transforms to the envelope. `get_diff(per_commit=False)` keeps its existing `{"diff": str}` shape since it is already self-describing.
+
 ### Release channels
 
 The release workflow (`.github/workflows/release.yml`) publishes two

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -712,7 +712,7 @@ List commits that touched a note (or the whole vault) within an optional time wi
 | `until` | string | `null` | ISO 8601 datetime string or git date expression, passed as `--until` to `git log`. Combined with `since` to bound a window. Inclusive at the boundary. |
 | `limit` | int | `20` | Maximum number of commits to return. Capped at 100. |
 
-**Returns:** Object with `commits` (list of commit entries, newest-first) and `total` (count). The envelope keeps the structured payload self-describing on the wire instead of relying on FastMCP's auto-wrapping `result` key. Each entry in `commits` contains:
+**Returns:** Object with `commits` (list of commit entries, newest-first) and `total` (count — always equals `len(commits)`; does NOT indicate how many commits exist beyond the `limit` cap). The envelope keeps the structured payload self-describing on the wire instead of relying on FastMCP's auto-wrapping `result` key. Each entry in `commits` contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -744,7 +744,7 @@ Exactly one of `since_sha` / `since_timestamp` must be supplied.
 **Returns:**
 
 - `per_commit=false`: object with `diff` (string) — unified diff from reference to HEAD. May include `[diff truncated: N bytes omitted]` if output exceeds 50 KB.
-- `per_commit=true`: object with `commits` (list of per-commit entries, newest-first — each containing `sha`, `short_sha`, `timestamp`, `message`, and `diff`) and `total` (count). The envelope keeps the structured payload self-describing on the wire instead of relying on FastMCP's auto-wrapping `result` key.
+- `per_commit=true`: object with `commits` (list of per-commit entries, newest-first — each containing `sha`, `short_sha`, `timestamp`, `message`, and `diff`) and `total` (count — always equals `len(commits)`; does NOT indicate how many commits exist beyond the `limit` cap). The envelope keeps the structured payload self-describing on the wire instead of relying on FastMCP's auto-wrapping `result` key.
 
 **Raises:** `ToolError` if parameters are invalid or the reference commit is not found.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -712,7 +712,7 @@ List commits that touched a note (or the whole vault) within an optional time wi
 | `until` | string | `null` | ISO 8601 datetime string or git date expression, passed as `--until` to `git log`. Combined with `since` to bound a window. Inclusive at the boundary. |
 | `limit` | int | `20` | Maximum number of commits to return. Capped at 100. |
 
-**Returns:** List of commit objects, newest-first. Each entry contains:
+**Returns:** Object with `commits` (list of commit entries, newest-first) and `total` (count). The envelope keeps the structured payload self-describing on the wire instead of relying on FastMCP's auto-wrapping `result` key. Each entry in `commits` contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -744,7 +744,7 @@ Exactly one of `since_sha` / `since_timestamp` must be supplied.
 **Returns:**
 
 - `per_commit=false`: object with `diff` (string) — unified diff from reference to HEAD. May include `[diff truncated: N bytes omitted]` if output exceeds 50 KB.
-- `per_commit=true`: list of objects, newest-first, each containing `sha`, `short_sha`, `timestamp`, `message`, and `diff`.
+- `per_commit=true`: object with `commits` (list of per-commit entries, newest-first — each containing `sha`, `short_sha`, `timestamp`, `message`, and `diff`) and `total` (count). The envelope keeps the structured payload self-describing on the wire instead of relying on FastMCP's auto-wrapping `result` key.
 
 **Raises:** `ToolError` if parameters are invalid or the reference commit is not found.
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1038,7 +1038,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         until: str | None = None,
         limit: int = 20,
         collection: Collection = Depends(get_collection),
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """List commits that touched a note or the whole vault.
 
         Only available for git-backed vaults. Use 'stats' to check
@@ -1058,18 +1058,21 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             limit: Maximum number of commits to return. Default 20, max 100.
 
         Returns:
-            List of commit dicts, newest-first. Each contains:
+            Envelope dict with the following fields:
 
-            - sha (str): Full 40-character commit SHA.
-            - short_sha (str): 7-character abbreviated SHA.
-            - timestamp (str): ISO 8601 author timestamp.
-            - author (str): Committer name and email, e.g. "Name <email>".
-            - message (str): First line of the commit message.
-            - paths_changed (list[str]): Files touched by the commit.
-              Populated for vault-wide queries (path=None). Always empty for
-              single-note queries, since the path is already determined by
-              the query arguments — callers know which file the commit
-              touched without needing it echoed back.
+            - commits (list[dict]): Commit entries, newest-first. Each entry
+              contains:
+                - sha (str): Full 40-character commit SHA.
+                - short_sha (str): 7-character abbreviated SHA.
+                - timestamp (str): ISO 8601 author timestamp.
+                - author (str): Committer name and email, e.g. "Name <email>".
+                - message (str): First line of the commit message.
+                - paths_changed (list[str]): Files touched by the commit.
+                  Populated for vault-wide queries (path=None). Always empty
+                  for single-note queries, since the path is already
+                  determined by the query arguments — callers know which
+                  file the commit touched without needing it echoed back.
+            - total (int): Number of entries in `commits`.
 
         Raises:
             ToolError: If the path is invalid.
@@ -1084,7 +1087,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             )
         except ValueError as exc:
             raise ToolError(str(exc)) from exc
-        return [asdict(r) for r in results]
+        commits = [asdict(r) for r in results]
+        return {"commits": commits, "total": len(commits)}
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_diff"],
@@ -1101,7 +1105,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         per_commit: bool = False,
         limit: int | None = None,
         collection: Collection = Depends(get_collection),
-    ) -> dict[str, Any] | list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """Return the diff of a note between a reference point and HEAD.
 
         Only available for git-backed vaults. Exactly one of 'since_sha' or
@@ -1130,20 +1134,21 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 auditing long histories.
 
         Returns:
-            When per_commit=False: dict with a single field:
+            Envelope dict whose shape depends on `per_commit`:
 
-            - diff (str): Unified diff from the reference to HEAD. Empty
-              string when there are no changes. May include a truncation
-              notice if the diff exceeds 50 KB.
-
-            When per_commit=True: list of commit dicts, newest-first, each
-            containing:
-
-            - sha (str): Full commit SHA.
-            - short_sha (str): Abbreviated SHA.
-            - timestamp (str): ISO 8601 author timestamp.
-            - message (str): First line of commit message.
-            - diff (str): Unified diff for this commit.
+            - When per_commit=False:
+                - diff (str): Unified diff from the reference to HEAD. Empty
+                  string when there are no changes. May include a truncation
+                  notice if the diff exceeds 50 KB.
+            - When per_commit=True:
+                - commits (list[dict]): Per-commit entries, newest-first.
+                  Each contains:
+                    - sha (str): Full commit SHA.
+                    - short_sha (str): Abbreviated SHA.
+                    - timestamp (str): ISO 8601 author timestamp.
+                    - message (str): First line of commit message.
+                    - diff (str): Unified diff for this commit.
+                - total (int): Number of entries in `commits`.
 
         Raises:
             ToolError: If neither or both reference parameters are supplied,
@@ -1161,7 +1166,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         except ValueError as exc:
             raise ToolError(str(exc)) from exc
         if isinstance(result, list):
-            return [asdict(r) for r in result]
+            commits = [asdict(r) for r in result]
+            return {"commits": commits, "total": len(commits)}
         return {"diff": result}
 
     # --- Index management tools ---

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1072,7 +1072,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                   for single-note queries, since the path is already
                   determined by the query arguments — callers know which
                   file the commit touched without needing it echoed back.
-            - total (int): Number of entries in `commits`.
+            - total (int): Count of entries in `commits` (always equals
+              `len(commits)`; does NOT indicate how many commits exist
+              beyond the `limit` cap).
 
         Raises:
             ToolError: If the path is invalid.
@@ -1148,7 +1150,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                     - timestamp (str): ISO 8601 author timestamp.
                     - message (str): First line of commit message.
                     - diff (str): Unified diff for this commit.
-                - total (int): Number of entries in `commits`.
+                - total (int): Count of entries in `commits` (always equals
+                  `len(commits)`; does NOT indicate how many commits exist
+                  beyond the `limit` cap).
 
         Raises:
             ToolError: If neither or both reference parameters are supplied,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3314,6 +3314,40 @@ class TestGetDiffTool:
         # Newest-first ordering: the two most recent commit messages.
         assert [c["message"] for c in commits] == ["edit v4", "edit v3"]
 
+    async def test_get_diff_envelope_wire_shape_per_commit_true(
+        self, git_vault: Path
+    ) -> None:
+        """structured_content uses the `commits` envelope, not FastMCP's
+        synthetic `result` wrap key."""
+        sha = self._first_sha(git_vault)
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "get_diff",
+                {"path": "alpha.md", "since_sha": sha, "per_commit": True},
+            )
+        assert result.structured_content is not None
+        assert "commits" in result.structured_content
+        assert "total" in result.structured_content
+        # The whole point of the refactor: payload is self-describing on
+        # the wire — no opaque `result` key from auto-wrapping a list.
+        assert "result" not in result.structured_content
+
+    async def test_get_diff_output_schema_not_auto_wrapped(self) -> None:
+        """outputSchema must not carry FastMCP's `x-fastmcp-wrap-result`
+        marker — it appears only when FastMCP auto-wraps a list/primitive
+        return under a synthetic `result` key; the dict envelope skips it."""
+        server = make_server()
+        async with Client(server) as client:
+            tools = await client.list_tools()
+        gd = next(t for t in tools if t.name == "get_diff")
+        schema = gd.outputSchema
+        assert schema is not None
+        assert schema.get("type") == "object"
+        assert "x-fastmcp-wrap-result" not in schema
+        # And no synthetic `result` key in any declared properties.
+        assert "result" not in schema.get("properties", {})
+
 
 async def test_search_tool_accepts_chunks_per_file_and_snippet_words(
     tmp_path: Path,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3096,9 +3096,12 @@ class TestGetHistoryTool:
         server = make_server()
         async with Client(server) as client:
             result = await client.call_tool("get_history", {})
-        entries = _parse_tool_data(result)
+        data = _parse_tool_data(result)
+        assert isinstance(data, dict)
+        entries = data["commits"]
         assert isinstance(entries, list)
         assert len(entries) == 2
+        assert data["total"] == 2
         messages = [e["message"] for e in entries]
         assert "edit: alpha.md" in messages
         assert "write: alpha.md" in messages
@@ -3108,17 +3111,19 @@ class TestGetHistoryTool:
         server = make_server()
         async with Client(server) as client:
             result = await client.call_tool("get_history", {"path": "alpha.md"})
-        entries = _parse_tool_data(result)
-        assert isinstance(entries, list)
-        assert len(entries) == 2
+        data = _parse_tool_data(result)
+        assert isinstance(data, dict)
+        assert isinstance(data["commits"], list)
+        assert len(data["commits"]) == 2
+        assert data["total"] == 2
 
     async def test_history_entry_fields(self) -> None:
         """Each history entry has the expected fields."""
         server = make_server()
         async with Client(server) as client:
             result = await client.call_tool("get_history", {"limit": 1})
-        entries = _parse_tool_data(result)
-        entry = entries[0]
+        data = _parse_tool_data(result)
+        entry = data["commits"][0]
         assert "sha" in entry and len(entry["sha"]) == 40
         assert "short_sha" in entry
         assert "timestamp" in entry
@@ -3131,8 +3136,9 @@ class TestGetHistoryTool:
         server = make_server()
         async with Client(server) as client:
             result = await client.call_tool("get_history", {"limit": 1})
-        entries = _parse_tool_data(result)
-        assert len(entries) == 1
+        data = _parse_tool_data(result)
+        assert len(data["commits"]) == 1
+        assert data["total"] == 1
 
     async def test_invalid_path_raises_tool_error(self) -> None:
         """A path that escapes the vault raises ToolError."""
@@ -3158,6 +3164,34 @@ class TestGetHistoryTool:
             tools = await client.list_tools()
         names = [t.name for t in tools]
         assert "get_diff" in names
+
+    async def test_get_history_envelope_wire_shape(self) -> None:
+        """structured_content uses the `commits` envelope, not FastMCP's
+        synthetic `result` wrap key."""
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool("get_history", {})
+        assert result.structured_content is not None
+        assert "commits" in result.structured_content
+        assert "total" in result.structured_content
+        # The whole point of the refactor: payload is self-describing on
+        # the wire — no opaque `result` key from auto-wrapping a list.
+        assert "result" not in result.structured_content
+
+    async def test_get_history_output_schema_not_auto_wrapped(self) -> None:
+        """outputSchema must not carry FastMCP's `x-fastmcp-wrap-result`
+        marker — it appears only when FastMCP auto-wraps a list/primitive
+        return under a synthetic `result` key; the dict envelope skips it."""
+        server = make_server()
+        async with Client(server) as client:
+            tools = await client.list_tools()
+        gh = next(t for t in tools if t.name == "get_history")
+        schema = gh.outputSchema
+        assert schema is not None
+        assert schema.get("type") == "object"
+        assert "x-fastmcp-wrap-result" not in schema
+        # And no synthetic `result` key in any declared properties.
+        assert "result" not in schema.get("properties", {})
 
 
 class TestGetDiffTool:
@@ -3190,7 +3224,7 @@ class TestGetDiffTool:
         assert "Version" in data["diff"] or data["diff"] == ""
 
     async def test_per_commit_diff(self, git_vault: Path) -> None:
-        """get_diff with per_commit=True returns a list of commit diffs."""
+        """get_diff with per_commit=True returns a {commits, total} envelope."""
         sha = self._first_sha(git_vault)
         server = make_server()
         async with Client(server) as client:
@@ -3199,10 +3233,12 @@ class TestGetDiffTool:
                 {"path": "alpha.md", "since_sha": sha, "per_commit": True},
             )
         data = _parse_tool_data(result)
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert "sha" in data[0]
-        assert "diff" in data[0]
+        assert isinstance(data, dict)
+        assert isinstance(data["commits"], list)
+        assert len(data["commits"]) == 1
+        assert data["total"] == 1
+        assert "sha" in data["commits"][0]
+        assert "diff" in data["commits"][0]
 
     async def test_no_reference_raises_tool_error(self) -> None:
         """Calling get_diff without any reference raises ToolError."""
@@ -3271,10 +3307,12 @@ class TestGetDiffTool:
                 },
             )
         data = _parse_tool_data(result)
-        assert isinstance(data, list)
-        assert len(data) == 2
+        assert isinstance(data, dict)
+        commits = data["commits"]
+        assert len(commits) == 2
+        assert data["total"] == 2
         # Newest-first ordering: the two most recent commit messages.
-        assert [c["message"] for c in data] == ["edit v4", "edit v3"]
+        assert [c["message"] for c in commits] == ["edit v4", "edit v3"]
 
 
 async def test_search_tool_accepts_chunks_per_file_and_snippet_words(
@@ -3378,10 +3416,14 @@ class TestGitToolsUntilParam:
             future = await client.call_tool(
                 "get_history", {"until": "2099-01-01T00:00:00"}
             )
-        assert len(_parse_tool_data(future)) == 2
+        future_data = _parse_tool_data(future)
+        assert len(future_data["commits"]) == 2
+        assert future_data["total"] == 2
 
         async with Client(server) as client:
             past = await client.call_tool(
                 "get_history", {"until": "2000-01-01T00:00:00"}
             )
-        assert _parse_tool_data(past) == []
+        past_data = _parse_tool_data(past)
+        assert past_data["commits"] == []
+        assert past_data["total"] == 0


### PR DESCRIPTION
## Summary

Bundle E — wire-shape refactor on two MCP tools.

| Commit | Closes | Scope |
|---|---|---|
| `8df464b` | #344 | `get_history` and `get_diff(per_commit=True)` MCP tools now return `{"commits": [...], "total": N}` instead of bare `list[dict]`. FastMCP no longer wraps under the opaque `"result"` key. `Collection.get_history` / `Collection.get_diff` Python APIs stay list-returning — only the MCP-tool wrapper transforms. `get_diff(per_commit=False)` keeps its existing `{"diff": str}` shape. Adds two wire-shape regression tests asserting `structured_content` has `commits`/`total` and NOT `result`, and that the output schema has no `x-fastmcp-wrap-result` marker. |
| `e1ea976` | (local circus fix) | Clarified `total` semantics in both docstrings + docs (always equals `len(commits)`; does NOT indicate counts beyond the `limit` cap). |

## FastMCP investigation

Issue #344 floated a hypothetical `Annotated[list[X], WrapAs("commits")]` API. Verified against FastMCP docs (`gofastmcp.com/servers/tools` + `clients/tools`): no such annotation exists. The only escape hatches are `@mcp.tool(output_schema=...)` override and returning `ToolResult` directly — neither fits this use case. Changing the MCP-wrapper return type to a dict is the right path.

## Test plan

- [x] `uv run pytest -x -q` — 1561 tests pass
- [x] `uv run mypy src/ tests/` — clean
- [x] `uv run ruff check` + `format --check` — clean
- [x] `diff-cover` — 100% on patch lines (4 of 4)
- [x] Local-review circus: pr-review-toolkit (primary) + feature-dev (second-opinion); second-opinion caught the `total`-ambiguity → fixed in `e1ea976`
- [x] Wire-shape regression tests added: `test_get_history_envelope_wire_shape` + `test_get_history_output_schema_not_auto_wrapped`

## Versioning

`feat:` not `feat!:` per the project's MCP-server-as-primary-product convention (memory `feedback_semver_mcp_server.md`): tool descriptions are re-fetched per session, so wire-shape changes aren't breaking for MCP clients. Python facade is unchanged. PSR will bump as a minor release. Operators see no env-var change.

## Out of scope

Other list-returning tools (`search`, `list_documents`, tag/folder listings) still emit `result`-wrapped payloads. Explicitly out of scope per the issue — "those responses have been shipped longer, are used by more clients, and changing them would be a larger coordinated change."

Closes #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)