### PR TITLE
fix(edit): report the real divergent line in multi-line edit diagnostics

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1024,11 +1024,14 @@ one normalized match is found, the original byte range is replaced and
 if the file does not exist. Raises `EditConflictError` if `old_text` is
 not found (after both exact and normalized matching) or appears more than
 once. When both exact and normalized match fail, `EditConflictError`
-includes diagnostic fields: `closest_match_line`, `first_diff_char`,
+carries optional diagnostic fields: `closest_match_line`, `first_diff_char`,
 `expected_snippet`, `found_snippet`. For a multi-line `old_text` these
 locate the *first line that genuinely diverges* from the file — the
 diagnostic anchors on the first line, then walks subsequent lines so a
 later-line mismatch is reported rather than a perfectly-matching first line.
+The fields are omitted (left `None`) when no divergence can be localized:
+no file line is similar enough to anchor on, or every line of `old_text`
+matches the file region.
 
 **`delete()` behavior**: removes the file from disk, deletes FTS and embedding
 entries, triggers `on_write`. Raises `DocumentNotFoundError` if not found.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1025,7 +1025,10 @@ if the file does not exist. Raises `EditConflictError` if `old_text` is
 not found (after both exact and normalized matching) or appears more than
 once. When both exact and normalized match fail, `EditConflictError`
 includes diagnostic fields: `closest_match_line`, `first_diff_char`,
-`expected_snippet`, `found_snippet`.
+`expected_snippet`, `found_snippet`. For a multi-line `old_text` these
+locate the *first line that genuinely diverges* from the file — the
+diagnostic anchors on the first line, then walks subsequent lines so a
+later-line mismatch is reported rather than a perfectly-matching first line.
 
 **`delete()` behavior**: removes the file from disk, deletes FTS and embedding
 entries, triggers `on_write`. Raises `DocumentNotFoundError` if not found.

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -17,10 +17,10 @@ class EditConflictError(MarkdownMCPError):
     """Raised when ``old_text`` is not found or appears more than once in a document.
 
     Attributes:
-        closest_match_line: 1-based line number of the nearest fuzzy match, if any.
-        first_diff_char: Character offset of the first difference from the nearest match.
-        expected_snippet: The ``old_text`` that was searched for (truncated).
-        found_snippet: The nearest match found in the document (truncated).
+        closest_match_line: 1-based file line where ``old_text`` first diverges.
+        first_diff_char: Character offset of the divergence within that line.
+        expected_snippet: The divergent ``old_text`` line (truncated).
+        found_snippet: The corresponding file line (truncated, empty past EOF).
     """
 
     def __init__(

--- a/src/markdown_vault_mcp/utils/text.py
+++ b/src/markdown_vault_mcp/utils/text.py
@@ -166,8 +166,10 @@ def find_closest_match(old_text: str, file_content: str) -> dict[str, Any]:
         divergent line), ``first_diff_char`` (char offset within that line),
         ``expected_snippet`` (the divergent ``old_text`` line), and
         ``found_snippet`` (the corresponding file line, empty if ``old_text``
-        extends past the file region); or an empty dict if no anchor line
-        with ratio >= 0.6 is found.
+        extends past the file region).  Returns an empty dict when no useful
+        diagnostic can be produced — either no anchor line reaches ratio
+        >= 0.6, or every line of ``old_text`` matches the file region (no
+        genuine divergence to point at).
     """
     old_lines = old_text.split("\n")
     file_lines = file_content.split("\n")
@@ -184,13 +186,19 @@ def find_closest_match(old_text: str, file_content: str) -> dict[str, Any]:
         return {}
 
     # Walk old_text lines against the file region; find the first that differs.
-    diff_offset = len(old_lines) - 1  # fallback: every line matched by content
+    diff_offset: int | None = None
     for offset, old_line in enumerate(old_lines):
         file_idx = anchor_idx + offset
         file_line = file_lines[file_idx] if file_idx < len(file_lines) else None
         if file_line is None or old_line != file_line:
             diff_offset = offset
             break
+
+    if diff_offset is None:
+        # Every line of old_text matched the file region — no genuine
+        # divergence to point at.  Emit no diagnostic rather than a
+        # misleading one with two identical snippets.
+        return {}
 
     expected_line = old_lines[diff_offset]
     file_idx = anchor_idx + diff_offset

--- a/src/markdown_vault_mcp/utils/text.py
+++ b/src/markdown_vault_mcp/utils/text.py
@@ -149,45 +149,63 @@ def build_position_map(original: str, normalized: str) -> list[int]:
 def find_closest_match(old_text: str, file_content: str) -> dict[str, Any]:
     """Find the closest fuzzy match for diagnostic error reporting.
 
