### PR TITLE
feat(search): deterministic section_id tiebreaker for tied search results

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -243,8 +243,12 @@ chunks under their parent document via `_group_by_path`:
 2. The helper walks rows, opening a new group per unseen path until
    `file_limit` groups exist; subsequent rows from a seen path append
    to the existing group up to `chunks_per_file` rows.
-3. Sections within a group are sorted `(score DESC, start_line ASC)`
-   so ties surface in document order.
+3. Sections within a group are sorted `(score DESC, start_line ASC,
+   section_id ASC)` so ties surface in document order. The `section_id`
+   key (the `sections` rowid) makes the order fully deterministic even
+   when chunks share a `start_line` — e.g. word-split fragments of one
+   oversize source line, which the adaptive chunker emits with identical
+   `start_line` values.
 
 The returned shape is `list[GroupedResult]` where each result wraps one
 file with a `sections: list[SectionHit]` sub-list (length 1..N).  File
@@ -583,8 +587,9 @@ class GroupedResult:
     score: float                      # file-level score = max(section.score)
     search_type: Literal["keyword", "semantic", "hybrid"]
     frontmatter: dict[str, Any]       # document frontmatter
-    sections: list[SectionHit]        # up to chunks_per_file sections,
-                                      # sorted by (score DESC, start_line ASC)
+    sections: list[SectionHit]        # up to chunks_per_file sections, sorted
+                                      # by (score DESC, start_line ASC,
+                                      # section_id ASC)
 
 @dataclass
 class SearchResult:

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -658,17 +658,22 @@ class FTSIndex:
             content_expr = "f.content AS content"
             snippet_params = []
 
-        # Correlated subquery picks the matching sections row to source
-        # start_line for each FTS hit, so the keyword/hybrid channels can
-        # honour the documented (score DESC, start_line ASC) within-group
-        # tie-break.  Matching is on (document_id, content, heading) —
-        # sections.content stores the chunk text unmodified, the same value
-        # that notes_fts.content stores; the snippet() projection only
-        # rewrites the SELECT list, not the underlying f.content column
-        # referenced here.  COALESCE on heading treats NULL/empty as
-        # equivalent so identical-content chunks under different headings
-        # don't cross-match.  MIN()+fallback 0 handles legacy on-disk
-        # indices that pre-date this query (preserves prior behaviour).
+        # Correlated subqueries pick the matching sections row to source
+        # start_line and section_id for each FTS hit, so the keyword/hybrid
+        # channels can honour the documented (score DESC, start_line ASC,
+        # section_id ASC) within-group tie-break.  Matching is on
+        # (document_id, content, heading) — sections.content stores the
+        # chunk text unmodified, the same value that notes_fts.content
+        # stores; the snippet() projection only rewrites the SELECT list,
+        # not the underlying f.content column referenced here.  COALESCE on
+        # heading treats NULL/empty as equivalent so identical-content
+        # chunks under different headings don't cross-match.  MIN()+fallback
+        # 0 handles legacy on-disk indices that pre-date this query
+        # (preserves prior behaviour).  Sections are inserted in document
+        # order, so within one document MIN(s.id) and MIN(s.start_line)
+        # resolve to the same row.  The trailing f.rowid tie-break makes the
+        # candidate set itself deterministic at the LIMIT boundary when
+        # several hits share a bm25 rank.
         sql = f"""
             SELECT
                 f.path,
@@ -684,13 +689,20 @@ class FTSIndex:
                     WHERE s.document_id = d.id
                       AND s.content = f.content
                       AND COALESCE(s.heading, '') = COALESCE(f.heading, '')
-                ), 0) AS start_line
+                ), 0) AS start_line,
+                COALESCE((
+                    SELECT MIN(s.id)
+                    FROM sections s
+                    WHERE s.document_id = d.id
+                      AND s.content = f.content
+                      AND COALESCE(s.heading, '') = COALESCE(f.heading, '')
+                ), 0) AS section_id
             FROM notes_fts f
             JOIN documents d ON d.path = f.path
             WHERE notes_fts MATCH ?
               {folder_clause}
               {tag_filter_sql}
-            ORDER BY score DESC
+            ORDER BY score DESC, f.rowid ASC
             LIMIT ?
         """
 
@@ -740,6 +752,7 @@ class FTSIndex:
                     score=row["score"],
                     chunk_count=row["chunk_count"],
                     start_line=row["start_line"],
