### PR TITLE
chore(copier): update to v1.8.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.6.1
+_commit: v1.8.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,3 +221,72 @@ jobs:
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  vale:
+    name: Docs Prose (Vale)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # vale-cli/vale-action posts findings as PR annotations via reviewdog.
+      # The default reporter (`github-pr-annotations`) uses the GitHub Checks
+      # API — `checks: write` is sufficient. If a downstream switches the
+      # reporter to `github-pr-review` (inline PR review comments), they
+      # need to add `pull-requests: write` here too.
+      checks: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Vale style packages
+        # Vale style packs are ~30 MB total and re-downloaded on every run
+        # without caching. Cache key invalidates when .vale.ini changes
+        # (Packages line edited, ai-tells URL bumped, etc.) OR when any
+        # vocab file under .vale/styles/config/ changes (added/removed
+        # accepted terms). Without the config/** hash, cache restore would
+        # silently clobber a newly-added vocab term on disk with the stale
+        # snapshot, making Vale flag the new term as unknown in CI even
+        # though the file is checked in. The `v1-` prefix is a manual
+        # escape hatch: bump it to force re-sync if Vale ever changes
+        # pack format backward-incompatibly.
+        uses: actions/cache@v4
+        with:
+          path: .vale/styles
+          key: vale-styles-v1-${{ hashFiles('.vale.ini', '.vale/styles/config/**') }}
+          # Fallback to any prior `vale-styles-v1-*` cache as a warm start
+          # when the exact key misses. `vale sync` will then only fetch the
+          # packs that actually changed instead of re-downloading all four.
+          restore-keys: vale-styles-v1-
+
+      - name: Run Vale
+        # SHA pin matches the gitleaks-action pattern earlier in this file.
+        # The current release is named "v2.1.2" in the GitHub UI but the
+        # underlying git tag is `2.1.2` (no `v` prefix) — pinning to the
+        # SHA sidesteps that mismatch and provides supply-chain hygiene.
+        uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a  # v2.1.2
+        with:
+          # Pin Vale CLI version explicitly. Bump in lockstep with the
+          # pre-commit hook `rev:` in .pre-commit-config.yaml — template-ci
+          # asserts the two stay synchronized.
+          version: "3.14.2"
+          files: docs
+          # Working specs follow internal conventions, not user-facing prose
+          # style — exclude from linting. NO inner single quotes around the
+          # glob value: vale-action splits `vale_flags` on whitespace and
+          # passes argv elements directly (no shell), so literal quotes here
+          # would be passed through to Vale, the glob would match no files,
+          # and CI would silently exit 0. Verified empirically.
+          vale_flags: "--glob=!docs/superpowers/**"
+          # Failure gating is controlled by MinAlertLevel = error in
+          # .vale.ini (governs both what Vale prints AND its exit code)
+          # combined with fail_on_error below — only error-severity
+          # findings fail CI; warnings and suggestions surface as advisory
+          # annotations. (The action also accepts a `level:` input, but at
+          # the pinned SHA that input is declared but never read — the
+          # reviewdog level is derived from Vale's exit code and
+          # fail_on_error. Setting it here would be a no-op.)
+          fail_on_error: true
+          # filter_mode defaults to `added` — only findings on lines this PR
+          # adds or modifies fail the build. Pre-existing prose debt isn't a
+          # blocker for new contributions; downstream's own untouched docs
+          # don't gate PRs that don't touch them. To enforce repo-wide
+          # cleanliness, set this to `nofilter`.
+          filter_mode: added

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,14 @@ on:
 
 jobs:
   claude-review:
+    # Skip PRs from forks: GitHub does not expose repository secrets
+    # (including CLAUDE_CODE_OAUTH_TOKEN) to workflows running in fork-PR
+    # context, regardless of maintainer approval. Running anyway produces
+    # a hard-failing check on every external contribution. Maintainers who
+    # want a bot review on a fork PR can push the contributor's branch to
+    # this repo under a topic name and the workflow will run.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,17 @@ on:
 
 jobs:
   claude:
+    # Trigger only on @claude mentions, AND on the two PR-context events
+    # (`pull_request_review*`) only when the PR head is in this repo. Those
+    # events run in PR context for fork PRs, where GitHub withholds repository
+    # secrets (incl. CLAUDE_CODE_OAUTH_TOKEN) and the action would auth-fail.
+    # `issues` and `issue_comment` always run in base-repo context, so secrets
+    # are available — no fork check needed there.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force version bump (leave empty for auto)'
+        description: 'Force version bump (empty = auto; "prerelease" advances the rc revision e.g. rc.1 → rc.2 — keep the pre-release box below checked)'
         type: choice
         default: ''
         options:
           - ''
+          - prerelease
           - patch
           - minor
           - major
@@ -32,6 +33,12 @@ jobs:
       id-token: write
 
     steps:
