### PR TITLE
Avoid eager embedding build during MCP startup

### DIFF
--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -111,7 +111,8 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # Build embeddings eagerly only when a vector sidecar already exists.
         # Initial corpus embedding can take minutes or hours and must not block
         # the MCP initialize handshake; use the explicit indexing command/tool.
-        if kwargs.get("embedding_provider") is not None:
+        embeddings_path = kwargs.get("embeddings_path")
+        if kwargs.get("embedding_provider") is not None and embeddings_path is not None:
             if collection.has_embedding_index_sidecar():
                 chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
                 logger.info("Embeddings ready: %d chunks", chunks_embedded)
@@ -119,7 +120,7 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
                 logger.info(
                     "Skipping eager embedding build because %s.npy is missing; "
                     "run the indexing command/tool to build vectors offline",
-                    kwargs.get("embeddings_path"),
+                    embeddings_path,
                 )
 
         # Start background tasks (e.g. git pull loop) after index is built.

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -108,12 +108,19 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
             stats.chunks_indexed,
         )
 
-        # Build embeddings eagerly when an embedding provider is configured.
-        # build_embeddings() skips work if the vector index already exists on disk,
-        # so this is safe to call on every startup.
+        # Build embeddings eagerly only when a vector sidecar already exists.
+        # Initial corpus embedding can take minutes or hours and must not block
+        # the MCP initialize handshake; use the explicit indexing command/tool.
         if kwargs.get("embedding_provider") is not None:
-            chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
-            logger.info("Embeddings ready: %d chunks", chunks_embedded)
+            if collection.has_embedding_index_sidecar():
+                chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
+                logger.info("Embeddings ready: %d chunks", chunks_embedded)
+            else:
+                logger.info(
+                    "Skipping eager embedding build because %s.npy is missing; "
+                    "run the indexing command/tool to build vectors offline",
+                    kwargs.get("embeddings_path"),
+                )
 
         # Start background tasks (e.g. git pull loop) after index is built.
         collection.start()

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -11,6 +11,7 @@ import logging
 import queue
 import re
 import threading
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from markdown_vault_mcp.fts_index import FTSIndex
@@ -46,7 +47,6 @@ from markdown_vault_mcp.utils import effective_attachment_extensions
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
     from markdown_vault_mcp.git import GitWriteStrategy
     from markdown_vault_mcp.providers import EmbeddingProvider
@@ -195,8 +195,9 @@ class Collection:
         )
         self._tracker = ChangeTracker(self._state_path)
 
-        # Lazy initialisation flag.
-        self._initialized = False
+        # Lazy initialisation flag.  Persistent indexes can already contain
+        # documents when a new process starts, so seed the flag from the DB.
+        self._initialized = self._persistent_index_has_documents()
 
         # Serialise concurrent write operations on this instance.
         # Re-entrant: periodic pull tick blocks writes, then reindex() acquires
@@ -357,6 +358,30 @@ class Collection:
         if not self._initialized:
             self.build_index()
 
+    def _persistent_index_has_documents(self) -> bool:
+        """Return whether the configured on-disk index already has documents."""
+        if self._index_path is None:
+            return False
+        try:
+            row = self._fts._conn.execute(
+                "SELECT 1 FROM documents LIMIT 1"
+            ).fetchone()
+        except Exception:
+            logger.debug(
+                "Could not probe existing FTS index; falling back to startup scan",
+                exc_info=True,
+            )
+            return False
+        if row is not None:
+            logger.debug("build_index: persistent index already contains documents")
+            return True
+        return False
+
+    def _indexed_document_count(self) -> int:
+        """Return the number of documents currently stored in the FTS index."""
+        row = self._fts._conn.execute("SELECT COUNT(*) FROM documents").fetchone()
+        return int(row[0]) if row is not None else 0
+
     @property
     def _vectors(self) -> VectorIndex | None:
         """Bridge property: vector index is owned by SearchManager."""
@@ -487,14 +512,14 @@ class Collection:
         """
         # Check if index already has data and we are not forcing.
         if not force and self._initialized:
-            existing = self._fts.list_notes()
-            if existing:
+            existing_count = self._indexed_document_count()
+            if existing_count > 0:
                 logger.debug(
                     "build_index: index already populated (%d docs), skipping",
-                    len(existing),
+                    existing_count,
                 )
                 return IndexStats(
-                    documents_indexed=len(existing),
+                    documents_indexed=existing_count,
                     chunks_indexed=0,
                     skipped=0,
                 )
@@ -529,6 +554,12 @@ class Collection:
         """
         self._ensure_initialized()
         return self._index_mgr.build_embeddings(force=force)
