### PR TITLE
fix(links): resolve vault wikilinks after every write/edit/delete/rename

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -843,8 +843,13 @@ vault-wide resolution rules rather than relative path resolution:
   shortest path wins. Path matches always take priority over alias matches.
 
 `resolve_vault_wikilinks()` is called automatically at the end of
-`Collection.build_index()` and `Collection.reindex()` so that the `links`
-table always reflects the fully resolved vault state.
+`Collection.build_index()` and `Collection.reindex()` and at the end of
+every `DocumentManager` write operation — `write()`, `edit()`, `delete()`,
+and `rename()` — so that the `links` table always reflects the fully
+resolved vault state.  Without the per-write call, wikilinks introduced by
+a tool-driven edit would remain stored as bare basenames (e.g.
+`Target.md`) and fail the exists check against full document paths (e.g.
+`notes/Target.md`).
 
 ### Graph Traversal
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -843,13 +843,15 @@ vault-wide resolution rules rather than relative path resolution:
   shortest path wins. Path matches always take priority over alias matches.
 
 `resolve_vault_wikilinks()` is called automatically at the end of
-`Collection.build_index()` and `Collection.reindex()` and at the end of
-every `DocumentManager` write operation — `write()`, `edit()`, `delete()`,
-and `rename()` — so that the `links` table always reflects the fully
-resolved vault state.  Without the per-write call, wikilinks introduced by
-a tool-driven edit would remain stored as bare basenames (e.g.
-`Target.md`) and fail the exists check against full document paths (e.g.
-`notes/Target.md`).
+`Collection.build_index()`, `Collection.reindex()`, and every
+`DocumentManager` write that mutates the `links` table — `write()` and
+`edit()` of a `.md` document, `delete()` of a `.md` document, and
+`rename()` of a `.md` document.  Attachment writes do not invoke the
+resolver because attachments do not produce `links` rows.  Without the
+per-write call, wikilinks introduced or invalidated by a tool-driven edit
+would persist as bare basenames (e.g. `Target.md`) — leaving them as
+false-positive broken outlinks and invisible to backlink queries against
+the full document path (e.g. `notes/Target.md`).
 
 ### Graph Traversal
 

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -513,6 +513,7 @@ class DocumentManager:
 
             note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
             self._fts.upsert_note(note)
+            self._fts.resolve_vault_wikilinks()
             self._on_vector_update(note)
 
             result = WriteResult(path=path, created=created)
@@ -735,6 +736,7 @@ class DocumentManager:
 
             note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
             self._fts.upsert_note(note)
+            self._fts.resolve_vault_wikilinks()
             self._on_vector_update(note)
 
         self._on_write_callback(abs_path, new_content, "edit")
@@ -888,6 +890,7 @@ class DocumentManager:
                         )
                 abs_path.unlink()
                 self._fts.delete_by_path(path)
+                self._fts.resolve_vault_wikilinks()
                 self._on_vector_dirty(path)
             else:
                 abs_path = self._validate_attachment_path(path)
@@ -989,6 +992,7 @@ class DocumentManager:
                     old_path, new_path, backlinks
                 )
                 updated_links = len(backlink_callbacks)
+                self._fts.resolve_vault_wikilinks()
             else:
                 old_abs = self._validate_attachment_path(old_path)
                 new_abs = self._validate_attachment_path(new_path)

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1600,6 +1600,102 @@ class TestResolveVaultWikilinks:
         # Note.md (length 7) is shorter than sub/Note.md (length 11).
         assert outlinks[0].target_path == "Note.md"
 
