### PR TITLE
feat(embeddings): support OpenAI-compatible API configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` pr
 | `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | auto-detect | Embedding provider: `openai`, `ollama`, or `fastembed` |
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL (**not** `MARKDOWN_VAULT_MCP_`-prefixed) |
 | `OPENAI_API_KEY` | — | OpenAI API key for the OpenAI embedding provider (**not** `MARKDOWN_VAULT_MCP_`-prefixed) |
+| `MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` / `OPENAI_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible API base URL for embeddings |
+| `MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL` / `OPENAI_EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI-compatible embedding model name |
 | `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` | `nomic-embed-text` | Ollama embedding model name |
 | `MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY` | `false` | Force Ollama to use CPU only |
 | `MARKDOWN_VAULT_MCP_FASTEMBED_MODEL` | `BAAI/bge-small-en-v1.5` | FastEmbed model name |

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -24,6 +24,10 @@ The `get_embedding_provider()` function auto-detects the best available provider
 3. **FastEmbed** — if the package is installed
 
 Override with `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai|ollama|fastembed`.
+For OpenAI-compatible APIs, set `OPENAI_BASE_URL` and
+`OPENAI_EMBEDDING_MODEL`, or the prefixed equivalents
+`MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` and
+`MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL`.
 
 ## API Reference
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,8 @@ The first three knobs adjust *ranking and rendering* — they take effect immedi
 | `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | string | auto-detect | Embedding provider: `openai`, `ollama`, or `fastembed`. **Breaking change** from `EMBEDDING_PROVIDER` in older versions |
 | `OLLAMA_HOST` | url | `http://localhost:11434` | Ollama server URL. **Not** `MARKDOWN_VAULT_MCP_`-prefixed |
 | `OPENAI_API_KEY` | string | — | OpenAI API key for the OpenAI embedding provider. **Not** `MARKDOWN_VAULT_MCP_`-prefixed |
+| `MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` / `OPENAI_BASE_URL` | url | `https://api.openai.com/v1` | OpenAI-compatible API base URL for embeddings |
+| `MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL` / `OPENAI_EMBEDDING_MODEL` | string | `text-embedding-3-small` | OpenAI-compatible embedding model name |
 | `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` | string | `nomic-embed-text` | Ollama embedding model name |
 | `MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY` | bool | `false` | Force Ollama to use CPU only |
 | `MARKDOWN_VAULT_MCP_FASTEMBED_MODEL` | string | `BAAI/bge-small-en-v1.5` | FastEmbed model name |

--- a/docs/design.md
+++ b/docs/design.md
@@ -1379,6 +1379,8 @@ For MCP server deployment:
 | `MARKDOWN_VAULT_MCP_FASTEMBED_MODEL` | FastEmbed model | `BAAI/bge-small-en-v1.5` |
 | `MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR` | FastEmbed model cache directory | FastEmbed default |
 | `OPENAI_API_KEY` | OpenAI API key | none |
+| `OPENAI_BASE_URL` / `MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` | OpenAI-compatible API base URL (SiliconFlow, Together, internal gateways, …) | `https://api.openai.com/v1` |
+| `OPENAI_EMBEDDING_MODEL` / `MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL` | OpenAI-compatible embedding model name | `text-embedding-3-small` |
 
 #### Example Configurations
 

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -172,8 +172,18 @@ OPENAI_API_KEY=sk-your-api-key-here
 MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH=/path/to/store/embeddings
 ```
 
+For OpenAI-compatible providers, override the base URL and model:
+
+```bash
+MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai
+OPENAI_API_KEY=your-provider-api-key
+OPENAI_BASE_URL=https://api.siliconflow.cn/v1
+OPENAI_EMBEDDING_MODEL=BAAI/bge-m3
+MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH=/path/to/store/embeddings
+```
+
 !!! warning "Privacy"
-    Document content (titles, headings, body text) is sent to OpenAI for embedding. Do not use this provider if your vault contains sensitive data you don't want to share with OpenAI. Use Ollama or FastEmbed for fully local, private embeddings.
+    Document content (titles, headings, body text) is sent to the configured OpenAI-compatible provider for embedding. Do not use this provider if your vault contains sensitive data you don't want to share with that provider. Use Ollama or FastEmbed for fully local, private embeddings.
 
 !!! tip "Cost"
     OpenAI embeddings are inexpensive. `text-embedding-3-small` costs $0.02 per million tokens. A vault of 1,000 notes (~500K tokens) costs about $0.01 to embed. Reindexing only processes changed documents.

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -198,6 +198,15 @@ curl https://api.openai.com/v1/embeddings \
   -d '{"input": "test", "model": "text-embedding-3-small"}'
 ```
 