+                    section_id=row["section_id"],
                 )
             )
         return results

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -108,16 +108,19 @@ def _apply_length_downweight(
 class _GroupableRow(Protocol):
     """Row contract consumed by :func:`_group_by_path`.
 
-    Adds ``heading`` and ``start_line`` to the cap-helper's contract so
-    grouped output preserves section identity and breaks score ties
-    deterministically.  ``start_line`` defaults to ``0`` for legacy vector
-    rows loaded from older .json sidecars.
+    Adds ``heading``, ``start_line`` and ``section_id`` to the cap-helper's
+    contract so grouped output preserves section identity and breaks score
+    ties deterministically.  ``start_line`` defaults to ``0`` for legacy
+    vector rows loaded from older .json sidecars; ``section_id`` is the
+    final tie-break (the ``sections`` rowid) and is ``0`` for any channel
+    that cannot resolve it (vector rows, legacy indices).
     """
 
     path: str
     heading: str | None
     score: float
     start_line: int
+    section_id: int
 
 
 _GroupableT = TypeVar("_GroupableT", bound=_GroupableRow)
@@ -132,7 +135,11 @@ def _group_by_path(
     of groups.  Each group is a list of rows sharing the same ``path``,
     capped at ``chunks_per_file`` rows.  At most ``file_limit`` groups are
     returned.  Sections within a group are sorted ``(score DESC,
-    start_line ASC)`` so ties surface in document order.
+    start_line ASC, section_id ASC)`` so ties surface in document order.
+    The ``section_id`` key (the ``sections`` rowid) makes the order fully
+    deterministic even when chunks share a ``start_line`` — e.g. word-split
+    fragments of a single oversize source line, which the chunker emits
+    with identical ``start_line`` values.
 
     Args:
         rows: Rows pre-sorted by descending score.
@@ -160,9 +167,13 @@ def _group_by_path(
         elif len(existing) < chunks_per_file:
             existing.append(row)
 
-    # Sort each group's sections by (score DESC, start_line ASC) so ties
-    # within a file surface in document order.
-    return [sorted(groups[p], key=lambda r: (-r.score, r.start_line)) for p in order]
+    # Sort each group's sections by (score DESC, start_line ASC, section_id
+    # ASC) so ties within a file surface in document order — section_id is
+    # the final tie-break for chunks sharing a start_line.
+    return [
+        sorted(groups[p], key=lambda r: (-r.score, r.start_line, r.section_id))
+        for p in order
+    ]
 
 
 def _compute_snippet_for_semantic(
@@ -234,7 +245,14 @@ def _compute_snippet_for_semantic(
 
 @dataclass
 class _SemanticRow:
-    """Adapter row for vector search results so they expose .score / .chunk_count."""
+    """Adapter row for vector search results so they expose .score / .chunk_count.
+
+    ``section_id`` is always ``0``: the vector store keys chunks by metadata,
+    not by ``sections`` rowid, and vector scores essentially never tie
+    (distinct embeddings → distinct cosine), so the tie-break never engages
+    for a pure semantic channel.  The field exists only to satisfy the
+    :class:`_GroupableRow` protocol.
+    """
 
     path: str
     title: str
@@ -244,12 +262,13 @@ class _SemanticRow:
     score: float
     chunk_count: int
     start_line: int = 0
+    section_id: int = 0
 
 
 @dataclass
 class _GroupableFTS:
-    """Adapter row exposing title/folder/content/start_line to _group_by_path
-    for the keyword channel."""
+    """Adapter row exposing title/folder/content/start_line/section_id to
+    _group_by_path for the keyword and hybrid channels."""
 
     path: str
     title: str
@@ -258,6 +277,7 @@ class _GroupableFTS:
     content: str
     score: float
     start_line: int
+    section_id: int = 0
 
 
 class SearchManager:
@@ -583,6 +603,7 @@ class SearchManager:
                 content=r.content,
                 score=r.score,
                 start_line=r.start_line,
+                section_id=r.section_id,
             )
             for r in downweighted
         ]
@@ -832,6 +853,7 @@ class SearchManager:
                     "content": fr.content,
                     "search_type": "keyword",
                     "start_line": fr.start_line,
+                    "section_id": fr.section_id,
                 },
             )
 
@@ -849,6 +871,7 @@ class SearchManager:
                     "content": vr.content,
                     "search_type": "semantic",
                     "start_line": vr.start_line,
+                    "section_id": vr.section_id,
                 },
             )
 