+    def test_write_resolves_new_wikilinks(self, tmp_path: Path) -> None:
+        """write() re-runs vault-wide resolution so new wikilinks aren't broken."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "notes").mkdir()
+        (vault / "notes" / "Target.md").write_text("# Target\n", encoding="utf-8")
+
+        col = Collection(source_dir=vault, read_only=False)
+        col.build_index()
+
+        col.write("source.md", "# Source\n\nSee [[Target]].\n")
+
+        outlinks = col.get_outlinks("source.md")
+        assert len(outlinks) == 1
+        assert outlinks[0].target_path == "notes/Target.md"
+        assert outlinks[0].exists is True
+        assert col.get_broken_links() == []
+
+    def test_edit_resolves_new_wikilinks(self, tmp_path: Path) -> None:
+        """edit() re-runs vault-wide resolution after the source content changes."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "source.md").write_text(
+            "# Source\n\nNo links yet.\n", encoding="utf-8"
+        )
+        (vault / "notes").mkdir()
+        (vault / "notes" / "Target.md").write_text("# Target\n", encoding="utf-8")
+
+        col = Collection(source_dir=vault, read_only=False)
+        col.build_index()
+
+        col.edit("source.md", old_text="No links yet.", new_text="See [[Target]].")
+
+        outlinks = col.get_outlinks("source.md")
+        assert len(outlinks) == 1
+        assert outlinks[0].target_path == "notes/Target.md"
+        assert outlinks[0].exists is True
+        assert col.get_broken_links() == []
+
+    def test_delete_target_falls_back_to_basename_twin(self, tmp_path: Path) -> None:
+        """delete() re-resolves inlinks; if a basename twin exists, they pick it up."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "source.md").write_text(
+            "# Source\n\nSee [[Target]].\n", encoding="utf-8"
+        )
+        (vault / "a").mkdir()
+        (vault / "a" / "Target.md").write_text("# Target A\n", encoding="utf-8")
+        (vault / "b").mkdir()
+        (vault / "b" / "Target.md").write_text("# Target B\n", encoding="utf-8")
+
+        col = Collection(source_dir=vault, read_only=False)
+        col.build_index()
+
+        # Initial resolution picks the shortest path; both candidates are the
+        # same length so either is correct — record whichever wins.
+        outlinks = col.get_outlinks("source.md")
+        initial_target = outlinks[0].target_path
+        assert initial_target in {"a/Target.md", "b/Target.md"}
+        assert outlinks[0].exists is True
+
+        col.delete(initial_target)
+
+        # The surviving twin must take over.
+        outlinks = col.get_outlinks("source.md")
+        survivor = "b/Target.md" if initial_target == "a/Target.md" else "a/Target.md"
+        assert outlinks[0].target_path == survivor
+        assert outlinks[0].exists is True
+        assert col.get_broken_links() == []
+
+    def test_rename_target_keeps_inlinks_resolved(self, tmp_path: Path) -> None:
+        """rename() re-resolves inlinks after the target moves to a new path."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "source.md").write_text(
+            "# Source\n\nSee [[Target]].\n", encoding="utf-8"
+        )
+        (vault / "Target.md").write_text("# Target\n", encoding="utf-8")
+
+        col = Collection(source_dir=vault, read_only=False)
+        col.build_index()
+
+        # Initial: bare [[Target]] resolves to root-level Target.md.
+        outlinks = col.get_outlinks("source.md")
+        assert outlinks[0].target_path == "Target.md"
+        assert outlinks[0].exists is True
+
+        col.rename("Target.md", "other/Target.md")
+
+        # After rename, the inlink must point at the new location.
+        outlinks = col.get_outlinks("source.md")
+        assert len(outlinks) == 1
+        assert outlinks[0].target_path == "other/Target.md"
+        assert outlinks[0].exists is True
+        assert col.get_broken_links() == []
+
 
 # ---------------------------------------------------------------------------
 # Alias resolution in wikilinks

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1646,27 +1646,27 @@ class TestResolveVaultWikilinks:
         (vault / "source.md").write_text(
             "# Source\n\nSee [[Target]].\n", encoding="utf-8"
         )
+        # Asymmetric depths so resolution is deterministic: a/Target.md is
+        # the shortest candidate before delete; aa/bb/Target.md is the only
+        # surviving twin afterwards.
         (vault / "a").mkdir()
         (vault / "a" / "Target.md").write_text("# Target A\n", encoding="utf-8")
-        (vault / "b").mkdir()
-        (vault / "b" / "Target.md").write_text("# Target B\n", encoding="utf-8")
+        (vault / "aa" / "bb").mkdir(parents=True)
+        (vault / "aa" / "bb" / "Target.md").write_text(
+            "# Target deep\n", encoding="utf-8"
+        )
 
         col = Collection(source_dir=vault, read_only=False)
         col.build_index()
 
-        # Initial resolution picks the shortest path; both candidates are the
-        # same length so either is correct — record whichever wins.
         outlinks = col.get_outlinks("source.md")
-        initial_target = outlinks[0].target_path
-        assert initial_target in {"a/Target.md", "b/Target.md"}
+        assert outlinks[0].target_path == "a/Target.md"
         assert outlinks[0].exists is True
 
-        col.delete(initial_target)
+        col.delete("a/Target.md")
 
-        # The surviving twin must take over.
         outlinks = col.get_outlinks("source.md")
-        survivor = "b/Target.md" if initial_target == "a/Target.md" else "a/Target.md"
-        assert outlinks[0].target_path == survivor
+        assert outlinks[0].target_path == "aa/bb/Target.md"
         assert outlinks[0].exists is True
         assert col.get_broken_links() == []
 


### PR DESCRIPTION
## Summary

- Adds `FTSIndex.resolve_vault_wikilinks()` call at the end of every `.md`-affecting `DocumentManager` write (`write` / `edit` / `delete` / `rename`), inside the existing `_write_lock`. Attachment writes intentionally skip the resolver because they don't produce `links` rows.
- Fixes the bug where any document touched by an MCP write since the last full `build_index` / `reindex` had its wikilinks reported as broken outlinks, missing from backlink queries, and counted in `get_broken_links()` — because `target_path` was still stored as the scan-time bare basename (e.g. `Target.md`) rather than the resolved full path (e.g. `notes/Target.md`).
- Quantified on a live deployment before the fix: 7.5% of 3435 wikilink rows were unresolved at any moment; ~26% of "broken" links were false positives.

Closes #494.

## Test plan

- [x] `uv run pytest tests/test_links.py -k TestResolveVaultWikilinks` — 12 pass (8 pre-existing + 4 new: write / edit / delete-falls-back-to-twin / rename-keeps-inlinks)
- [x] `uv run pytest` full suite — 1567 pass
- [x] `uv run ruff check .` / `ruff format --check .` — clean
- [x] `uv run mypy src/ tests/` — clean
- [x] `diff-cover` — 100% patch coverage (4/4 changed lines covered)
- [x] Local code-review circus — both `pr-review-toolkit:code-reviewer` agents return clean after one polish iteration (design.md scope clarification + deterministic twin-test restructure)
- [ ] CI green
- [ ] Bot reviews (claude-review, gemini-code-assist) clean on first pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)