+      - name: Reject contradictory dispatch inputs
+        if: inputs.force == 'prerelease' && inputs.prerelease == false
+        run: |
+          echo "::error::force=prerelease advances the rc revision and requires the pre-release box to stay checked"
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,48 @@
+# Vale prose linter — https://vale.sh
+#
+# Lints `docs/**` for prose issues. Working specs under `docs/superpowers/**`
+# are excluded by the pre-commit hook (`exclude:` pattern) and the CI step
+# (`--glob='!docs/superpowers/**'`); Vale itself has no notion of "skip this
+# subtree", so the exclusion lives at the invocation site.
+#
+# `MinAlertLevel = error` governs both what Vale prints AND its exit code —
+# warnings and suggestions are advisory (visible in `vale --minAlertLevel=
+# warning` runs) but do not fail CI / pre-commit. Tune individual rules
+# (e.g. disable a noisy one) via per-rule overrides:
+#
+#     [*.md]
+#     Google.Spelling = NO
+#
+# See https://vale.sh/docs/keys/format for the full key reference and
+# https://vale.sh/docs/topics/styles for rule-tuning syntax.
+#
+# Project-specific accepted vocabulary lives at
+# `.vale/styles/config/vocabularies/Base/accept.txt` (one term per line,
+# matched case-insensitively). The `Vocab = Base` line below activates it.
+# The config/ subtree is preserved across `vale sync`; see .gitignore for
+# the include/exclude rules.
+
+StylesPath = .vale/styles
+MinAlertLevel = error
+Vocab = Base
+
+# `Vale` is a built-in style, always available without listing here.
+# `Google`, `proselint`, `write-good` are upstream packages fetched by
+# `vale sync` from Vale's package registry — listed by name without an
+# `@version` suffix means they resolve to the latest registry release on
+# each sync. Intentional: keeps style rules current. To pin for
+# reproducibility, append a version (e.g. `Google@1.0.0`).
+# `ai-tells` (https://github.com/tbhb/vale-ai-tells) catches common
+# LLM-prose tells; pinned to a release URL since it is not in Vale's
+# package index.
+Packages = Google, proselint, write-good, https://github.com/tbhb/vale-ai-tells/releases/download/v1.9.0/ai-tells.zip
+
+[*.md]
+BasedOnStyles = Vale, Google, proselint, write-good, ai-tells
+
+# Vale.Terms enforces strict casing of every accept.txt entry — useful for
+# product names (e.g. "GitHub" not "Github") but overzealous for generic
+# tech vocab where sentence-start, heading-start, and mid-sentence usages
+# legitimately appear with different casing. Vale.Spelling still accepts
+# all entries case-insensitively; we just don't enforce one canonical form.
+Vale.Terms = NO

--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -1,0 +1,43 @@
+# Project vocabulary — accepted tech terms that Vale's default spell-check
+# would otherwise flag as unknown words. One term per line. Vale matches
+# case-insensitively by default. See https://vale.sh/docs/topics/vocab.
+#
+# Add new accepted terms below as your docs corpus grows. Keep entries
+# alphabetical within their category for easy review.
+
+# --- Identity providers and auth-stack tooling ---
+Authelia
+Keycloak
+OAuth
+OIDC
+Traefik
+
+# --- HTTP / URL terminology ---
+hostname
+subpath
+URIs
+
+# --- OAuth / OIDC token fields ---
+access_token
+id_token
+
+# --- Python / runtime ecosystem ---
+debugpy
+mypy
+namespace
+namespaced
+pytest
+ruff
+
+# --- Operational / config jargon ---
+config
+deployer
+env
+truthy
+uncommented
+uncommenting
+unprefixed
+validators
+
+# --- Diagnostics / observability ---
+traceback

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,6 @@
 # Configuration
 