-    Compares the first line of *old_text* against every line in the file
-    using ``difflib.SequenceMatcher``.  If a match with ratio >= 0.6 is
-    found, returns diagnostic info about the first character divergence.
+    Anchors on the first line of *old_text* — the file line most similar to
+    it (``difflib.SequenceMatcher`` ratio >= 0.6) — then walks the remaining
+    lines of *old_text* against the file region starting at that anchor to
+    locate the *first line that genuinely diverges*.  This matters for
+    multi-line ``old_text``: when the first line matches the file exactly,
+    reporting that line would show two identical snippets and a meaningless
+    diff position; the real mismatch is on a later line.
 
     Args:
         old_text: The text the caller tried to match.
         file_content: The full file content.
 
     Returns:
-        A dict with ``closest_match_line``, ``first_diff_char``,
-        ``expected_snippet``, and ``found_snippet``; or an empty dict
-        if no match with ratio >= 0.6 is found.
+        A dict with ``closest_match_line`` (1-based file line of the first
+        divergent line), ``first_diff_char`` (char offset within that line),
+        ``expected_snippet`` (the divergent ``old_text`` line), and
+        ``found_snippet`` (the corresponding file line, empty if ``old_text``
+        extends past the file region); or an empty dict if no anchor line
+        with ratio >= 0.6 is found.
     """
-    first_line = old_text.split("\n", 1)[0]
+    old_lines = old_text.split("\n")
     file_lines = file_content.split("\n")
-    best_ratio = 0.0
-    best_line_num = 0
-    best_line_text = ""
 
-    for i, line in enumerate(file_lines, 1):
-        ratio = SequenceMatcher(None, first_line, line).ratio()
+    best_ratio = 0.0
+    anchor_idx = -1  # 0-based index into file_lines
+    for i, line in enumerate(file_lines):
+        ratio = SequenceMatcher(None, old_lines[0], line).ratio()
         if ratio > best_ratio:
             best_ratio = ratio
-            best_line_num = i
-            best_line_text = line
+            anchor_idx = i
 
     if best_ratio < 0.6:
         return {}
 
-    # Find first character difference.
+    # Walk old_text lines against the file region; find the first that differs.
+    diff_offset = len(old_lines) - 1  # fallback: every line matched by content
+    for offset, old_line in enumerate(old_lines):
+        file_idx = anchor_idx + offset
+        file_line = file_lines[file_idx] if file_idx < len(file_lines) else None
+        if file_line is None or old_line != file_line:
+            diff_offset = offset
+            break
+
+    expected_line = old_lines[diff_offset]
+    file_idx = anchor_idx + diff_offset
+    found_line = file_lines[file_idx] if file_idx < len(file_lines) else ""
+
+    # First character difference within the divergent line pair.
     diff_pos = 0
-    min_len = min(len(first_line), len(best_line_text))
-    while diff_pos < min_len and first_line[diff_pos] == best_line_text[diff_pos]:
+    min_len = min(len(expected_line), len(found_line))
+    while diff_pos < min_len and expected_line[diff_pos] == found_line[diff_pos]:
         diff_pos += 1
 
     ctx = 30
     return {
-        "closest_match_line": best_line_num,
+        "closest_match_line": file_idx + 1,
         "first_diff_char": diff_pos,
-        "expected_snippet": first_line[max(0, diff_pos - ctx) : diff_pos + ctx],
-        "found_snippet": best_line_text[max(0, diff_pos - ctx) : diff_pos + ctx],
+        "expected_snippet": expected_line[max(0, diff_pos - ctx) : diff_pos + ctx],
+        "found_snippet": found_line[max(0, diff_pos - ctx) : diff_pos + ctx],
     }

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -154,3 +154,32 @@ class TestFindClosestMatch:
     def test_diff_position_reported(self) -> None:
         result = find_closest_match("abcXef", "abcdef")
         assert result["first_diff_char"] == 3
+
+    def test_multiline_reports_divergent_line(self) -> None:
+        """First line matches exactly; a later line is the real divergence."""
+        old = "## Heading\nfirst line\nsecond lXne"
+        file_content = "intro\n## Heading\nfirst line\nsecond line\ntail"
+        result = find_closest_match(old, file_content)
+        assert result["closest_match_line"] == 4
+        assert result["first_diff_char"] == 8
+        assert result["expected_snippet"] != result["found_snippet"]
+
+    def test_multiline_first_line_match_not_reported_as_diff(self) -> None:
+        """A perfectly-matching first line must not be reported as the diff."""
+        # old_text differs from the file only by a zero-width space (U+200B)
+        # on the third line; the first line matches the file byte-for-byte.
+        old = "### The six links\n\nThe chain has​ six links"
+        file_content = "### The six links\n\nThe chain has six links\n"
+        result = find_closest_match(old, file_content)
+        assert result["closest_match_line"] == 3
+        assert result["first_diff_char"] == 13
+        assert result["expected_snippet"] != result["found_snippet"]
+
+    def test_old_text_extends_past_file(self) -> None:
+        """old_text has more lines than the matched file region."""
+        old = "alpha\nbeta\ngamma"
+        file_content = "alpha\nbeta"
+        result = find_closest_match(old, file_content)
+        assert result["closest_match_line"] == 3
+        assert result["found_snippet"] == ""
+        assert result["expected_snippet"] == "gamma"

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -126,9 +126,10 @@ class TestBuildPositionMap:
 
 
 class TestFindClosestMatch:
-    def test_exact_match(self) -> None:
+    def test_exact_match_returns_empty(self) -> None:
+        """A fully-matching old_text has no divergence to report."""
         result = find_closest_match("hello world", "hello world\ngoodbye")
-        assert result["closest_match_line"] == 1
+        assert result == {}
 
     def test_no_match(self) -> None:
         result = find_closest_match("xxxxxxxxx", "hello\nworld")
@@ -146,10 +147,9 @@ class TestFindClosestMatch:
         result = find_closest_match("abcdef", "xyzxyz\n123456")
         assert result == {}
 
-    def test_single_line_file(self) -> None:
+    def test_single_line_file_full_match_returns_empty(self) -> None:
         result = find_closest_match("hello", "hello")
-        assert result["closest_match_line"] == 1
-        assert result["first_diff_char"] == 5  # past end
+        assert result == {}
 
     def test_diff_position_reported(self) -> None:
         result = find_closest_match("abcXef", "abcdef")
@@ -183,3 +183,10 @@ class TestFindClosestMatch:
         assert result["closest_match_line"] == 3
         assert result["found_snippet"] == ""
         assert result["expected_snippet"] == "gamma"
+
+    def test_multiline_all_lines_match_returns_empty(self) -> None:
+        """Every old_text line matches the file region — no diagnostic."""
+        old = "alpha\nbeta\ngamma"
+        file_content = "intro\nalpha\nbeta\ngamma\ntail"
+        result = find_closest_match(old, file_content)
+        assert result == {}


### PR DESCRIPTION
## Summary

`find_closest_match()` (the source of `EditConflictError`'s diagnostic) only ever inspected the **first line** of `old_text`. When that line matched the file exactly — common for a multi-line `old_text` — the char-diff loop returned `min_len` and the diagnostic emitted two byte-identical snippets with a meaningless `first_diff_at_char`, reading as a false negative:

```
closest_match_line: 289
first_diff_at_char: 17
expected: '### The six links'
found: '### The six links'
```

- Anchor on the first line, then walk `old_text`'s lines against the file region to report the **first line that genuinely diverges** (file line number + char offset within that line). Invisible-character differences become visible because `_server_tools.py` already `repr()`s the snippets.
- Return an empty dict (no diagnostic) when every line of `old_text` matches the file region — instead of falling back to the last line with two identical snippets, which would reintroduce the very bug being fixed. Consistent with the existing no-anchor `{}` return.
- Docstrings (`find_closest_match`, `EditConflictError`) and `docs/design.md` updated to match.

Closes #501

## Test plan

- [x] `tests/test_utils_text.py::TestFindClosestMatch` — new tests: later-line divergence, perfectly-matching first line with a U+200B difference on a later line, `old_text` extending past the file region, single-line and multi-line all-lines-match returning `{}`
- [x] `uv run pytest -x -q` — 1583 passed
- [x] `uv run ruff check` / `ruff format --check` / `uv run mypy src/ tests/` — clean
- [x] `diff-cover` patch coverage — 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)