@@ -866,6 +889,7 @@ class SearchManager:
                 content=chunk_meta[k]["content"],
                 score=rrf_scores[k],
                 start_line=int(chunk_meta[k].get("start_line", 0)),
+                section_id=int(chunk_meta[k].get("section_id", 0)),
             )
             for k in sorted_keys
         ]

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -742,6 +742,7 @@ class SearchManager:
                 score=r["score"],
                 chunk_count=chunk_counts.get(r["path"], 1),
                 start_line=int(r.get("start_line", 0)),
+                section_id=0,  # vector store has no sections rowid; see dataclass
             )
             for r in filtered
         ]
@@ -827,6 +828,7 @@ class SearchManager:
                 score=r["score"],
                 chunk_count=vec_chunk_counts.get(r["path"], 1),
                 start_line=int(r.get("start_line", 0)),
+                section_id=0,  # vector store has no sections rowid; see dataclass
             )
             for r in vec_filtered
         ]
@@ -839,6 +841,12 @@ class SearchManager:
         keyword_keys: set[tuple[str, str | None]] = set()
         vec_keys: set[tuple[str, str | None]] = set()
 
+        # FTS results are walked before vector results, so chunk_meta's
+        # setdefault keeps the keyword channel's section_id (a real sections
+        # rowid >= 1) for any chunk present in both channels; a vector-only
+        # chunk keeps section_id=0.  Both are correct: the keyword rowid is
+        # the authoritative tie-break value, and vector-only ties are
+        # measure-zero (distinct embeddings -> distinct cosine scores).
         for rank, fr in enumerate(fts_results, start=1):
             key = (fr.path, fr.heading)
             rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (_RRF_K + rank)
@@ -1166,6 +1174,7 @@ class SearchManager:
                 score=r.get("score", 0.0),
                 chunk_count=chunk_counts.get(r["path"], 1),
                 start_line=int(r.get("start_line", 0)),
+                section_id=0,  # vector store has no sections rowid; see dataclass
             )
             for r in raw_results
         ]

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -130,7 +130,10 @@ class GroupedResult:
         search_type: ``"keyword"``, ``"semantic"``, or ``"hybrid"``.
         frontmatter: Parsed YAML frontmatter.
         sections: Up to the per-file cap best-matching sections, sorted by
-            ``(score DESC, start_line ASC)`` so ties surface in document order.
+            ``(score DESC, start_line ASC, section_id ASC)`` so ties surface
+            in document order — the ``section_id`` key gives a fully
+            deterministic order even when chunks share a ``start_line``
+            (e.g. word-split fragments of one oversize source line).
     """
 
     path: str
@@ -159,6 +162,11 @@ class FTSResult:
         start_line: Line number of the chunk's first line in the source
             document.  Defaults to ``0`` for the document intro chunk and as
             a fallback when the underlying section row cannot be resolved.
+        section_id: ``sections`` table rowid of the matched chunk, used as
+            the final deterministic tie-break when chunks share both
+            ``score`` and ``start_line`` (e.g. word-split fragments of one
+            oversize source line).  Defaults to ``0`` when the section row
+            cannot be resolved (legacy index) or for non-keyword channels.
     """
 
     path: str
@@ -169,6 +177,7 @@ class FTSResult:
     score: float
     chunk_count: int = 1
     start_line: int = 0
+    section_id: int = 0
 
 
 @dataclass

--- a/tests/test_field_collapsing.py
+++ b/tests/test_field_collapsing.py
@@ -37,6 +37,7 @@ class _Row:
     content: str
     score: float
     start_line: int = 0
+    section_id: int = 0
 
 
 def test_group_by_path_collapses_same_file():
@@ -73,6 +74,26 @@ def test_group_by_path_section_ties_sort_by_start_line():
     headings = [r.heading for r in groups[0]]
     assert headings == ["Early", "Late"], (
         "ties on score should resolve by start_line ASC (document order)"
+    )
+
+
+def test_group_by_path_section_id_breaks_start_line_ties():
+    """Chunks tying on both score and start_line resolve by section_id ASC.
+
+    Models word-split fragments of one oversize source line: they share a
+    score (uniform term frequency) and a start_line (same source line), so
+    only section_id (the sections rowid, monotonic with document order)
+    gives a deterministic order.  Input is deliberately section_id-shuffled.
+    """
+    rows = [
+        _Row("a.md", "frag3", "", 0.9, 10, section_id=303),
+        _Row("a.md", "frag1", "", 0.9, 10, section_id=101),
+        _Row("a.md", "frag2", "", 0.9, 10, section_id=202),
+    ]
+    groups = _group_by_path(rows, chunks_per_file=5, file_limit=10)
+    headings = [r.heading for r in groups[0]]
+    assert headings == ["frag1", "frag2", "frag3"], (
+        "score+start_line ties must resolve by section_id ASC"
     )
 
 