+<<<<<<< before updating
 All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP_` prefix. `OLLAMA_HOST` and `OPENAI_API_KEY` are bare ecosystem-standard names; all other variables use the `MARKDOWN_VAULT_MCP_` prefix.
 
 ## Core
@@ -41,6 +42,50 @@ timeout the tool returns the result with `stale=true` rather than
 raising — best-effort fresh read. Increase for very large vaults
 where reindex / build_embeddings jobs take longer; decrease for
 faster client feedback when the index has chronic backlog.
+=======
+Markdown Vault MCP is configured via environment variables with the
+``MARKDOWN_VAULT_MCP_`` prefix.
+
+## Common variables
+
+See `fastmcp-pvl-core`'s README for the full list of universal
+variables (`MARKDOWN_VAULT_MCP_TRANSPORT`, `MARKDOWN_VAULT_MCP_HOST`,
+`MARKDOWN_VAULT_MCP_PORT`, `MARKDOWN_VAULT_MCP_HTTP_PATH`,
+`MARKDOWN_VAULT_MCP_BASE_URL`, auth vars, etc.).
+
+## MCP File Exchange
+
+These variables control [MCP File Exchange](guides/file-exchange.md)
+participation: pass-by-reference file transfer between co-deployed
+servers (and HTTP fallback for remote clients). All are optional; the
+defaults are sensible for both stdio and HTTP deployments.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch. Set `false` to opt out entirely. |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_PRODUCE` | `true` | Allow this server to mint `FileRef` objects via `handle.publish(...)`. |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_CONSUME` | `true` | Master toggle for the consumer side. **Only effective when `consumer_sink=` is wired in `server.py`**; without that argument, `fetch_file` is never registered no matter how this var is set. See [the guide](guides/file-exchange.md#consuming-files-consumer_sink). |
+| `MARKDOWN_VAULT_MCP_FILE_EXCHANGE_TTL` | `3600` | Lifetime in seconds for download links and exchange-volume records. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch for the upload direction. **Only effective when `register_file_exchange_upload(...)` is uncommented in `server.py`**; without that call, no upload route is mounted regardless of this var. Also requires `MARKDOWN_VAULT_MCP_BASE_URL` to be set so `create_upload_link` can mint usable URLs. See [the guide](guides/file-exchange.md#uploading-files-receiver). |
+| `MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES` | `10485760` (10 MiB) | Maximum POST body size for the upload route. Bodies exceeding this return HTTP 413. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_TTL` | `300` | Default lifetime in seconds for upload links. Caller-requested TTL is clamped to `MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX`. |
+| `MARKDOWN_VAULT_MCP_UPLOAD_TTL_MAX` | `3600` | Operator ceiling for caller-requested upload-link TTL. |
+| `MARKDOWN_VAULT_MCP_BASE_URL` | unset | Public base URL of this server. Required for the `http` transfer method; the `create_download_link` tool and (when upload is wired) the `create_upload_link` tool both build URLs against it. Also referenced by the OIDC guide and the universal-variables list above. Set it once and every consumer picks it up. |
+
+Note the upload-direction variables are namespaced under `_UPLOAD_*`,
+not `_FILE_EXCHANGE_UPLOAD_*`. This matches the upstream
+`fastmcp-pvl-core` 2.1.0 contract. The download-direction variables
+keep the historical `_FILE_EXCHANGE_*` namespace.
+
+The deployer also controls three **unprefixed** environment variables
+shared by every co-deployed server:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_EXCHANGE_DIR` | unset | Path to a directory shared between co-deployed MCP servers. When set, the `exchange://` transfer method activates; when unset, only the HTTP method is available. |
+| `MCP_EXCHANGE_ID` | persisted in `.exchange-id` | Optional explicit exchange-group identifier; first server to start writes a UUID into `${MCP_EXCHANGE_DIR}/.exchange-id`, subsequent starts must agree. |
+| `MCP_EXCHANGE_NAMESPACE` | the server's `namespace=` argument | Override the namespace used in `exchange://` URIs for this process. |
+>>>>>>> after updating
 
 <!-- DOMAIN-CONFIG-VARS-START -->
 ## Server Identity

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -62,7 +62,18 @@ All `/data/*` directories are pre-created and owned by the runtime user in the i
 
 The `compose.yml` includes Traefik labels out of the box. When Traefik is running and watching Docker, it picks up these labels and routes traffic automatically.
 
+<<<<<<< before updating
 **What the labels do:**