+For OpenAI-compatible providers:
+
+```bash
+curl "$OPENAI_BASE_URL/embeddings" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": \"test\", \"model\": \"$OPENAI_EMBEDDING_MODEL\"}"
+```
+
 You should get a JSON response with an embedding array. After starting the server, test hybrid search:
 
 > Search for "project ideas" using hybrid mode

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -101,6 +101,14 @@ MARKDOWN_VAULT_MCP_INDEX_PATH=/var/lib/markdown-vault-mcp/index.db
 # OpenAI API key (required when MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai or auto-detection).
 #OPENAI_API_KEY=
 
+# OpenAI-compatible API base URL. Override to point at SiliconFlow, Together, OpenRouter, or
+# an internal gateway. (default: https://api.openai.com/v1)
+#OPENAI_BASE_URL=https://api.openai.com/v1
+
+# OpenAI-compatible embedding model name. Must be valid for the configured OPENAI_BASE_URL.
+# (default: text-embedding-3-small — valid against api.openai.com)
+#OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+
 # Ollama server URL. (default: http://localhost:11434)
 #OLLAMA_HOST=http://localhost:11434
 

--- a/packaging/mcpb/manifest.json.in
+++ b/packaging/mcpb/manifest.json.in
@@ -35,6 +35,8 @@
         "MARKDOWN_VAULT_MCP_OLLAMA_MODEL":     "${user_config.ollama_model}",
         "MARKDOWN_VAULT_MCP_FASTEMBED_MODEL":  "${user_config.fastembed_model}",
         "OPENAI_API_KEY":                      "${user_config.openai_api_key}",
+        "OPENAI_BASE_URL":                     "${user_config.openai_base_url}",
+        "OPENAI_EMBEDDING_MODEL":              "${user_config.openai_embedding_model}",
         "MARKDOWN_VAULT_MCP_GIT_REPO_URL":     "${user_config.git_repo_url}",
         "MARKDOWN_VAULT_MCP_GIT_TOKEN":        "${user_config.git_token}",
         "MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S": "${user_config.git_push_delay_s}",
@@ -138,6 +140,20 @@
       "description": "Only used when embedding_provider=openai. Stored in the OS keychain.",
       "required": false,
       "sensitive": true
