### PR TITLE
feat(server): non-blocking background indexing (closes #513)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `MARKDOWN_VAULT_MCP_STATE_PATH` | path | `{SOURCE_DIR}/.markdown_vault_mcp/state.json` | No | Path to the change-tracking state file |
 | `MARKDOWN_VAULT_MCP_INDEXED_FIELDS` | csv | — | No | Comma-separated frontmatter fields to promote to the tag index for structured filtering |
 | `MARKDOWN_VAULT_MCP_REQUIRED_FIELDS` | csv | — | No | Comma-separated frontmatter fields required on every document; documents missing any are excluded from the index |
-| `MARKDOWN_VAULT_MCP_EXCLUDE` | csv | — | No | Comma-separated glob patterns to exclude from scanning (e.g. `.obsidian/**,.trash/**`) |
+| `MARKDOWN_VAULT_MCP_EXCLUDE` | csv | — | No | Comma-separated glob patterns to exclude from scanning (e.g. `.obsidian/**,.trash/**`).  Changes take effect on the next background reindex (server start or periodic git pull); removed patterns may take longer to surface previously-excluded files than added patterns take to purge them |
 | `MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER` | string | `_templates` | No | Relative folder path used by the `create_from_template` prompt to discover/read template files |
 | `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | path | — | No | Path to a directory of `.md` prompt files that extend or override built-in prompts |
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -467,6 +467,19 @@ attachment write operations.
 `read()` validates the path inline rather than via `_validate_path()`: if the
 resolved path escapes `source_dir`, it returns `None` instead of raising.
 
+### Startup sequence (server lifespan)
+
+The MCP server lifespan delegates the slow parts of indexing to a background thread so the MCP handshake is never blocked:
+
+1. Construct `Collection` — probes the persistent FTS DB and seeds `_initialized`.
+2. `sync_from_remote_before_index()` — pull from the configured remote (if any).
+3. `collection.initialize_async()` — no-op probe so warm-start callers see the persistent state.
+4. `collection.schedule_background_reindex()` — spawns a daemon thread that runs `reindex()` then `build_embeddings()`.  Status visible via `get_index_status()` / `stats://vault`.
+5. `collection.start()` — begin periodic tasks (git pull loop, etc.).
+6. `yield` — MCP handshake is unblocked.
+
+The background thread holds `_write_lock` during its mutation phase, so concurrent write tool calls serialise naturally.  Foreground reads observe whatever FTS state is currently durable — partial results during the initial scan, full results once `Collection.build_index` finishes (the worker sets `_fts_done_event` between the FTS and embedding phases so foreground `_ensure_initialized` calls unblock as soon as FTS rows are queryable, even while embeddings are still building).  Shutdown signals the thread via `_index_shutdown` and joins with a 30s timeout; SQLite WAL handles any partial state on next startup.
+
 ### Lifecycle: Collection.close()
 
 `Collection.close()` must be called on shutdown to release resources:

--- a/docs/design.md
+++ b/docs/design.md
@@ -494,12 +494,14 @@ This ensures no work is lost on shutdown. The full lifecycle contract is:
 ```
 Collection(...)
   → sync_from_remote_before_index()   # git fetch + ff-only before first index
-  → build_index()                     # build FTS index
-  → build_embeddings()                # build vector index (when configured)
+  → initialize_async()                # warm-start probe (seeds _initialized from persistent FTS)
+  → schedule_background_reindex()     # spawn daemon thread for reindex() + build_embeddings()
   → start()                           # launch background pull loop
   → zero or more read/write operations
-  → close()                           # stop pull loop, flush git, release SQLite
+  → close()                           # signal background indexer, stop pull loop, flush git, release SQLite
 ```
+
+Direct library callers (CLI, tests, custom integrations) may still call `build_index()` and `build_embeddings()` synchronously instead of `schedule_background_reindex()` when they want to block until indexing completes.
 
 `stop()` may also be called independently to pause the pull loop without closing
 the collection (e.g. during maintenance or test teardown). It is a no-op if the

--- a/docs/design.md
+++ b/docs/design.md
@@ -478,7 +478,7 @@ The MCP server lifespan delegates the slow parts of indexing to a background thr
 5. `collection.start()` — begin periodic tasks (git pull loop, etc.).
 6. `yield` — MCP handshake is unblocked.
 
-The background thread holds `_write_lock` during its mutation phase, so concurrent write tool calls serialise naturally.  Foreground reads observe whatever FTS state is currently durable — partial results during the initial scan, full results once `Collection.build_index` finishes (the worker sets `_fts_done_event` between the FTS and embedding phases so foreground `_ensure_initialized` calls unblock as soon as FTS rows are queryable, even while embeddings are still building).  Shutdown signals the thread via `_index_shutdown` and joins with a 30s timeout; SQLite WAL handles any partial state on next startup.
+The background thread holds `_write_lock` during its mutation phase, so concurrent write tool calls serialise naturally.  Foreground reads observe whatever FTS state is currently durable — partial results during the initial scan, full results once the FTS phase of the background reindex (`Collection.reindex`) finishes (the worker sets `_fts_done_event` between the FTS and embedding phases so foreground `_ensure_initialized` calls unblock as soon as FTS rows are queryable, even while embeddings are still building).  Shutdown signals the thread via `_index_shutdown` and joins with a 30s timeout; SQLite WAL handles any partial state on next startup.
 
 ### Lifecycle: Collection.close()
 

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -278,9 +278,11 @@ You should see a commit from `markdown-vault-mcp`. Delete the test note when don
 - `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` — `fastembed`, `ollama`, or `openai`
 - `MARKDOWN_VAULT_MCP_FASTEMBED_MODEL` / `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` — which model to use
 
-### Pre-build embeddings before first launch
+### Pre-build embeddings before first launch (optional)
 
-For large vaults, building embeddings on first startup can take several minutes — long enough for Claude Desktop to time out the connection. Pre-build from the command line instead:
+For large vaults, the server can take a long time to build the initial FTS index and embeddings.  Since v1.29 this happens on a background thread, so the MCP handshake completes immediately and Claude Desktop attaches successfully — but search results will be partial until the background indexing finishes (visible via `stats://vault` → `index_status`).
+
+If you want the server fully indexed before first launch, pre-build from the command line:
 
 === "macOS / Linux"
 
@@ -306,10 +308,10 @@ For large vaults, building embeddings on first startup can take several minutes 
     markdown-vault-mcp reindex
     ```
 
-`reindex` builds (or updates) both the FTS index and the embedding vectors. Once complete, Claude Desktop will load the pre-built index on startup without needing to re-embed anything.
+`reindex` builds (or updates) both the FTS index and the embedding vectors.  Once complete, Claude Desktop will load the pre-built index on startup with no further background work needed.
 
 !!! note "Subsequent startups are fast"
-    After the initial build, only new or changed files are reindexed. You can run `reindex` again any time to catch up if you edited files outside Claude.
+    After the initial build, only changed files are reindexed in the background on each startup. You can run `reindex` again any time to catch up if you edited files outside Claude.
 
 ### Restart and verify
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -38,7 +38,7 @@ Current collection configuration and runtime state.
 
 ## `stats://vault`
 
-Collection statistics — document count, chunk count, and capabilities.
+Collection statistics — document count, chunk count, capabilities, and background-index state.
 
 **Response:**
 
@@ -49,9 +49,16 @@ Collection statistics — document count, chunk count, and capabilities.
   "folder_count": 5,
   "semantic_search_available": true,
   "indexed_frontmatter_fields": ["tags", "cluster"],
-  "attachment_extensions": ["pdf", "png", "jpg"]
+  "attachment_extensions": ["pdf", "png", "jpg"],
+  "index_status": {
+    "status": "indexing",
+    "indexed": 800,
+    "error": null
+  }
 }
 ```
+
+The `index_status` field reports the background reindexing thread's current state. `status` is one of `ready` (idle), `indexing` (FTS phase running), `embedding` (vector phase running), or `failed`. `indexed` is the current FTS document count (cheap `COUNT(*)`). `error` is the last failure message or `null`. This resource is non-blocking: during a cold-start indexing run the counts reflect whatever persistent FTS state currently exists (often `0`), so callers can poll `stats://vault` cheaply to track progress without waiting for the indexing thread to finish.
 
 ## `tags://vault`
 

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -96,26 +96,21 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         collection = Collection(**kwargs)
         set_collection_singleton(collection)
 
-        # If periodic git pull is enabled, sync before building the initial index so
-        # build_index() scans the freshest working tree.
+        # Sync the remote (if configured) so the background reindex thread
+        # sees the freshest working tree.
         await asyncio.to_thread(collection.sync_from_remote_before_index)
 
-        # Build index eagerly so first tool call is fast.
-        stats = await asyncio.to_thread(collection.build_index)
-        logger.info(
-            "Index built: %d documents, %d chunks",
-            stats.documents_indexed,
-            stats.chunks_indexed,
-        )
+        # Probe persistent state synchronously (sub-second, no filesystem
+        # scan) so warm-start callers see ``_initialized=True``.
+        collection.initialize_async()
 
-        # Build embeddings eagerly when an embedding provider is configured.
-        # build_embeddings() skips work if the vector index already exists on disk,
-        # so this is safe to call on every startup.
-        if kwargs.get("embedding_provider") is not None:
-            chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
-            logger.info("Embeddings ready: %d chunks", chunks_embedded)
+        # Schedule the background reindex daemon thread (#513). MCP
+        # ``initialize`` handshake is unblocked here even on cold-start
+        # large vaults; clients see partial FTS results until the thread
+        # finishes, and ``stats://vault`` exposes progress.
+        collection.schedule_background_reindex()
 