--- a/tests/test_fts_index.py
+++ b/tests/test_fts_index.py
@@ -410,6 +410,48 @@ class TestSearch:
         # column was actually plumbed through (vs. the prior hardcoded 0).
         assert {r.start_line for r in results} == {0, 10, 42}
 
+    def test_search_returns_section_id(self) -> None:
+        """search() propagates the sections rowid as section_id.
+
+        section_id is the final deterministic tie-break in
+        :func:`_group_by_path` for chunks sharing (score, start_line) — e.g.
+        word-split fragments of one oversize source line.  Each FTSResult
+        must carry the rowid of its matching sections row.
+        """
+        idx = FTSIndex(":memory:")
+        idx.upsert_note(
+            make_note(
+                "doc.md",
+                title="Doc",
+                chunks=[
+                    Chunk(
+                        heading="One",
+                        heading_level=1,
+                        content="alpha keyword first",
+                        start_line=0,
+                    ),
+                    Chunk(
+                        heading="Two",
+                        heading_level=1,
+                        content="alpha keyword second",
+                        start_line=8,
+                    ),
+                ],
+            )
+        )
+        results = idx.search("keyword", limit=10)
+        assert len(results) == 2
+        # Every result carries a positive section_id (SQLite rowid >= 1).
+        for r in results:
+            assert isinstance(r.section_id, int)
+            assert r.section_id >= 1
+        # The two chunks resolve to distinct sections rows.
+        assert len({r.section_id for r in results}) == 2
+        # section_id order matches start_line order (sections inserted in
+        # document order), so it is a valid document-order tie-break.
+        by_start = sorted(results, key=lambda r: r.start_line)
+        assert [r.section_id for r in by_start] == sorted(r.section_id for r in results)
+
     def test_sections_has_document_id_index(self) -> None:
         """sections.document_id is indexed for the correlated subquery in search().
 


### PR DESCRIPTION
## Summary

- `_group_by_path` sorted grouped search-result sections by `(score DESC, start_line ASC)`. Chunks tying on both — word-split fragments of one oversize source line, which the adaptive chunker (#496) emits with identical `start_line` values — had an **undefined relative order**: the stable sort just preserved whatever order the upstream FTS5/vector query returned, and FTS5 guarantees no secondary order on tied bm25 ranks.
- Adds `sections.id` (rowid, monotonic with document insertion order) as an explicit third sort key — `(score DESC, start_line ASC, section_id ASC)` — making the order fully deterministic.

Closes #498.

## Threading

- `FTSIndex.search()` projects `MIN(s.id) AS section_id` via a correlated subquery parallel to the existing `MIN(s.start_line)` one. Within a document, rowid order == start_line order (sections inserted in document order), so both subqueries resolve to the same row. The FTS `ORDER BY` also gains `, f.rowid ASC` so the candidate set itself is deterministic at the `LIMIT` boundary on tied bm25 ranks.
- `FTSResult` carries `section_id` (default `0`).
- `_GroupableRow` protocol + `_GroupableFTS` / `_SemanticRow` dataclasses gain `section_id`; `_group_by_path` sorts on it; hybrid RRF threads it through `chunk_meta`.
- Vector rows carry `section_id=0`: the vector store keys chunks by metadata, not rowid, and distinct embeddings make vector-score ties measure-zero, so the tiebreaker never engages for the semantic channel. The field exists there only to satisfy the protocol. `0` is never a valid SQLite rowid, so it is an unambiguous sentinel.

## Test plan

- [x] `test_group_by_path_section_id_breaks_start_line_ties` — section_id-shuffled input tying on `(score, start_line)`; **verified to fail without the new sort key** (pre-fix stable sort preserves shuffled order).
- [x] `test_search_returns_section_id` — keyword search populates a positive, document-order-consistent rowid.
- [x] `uv run pytest` — 1579 pass
- [x] `uv run ruff check .` / `ruff format --check .` — clean
- [x] `uv run mypy src/ tests/` — clean
- [x] Local code-review circus — both reviewers clean on first pass
- [ ] CI green
- [ ] Bot reviews clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)