+    },
+    "openai_base_url": {
+      "type": "string",
+      "title": "OpenAI-compatible API base URL",
+      "description": "Override to point at SiliconFlow, Together, OpenRouter, or an internal gateway. Only used when embedding_provider=openai.",
+      "required": false,
+      "default": "https://api.openai.com/v1"
+    },
+    "openai_embedding_model": {
+      "type": "string",
+      "title": "OpenAI-compatible embedding model",
+      "description": "Embedding model name. Must be valid for the configured OpenAI base URL. Only used when embedding_provider=openai.",
+      "required": false,
+      "default": "text-embedding-3-small"
     },
     "git_repo_url": {
       "type": "string",

--- a/server.json
+++ b/server.json
@@ -95,6 +95,16 @@
           "isSecret": true
         },
         {
+          "name": "OPENAI_BASE_URL",
+          "description": "OpenAI-compatible API base URL (e.g. SiliconFlow, Together, internal gateways); also accepts MARKDOWN_VAULT_MCP_OPENAI_BASE_URL",
+          "default": "https://api.openai.com/v1"
+        },
+        {
+          "name": "OPENAI_EMBEDDING_MODEL",
+          "description": "OpenAI-compatible embedding model name; also accepts MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL",
+          "default": "text-embedding-3-small"
+        },
+        {
           "name": "MARKDOWN_VAULT_MCP_OLLAMA_MODEL",
           "description": "Ollama embedding model name",
           "default": "nomic-embed-text"
@@ -315,6 +325,16 @@
           "name": "OPENAI_API_KEY",
           "description": "OpenAI API key (required when MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai)",
           "isSecret": true
+        },
+        {
+          "name": "OPENAI_BASE_URL",
+          "description": "OpenAI-compatible API base URL (e.g. SiliconFlow, Together, internal gateways); also accepts MARKDOWN_VAULT_MCP_OPENAI_BASE_URL",
+          "default": "https://api.openai.com/v1"
+        },
+        {
+          "name": "OPENAI_EMBEDDING_MODEL",
+          "description": "OpenAI-compatible embedding model name; also accepts MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL",
+          "default": "text-embedding-3-small"
         },
         {
           "name": "MARKDOWN_VAULT_MCP_OLLAMA_MODEL",

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -733,19 +733,15 @@ def load_config() -> CollectionConfig:
     raw_openai_base_url = (
         _env("OPENAI_BASE_URL") or os.environ.get("OPENAI_BASE_URL") or ""
     ).strip()
-    openai_base_url: str = (
-        raw_openai_base_url or "https://api.openai.com/v1"
-    ).rstrip("/")
+    openai_base_url: str = (raw_openai_base_url or "https://api.openai.com/v1").rstrip(
+        "/"
+    )
     logger.debug("load_config: openai_base_url=%s", openai_base_url)
 
     raw_openai_embedding_model = (
-        _env("OPENAI_EMBEDDING_MODEL")
-        or os.environ.get("OPENAI_EMBEDDING_MODEL")
-        or ""
+        _env("OPENAI_EMBEDDING_MODEL") or os.environ.get("OPENAI_EMBEDDING_MODEL") or ""
     ).strip()
-    openai_embedding_model: str = (
-        raw_openai_embedding_model or "text-embedding-3-small"
-    )
+    openai_embedding_model: str = raw_openai_embedding_model or "text-embedding-3-small"
     logger.debug("load_config: openai_embedding_model=%s", openai_embedding_model)
 
     raw_fastembed_model = (_env("FASTEMBED_MODEL") or "").strip()

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -142,6 +142,12 @@ class CollectionConfig:
             Ollama (default ``False``).
         openai_api_key: OpenAI API key for embeddings (logged as set/not
             set).
+        openai_base_url: OpenAI-compatible API base URL for embeddings
+            (default ``"https://api.openai.com/v1"``).  This can point to
+            providers such as SiliconFlow that expose the OpenAI embeddings
+            API shape.
+        openai_embedding_model: OpenAI-compatible embedding model name
+            (default ``"text-embedding-3-small"``).
         fastembed_model: FastEmbed model name (default
             ``"BAAI/bge-small-en-v1.5"``).
         fastembed_cache_dir: Directory for FastEmbed model cache.  ``None``
@@ -205,6 +211,8 @@ class CollectionConfig:
     ollama_model: str = "nomic-embed-text"
     ollama_cpu_only: bool = False
     openai_api_key: str | None = None
+    openai_base_url: str = "https://api.openai.com/v1"
+    openai_embedding_model: str = "text-embedding-3-small"
     fastembed_model: str = "BAAI/bge-small-en-v1.5"
     fastembed_cache_dir: str | None = None
 
@@ -429,6 +437,11 @@ def load_config() -> CollectionConfig:
     - ``MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY``: CPU-only Ollama inference;
       default ``false``.
     - ``OPENAI_API_KEY``: OpenAI API key (ecosystem standard, bare env var).
+    - ``MARKDOWN_VAULT_MCP_OPENAI_BASE_URL`` or ``OPENAI_BASE_URL``:
+      OpenAI-compatible API base URL; default ``"https://api.openai.com/v1"``.
+    - ``MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL`` or
+      ``OPENAI_EMBEDDING_MODEL``: embedding model name; default
+      ``"text-embedding-3-small"``.
     - ``MARKDOWN_VAULT_MCP_FASTEMBED_MODEL``: FastEmbed model name; default
       ``"BAAI/bge-small-en-v1.5"``.
     - ``MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR``: FastEmbed model cache
@@ -717,6 +730,24 @@ def load_config() -> CollectionConfig:
         "load_config: openai_api_key=%s", "set" if openai_api_key else "not set"
     )
 
