### PR TITLE
docs: drop copier-template sentinel marker names from user-facing prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,24 +165,24 @@ For reverse proxy (Traefik) and deployment setup, see [`docs/deployment.md`](doc
 
 ### Server info
 
-The server registers a built-in `get_server_info` tool (via `fastmcp_pvl_core.register_server_info_tool`) so operators can confirm the deployed version with a single MCP call. The response carries `server_name`, `server_version`, and `core_version`. Wire upstream version reporting (when applicable) inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/markdown_vault_mcp/server.py`.
+The server registers a built-in `get_server_info` tool (via `fastmcp_pvl_core.register_server_info_tool`) so operators can confirm the deployed version with a single MCP call. The response carries `server_name`, `server_version`, and `core_version`.
 
 ### File exchange
 
-A `DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel
-block in `server.py` wires the
-[MCP File Exchange](docs/guides/file-exchange.md) helpers from
-`fastmcp-pvl-core`. The **upload direction is wired** (#443) — agents
-mint a one-time HTTPS POST URL via `create_upload_link(target_id,
-ttl_seconds)` and push bytes outside the MCP context, with the route
-mounted only on HTTP/SSE transports when `MARKDOWN_VAULT_MCP_BASE_URL`
-is set. The **download direction remains deferred to #431** because
-the spec-compliant `create_download_link(origin_id, ttl_seconds)` tool
-collides on name with MV's existing `create_download_link(path,
-ttl_seconds)` registered via `ArtifactStore`. See the guide for the
-upload-flow walkthrough and the producer / consumer patterns waiting on
-#431, or [`CLAUDE.md`](CLAUDE.md#file-exchange-register_file_exchange--opt-in-upload)
-for the wiring overview.
+`markdown-vault-mcp` participates in the
+[MCP File Exchange](docs/guides/file-exchange.md) convention via
+`fastmcp-pvl-core` helpers. The **upload direction is wired** (#443) —
+agents call `create_upload_link(target_id, ttl_seconds)` to mint a
+one-time HTTPS POST URL and push bytes outside the MCP context. The
+route mounts only on HTTP/SSE transports when
+`MARKDOWN_VAULT_MCP_BASE_URL` is set, and uploads are gated by
+`MARKDOWN_VAULT_MCP_READ_ONLY=false`. The **download direction is
+deferred to #431** because the spec-compliant
+`create_download_link(origin_id, ttl_seconds)` tool collides on name
+with MV's existing `create_download_link(path, ttl_seconds)`
+(registered via `ArtifactStore`). See the
+[guide](docs/guides/file-exchange.md) for the upload-flow walkthrough
+and the producer / consumer patterns waiting on #431.
 
 ## Configuration
 

--- a/docs/guides/file-exchange.md
+++ b/docs/guides/file-exchange.md
@@ -11,10 +11,7 @@ remote clients):
   spec-compliant `create_upload_link(target_id, ttl_seconds)` tool and
   a one-time `POST /markdown-vault-mcp/uploads/{token}` route.
 
-Both helpers' wiring lives inside the
-`DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel
-block in `src/markdown_vault_mcp/server.py`. The block is preserved
-across `copier update`.
+Both helpers are wired in `src/markdown_vault_mcp/server.py`.
 
 ## Status in markdown-vault-mcp
 
@@ -34,9 +31,9 @@ across `copier update`.
     pvl-core's spec-compliant `create_download_link(origin_id,
     ttl_seconds)` tool name collides with MV's existing
     `create_download_link(path, ttl_seconds)` (registered via
-    `ArtifactStore` in the `DOMAIN-WIRING` block). Wiring both would
-    silently shadow one or the other depending on registration order,
-    so `register_file_exchange(...)` is intentionally not called in
+    `ArtifactStore`). Wiring both would silently shadow one or the
+    other depending on registration order, so
+    `register_file_exchange(...)` is intentionally not called in
     `server.py` until #431 resolves the collision.
 
 ## Today
@@ -87,9 +84,9 @@ today; download-direction variables
 The migration in #431 will:
 
 1. Drop MV's bespoke `create_download_link` tool registration.
-2. Drop the `ArtifactStore` HTTP route in the `DOMAIN-WIRING` block.
-3. Uncomment the `register_file_exchange(...)` call in the
-   `DOMAIN-FILE-EXCHANGE` sentinel block.
+2. Drop the `ArtifactStore` HTTP route registration.
+3. Add the `register_file_exchange(...)` call in
+   `src/markdown_vault_mcp/server.py`.
 4. Update this guide to retire the "deferred" half of the status
    admonition and document the wired download patterns.
 


### PR DESCRIPTION
Closes #486.

## Summary

- Rewrites the README "File exchange" subsection and drops the `DOMAIN-UPSTREAM` reference from the "Server info" subsection, so neither paragraph mentions copier-template sentinel marker names.
- Cleans `docs/guides/file-exchange.md` of four references to `DOMAIN-FILE-EXCHANGE` and `DOMAIN-WIRING` markers, replacing them with the actual file path or operation being described.
- Preserves all factual content: wired-vs-deferred status, env-var preconditions (`MARKDOWN_VAULT_MCP_BASE_URL`, `MARKDOWN_VAULT_MCP_READ_ONLY=false`), route path (`POST /markdown-vault-mcp/uploads/{token}`), and the #431 deferral reason (tool-name collision with MV's `create_download_link`).

## Why

Copier-template sentinel markers (`# DOMAIN-FILE-EXCHANGE-START` etc. in code, `<!-- DOMAIN-START -->` etc. in markdown) are internal template machinery for `copier update` zone preservation. HTML-comment markers stay (invisible in rendered output). Visible prose mentions of the marker names had crept into user-facing docs through the v1.6.1 copier-update PR (`e46f7b79`, May 11) — operators reading the README don't need to know the name of a sentinel block in `server.py`.

## What is **not** touched

- `CLAUDE.md` — contributor-facing; sentinel mentions there are appropriate.
- `docs/configuration.md` — its file-exchange section uses public API names (helpers, env vars), no marker leak.
- Any code under `src/` — implementation is sound; the audit confirmed `register_file_exchange_upload` wiring, read-only gating via `tool_tags=frozenset({"write"})`, and the `#431` deferral story all check out against the actual code.

## Test plan

- [x] `grep -rn 'DOMAIN-FILE-EXCHANGE\|DOMAIN-WIRING\|DOMAIN-UPSTREAM\|DOMAIN-INDEX-FEATURES\|DOMAIN-INDEX-USE-CASES\|DOMAIN-CONFIG-VARS\|DOMAIN-TOOLS-LIST' README.md docs/ | grep -v '^[^:]*:[^:]*:<!--' | grep -v '^docs/superpowers/'` — empty, all leaks gone
- [x] `pr-review-toolkit:code-reviewer` local pass — clean (verified factual claims against `server.py` / `uploads.py` / pvl-core source)
- [x] `feature-dev:code-reviewer` independent second pass — clean (verified read-only gating, cross-doc consistency, link integrity)
- [x] `git diff HEAD -- CLAUDE.md` — empty
- [ ] CI (`ci.yml`) green
- [ ] `claude-review` and `gemini-code-assist` clean on flip-to-ready

## Documentation

This PR **is** the documentation update. No spec/design changes needed; the `docs/design.md` and `docs/configuration.md` were already free of the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)