### PR TITLE
docs(git-tools): --since/--until filter on committer date

### DIFF
--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1053,8 +1053,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 Omit for full history.
             until: ISO 8601 datetime string or git date expression, passed as
                 --until to git log. Both 'since' and 'until' boundaries are
-                inclusive: a commit whose author date equals either endpoint
-                is included in the result. Omit to disable the upper bound.
+                inclusive: a commit whose committer date equals either
+                endpoint is included in the result. Omit to disable the upper
+                bound.
             limit: Maximum number of commits to return. Default 20, max 100.
 
         Returns:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -789,7 +789,7 @@ class Collection:
             until: ISO 8601 datetime string or git date expression, passed as
                 ``--until`` to ``git log``.  ``None`` disables the filter.
                 Both ``since`` and ``until`` boundaries are **inclusive**: a
-                commit whose author date equals either endpoint is included
+                commit whose committer date equals either endpoint is included
                 in the result.
             limit: Maximum number of commits to return.  Clamped to
                 ``[1, 100]``.  Defaults to ``20``.

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -2044,8 +2044,8 @@ class GitWriteStrategy:
                 *since*).  ``None`` disables the filter.  When both *since*
                 and *until* are given the window is bounded on both sides,
                 inclusive at both endpoints (git's ``--since`` / ``--until``
-                semantics: a commit whose author date equals either boundary
-                is included).
+                semantics: a commit whose committer date equals either
+                boundary is included).
 
         Returns:
             List of :class:`HistoryEntry` ordered from newest to oldest.


### PR DESCRIPTION
## Summary

Three docstrings for `get_history` / `get_file_history` claimed `--since`/`--until` filter on author date. Empirically (and per [Alex Peattie's authoritative writeup](https://alexpeattie.com/blog/working-with-dates-in-git/)) they filter on **committer date**. This matches the boundary semantics already corrected for `since_timestamp` in #481.

Three sites updated (+6/-5):
- `src/markdown_vault_mcp/_server_tools.py:1056` — `get_history` MCP tool
- `src/markdown_vault_mcp/collection.py:792` — `Collection.get_history`
- `src/markdown_vault_mcp/git.py:2047` — `GitWriteStrategy.get_file_history`

Docs-only fix. No production code touched, no test changes. `HistoryEntry.author` / `timestamp` (which DO surface author identity + author date via `%aN`/`%aE`/`%aI`) are unchanged — only the boundary-filter semantics needed correcting.

Closes #480.

## Test plan

- [x] `uv run pytest -x -q` — 1563 passed
- [x] `uv run mypy src/ tests/` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `grep -rn 'author date' src/ docs/` — no remaining occurrences
- [x] Local-circus passed (pr-review-toolkit + feature-dev reviewers both green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)