+    raw_openai_base_url = (
+        _env("OPENAI_BASE_URL") or os.environ.get("OPENAI_BASE_URL") or ""
+    ).strip()
+    openai_base_url: str = (
+        raw_openai_base_url or "https://api.openai.com/v1"
+    ).rstrip("/")
+    logger.debug("load_config: openai_base_url=%s", openai_base_url)
+
+    raw_openai_embedding_model = (
+        _env("OPENAI_EMBEDDING_MODEL")
+        or os.environ.get("OPENAI_EMBEDDING_MODEL")
+        or ""
+    ).strip()
+    openai_embedding_model: str = (
+        raw_openai_embedding_model or "text-embedding-3-small"
+    )
+    logger.debug("load_config: openai_embedding_model=%s", openai_embedding_model)
+
     raw_fastembed_model = (_env("FASTEMBED_MODEL") or "").strip()
     fastembed_model: str = raw_fastembed_model or "BAAI/bge-small-en-v1.5"
     logger.debug("load_config: fastembed_model=%s", fastembed_model)
@@ -834,6 +865,8 @@ def load_config() -> CollectionConfig:
         ollama_model=ollama_model,
         ollama_cpu_only=ollama_cpu_only,
         openai_api_key=openai_api_key,
+        openai_base_url=openai_base_url,
+        openai_embedding_model=openai_embedding_model,
         fastembed_model=fastembed_model,
         fastembed_cache_dir=fastembed_cache_dir,
         chunks_per_file=chunks_per_file,

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -173,22 +173,30 @@ class OllamaProvider(EmbeddingProvider):
 
 
 class OpenAIProvider(EmbeddingProvider):
-    """Embedding provider backed by the OpenAI Embeddings API.
+    """Embedding provider backed by the OpenAI-compatible Embeddings API.
 
     Args:
         api_key: OpenAI API key for authentication.
-
-    Uses the ``text-embedding-3-small`` model.
+        base_url: Base URL for an OpenAI-compatible API.
+        model: Embedding model name.
     """
 
     _MODEL = "text-embedding-3-small"
-    _ENDPOINT = "https://api.openai.com/v1/embeddings"
+    _BASE_URL = "https://api.openai.com/v1"
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = _BASE_URL,
+        model: str = _MODEL,
+    ) -> None:
         """Initialise OpenAIProvider with an explicit API key.
 
         Args:
             api_key: OpenAI API key for authentication.
+            base_url: Base URL for an OpenAI-compatible API.
+            model: Embedding model name.
 
         Raises:
             ImportError: If ``httpx`` is not installed.
@@ -206,9 +214,16 @@ class OpenAIProvider(EmbeddingProvider):
         if not api_key:
             raise RuntimeError("OpenAIProvider requires a non-empty api_key.")
         self._api_key = api_key
+        self._base_url = (base_url or self._BASE_URL).rstrip("/")
+        self._endpoint = f"{self._base_url}/embeddings"
+        self._model = model or self._MODEL
         self._dimension: int | None = None
 