+=======
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | Disable write tools |
+| `MARKDOWN_VAULT_MCP_BEARER_TOKEN` | n/a | Enable bearer token auth |
+| `MARKDOWN_VAULT_MCP_LOG_LEVEL` | `INFO` | Log level |
+| `MARKDOWN_VAULT_MCP_INSTRUCTIONS` | (computed at startup) | System instructions for LLM context |
+| `MARKDOWN_VAULT_MCP_DEBUG_PORT` | n/a | Remote-debugger TCP port (see [Remote debugging](#remote-debugging); requires `--build-arg DEBUG=true` image) |
+| `MARKDOWN_VAULT_MCP_DEBUG_WAIT` | `false` | Block startup until IDE attaches (see [Remote debugging](#remote-debugging)) |
+>>>>>>> after updating
 
 - `traefik.enable=true` — opt this service in to Traefik discovery
 - `traefik.http.routers.markdown-vault-mcp.rule` — defines the `Host` rule; defaults to `markdown-vault-mcp.local`
@@ -237,7 +248,7 @@ services:
 
 ## Remote debugging
 
-Production images ship without `debugpy` to keep the image lean.  To attach a remote Python debugger from VS Code or PyCharm:
+Production images ship without `debugpy` to keep the image lean. To attach a remote Python debugger from VS Code or PyCharm:
 
 1. **Build with the debug extra:**
 
@@ -245,7 +256,7 @@ Production images ship without `debugpy` to keep the image lean.  To attach a re
     docker build --build-arg DEBUG=true -t markdown-vault-mcp:debug .
     ```
 
-    This installs the `[debug]` optional-dependency group (which pulls `debugpy` transitively from `fastmcp-pvl-core`).  Default builds (`DEBUG=false`) skip it.
+    This installs the `[debug]` optional-dependency group (which pulls `debugpy` transitively from `fastmcp-pvl-core`). Default builds (`DEBUG=false`) skip it.
 
 2. **Run with the debug env vars set and the port mapped:**
 
@@ -261,9 +272,9 @@ Production images ship without `debugpy` to keep the image lean.  To attach a re
     | Env var | Effect |
     |---------|--------|
     | `MARKDOWN_VAULT_MCP_DEBUG_PORT` | TCP port the debugger listens on (any value parsing to ``0`` disables; non-numeric or out-of-range values log a WARNING and the listener stays off) |
-    | `MARKDOWN_VAULT_MCP_DEBUG_WAIT` | When truthy (``1``/``true``/``yes``/``on``), block startup until the IDE attaches.  Default is non-blocking. |
+    | `MARKDOWN_VAULT_MCP_DEBUG_WAIT` | When truthy (``1``/``true``/``yes``/``on``), block startup until the IDE attaches. Default is non-blocking. |
 
-3. **Attach from VS Code** — add a launch config:
+3. **Attach from VS Code**, adding a launch config:
 
     ```json
     {
@@ -277,9 +288,9 @@ Production images ship without `debugpy` to keep the image lean.  To attach a re
     PyCharm uses *Run → Edit Configurations → Python Debug Server* with the same host/port.
 
 !!! danger "Never publish the debug port on a public network"
-    The debug listener binds `0.0.0.0` inside the container so the IDE can reach it from the host, but **debugpy's DAP protocol is unauthenticated** — any peer that can reach the port has arbitrary code execution as the server process.  Always bind the port mapping to localhost (`-p 127.0.0.1:5678:5678`) or tunnel via `kubectl port-forward` / SSH.  Production images should be built with default `DEBUG=false`.
+    The debug listener binds `0.0.0.0` inside the container so the IDE can reach it from the host, but **debugpy's DAP protocol is unauthenticated**: any peer that can reach the port has arbitrary code execution as the server process. Always bind the port mapping to localhost (`-p 127.0.0.1:5678:5678`) or tunnel via `kubectl port-forward` / SSH. Production images should be built with default `DEBUG=false`.
 
-When the helper is invoked but `debugpy` isn't installed (e.g. someone sets `DEBUG_PORT` on a non-debug image), it logs a WARNING and continues — safe failure mode.
+When the helper is invoked but `debugpy` isn't installed (say, someone sets `DEBUG_PORT` on a non-debug image), it logs a WARNING and continues; this is the safe failure mode.
 
 <!-- DOMAIN-DOCKER-EXTRA-START -->
 <!-- DOMAIN-DOCKER-EXTRA-END -->

--- a/docs/deployment/oidc.md
+++ b/docs/deployment/oidc.md
@@ -29,8 +29,13 @@ No `CLIENT_ID` or `CLIENT_SECRET` needed — tokens are validated locally via JW
 
 | Variable | Description |
 |----------|-------------|
+<<<<<<< before updating
 | `MARKDOWN_VAULT_MCP_BASE_URL` | Public base URL of the server (e.g. `https://mcp.example.com`; include prefix when mounted under subpath, e.g. `https://mcp.example.com/vault`) |
 | `MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL` | OIDC discovery endpoint (e.g. `https://auth.example.com/.well-known/openid-configuration`) |
+=======
+| `MARKDOWN_VAULT_MCP_BASE_URL` | Public base URL of the server (such as `https://mcp.example.com`; include prefix when mounted under subpath, such as `https://mcp.example.com/myservice`) |
+| `MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL` | OIDC discovery endpoint (such as `https://auth.example.com/.well-known/openid-configuration`) |
+>>>>>>> after updating
 | `MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID` | OIDC client ID registered with your provider |
 | `MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET` | OIDC client secret |
 
@@ -38,8 +43,8 @@ No `CLIENT_ID` or `CLIENT_SECRET` needed — tokens are validated locally via JW
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY` | ephemeral | JWT signing key. **Required on Linux/Docker** — the default is ephemeral and invalidates tokens on restart |
-| `MARKDOWN_VAULT_MCP_OIDC_AUDIENCE` | — | Expected JWT audience claim; leave unset if your provider does not set one |
+| `MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY` | ephemeral | JWT signing key. **Required on Linux/Docker**: the default is ephemeral and invalidates tokens on restart |
+| `MARKDOWN_VAULT_MCP_OIDC_AUDIENCE` | n/a | Expected JWT audience claim; leave unset if your provider does not set one |
 | `MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES` | `openid` | Comma-separated required scopes |
 | `MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN` | `false` | Set `true` to verify the upstream access token as JWT instead of the id token. Only needed when your provider issues JWT access tokens and you require audience-claim validation on that token |
 
@@ -101,7 +106,7 @@ markdown-vault-mcp serve --transport http --port 8000
 ### OIDCProxy mode (fallback)
 
 !!! note "Opaque access tokens"
-    Authelia issues opaque (non-JWT) access tokens. This is handled automatically — the server verifies the `id_token` (always a standard JWT) instead. No extra configuration is needed.
+    Authelia issues opaque (non-JWT) access tokens. This is handled automatically: the server verifies the `id_token` (always a standard JWT) instead. No extra configuration is needed.
 
 ### 1. Register the client in Authelia
 
@@ -213,7 +218,11 @@ MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET=your-client-secret
 MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY=your-stable-hex-key
 ```
 
+<<<<<<< before updating
 For a prefixed deployment (e.g., `https://mcp.example.com/vault/mcp`), see [Subpath Deployments](#subpath-deployments) below.
+=======
+For a prefixed deployment (such as `https://mcp.example.com/myservice/mcp`), see [Subpath Deployments](#subpath-deployments) below.
+>>>>>>> after updating
 
 ## Subpath Deployments
 
@@ -221,13 +230,22 @@ When OIDC is enabled behind a reverse-proxy subpath, `BASE_URL` and `HTTP_PATH` 
 
 | Variable | Purpose | Example |
 |----------|---------|---------|
+<<<<<<< before updating
 | `BASE_URL` | Public URL of the server, **including the subpath prefix** | `https://mcp.example.com/vault` |
 | `HTTP_PATH` | Internal MCP endpoint mount point — **no subpath prefix** | `/mcp` |
+=======
+| `BASE_URL` | Public URL of the server, **including the subpath prefix** | `https://mcp.example.com/myservice` |
+| `HTTP_PATH` | Internal MCP endpoint mount point (**no subpath prefix**) | `/mcp` |
+>>>>>>> after updating
 
 The reverse proxy strips the subpath prefix before forwarding to the application. FastMCP concatenates `BASE_URL + HTTP_PATH` to build the public resource URL, so including the prefix in both produces broken URLs with duplicated path segments.
 
 !!! danger "Do not duplicate the subpath"
+<<<<<<< before updating
     Setting `BASE_URL=https://mcp.example.com/vault` **and** `HTTP_PATH=/vault/mcp` produces a duplicated resource URL: `https://mcp.example.com/vault/vault/mcp`. The subpath belongs in `BASE_URL` only.
+=======
+    Setting `BASE_URL=https://mcp.example.com/myservice` together with `HTTP_PATH=/myservice/mcp` produces a duplicated resource URL: `https://mcp.example.com/myservice/myservice/mcp`. The subpath belongs in `BASE_URL` only.
+>>>>>>> after updating
 
 ### Configuration
 
@@ -250,8 +268,13 @@ The reverse proxy must:
 
 1. **Strip the prefix** (`/vault`) from operational routes before forwarding to the app
 2. **Forward OAuth discovery routes** to this service (without stripping prefixes):
+<<<<<<< before updating
     - `/.well-known/oauth-authorization-server` — authorization server metadata
     - `/.well-known/oauth-protected-resource/vault/mcp` — protected resource metadata
+=======
+    - `/.well-known/oauth-authorization-server`: authorization server metadata
+    - `/.well-known/oauth-protected-resource/myservice/mcp`: protected resource metadata
+>>>>>>> after updating
 
 Example Traefik configuration:
 
@@ -283,7 +306,11 @@ labels:
 
 **Recommendations for shared-hostname scenarios:**
 
+<<<<<<< before updating
 - **Dedicated hostname** (preferred): give `markdown-vault-mcp` its own hostname (e.g., `vault.example.com`) so discovery routes do not collide.
+=======
+- **Dedicated hostname** (preferred): give the MCP server its own hostname (such as `myservice.example.com`) so discovery routes do not collide.
+>>>>>>> after updating
 - **External auth gateway**: use `mcp-auth-proxy` as a sidecar instead of native OIDC. The MCP server runs unauthenticated behind the proxy, and the proxy handles OAuth discovery at its own routes.
 
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -11,13 +11,21 @@ The server supports five authentication modes:
 
 | Mode | When to use | Configuration |
 |------|-------------|---------------|
+<<<<<<< before updating
 | **Multi-auth** | Mixed clients — e.g. Claude web (OIDC) + Claude Code (bearer token) on the same server | Set both `MARKDOWN_VAULT_MCP_BEARER_TOKEN` and OIDC variables |
+=======
+| **Multi-auth** | Mixed clients, such as Claude web (OIDC) + Claude Code (bearer token) on the same server | Set both `MARKDOWN_VAULT_MCP_BEARER_TOKEN` and all four OIDC variables |
+>>>>>>> after updating
 | **Bearer token** | Simple deployments behind a VPN, Docker compose stacks, development | Set `MARKDOWN_VAULT_MCP_BEARER_TOKEN` only |
 | **OIDC (remote)** | Production — recommended over oidc-proxy. Local JWKS validation, no token re-validation | Set `MARKDOWN_VAULT_MCP_BASE_URL` + `MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL` only |
 | **OIDC (oidc-proxy)** | Production with user identity, SSO, multi-user access; backward-compatible mode | Set all four OIDC variables (`BASE_URL`, `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`) |
 | **No auth** | Local stdio usage, trusted networks | Default (nothing to configure) |
 
+<<<<<<< before updating
 When both bearer token and OIDC are configured, the server accepts **either** credential — a valid bearer token or a valid OIDC session. This is useful when different clients require different authentication flows against the same vault instance.
+=======
+When both bearer token and OIDC are configured, the server accepts **either** credential: a valid bearer token or a valid OIDC session. This is useful when different clients require different authentication flows against the same server instance.
+>>>>>>> after updating
 
 ---
 
@@ -64,7 +72,7 @@ See also: [`examples/bearer-auth.env`](https://github.com/pvliesdonk/markdown-va
 
 ### Mapped bearer tokens (multi-subject)
 
-The bearer-token mode above shares one subject across every authenticated caller — by default the library's `bearer-anon`, override with `MARKDOWN_VAULT_MCP_BEARER_DEFAULT_SUBJECT`.  For audit logs and authorization that distinguish callers, switch to mapped-token mode by pointing `MARKDOWN_VAULT_MCP_BEARER_TOKENS_FILE` at a TOML file:
+The bearer-token mode above shares one subject across every authenticated caller. By default this is the library's `bearer-anon`; override with `MARKDOWN_VAULT_MCP_BEARER_DEFAULT_SUBJECT`. For audit logs and authorization that distinguish callers, switch to mapped-token mode by pointing `MARKDOWN_VAULT_MCP_BEARER_TOKENS_FILE` at a TOML file:
 
 ```toml
 # tokens.toml
@@ -73,7 +81,7 @@ The bearer-token mode above shares one subject across every authenticated caller
 "sk_ci_yyyyyyyy"     = "service:ci-bot"
 ```
 
-Each token resolves to a distinct subject string for downstream attribution.  Subject strings are opaque — the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only.  When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present).  A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
+Each token resolves to a distinct subject string for downstream attribution. Subject strings are opaque: the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only. When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present). A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
 
 For the per-tool authorization that consumes these subjects, see [Authorization (opt-in)](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/README.md#authorization-opt-in) in the project README.
 
@@ -111,7 +119,7 @@ Client → markdown-vault-mcp (present JWT → validate via JWKS)
 
 ### How it works (oidc-proxy mode)
 
-The server uses FastMCP's built-in `OIDCProxy` — no external auth sidecar needed:
+The server uses FastMCP's built-in `OIDCProxy`. No external auth sidecar needed:
 
 ```
 Client → markdown-vault-mcp (OIDCProxy) → OIDC Provider
@@ -127,7 +135,11 @@ Client → markdown-vault-mcp (OIDCProxy) → OIDC Provider
 
 | Variable | Description |
 |----------|-------------|
+<<<<<<< before updating
 | `MARKDOWN_VAULT_MCP_BASE_URL` | Public base URL (e.g. `https://mcp.example.com`). Also required for MCP Apps domain computation. |
+=======
+| `MARKDOWN_VAULT_MCP_BASE_URL` | Public base URL (such as `https://mcp.example.com`) |
+>>>>>>> after updating
 | `MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL` | OIDC discovery endpoint |
 | `MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID` | Client ID registered with your provider (oidc-proxy mode only) |
 | `MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET` | Client secret (oidc-proxy mode only) |
@@ -136,9 +148,14 @@ Client → markdown-vault-mcp (OIDCProxy) → OIDC Provider
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+<<<<<<< before updating
 | `MARKDOWN_VAULT_MCP_AUTH_MODE` | auto-detected | Force OIDC mode: `remote` or `oidc-proxy` |
 | `MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY` | ephemeral | JWT signing key — **required on Linux/Docker** (oidc-proxy mode only) |
 | `MARKDOWN_VAULT_MCP_OIDC_AUDIENCE` | — | Expected JWT audience claim; leave unset if your provider does not set one |
+=======
+| `MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY` | ephemeral | JWT signing key (**required on Linux/Docker**) |
+| `MARKDOWN_VAULT_MCP_OIDC_AUDIENCE` | n/a | Expected JWT audience claim; leave unset if your provider does not set one |
+>>>>>>> after updating
 | `MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES` | `openid` | Comma-separated required scopes |
 | `MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN` | `false` | Set `true` to verify the access token as a JWT instead of the id token; useful for audience-claim validation on JWT access tokens (oidc-proxy mode only) |
 
@@ -150,7 +167,7 @@ Client → markdown-vault-mcp (OIDCProxy) → OIDC Provider
     ```
 
 !!! tip "Long-running sessions"
-    Current MCP clients do not reliably refresh tokens — see [Known Limitations](#known-limitations-mcp-oauth-token-refresh). Configure **all** token lifetimes (access, id, refresh) on your identity provider to cover a full workday (8h+). For simpler deployments, bearer token auth is unaffected by these limitations.
+    Current MCP clients do not reliably refresh tokens; see [Known Limitations](#known-limitations-mcp-oauth-token-refresh). Configure **all** token lifetimes (access, id, refresh) on your identity provider to cover a full workday (8 hours or more). For simpler deployments, bearer token auth is unaffected by these limitations.
 
 ### Provider guides
 
@@ -189,13 +206,13 @@ Authentication only works with HTTP transport. If you're using `--transport stdi
 
 - Verify the env var is set and non-empty (whitespace-only values are ignored)
 - Check that clients send `Authorization: Bearer <token>` (not `Basic` or other schemes)
-- If OIDC is also configured, multi-auth is active — both bearer and OIDC are accepted simultaneously
+- If OIDC is also configured, multi-auth is active: both bearer and OIDC are accepted simultaneously
 
 ### OIDC redirect fails
 
 - Verify `BASE_URL` matches your public URL exactly (including any subpath prefix)
-- For subpath deployments, see the [subpath deployment guide](../deployment/oidc.md#subpath-deployments) — `BASE_URL` must include the prefix, `HTTP_PATH` must not
-- Check that `redirect_uris` in your provider config includes your callback URL (e.g., `https://mcp.example.com/auth/callback`)
+- For subpath deployments, see the [subpath deployment guide](../deployment/oidc.md#subpath-deployments); `BASE_URL` must include the prefix, `HTTP_PATH` must not
+- Check that `redirect_uris` in your provider config includes your callback URL (such as `https://mcp.example.com/auth/callback`)
 
 ### Session drops after token expiry
 
@@ -203,11 +220,11 @@ Authentication only works with HTTP transport. If you're using `--transport stdi
 
 **Root cause:** this is almost always a token lifetime issue, not a server bug. Check three things:
 
-1. **id_token lifetime** (most common): When using `verify_id_token` mode (the default for Authelia), the server re-validates the upstream `id_token` on every request. If your provider's `id_token` lifetime is shorter than the `access_token` lifetime, the session dies at the `id_token` expiry — even though the access token is still valid. Authelia defaults `id_token` to 1 hour. **Fix: set `id_token` lifetime to match `access_token`** in your provider config.
+1. **id_token lifetime** (most common): When using `verify_id_token` mode (the default for Authelia), the server re-validates the upstream `id_token` on every request. If your provider's `id_token` lifetime is shorter than the `access_token` lifetime, the session dies at the `id_token` expiry, even though the access token is still valid. Authelia defaults `id_token` to 1 hour. **Fix: set `id_token` lifetime to match `access_token`** in your provider config.
 
 2. **access_token lifetime**: If both `id_token` and `access_token` are set correctly but sessions still drop, check that the provider's `expires_in` response matches your configured lifetime.
 
-3. **No refresh token**: See [Known Limitations](#known-limitations-mcp-oauth-token-refresh) below — current MCP clients cannot refresh tokens, so sessions are limited to the token lifetime.
+3. **No refresh token**: See [Known Limitations](#known-limitations-mcp-oauth-token-refresh) below; current MCP clients cannot refresh tokens, so sessions are limited to the token lifetime.
 
 **Workaround:** configure **all** token lifetimes on your identity provider to cover a full workday:
 
@@ -225,7 +242,11 @@ See the [Authelia provider guide](oidc-providers.md#authelia) for the full confi
 
 ### Opaque access tokens (Authelia)
 
+<<<<<<< before updating
 Authelia issues opaque (non-JWT) access tokens. This is handled automatically — the server verifies the `id_token` instead. No extra configuration needed. See the [Authelia guide](oidc-providers.md#authelia) for details.
+=======
+Authelia issues opaque (non-JWT) access tokens. This is handled automatically: the server verifies the `id_token` instead. No extra configuration needed.
+>>>>>>> after updating
 
 ---
 
@@ -236,7 +257,11 @@ Authelia issues opaque (non-JWT) access tokens. This is handled automatically �
 
 ### The problem
 
+<<<<<<< before updating
 MCP clients cannot maintain sessions beyond the token lifetime because token refresh does not work. When tokens expire, the session drops and requires manual re-authentication. This affects every provider — Authelia, Keycloak, Google, Slack, Notion, Atlassian, and others.
+=======
+MCP clients cannot maintain sessions beyond the token lifetime because token refresh does not work. When tokens expire, the session drops and requires manual re-authentication. This affects every provider: Authelia, Keycloak, Google, and others.
+>>>>>>> after updating
 
 ### Why refresh doesn't work
 
@@ -248,28 +273,32 @@ Three independent issues prevent token refresh:
 | **Claude Code** | Never requests `offline_access` scope ([claude-code#7744](https://github.com/anthropics/claude-code/issues/7744)) | Most OIDC providers won't issue a refresh token without this scope |
 | **MCP Python SDK** | Token refresh deadlocks inside SSE streams ([python-sdk#1326](https://github.com/modelcontextprotocol/python-sdk/issues/1326)) | Even with a valid refresh token, the SDK hangs when attempting refresh during an active stream |
 
-The server-side refresh architecture (FastMCP's `OAuthProxy.exchange_refresh_token()`) is correctly implemented and would work — but it requires the client to initiate the refresh, which none of the current clients do reliably.
+The server-side refresh architecture (FastMCP's `OAuthProxy.exchange_refresh_token()`) is correctly implemented and would work, but it requires the client to initiate the refresh, which none of the current clients do reliably.
 
 ### What works today
 
+<<<<<<< before updating
 **Remote auth mode** (`AUTH_MODE=remote` or auto-detected) avoids the double-validation problem entirely. The server validates tokens locally via JWKS — it never stores or re-validates upstream tokens. This is the recommended mode for new deployments.
 
 **Bearer token auth** is unaffected by all of the above. If your deployment allows it (e.g., Claude Code with env vars, or API clients), bearer tokens are the simplest and most reliable option.
+=======
+**Bearer token auth** is unaffected by all of the above. If your deployment allows it (such as Claude Code with env vars, or API clients), bearer tokens are the simplest and most reliable option.
+>>>>>>> after updating
 
 **Long token lifetimes** are the only viable workaround for OIDC in oidc-proxy mode. Set all three lifetimes (access, id, refresh) to cover your typical session duration:
 
-- `access_token: '8h'` — covers a workday
-- `id_token: '8h'` — **must match access_token** when using `verify_id_token` mode (critical for Authelia)
-- `refresh_token: '30d'` — ready for when clients support refresh
-- Include `offline_access` in provider-side scopes — no effect today, but will enable refresh when clients are fixed
+- `access_token: '8h'`: covers a workday
+- `id_token: '8h'`: **must match access_token** when using `verify_id_token` mode (critical for Authelia)
+- `refresh_token: '30d'`: ready for when clients support refresh
+- Include `offline_access` in provider-side scopes; no effect today, but enables refresh when clients are fixed
 
 ### Tracking
 
 These upstream issues are actively tracked:
 
-- [anthropics/claude-code#21333](https://github.com/anthropics/claude-code/issues/21333) — refresh tokens stored but never used
-- [anthropics/claude-code#7744](https://github.com/anthropics/claude-code/issues/7744) — `offline_access` scope never requested
-- [modelcontextprotocol/python-sdk#1326](https://github.com/modelcontextprotocol/python-sdk/issues/1326) — SSE refresh deadlock
+- [anthropics/claude-code#21333](https://github.com/anthropics/claude-code/issues/21333): refresh tokens stored but never used
+- [anthropics/claude-code#7744](https://github.com/anthropics/claude-code/issues/7744): `offline_access` scope never requested
+- [modelcontextprotocol/python-sdk#1326](https://github.com/modelcontextprotocol/python-sdk/issues/1326): SSE refresh deadlock
 
 When these are resolved, OIDC sessions should persist indefinitely via automatic token refresh with no changes needed to markdown-vault-mcp.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -128,7 +128,7 @@ markdown-vault-mcp search "hello world"
 
 ## Project-specific notes
 
-_Add domain-specific install notes here, e.g. system dependencies, optional
+_Add domain-specific install notes here, such as system dependencies, optional
 extras, or custom configuration steps._
 
 <!-- DOMAIN-INSTALL-EXTRA-END -->

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,6 +4,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 
 <!-- DOMAIN-TOOLS-LIST-START -->
 
+<<<<<<< before updating
 ## Quick Reference
 
 | Tool | Category | Description |
@@ -830,4 +831,9 @@ Open the Context Card view for a specific note, showing backlinks, outlinks, sim
 | `path` | string | Relative path to the document |
 
 **Returns:** For Apps-capable clients, opens the Context Card. For other clients, returns the context dossier as text.
+=======
+Health-check tool that returns `"pong"` if the service is alive.
+Replace with real tools per the scaffold in
+`src/markdown_vault_mcp/tools.py`.
+>>>>>>> after updating
 <!-- DOMAIN-TOOLS-LIST-END -->


### PR DESCRIPTION
## Template update: `v1.6.1` → `v1.8.0`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v1.6.1...v1.8.0)

<details><summary>Release notes (v1.8.0)</summary>

- #145 docs: clean up rendered docs/** to pass Vale (closes #141)
- #142 feat(docs): add Vale prose linter for downstream docs/**
- #140 ci(claude-review): skip on fork PRs to avoid auth-failing checks

</details>

<details><summary>Files changed (13)</summary>

```
 .copier-answers.yml                              |  2 +-
 .github/workflows/ci.yml                         | 69 ++++++++++++++++++++++++
 .github/workflows/claude-code-review.yml         |  8 +++
 .github/workflows/claude.yml                     | 12 +++--
 .github/workflows/release.yml                    |  9 +++-
 .vale.ini                                        | 48 +++++++++++++++++
 .vale/styles/config/vocabularies/Base/accept.txt | 43 +++++++++++++++
 docs/configuration.md                            | 45 ++++++++++++++++
 docs/deployment/docker.md                        | 23 +++++---
 docs/deployment/oidc.md                          | 33 ++++++++++--
 docs/guides/authentication.md                    | 63 ++++++++++++++++------
 docs/installation.md                             |  2 +-
 docs/tools/index.md                              |  6 +++
 13 files changed, 331 insertions(+), 32 deletions(-)
```

</details>

### ⚠️ 5 file(s) with unresolved conflict markers

The `<<<<<<< before updating` markers **are committed to this branch** — resolve them before merging:

- `docs/configuration.md`
- `docs/deployment/docker.md`
- `docs/deployment/oidc.md`
- `docs/guides/authentication.md`
- `docs/tools/index.md`

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

---

## Agent analysis

### 🔧 Conflict resolutions

⚠️ Agent failed — see workflow log.

### ✨ New features in this update

⚠️ Agent failed — see workflow log.

### 📦 Excluded-file upstream changes

⚠️ Agent failed — see workflow log.