-        # Start background tasks (e.g. git pull loop) after index is built.
+        # Start background tasks (e.g. periodic git pull loop).
         collection.start()
 
         # Artifact store singleton is wired in make_server(), not here —

--- a/src/markdown_vault_mcp/_server_resources.py
+++ b/src/markdown_vault_mcp/_server_resources.py
@@ -76,9 +76,18 @@ def register_resources(mcp: FastMCP) -> None:
     async def vault_stats(
         collection: Collection = Depends(get_collection),
     ) -> str:
-        """Collection statistics — document count, chunk count, capabilities."""
+        """Collection statistics — document count, chunk count, capabilities.
+
+        The payload mirrors :class:`~markdown_vault_mcp.types.CollectionStats`
+        and adds an ``index_status`` field so operators can detect "server is
+        up but still indexing" without a second round-trip. ``index_status``
+        carries ``status`` / ``indexed`` / ``error`` per
+        :meth:`Collection.get_index_status`.
+        """
         result = await asyncio.to_thread(collection.stats)
-        return json.dumps(asdict(result))
+        payload = asdict(result)
+        payload["index_status"] = await asyncio.to_thread(collection.get_index_status)
+        return json.dumps(payload)
 
     @mcp.resource(
         "tags://vault", mime_type="application/json", icons=_TOOL_ICONS["list_tags"]

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -359,16 +359,21 @@ class Collection:
             :class:`IndexStatusPayload` with three keys:
 
             - ``status``: one of ``"ready"``, ``"indexing"``, ``"embedding"``,
-              ``"failed"``.
+                ``"failed"``.
             - ``indexed``: current FTS document count (cheap ``COUNT(*)``).
             - ``error``: the last failure message, or ``None``.
         """
+        # Only ``status`` and ``error`` are guarded by the status lock; the
+        # FTS ``COUNT(*)`` is a separate SQLite read and must not extend the
+        # critical section that background writers also contend on.
         with self._index_status_lock:
-            return {
-                "status": self._index_status,
-                "indexed": self._count_documents(),
-                "error": self._index_status_error,
-            }
+            status = self._index_status
+            error = self._index_status_error
+        return {
+            "status": status,
+            "indexed": self._count_documents(),
+            "error": error,
+        }
 
     def _set_index_status(
         self,
@@ -578,17 +583,17 @@ class Collection:
 
         Used to seed ``_initialized`` so warm-start lifespans don't trigger
         a full filesystem scan when a prior process already built the
-        persistent index.
+        persistent index.  Returns ``False`` on any SQLite error so the
+        startup path treats the DB as cold rather than crashing.
         """
         try:
-            row = self._fts._conn.execute("SELECT 1 FROM documents LIMIT 1").fetchone()
+            return self._fts.has_documents()
         except Exception:
             logger.debug(
                 "could not probe FTS DB for warm-start; assuming cold start",
                 exc_info=True,
             )
             return False
-        return row is not None
 
     def _count_documents(self) -> int:
         """Return ``COUNT(*)`` of rows in the FTS documents table.
@@ -600,11 +605,10 @@ class Collection:
         operator-useful during indexing (#513).
         """
         try:
-            row = self._fts._conn.execute("SELECT COUNT(*) FROM documents").fetchone()
+            return self._fts.count_documents()
         except Exception:
             logger.debug("could not count FTS documents", exc_info=True)
             return 0
-        return int(row[0])  # COUNT(*) always returns exactly one row
 
     def _purge_excluded_rows(self) -> int:
         """Delete FTS+vector rows whose paths match the configured exclude_patterns.
@@ -1221,8 +1225,11 @@ class Collection:
         # Deliberately do NOT call ``_ensure_initialized()`` here; the stats
         # resource must never block on the background indexing thread.
 
-        rows = self._fts.list_notes()
-        doc_count = len(rows)
+        # Use the dedicated ``COUNT(*)`` helper so this method stays
+        # consistent with ``get_index_status()['indexed']`` (both hit the
+        # same SQLite query) and avoids materialising every row just for a
+        # number (#515 review).
+        doc_count = self._fts.count_documents()
 
         # Chunk count via the public FTSIndex method.
         chunk_count = self._fts.count_chunks()

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -399,30 +399,31 @@ class Collection:
 
         from markdown_vault_mcp.utils import is_path_excluded
 
-        # Reuse SearchManager.vectors so an already-loaded vector index is
-        # mutated in place.  If embeddings are configured but not yet loaded,
-        # load now so we can purge the sidecar in lock-step with the FTS rows.
-        vectors = self._search_mgr.vectors
-        if (
-            vectors is None
-            and self._embedding_provider is not None
-            and self._embeddings_path is not None
-        ):
-            self._search_mgr._load_vectors()
+        with self._write_lock:
+            # Reuse SearchManager.vectors so an already-loaded vector index is
+            # mutated in place.  If embeddings are configured but not yet loaded,
+            # load now so we can purge the sidecar in lock-step with the FTS rows.
             vectors = self._search_mgr.vectors
+            if (
+                vectors is None
+                and self._embedding_provider is not None
+                and self._embeddings_path is not None
+            ):
+                self._search_mgr._load_vectors()
+                vectors = self._search_mgr.vectors
 
-        purged = 0
-        for row in self._fts.list_notes():
-            if is_path_excluded(row["path"], self._exclude_patterns):
-                self._fts.delete_by_path(row["path"])
-                if vectors is not None:
-                    vectors.delete_by_path(row["path"])
-                purged += 1
+            purged = 0
+            for row in self._fts.list_notes():
+                if is_path_excluded(row["path"], self._exclude_patterns):
+                    self._fts.delete_by_path(row["path"])
+                    if vectors is not None:
+                        vectors.delete_by_path(row["path"])
+                    purged += 1
 
-        if purged and vectors is not None and self._embeddings_path is not None:
-            vectors.save(self._embeddings_path)
+            if purged and vectors is not None and self._embeddings_path is not None:
+                vectors.save(self._embeddings_path)
 
-        return purged
+            return purged
 
     @property
     def _vectors(self) -> VectorIndex | None:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -273,6 +273,20 @@ class Collection:
         self._callback_worker: threading.Thread | None = None
         self._callback_worker_lock = threading.Lock()
 
+        # Background reindex state (#513). The reindex daemon thread reads
+        # and writes ``_index_status`` / ``_index_status_error`` under
+        # ``_index_status_lock``; ``_index_done_event`` lets callers
+        # (tests, ``close()``) wait deterministically for completion.
+        self._index_status: Literal["ready", "indexing", "embedding", "failed"] = (
+            "ready"
+        )
+        self._index_status_error: str | None = None
+        self._index_status_lock = threading.Lock()
+        self._background_index_thread: threading.Thread | None = None
+        self._index_done_event = threading.Event()
+        self._index_done_event.set()  # initial state: no work in flight
+        self._index_shutdown = threading.Event()
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -308,6 +322,36 @@ class Collection:
             pause_writes=self.pause_writes,
             on_pull=self.reindex,
         )
+
+    def get_index_status(self) -> dict[str, Any]:
+        """Return current background-index status for client / monitoring callers.
+
+        Returns:
+            Dict with three keys:
+
+            - ``status``: one of ``"ready"``, ``"indexing"``, ``"embedding"``,
+              ``"failed"``.
+            - ``indexed``: current FTS document count (cheap ``COUNT(*)``).
+            - ``error``: the last failure message, or ``None``.
+        """
+        with self._index_status_lock:
+            return {
+                "status": self._index_status,
+                "indexed": self._count_documents(),
+                "error": self._index_status_error,
+            }
+
+    def _set_index_status(
+        self,
+        status: Literal["ready", "indexing", "embedding", "failed"],
+        *,
+        error: str | None = None,
+    ) -> None:
+        """Update background-index status under the status lock."""
+        with self._index_status_lock:
+            self._index_status = status
+            self._index_status_error = error if status == "failed" else None
+        logger.debug("index_status set status=%s error=%s", status, error)
 
     def stop(self) -> None:
         """Stop background tasks (e.g. git pull loop) without closing the collection.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -353,6 +353,75 @@ class Collection:
             self._index_status_error = error if status == "failed" else None
         logger.debug("index_status set status=%s error=%s", status, error)
 
+    def schedule_background_reindex(self) -> None:
+        """Spawn a daemon thread that runs ``reindex()`` then ``build_embeddings()``.
+
+        Returns immediately so the MCP ``initialize`` handshake can complete.
+        Idempotent: if a background thread is currently running, this is a
+        no-op.  Status visible via :meth:`get_index_status`.
+
+        The worker uses ``_write_lock`` for its mutation phase (same as a
+        manual ``reindex()`` call from the CLI), so concurrent write tool
+        calls serialise naturally.  Failures are caught and surfaced via
+        ``get_index_status()["error"]`` — the server itself stays up.
+        """
+        with self._index_status_lock:
+            if (
+                self._background_index_thread is not None
+                and self._background_index_thread.is_alive()
+            ):
+                logger.debug(
+                    "schedule_background_reindex: thread already in flight, skipping"
+                )
+                return
+
+            self._index_status = "indexing"
+            self._index_status_error = None
+            self._index_done_event.clear()
+            self._index_shutdown.clear()
+
+            thread = threading.Thread(
+                target=self._background_reindex_target,
+                name="markdown-vault-mcp-bg-reindex",
+                daemon=True,
+            )
+            self._background_index_thread = thread
+
+        thread.start()
+        logger.info("background reindex thread started")
+
+    def _background_reindex_target(self) -> None:
+        """Worker target for the background reindex thread.
+
+        Runs ``reindex()`` then ``build_embeddings()`` (if a provider is
+        configured) with status transitions:
+        ``indexing -> embedding -> ready``.  On failure, sets status to
+        ``failed`` and records the message; the server itself is never
+        crashed by an indexing error.
+        """
+        try:
+            if self._index_shutdown.is_set():
+                logger.info("background reindex aborted before start")
+                return
+
+            self.reindex()
+
+            if self._index_shutdown.is_set():
+                logger.info("background reindex aborted after FTS phase")
+                return
+
+            if self._embedding_provider is not None:
+                self._set_index_status("embedding")
+                self.build_embeddings()
+
+            self._set_index_status("ready")
+            logger.info("background reindex complete")
+        except Exception as exc:
+            logger.error("background reindex failed", exc_info=True)
+            self._set_index_status("failed", error=str(exc))
+        finally:
+            self._index_done_event.set()
+
     def stop(self) -> None:
         """Stop background tasks (e.g. git pull loop) without closing the collection.
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -195,8 +195,11 @@ class Collection:
         )
         self._tracker = ChangeTracker(self._state_path)
 
-        # Lazy initialisation flag.
-        self._initialized = False
+        # Lazy initialisation flag.  Seed from the on-disk FTS DB so a
+        # persistent index built by a prior process (CLI ``reindex`` or
+        # a previous server run) short-circuits the startup scan — see
+        # #513 / issue #509.
+        self._initialized = self._fts_has_documents()
 
         # Serialise concurrent write operations on this instance.
         # Re-entrant: periodic pull tick blocks writes, then reindex() acquires
@@ -356,6 +359,23 @@ class Collection:
         """Build the FTS index on first access if it has not been built yet."""
         if not self._initialized:
             self.build_index()
+
+    def _fts_has_documents(self) -> bool:
+        """Return True if the FTS DB currently has at least one row.
+
+        Used to seed ``_initialized`` so warm-start lifespans don't trigger
+        a full filesystem scan when a prior process already built the
+        persistent index.
+        """
+        try:
+            row = self._fts._conn.execute("SELECT 1 FROM documents LIMIT 1").fetchone()
+        except Exception:
+            logger.debug(
+                "could not probe FTS DB for warm-start; assuming cold start",
+                exc_info=True,
+            )
+            return False
+        return row is not None
 
     @property
     def _vectors(self) -> VectorIndex | None:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -11,6 +11,7 @@ import logging
 import queue
 import re
 import threading
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from markdown_vault_mcp.fts_index import FTSIndex
@@ -46,7 +47,6 @@ from markdown_vault_mcp.utils import effective_attachment_extensions
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
     from markdown_vault_mcp.git import GitWriteStrategy
     from markdown_vault_mcp.providers import EmbeddingProvider
@@ -586,20 +586,40 @@ class Collection:
         self._ensure_initialized()
         return self._index_mgr.reindex()
 
-    def build_embeddings(self, *, force: bool = False) -> int:
+    def build_embeddings(
+        self, *, force: bool = False, skip_if_missing: bool = False
+    ) -> int:
         """Build the vector index from all chunks currently in the FTS index.
 
         Args:
             force: If ``True``, rebuild from scratch even if a vector index
                 already exists on disk.
+            skip_if_missing: If ``True`` and the ``.npy`` sidecar does not yet
+                exist on disk, log a warning pointing operators at the
+                ``markdown-vault-mcp reindex`` CLI command and return 0
+                without doing any embedding work.  Used by the server
+                lifespan so MCP startup is not blocked on an initial
+                corpus build (#513).  Has no effect when ``force=True``.
 
         Returns:
-            Total number of chunks embedded.
+            Total number of chunks embedded (or 0 when skipped).
 
         Raises:
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is
                 not configured.
         """
+        if skip_if_missing and not force and self._embeddings_path is not None:
+            npy_path = Path(str(self._embeddings_path) + ".npy")
+            if not npy_path.exists():
+                logger.warning(
+                    "build_embeddings: %s.npy missing — skipping initial corpus "
+                    "build to keep the MCP handshake non-blocking.  Run "
+                    "'markdown-vault-mcp reindex' to bootstrap the vector index, "
+                    "or wait for the background indexing thread to finish.",
+                    self._embeddings_path,
+                )
+                return 0
+
         self._ensure_initialized()
         return self._index_mgr.build_embeddings(force=force)
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -377,6 +377,53 @@ class Collection:
             return False
         return row is not None
 
+    def _count_documents(self) -> int:
+        """Return ``COUNT(*)`` of rows currently in the FTS documents table."""
+        row = self._fts._conn.execute("SELECT COUNT(*) FROM documents").fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def _purge_excluded_rows(self) -> int:
+        """Delete FTS+vector rows whose paths match the configured exclude_patterns.
+
+        Runs purely against the persistent DB — no filesystem scan — so it is
+        cheap enough to call on every warm-start ``build_index()``.  Returns
+        the number of rows purged so callers can log progress.
+
+        When embeddings are configured but the vector sidecar has not been
+        loaded yet, this loads it on demand so stale rows can be purged from
+        the on-disk ``.npy`` too (mirrors the IndexManager full-scan
+        behaviour from #255).
+        """
+        if not self._exclude_patterns:
+            return 0
+
+        from markdown_vault_mcp.utils import is_path_excluded
+
+        # Reuse SearchManager.vectors so an already-loaded vector index is
+        # mutated in place.  If embeddings are configured but not yet loaded,
+        # load now so we can purge the sidecar in lock-step with the FTS rows.
+        vectors = self._search_mgr.vectors
+        if (
+            vectors is None
+            and self._embedding_provider is not None
+            and self._embeddings_path is not None
+        ):
+            self._search_mgr._load_vectors()
+            vectors = self._search_mgr.vectors
+
+        purged = 0
+        for row in self._fts.list_notes():
+            if is_path_excluded(row["path"], self._exclude_patterns):
+                self._fts.delete_by_path(row["path"])
+                if vectors is not None:
+                    vectors.delete_by_path(row["path"])
+                purged += 1
+
+        if purged and vectors is not None and self._embeddings_path is not None:
+            vectors.save(self._embeddings_path)
+
+        return purged
+
     @property
     def _vectors(self) -> VectorIndex | None:
         """Bridge property: vector index is owned by SearchManager."""
@@ -505,19 +552,24 @@ class Collection:
         Returns:
             :class:`~markdown_vault_mcp.types.IndexStats` describing what was indexed.
         """
-        # Check if index already has data and we are not forcing.
-        if not force and self._initialized:
-            existing = self._fts.list_notes()
-            if existing:
-                logger.debug(
-                    "build_index: index already populated (%d docs), skipping",
-                    len(existing),
-                )
-                return IndexStats(
-                    documents_indexed=len(existing),
-                    chunks_indexed=0,
-                    skipped=0,
-                )
+        # Warm-start fast path: persistent DB already has rows.  Use
+        # ``COUNT(*)`` for the doc count (cheap) and run a DB-only purge for
+        # any rows that match the configured ``exclude_patterns`` — without
+        # this, reopening a Collection with new excludes leaves stale rows
+        # behind (#513, regression killed by PR #510).
+        if not force and self._initialized and self._count_documents() > 0:
+            purged = self._purge_excluded_rows()
+            doc_count = self._count_documents()
+            logger.info(
+                "build_index: persistent DB has %d documents (%d purged by excludes)",
+                doc_count,
+                purged,
+            )
+            return IndexStats(
+                documents_indexed=doc_count,
+                chunks_indexed=0,
+                skipped=0,
+            )
 
         result = self._index_mgr.build_index(force=force)
         self._initialized = True

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -446,9 +446,18 @@ class Collection:
                 logger.info("background reindex aborted after FTS phase")
                 return
 
-            if self._embedding_provider is not None:
+            if (
+                self._embedding_provider is not None
+                and self._embeddings_path is not None
+            ):
                 self._set_index_status("embedding")
                 self.build_embeddings()
+            elif self._embedding_provider is not None:
+                logger.info(
+                    "background reindex: embedding provider configured but "
+                    "embeddings_path is unset; skipping vector build "
+                    "(semantic search disabled)"
+                )
 
             self._set_index_status("ready")
             logger.info("background reindex complete")

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -394,10 +394,10 @@ class Collection:
         """Worker target for the background reindex thread.
 
         Runs ``reindex()`` then ``build_embeddings()`` (if a provider is
-        configured) with status transitions:
-        ``indexing -> embedding -> ready``.  On failure, sets status to
-        ``failed`` and records the message; the server itself is never
-        crashed by an indexing error.
+        configured). Drives status transitions ``embedding -> ready``;
+        the scheduler sets ``indexing`` before this method starts.  On
+        failure, sets status to ``failed`` and records the message; the
+        server itself is never crashed by an indexing error.
         """
         try:
             if self._index_shutdown.is_set():

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -441,6 +441,20 @@ class Collection:
         # 1. Flush any deferred embedding updates.
         self._index_mgr.flush_dirty_embeddings()
 
+        # Signal the background reindex thread to stop and give it a bounded
+        # window to wind down.  SQLite WAL + the existing crash-resilience
+        # paths handle any partial mutation if the daemon thread is abandoned
+        # after the timeout (#513).
+        self._index_shutdown.set()
+        bg_thread = self._background_index_thread
+        if bg_thread is not None and bg_thread.is_alive():
+            bg_thread.join(timeout=30)
+            if bg_thread.is_alive():
+                logger.warning(
+                    "Collection.close: background reindex thread still alive "
+                    "after 30s — abandoning (daemon)"
+                )
+
         # 2. Drain the write-callback queue (git commits).
         if self._callback_worker is not None and self._callback_worker.is_alive():
             self._callback_queue.put(None)  # sentinel

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -323,6 +323,21 @@ class Collection:
             on_pull=self.reindex,
         )
 
+    def initialize_async(self) -> None:
+        """Synchronously probe persistent state.  No filesystem scan.
+
+        Idempotent.  After this returns, ``_initialized`` reflects whether
+        the persistent FTS DB contains documents.  Used by the server
+        lifespan in place of the blocking ``build_index()`` so MCP startup
+        is non-blocking (#513).
+        """
+        self._initialized = self._fts_has_documents()
+        logger.debug(
+            "initialize_async: _initialized=%s (DB has rows=%s)",
+            self._initialized,
+            self._initialized,
+        )
+
     def get_index_status(self) -> dict[str, Any]:
         """Return current background-index status for client / monitoring callers.
 
@@ -483,7 +498,34 @@ class Collection:
     # ------------------------------------------------------------------
 
     def _ensure_initialized(self) -> None:
-        """Build the FTS index on first access if it has not been built yet."""
+        """Build the FTS index on first access if it has not been built yet.
+
+        If a background reindex thread is currently in flight (#513), wait
+        for it to finish before falling back to a synchronous
+        :meth:`build_index` call.  Without this guard, a foreground tool
+        call and the background daemon both run ``build_index`` against
+        the same SQLite connection and collide on inserts.
+
+        The wait is skipped when the calling thread *is* the background
+        reindex thread itself (otherwise the worker would deadlock waiting
+        for its own completion event).
+        """
+        if self._initialized:
+            return
+
+        # If the background reindex thread is in flight, wait for it to
+        # finish — it will set ``_initialized`` itself via build_index().
+        # Skip the wait when called from inside the background thread; the
+        # worker target must drive build_index() forward.
+        with self._index_status_lock:
+            bg_thread = self._background_index_thread
+        if (
+            bg_thread is not None
+            and bg_thread.is_alive()
+            and bg_thread is not threading.current_thread()
+        ):
+            self._index_done_event.wait()
+
         if not self._initialized:
             self.build_index()
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -276,7 +276,10 @@ class Collection:
         # Background reindex state (#513). The reindex daemon thread reads
         # and writes ``_index_status`` / ``_index_status_error`` under
         # ``_index_status_lock``; ``_index_done_event`` lets callers
-        # (tests, ``close()``) wait deterministically for completion.
+        # (tests, ``close()``) wait deterministically for full completion;
+        # ``_fts_done_event`` fires earlier — right after the FTS phase —
+        # so foreground tool calls see partial FTS results without waiting
+        # for the embedding phase.
         self._index_status: Literal["ready", "indexing", "embedding", "failed"] = (
             "ready"
         )
@@ -285,6 +288,8 @@ class Collection:
         self._background_index_thread: threading.Thread | None = None
         self._index_done_event = threading.Event()
         self._index_done_event.set()  # initial state: no work in flight
+        self._fts_done_event = threading.Event()
+        self._fts_done_event.set()  # initial state: no work in flight
         self._index_shutdown = threading.Event()
 
     # ------------------------------------------------------------------
@@ -393,6 +398,7 @@ class Collection:
             self._index_status = "indexing"
             self._index_status_error = None
             self._index_done_event.clear()
+            self._fts_done_event.clear()
             self._index_shutdown.clear()
 
             thread = threading.Thread(
@@ -401,8 +407,7 @@ class Collection:
                 daemon=True,
             )
             self._background_index_thread = thread
-
-        thread.start()
+            thread.start()
         logger.info("background reindex thread started")
 
     def _background_reindex_target(self) -> None:
@@ -420,6 +425,7 @@ class Collection:
                 return
 
             self.reindex()
+            self._fts_done_event.set()
 
             if self._index_shutdown.is_set():
                 logger.info("background reindex aborted after FTS phase")
@@ -435,6 +441,7 @@ class Collection:
             logger.error("background reindex failed", exc_info=True)
             self._set_index_status("failed", error=str(exc))
         finally:
+            self._fts_done_event.set()
             self._index_done_event.set()
 
     def stop(self) -> None:
@@ -461,6 +468,7 @@ class Collection:
         # paths handle any partial mutation if the daemon thread is abandoned
         # after the timeout (#513).
         self._index_shutdown.set()
+        self._fts_done_event.set()
         bg_thread = self._background_index_thread
         if bg_thread is not None and bg_thread.is_alive():
             bg_thread.join(timeout=30)
@@ -524,7 +532,7 @@ class Collection:
             and bg_thread.is_alive()
             and bg_thread is not threading.current_thread()
         ):
-            self._index_done_event.wait()
+            self._fts_done_event.wait()
 
         if not self._initialized:
             self.build_index()

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -350,11 +350,7 @@ class Collection:
         is non-blocking (#513).
         """
         self._initialized = self._fts_has_documents()
-        logger.debug(
-            "initialize_async: _initialized=%s (DB has rows=%s)",
-            self._initialized,
-            self._initialized,
-        )
+        logger.debug("initialize_async: _initialized=%s", self._initialized)
 
     def get_index_status(self) -> IndexStatusPayload:
         """Return current background-index status for client / monitoring callers.
@@ -427,10 +423,11 @@ class Collection:
         """Worker target for the background reindex thread.
 
         Runs ``reindex()`` then ``build_embeddings()`` (if a provider is
-        configured). Drives status transitions ``embedding -> ready``;
-        the scheduler sets ``indexing`` before this method starts.  On
-        failure, sets status to ``failed`` and records the message; the
-        server itself is never crashed by an indexing error.
+        configured).  Status transitions: ``indexing -> embedding -> ready``
+        when an embedding provider is configured, ``indexing -> ready`` when
+        it isn't.  On uncaught exceptions, transitions to ``failed`` (unless
+        shutdown was signalled, in which case the run exits without changing
+        status).
         """
         try:
             if self._index_shutdown.is_set():
@@ -474,8 +471,17 @@ class Collection:
     def close(self) -> None:
         """Release resources held by the collection.
 
-        Flushes deferred embeddings and pending write callbacks, then
-        closes the SQLite connection and git strategy.
+        Shutdown steps:
+
+        1. Flush deferred embeddings (re-embed dirty documents, save ``.npy``).
+        2. Signal the background reindex thread and join with a 30-second
+           timeout.  Daemon-abandoned on timeout; SQLite WAL handles partial
+           state on next startup (#513).
+        3. Drain the background write-callback queue (waits for pending git
+           commits).
+        4. Close the :class:`~markdown_vault_mcp.git.GitWriteStrategy`
+           (flushes and pushes pending commits).
+        5. Close the SQLite database connection.
         """
         # 1. Flush any deferred embedding updates.
         self._index_mgr.flush_dirty_embeddings()
@@ -526,10 +532,15 @@ class Collection:
         """Build the FTS index on first access if it has not been built yet.
 
         If a background reindex thread is currently in flight (#513), wait
-        for it to finish before falling back to a synchronous
-        :meth:`build_index` call.  Without this guard, a foreground tool
-        call and the background daemon both run ``build_index`` against
-        the same SQLite connection and collide on inserts.
+        for its FTS phase to complete before proceeding.  Without this guard,
+        a foreground tool call and the background daemon both run
+        ``build_index`` against the same SQLite connection and collide on
+        inserts.
+
+        If the background thread does not signal FTS completion within 60
+        seconds, this method logs a warning and falls back to running
+        :meth:`build_index` inline; the inline call surfaces any indexing
+        error to the caller.
 
         The wait is skipped when the calling thread *is* the background
         reindex thread itself (otherwise the worker would deadlock waiting
@@ -757,8 +768,10 @@ class Collection:
         """Scan source_dir and build the FTS index.
 
         If the index already contains documents and *force* is ``False``,
-        this is a no-op.  ``force=True`` drops all existing data and rebuilds
-        from scratch.
+        takes the warm-start fast path: existing rows are kept, but any rows
+        whose paths now match ``exclude_patterns`` are purged from the FTS DB
+        and vector sidecar.  ``force=True`` drops all existing data and
+        rebuilds from scratch.
 
         Args:
             force: When ``True``, drop and rebuild the index unconditionally.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -12,7 +12,7 @@ import queue
 import re
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.scanner import (
@@ -56,6 +56,21 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_STATE_SUBDIR = ".markdown_vault_mcp"
 _DEFAULT_STATE_FILENAME = "state.json"
+
+
+IndexStatusLiteral = Literal["ready", "indexing", "embedding", "failed"]
+
+
+class IndexStatusPayload(TypedDict):
+    """Shape of the ``get_index_status`` return value.
+
+    Also serialised as the ``index_status`` field of the ``stats://vault``
+    MCP resource — treat as a public contract.
+    """
+
+    status: IndexStatusLiteral
+    indexed: int
+    error: str | None
 
 
 def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
@@ -280,9 +295,7 @@ class Collection:
         # ``_fts_done_event`` fires earlier — right after the FTS phase —
         # so foreground tool calls see partial FTS results without waiting
         # for the embedding phase.
-        self._index_status: Literal["ready", "indexing", "embedding", "failed"] = (
-            "ready"
-        )
+        self._index_status: IndexStatusLiteral = "ready"
         self._index_status_error: str | None = None
         self._index_status_lock = threading.Lock()
         self._background_index_thread: threading.Thread | None = None
@@ -343,11 +356,11 @@ class Collection:
             self._initialized,
         )
 
-    def get_index_status(self) -> dict[str, Any]:
+    def get_index_status(self) -> IndexStatusPayload:
         """Return current background-index status for client / monitoring callers.
 
         Returns:
-            Dict with three keys:
+            :class:`IndexStatusPayload` with three keys:
 
             - ``status``: one of ``"ready"``, ``"indexing"``, ``"embedding"``,
               ``"failed"``.
@@ -363,7 +376,7 @@ class Collection:
 
     def _set_index_status(
         self,
-        status: Literal["ready", "indexing", "embedding", "failed"],
+        status: IndexStatusLiteral,
         *,
         error: str | None = None,
     ) -> None:
@@ -438,8 +451,12 @@ class Collection:
             self._set_index_status("ready")
             logger.info("background reindex complete")
         except Exception as exc:
-            logger.error("background reindex failed", exc_info=True)
-            self._set_index_status("failed", error=str(exc))
+            if self._index_shutdown.is_set():
+                logger.info("background reindex aborted by shutdown: %s", exc)
+                # Don't mark failed — shutdown is the cause, not a real fault.
+            else:
+                logger.error("background reindex failed", exc_info=True)
+                self._set_index_status("failed", error=str(exc))
         finally:
             self._fts_done_event.set()
             self._index_done_event.set()
@@ -531,8 +548,16 @@ class Collection:
             bg_thread is not None
             and bg_thread.is_alive()
             and bg_thread is not threading.current_thread()
+            and not self._fts_done_event.wait(timeout=60)
         ):
-            self._fts_done_event.wait()
+            logger.warning(
+                "_ensure_initialized: background reindex did not finish FTS "
+                "phase within 60s; proceeding with inline build_index() as "
+                "fallback"
+            )
+            # Fall through — the ``if not self._initialized: ...`` line below
+            # runs ``build_index()`` synchronously and surfaces any real
+            # error to the caller.
 
         if not self._initialized:
             self.build_index()
@@ -555,9 +580,20 @@ class Collection:
         return row is not None
 
     def _count_documents(self) -> int:
-        """Return ``COUNT(*)`` of rows currently in the FTS documents table."""
-        row = self._fts._conn.execute("SELECT COUNT(*) FROM documents").fetchone()
-        return int(row[0]) if row is not None else 0
+        """Return ``COUNT(*)`` of rows in the FTS documents table.
+
+        Returns 0 on any SQLite error (e.g. closed connection during shutdown,
+        transient lock contention).  Used by ``get_index_status()`` and by the
+        warm-start fast path in ``build_index()``; both callers must remain
+        non-blocking and crash-resistant for the status resource to stay
+        operator-useful during indexing (#513).
+        """
+        try:
+            row = self._fts._conn.execute("SELECT COUNT(*) FROM documents").fetchone()
+        except Exception:
+            logger.debug("could not count FTS documents", exc_info=True)
+            return 0
+        return int(row[0])  # COUNT(*) always returns exactly one row
 
     def _purge_excluded_rows(self) -> int:
         """Delete FTS+vector rows whose paths match the configured exclude_patterns.
@@ -774,9 +810,12 @@ class Collection:
             skip_if_missing: If ``True`` and the ``.npy`` sidecar does not yet
                 exist on disk, log a warning pointing operators at the
                 ``markdown-vault-mcp reindex`` CLI command and return 0
-                without doing any embedding work.  Used by the server
-                lifespan so MCP startup is not blocked on an initial
-                corpus build (#513).  Has no effect when ``force=True``.
+                without doing any embedding work.  Originally designed for
+                non-blocking startup (#513); the production lifespan now
+                uses ``schedule_background_reindex()`` instead, but this
+                parameter remains available for direct callers (CLI, tests,
+                custom integrations) that want a non-blocking variant.  Has
+                no effect when ``force=True``.
 
         Returns:
             Total number of chunks embedded (or 0 when skipped).
@@ -1158,10 +1197,16 @@ class Collection:
     def stats(self) -> CollectionStats:
         """Return collection-wide statistics.
 
+        Non-blocking on cold-start: the persistent FTS state is reported as-is,
+        without waiting for a background reindex to finish.  Zero counts during
+        cold-start indexing are the correct/expected reading and let the
+        ``stats://vault`` resource stay a fast status probe (#513).
+
         Returns:
             :class:`~markdown_vault_mcp.types.CollectionStats` snapshot.
         """
-        self._ensure_initialized()
+        # Deliberately do NOT call ``_ensure_initialized()`` here; the stats
+        # resource must never block on the background indexing thread.
 
         rows = self._fts.list_notes()
         doc_count = len(rows)

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -860,6 +860,34 @@ class FTSIndex:
         row = self._conn.execute("SELECT COUNT(*) FROM sections").fetchone()
         return row[0] if row else 0
 
+    def count_documents(self) -> int:
+        """Return the total number of rows in the ``documents`` table.
+
+        Cheaper than materialising ``list_notes()`` for callers that only
+        need the count (e.g. ``stats://vault`` and the background-index
+        status probe in #513).
+
+        Returns:
+            Integer count of all indexed documents.
+        """
+        row = self._conn.execute("SELECT COUNT(*) FROM documents").fetchone()
+        return int(row[0]) if row else 0
+
+    def has_documents(self) -> bool:
+        """Return ``True`` if the ``documents`` table has at least one row.
+
+        Cheaper than ``count_documents()`` because the probe stops at the
+        first row.  Used by the warm-start fast path to skip a full
+        filesystem scan when a prior process already built the persistent
+        index (#513).
+
+        Returns:
+            ``True`` when at least one document is indexed, ``False``
+            otherwise.
+        """
+        row = self._conn.execute("SELECT 1 FROM documents LIMIT 1").fetchone()
+        return row is not None
+
     def get_toc(self, path: str) -> list[dict[str, str | int]]:
         """Return headings for a document, ordered by position.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ class MockEmbeddingProvider(EmbeddingProvider):
             dim: Embedding dimension. Defaults to 32.
         """
         self._dim = dim
+        self.embed_calls = 0
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Return deterministic hash-based vectors for each text.
@@ -36,6 +37,7 @@ class MockEmbeddingProvider(EmbeddingProvider):
         Returns:
             List of embedding vectors, one per input text.
         """
+        self.embed_calls += len(texts)
         vectors = []
         for text in texts:
             seed = int(hashlib.md5(text.encode()).hexdigest(), 16) % 2**31

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4089,3 +4089,86 @@ class TestInitializeAsync:
             assert col._initialized is False
         finally:
             col.close()
+
+
+class TestBuildEmbeddingsSkipIfMissing:
+    """build_embeddings(skip_if_missing=True) skips the initial corpus build."""
+
+    def test_skip_when_sidecar_missing(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """Returns 0 + warns when .npy is absent and skip_if_missing=True."""
+        embeddings_path = tmp_path / "embeddings"
+        col = _make_collection(
+            vault_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=mock_provider,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            col.build_index()
+            mock_provider.embed_calls = 0  # type: ignore[attr-defined]
+
+            n = col.build_embeddings(skip_if_missing=True)
+
+            assert n == 0
+            assert mock_provider.embed_calls == 0  # type: ignore[attr-defined]
+        finally:
+            col.close()
+
+    def test_load_when_sidecar_present(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """Loads the existing sidecar instead of bootstrapping when skip_if_missing=True."""
+        embeddings_path = tmp_path / "embeddings"
+        col1 = _make_collection(
+            vault_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=mock_provider,
+            state_path=tmp_path / "state1.json",
+        )
+        col1.build_index()
+        bootstrap_count = col1.build_embeddings()
+        col1.close()
+        assert bootstrap_count > 0
+
+        col2 = _make_collection(
+            vault_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=mock_provider,
+            state_path=tmp_path / "state2.json",
+        )
+        try:
+            mock_provider.embed_calls = 0  # type: ignore[attr-defined]
+            n = col2.build_embeddings(skip_if_missing=True)
+            assert n == bootstrap_count
+            assert mock_provider.embed_calls == 0  # type: ignore[attr-defined]
+        finally:
+            col2.close()
+
+    def test_default_still_bootstraps(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """The default (skip_if_missing=False) still bootstraps when .npy is missing."""
+        embeddings_path = tmp_path / "embeddings"
+        col = _make_collection(
+            vault_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=mock_provider,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            col.build_index()
+            n = col.build_embeddings()
+            assert n > 0
+        finally:
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4430,3 +4430,61 @@ class TestIndexStatus:
         finally:
             col._background_index_thread = None
             col.close()
+
+    def test_fts_done_event_fires_before_embedding_phase(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """Foreground readers unblock as soon as FTS phase completes, not after embeddings."""
+        import threading
+
+        # Block build_embeddings on a gate so we can observe the intermediate state.
+        gate = threading.Event()
+        embedding_started = threading.Event()
+
+        col = _make_collection(
+            vault_path,
+            index_path=tmp_path / "index.db",
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=mock_provider,
+            state_path=tmp_path / "state.json",
+        )
+        original_build_embeddings = col.build_embeddings
+
+        def gated_build_embeddings(*args, **kwargs):
+            embedding_started.set()
+            gate.wait(timeout=10)
+            return original_build_embeddings(*args, **kwargs)
+
+        try:
+            with patch.object(
+                col, "build_embeddings", side_effect=gated_build_embeddings
+            ):
+                col.schedule_background_reindex()
+
+                # Wait for the worker to reach the embedding phase.
+                assert embedding_started.wait(timeout=30), (
+                    "background thread did not reach embedding phase"
+                )
+
+                # At this point: FTS phase is done, embedding phase is paused.
+                assert col._fts_done_event.is_set(), (
+                    "FTS event should fire after reindex()"
+                )
+                assert not col._index_done_event.is_set(), (
+                    "full-pipeline event should not fire yet (embedding paused)"
+                )
+
+                # Foreground _ensure_initialized must return immediately (event is set).
+                col._ensure_initialized()  # would block if waiting on the wrong event
+
+                # Release the gate and let the worker finish.
+                gate.set()
+                assert col._index_done_event.wait(timeout=30), (
+                    "background thread did not complete after gate release"
+                )
+        finally:
+            gate.set()  # ensure no hang on teardown
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4296,3 +4296,31 @@ class TestIndexStatus:
             assert "embedding failed" in status["error"]
         finally:
             col.close()
+
+    def test_close_signals_background_thread(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """close() sets the shutdown flag and joins the background thread within timeout."""
+        col = _make_collection(
+            vault_path,
+            index_path=tmp_path / "index.db",
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=mock_provider,
+            state_path=tmp_path / "state.json",
+        )
+        col.schedule_background_reindex()
+        # Don't wait for completion — close() must handle the in-flight case.
+        col.close()
+
+        # After close(): the shutdown event must be set, and either the
+        # thread completed (done event set) or was abandoned (no live thread
+        # blocking subsequent work).
+        assert col._index_shutdown.is_set()
+        thread = col._background_index_thread
+        # Allow up to 30s for the thread to wind down (matches close() timeout).
+        if thread is not None:
+            thread.join(timeout=1)
+        assert thread is None or not thread.is_alive()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4172,3 +4172,32 @@ class TestBuildEmbeddingsSkipIfMissing:
             assert n > 0
         finally:
             col.close()
+
+
+class TestIndexStatus:
+    """Collection exposes a structured index status for clients."""
+
+    def test_initial_status_is_ready(self, vault_path: Path, tmp_path: Path) -> None:
+        col = _make_collection(
+            vault_path,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            status = col.get_index_status()
+            assert status["status"] == "ready"
+            assert status["error"] is None
+            assert isinstance(status["indexed"], int)
+        finally:
+            col.close()
+
+    def test_status_dict_shape(self, vault_path: Path, tmp_path: Path) -> None:
+        col = _make_collection(
+            vault_path,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            status = col.get_index_status()
+            assert set(status.keys()) == {"status", "indexed", "error"}
+            assert status["status"] in {"ready", "indexing", "embedding", "failed"}
+        finally:
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4217,3 +4217,45 @@ class TestIndexStatus:
             assert col.get_index_status()["error"] is None
         finally:
             col.close()
+
+    def test_schedule_background_reindex_transitions_to_ready(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """schedule_background_reindex() runs reindex+embed in a thread, ending in 'ready'."""
+        col = _make_collection(
+            vault_path,
+            index_path=tmp_path / "index.db",
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=mock_provider,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            col.schedule_background_reindex()
+            done = col._index_done_event.wait(timeout=30)
+            assert done, "background reindex did not complete within 30s"
+            assert col.get_index_status()["status"] == "ready"
+            assert col.get_index_status()["indexed"] > 0
+        finally:
+            col.close()
+
+    def test_schedule_background_reindex_is_idempotent(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        """A second call while a thread is in flight returns without spawning."""
+        col = _make_collection(
+            vault_path,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            col.schedule_background_reindex()
+            first_thread = col._background_index_thread
+            col.schedule_background_reindex()
+            assert col._background_index_thread is first_thread
+            col._index_done_event.wait(timeout=30)
+        finally:
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -393,6 +393,78 @@ class TestBuildIndex:
         vec_paths2 = [m["path"] for m in col2._vectors._metadata]
         assert ".claude/test.md" not in vec_paths2
 
+    def test_warm_start_uses_count_not_list_notes(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """The warm-start no-op path uses COUNT(*), not list_notes()."""
+        index_path = tmp_path / "index.db"
+
+        col1 = _make_collection(
+            vault_path,
+            index_path=index_path,
+            state_path=tmp_path / "state1.json",
+        )
+        col1.build_index()
+        col1.close()
+
+        col2 = _make_collection(
+            vault_path,
+            index_path=index_path,
+            state_path=tmp_path / "state2.json",
+        )
+
+        with patch.object(
+            col2._fts,
+            "list_notes",
+            side_effect=AssertionError("warm-start must not materialise rows"),
+        ):
+            stats = col2.build_index()
+
+        assert stats.documents_indexed == 9
+        assert stats.chunks_indexed == 0
+        col2.close()
+
+    def test_warm_start_purges_newly_excluded_paths(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """Reopening with new exclude_patterns purges stale rows via the warm-start path."""
+        # Phase 1: build index without excludes; .claude/test.md ends up in the DB.
+        excluded_dir = vault_path / ".claude"
+        excluded_dir.mkdir(parents=True, exist_ok=True)
+        (excluded_dir / "test.md").write_text("# Excluded\nSome content.\n")
+        index_path = tmp_path / "index.db"
+
+        col1 = _make_collection(
+            vault_path,
+            index_path=index_path,
+            state_path=tmp_path / "state1.json",
+        )
+        col1.build_index()
+        paths1 = [row["path"] for row in col1._fts.list_notes()]
+        assert ".claude/test.md" in paths1
+        col1.close()
+
+        # Phase 2: reopen with exclude_patterns; warm-start must still purge.
+        col2 = _make_collection(
+            vault_path,
+            index_path=index_path,
+            state_path=tmp_path / "state2.json",
+            exclude_patterns=[".claude/**"],
+        )
+        # Confirm the warm-start path is taken: scan_directory must not be invoked.
+        import markdown_vault_mcp.managers.index as idx_mod
+
+        with patch.object(
+            idx_mod,
+            "scan_directory",
+            side_effect=AssertionError("warm-start must not scan"),
+        ):
+            col2.build_index()
+
+        paths2 = [row["path"] for row in col2._fts.list_notes()]
+        assert ".claude/test.md" not in paths2
+        col2.close()
+
 
 # ---------------------------------------------------------------------------
 # Lazy initialisation

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3962,3 +3962,58 @@ def test_collection_search_honours_default_chunks_per_file(tmp_path):
     long_groups = [r for r in results if r.path == "long.md"]
     if long_groups:
         assert len(long_groups[0].sections) <= 2
+
+
+class TestInitializeAsync:
+    """Collection.initialize_async() synchronously seeds _initialized from FTS DB."""
+
+    def test_warm_start_marks_initialized(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """A pre-populated persistent DB sets _initialized=True on construction."""
+        index_path = tmp_path / "index.db"
+        col1 = _make_collection(
+            vault_path,
+            index_path=index_path,
+            state_path=tmp_path / "state1.json",
+        )
+        col1.build_index()
+        col1.close()
+
+        col2 = _make_collection(
+            vault_path,
+            index_path=index_path,
+            state_path=tmp_path / "state2.json",
+        )
+        try:
+            assert col2._initialized is True
+        finally:
+            col2.close()
+
+    def test_cold_start_leaves_initialized_false(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """An empty (or missing) persistent DB leaves _initialized=False."""
+        col = _make_collection(
+            vault_path,
+            index_path=tmp_path / "fresh-index.db",
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            assert col._initialized is False
+        finally:
+            col.close()
+
+    def test_in_memory_db_leaves_initialized_false(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """In-memory FTS (no index_path) cannot be pre-populated; flag stays False."""
+        col = _make_collection(
+            vault_path,
+            index_path=None,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            assert col._initialized is False
+        finally:
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4374,3 +4374,59 @@ class TestIndexStatus:
             col._background_index_thread = None
             col._fts_done_event.set()
             col.close()
+
+    def test_ensure_initialized_falls_back_after_timeout(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """When _fts_done_event never fires within 60s, _ensure_initialized falls back to inline build_index()."""
+        import threading
+        from unittest.mock import MagicMock
+
+        col = _make_collection(
+            vault_path,
+            index_path=tmp_path / "index.db",
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            # Inject a fake in-flight bg thread and a never-firing FTS event,
+            # mock the wait() to return False immediately (simulating timeout).
+            fake_thread = MagicMock(spec=threading.Thread)
+            fake_thread.is_alive.return_value = True
+            col._background_index_thread = fake_thread
+            col._initialized = False
+            col._fts_done_event.clear()
+
+            with patch.object(col._fts_done_event, "wait", return_value=False):
+                col._ensure_initialized()
+
+            # After fallback, _initialized should be True (build_index ran inline).
+            assert col._initialized is True
+        finally:
+            col._background_index_thread = None
+            col.close()
+
+    def test_ensure_initialized_self_thread_skips_wait(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """When called from the bg worker thread itself, _ensure_initialized must not wait on its own event."""
+        import threading
+
+        col = _make_collection(
+            vault_path,
+            index_path=tmp_path / "index.db",
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            # Simulate "we are the bg thread" by setting _background_index_thread to the current thread.
+            col._background_index_thread = threading.current_thread()
+            col._initialized = False
+            col._fts_done_event.clear()  # event is unset — would deadlock if we waited
+
+            # If the guard is missing, this would block forever on _fts_done_event.
+            # With the guard, it falls through to inline build_index().
+            col._ensure_initialized()
+
+            assert col._initialized is True
+        finally:
+            col._background_index_thread = None
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4257,5 +4257,6 @@ class TestIndexStatus:
             col.schedule_background_reindex()
             assert col._background_index_thread is first_thread
             col._index_done_event.wait(timeout=30)
+            assert col.get_index_status()["status"] == "ready"
         finally:
             col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4305,6 +4305,32 @@ class TestIndexStatus:
         finally:
             col.close()
 
+    def test_schedule_background_reindex_skips_embeddings_without_path(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        # Configuring an embedding provider without an embeddings_path means
+        # the operator opted out of semantic search; the bg worker must not
+        # mark the run as 'failed' for that valid config.
+        col = _make_collection(
+            vault_path,
+            index_path=tmp_path / "index.db",
+            embeddings_path=None,
+            embedding_provider=mock_provider,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            col.schedule_background_reindex()
+            done = col._index_done_event.wait(timeout=30)
+            assert done, "background reindex did not complete within 30s"
+            status = col.get_index_status()
+            assert status["status"] == "ready"
+            assert status["error"] is None
+        finally:
+            col.close()
+
     def test_close_signals_background_thread(
         self,
         vault_path: Path,

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4247,18 +4247,26 @@ class TestIndexStatus:
         tmp_path: Path,
     ) -> None:
         """A second call while a thread is in flight returns without spawning."""
+        import threading
+        from unittest.mock import MagicMock
+
         col = _make_collection(
             vault_path,
             state_path=tmp_path / "state.json",
         )
         try:
+            # Inject a fake "in-flight" thread so idempotency is deterministic.
+            fake = MagicMock(spec=threading.Thread)
+            fake.is_alive.return_value = True
+            col._background_index_thread = fake
+
             col.schedule_background_reindex()
-            first_thread = col._background_index_thread
-            col.schedule_background_reindex()
-            assert col._background_index_thread is first_thread
-            col._index_done_event.wait(timeout=30)
-            assert col.get_index_status()["status"] == "ready"
+            assert col._background_index_thread is fake, (
+                "second schedule should be a no-op while a thread is in flight"
+            )
         finally:
+            # Restore so close() doesn't try to join the mock.
+            col._background_index_thread = None
             col.close()
 
     def test_schedule_background_reindex_failure_sets_status_failed(
@@ -4324,3 +4332,45 @@ class TestIndexStatus:
         if thread is not None:
             thread.join(timeout=1)
         assert thread is None or not thread.is_alive()
+
+    def test_stats_does_not_block_during_background_reindex(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        """stats() must return immediately even while a bg reindex is in flight (#513).
+
+        Simulates a stuck background thread by clearing _fts_done_event and
+        injecting a fake live thread. If stats() were to wait on the event
+        (via _ensure_initialized), the call would hang past the timeout below.
+        """
+        import threading
+        import time
+        from unittest.mock import MagicMock
+
+        col = _make_collection(
+            vault_path,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            # Simulate "bg reindex in flight, FTS phase still running".
+            col._initialized = False
+            col._fts_done_event.clear()
+            fake = MagicMock(spec=threading.Thread)
+            fake.is_alive.return_value = True
+            col._background_index_thread = fake
+
+            start = time.monotonic()
+            result = col.stats()
+            elapsed = time.monotonic() - start
+
+            assert elapsed < 1.0, (
+                f"stats() blocked for {elapsed:.2f}s; must be non-blocking"
+            )
+            # Persistent FTS state should be reported as-is; counts may be 0.
+            assert result.document_count >= 0
+        finally:
+            # Restore so close() doesn't try to join the mock.
+            col._background_index_thread = None
+            col._fts_done_event.set()
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4260,3 +4260,39 @@ class TestIndexStatus:
             assert col.get_index_status()["status"] == "ready"
         finally:
             col.close()
+
+    def test_schedule_background_reindex_failure_sets_status_failed(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        """A failing reindex sets status=failed + records the error, server stays up."""
+
+        class _ExplodingProvider:
+            provider_name = "exploding"
+            model_name = "test-bomb"
+            dimension = 4
+
+            def embed(self, texts: list[str]) -> list[list[float]]:  # noqa: ARG002
+                raise RuntimeError("embedding failed")
+
+            def normalise(self, vec: list[float]) -> list[float]:
+                return vec
+
+        col = _make_collection(
+            vault_path,
+            index_path=tmp_path / "index.db",
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=_ExplodingProvider(),
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            col.schedule_background_reindex()
+            done = col._index_done_event.wait(timeout=30)
+            assert done, "background reindex did not complete within 30s"
+            status = col.get_index_status()
+            assert status["status"] == "failed"
+            assert status["error"] is not None
+            assert "embedding failed" in status["error"]
+        finally:
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4201,3 +4201,19 @@ class TestIndexStatus:
             assert status["status"] in {"ready", "indexing", "embedding", "failed"}
         finally:
             col.close()
+
+    def test_set_index_status_clears_error_on_non_failed_transition(
+        self, vault_path: Path, tmp_path: Path
+    ) -> None:
+        """Transitioning from 'failed' to any other status clears the recorded error."""
+        col = _make_collection(
+            vault_path,
+            state_path=tmp_path / "state.json",
+        )
+        try:
+            col._set_index_status("failed", error="boom")
+            assert col.get_index_status()["error"] == "boom"
+            col._set_index_status("ready")
+            assert col.get_index_status()["error"] is None
+        finally:
+            col.close()

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -553,6 +553,7 @@ class TestGraphNeighborhoodMaxNodes:
         ):
             server = make_server()
             async with Client(server) as client:
+                _wait_for_background_index()
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {
@@ -607,6 +608,7 @@ class TestGraphNeighborhoodMaxNodes:
         ):
             server = make_server()
             async with Client(server) as client:
+                _wait_for_background_index()
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -14,8 +14,22 @@ import pytest
 from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import _hashed
+from markdown_vault_mcp._server_deps import get_collection_singleton
 from markdown_vault_mcp.server import make_server
 from tests.conftest import _CLEAR_VARS, get_app_html
+
+
+def _wait_for_background_index(timeout: float = 30.0) -> None:
+    """Block until the background reindex thread finishes embeddings, too.
+
+    Foreground reads only wait for the FTS phase (see Collection
+    ``_ensure_initialized``); tests that need semantic search must wait for
+    the full pipeline.
+    """
+    col = get_collection_singleton()
+    if not col._index_done_event.wait(timeout=timeout):
+        raise RuntimeError("background index did not finish within timeout")
+
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -315,6 +329,7 @@ class TestIncludeSemanticEdges:
         ):
             server = make_server()
             async with Client(server) as client:
+                _wait_for_background_index()
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "include_semantic": True},
@@ -349,6 +364,7 @@ class TestIncludeSemanticEdges:
         ):
             server = make_server()
             async with Client(server) as client:
+                _wait_for_background_index()
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "include_semantic": True},
@@ -380,6 +396,7 @@ class TestIncludeSemanticEdges:
         ):
             server = make_server()
             async with Client(server) as client:
+                _wait_for_background_index()
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "depth": 0, "include_semantic": True},

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2270,8 +2270,14 @@ class TestLifespanAutoEmbeddings:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """With EMBEDDINGS_PATH set, startup builds vectors automatically."""
+        """With EMBEDDINGS_PATH set, startup builds vectors automatically.
+
+        Indexing now runs in a background thread (#513), so we wait on the
+        Collection singleton's done event before asserting.
+        """
         from unittest.mock import patch
+
+        from markdown_vault_mcp._server_deps import get_collection_singleton
 
         from .conftest import MockEmbeddingProvider
 
@@ -2292,6 +2298,9 @@ class TestLifespanAutoEmbeddings:
         ):
             server = make_server()
             async with Client(server) as client:
+                # Wait for the background reindex thread to finish embedding.
+                col = get_collection_singleton()
+                assert col._index_done_event.wait(timeout=30)
                 result = await client.call_tool_mcp("embeddings_status", {})
         data = json.loads(result.content[0].text)
         assert data["chunk_count"] > 0
@@ -2302,8 +2311,14 @@ class TestLifespanAutoEmbeddings:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """With existing embeddings on disk, startup loads them without rebuilding."""
+        """With existing embeddings on disk, startup loads them without rebuilding.
+
+        Indexing now runs in a background thread (#513), so we wait on the
+        Collection singleton's done event before asserting.
+        """
         from unittest.mock import patch
+
+        from markdown_vault_mcp._server_deps import get_collection_singleton
 
         from .conftest import MockEmbeddingProvider
 
@@ -2322,6 +2337,8 @@ class TestLifespanAutoEmbeddings:
         ):
             server = make_server()
             async with Client(server) as client:
+                col = get_collection_singleton()
+                assert col._index_done_event.wait(timeout=30)
                 r1 = await client.call_tool_mcp("embeddings_status", {})
         count1 = json.loads(r1.content[0].text)["chunk_count"]
         assert count1 > 0
@@ -2342,6 +2359,8 @@ class TestLifespanAutoEmbeddings:
         ):
             server2 = make_server()
             async with Client(server2) as client2:
+                col2 = get_collection_singleton()
+                assert col2._index_done_event.wait(timeout=30)
                 r2 = await client2.call_tool_mcp("embeddings_status", {})
         count2 = json.loads(r2.content[0].text)["chunk_count"]
         assert count2 == count1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1838,6 +1838,26 @@ class TestResources:
         assert resource_data["chunk_count"] == tool_data["chunk_count"]
 
     @pytest.mark.usefixtures("_mcp_env_with_fields")
+    async def test_stats_resource_includes_index_status(self) -> None:
+        """stats://vault exposes background index_status with the expected shape.
+
+        Operators detect "server is up but still indexing" by polling this
+        resource. The contract is fixed by ``Collection.get_index_status()``:
+        keys ``status`` / ``indexed`` / ``error`` with ``status`` drawn from
+        the four-state enum.
+        """
+        server = make_server()
+        async with Client(server) as client:
+            resource_result = await client.read_resource("stats://vault")
+        resource_data = json.loads(resource_result[0].text)
+        assert "index_status" in resource_data
+        idx = resource_data["index_status"]
+        assert set(idx.keys()) == {"status", "indexed", "error"}
+        assert idx["status"] in {"ready", "indexing", "embedding", "failed"}
+        assert isinstance(idx["indexed"], int)
+        assert idx["error"] is None or isinstance(idx["error"], str)
+
+    @pytest.mark.usefixtures("_mcp_env_with_fields")
     async def test_tags_resource_grouped(self) -> None:
         server = make_server()
         async with Client(server) as client:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -406,8 +406,18 @@ class TestStatsTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_stats(self) -> None:
+        """stats reports populated counts once background indexing finishes (#513).
+
+        ``stats()`` is non-blocking: we must wait on the singleton's done
+        event before asserting non-zero counts, otherwise we race the
+        cold-start background reindex.
+        """
+        from markdown_vault_mcp._server_deps import get_collection_singleton
+
         server = make_server()
         async with Client(server) as client:
+            col = get_collection_singleton()
+            assert col._index_done_event.wait(timeout=30)
             result = await client.call_tool("stats", {})
         data = result.data
         assert isinstance(data, dict)

--- a/tests/test_server_deps.py
+++ b/tests/test_server_deps.py
@@ -2,20 +2,22 @@
 
 Covers the module-level Collection singleton accessors used by HTTP
 route handlers that run outside FastMCP's ``Depends(get_collection)``
-injection (e.g. the pvl-core file-exchange upload receiver).
+injection (e.g. the pvl-core file-exchange upload receiver), and the
+``make_collection_lifespan`` factory's startup wiring.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from markdown_vault_mcp._server_deps import (
     get_collection_singleton,
+    make_collection_lifespan,
     set_collection_singleton,
 )
-from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.collection import Collection, IndexStats
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -47,3 +49,150 @@ class TestCollectionSingleton:
             assert get_collection_singleton() is col
         finally:
             _deps_module._collection_singleton = saved
+
+
+class TestCollectionLifespan:
+    """``make_collection_lifespan`` wires startup without blocking on indexing."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_does_not_block_on_initial_indexing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Lifespan must yield within a bounded time even if build_index is slow."""
+        instances: list[FakeCollection] = []
+
+        class FakeCollection:
+            def __init__(self, **kwargs: Any) -> None:
+                self.kwargs = kwargs
+                self.scheduled = 0
+                self.build_index_calls = 0
+                self.embeddings_calls = 0
+                self.initialize_async_calls = 0
+                self.start_calls = 0
+                self.close_calls = 0
+                instances.append(self)
+
+            def sync_from_remote_before_index(self) -> None:
+                pass
+
+            def initialize_async(self) -> None:
+                self.initialize_async_calls += 1
+
+            def schedule_background_reindex(self) -> None:
+                self.scheduled += 1
+
+            def build_index(self) -> IndexStats:  # would be slow if called
+                self.build_index_calls += 1
+                return IndexStats(documents_indexed=0, chunks_indexed=0, skipped=0)
+
+            def build_embeddings(self) -> int:
+                self.embeddings_calls += 1
+                return 0
+
+            def start(self) -> None:
+                self.start_calls += 1
+
+            def close(self) -> None:
+                self.close_calls += 1
+
+        class FakeConfig:
+            source_dir = tmp_path
+
+            def to_collection_kwargs(self) -> dict[str, Any]:
+                return {
+                    "source_dir": tmp_path,
+                    "embedding_provider": object(),
+                    "embeddings_path": tmp_path / "embeddings",
+                }
+
+        import markdown_vault_mcp._server_deps as _deps_module
+
+        monkeypatch.setattr(_deps_module, "Collection", FakeCollection)
+        lifespan = make_collection_lifespan(FakeConfig())
+        agen = lifespan._fn(None)
+        try:
+            await agen.__anext__()
+            assert instances[0].scheduled == 1
+            assert instances[0].build_index_calls == 0  # must NOT block on build_index
+            assert instances[0].embeddings_calls == 0  # must NOT block on embeddings
+            assert instances[0].initialize_async_calls == 1
+            assert instances[0].start_calls == 1
+        finally:
+            await agen.aclose()
+            # Singleton was cleared on shutdown.
+            assert _deps_module._collection_singleton is None
+            assert instances[0].close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_lifespan_without_embedding_provider(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Without an embedding provider, lifespan still schedules background reindex.
+
+        The background thread is responsible for honouring the absence of an
+        embedding provider; the lifespan unconditionally schedules.
+        """
+        instances: list[FakeCollection] = []
+
+        class FakeCollection:
+            def __init__(self, **kwargs: Any) -> None:
+                self.kwargs = kwargs
+                self.scheduled = 0
+                self.build_index_calls = 0
+                self.embeddings_calls = 0
+                self.initialize_async_calls = 0
+                self.start_calls = 0
+                self.close_calls = 0
+                instances.append(self)
+
+            def sync_from_remote_before_index(self) -> None:
+                pass
+
+            def initialize_async(self) -> None:
+                self.initialize_async_calls += 1
+
+            def schedule_background_reindex(self) -> None:
+                self.scheduled += 1
+
+            def build_index(self) -> IndexStats:
+                self.build_index_calls += 1
+                return IndexStats(documents_indexed=0, chunks_indexed=0, skipped=0)
+
+            def build_embeddings(self) -> int:
+                self.embeddings_calls += 1
+                return 0
+
+            def start(self) -> None:
+                self.start_calls += 1
+
+            def close(self) -> None:
+                self.close_calls += 1
+
+        class FakeConfig:
+            source_dir = tmp_path
+
+            def to_collection_kwargs(self) -> dict[str, Any]:
+                return {
+                    "source_dir": tmp_path,
+                    "embedding_provider": None,
+                }
+
+        import markdown_vault_mcp._server_deps as _deps_module
+
+        monkeypatch.setattr(_deps_module, "Collection", FakeCollection)
+        lifespan = make_collection_lifespan(FakeConfig())
+        agen = lifespan._fn(None)
+        try:
+            ctx = await agen.__anext__()
+            assert ctx["collection"] is instances[0]
+            assert instances[0].scheduled == 1
+            assert instances[0].build_index_calls == 0
+            assert instances[0].embeddings_calls == 0
+            assert instances[0].initialize_async_calls == 1
+            assert instances[0].start_calls == 1
+        finally:
+            await agen.aclose()


### PR DESCRIPTION
## Summary

Closes #513 (supersedes #509; replaces the abandoned PR #510).

Moves FTS index and embedding builds off the startup hot path. The MCP `initialize` handshake now completes within seconds regardless of vault size; a daemon thread runs `reindex()` then `build_embeddings()` after the handshake. Status surfaces via `stats://vault → index_status`.

Preserves the warm-start fast path: pre-built persistent state loads in sub-second; the background reindex confirms no drift. Preserves the PR #256 `exclude_patterns` purge invariant via `Collection.build_index()`'s warm-start no-op-with-purge logic (the regression that killed PR #510).

(Re-opened from PR #514 which was closed when its branch was renamed — `+` in the original branch name caused 403s in the CI checkout step. Same commits.)

## Highlights

- **`Collection.initialize_async()`** — synchronous persistent-state probe; sub-second; no filesystem scan.
- **`Collection.schedule_background_reindex()`** — spawns a daemon thread running `reindex()` then `build_embeddings()`. Status transitions `indexing → embedding → ready`; failure → `failed`. Shutdown via `_index_shutdown` + 30s join in `Collection.close()`.
- **`_fts_done_event` / `_index_done_event` split** — foreground tool calls unblock as soon as FTS phase completes, not waiting for embeddings (preserves the "partial FTS results during indexing" promise).
- **`Collection.build_index()` warm-start fast path** — replaces the prior `list_notes()` materialization with `COUNT(*)` + DB-only `_purge_excluded_rows()`; keeps PR #256's exclude purge invariant.
- **`Collection.build_embeddings(skip_if_missing=)`** — opt-in non-blocking variant for direct callers.
- **`Collection._ensure_initialized`** — waits on `_fts_done_event` with bounded 60s timeout (warning + inline fallback on timeout); self-thread guard prevents worker self-deadlock.
- **`Collection.stats()`** — no longer calls `_ensure_initialized`; non-blocking during cold-start so `stats://vault` stays a fast status probe.
- **`stats://vault` resource** — gains `index_status` field with shape `{status, indexed, error}` (typed via `IndexStatusPayload` TypedDict).
- **Lifespan** — `_server_deps.py` rewired: `initialize_async()` + `schedule_background_reindex()` replace the blocking `build_index` + `build_embeddings`.

## Test plan

- [x] 1613 tests pass locally (was 1456 on main; +157 new tests cover the state machine, lifespan rewire, stats non-blocking, warm-start purge, etc.)
- [x] `ruff check`, `ruff format --check src/ tests/`, `mypy src/ tests/` — all clean
- [ ] CI passes on Python 3.11, 3.12, 3.13, 3.14
- [ ] `claude-review` and `gemini-code-assist` bot bodies LGTM
- [ ] CHANGELOG entry auto-generated from conventional commits

## Notes

- 18 commits with clean conventional-commit granularity — PSR will compute the next minor bump from the `feat:` commits. Prefer merge (not squash) per repo policy so PSR walks individual messages.
- Documentation updated: `docs/guides/claude-desktop.md`, `docs/configuration.md`, `docs/design.md`, `docs/resources.md`.