-        logger.debug("OpenAIProvider initialised: model=%s", self._MODEL)
+        logger.debug(
+            "OpenAIProvider initialised: base_url=%s model=%s",
+            self._base_url,
+            self._model,
+        )
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed a batch of texts via the OpenAI Embeddings API.
@@ -222,19 +237,19 @@ class OpenAIProvider(EmbeddingProvider):
         Raises:
             RuntimeError: If the OpenAI API returns an error response.
         """
-        payload = {"input": texts, "model": self._MODEL}
+        payload = {"input": texts, "model": self._model}
         headers = {
             "Authorization": f"Bearer {self._api_key}",
             "Content-Type": "application/json",
         }
 
         logger.debug(
-            "POST %s model=%s texts=%d", self._ENDPOINT, self._MODEL, len(texts)
+            "POST %s model=%s texts=%d", self._endpoint, self._model, len(texts)
         )
 
         with self._httpx.Client() as client:
             response = client.post(
-                self._ENDPOINT, json=payload, headers=headers, timeout=30.0
+                self._endpoint, json=payload, headers=headers, timeout=30.0
             )
 
         if response.status_code != 200:
@@ -277,7 +292,7 @@ class OpenAIProvider(EmbeddingProvider):
 
     @property
     def model_name(self) -> str:
-        return self._MODEL
+        return self._model
 
 
 class FastEmbedProvider(EmbeddingProvider):
@@ -396,7 +411,11 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
 
     if explicit == "openai":
         logger.info("Using OpenAIProvider (embedding_provider=openai)")
-        return OpenAIProvider(api_key=config.openai_api_key or "")
+        return OpenAIProvider(
+            api_key=config.openai_api_key or "",
+            base_url=config.openai_base_url,
+            model=config.openai_embedding_model,
+        )
 
     if explicit == "ollama":
         logger.info("Using OllamaProvider (embedding_provider=ollama)")
@@ -425,7 +444,11 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
     # Auto-detect: OpenAI API key present?
     if config.openai_api_key:
         logger.info("Auto-detected OpenAIProvider (openai_api_key is set)")
-        return OpenAIProvider(api_key=config.openai_api_key)
+        return OpenAIProvider(
+            api_key=config.openai_api_key,
+            base_url=config.openai_base_url,
+            model=config.openai_embedding_model,
+        )
 
     # Auto-detect: Ollama reachable?
     host = config.ollama_host.rstrip("/")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -589,6 +589,8 @@ class TestCollectionConfigDefaults:
         assert config.ollama_model == "nomic-embed-text"
         assert config.ollama_cpu_only is False
         assert config.openai_api_key is None
+        assert config.openai_base_url == "https://api.openai.com/v1"
+        assert config.openai_embedding_model == "text-embedding-3-small"
         assert config.fastembed_model == "BAAI/bge-small-en-v1.5"
         assert config.fastembed_cache_dir is None
 
@@ -613,6 +615,8 @@ class TestCollectionConfigDefaults:
             ollama_model="mxbai-embed-large",
             ollama_cpu_only=True,
             openai_api_key="sk-test",
+            openai_base_url="https://api.siliconflow.cn/v1",
+            openai_embedding_model="BAAI/bge-m3",
             fastembed_model="BAAI/bge-base-en-v1.5",
             fastembed_cache_dir="/tmp/cache",
         )
@@ -629,6 +633,8 @@ class TestCollectionConfigDefaults:
         assert config.ollama_model == "mxbai-embed-large"
         assert config.ollama_cpu_only is True
         assert config.openai_api_key == "sk-test"
+        assert config.openai_base_url == "https://api.siliconflow.cn/v1"
+        assert config.openai_embedding_model == "BAAI/bge-m3"
         assert config.fastembed_model == "BAAI/bge-base-en-v1.5"
         assert config.fastembed_cache_dir == "/tmp/cache"
 
@@ -835,6 +841,65 @@ class TestLoadConfigEmbeddingFields:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         config = load_config()
         assert config.openai_api_key is None
+
+    def test_openai_base_url_prefixed_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() reads MARKDOWN_VAULT_MCP_OPENAI_BASE_URL."""
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_OPENAI_BASE_URL",
+            "https://api.siliconflow.cn/v1/",
+        )
+        config = load_config()
+        assert config.openai_base_url == "https://api.siliconflow.cn/v1"
+
+    def test_openai_base_url_bare_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() reads OPENAI_BASE_URL when the prefixed var is absent."""
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_BASE_URL", raising=False)
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://api.compat.example/v1")
+        config = load_config()
+        assert config.openai_base_url == "https://api.compat.example/v1"
+
+    def test_openai_base_url_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() defaults openai_base_url to the OpenAI API base URL."""
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        config = load_config()
+        assert config.openai_base_url == "https://api.openai.com/v1"
+
+    def test_openai_embedding_model_prefixed_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() reads MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL."""
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", "BAAI/bge-m3")
+        config = load_config()
+        assert config.openai_embedding_model == "BAAI/bge-m3"
+
+    def test_openai_embedding_model_bare_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() reads OPENAI_EMBEDDING_MODEL when prefixed var is absent."""
+        monkeypatch.delenv(
+            "MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", raising=False
+        )
+        monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
+        config = load_config()
+        assert config.openai_embedding_model == "text-embedding-3-large"
+
+    def test_openai_embedding_model_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() defaults openai_embedding_model to text-embedding-3-small."""
+        monkeypatch.delenv(
+            "MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", raising=False
+        )
+        monkeypatch.delenv("OPENAI_EMBEDDING_MODEL", raising=False)
+        config = load_config()
+        assert config.openai_embedding_model == "text-embedding-3-small"
 
     def test_fastembed_model_prefixed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() reads MARKDOWN_VAULT_MCP_FASTEMBED_MODEL."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -874,9 +874,7 @@ class TestLoadConfigEmbeddingFields:
         config = load_config()
         assert config.openai_base_url == "https://api.prefixed.example/v1"
 
-    def test_openai_base_url_default(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_openai_base_url_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() defaults openai_base_url to the OpenAI API base URL."""
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_BASE_URL", raising=False)
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
@@ -895,9 +893,7 @@ class TestLoadConfigEmbeddingFields:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """load_config() reads OPENAI_EMBEDDING_MODEL when prefixed var is absent."""
-        monkeypatch.delenv(
-            "MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", raising=False
-        )
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", raising=False)
         monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
         config = load_config()
         assert config.openai_embedding_model == "text-embedding-3-large"