+
+    def has_embedding_index_sidecar(self) -> bool:
+        """Return whether the vector index sidecar exists on disk."""
+        if self._embeddings_path is None:
+            return False
+        return Path(str(self._embeddings_path) + ".npy").exists()
 
     def embeddings_status(self) -> dict:
         """Return status information about the vector index.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -380,7 +380,7 @@ class Collection:
     def _indexed_document_count(self) -> int:
         """Return the number of documents currently stored in the FTS index."""
         row = self._fts._conn.execute("SELECT COUNT(*) FROM documents").fetchone()
-        return int(row[0]) if row is not None else 0
+        return int(row[0])
 
     @property
     def _vectors(self) -> VectorIndex | None:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3004,7 +3004,14 @@ class TestBuildIndexNoOp:
             scan_calls.append(args)
             return original_scan(*args, **kwargs)
 
-        with patch.object(idx_mod, "scan_directory", side_effect=tracking_scan):
+        with (
+            patch.object(idx_mod, "scan_directory", side_effect=tracking_scan),
+            patch.object(
+                col._fts,
+                "list_notes",
+                side_effect=AssertionError("no-op path must not materialize rows"),
+            ),
+        ):
             stats2 = col.build_index()
 
         # scan_directory must not have been invoked on the second call.
@@ -3012,6 +3019,62 @@ class TestBuildIndexNoOp:
         # Returned stats reflect the existing index content.
         assert stats2.documents_indexed == 9
         assert stats2.chunks_indexed == 0
+
+    def test_persistent_index_is_noop_on_new_collection(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """A new process skips scanning when the persistent index has documents."""
+        index_path = tmp_path / "index.db"
+
+        col1 = _make_collection(
+            vault_path,
+            index_path=index_path,
+            state_path=tmp_path / "state1.json",
+        )
+        col1.build_index()
+        col1.close()
+
+        col2 = _make_collection(
+            vault_path,
+            index_path=index_path,
+            state_path=tmp_path / "state2.json",
+        )
+
+        import markdown_vault_mcp.managers.index as idx_mod
+
+        with (
+            patch.object(
+                idx_mod,
+                "scan_directory",
+                side_effect=AssertionError("persistent fast path must not scan"),
+            ),
+            patch.object(
+                col2._fts,
+                "list_notes",
+                side_effect=AssertionError("fast path must use COUNT(*)"),
+            ),
+        ):
+            stats = col2.build_index()
+
+        assert stats.documents_indexed == 9
+        assert stats.chunks_indexed == 0
+        col2.close()
+
+    def test_has_embedding_index_sidecar(
+        self, vault_path: Path, tmp_path: Path, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        """Vector sidecar detection is based on the persisted .npy file."""
+        embeddings_path = tmp_path / "embeddings"
+        col = _make_collection(
+            vault_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=mock_provider,
+        )
+
+        assert col.has_embedding_index_sidecar() is False
+        col.build_index()
+        col.build_embeddings()
+        assert col.has_embedding_index_sidecar() is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_deps.py
+++ b/tests/test_server_deps.py
@@ -109,6 +109,62 @@ class TestCollectionLifespan:
             await agen.aclose()
 
     @pytest.mark.asyncio
+    async def test_startup_skips_embedding_sidecar_probe_without_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A provider without embeddings_path disables semantic startup work."""
+        instances: list[FakeCollection] = []
+
+        class FakeCollection:
+            def __init__(self, **kwargs: Any) -> None:
+                self.kwargs = kwargs
+                self.sidecar_checked = 0
+                self.embeddings_built = 0
+                instances.append(self)
+
+            def sync_from_remote_before_index(self) -> None:
+                pass
+
+            def build_index(self) -> IndexStats:
+                return IndexStats(documents_indexed=1, chunks_indexed=1, skipped=0)
+
+            def has_embedding_index_sidecar(self) -> bool:
+                self.sidecar_checked += 1
+                return False
+
+            def build_embeddings(self) -> int:
+                self.embeddings_built += 1
+                return 1
+
+            def start(self) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        class FakeConfig:
+            source_dir = tmp_path
+
+            def to_collection_kwargs(self) -> dict[str, Any]:
+                return {
+                    "source_dir": tmp_path,
+                    "embedding_provider": object(),
+                    "embeddings_path": None,
+                }
+
+        import markdown_vault_mcp._server_deps as _deps_module
+
+        monkeypatch.setattr(_deps_module, "Collection", FakeCollection)
+        lifespan = make_collection_lifespan(FakeConfig())
+        agen = lifespan._fn(None)
+        try:
+            await agen.__anext__()
+            assert instances[0].sidecar_checked == 0
+            assert instances[0].embeddings_built == 0
+        finally:
+            await agen.aclose()
+
+    @pytest.mark.asyncio
     async def test_startup_builds_embeddings_when_sidecar_exists(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/test_server_deps.py
+++ b/tests/test_server_deps.py
@@ -13,12 +13,15 @@ import pytest
 
 from markdown_vault_mcp._server_deps import (
     get_collection_singleton,
+    make_collection_lifespan,
     set_collection_singleton,
 )
 from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.types import IndexStats
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Any
 
 
 class TestCollectionSingleton:
@@ -47,3 +50,113 @@ class TestCollectionSingleton:
             assert get_collection_singleton() is col
         finally:
             _deps_module._collection_singleton = saved
+
+
+class TestCollectionLifespan:
+    """Server startup keeps MCP handshake work bounded."""
+
+    @pytest.mark.asyncio
+    async def test_startup_skips_embedding_build_when_sidecar_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Configured embeddings do not trigger first corpus build at startup."""
+        instances: list[FakeCollection] = []
+
+        class FakeCollection:
+            def __init__(self, **kwargs: Any) -> None:
+                self.kwargs = kwargs
+                self.embeddings_built = 0
+                instances.append(self)
+
+            def sync_from_remote_before_index(self) -> None:
+                pass
+
+            def build_index(self) -> IndexStats:
+                return IndexStats(documents_indexed=1, chunks_indexed=1, skipped=0)
+
+            def has_embedding_index_sidecar(self) -> bool:
+                return False
+
+            def build_embeddings(self) -> int:
+                self.embeddings_built += 1
+                return 1
+
+            def start(self) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        class FakeConfig:
+            source_dir = tmp_path
+
+            def to_collection_kwargs(self) -> dict[str, Any]:
+                return {
+                    "source_dir": tmp_path,
+                    "embedding_provider": object(),
+                    "embeddings_path": tmp_path / "embeddings",
+                }
+
+        import markdown_vault_mcp._server_deps as _deps_module
+
+        monkeypatch.setattr(_deps_module, "Collection", FakeCollection)
+        lifespan = make_collection_lifespan(FakeConfig())
+        agen = lifespan._fn(None)
+        try:
+            await agen.__anext__()
+            assert instances[0].embeddings_built == 0
+        finally:
+            await agen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_startup_builds_embeddings_when_sidecar_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Existing vectors are loaded/refreshed at startup."""
+        instances: list[FakeCollection] = []
+
+        class FakeCollection:
+            def __init__(self, **kwargs: Any) -> None:
+                self.kwargs = kwargs
+                self.embeddings_built = 0
+                instances.append(self)
+
+            def sync_from_remote_before_index(self) -> None:
+                pass
+
+            def build_index(self) -> IndexStats:
+                return IndexStats(documents_indexed=1, chunks_indexed=1, skipped=0)
+
+            def has_embedding_index_sidecar(self) -> bool:
+                return True
+
+            def build_embeddings(self) -> int:
+                self.embeddings_built += 1
+                return 1
+
+            def start(self) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        class FakeConfig:
+            source_dir = tmp_path
+
+            def to_collection_kwargs(self) -> dict[str, Any]:
+                return {
+                    "source_dir": tmp_path,
+                    "embedding_provider": object(),
+                    "embeddings_path": tmp_path / "embeddings",
+                }
+
+        import markdown_vault_mcp._server_deps as _deps_module
+
+        monkeypatch.setattr(_deps_module, "Collection", FakeCollection)
+        lifespan = make_collection_lifespan(FakeConfig())
+        agen = lifespan._fn(None)
+        try:
+            await agen.__anext__()
+            assert instances[0].embeddings_built == 1
+        finally:
+            await agen.aclose()


### PR DESCRIPTION
## Summary
- seed Collection initialization from an existing persistent FTS DB so warm indexes skip startup scans after process restart
- use COUNT(*) for the build_index no-op path instead of materializing every note
- skip eager build_embeddings() during server lifespan when the vector .npy sidecar is absent, leaving first corpus embedding to explicit offline commands/tools

## Tests
- uv run --extra embeddings-api pytest tests/test_collection.py::TestBuildIndexNoOp tests/test_server_deps.py -q
- uv run ruff check src/markdown_vault_mcp/collection.py src/markdown_vault_mcp/_server_deps.py tests/test_collection.py tests/test_server_deps.py

Fixes #509