@@ -918,9 +914,7 @@ class TestLoadConfigEmbeddingFields:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """load_config() defaults openai_embedding_model to text-embedding-3-small."""
-        monkeypatch.delenv(
-            "MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", raising=False
-        )
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", raising=False)
         monkeypatch.delenv("OPENAI_EMBEDDING_MODEL", raising=False)
         config = load_config()
         assert config.openai_embedding_model == "text-embedding-3-small"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -862,6 +862,18 @@ class TestLoadConfigEmbeddingFields:
         config = load_config()
         assert config.openai_base_url == "https://api.compat.example/v1"
 
+    def test_openai_base_url_prefixed_env_var_wins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() prefers prefixed base URL over OPENAI_BASE_URL."""
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_OPENAI_BASE_URL",
+            "https://api.prefixed.example/v1",
+        )
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://api.bare.example/v1")
+        config = load_config()
+        assert config.openai_base_url == "https://api.prefixed.example/v1"
+
     def test_openai_base_url_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -889,6 +901,18 @@ class TestLoadConfigEmbeddingFields:
         monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
         config = load_config()
         assert config.openai_embedding_model == "text-embedding-3-large"
+
+    def test_openai_embedding_model_prefixed_env_var_wins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() prefers prefixed model over OPENAI_EMBEDDING_MODEL."""
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL",
+            "prefixed-embedding-model",
+        )
+        monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "bare-embedding-model")
+        config = load_config()
+        assert config.openai_embedding_model == "prefixed-embedding-model"
 
     def test_openai_embedding_model_default(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -258,6 +258,25 @@ class TestOpenAIProvider:
         url = call_args[0][0] if call_args[0] else call_args[1]["url"]
         assert url == "https://api.openai.com/v1/embeddings"
 
+    def test_custom_base_url_and_model(self) -> None:
+        mock_client, _ = _make_httpx_mock(
+            json_body={"data": [{"index": 0, "embedding": [0.1]}]}
+        )
+        with patch("httpx.Client", return_value=mock_client):
+            provider = OpenAIProvider(
+                api_key="sk-test",
+                base_url="https://api.siliconflow.cn/v1/",
+                model="BAAI/bge-m3",
+            )
+            provider.embed(["hello"])
+
+        call_args = mock_client.post.call_args
+        url = call_args[0][0] if call_args[0] else call_args[1]["url"]
+        assert url == "https://api.siliconflow.cn/v1/embeddings"
+        _, call_kwargs = mock_client.post.call_args
+        assert call_kwargs["json"]["model"] == "BAAI/bge-m3"
+        assert provider.model_name == "BAAI/bge-m3"
+
 
 class TestFastEmbedProvider:
     def test_embed_uses_fastembed_model_and_cache(self) -> None:
@@ -324,10 +343,16 @@ class TestGetEmbeddingProvider:
         return mock_client
 
     def test_explicit_openai_returns_openai_provider(self) -> None:
-        cfg = _config(embedding_provider="openai", openai_api_key="sk-test")
+        cfg = _config(
+            embedding_provider="openai",
+            openai_api_key="sk-test",
+            openai_base_url="https://api.siliconflow.cn/v1",
+            openai_embedding_model="BAAI/bge-m3",
+        )
         with patch("httpx.Client"):
             provider = get_embedding_provider(cfg)
         assert isinstance(provider, OpenAIProvider)
+        assert provider.model_name == "BAAI/bge-m3"
 
     def test_explicit_ollama_returns_ollama_provider(self) -> None:
         cfg = _config(embedding_provider="ollama")


### PR DESCRIPTION
## Summary

This PR adds configurable OpenAI-compatible embeddings support while preserving the existing OpenAI defaults. It allows users to point the `openai` embedding provider at providers that implement the OpenAI embeddings API shape, such as SiliconFlow or internal OpenAI-compatible gateways.

Changes included:
- add `openai_base_url` and `openai_embedding_model` to `CollectionConfig`
- read `MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` / `OPENAI_BASE_URL`
- read `MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL` / `OPENAI_EMBEDDING_MODEL`
- pass the configured base URL and model into `OpenAIProvider`
- keep existing defaults: `https://api.openai.com/v1` and `text-embedding-3-small`
- update README/docs for the new configuration variables
- add tests for defaults, env loading, provider behavior, and prefixed-env precedence

## Why

The current `OpenAIProvider` uses a fixed embeddings endpoint and model. That works for OpenAI directly, but prevents users from using OpenAI-compatible embedding services without patching installed package files. This makes semantic search brittle when the package is installed via tools like `uvx`, because temporary local patches are lost across new environments.

## Validation

- `uv run --extra embeddings-api pytest tests/test_providers.py tests/test_config.py`
- `uv run ruff check src/markdown_vault_mcp/providers.py src/markdown_vault_mcp/config.py tests/test_providers.py tests/test_config.py`
- `uv run --group docs mkdocs build --strict`

The docs build reports existing informational messages about unrelated guide links, but exits successfully.

## Compatibility

Existing OpenAI users do not need to change any configuration. If no new variables are set, the provider still uses `https://api.openai.com/v1/embeddings` with `text-embedding-3-small`.
