### PR TITLE
feat(server): non-blocking background indexing, second attempt (closes #513)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b0c2a392-87fc-41c9-8e2c-d7a596000a80","pid":254519,"procStart":"543893","acquiredAt":1778439832390}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b0c2a392-87fc-41c9-8e2c-d7a596000a80","pid":254519,"procStart":"543893","acquiredAt":1778439832390}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ site/
 .claude/worktrees/
 .claude/settings.local.json
 docs/superpowers/
+.claude/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 > **Upgrading.** As of this release, `search` returns query-relevant snippets in the `content` field by default (approximately 200 words). Pass `snippet_words=0` to recover the prior full-chunk behaviour, or use `read(path, section=heading)` to fetch a specific chunk after seeing a snippet. Documents are also re-chunked on next `reindex` to honour the adaptive `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` threshold (default 400).
 - **Frontmatter-aware** — indexes YAML frontmatter fields, supports required field enforcement
 - **Incremental reindexing** — hash-based change detection, only re-processes modified files
+- **Non-blocking startup** — the server starts immediately and builds its index in the background; tools are usable straight away and clients can check progress via the `stats` tool's `index_status` field
 - **Write operations** — create, edit, delete, rename documents with automatic index updates
 - **Attachment support** — read, write, delete, and list non-markdown files (PDFs, images, etc.)
 - **Git integration** — optional auto-commit and push on every write via `GIT_ASKPASS`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `MARKDOWN_VAULT_MCP_STATE_PATH` | path | `{SOURCE_DIR}/.markdown_vault_mcp/state.json` | No | Path to the change-tracking state file |
 | `MARKDOWN_VAULT_MCP_INDEXED_FIELDS` | csv | — | No | Comma-separated frontmatter fields to promote to the tag index for structured filtering |
 | `MARKDOWN_VAULT_MCP_REQUIRED_FIELDS` | csv | — | No | Comma-separated frontmatter fields required on every document; documents missing any are excluded from the index |
-| `MARKDOWN_VAULT_MCP_EXCLUDE` | csv | — | No | Comma-separated glob patterns to exclude from scanning (e.g. `.obsidian/**,.trash/**`) |
+| `MARKDOWN_VAULT_MCP_EXCLUDE` | csv | — | No | Comma-separated glob patterns to exclude from scanning (e.g. `.obsidian/**,.trash/**`). Changes take effect on the next background reindex (server start or periodic git pull). |
 | `MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER` | string | `_templates` | No | Relative folder path used by the `create_from_template` prompt to discover/read template files |
 | `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | path | — | No | Path to a directory of `.md` prompt files that extend or override built-in prompts |
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -365,11 +365,6 @@ Two methods manage the index:
   adds/modifies/deletes since the last scan and applies only the delta.
   Applies `exclude_patterns` filtering and purges stale excluded documents.
 
-**Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
-`Collection` lazily builds the FTS index from `source_dir` if no pre-built
-`index_path` was provided. `build_index()` can be called explicitly to
-pre-warm the index or to force a rebuild.
-
 ### Error Handling
 
 Two-layer model:
@@ -1021,10 +1016,6 @@ class Collection:
   provided, persisted to disk.
 - `embeddings_path=None`: semantic search is disabled.
 - `state_path=None`: defaults to `{source_dir}/.markdown_vault_mcp/state.json`.
-
-**Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
-`Collection` lazily builds the FTS index from `source_dir` if no pre-built
-`index_path` was provided.
 
 **Write operations** (`write`, `edit`, `delete`, `rename`) raise
 `ReadOnlyError` when `read_only=True`.

--- a/docs/design.md
+++ b/docs/design.md
@@ -488,6 +488,8 @@ an error to wait out. This rule is enforced by
 stop. The PR #515 abandonment retrospective in
 `memory/feedback_background_indexing_abandon.md` explains why.
 
+Note: every startup briefly reports `background_running=True` even on a warm restart with a fully-populated FTS DB on disk. The background worker calls `reindex()`, which always runs a change-tracker pass to confirm the persisted index matches the on-disk vault. On warm restart that pass finds no changes and completes quickly, but `index_status` will show indexing briefly. To skip that confirmation pass entirely (i.e. trust the persisted index), call the CLI `markdown-vault-mcp index` before starting the server.
+
 ### Lifecycle: Collection.close()
 
 `Collection.close()` must be called on shutdown to release resources:

--- a/docs/design.md
+++ b/docs/design.md
@@ -467,6 +467,27 @@ attachment write operations.
 `read()` validates the path inline rather than via `_validate_path()`: if the
 resolved path escapes `source_dir`, it returns `None` instead of raising.
 
+### Background indexing (non-blocking startup)
+
+The MCP `initialize` handshake never blocks on FTS or embedding work. On
+server start, `Collection.start_background_reindex()` spawns a daemon
+thread that runs `reindex()` followed by `build_embeddings()` (when an
+embedding provider is configured). Tools become available immediately;
+read tools return whatever's currently in the index. Clients learn the
+state via `stats` or `get_server_info`, both of which carry a nested
+`index_status` snapshot (`background_running`, `background_phase`,
+`last_run_started_at`, `last_run_completed_at`, `last_error`).
+
+**Load-bearing rule:** No public method on `Collection` may block on
+background indexing state. Foreground reads return whatever's currently
+in the FTS/vector index. Empty-during-cold-start is a valid result, not
+an error to wait out. This rule is enforced by
+`test_foreground_reads_never_block_on_background` in
+`tests/test_background_indexing.py` — if you find yourself adding a
+`threading.Event.wait()` or `Thread.join()` to a foreground method,
+stop. The PR #515 abandonment retrospective in
+`memory/feedback_background_indexing_abandon.md` explains why.
+
 ### Lifecycle: Collection.close()
 
 `Collection.close()` must be called on shutdown to release resources:

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -280,7 +280,7 @@ You should see a commit from `markdown-vault-mcp`. Delete the test note when don
 
 ### Pre-build embeddings before first launch
 
-For large vaults, building embeddings on first startup can take several minutes — long enough for Claude Desktop to time out the connection. Pre-build from the command line instead:
+Pre-building the index before the first launch is **no longer required** — the server starts immediately and fills in the FTS and vector indexes in the background. Pre-building remains the **fastest path to immediate full readiness**: if you want all tools to return complete results on the very first request after startup, run `markdown-vault-mcp index` before launching the server. For large vaults, building embeddings on first startup can take several minutes — long enough for Claude Desktop to time out the connection. Pre-build from the command line instead:
 
 === "macOS / Linux"
 

--- a/docs/superpowers/plans/2026-05-26-background-indexing-v2.md
+++ b/docs/superpowers/plans/2026-05-26-background-indexing-v2.md
@@ -1,0 +1,1232 @@
+# Non-blocking startup via Collection-owned background reindex — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MCP `initialize` handshake non-blocking on cold start by moving index/embedding work to a daemon thread owned by `Collection`, with no foreground waiters anywhere in the public API.
+
+**Architecture:** Add two methods to `Collection` (`start_background_reindex()` fire-and-forget, `index_status()` read-only snapshot) and remove `_ensure_initialized()`. Foreground reads return whatever's currently in the index. A regression test pinning sub-500ms foreground latency under a deliberately slow background enforces the no-waiter rule.
+
+**Tech Stack:** Python 3.11+, `threading.Thread` (daemon), `threading.Event` (shutdown only), pytest, FastMCP, SQLite FTS5.
+
+**Spec:** `docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md`
+
+**Branch:** `feat/513-background-indexing-v2` (already created off `origin/main`; spec already committed as `6770af2`).
+
+---
+
+## Pre-flight context (read before starting)
+
+- The spec is the source of truth. If this plan conflicts with the spec, fix the plan.
+- **Hard rule:** `_ensure_initialized()` must end up deleted from `Collection`. No method on `Collection` may block waiting on the background thread. This rule killed PR #515 and we are not re-litigating it.
+- The existing lifespan (`src/markdown_vault_mcp/_server_deps.py:83-137`) calls `collection.build_index()` synchronously. We will replace this with `start_background_reindex()` *after* the strip task, so the eager-build path remains intact during intermediate states.
+- `_ensure_initialized()` currently has ~22 call sites in `src/markdown_vault_mcp/collection.py`. All of them must be removed.
+- Test count baseline: 1456 (per PR #433). Expect to land at ~1465–1475 after this work.
+- Run gates locally before each commit: `uv run pytest -x -q`, `uv run ruff check --fix . && uv run ruff format .`, `uv run mypy src/ tests/`.
+
+---
+
+## File map
+
+**Modify:**
+- `src/markdown_vault_mcp/collection.py` — add background state + 2 new methods + close() shutdown step; remove `_ensure_initialized()` and 22 call sites; nest `index_status` in `stats()`.
+- `src/markdown_vault_mcp/types.py` — extend `CollectionStats` with `index_status: dict[str, Any]` field.
+- `src/markdown_vault_mcp/_server_deps.py` — lifespan switches from synchronous `build_index()` + `build_embeddings()` to `start_background_reindex()`.
+- `src/markdown_vault_mcp/server.py` — `register_server_info_tool(...)` gains an `extra_status` (or equivalent) callable wiring index_status into the response. See Task 8 for the exact mechanism check.
+- `docs/design.md` — add "Background indexing" section.
+- `docs/configuration.md` — `EXCLUDE_PATTERNS` row note.
+- `docs/guides/claude-desktop.md` — pre-build optional now.
+- `docs/tools/index.md` — `stats` and `get_server_info` return shape updates.
+- `README.md` — "How it works" note.
+
+**Create:**
+- `tests/test_background_indexing.py` — all tests for the new behaviour.
+
+**Touch only if tests force it:**
+- `tests/test_collection.py`, `tests/test_managers_*.py`, etc. — audit for places that rely on lazy `_ensure_initialized()` and fix by adding explicit `collection.build_index()` (or fixture update).
+
+---
+
+## Task 1: Add background-state fields and helpers to Collection (no behaviour change)
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/collection.py` (`__init__` region + helper section)
+- Test: `tests/test_background_indexing.py` (new file — write empty `import` + one stub test first)
+
+- [ ] **Step 1.1: Create the test file with the stub test**
+
+Create `tests/test_background_indexing.py`:
+
+```python
+"""Tests for non-blocking startup background indexing (#513)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from markdown_vault_mcp.collection import Collection
+
+
+def test_index_status_idle_before_anything_runs(tmp_path: Path) -> None:
+    """A fresh Collection that hasn't started background work reports idle status."""
+    collection = Collection(source_dir=tmp_path)
+    try:
+        status = collection.index_status()
+        assert status == {
+            "background_running": False,
+            "background_phase": None,
+            "last_run_started_at": None,
+            "last_run_completed_at": None,
+            "last_error": None,
+        }
+    finally:
+        collection.close()
+```
+
+- [ ] **Step 1.2: Run the test — it must fail with AttributeError**
+
+Run: `uv run pytest tests/test_background_indexing.py::test_index_status_idle_before_anything_runs -v`
+
+Expected: `AttributeError: 'Collection' object has no attribute 'index_status'`.
+
+- [ ] **Step 1.3: Add background-state fields to `Collection.__init__`**
+
+Locate `Collection.__init__` in `src/markdown_vault_mcp/collection.py`. Find the section where instance attributes are initialised (look for `self._write_lock = threading.RLock()` or similar — that's the threading-state area). Add directly after the existing threading-state initialisations:
+
+```python
+# Background reindex state (see docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md).
+# These fields exist so background indexing state is visible to read-only
+# snapshots; foreground methods MUST NOT wait on any of them.
+self._background_thread: threading.Thread | None = None
+self._background_shutdown: threading.Event = threading.Event()
+self._background_state_lock: threading.Lock = threading.Lock()
+self._background_phase: str | None = None  # "indexing" | "embedding" | None
+self._background_last_started_at: str | None = None
+self._background_last_completed_at: str | None = None
+self._background_last_error: str | None = None
+```
+
+- [ ] **Step 1.4: Add `index_status()` method**
+
+Add directly after the `# Lazy initialisation` section header (currently around line 351-358, where `_ensure_initialized()` lives — put the new method just above it; we'll remove `_ensure_initialized()` in Task 6):
+
+```python
+def index_status(self) -> dict[str, Any]:
+    """Snapshot of background reindex state. Never blocks.
+
+    Returns:
+        Dict with keys ``background_running``, ``background_phase``,
+        ``last_run_started_at``, ``last_run_completed_at``, ``last_error``.
+        Phase is ``"indexing"``, ``"embedding"``, or ``None``.
+        Timestamps are ISO-8601 UTC strings or ``None``.
+    """
+    with self._background_state_lock:
+        thread = self._background_thread
+        return {
+            "background_running": thread is not None and thread.is_alive(),
+            "background_phase": self._background_phase,
+            "last_run_started_at": self._background_last_started_at,
+            "last_run_completed_at": self._background_last_completed_at,
+            "last_error": self._background_last_error,
+        }
+```
+
+- [ ] **Step 1.5: Run the test — it must pass**
+
+Run: `uv run pytest tests/test_background_indexing.py::test_index_status_idle_before_anything_runs -v`
+
+Expected: PASS.
+
+- [ ] **Step 1.6: Run gates and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+uv run mypy src/ tests/
+uv run pytest -x -q tests/test_background_indexing.py tests/test_collection.py
+git add src/markdown_vault_mcp/collection.py tests/test_background_indexing.py
+git commit -m "feat(collection): add background state fields and index_status snapshot
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Implement `start_background_reindex()` and the worker
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/collection.py`
+- Test: `tests/test_background_indexing.py`
+
+- [ ] **Step 2.1: Write the failing test for idempotent start and phase transition**
+
+Append to `tests/test_background_indexing.py`:
+
+```python
+def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.01) -> None:
+    """Poll a predicate until it returns truthy or timeout expires.
+
+    Raises AssertionError if predicate never becomes true.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError(f"predicate {predicate!r} not satisfied within {timeout}s")
+
+
+def test_start_background_reindex_runs_and_completes(tmp_path: Path) -> None:
+    """Background reindex transitions through phases and reaches idle."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    try:
+        collection.start_background_reindex()
+
+        # Eventually the background thread completes; final state is idle, no error.
+        _wait_until(lambda: not collection.index_status()["background_running"])
+
+        status = collection.index_status()
+        assert status["background_running"] is False
+        assert status["background_phase"] is None
+        assert status["last_error"] is None
+        assert status["last_run_started_at"] is not None
+        assert status["last_run_completed_at"] is not None
+    finally:
+        collection.close()
+
+
+def test_start_background_reindex_is_idempotent(tmp_path: Path) -> None:
+    """Calling start twice while a thread is alive does not spawn a second thread."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    try:
+        collection.start_background_reindex()
+        first_thread = collection._background_thread
+
+        # Second call must be a no-op while the first thread is alive.
+        # If the first thread completes between calls, this still must not
+        # raise — we just accept whichever invariant holds.
+        collection.start_background_reindex()
+        second_thread = collection._background_thread
+
+        assert second_thread is first_thread or not first_thread.is_alive()
+
+        _wait_until(lambda: not collection.index_status()["background_running"])
+    finally:
+        collection.close()
+```
+
+- [ ] **Step 2.2: Run tests — they must fail with AttributeError**
+
+Run: `uv run pytest tests/test_background_indexing.py -v -k start_background_reindex`
+
+Expected: `AttributeError: 'Collection' object has no attribute 'start_background_reindex'`.
+
+- [ ] **Step 2.3: Add the worker and start method**
+
+Add directly after `index_status()` in `src/markdown_vault_mcp/collection.py`:
+
+```python
+def _set_background_phase(self, phase: str | None) -> None:
+    """Update the background phase field under the state lock."""
+    with self._background_state_lock:
+        self._background_phase = phase
+
+def _set_background_completed(self, error: str | None) -> None:
+    """Mark a background run as completed under the state lock."""
+    with self._background_state_lock:
+        self._background_last_completed_at = datetime.now(timezone.utc).isoformat()
+        self._background_last_error = error
+
+def _background_reindex_worker(self) -> None:
+    """Daemon-thread target: run reindex() then build_embeddings()."""
+    try:
+        if self._background_shutdown.is_set():
+            return
+        self._set_background_phase("indexing")
+        self.reindex()
+
+        if (
+            self._embedding_provider is not None
+            and self._embeddings_path is not None
+        ):
+            if self._background_shutdown.is_set():
+                return
+            self._set_background_phase("embedding")
+            self.build_embeddings()
+
+        self._set_background_completed(error=None)
+    except Exception as exc:  # noqa: BLE001 — top-level boundary for daemon thread
+        logger.error("background_reindex_failed", exc_info=True)
+        self._set_background_completed(error=str(exc))
+    finally:
+        self._set_background_phase(None)
+
+def start_background_reindex(self) -> None:
+    """Spawn a daemon thread that runs reindex() then build_embeddings().
+
+    No-op (logged at DEBUG) when a background thread is already alive.
+    Returns immediately. The thread is daemonic, so a hard process exit
+    does not block on it; SQLite WAL handles any partial uncommitted state
+    on the next startup.
+
+    See the spec at
+    ``docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md``
+    for the no-foreground-waiter rule that motivates this method.
+    """
+    with self._background_state_lock:
+        existing = self._background_thread
+        if existing is not None and existing.is_alive():
+            logger.debug("start_background_reindex skipped — thread already alive")
+            return
+        self._background_shutdown.clear()
+        self._background_last_started_at = datetime.now(timezone.utc).isoformat()
+        self._background_last_error = None
+        thread = threading.Thread(
+            target=self._background_reindex_worker,
+            name="markdown-vault-mcp-bg-reindex",
+            daemon=True,
+        )
+        self._background_thread = thread
+        thread.start()
+```
+
+Ensure `from datetime import datetime, timezone` is imported at the top of the file (add to the existing imports if not present).
+
+- [ ] **Step 2.4: Run the tests — they must pass**
+
+Run: `uv run pytest tests/test_background_indexing.py -v -k start_background_reindex`
+
+Expected: both PASS.
+
+- [ ] **Step 2.5: Run gates and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+uv run mypy src/ tests/
+uv run pytest -x -q tests/test_background_indexing.py
+git add src/markdown_vault_mcp/collection.py tests/test_background_indexing.py
+git commit -m "feat(collection): add start_background_reindex daemon worker
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Background failure path
+
+**Files:**
+- Test: `tests/test_background_indexing.py`
+
+- [ ] **Step 3.1: Write the failing test**
+
+Append:
+
+```python
+def test_background_failure_sets_last_error_and_recovers(tmp_path: Path) -> None:
+    """When reindex raises, last_error is set, phase returns to None, server lives."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    try:
+        # Patch reindex to raise.
+        original_reindex = collection.reindex
+
+        def boom() -> object:
+            raise RuntimeError("synthetic failure")
+
+        collection.reindex = boom  # type: ignore[method-assign]
+
+        collection.start_background_reindex()
+        _wait_until(lambda: not collection.index_status()["background_running"])
+
+        status = collection.index_status()
+        assert status["background_running"] is False
+        assert status["background_phase"] is None
+        assert status["last_error"] == "synthetic failure"
+
+        # Server-equivalent behaviour: foreground operations still work.
+        # (We don't have a populated index, but list_documents must not raise.)
+        collection.reindex = original_reindex  # type: ignore[method-assign]
+        # No further assertion needed — we already verified the worker did not
+        # propagate the exception out of the thread.
+    finally:
+        collection.close()
+```
+
+- [ ] **Step 3.2: Run it — should already PASS (Task 2 already handles exceptions)**
+
+Run: `uv run pytest tests/test_background_indexing.py::test_background_failure_sets_last_error_and_recovers -v`
+
+Expected: PASS. (The worker's `try/except` set up in Task 2.3 already covers this. If it fails, fix Task 2's implementation rather than this test.)
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add tests/test_background_indexing.py
+git commit -m "test(collection): pin background-failure last_error semantics
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Shutdown during background — extend `close()`
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/collection.py` (`close` method, around line 290-350)
+- Test: `tests/test_background_indexing.py`
+
+- [ ] **Step 4.1: Write the failing test**
+
+Append:
+
+```python
+def test_close_joins_background_thread_within_timeout(tmp_path: Path) -> None:
+    """close() returns within the 30s bounded join; background thread is gone."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    collection.start_background_reindex()
+
+    start = time.monotonic()
+    collection.close()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 30.0
+    thread = collection._background_thread
+    # Either the thread completed before close() arrived, or close() joined it.
+    assert thread is None or not thread.is_alive()
+```
+
+- [ ] **Step 4.2: Run it — should already PASS for fast vaults**
+
+Run: `uv run pytest tests/test_background_indexing.py::test_close_joins_background_thread_within_timeout -v`
+
+Expected: likely PASS already (a single doc finishes near-instantly). The interesting assertion is the *bounded* one; that's exercised in step 4.4. If this fails, jump straight to step 4.3.
+
+- [ ] **Step 4.3: Add the shutdown step to `close()`**
+
+In `src/markdown_vault_mcp/collection.py`, find the `def close(self) -> None:` method (around line 290-350). Add a new step as the **very first** action inside the method, before any existing teardown:
+
+```python
+def close(self) -> None:
+    """Tear down the Collection. See spec section "Shutdown" for ordering."""
+    # 1. Signal the background reindex thread and join with a bounded timeout.
+    #    daemon=True ensures the process can still exit if the thread is stuck
+    #    inside reindex()'s scanner work; SQLite WAL recovers on next startup.
+    self._background_shutdown.set()
+    thread = self._background_thread
+    if thread is not None and thread.is_alive():
+        thread.join(timeout=30.0)
+        if thread.is_alive():
+            logger.warning(
+                "background_reindex_thread_join_timeout "
+                "thread=%s — abandoning (daemon=True ensures process exit)",
+                thread.name,
+            )
+
+    # 2. (existing teardown steps — embeddings flush, callback drain, git
+    #    strategy close, FTS close — keep the existing comments and code.)
+```
+
+- [ ] **Step 4.4: Write the bounded-timeout regression test**
+
+Append:
+
+```python
+def test_close_bounded_join_does_not_hang_indefinitely(tmp_path: Path) -> None:
+    """A background thread that ignores shutdown still lets close() return."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+
+    # Replace the worker target with one that sleeps past the 30s timeout.
+    stop_sleeping = threading.Event()
+
+    def slow_worker() -> None:
+        stop_sleeping.wait(timeout=60.0)
+
+    # We cannot easily replace the thread target after .start(); instead we
+    # construct the thread manually to bypass start_background_reindex.
+    collection._background_shutdown.clear()
+    collection._background_thread = threading.Thread(
+        target=slow_worker, daemon=True, name="test-slow-bg"
+    )
+    collection._background_thread.start()
+
+    # Patch the join timeout to keep the test under 5 seconds.
+    original_close = collection.close
+
+    def fast_close() -> None:
+        collection._background_shutdown.set()
+        t = collection._background_thread
+        if t is not None and t.is_alive():
+            t.join(timeout=2.0)  # short for the test
+        # Skip the rest of close() — we only want to verify the join semantics.
+
+    fast_close()
+
+    # The slow thread is still alive (it ignored shutdown), but fast_close returned.
+    assert collection._background_thread is not None
+    assert collection._background_thread.is_alive()
+
+    # Cleanup.
+    stop_sleeping.set()
+    collection._background_thread.join(timeout=2.0)
+    # Now do the real close.
+    original_close()
+```
+
+- [ ] **Step 4.5: Run all task-4 tests**
+
+Run: `uv run pytest tests/test_background_indexing.py -v -k close`
+
+Expected: both PASS.
+
+- [ ] **Step 4.6: Run gates and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+uv run mypy src/ tests/
+uv run pytest -x -q tests/test_background_indexing.py
+git add src/markdown_vault_mcp/collection.py tests/test_background_indexing.py
+git commit -m "feat(collection): bounded-join background thread in close()
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: The load-bearing no-wait regression test
+
+**Files:**
+- Test: `tests/test_background_indexing.py`
+- Test fixture: `tests/conftest.py` (only if the slow embedding provider needs to be shared)
+
+- [ ] **Step 5.1: Build a deliberately slow embedding provider in-line**
+
+Append to `tests/test_background_indexing.py`:
+
+```python
+import numpy as np  # noqa: E402  — kept near use site for clarity
+
+from markdown_vault_mcp.providers import EmbeddingProvider
+
+
+class _SlowEmbeddingProvider(EmbeddingProvider):
+    """Deterministic provider that sleeps per call to simulate a slow backend.
+
+    Used by the no-foreground-waiter regression test. Each ``embed`` call
+    blocks for ``per_call_delay`` seconds before returning a fixed vector,
+    which lets the test assert foreground reads remain responsive while a
+    background embedding pass is in flight.
+    """
+
+    def __init__(self, *, per_call_delay: float = 0.5, dim: int = 8) -> None:
+        self.per_call_delay = per_call_delay
+        self.dim = dim
+
+    def embed(self, texts: list[str]) -> np.ndarray:
+        time.sleep(self.per_call_delay)
+        # Deterministic non-zero vector per text.
+        return np.ones((len(texts), self.dim), dtype=np.float32)
+```
+
+If `EmbeddingProvider` lives under a different module path, adjust the import. Check `src/markdown_vault_mcp/providers.py` for the ABC's exact name and method signature.
+
+- [ ] **Step 5.2: Verify the import resolves**
+
+Run: `uv run python -c "from markdown_vault_mcp.providers import EmbeddingProvider; print(EmbeddingProvider)"`
+
+Expected: prints the class. If `ImportError`, find the right symbol in `src/markdown_vault_mcp/providers.py` and update the import in step 5.1.
+
+- [ ] **Step 5.3: Write the load-bearing test**
+
+Append:
+
+```python
+def test_foreground_reads_never_block_on_background(tmp_path: Path) -> None:
+    """REGRESSION TEST FOR PR #515.
+
+    Foreground methods must NOT wait on the background thread. With a
+    deliberately slow embedding provider, search/list_documents/stats/
+    index_status must all return promptly while the background thread
+    is mid-embedding. If this test ever fails, a foreground waiter has
+    been reintroduced — find and remove it before re-running.
+
+    See docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md
+    section "The load-bearing rule".
+    """
+    # Seed a handful of docs so the embedding phase has real work.
+    for i in range(5):
+        (tmp_path / f"doc{i}.md").write_text(f"# Doc {i}\n\nbody {i}\n", encoding="utf-8")
+
+    embeddings_path = tmp_path / ".embeddings"
+    collection = Collection(
+        source_dir=tmp_path,
+        embedding_provider=_SlowEmbeddingProvider(per_call_delay=0.2),
+        embeddings_path=embeddings_path,
+    )
+    try:
+        # Pre-build the FTS index synchronously so search has something to
+        # return; the slow path we're testing is the embedding phase.
+        collection.build_index()
+
+        collection.start_background_reindex()
+
+        # Wait until the worker enters the embedding phase (deterministic
+        # signal that the slow path is now active).
+        _wait_until(
+            lambda: collection.index_status()["background_phase"] == "embedding",
+            timeout=5.0,
+        )
+
+        # Each foreground call must return within 500ms while the slow
+        # embedding loop is in flight.
+        for op_name, op in [
+            ("search", lambda: collection.search("body", limit=5)),
+            ("list_documents", lambda: collection.list_documents()),
+            ("stats", lambda: collection.stats()),
+            ("index_status", lambda: collection.index_status()),
+        ]:
+            start = time.monotonic()
+            op()
+            elapsed = time.monotonic() - start
+            assert elapsed < 0.5, (
+                f"{op_name} took {elapsed:.3f}s — a foreground waiter has been "
+                "reintroduced. See spec section 'The load-bearing rule'."
+            )
+    finally:
+        collection.close()
+```
+
+- [ ] **Step 5.4: Run it — it should PASS already**
+
+Run: `uv run pytest tests/test_background_indexing.py::test_foreground_reads_never_block_on_background -v`
+
+Expected: PASS. If it fails because foreground methods take >500ms, that means `_ensure_initialized()` (still present at this point) is being hit and is slow. That's expected — Task 6 strips it, which is what makes this test bulletproof going forward. If it fails for this reason, **skip ahead to Task 6 and come back to verify this test**.
+
+If it fails for any *other* reason — investigate and fix before continuing.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add tests/test_background_indexing.py
+git commit -m "test(collection): regression test for no foreground waiter on background
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Strip `_ensure_initialized()` from Collection
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/collection.py`
+- Update: any test file that breaks (audit `tests/test_collection.py`, `tests/test_managers_*.py`)
+
+- [ ] **Step 6.1: Identify all call sites**
+
+Run: `grep -n "_ensure_initialized" src/markdown_vault_mcp/collection.py`
+
+Expected: ~22 lines listing the method definition and call sites.
+
+- [ ] **Step 6.2: Delete the method and every call site**
+
+In `src/markdown_vault_mcp/collection.py`:
+
+a. Delete the method body (around line 355-358):
+```python
+def _ensure_initialized(self) -> None:
+    """Build the FTS index on first access if it has not been built yet."""
+    if not self._initialized:
+        self.build_index()
+```
+
+b. Delete every `self._ensure_initialized()` call. Use:
+```bash
+# Sanity check before edit:
+grep -n "self._ensure_initialized()" src/markdown_vault_mcp/collection.py
+```
+Then remove each call line. There are ~21 of them — one per public method that currently lazy-builds. Each removal is a single-line delete; nothing else on those lines needs to change.
+
+c. After all edits, verify the symbol is gone:
+```bash
+grep -n "_ensure_initialized" src/markdown_vault_mcp/collection.py
+```
+Expected: no output (empty).
+
+- [ ] **Step 6.3: Audit `Collection` for other #515 leftovers and remove them**
+
+Search for the helper names that the abandon memo identified as #515 leftovers — these are *probably* not present in the current branch (which is fresh from main), but verify:
+
+```bash
+grep -n "_count_documents\|_fts_has_documents\|skip_if_missing" src/markdown_vault_mcp/collection.py src/markdown_vault_mcp/managers/index.py
+```
+
+Expected: empty (or only legitimate uses unrelated to the spike). If any spike-leftover symbol appears, delete it. If a real production caller uses it (unlikely on a clean branch), file a follow-up issue rather than rip it out here.
+
+- [ ] **Step 6.4: Run the full test suite — expect some failures**
+
+Run: `uv run pytest -x -q`
+
+Expected: Some tests in `tests/test_collection.py`, `tests/test_managers_*.py`, or similar may fail because they implicitly relied on lazy initialisation. The failures will look like "empty result" or "no rows in FTS" assertions. **This is expected.** Continue to step 6.5.
+
+- [ ] **Step 6.5: Fix each failing test by adding an explicit `collection.build_index()`**
+
+For every test that fails because of the strip:
+- Locate the test.
+- Add `collection.build_index()` (or `collection.start_background_reindex(); _wait_until(...)`) **before** the first assertion that depends on indexed content.
+- Prefer `build_index()` for tests that need synchronous correctness; only use the background helper if testing the background path itself.
+
+If a test was *already* calling `build_index()` (most should be), no change needed.
+
+- [ ] **Step 6.6: Re-run the suite to green**
+
+Run: `uv run pytest -x -q`
+
+Expected: PASS. If still failing, repeat 6.5 for the new failures.
+
+- [ ] **Step 6.7: Re-run the load-bearing test (Task 5)**
+
+Run: `uv run pytest tests/test_background_indexing.py::test_foreground_reads_never_block_on_background -v`
+
+Expected: PASS, more solidly than before — the foreground paths now have zero possibility of triggering a lazy build.
+
+- [ ] **Step 6.8: Run gates and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+uv run mypy src/ tests/
+uv run pytest -x -q
+git add -A
+git commit -m "refactor(collection): strip _ensure_initialized and lazy-build call sites
+
+The lazy-build entry point was the structural vehicle of the PR #515
+foreground/background coupling failure. Removing it makes the
+no-foreground-waiter rule executable: there is no longer any method
+on Collection that performs implicit blocking initialisation.
+
+Tests that relied on lazy-init updated to call build_index() explicitly.
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Nest `index_status` into `stats()` and `CollectionStats`
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/types.py`
+- Modify: `src/markdown_vault_mcp/collection.py` (`stats` method, around line 888)
+- Test: `tests/test_background_indexing.py`
+
+- [ ] **Step 7.1: Write the failing test**
+
+Append:
+
+```python
+def test_stats_includes_index_status_field(tmp_path: Path) -> None:
+    """CollectionStats now carries the index_status snapshot."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    try:
+        collection.build_index()
+        result = collection.stats()
+        # Either dataclass attribute or dict key — depends on dataclass shape.
+        assert hasattr(result, "index_status")
+        status = result.index_status
+        assert set(status.keys()) == {
+            "background_running",
+            "background_phase",
+            "last_run_started_at",
+            "last_run_completed_at",
+            "last_error",
+        }
+    finally:
+        collection.close()
+```
+
+- [ ] **Step 7.2: Run it — expect failure**
+
+Run: `uv run pytest tests/test_background_indexing.py::test_stats_includes_index_status_field -v`
+
+Expected: `AssertionError: hasattr(result, 'index_status')` returns False.
+
+- [ ] **Step 7.3: Extend `CollectionStats`**
+
+In `src/markdown_vault_mcp/types.py`, locate `class CollectionStats:` (line 355). Add the new field at the end of the field list (last position) and document it:
+
+```python
+@dataclass
+class CollectionStats:
+    """Collection-wide statistics, returned by :meth:`~markdown_vault_mcp.collection.Collection.stats`.
+
+    Attributes:
+        document_count: Number of indexed markdown documents.
+        chunk_count: Total number of indexed sections (chunks).
+        folder_count: Number of distinct folder paths.
+        semantic_search_available: ``True`` if a vector index is loaded and ready.
+        indexed_frontmatter_fields: Frontmatter fields configured for tag indexing.
+        attachment_extensions: File extensions recognised as attachments.
+        link_count: Total number of links extracted from all documents.
+        broken_link_count: Number of links whose target does not exist.
+        orphan_count: Number of documents with no inbound or outbound links.
+        index_status: Snapshot of background reindex state. See
+            :meth:`~markdown_vault_mcp.collection.Collection.index_status`.
+    """
+
+    document_count: int
+    chunk_count: int
+    folder_count: int
+    semantic_search_available: bool
+    indexed_frontmatter_fields: list[str] = field(default_factory=list)
+    attachment_extensions: list[str] = field(default_factory=list)
+    link_count: int = 0
+    broken_link_count: int = 0
+    orphan_count: int = 0
+    index_status: dict[str, Any] = field(default_factory=dict)
+```
+
+Ensure `from typing import Any` is imported at the top of `types.py` (add to existing imports if missing).
+
+- [ ] **Step 7.4: Populate the field in `Collection.stats()`**
+
+In `src/markdown_vault_mcp/collection.py`, locate `def stats(self) -> CollectionStats:` (around line 888). It currently returns a `CollectionStats(...)`. Add `index_status=self.index_status(),` as the last keyword argument in the return statement.
+
+- [ ] **Step 7.5: Run all stats-related tests**
+
+Run: `uv run pytest -x -q -k stats`
+
+Expected: PASS. If the new field breaks downstream serialisation tests (e.g. JSON marshaling), they may need to expect the new field; fix those.
+
+- [ ] **Step 7.6: Run gates and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+uv run mypy src/ tests/
+uv run pytest -x -q
+git add -A
+git commit -m "feat(stats): nest index_status snapshot inside CollectionStats
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Wire `index_status` into `get_server_info`
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/server.py` (around line 225)
+- Test: `tests/test_background_indexing.py`
+
+- [ ] **Step 8.1: Investigate `register_server_info_tool`'s extension surface**
+
+Run: `uv run python -c "from fastmcp_pvl_core import register_server_info_tool; import inspect; print(inspect.signature(register_server_info_tool))"`
+
+Expected: prints the signature. Look for an `extras` / `extra_status` / `extra_fields` parameter, or a callable that returns supplementary data alongside `upstream_version`.
+
+If `register_server_info_tool` does NOT support arbitrary extra fields, take one of these fallback paths (in priority order):
+- **Fallback A:** Use the existing `upstream_version` callable to inject the `index_status` dict as the upstream-version payload (semantic abuse — only if A and B below are also blocked, which is unlikely).
+- **Fallback B:** Replace the `register_server_info_tool` call with a thin local `@mcp.tool` decorator that constructs the same payload plus the `index_status` field. The pvl-core helper is small; copying its shape is acceptable. Open a follow-up issue against `fastmcp-pvl-core` asking for an `extras` parameter so this can be reverted later.
+- **Fallback C:** Skip the `get_server_info` exposure entirely; surface `index_status` only via `stats`. Update the spec's Acceptance criteria to note this. Filing the `fastmcp-pvl-core` issue is still required.
+
+Record which path you took in the commit message.
+
+- [ ] **Step 8.2: Write the failing test for the chosen path**
+
+If you took the happy path (`register_server_info_tool` supports extras) or Fallback B (local tool):
+
+Append to `tests/test_background_indexing.py`:
+
+```python
+import asyncio  # noqa: E402
+
+from fastmcp import Client  # noqa: E402
+
+from markdown_vault_mcp.server import make_server  # noqa: E402
+from markdown_vault_mcp.config import CollectionConfig  # noqa: E402
+
+
+async def _call_get_server_info(server) -> dict:
+    async with Client(server) as client:
+        result = await client.call_tool("get_server_info", {})
+        # Result shape depends on FastMCP version; adapt as needed.
+        return result.data if hasattr(result, "data") else result
+
+
+def test_get_server_info_includes_index_status(tmp_path: Path, monkeypatch) -> None:
+    """get_server_info exposes the index_status snapshot."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    config = CollectionConfig.from_env()
+    server = make_server(config)
+    payload = asyncio.run(_call_get_server_info(server))
+    assert "index_status" in payload
+    assert set(payload["index_status"].keys()) == {
+        "background_running",
+        "background_phase",
+        "last_run_started_at",
+        "last_run_completed_at",
+        "last_error",
+    }
+```
+
+If you took Fallback C, instead add a test that asserts the field is NOT present (so the absence is deliberate, not regression):
+
+```python
+def test_get_server_info_does_not_include_index_status_yet(tmp_path: Path, monkeypatch) -> None:
+    """Documented limitation until fastmcp-pvl-core gains an extras param."""
+    # (same setup as above)
+    payload = asyncio.run(_call_get_server_info(server))
+    assert "index_status" not in payload
+```
+
+- [ ] **Step 8.3: Run the test — should fail before wiring**
+
+Run: `uv run pytest tests/test_background_indexing.py -v -k get_server_info`
+
+Expected: FAIL with "'index_status' not in payload".
+
+- [ ] **Step 8.4: Wire it**
+
+Edit `src/markdown_vault_mcp/server.py` (around line 225). The exact change depends on the path chosen in step 8.1.
+
+**Happy path** (pvl-core supports extras):
+
+```python
+def _live_index_status() -> dict[str, Any]:
+    """Zero-arg callable for register_server_info_tool's extras parameter."""
+    collection = _maybe_get_collection_singleton()
+    if collection is None:
+        return {
+            "background_running": False,
+            "background_phase": None,
+            "last_run_started_at": None,
+            "last_run_completed_at": None,
+            "last_error": None,
+        }
+    return collection.index_status()
+
+
+register_server_info_tool(
+    mcp,
+    server_name=server_name,
+    server_version=pkg_ver,
+    extras={"index_status": _live_index_status},  # exact kwarg name from 8.1
+    # DOMAIN-UPSTREAM-START ... DOMAIN-UPSTREAM-END (unchanged)
+)
+```
+
+Make sure `_maybe_get_collection_singleton` exists in `_server_deps.py` — if not, add it as a safe variant of `set_collection_singleton`'s reader that returns `None` when uninitialised. (The lifespan may not have run yet during health checks.)
+
+**Fallback B** (local tool replacing the helper): copy the pvl-core helper's shape into `server.py` and add the `index_status` field. Keep it small.
+
+**Fallback C**: leave `register_server_info_tool` unchanged. Update the spec acceptance criteria in the same commit.
+
+- [ ] **Step 8.5: Run the test — must PASS**
+
+Run: `uv run pytest tests/test_background_indexing.py -v -k get_server_info`
+
+Expected: PASS (for happy path or Fallback B) or PASS-as-documented-limitation (Fallback C).
+
+- [ ] **Step 8.6: Run gates and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+uv run mypy src/ tests/
+uv run pytest -x -q
+git add -A
+git commit -m "feat(server): expose index_status via get_server_info
+
+Path chosen: <happy / fallback-B / fallback-C>. <One-line reason.>
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Switch lifespan to background mode
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/_server_deps.py` (around line 83-137)
+- Test: existing tests; no new test needed (the integration is exercised by the test in Task 8 and existing lifespan tests).
+
+- [ ] **Step 9.1: Locate the lifespan body**
+
+Open `src/markdown_vault_mcp/_server_deps.py` and find `_collection_lifespan` (around line 83-137). The current body builds the index and embeddings synchronously before yielding.
+
+- [ ] **Step 9.2: Replace the synchronous build with the background spawn**
+
+Replace the block:
+
+```python
+        # Build index eagerly so first tool call is fast.
+        stats = await asyncio.to_thread(collection.build_index)
+        logger.info(
+            "Index built: %d documents, %d chunks",
+            stats.documents_indexed,
+            stats.chunks_indexed,
+        )
+
+        # Build embeddings eagerly when an embedding provider is configured.
+        # build_embeddings() skips work if the vector index already exists on disk,
+        # so this is safe to call on every startup.
+        if kwargs.get("embedding_provider") is not None:
+            chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
+            logger.info("Embeddings ready: %d chunks", chunks_embedded)
+
+        # Start background tasks (e.g. git pull loop) after index is built.
+        collection.start()
+```
+
+with:
+
+```python
+        # Start background tasks (git pull loop, etc.) so reindex can see
+        # the freshest tree if a pull happens early.
+        collection.start()
+
+        # Kick off the background reindex (FTS + embeddings if configured).
+        # Returns immediately; foreground tools are usable straight away,
+        # initially returning empty/partial results until the worker fills
+        # in the index. Clients learn the state via stats / get_server_info.
+        collection.start_background_reindex()
+        logger.info(
+            "Background reindex started; server is accepting requests immediately"
+        )
+```
+
+- [ ] **Step 9.3: Run the full suite**
+
+Run: `uv run pytest -x -q`
+
+Expected: PASS. Tests that previously relied on lifespan-built indexes will still work because `Collection.build_index()` is still called by the CLI and by tests directly. If any test fails because it expected the *lifespan* to have built the index, replace that expectation with a wait-for-background or an explicit `build_index()` call.
+
+- [ ] **Step 9.4: Manual smoke check**
+
+Run the server once in an empty vault and verify it accepts an `initialize` handshake in <1s:
+
+```bash
+mkdir -p /tmp/smoke-vault
+MARKDOWN_VAULT_MCP_SOURCE_DIR=/tmp/smoke-vault uv run markdown-vault-mcp serve --transport stdio < /dev/null &
+sleep 1
+kill %1 2>/dev/null
+```
+
+Expected: process started and shut down cleanly within ~1s; no `Index built` log line during startup (it now happens asynchronously).
+
+- [ ] **Step 9.5: Run gates and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+uv run mypy src/ tests/
+uv run pytest -x -q
+git add -A
+git commit -m "feat(server): non-blocking startup via background reindex
+
+The MCP initialize handshake no longer waits on build_index() or
+build_embeddings(). The collection is constructed, git sync runs, the
+periodic-pull background tasks start, and then start_background_reindex
+fires a daemon thread that fills in the FTS and vector indexes. Tools
+are usable immediately; clients learn state via stats / get_server_info.
+
+Closes #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Documentation updates
+
+**Files:**
+- Modify: `docs/design.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/guides/claude-desktop.md`
+- Modify: `docs/tools/index.md`
+- Modify: `README.md`
+
+- [ ] **Step 10.1: Add "Background indexing" section to `docs/design.md`**
+
+Find the appropriate location (probably near "Indexing" or "Architecture"). Add:
+
+```markdown
+### Background indexing (non-blocking startup)
+
+The MCP `initialize` handshake never blocks on FTS or embedding work. On
+server start, `Collection.start_background_reindex()` spawns a daemon
+thread that runs `reindex()` followed by `build_embeddings()` (when an
+embedding provider is configured). Tools become available immediately;
+read tools return whatever's currently in the index. Clients learn the
+state via `stats` or `get_server_info`, both of which carry a nested
+`index_status` snapshot (`background_running`, `background_phase`,
+`last_run_started_at`, `last_run_completed_at`, `last_error`).
+
+**Load-bearing rule:** No public method on `Collection` may block on
+background indexing state. Foreground reads return whatever's currently
+in the FTS/vector index. Empty-during-cold-start is a valid result, not
+an error to wait out. This rule is enforced by
+`test_foreground_reads_never_block_on_background` in
+`tests/test_background_indexing.py` — if you find yourself adding a
+`threading.Event.wait()` or `Thread.join()` to a foreground method,
+stop. The PR #515 abandonment retrospective in
+`memory/feedback_background_indexing_abandon.md` explains why.
+```
+
+- [ ] **Step 10.2: Update `docs/configuration.md`**
+
+Find the `EXCLUDE_PATTERNS` row in the configuration table. Append a note:
+
+> Changes take effect on the next background reindex (server start or periodic git pull).
+
+- [ ] **Step 10.3: Update `docs/guides/claude-desktop.md`**
+
+Find the section `## Pre-build embeddings before first launch` (or the closest equivalent — the exact anchor matters because it's referenced from `README.md` and the spec). Reframe its opening paragraph:
+
+> Pre-building the index before the first launch is **no longer required** — the server starts immediately and fills in the FTS and vector indexes in the background. Pre-building remains the **fastest path to immediate full readiness**: if you want all tools to return complete results on the very first request after startup, run `markdown-vault-mcp index` before launching the server.
+
+- [ ] **Step 10.4: Update `docs/tools/index.md`**
+
+Find the `stats` tool entry. Add `index_status` to the Returns description:
+
+> - `index_status`: snapshot of background reindex state. Keys: `background_running` (bool), `background_phase` (`"indexing" | "embedding" | None`), `last_run_started_at`, `last_run_completed_at`, `last_error`.
+
+Find the `get_server_info` tool entry (if present in this file; it's registered by `fastmcp-pvl-core`). If absent, skip — the field is documented in the spec. If present, add the same `index_status` Returns bullet.
+
+- [ ] **Step 10.5: Update `README.md`**
+
+Find the "How it works" or similar section. Add a one-sentence note:
+
+> The server starts immediately and builds its index in the background; tools are usable straight away and clients can check progress via the `stats` tool's `index_status` field.
+
+- [ ] **Step 10.6: Verify docs build**
+
+Run: `uv run mkdocs build --strict` (if the project uses MkDocs — based on the file map it does).
+
+Expected: clean build, no warnings treated as errors.
+
+- [ ] **Step 10.7: Commit**
+
+```bash
+git add docs/ README.md
+git commit -m "docs(513): describe background indexing and the no-waiter rule
+
+Refs #513.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Pre-flight circus and PR open
+
+**Files:** none (process task)
+
+- [ ] **Step 11.1: Verify the cumulative diff**
+
+```bash
+git fetch origin main
+git log --oneline origin/main..HEAD
+git diff --stat origin/main..HEAD
+```
+
+Expected: a handful of focused commits (spec + ~10 task commits). Total diff under ~800 added LOC excluding the spec.
+
+- [ ] **Step 11.2: Run all gates one more time**
+
+```bash
+uv run pre-commit run --all-files
+uv run pytest -x -q
+uv run mypy src/ tests/
+uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=80 || true
+```
+
+Expected: pre-commit green; pytest green; mypy clean; diff-cover ≥ 80% on the diff.
+
+- [ ] **Step 11.3: Invoke the preflight-circus skill**
+
+This is non-negotiable per CLAUDE.md. The skill runs the same five-lens review the bot will run post-push; the steady state is bot LGTM on first run because the bot is re-running prompts the skill already exercised.
+
+Invoke `~/.claude/skills/preflight-circus/` against `BASE..HEAD` where `BASE = $(git merge-base HEAD origin/main)`. Address every finding at confidence ≥ 80 before pushing.
+
+- [ ] **Step 11.4: Push as draft and verify CI**
+
+```bash
+git push -u origin feat/513-background-indexing-v2
+gh pr create --draft --title "feat(server): non-blocking background indexing (closes #513, second attempt)" --body "$(cat <<'EOF'
+## Summary
+
+Replaces the abandoned PR #515 with a structurally different approach:
+indexing stays in Collection, but the public API gains
+`start_background_reindex()` (fire-and-forget daemon spawn) and
+`index_status()` (read-only snapshot) — and the foreground waiter
+`_ensure_initialized()` is **removed entirely**. The no-foreground-waiter
+rule that PR #515 violated is now executable: a regression test asserts
+foreground reads return within 500ms while a deliberately slow background
+embedding pass is in flight.
+
+See spec: `docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md`.
+
+Closes #513.
+
+## Test plan
+
+- [ ] Tests added in `tests/test_background_indexing.py` cover: idempotent
+      start, phase transitions, failure path, bounded close() join,
+      foreground non-blocking under slow background, stats+server_info
+      exposure.
+- [ ] PR #256 regression test still passes (build_index purge invariant).
+- [ ] Manual smoke: server initialize handshake completes in <1s on a
+      vault with no pre-built index.
+EOF
+)"
+```
+
+- [ ] **Step 11.5: Read bot review bodies, not just check statuses**
+
+After the push triggers `claude-review`:
+
+```bash
+gh pr view --json number,url
+# Wait for claude-review to post (1-3 min):
+gh pr checks <N>
+# Read the actual body, not just the check status:
+gh api repos/pvliesdonk/markdown-vault-mcp/pulls/<N>/reviews
+gh api repos/pvliesdonk/markdown-vault-mcp/issues/<N>/comments
+```
+
+Expected: LGTM on first run. If anything is flagged at ≥ 80 confidence: address it, re-invoke the preflight-circus skill on the new cumulative diff, push, and re-read the bots. **Cap: one bot iteration round.** If something turns up on the second post-push round, surface to the user with a written diagnosis before pushing again.
+
+- [ ] **Step 11.6: Flip to ready when bots LGTM and CI is green**
+
+```bash
+gh pr ready <N>
+```
+
+Then hand off to the user for human merge.
+
+---
+
+## Self-review (already run)
+
+- **Spec coverage:** All eleven acceptance-criteria bullets in the spec map to tasks: criteria 1, 5 → Task 9; 2 → Tasks 2, 7; 3 → Task 3; 4 → Task 5; 6 → Task 4; 7 → Task 6 (PR #256 preservation) and Task 9 (warm-start path); 8 → Task 6; 9, 10 → unchanged behaviours (no task needed); 11 → Task 10.
+- **Placeholders:** scanned — none. Task 8 has a documented fallback decision tree but every branch has concrete steps and a commit.
+- **Type/symbol consistency:** `index_status` field name used identically across `Collection.index_status()`, `CollectionStats.index_status`, the `stats` tool response, and the `get_server_info` response. `background_running` / `background_phase` / `last_run_started_at` / `last_run_completed_at` / `last_error` field names match between code and tests.

--- a/docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md
+++ b/docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md
@@ -1,0 +1,216 @@
+# Non-blocking startup via Collection-owned background reindex (#513, second attempt)
+
+**Status:** Approved — ready for implementation planning.
+**Supersedes:** PR #515 (own attempt, abandoned 2026-05-26) and PR #510 (external attempt, abandoned earlier).
+**Issue:** [#513](https://github.com/pvliesdonk/markdown-vault-mcp/issues/513).
+
+## Background
+
+PR #515 attempted non-blocking startup by extracting an event-driven coupling between `Collection._ensure_initialized` and a background thread's `_fts_done_event`. After six rounds of whack-a-mole bug-fixing, the branch was abandoned per the project's "abandon the branch" rule. The structural root cause: foreground methods waiting on background-thread state cascaded into every downstream issue (two-event split, 60s timeout race against `_write_lock`, broad `except` masks in `_count_documents`/`_fts_has_documents`, dual-invariant `stats()` bypass, dead `skip_if_missing` parameter).
+
+The first attempt was a productive spike — its findings carry forward (warm-start fast path with `exclude_patterns` purge, close() shutdown ordering, the value of distinguishing FTS-done from full-done). Only the messy diff is discarded.
+
+PR #510 (external) used a "skip eager build" approach that regressed PR #256's `exclude_patterns` purge logic. That regression mode is also avoided by this design.
+
+## Goal
+
+Server startup completes within seconds even on a fresh deploy with thousands of documents and no pre-built index. The MCP `initialize` handshake never blocks on FTS or embedding work. Tools become usable immediately; clients can see what's currently indexed and learn that indexing is still in progress.
+
+## Architecture
+
+`Collection` owns indexing in both invocation modes:
+
+- **Synchronous** — `build_index()` / `reindex()`. Used by the CLI and the existing `reindex` MCP tool. Caller blocks until done. Unchanged behaviour.
+- **Background** — `start_background_reindex()` (new). Spawns a daemon thread that runs `reindex()` followed by `build_embeddings()` (when a provider is configured). Returns immediately. Idempotent (no-op if a background thread is already alive).
+
+### The load-bearing rule
+
+> **No public method on `Collection` may block on background indexing state.** Foreground reads return whatever is currently in the FTS / vector index. Empty-during-cold-start is a valid result, not an error to wait out.
+
+The rule is enforced two ways:
+
+1. **`_ensure_initialized()` is stripped entirely** — method deleted, all call sites cleaned. It was the structural vehicle of the #515 failure; deleting it removes the temptation to re-add a waiter to it. Methods that used to call it instead trust the underlying FTS / vector indexes to return what they have.
+2. **A regression test** asserts that `search()`, `list_documents()`, and `stats()` return within 500ms while a deliberately slow background reindex is in flight (see Tests below). Future code that re-introduces a foreground waiter will fail this test.
+
+Why a wrapper class (`BackgroundIndexer`) was rejected: indexing IS Collection's responsibility (its FTS table, vector index, and tracker are Collection internals; "what's currently indexed" is intrinsic state). A wrapper that exists only to ask Collection for state and re-expose it through a thread-aware facade adds indirection, not architecture. The right fix is to make Collection's foreground methods non-blocking, not to extract the threading concern into a separate type.
+
+## New Collection state
+
+```python
+_background_thread: threading.Thread | None
+_background_shutdown: threading.Event       # cooperative shutdown signal
+_background_state_lock: threading.Lock      # protects status snapshot fields
+_background_phase: Literal["indexing", "embedding"] | None
+_background_last_started_at: str | None     # ISO-8601 UTC
+_background_last_completed_at: str | None
+_background_last_error: str | None
+```
+
+There is no event the foreground waits on. `_background_state_lock` exists only to serialise the status-snapshot read against the background thread's status updates.
+
+## New / changed methods
+
+```python
+def start_background_reindex(self) -> None:
+    """Spawn a daemon thread running reindex() then build_embeddings().
+
+    No-op if a background thread is already alive (logs at DEBUG).
+    Returns immediately.
+    """
+
+def index_status(self) -> dict[str, Any]:
+    """Read-only snapshot of background indexing state. Never blocks.
+
+    Returns a dict with:
+        background_running: bool
+        background_phase:   "indexing" | "embedding" | None
+        last_run_started_at:   ISO-8601 UTC string or None
+        last_run_completed_at: ISO-8601 UTC string or None
+        last_error: str or None    # from most recent failed run; cleared on success
+    """
+
+def stats(self) -> CollectionStats:
+    # Existing method. Two changes:
+    #   - Stops calling self._ensure_initialized().
+    #   - Returned CollectionStats gains a nested index_status field
+    #     (same dict shape as index_status()).
+
+def close(self) -> None:
+    # Existing method. Gains a new first step:
+    #   1. Set _background_shutdown.
+    #   2. Join _background_thread with 30s timeout.
+    #   3. (If still alive) log a warning; daemon=True ensures process exit.
+    # Then the existing FTS / git teardown runs unchanged.
+```
+
+`build_index()` retains its warm-start fast path (no-op when the FTS DB already has rows) and the PR #256 `exclude_patterns` purge — both preserved from the #515 spike and sound regardless of foreground/background split.
+
+`_ensure_initialized()` is removed. Any helper introduced during the #515 spike (`_count_documents`, `_fts_has_documents`, `skip_if_missing` parameter on `build_embeddings`) is also removed — they existed only to paper over the foreground waiter.
+
+## Background worker logic
+
+```python
+def _background_reindex_worker(self) -> None:
+    try:
+        self._set_phase("indexing")
+        if self._background_shutdown.is_set():
+            return
+        self.reindex()  # acquires _write_lock during mutation phase
+
+        if self._embedding_provider is not None and self._embeddings_path is not None:
+            if self._background_shutdown.is_set():
+                return
+            self._set_phase("embedding")
+            self.build_embeddings()
+
+        self._set_completed(error=None)
+    except Exception as exc:
+        logger.error("background_reindex_failed", exc_info=True)
+        self._set_completed(error=str(exc))
+    finally:
+        self._set_phase(None)
+```
+
+The thread checks `_background_shutdown` between phases. Mid-`reindex()` interruption is not supported (would require invasive changes to the scanner); `daemon=True` ensures the Python process exits regardless on hard shutdown.
+
+The embedding phase is guarded by an explicit `if self._embedding_provider is not None and self._embeddings_path is not None:` check — **not** by a `skip_if_missing` parameter on `build_embeddings()`. The dead parameter from #515 is not reintroduced.
+
+## Lifespan composition (`_server_deps.py`)
+
+```python
+collection = Collection(**kwargs)
+set_collection_singleton(collection)
+
+await asyncio.to_thread(collection.sync_from_remote_before_index)
+collection.start()                       # FTS open, git start — fast
+collection.start_background_reindex()    # fire-and-forget
+yield {"collection": collection, "config": config}
+# on shutdown: collection.close() handles bg join + existing teardown
+```
+
+The lifespan no longer calls `build_index()`. The CLI path (`markdown-vault-mcp index`) still calls it synchronously — unchanged.
+
+## Exposure
+
+- **`stats` MCP tool** (and the `stats://vault` resource): `CollectionStats` gains a nested `index_status` field. An LLM client that wants "is the index ready?" calls `stats` and reads it.
+- **`get_server_info` tool**: gains an `index_status` field for operator health checks and "is my latest fix actually running?" workflows.
+- **No separate `index_status` MCP tool** — keeps the surface tight. The information is composable from `stats` + `embeddings_status` for clients that want counts.
+
+## Failure recovery
+
+On background failure: `last_error` is set, `background_phase` returns to `None`, `background_running` becomes `False`, the server stays running. Operator recovers via either:
+
+- CLI: `markdown-vault-mcp index` (rebuilds from scratch).
+- MCP `reindex` tool: incremental from current FTS state. Contends naturally on `_write_lock` if a background run is somehow still in flight.
+
+`last_error` clears on the next successful background run, or is overwritten by the next failure. No automatic retry — sustained transient errors would otherwise burn provider quota and mask config problems.
+
+## Concurrency contract
+
+| Caller | Behaviour |
+|--------|-----------|
+| Foreground reads (`search`, `list_documents`, `stats`, `index_status`) | Never block on background. Return current FTS / vector contents. |
+| Foreground writes (`write`, `edit`, `delete`, `rename`) | Acquire `_write_lock`. If background is in its mutation phase, write waits briefly (existing behaviour). Tracker hash ensures the next background pass skips the file the foreground just wrote. |
+| Periodic git pull | Unchanged. Calls `collection.reindex()` synchronously in its own thread; contends on `_write_lock`. |
+| `reindex` MCP tool | Unchanged. Sync, contends on `_write_lock`. |
+| `start_background_reindex()` called twice | No-op on second call (thread alive check); DEBUG log. |
+
+## Tests
+
+### The load-bearing test
+
+**`test_foreground_reads_never_block_on_background`** — instantiate a Collection with a `MockEmbeddingProvider` that sleeps per chunk to deliberately slow the background run. Call `start_background_reindex()`. While the background thread is in its `indexing` phase, assert each of `search(...)`, `list_documents(...)`, `stats()`, `index_status()` returns within 500ms. This is the regression test that future code re-adding a foreground waiter will fail.
+
+### Other tests
+
+- Phase transitions: `idle → indexing → embedding → idle` (with provider); `idle → indexing → idle` (without provider).
+- Failure path: provider raises mid-embedding → phase returns to `None`, `last_error` set, foreground reads still work.
+- Shutdown during background: `close()` returns within 30s; daemon-thread fallback observable when leaving a deliberately stuck thread.
+- Idempotent `start_background_reindex()`: two calls → one thread; second call returns immediately and logs at DEBUG.
+- Warm-start fast path: existing populated DB → `build_index()` returns quickly, `exclude_patterns` purge still applies (preserve PR #256 regression test).
+- Concurrent write during background: write succeeds, tracker hash causes background reindex to skip the just-written file.
+- `index_status` snapshot during each phase reports correct values; ISO timestamps parse round-trip.
+- `get_server_info` includes the `index_status` field with the expected shape.
+- `stats` MCP tool returns nested `index_status` with the expected shape.
+
+## Documentation updates (must land with implementation)
+
+- **`docs/design.md`** — add a "Background indexing" section that names the no-foreground-waiter rule explicitly and references the regression test.
+- **`docs/configuration.md`** — `EXCLUDE_PATTERNS` row note: "Changes take effect on the next background reindex (server start or git pull)."
+- **`docs/guides/claude-desktop.md`** — pre-build is no longer required for the server to start; it remains the fastest path to immediate full readiness.
+- **`docs/tools/index.md`** — `stats` tool gains `index_status` nested field; `get_server_info` tool gains `index_status` field. Update return descriptions.
+- **`README.md`** — brief note on non-blocking startup in the "How it works" section.
+
+## Explicitly out of scope
+
+- A `BackgroundIndexer` wrapper class — rejected as bolt-on; indexing belongs in Collection.
+- `skip_if_missing` parameter on `build_embeddings()` — dead code from #515; use an `if provider:` guard in the worker.
+- Tracker `exclude_patterns` checksum for finer-grained warm-start invalidation — covered by follow-up issue #257.
+- Symlink cycle detection — covered by #508's docs warning; separate hardening if ever needed.
+- Two-thread parallel FTS + embeddings — complexity not justified without measured cold-start latency need.
+- Mid-`reindex()` cooperative interruption — would require scanner-level changes; daemon-thread shutdown is sufficient.
+
+## Acceptance criteria
+
+- [ ] MCP `initialize` handshake completes within seconds on a fresh deploy with thousands of documents and no pre-built indexes.
+- [ ] Background thread transitions through `indexing → embedding → idle` (or `indexing → idle` without provider); `stats` and `get_server_info` reflect this.
+- [ ] Background failure sets `last_error`, returns `background_phase` to `None`, logs at ERROR, leaves the server running.
+- [ ] Foreground reads during background indexing return promptly (regression test passes).
+- [ ] Foreground writes during background indexing serialise correctly via `_write_lock` (no corruption; tracker prevents double-processing).
+- [ ] `close()` during background indexing aborts cleanly within ~30s.
+- [ ] Warm-start path: pre-built DB + `.npy` → background reindex finds no changes and completes quickly.
+- [ ] PR #256 regression test (`test_build_index_purges_stale_excluded_docs`) still passes — `Collection.build_index()` retains purge semantics for the direct-call path.
+- [ ] `_ensure_initialized` and all related helpers from the #515 spike (`_count_documents`, `_fts_has_documents`, `skip_if_missing`) are absent from the final diff.
+- [ ] CLI `markdown-vault-mcp index` unchanged in behaviour.
+- [ ] MCP `reindex` tool unchanged in behaviour.
+- [ ] Documentation updates listed above land in the same PR.
+
+## References
+
+- [#513](https://github.com/pvliesdonk/markdown-vault-mcp/issues/513) — original issue.
+- [#509](https://github.com/pvliesdonk/markdown-vault-mcp/issues/509) — original "handshake timeout" report (superseded by #513).
+- [#510](https://github.com/pvliesdonk/markdown-vault-mcp/pull/510) — abandoned external PR (skip approach; regressed #256).
+- [#515](https://github.com/pvliesdonk/markdown-vault-mcp/pull/515) — abandoned own PR (foreground waiter coupled to background event).
+- [#256](https://github.com/pvliesdonk/markdown-vault-mcp/pull/256) — `exclude_patterns` purge invariant that must be preserved.
+- `memory/feedback_background_indexing_abandon.md` — post-abandon analysis that this design responds to.
+- `docs/guides/claude-desktop.md#pre-build-embeddings-before-first-launch` — operator guidance retained as an optional acceleration path.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -180,9 +180,18 @@ Get an overview of the collection's size, capabilities, and configuration. Call 
   "folder_count": 5,
   "semantic_search_available": true,
   "indexed_frontmatter_fields": ["tags", "cluster"],
-  "attachment_extensions": ["pdf", "png", "jpg"]
+  "attachment_extensions": ["pdf", "png", "jpg"],
+  "index_status": {
+    "background_running": true,
+    "background_phase": "embedding",
+    "last_run_started_at": "2026-05-26T10:15:30Z",
+    "last_run_completed_at": null,
+    "last_error": null
+  }
 }
 ```
+
+- `index_status`: snapshot of background reindex state. Keys: `background_running` (bool), `background_phase` (`"indexing"` | `"embedding"` | `null`), `last_run_started_at`, `last_run_completed_at`, `last_error`.
 
 ### `embeddings_status`
 

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -96,8 +96,8 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         collection = Collection(**kwargs)
         set_collection_singleton(collection)
 
-        # If periodic git pull is enabled, sync before building the initial index so
-        # build_index() scans the freshest working tree.
+        # If periodic git pull is enabled, sync before kicking off the initial
+        # background reindex so reindex() scans the freshest working tree.
         await asyncio.to_thread(collection.sync_from_remote_before_index)
 
         # Start background tasks (git pull loop, etc.) so reindex sees the

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -100,23 +100,18 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # build_index() scans the freshest working tree.
         await asyncio.to_thread(collection.sync_from_remote_before_index)
 
-        # Build index eagerly so first tool call is fast.
-        stats = await asyncio.to_thread(collection.build_index)
-        logger.info(
-            "Index built: %d documents, %d chunks",
-            stats.documents_indexed,
-            stats.chunks_indexed,
-        )
-
-        # Build embeddings eagerly when an embedding provider is configured.
-        # build_embeddings() skips work if the vector index already exists on disk,
-        # so this is safe to call on every startup.
-        if kwargs.get("embedding_provider") is not None:
-            chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
-            logger.info("Embeddings ready: %d chunks", chunks_embedded)
-
-        # Start background tasks (e.g. git pull loop) after index is built.
+        # Start background tasks (git pull loop, etc.) so reindex can see
+        # the freshest tree if a pull happens early.
         collection.start()
+
+        # Kick off the background reindex (FTS + embeddings if configured).
+        # Returns immediately; foreground tools are usable straight away,
+        # initially returning empty/partial results until the worker fills
+        # in the index. Clients learn the state via stats / get_server_info.
+        collection.start_background_reindex()
+        logger.info(
+            "Background reindex started; server is accepting requests immediately"
+        )
 
         # Artifact store singleton is wired in make_server(), not here —
         # the HTTP route captures the store at server-construction time and

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -100,8 +100,11 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # build_index() scans the freshest working tree.
         await asyncio.to_thread(collection.sync_from_remote_before_index)
 
-        # Start background tasks (git pull loop, etc.) so reindex can see
-        # the freshest tree if a pull happens early.
+        # Start background tasks (git pull loop, etc.) so reindex sees the
+        # freshest tree if a pull happens early. Both start() (pull callback)
+        # and start_background_reindex() (initial reindex) may call reindex();
+        # they serialise via Collection._write_lock, which is safe but means an
+        # early git pull can briefly delay the initial reindex.
         collection.start()
 
         # Kick off the background reindex (FTS + embeddings if configured).

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -203,6 +203,17 @@ class Collection:
         # this lock again for its mutation phase.
         self._write_lock = threading.RLock()
 
+        # Background reindex state (see docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md).
+        # These fields exist so background indexing state is visible to read-only
+        # snapshots; foreground methods MUST NOT wait on any of them.
+        self._background_thread: threading.Thread | None = None
+        self._background_shutdown: threading.Event = threading.Event()
+        self._background_state_lock: threading.Lock = threading.Lock()
+        self._background_phase: str | None = None  # "indexing" | "embedding" | None
+        self._background_last_started_at: str | None = None
+        self._background_last_completed_at: str | None = None
+        self._background_last_error: str | None = None
+
         # Manager modules (dependency-injected, no back-reference).
         from markdown_vault_mcp.managers.document import DocumentManager
         from markdown_vault_mcp.managers.index import IndexManager
@@ -351,6 +362,25 @@ class Collection:
     # ------------------------------------------------------------------
     # Lazy initialisation
     # ------------------------------------------------------------------
+
+    def index_status(self) -> dict[str, Any]:
+        """Snapshot of background reindex state. Never blocks.
+
+        Returns:
+            Dict with keys ``background_running``, ``background_phase``,
+            ``last_run_started_at``, ``last_run_completed_at``, ``last_error``.
+            Phase is ``"indexing"``, ``"embedding"``, or ``None``.
+            Timestamps are ISO-8601 UTC strings or ``None``.
+        """
+        with self._background_state_lock:
+            thread = self._background_thread
+            return {
+                "background_running": thread is not None and thread.is_alive(),
+                "background_phase": self._background_phase,
+                "last_run_started_at": self._background_last_started_at,
+                "last_run_completed_at": self._background_last_completed_at,
+                "last_error": self._background_last_error,
+            }
 
     def _ensure_initialized(self) -> None:
         """Build the FTS index on first access if it has not been built yet."""

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -994,6 +994,7 @@ class Collection:
             link_count=self._fts.count_links(),
             broken_link_count=self._fts.count_broken_links(),
             orphan_count=self._fts.count_orphans(),
+            index_status=self.index_status(),
         )
 
     # ------------------------------------------------------------------

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -450,11 +450,6 @@ class Collection:
             self._background_thread = thread
             thread.start()
 
-    def _ensure_initialized(self) -> None:
-        """Build the FTS index on first access if it has not been built yet."""
-        if not self._initialized:
-            self.build_index()
-
     @property
     def _vectors(self) -> VectorIndex | None:
         """Bridge property: vector index is owned by SearchManager."""
@@ -504,7 +499,6 @@ class Collection:
             ValueError: If *mode* is ``"semantic"`` or ``"hybrid"`` but no
                 embedding provider or embeddings path is configured.
         """
-        self._ensure_initialized()
         return self._search_mgr.search(
             query,
             limit=limit,
@@ -534,7 +528,6 @@ class Collection:
             A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``
             if the file does not exist.
         """
-        self._ensure_initialized()
         return self._doc_mgr.read(path, section=section)
 
     def list(
@@ -561,7 +554,6 @@ class Collection:
             optionally :class:`~markdown_vault_mcp.types.AttachmentInfo`)
             objects.
         """
-        self._ensure_initialized()
         return self._search_mgr.list(
             folder=folder, pattern=pattern, include_attachments=include_attachments
         )
@@ -608,7 +600,6 @@ class Collection:
             :class:`~markdown_vault_mcp.types.ReindexResult` with counts of changes
             applied.
         """
-        self._ensure_initialized()
         return self._index_mgr.reindex()
 
     def build_embeddings(self, *, force: bool = False) -> int:
@@ -625,7 +616,6 @@ class Collection:
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is
                 not configured.
         """
-        self._ensure_initialized()
         return self._index_mgr.build_embeddings(force=force)
 
     def embeddings_status(self) -> dict:
@@ -647,7 +637,6 @@ class Collection:
         Returns:
             Sorted list of folder strings (``""`` for the collection root).
         """
-        self._ensure_initialized()
         return self._search_mgr.list_folders()
 
     def list_tags(self, field: str = "tags") -> list[str]:
@@ -661,7 +650,6 @@ class Collection:
         Returns:
             Sorted list of distinct value strings.
         """
-        self._ensure_initialized()
         return self._search_mgr.list_tags(field)
 
     def get_toc(self, path: str) -> list[dict[str, Any]]:
@@ -680,7 +668,6 @@ class Collection:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        self._ensure_initialized()
         return self._doc_mgr.get_toc(path)
 
     def get_backlinks(self, path: str) -> list[BacklinkInfo]:
@@ -697,7 +684,6 @@ class Collection:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_backlinks(path)
 
     def get_outlinks(self, path: str) -> list[OutlinkInfo]:
@@ -717,7 +703,6 @@ class Collection:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_outlinks(path)
 
     def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
@@ -730,7 +715,6 @@ class Collection:
         Returns:
             List of :class:`~markdown_vault_mcp.types.BrokenLinkInfo` objects.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_broken_links(folder=folder)
 
     def get_similar(
@@ -755,7 +739,6 @@ class Collection:
         Returns:
             List of grouped results.
         """
-        self._ensure_initialized()
         return self._search_mgr.get_similar(
             path, limit=limit, chunks_per_file=chunks_per_file
         )
@@ -774,7 +757,6 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.NoteInfo` objects
             ordered by modification time (most recent first).
         """
-        self._ensure_initialized()
         return self._search_mgr.get_recent(limit=limit, folder=folder)
 
     def get_context(
@@ -805,7 +787,6 @@ class Collection:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        self._ensure_initialized()
         return self._search_mgr.get_context(
             path, similar_limit=similar_limit, link_limit=link_limit
         )
@@ -820,7 +801,6 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.NoteInfo` objects,
             ordered by path.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_orphan_notes()
 
     def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]:
@@ -833,7 +813,6 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.MostLinkedNote` ordered
             by backlink_count descending.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_most_linked(limit=limit)
 
     def get_connection_path(
@@ -857,7 +836,6 @@ class Collection:
         Raises:
             ValueError: If *source* or *target* is not found in the index.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_connection_path(source, target, max_depth=max_depth)
 
     # ------------------------------------------------------------------
@@ -989,7 +967,6 @@ class Collection:
         Returns:
             :class:`~markdown_vault_mcp.types.CollectionStats` snapshot.
         """
-        self._ensure_initialized()
 
         rows = self._fts.list_notes()
         doc_count = len(rows)
@@ -1110,7 +1087,6 @@ class Collection:
         already validated against ``MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES``);
         leave ``False`` for base64 callers of the MCP ``write`` tool.
         """
-        self._ensure_initialized()
         return self._doc_mgr.write_attachment(
             path, content, if_match=if_match, skip_size_cap=skip_size_cap
         )
@@ -1145,7 +1121,6 @@ class Collection:
                 not match the current file hash.
             ValueError: If *path* escapes the source directory.
         """
-        self._ensure_initialized()
         return self._doc_mgr.write(
             path, content, frontmatter=frontmatter, if_match=if_match
         )
@@ -1186,7 +1161,6 @@ class Collection:
                 not match.
             ValueError: If *path* escapes the source directory.
         """
-        self._ensure_initialized()
         return self._doc_mgr.edit(
             path,
             old_text=old_text,
@@ -1216,7 +1190,6 @@ class Collection:
                 not match.
             DocumentNotFoundError: If *path* does not exist.
         """
-        self._ensure_initialized()
         return self._doc_mgr.delete(path, if_match=if_match)
 
     def rename(
@@ -1252,7 +1225,6 @@ class Collection:
             ValueError: If *old_path* or *new_path* escapes the source
                 directory.
         """
-        self._ensure_initialized()
         return self._doc_mgr.rename(
             old_path, new_path, if_match=if_match, update_links=update_links
         )

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -87,8 +87,10 @@ def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
 class Collection:
     """Facade over FTS5 index, vector index, and change tracker.
 
-    Instantiate once per collection root.  Call :meth:`build_index` (or let
-    lazy initialisation handle it) before querying.
+    Instantiate once per collection root. Call :meth:`build_index` or
+    :meth:`start_background_reindex` before querying; otherwise foreground
+    reads return whatever is currently in the FTS/vector index (possibly
+    empty).
 
     Args:
         source_dir: Root directory of the markdown collection.
@@ -416,6 +418,9 @@ class Collection:
         """Daemon-thread target: run reindex() then build_embeddings()."""
         try:
             if self._background_shutdown.is_set():
+                self._set_background_completed(
+                    error="aborted: shutdown signalled before indexing"
+                )
                 return
             self._set_background_phase("indexing")
             reindex_result = self.reindex()
@@ -432,6 +437,9 @@ class Collection:
                 and self._embeddings_path is not None
             ):
                 if self._background_shutdown.is_set():
+                    self._set_background_completed(
+                        error="aborted: shutdown signalled before embedding"
+                    )
                     return
                 self._set_background_phase("embedding")
                 embedded_count = self.build_embeddings()
@@ -458,7 +466,6 @@ class Collection:
                 return
             self._background_shutdown.clear()
             self._background_last_started_at = datetime.now(UTC).isoformat()
-            self._background_last_error = None
             thread = threading.Thread(
                 target=self._background_reindex_worker,
                 name="markdown-vault-mcp-bg-reindex",

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -334,10 +334,24 @@ class Collection:
         Flushes deferred embeddings and pending write callbacks, then
         closes the SQLite connection and git strategy.
         """
-        # 1. Flush any deferred embedding updates.
+        # 1. Signal the background reindex thread and join with a bounded timeout.
+        #    daemon=True ensures the process can still exit if the thread is stuck
+        #    inside reindex()'s scanner work; SQLite WAL recovers on next startup.
+        self._background_shutdown.set()
+        thread = self._background_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=30.0)
+            if thread.is_alive():
+                logger.warning(
+                    "background_reindex_thread_join_timeout "
+                    "thread=%s — abandoning (daemon=True ensures process exit)",
+                    thread.name,
+                )
+
+        # 2. Flush any deferred embedding updates.
         self._index_mgr.flush_dirty_embeddings()
 
-        # 2. Drain the write-callback queue (git commits).
+        # 3. Drain the write-callback queue (git commits).
         if self._callback_worker is not None and self._callback_worker.is_alive():
             self._callback_queue.put(None)  # sentinel
             self._callback_worker.join(timeout=30)
@@ -347,7 +361,7 @@ class Collection:
                     "pending git commits may be lost."
                 )
 
-        # 3. Close git strategy (flush push, etc.).
+        # 4. Close git strategy (flush push, etc.).
         if self._git_strategy is not None:
             self._git_strategy.close()
         if (
@@ -357,7 +371,7 @@ class Collection:
         ):
             self._on_write.close()  # type: ignore[union-attr]
 
-        # 4. Close SQLite.
+        # 5. Close SQLite.
         self._fts.close()
 
     # ------------------------------------------------------------------

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -11,6 +11,7 @@ import logging
 import queue
 import re
 import threading
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from markdown_vault_mcp.fts_index import FTSIndex
@@ -381,6 +382,59 @@ class Collection:
                 "last_run_completed_at": self._background_last_completed_at,
                 "last_error": self._background_last_error,
             }
+
+    def _set_background_phase(self, phase: str | None) -> None:
+        """Update the background phase field under the state lock."""
+        with self._background_state_lock:
+            self._background_phase = phase
+
+    def _set_background_completed(self, error: str | None) -> None:
+        """Mark a background run as completed under the state lock."""
+        with self._background_state_lock:
+            self._background_last_completed_at = datetime.now(UTC).isoformat()
+            self._background_last_error = error
+
+    def _background_reindex_worker(self) -> None:
+        """Daemon-thread target: run reindex() then build_embeddings()."""
+        try:
+            if self._background_shutdown.is_set():
+                return
+            self._set_background_phase("indexing")
+            self.reindex()
+
+            if (
+                self._embedding_provider is not None
+                and self._embeddings_path is not None
+            ):
+                if self._background_shutdown.is_set():
+                    return
+                self._set_background_phase("embedding")
+                self.build_embeddings()
+
+            self._set_background_completed(error=None)
+        except Exception as exc:
+            logger.error("background_reindex_failed", exc_info=True)
+            self._set_background_completed(error=str(exc))
+        finally:
+            self._set_background_phase(None)
+
+    def start_background_reindex(self) -> None:
+        """Spawn a daemon thread that runs reindex() then build_embeddings()."""
+        with self._background_state_lock:
+            existing = self._background_thread
+            if existing is not None and existing.is_alive():
+                logger.debug("start_background_reindex skipped — thread already alive")
+                return
+            self._background_shutdown.clear()
+            self._background_last_started_at = datetime.now(UTC).isoformat()
+            self._background_last_error = None
+            thread = threading.Thread(
+                target=self._background_reindex_worker,
+                name="markdown-vault-mcp-bg-reindex",
+                daemon=True,
+            )
+            self._background_thread = thread
+            thread.start()
 
     def _ensure_initialized(self) -> None:
         """Build the FTS index on first access if it has not been built yet."""

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -196,7 +196,7 @@ class Collection:
         )
         self._tracker = ChangeTracker(self._state_path)
 
-        # Lazy initialisation flag.
+        # Set to True by build_index() so a redundant call can short-circuit.
         self._initialized = False
 
         # Serialise concurrent write operations on this instance.
@@ -347,6 +347,10 @@ class Collection:
                     "thread=%s — abandoning (daemon=True ensures process exit)",
                     thread.name,
                 )
+                self._set_background_completed(
+                    error="abandoned at shutdown after 30s join timeout"
+                )
+                self._set_background_phase(None)
 
         # 2. Flush any deferred embedding updates.
         self._index_mgr.flush_dirty_embeddings()
@@ -414,7 +418,14 @@ class Collection:
             if self._background_shutdown.is_set():
                 return
             self._set_background_phase("indexing")
-            self.reindex()
+            reindex_result = self.reindex()
+            logger.info(
+                "background_reindex_indexing_completed added=%s modified=%s deleted=%s unchanged=%s",
+                reindex_result.added,
+                reindex_result.modified,
+                reindex_result.deleted,
+                reindex_result.unchanged,
+            )
 
             if (
                 self._embedding_provider is not None
@@ -423,12 +434,16 @@ class Collection:
                 if self._background_shutdown.is_set():
                     return
                 self._set_background_phase("embedding")
-                self.build_embeddings()
+                embedded_count = self.build_embeddings()
+                logger.info(
+                    "background_reindex_embedding_completed chunks_embedded=%s",
+                    embedded_count,
+                )
 
             self._set_background_completed(error=None)
         except Exception as exc:
             logger.error("background_reindex_failed", exc_info=True)
-            self._set_background_completed(error=str(exc))
+            self._set_background_completed(error=f"{type(exc).__name__}: {exc!r}")
         finally:
             self._set_background_phase(None)
 
@@ -437,7 +452,9 @@ class Collection:
         with self._background_state_lock:
             existing = self._background_thread
             if existing is not None and existing.is_alive():
-                logger.debug("start_background_reindex skipped — thread already alive")
+                logger.info(
+                    "start_background_reindex skipped — previous run still in progress"
+                )
                 return
             self._background_shutdown.clear()
             self._background_last_started_at = datetime.now(UTC).isoformat()

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -178,8 +178,9 @@ class IndexManager:
         this is a no-op.  ``force=True`` drops all existing data and rebuilds
         from scratch.
 
-        Note: the caller is responsible for setting any ``_initialized``
-        flag after this method returns.
+        Note: :meth:`Collection.build_index` sets ``self._initialized`` after
+        this returns to short-circuit redundant calls; no other caller should
+        need to.
 
         Args:
             force: When ``True``, drop and rebuild the index unconditionally.

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -73,7 +73,7 @@ def _index_status_for_server_info() -> dict[str, object]:
     from ._server_deps import _collection_singleton as live_singleton
 
     if live_singleton is None:
-        logger.warning("index_status_requested_before_collection_initialized")
+        logger.debug("index_status_requested_before_collection_initialized")
         return dict(_IDLE_INDEX_STATUS)
     return live_singleton.index_status()
 

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -60,7 +60,7 @@ _IDLE_INDEX_STATUS = {
     "background_phase": None,
     "last_run_started_at": None,
     "last_run_completed_at": None,
-    "last_error": None,
+    "last_error": "collection not yet initialised — server lifespan has not run",
 }
 
 
@@ -73,6 +73,7 @@ def _index_status_for_server_info() -> dict[str, object]:
     from ._server_deps import _collection_singleton as live_singleton
 
     if live_singleton is None:
+        logger.warning("index_status_requested_before_collection_initialized")
         return dict(_IDLE_INDEX_STATUS)
     return live_singleton.index_status()
 

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -55,6 +55,28 @@ from ._server_tools import register_tools
 logger = logging.getLogger(__name__)
 
 
+_IDLE_INDEX_STATUS = {
+    "background_running": False,
+    "background_phase": None,
+    "last_run_started_at": None,
+    "last_run_completed_at": None,
+    "last_error": None,
+}
+
+
+def _index_status_for_server_info() -> dict[str, object]:
+    """Provide the background-index status to ``get_server_info``.
+
+    Reads the Collection singleton if set (lifespan has run); otherwise
+    returns an idle snapshot so early health checks don't fail.
+    """
+    from ._server_deps import _collection_singleton as live_singleton
+
+    if live_singleton is None:
+        return dict(_IDLE_INDEX_STATUS)
+    return live_singleton.index_status()
+
+
 # ---------------------------------------------------------------------------
 # Event store
 # ---------------------------------------------------------------------------
@@ -226,14 +248,13 @@ def make_server(transport: str = "stdio") -> FastMCP:
         mcp,
         server_name=server_name,
         server_version=pkg_ver,
-        # DOMAIN-UPSTREAM-START — wire upstream version reporting for servers
-        # that talk to a remote service (paperless-mcp, etc.). The provider is
-        # a zero-arg callable; the simplest pattern is a module-level upstream
-        # client (typically constructed from env vars at import time) whose
-        # version method is referenced here.
-        # Uncomment the kwargs below as additional arguments to this call:
-        # upstream_version=lambda: _upstream_client.remote_version(),
-        # upstream_label="paperless",
+        # DOMAIN-UPSTREAM-START — markdown-vault-mcp has no remote upstream
+        # service to report on, so we repurpose the upstream block to expose
+        # the background-indexing status snapshot (see #513). This is the
+        # documented extension point: upstream_version returns a dict that
+        # gets placed under upstream_label in the response payload.
+        upstream_version=_index_status_for_server_info,
+        upstream_label="index_status",
         # DOMAIN-UPSTREAM-END
     )
 

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -366,6 +366,8 @@ class CollectionStats:
         link_count: Total number of links extracted from all documents.
         broken_link_count: Number of links whose target does not exist.
         orphan_count: Number of documents with no inbound or outbound links.
+        index_status: Snapshot of background reindex state. See
+            :meth:`~markdown_vault_mcp.collection.Collection.index_status`.
     """
 
     document_count: int
@@ -377,6 +379,7 @@ class CollectionStats:
     link_count: int = 0
     broken_link_count: int = 0
     orphan_count: int = 0
+    index_status: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import numpy as np
 import pytest
+from fastmcp import Client
 
 from markdown_vault_mcp.providers import EmbeddingProvider
 
@@ -177,3 +181,41 @@ def vault_path(tmp_path: Path, fixtures_path: Path) -> Path:
         shutil.copy2(src, dest)
 
     return vault
+
+
+async def wait_for_background_reindex(collection) -> None:
+    """Wait for the background reindex task to complete.
+
+    Args:
+        collection: The Collection instance.
+    """
+    # Poll index_status until background_running is False
+    max_attempts = 300  # ~15 seconds at 50ms intervals
+    attempt = 0
+    while attempt < max_attempts:
+        status = collection.index_status()
+        if not status.get("background_running", False):
+            break
+        await asyncio.sleep(0.05)
+        attempt += 1
+
+
+@asynccontextmanager
+async def mcp_client_ready(server) -> AsyncIterator[Client]:
+    """Connect a Client and wait for the background reindex to complete.
+
+    Most MCP tests need the index to be populated before calling tools;
+    this helper centralises the wait pattern.
+
+    Args:
+        server: The FastMCP server instance.
+
+    Yields:
+        Connected Client with the background reindex completed.
+    """
+    from markdown_vault_mcp._server_deps import get_collection_singleton
+
+    async with Client(server) as client:
+        collection = get_collection_singleton()
+        await wait_for_background_reindex(collection)
+        yield client

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import time
 from pathlib import Path  # noqa: TC003
 
+import pytest  # noqa: TC002 — runtime use for monkeypatch fixture annotation
+
 from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.providers import EmbeddingProvider
 
@@ -284,3 +286,41 @@ def test_stats_includes_index_status_field(tmp_path: Path) -> None:
         }
     finally:
         collection.close()
+
+
+def test_get_server_info_exposes_index_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """get_server_info payload carries the background-index snapshot under
+    the ``index_status`` key (we repurpose pvl-core's upstream slot for it,
+    since markdown-vault-mcp has no remote upstream to report on).
+    """
+    import asyncio
+
+    from fastmcp import Client
+
+    from markdown_vault_mcp.server import make_server
+
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    server = make_server()
+
+    async def _call() -> dict:
+        async with Client(server) as client:
+            result = await client.call_tool("get_server_info", {})
+            payload = result.data if hasattr(result, "data") else result
+            assert isinstance(payload, dict)
+            return payload
+
+    payload = asyncio.run(_call())
+
+    assert "index_status" in payload, payload
+    status = payload["index_status"]
+    assert isinstance(status, dict)
+    assert set(status.keys()) == {
+        "background_running",
+        "background_phase",
+        "last_run_started_at",
+        "last_run_completed_at",
+        "last_error",
+    }

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -60,25 +60,47 @@ def test_start_background_reindex_runs_and_completes(tmp_path: Path) -> None:
         collection.close()
 
 
-def test_start_background_reindex_is_idempotent(tmp_path: Path) -> None:
+def test_start_background_reindex_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Calling start twice while a thread is alive does not spawn a second thread."""
+    import threading as _threading
+
     (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
     collection = Collection(source_dir=tmp_path)
+
+    # Block the first reindex inside an event so it's guaranteed alive
+    # when the second start_background_reindex() call lands.
+    release = _threading.Event()
+    original_reindex = collection.reindex
+
+    def slow_reindex():
+        release.wait(timeout=5.0)
+        return original_reindex()
+
+    monkeypatch.setattr(collection, "reindex", slow_reindex)
+
     try:
         collection.start_background_reindex()
+
+        # Wait briefly until the worker has stored the thread reference.
+        _wait_until(lambda: collection._background_thread is not None)
         first_thread = collection._background_thread
         assert first_thread is not None
+        assert first_thread.is_alive()
 
         # Second call must be a no-op while the first thread is alive.
-        # If the first thread completes between calls, this still must not
-        # raise — we just accept whichever invariant holds.
         collection.start_background_reindex()
         second_thread = collection._background_thread
 
-        assert second_thread is first_thread or not first_thread.is_alive()
+        # Same thread — idempotency held under guaranteed-alive conditions.
+        assert second_thread is first_thread
 
+        # Now let the first run complete.
+        release.set()
         _wait_until(lambda: not collection.index_status()["background_running"])
     finally:
+        release.set()
         collection.close()
 
 
@@ -144,18 +166,18 @@ def test_close_bounded_join_does_not_hang_indefinitely(tmp_path: Path) -> None:
     collection.close()
 
 
-def test_background_failure_sets_last_error_and_recovers(tmp_path: Path) -> None:
+def test_background_failure_sets_last_error_and_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """When reindex raises, last_error is set, phase returns to None, server lives."""
     (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
     collection = Collection(source_dir=tmp_path)
     try:
-        # Patch reindex to raise.
-        original_reindex = collection.reindex
 
         def boom() -> object:
             raise RuntimeError("synthetic failure")
 
-        collection.reindex = boom  # type: ignore[method-assign]
+        monkeypatch.setattr(collection, "reindex", boom)
 
         collection.start_background_reindex()
         _wait_until(lambda: not collection.index_status()["background_running"])
@@ -163,11 +185,9 @@ def test_background_failure_sets_last_error_and_recovers(tmp_path: Path) -> None
         status = collection.index_status()
         assert status["background_running"] is False
         assert status["background_phase"] is None
-        assert status["last_error"] == "synthetic failure"
+        assert "synthetic failure" in (status["last_error"] or "")
+        assert "RuntimeError" in (status["last_error"] or "")
 
-        # Server-equivalent behaviour: foreground operations still work.
-        # (We don't have a populated index, but list_documents must not raise.)
-        collection.reindex = original_reindex  # type: ignore[method-assign]
         # No further assertion needed — we already verified the worker did not
         # propagate the exception out of the thread.
     finally:
@@ -265,6 +285,27 @@ def test_foreground_reads_never_block_on_background(tmp_path: Path) -> None:
             )
     finally:
         collection.close()
+
+
+def test_index_status_for_server_info_fallback_when_singleton_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the lifespan hasn't set the collection singleton (early
+    health check, broken startup), the fallback returns a snapshot whose
+    last_error indicates uninitialisation rather than a healthy idle."""
+    from markdown_vault_mcp import _server_deps
+    from markdown_vault_mcp.server import _index_status_for_server_info
+
+    monkeypatch.setattr(_server_deps, "_collection_singleton", None)
+    status = _index_status_for_server_info()
+    assert status["background_running"] is False
+    assert status["last_error"] is not None
+    assert "not yet initialised" in status["last_error"]
+
+    # Returned dict must be a copy — mutating it must not affect future calls.
+    status["last_error"] = "mutated"
+    status2 = _index_status_for_server_info()
+    assert status2["last_error"] != "mutated"
 
 
 def test_stats_includes_index_status_field(tmp_path: Path) -> None:

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -79,6 +79,68 @@ def test_start_background_reindex_is_idempotent(tmp_path: Path) -> None:
         collection.close()
 
 
+def test_close_joins_background_thread_within_timeout(tmp_path: Path) -> None:
+    """close() returns within the 30s bounded join; background thread is gone."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    collection.start_background_reindex()
+
+    start = time.monotonic()
+    collection.close()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 30.0
+    thread = collection._background_thread
+    # Either the thread completed before close() arrived, or close() joined it.
+    assert thread is None or not thread.is_alive()
+
+
+def test_close_bounded_join_does_not_hang_indefinitely(tmp_path: Path) -> None:
+    """A background thread that ignores shutdown still lets close() return."""
+    import threading  # local import; only needed here
+
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+
+    # Replace the worker target with one that sleeps past the 30s timeout.
+    stop_sleeping = threading.Event()
+
+    def slow_worker() -> None:
+        stop_sleeping.wait(timeout=60.0)
+
+    # We cannot easily replace the thread target after .start(); instead we
+    # construct the thread manually to bypass start_background_reindex.
+    collection._background_shutdown.clear()
+    collection._background_thread = threading.Thread(
+        target=slow_worker, daemon=True, name="test-slow-bg"
+    )
+    collection._background_thread.start()
+
+    # Verify the bounded-join semantics directly without invoking close()'s
+    # full teardown (which would also try to flush embeddings, close git, etc.,
+    # adding noise to what we're trying to assert).
+    start = time.monotonic()
+    collection._background_shutdown.set()
+    t = collection._background_thread
+    assert t is not None
+    if t.is_alive():
+        t.join(timeout=2.0)  # short for the test
+    elapsed = time.monotonic() - start
+
+    # The slow thread is still alive (it ignored shutdown), but the join returned.
+    assert elapsed < 5.0
+    assert collection._background_thread is not None
+    assert collection._background_thread.is_alive()
+
+    # Cleanup the deliberately-stuck thread.
+    stop_sleeping.set()
+    collection._background_thread.join(timeout=2.0)
+
+    # Now do the real close (which will hit the daemon-thread fallback path
+    # if the worker is still alive, or join cleanly if not).
+    collection.close()
+
+
 def test_background_failure_sets_last_error_and_recovers(tmp_path: Path) -> None:
     """When reindex raises, last_error is set, phase returns to None, server lives."""
     (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import time
+from pathlib import Path  # noqa: TC003
 
 from markdown_vault_mcp.collection import Collection
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_index_status_idle_before_anything_runs(tmp_path: Path) -> None:
@@ -22,5 +20,59 @@ def test_index_status_idle_before_anything_runs(tmp_path: Path) -> None:
             "last_run_completed_at": None,
             "last_error": None,
         }
+    finally:
+        collection.close()
+
+
+def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.01) -> None:
+    """Poll a predicate until it returns truthy or timeout expires.
+
+    Raises AssertionError if predicate never becomes true.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError(f"predicate {predicate!r} not satisfied within {timeout}s")
+
+
+def test_start_background_reindex_runs_and_completes(tmp_path: Path) -> None:
+    """Background reindex transitions through phases and reaches idle."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    try:
+        collection.start_background_reindex()
+
+        # Eventually the background thread completes; final state is idle, no error.
+        _wait_until(lambda: not collection.index_status()["background_running"])
+
+        status = collection.index_status()
+        assert status["background_running"] is False
+        assert status["background_phase"] is None
+        assert status["last_error"] is None
+        assert status["last_run_started_at"] is not None
+        assert status["last_run_completed_at"] is not None
+    finally:
+        collection.close()
+
+
+def test_start_background_reindex_is_idempotent(tmp_path: Path) -> None:
+    """Calling start twice while a thread is alive does not spawn a second thread."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    try:
+        collection.start_background_reindex()
+        first_thread = collection._background_thread
+
+        # Second call must be a no-op while the first thread is alive.
+        # If the first thread completes between calls, this still must not
+        # raise — we just accept whichever invariant holds.
+        collection.start_background_reindex()
+        second_thread = collection._background_thread
+
+        assert second_thread is first_thread or not first_thread.is_alive()
+
+        _wait_until(lambda: not collection.index_status()["background_running"])
     finally:
         collection.close()

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -263,3 +263,24 @@ def test_foreground_reads_never_block_on_background(tmp_path: Path) -> None:
             )
     finally:
         collection.close()
+
+
+def test_stats_includes_index_status_field(tmp_path: Path) -> None:
+    """CollectionStats now carries the index_status snapshot."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    try:
+        collection.build_index()
+        result = collection.stats()
+        # Either dataclass attribute or dict key — depends on dataclass shape.
+        assert hasattr(result, "index_status")
+        status = result.index_status
+        assert set(status.keys()) == {
+            "background_running",
+            "background_phase",
+            "last_run_started_at",
+            "last_run_completed_at",
+            "last_error",
+        }
+    finally:
+        collection.close()

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path  # noqa: TC003
 
 from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.providers import EmbeddingProvider
 
 
 def test_index_status_idle_before_anything_runs(tmp_path: Path) -> None:
@@ -167,5 +168,98 @@ def test_background_failure_sets_last_error_and_recovers(tmp_path: Path) -> None
         collection.reindex = original_reindex  # type: ignore[method-assign]
         # No further assertion needed — we already verified the worker did not
         # propagate the exception out of the thread.
+    finally:
+        collection.close()
+
+
+# ---------------------------------------------------------------------------
+# Slow embedding provider for the no-foreground-waiter regression test
+# ---------------------------------------------------------------------------
+
+
+class _SlowEmbeddingProvider(EmbeddingProvider):
+    """Deterministic provider that sleeps per call to simulate a slow backend.
+
+    Used by the no-foreground-waiter regression test. Each ``embed`` call
+    blocks for ``per_call_delay`` seconds before returning a fixed vector
+    per input text, letting the test assert foreground reads stay
+    responsive while a background embedding pass is in flight.
+    """
+
+    def __init__(self, *, per_call_delay: float = 0.5, dim: int = 8) -> None:
+        self._per_call_delay = per_call_delay
+        self._dim = dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        time.sleep(self._per_call_delay)
+        # Deterministic non-zero vector per text.
+        return [[1.0] * self._dim for _ in texts]
+
+    @property
+    def dimension(self) -> int:
+        return self._dim
+
+    @property
+    def provider_name(self) -> str:
+        return "slow-test"
+
+    @property
+    def model_name(self) -> str:
+        return "slow-test-v0"
+
+
+def test_foreground_reads_never_block_on_background(tmp_path: Path) -> None:
+    """REGRESSION TEST FOR PR #515.
+
+    Foreground methods must NOT wait on the background thread. With a
+    deliberately slow embedding provider, search/list/stats/
+    index_status must all return promptly while the background thread
+    is mid-embedding. If this test ever fails, a foreground waiter has
+    been reintroduced — find and remove it before re-running.
+
+    See docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md
+    section "The load-bearing rule".
+    """
+    # Seed a handful of docs so the embedding phase has real work.
+    for i in range(5):
+        (tmp_path / f"doc{i}.md").write_text(
+            f"# Doc {i}\n\nbody {i}\n", encoding="utf-8"
+        )
+
+    embeddings_path = tmp_path / ".embeddings"
+    collection = Collection(
+        source_dir=tmp_path,
+        embedding_provider=_SlowEmbeddingProvider(per_call_delay=0.2),
+        embeddings_path=embeddings_path,
+    )
+    try:
+        # Pre-build the FTS index synchronously so search has something to
+        # return; the slow path we're testing is the embedding phase.
+        collection.build_index()
+
+        collection.start_background_reindex()
+
+        # Wait until the worker enters the embedding phase (deterministic
+        # signal that the slow path is now active).
+        _wait_until(
+            lambda: collection.index_status()["background_phase"] == "embedding",
+            timeout=5.0,
+        )
+
+        # Each foreground call must return within 500ms while the slow
+        # embedding loop is in flight.
+        for op_name, op in [
+            ("search", lambda: collection.search("body", limit=5)),
+            ("list", lambda: collection.list()),
+            ("stats", lambda: collection.stats()),
+            ("index_status", lambda: collection.index_status()),
+        ]:
+            start = time.monotonic()
+            op()
+            elapsed = time.monotonic() - start
+            assert elapsed < 0.5, (
+                f"{op_name} took {elapsed:.3f}s — a foreground waiter has been "
+                "reintroduced. See spec section 'The load-bearing rule'."
+            )
     finally:
         collection.close()

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -64,6 +64,7 @@ def test_start_background_reindex_is_idempotent(tmp_path: Path) -> None:
     try:
         collection.start_background_reindex()
         first_thread = collection._background_thread
+        assert first_thread is not None
 
         # Second call must be a no-op while the first thread is alive.
         # If the first thread completes between calls, this still must not
@@ -74,5 +75,35 @@ def test_start_background_reindex_is_idempotent(tmp_path: Path) -> None:
         assert second_thread is first_thread or not first_thread.is_alive()
 
         _wait_until(lambda: not collection.index_status()["background_running"])
+    finally:
+        collection.close()
+
+
+def test_background_failure_sets_last_error_and_recovers(tmp_path: Path) -> None:
+    """When reindex raises, last_error is set, phase returns to None, server lives."""
+    (tmp_path / "doc.md").write_text("# Doc\n\nbody\n", encoding="utf-8")
+    collection = Collection(source_dir=tmp_path)
+    try:
+        # Patch reindex to raise.
+        original_reindex = collection.reindex
+
+        def boom() -> object:
+            raise RuntimeError("synthetic failure")
+
+        collection.reindex = boom  # type: ignore[method-assign]
+
+        collection.start_background_reindex()
+        _wait_until(lambda: not collection.index_status()["background_running"])
+
+        status = collection.index_status()
+        assert status["background_running"] is False
+        assert status["background_phase"] is None
+        assert status["last_error"] == "synthetic failure"
+
+        # Server-equivalent behaviour: foreground operations still work.
+        # (We don't have a populated index, but list_documents must not raise.)
+        collection.reindex = original_reindex  # type: ignore[method-assign]
+        # No further assertion needed — we already verified the worker did not
+        # propagate the exception out of the thread.
     finally:
         collection.close()

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -1,0 +1,26 @@
+"""Tests for non-blocking startup background indexing (#513)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.collection import Collection
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_index_status_idle_before_anything_runs(tmp_path: Path) -> None:
+    """A fresh Collection that hasn't started background work reports idle status."""
+    collection = Collection(source_dir=tmp_path)
+    try:
+        status = collection.index_status()
+        assert status == {
+            "background_running": False,
+            "background_phase": None,
+            "last_run_started_at": None,
+            "last_run_completed_at": None,
+            "last_error": None,
+        }
+    finally:
+        collection.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -399,27 +399,6 @@ class TestBuildIndex:
 # ---------------------------------------------------------------------------
 
 
-class TestLazyInitialisation:
-    def test_search_without_build_index(self, vault_path: Path) -> None:
-        """search() triggers lazy initialisation without an explicit build_index()."""
-        col = _make_collection(vault_path)
-
-        # Do NOT call build_index() — search() should initialise automatically.
-        results = col.search("simple")
-
-        # Either finds something or returns [] — the key is it does not crash.
-        assert isinstance(results, list)
-
-    def test_list_without_build_index(self, vault_path: Path) -> None:
-        """list() triggers lazy initialisation without an explicit build_index()."""
-        col = _make_collection(vault_path)
-
-        notes = col.list()
-
-        assert isinstance(notes, list)
-        assert len(notes) == 9
-
-
 # ---------------------------------------------------------------------------
 # Search tests
 # ---------------------------------------------------------------------------

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -12,10 +12,10 @@ import json
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from fastmcp import Client
 
 from markdown_vault_mcp import _server_deps
 from markdown_vault_mcp.server import make_server
+from tests.conftest import mcp_client_ready
 from tests.fixtures.git import _run_git
 
 if TYPE_CHECKING:
@@ -120,7 +120,7 @@ class TestGitSync:
         _run_git(git_repo_pair.local_path, "commit", "-m", "local commit")
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("git_sync", {"direction": "both"})
 
         payload = _parse_tool_data(result)
@@ -148,7 +148,7 @@ class TestGitSync:
         )
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("git_sync", {"direction": "pull"})
 
         payload = _parse_tool_data(result)
@@ -173,7 +173,7 @@ class TestGitSync:
         head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "git_sync", {"direction": "pull", "dry_run": True}
             )
@@ -195,7 +195,7 @@ class TestGitSync:
     ) -> None:
         """Refs #467: dry-run pull on an up-to-date clone reports would_apply=False."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "git_sync", {"direction": "pull", "dry_run": True}
             )
@@ -238,7 +238,7 @@ class TestGitSync:
         )
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "git_sync", {"direction": "both", "dry_run": True}
             )
@@ -288,7 +288,7 @@ class TestGitSync:
         _run_git(git_repo_pair.local_path, "commit", "-m", "local edit")
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("git_sync", {"direction": "pull"})
 
         payload = _parse_tool_data(result)
@@ -346,7 +346,7 @@ class TestGitSync:
         )
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             # Lifespan has set the singleton; monkey-patch reindex BEFORE
             # the tool call so the post-pull bookkeeping path raises.
             collection = _server_deps.get_collection_singleton()
@@ -401,7 +401,7 @@ class TestGitSync:
         _run_git(git_repo_pair.local_path, "commit", "-m", "would push")
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             collection = _server_deps.get_collection_singleton()
             strategy = collection._git_strategy
 
@@ -453,7 +453,7 @@ class TestGitSyncVisibility:
     async def test_visible_in_managed_mode(self, _git_managed_env: Path) -> None:
         """git_sync IS listed in managed git + read-write mode."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         names = [t.name for t in tools]
         assert "git_sync" in names
@@ -470,7 +470,7 @@ class TestGitSyncVisibility:
         # commit-only branch, which builds a strategy with managed=False.
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         names = [t.name for t in tools]
         assert "git_sync" not in names
@@ -496,7 +496,7 @@ class TestGitSyncVisibility:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S", "0")
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         names = [t.name for t in tools]
         assert "git_sync" not in names

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -9,6 +9,7 @@ import pytest
 
 from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.server import make_server
 from markdown_vault_mcp.types import (
     Chunk,
     LinkInfo,
@@ -16,6 +17,7 @@ from markdown_vault_mcp.types import (
     NoteInfo,
     ParsedNote,
 )
+from tests.conftest import mcp_client_ready
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -336,12 +338,8 @@ def _mcp_env_graph(mcp_graph_vault: Path, monkeypatch: pytest.MonkeyPatch) -> No
 class TestMCPGraphTools:
     async def test_get_orphan_notes_tool(self, _mcp_env_graph: None) -> None:
         """get_orphan_notes MCP tool returns orphan notes."""
-        from fastmcp import Client
-
-        from markdown_vault_mcp.server import make_server
-
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_orphan_notes", {})
         items = _parse_tool_data(result)
         assert isinstance(items, list)
@@ -351,12 +349,8 @@ class TestMCPGraphTools:
 
     async def test_get_most_linked_tool(self, _mcp_env_graph: None) -> None:
         """get_most_linked MCP tool returns hub note first."""
-        from fastmcp import Client
-
-        from markdown_vault_mcp.server import make_server
-
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_most_linked", {"limit": 5})
         items = _parse_tool_data(result)
         assert isinstance(items, list)
@@ -366,12 +360,8 @@ class TestMCPGraphTools:
 
     async def test_get_most_linked_tool_limit(self, _mcp_env_graph: None) -> None:
         """get_most_linked respects the limit parameter."""
-        from fastmcp import Client
-
-        from markdown_vault_mcp.server import make_server
-
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_most_linked", {"limit": 1})
         items = _parse_tool_data(result)
         assert len(items) == 1
@@ -656,12 +646,8 @@ def _mcp_env_path(mcp_path_vault: Path, monkeypatch: pytest.MonkeyPatch) -> None
 class TestMCPGetConnectionPath:
     async def test_found_path(self, _mcp_env_path: None) -> None:
         """get_connection_path tool returns found=True and correct path."""
-        from fastmcp import Client
-
-        from markdown_vault_mcp.server import make_server
-
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "get_connection_path", {"source": "a.md", "target": "c.md"}
             )
@@ -672,12 +658,8 @@ class TestMCPGetConnectionPath:
 
     async def test_not_found_path(self, _mcp_env_path: None) -> None:
         """get_connection_path tool returns found=False when no path exists."""
-        from fastmcp import Client
-
-        from markdown_vault_mcp.server import make_server
-
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "get_connection_path",
                 {"source": "a.md", "target": "isolated.md"},
@@ -689,12 +671,8 @@ class TestMCPGetConnectionPath:
 
     async def test_source_equals_target(self, _mcp_env_path: None) -> None:
         """get_connection_path tool returns found=True with 0 hops for source==target."""
-        from fastmcp import Client
-
-        from markdown_vault_mcp.server import make_server
-
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "get_connection_path", {"source": "a.md", "target": "a.md"}
             )
@@ -705,13 +683,10 @@ class TestMCPGetConnectionPath:
 
     async def test_invalid_source_raises_error(self, _mcp_env_path: None) -> None:
         """get_connection_path tool surfaces ValueError for an unindexed source path."""
-        from fastmcp import Client
         from fastmcp.exceptions import ToolError
 
-        from markdown_vault_mcp.server import make_server
-
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError):
                 await client.call_tool(
                     "get_connection_path",

--- a/tests/test_mcp_apps_browser.py
+++ b/tests/test_mcp_apps_browser.py
@@ -10,11 +10,10 @@ import json
 from typing import Any
 
 import pytest
-from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
-from tests.conftest import get_app_html
+from tests.conftest import get_app_html, mcp_client_ready
 
 
 def _parse_tool_data(result: Any) -> Any:
@@ -113,7 +112,7 @@ class TestBrowserDataTools:
 
     async def test_vault_list_root(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_list"), {})
             data = _parse_tool_data(result)
             assert "folders" in data
@@ -125,7 +124,7 @@ class TestBrowserDataTools:
 
     async def test_vault_list_subfolder(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_list"), {"folder": "subfolder"}
             )
@@ -135,7 +134,7 @@ class TestBrowserDataTools:
 
     async def test_vault_read_note(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_read"), {"path": "simple.md"}
             )
@@ -149,7 +148,7 @@ class TestBrowserDataTools:
 
     async def test_vault_read_with_frontmatter(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_read"), {"path": "full_frontmatter.md"}
             )
@@ -159,7 +158,7 @@ class TestBrowserDataTools:
 
     async def test_vault_search_keyword(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_search"), {"query": "simple", "mode": "keyword"}
             )
@@ -173,7 +172,7 @@ class TestBrowserDataTools:
 
     async def test_vault_search_respects_limit(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_search"),
                 {"query": "document", "mode": "keyword", "limit": 2},
@@ -183,7 +182,7 @@ class TestBrowserDataTools:
 
     async def test_notes_have_kind_field(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_list"), {})
             data = _parse_tool_data(result)
             for note in data["notes"]:

--- a/tests/test_mcp_apps_context.py
+++ b/tests/test_mcp_apps_context.py
@@ -10,11 +10,10 @@ import json
 from typing import Any
 
 import pytest
-from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
-from tests.conftest import get_app_html
+from tests.conftest import get_app_html, mcp_client_ready
 
 
 def _parse_tool_data(result: Any) -> Any:
@@ -110,7 +109,7 @@ class TestVaultContextToolData:
 
     async def test_all_context_fields_present(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "simple.md"}
             )
@@ -128,7 +127,7 @@ class TestVaultContextToolData:
 
     async def test_context_with_frontmatter(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "full_frontmatter.md"}
             )
@@ -148,7 +147,7 @@ class TestShowContextTool:
 
     async def test_returns_view_and_summary(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("show_context", {"path": "simple.md"})
             data = _parse_tool_data(result)
             assert data["view"] == "context"
@@ -157,7 +156,7 @@ class TestShowContextTool:
 
     async def test_summary_contains_relationship_counts(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("show_context", {"path": "simple.md"})
             data = _parse_tool_data(result)
             summary = data["summary"]
@@ -167,7 +166,7 @@ class TestShowContextTool:
 
     async def test_show_context_visible_to_llm(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
             names = [t.name for t in tools]
             assert "show_context" in names
@@ -176,7 +175,7 @@ class TestShowContextTool:
 
     async def test_missing_note_returns_error_summary(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("show_context", {"path": "nonexistent.md"})
             data = _parse_tool_data(result)
             assert data["view"] == "context"

--- a/tests/test_mcp_apps_foundation.py
+++ b/tests/test_mcp_apps_foundation.py
@@ -10,7 +10,6 @@ import json
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import (
     _VAULT_APP_TOOL_NAMES,
@@ -20,7 +19,7 @@ from markdown_vault_mcp._server_apps import (
     _rewrite_spa_app_tool_calls,
 )
 from markdown_vault_mcp.server import make_server
-from tests.conftest import _CLEAR_VARS
+from tests.conftest import _CLEAR_VARS, mcp_client_ready
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -103,14 +102,14 @@ class TestSPAShellResource:
 
     async def test_resource_registered(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resources = await client.list_resources()
             uris = [str(r.uri) for r in resources]
             assert "ui://vault/app.html" in uris
 
     async def test_html_contains_ext_apps_sdk(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -119,7 +118,7 @@ class TestSPAShellResource:
 
     async def test_html_contains_tab_navigation(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -130,7 +129,7 @@ class TestSPAShellResource:
 
     async def test_html_contains_host_theming(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -142,7 +141,7 @@ class TestSPAShellResource:
 
     async def test_html_handlers_before_connect(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -154,7 +153,7 @@ class TestSPAShellResource:
 
     async def test_html_contains_fullscreen_toggle(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -164,7 +163,7 @@ class TestSPAShellResource:
 
     async def test_html_contains_ontoolinput(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = resource[0].text
             assert "app.ontoolinput" in html
@@ -173,21 +172,21 @@ class TestSPAShellResource:
 
     async def test_html_contains_ontoolcancelled(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = resource[0].text
             assert "app.ontoolcancelled" in html
 
     async def test_html_contains_onteardown(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = resource[0].text
             assert "app.onteardown" in html
 
     async def test_html_static_import(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = resource[0].text
             # Static import via import map (vendored SDK, Android compatible)
@@ -197,7 +196,7 @@ class TestSPAShellResource:
 
     async def test_html_parse_tool_result(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = resource[0].text
             # parseToolResult extracts JSON from CallToolResult.content[0].text
@@ -216,7 +215,7 @@ class TestSPAShellResource:
     async def test_html_browse_fallback_when_no_tool_input(self) -> None:
         """After connect, app defaults to browse view when ontoolinput never fires."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = resource[0].text
             # The else branch after pendingToolInput check must switch to browse
@@ -225,7 +224,7 @@ class TestSPAShellResource:
 
     async def test_html_contains_error_handler(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -234,7 +233,7 @@ class TestSPAShellResource:
 
     async def test_html_contains_navigate_to(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -243,7 +242,7 @@ class TestSPAShellResource:
 
     async def test_html_contains_send_to_llm(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -253,7 +252,7 @@ class TestSPAShellResource:
 
     async def test_html_contains_update_context(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource = await client.read_resource("ui://vault/app.html")
             html = (
                 resource[0].text if hasattr(resource[0], "text") else str(resource[0])
@@ -273,14 +272,14 @@ class TestBrowseVaultTool:
 
     async def test_tool_registered(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
             names = [t.name for t in tools]
             assert "browse_vault" in names
 
     async def test_no_args_returns_vault_summary(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("browse_vault", {})
             data = _parse_tool_data(result)
             assert data["view"] == "browse"
@@ -289,7 +288,7 @@ class TestBrowseVaultTool:
 
     async def test_with_path_returns_note_info(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("browse_vault", {"path": "simple.md"})
             data = _parse_tool_data(result)
             assert data["path"] == "simple.md"
@@ -297,14 +296,14 @@ class TestBrowseVaultTool:
 
     async def test_with_view_override(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("browse_vault", {"view": "graph"})
             data = _parse_tool_data(result)
             assert data["view"] == "graph"
 
     async def test_missing_path(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "browse_vault", {"path": "nonexistent/path.md"}
             )
@@ -323,14 +322,14 @@ class TestShowContextTool:
 
     async def test_tool_registered(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
             names = [t.name for t in tools]
             assert "show_context" in names
 
     async def test_returns_context_summary(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("show_context", {"path": "simple.md"})
             data = _parse_tool_data(result)
             assert data["path"] == "simple.md"
@@ -350,7 +349,7 @@ class TestAppOnlyTools:
 
     async def test_vault_context_returns_note_context(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "simple.md"}
             )
@@ -364,7 +363,7 @@ class TestAppOnlyTools:
 
     async def test_vault_graph_neighborhood(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "simple.md"}
             )
@@ -379,7 +378,7 @@ class TestAppOnlyTools:
 
     async def test_vault_graph_hubs(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_graph_hubs"), {})
             data = _parse_tool_data(result)
             assert "nodes" in data
@@ -387,7 +386,7 @@ class TestAppOnlyTools:
 
     async def test_vault_list_root(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_list"), {})
             data = _parse_tool_data(result)
             assert "folders" in data
@@ -397,7 +396,7 @@ class TestAppOnlyTools:
     async def test_vault_list_root_notes_are_root_only(self) -> None:
         """Root listing must not include notes from subfolders."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_list"), {})
             data = _parse_tool_data(result)
             for note in data["notes"]:
@@ -408,7 +407,7 @@ class TestAppOnlyTools:
     async def test_vault_list_subfolder_notes_are_direct_children(self) -> None:
         """Subfolder listing must only include direct children, not deeper nesting."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_list"), {"folder": "subfolder"}
             )
@@ -438,7 +437,7 @@ class TestAppOnlyTools:
         for var in _CLEAR_VARS:
             monkeypatch.delenv(var, raising=False)
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_list"), {})
             data = _parse_tool_data(result)
             # 'ai' must appear even though list_folders() only returns 'ai/llm'
@@ -451,7 +450,7 @@ class TestAppOnlyTools:
 
     async def test_vault_read(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_read"), {"path": "simple.md"}
             )
@@ -462,7 +461,7 @@ class TestAppOnlyTools:
 
     async def test_vault_read_missing(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_read"), {"path": "does-not-exist.md"}
             )
@@ -471,7 +470,7 @@ class TestAppOnlyTools:
 
     async def test_vault_search(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_search"), {"query": "hello", "mode": "keyword"}
             )
@@ -544,7 +543,7 @@ class TestAppToolData:
 
     async def test_browse_vault_with_path(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "browse_vault", {"path": "full_frontmatter.md", "view": "browse"}
             )
@@ -555,14 +554,14 @@ class TestAppToolData:
 
     async def test_browse_vault_no_path(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("browse_vault", {})
             data = _parse_tool_data(result)
             assert "Vault:" in data["summary"]
 
     async def test_show_context_tool(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("show_context", {"path": "simple.md"})
             data = _parse_tool_data(result)
             assert data["path"] == "simple.md"
@@ -571,7 +570,7 @@ class TestAppToolData:
 
     async def test_vault_graph_hubs(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_graph_hubs"), {})
             data = _parse_tool_data(result)
             assert "nodes" in data
@@ -579,7 +578,7 @@ class TestAppToolData:
 
     async def test_vault_list_root(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_list"), {})
             data = _parse_tool_data(result)
             assert "folders" in data
@@ -590,7 +589,7 @@ class TestAppToolData:
 
     async def test_vault_read_note(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_read"), {"path": "simple.md"}
             )
@@ -600,7 +599,7 @@ class TestAppToolData:
 
     async def test_vault_search_keyword(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_search"), {"query": "simple", "mode": "keyword"}
             )
@@ -618,7 +617,7 @@ class TestAppToolData:
 
     async def test_vault_context_missing_path(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "does-not-exist.md"}
             )
@@ -628,7 +627,7 @@ class TestAppToolData:
 
     async def test_show_context_missing_path(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "show_context", {"path": "does-not-exist.md"}
             )
@@ -638,7 +637,7 @@ class TestAppToolData:
 
     async def test_vault_search_semantic_no_embeddings(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_search"), {"query": "test", "mode": "semantic"}
             )
@@ -654,7 +653,7 @@ class TestAppToolLinkedData:
 
     async def test_vault_graph_neighborhood_with_links(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "linked_a.md", "depth": 2}
             )
@@ -667,7 +666,7 @@ class TestAppToolLinkedData:
 
     async def test_vault_graph_neighborhood_dedup(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "linked_a.md", "depth": 2}
             )
@@ -677,7 +676,7 @@ class TestAppToolLinkedData:
 
     async def test_vault_graph_hubs_with_links(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_graph_hubs"), {})
             data = _parse_tool_data(result)
             assert "nodes" in data
@@ -687,7 +686,7 @@ class TestAppToolLinkedData:
 
     async def test_vault_context_with_links(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "linked_a.md"}
             )
@@ -706,7 +705,7 @@ class TestAppToolLinkedData:
             if var != "MARKDOWN_VAULT_MCP_INDEXED_FIELDS":
                 monkeypatch.delenv(var, raising=False)
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("show_context", {"path": "linked_b.md"})
             data = _parse_tool_data(result)
             assert "Tags:" in data["summary"]

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -15,7 +15,7 @@ from fastmcp import Client
 
 from markdown_vault_mcp._server_apps import _hashed
 from markdown_vault_mcp.server import make_server
-from tests.conftest import _CLEAR_VARS, get_app_html
+from tests.conftest import _CLEAR_VARS, get_app_html, mcp_client_ready
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -127,7 +127,7 @@ class TestGraphDataTools:
 
     async def test_neighborhood_returns_graph(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "simple.md"}
             )
@@ -144,7 +144,7 @@ class TestGraphDataTools:
 
     async def test_neighborhood_with_depth(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             r1 = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "simple.md", "depth": 1}
             )
@@ -159,7 +159,7 @@ class TestGraphDataTools:
 
     async def test_hubs_returns_graph(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_graph_hubs"), {})
             data = _parse_tool_data(result)
             assert "nodes" in data
@@ -180,7 +180,7 @@ class TestGraphDataTools:
 
         monkeypatch.setattr(Collection, "read", _spy)
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(_hashed("vault_graph_hubs"), {})
             data = _parse_tool_data(result)
         hub_paths = {n["id"] for n in data["nodes"] if n["group"] == "hub"}
@@ -191,7 +191,7 @@ class TestGraphDataTools:
 
     async def test_edges_have_type(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "simple.md"}
             )
@@ -203,7 +203,7 @@ class TestGraphDataTools:
 
     async def test_neighborhood_nodes_have_backlink_count(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "simple.md"}
             )
@@ -214,7 +214,7 @@ class TestGraphDataTools:
 
     async def test_edges_deduplicated(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "simple.md"}
             )
@@ -225,7 +225,7 @@ class TestGraphDataTools:
     async def test_include_semantic_false_by_default(self) -> None:
         """Default call returns no semantic edges."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "simple.md"}
             )
@@ -236,7 +236,7 @@ class TestGraphDataTools:
     async def test_include_semantic_true_no_embeddings(self) -> None:
         """include_semantic=True without embeddings returns graph without semantic edges."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"),
                 {"path": "simple.md", "include_semantic": True},
@@ -313,8 +313,15 @@ class TestIncludeSemanticEdges:
             "markdown_vault_mcp.providers.get_embedding_provider",
             return_value=mock_prov,
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "include_semantic": True},
@@ -347,8 +354,15 @@ class TestIncludeSemanticEdges:
             "markdown_vault_mcp.providers.get_embedding_provider",
             return_value=mock_prov,
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "include_semantic": True},
@@ -378,8 +392,15 @@ class TestIncludeSemanticEdges:
             "markdown_vault_mcp.providers.get_embedding_provider",
             return_value=mock_prov,
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "depth": 0, "include_semantic": True},
@@ -413,8 +434,15 @@ class TestIncludeSemanticEdges:
                 side_effect=ValueError("not found"),
             ),
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "include_semantic": True},
@@ -448,8 +476,15 @@ class TestIncludeSemanticEdges:
                 side_effect=RuntimeError("embedding backend unavailable"),
             ),
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "include_semantic": True},
@@ -487,7 +522,7 @@ class TestGraphNeighborhoodMaxNodes:
 
     async def test_max_nodes_caps_node_count(self, _star_vault: Path) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"),
                 {"path": "hub.md", "depth": 2, "max_nodes": 5},
@@ -498,7 +533,7 @@ class TestGraphNeighborhoodMaxNodes:
 
     async def test_truncated_false_when_under_cap(self, _star_vault: Path) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"),
                 {"path": "hub.md", "depth": 2, "max_nodes": 500},
@@ -534,8 +569,15 @@ class TestGraphNeighborhoodMaxNodes:
             "markdown_vault_mcp.providers.get_embedding_provider",
             return_value=mock_prov,
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {
@@ -588,8 +630,15 @@ class TestGraphNeighborhoodMaxNodes:
             "markdown_vault_mcp.providers.get_embedding_provider",
             return_value=mock_prov,
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {
@@ -616,7 +665,7 @@ class TestGraphNeighborhoodMaxNodesDefault:
 
     async def test_default_does_not_truncate_small_vault(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"),
                 {"path": "simple.md", "depth": 2},

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 from pathlib import Path  # noqa: TC003
 
 import pytest
-from fastmcp import Client
 
 from markdown_vault_mcp._server_prompts import _load_user_prompt_defs
 from markdown_vault_mcp.server import make_server
+from tests.conftest import mcp_client_ready
 
 # ---------------------------------------------------------------------------
 # _load_user_prompt_defs unit tests
@@ -249,7 +249,7 @@ class TestUserPromptNoArgs:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("greet", {})
         text = result.messages[0].content.text
         assert text == "Hello from user prompt!"
@@ -267,7 +267,7 @@ class TestUserPromptNoArgs:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         names = {p.name for p in prompts}
         assert "greet" in names
@@ -296,7 +296,7 @@ class TestUserPromptWithArgs:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("myread", {"path": "notes/foo.md"})
         text = result.messages[0].content.text
         assert "notes/foo.md" in text
@@ -320,7 +320,7 @@ class TestUserPromptWithArgs:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("styled", {})
         text = result.messages[0].content.text
         assert "[]" in text  # empty string substituted
@@ -348,7 +348,7 @@ class TestUserPromptOverride:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("summarize", {"path": "some.md"})
         text = result.messages[0].content.text
         assert "CUSTOM SUMMARIZE" in text
@@ -367,7 +367,7 @@ class TestUserPromptOverride:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt(
                 "compare", {"path1": "a.md", "path2": "b.md"}
             )
@@ -386,7 +386,7 @@ class TestUserPromptOverride:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         summarize_entries = [p for p in prompts if p.name == "summarize"]
         assert len(summarize_entries) == 1
@@ -407,7 +407,7 @@ class TestUserPromptWriteTag:
         # READ_ONLY is True by default (env not set)
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         names = {p.name for p in prompts}
         assert "mywriter" not in names
@@ -424,7 +424,7 @@ class TestUserPromptWriteTag:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         names = {p.name for p in prompts}
         assert "mywriter" in names
@@ -436,7 +436,7 @@ class TestNoPromptsFolder:
     @pytest.mark.usefixtures("_clear_vars")
     async def test_all_builtins_present_without_prompts_folder(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         names = {p.name for p in prompts}
         # Read-only mode: these built-ins should be present
@@ -459,7 +459,7 @@ class TestProposeLinks:
         # propose-links is tagged "write"; must enable write mode to see it.
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         propose_links = next(p for p in prompts if p.name == "propose-links")
         assert (
@@ -478,7 +478,7 @@ class TestProposeLinks:
         """Invoking propose-links substitutes $scope and $per_note_limit into the body."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt(
                 "propose-links", {"scope": "1-Projects", "per_note_limit": "7"}
             )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -24,6 +24,7 @@ from markdown_vault_mcp.config import (
     resolve_auth_mode,
 )
 from markdown_vault_mcp.server import make_server
+from tests.conftest import mcp_client_ready
 
 if TYPE_CHECKING:
     import mcp.types as mcp_types
@@ -164,7 +165,7 @@ class TestToolListing:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_write_tools_absent_when_readonly(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
             names = {t.name for t in tools}
 
@@ -192,7 +193,7 @@ class TestToolListing:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_write_tools_present_when_writable(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
             names = {t.name for t in tools}
 
@@ -209,7 +210,7 @@ class TestToolAnnotations:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_annotations(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
             by_name = {t.name: t for t in tools}
 
@@ -264,7 +265,7 @@ class TestSearchTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_keyword_search(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "search", {"query": "simple document", "limit": 5}
             )
@@ -277,7 +278,7 @@ class TestSearchTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_search_with_folder_filter(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "search",
                 {"query": "subfolder nested", "folder": "subfolder"},
@@ -297,7 +298,7 @@ class TestReadTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_read_existing(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("read", {"path": "simple.md"})
         data = result.data
         assert isinstance(data, dict)
@@ -307,14 +308,14 @@ class TestReadTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_read_nonexistent(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp("read", {"path": "nonexistent.md"})
         assert result.isError is True
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_read_with_frontmatter(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("read", {"path": "full_frontmatter.md"})
         data = result.data
         assert data["title"] == "Full Frontmatter Note"
@@ -327,7 +328,7 @@ class TestReadTool:
         template_path.write_text("# Meeting Template\n\n- Date:\n- Attendees:\n")
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("read", {"path": "_templates/meeting.md"})
         data = result.data
         assert data["path"] == "_templates/meeting.md"
@@ -340,7 +341,7 @@ class TestListDocumentsTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_list_all(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("list_documents", {})
         data = _parse_tool_data(result)
         assert isinstance(data, list)
@@ -351,7 +352,7 @@ class TestListDocumentsTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_list_by_folder(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("list_documents", {"folder": "subfolder"})
         data = _parse_tool_data(result)
         assert isinstance(data, list)
@@ -368,7 +369,7 @@ class TestListDocumentsTool:
         template_path.write_text("# Daily Template\n\n## Highlights\n\n- \n")
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("list_documents", {"folder": "_templates"})
         data = _parse_tool_data(result)
         paths = {doc["path"] for doc in data}
@@ -381,7 +382,7 @@ class TestListFoldersTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_list_folders(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("list_folders", {})
         folders = result.data
         assert isinstance(folders, list)
@@ -394,7 +395,7 @@ class TestListTagsTool:
     @pytest.mark.usefixtures("_mcp_env_with_fields")
     async def test_list_tags(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("list_tags", {"field": "cluster"})
         tags = result.data
         assert isinstance(tags, list)
@@ -407,7 +408,7 @@ class TestStatsTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_stats(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("stats", {})
         data = result.data
         assert isinstance(data, dict)
@@ -422,7 +423,7 @@ class TestEmbeddingsStatusTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_embeddings_status_no_provider(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("embeddings_status", {})
         data = result.data
         assert isinstance(data, dict)
@@ -435,7 +436,7 @@ class TestReindexTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_reindex_no_changes(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("reindex", {})
         data = result.data
         assert isinstance(data, dict)
@@ -456,7 +457,7 @@ class TestErrorHandling:
     async def test_semantic_search_without_embeddings_returns_error(self) -> None:
         """search with mode='semantic' when no embeddings configured returns error."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "search", {"query": "test", "mode": "semantic"}
             )
@@ -474,7 +475,7 @@ class TestWriteTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_write_creates_document(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "write", {"path": "new_note.md", "content": "# New\n\nBody.\n"}
             )
@@ -486,7 +487,7 @@ class TestWriteTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_write_overwrites_existing(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "write", {"path": "simple.md", "content": "# Replaced\n"}
             )
@@ -497,7 +498,7 @@ class TestWriteTool:
     async def test_write_with_frontmatter(self) -> None:
         """write tool with frontmatter parameter creates document and returns created=True."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "write",
                 {
@@ -518,7 +519,7 @@ class TestEditTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_edit_patches_document(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "edit",
                 {
@@ -534,7 +535,7 @@ class TestEditTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_edit_nonexistent_returns_error(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "edit",
                 {"path": "nonexistent.md", "old_text": "a", "new_text": "b"},
@@ -544,7 +545,7 @@ class TestEditTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_edit_conflict_returns_error(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "edit",
                 {"path": "simple.md", "old_text": "missing text", "new_text": "b"},
@@ -555,7 +556,7 @@ class TestEditTool:
     async def test_edit_line_range(self) -> None:
         """MCP edit tool accepts line_start/line_end."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             await client.call_tool(
                 "write",
                 {"path": "lines.md", "content": "line1\nline2\nline3\n"},
@@ -577,7 +578,7 @@ class TestEditTool:
     async def test_edit_normalized_match(self) -> None:
         """MCP edit response includes match_type."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             await client.call_tool(
                 "write",
                 {"path": "norm.md", "content": "hello \u2014 world\n"},
@@ -597,7 +598,7 @@ class TestEditTool:
     async def test_edit_diagnostic_error(self) -> None:
         """MCP edit error includes diagnostic info."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             await client.call_tool(
                 "write",
                 {"path": "diag.md", "content": "the quick brown fox\n"},
@@ -621,7 +622,7 @@ class TestDeleteTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_delete_removes_document(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("delete", {"path": "simple.md"})
         data = result.data
         assert data["path"] == "simple.md"
@@ -629,7 +630,7 @@ class TestDeleteTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_delete_nonexistent_returns_error(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp("delete", {"path": "nonexistent.md"})
         assert result.isError is True
 
@@ -640,7 +641,7 @@ class TestRenameTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_rename_moves_document(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "rename", {"old_path": "simple.md", "new_path": "renamed.md"}
             )
@@ -651,7 +652,7 @@ class TestRenameTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_rename_nonexistent_returns_error(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "rename",
                 {"old_path": "nonexistent.md", "new_path": "target.md"},
@@ -661,7 +662,7 @@ class TestRenameTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_rename_target_exists_returns_error(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "rename",
                 {"old_path": "simple.md", "new_path": "no_frontmatter.md"},
@@ -672,7 +673,7 @@ class TestRenameTool:
     async def test_rename_to_same_path_returns_error(self) -> None:
         """rename to same old_path and new_path should return an error."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "rename",
                 {"old_path": "simple.md", "new_path": "simple.md"},
@@ -702,7 +703,7 @@ class TestMCPExcludePatterns:
                 monkeypatch.delenv(var, raising=False)
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("list_documents", {})
 
         data = _parse_tool_data(result)
@@ -1028,7 +1029,7 @@ class TestMCPReadAttachment:
         import base64
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("read", {"path": "assets/report.pdf"})
         data = result.data
         assert data["path"] == "assets/report.pdf"
@@ -1042,7 +1043,7 @@ class TestMCPReadAttachment:
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("read", {"path": "assets/image.png"})
         assert result.data["mime_type"] == "image/png"
 
@@ -1050,7 +1051,7 @@ class TestMCPReadAttachment:
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError):
                 await client.call_tool("read", {"path": "assets/missing.pdf"})
 
@@ -1066,7 +1067,7 @@ class TestMCPWriteAttachment:
         raw = b"new pdf binary content"
         b64 = base64.b64encode(raw).decode("ascii")
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "write",
                 {"path": "assets/new.pdf", "content_base64": b64},
@@ -1082,7 +1083,7 @@ class TestMCPWriteAttachment:
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError):
                 await client.call_tool("write", {"path": "assets/new.pdf"})
 
@@ -1090,7 +1091,7 @@ class TestMCPWriteAttachment:
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError):
                 await client.call_tool(
                     "write",
@@ -1138,8 +1139,15 @@ class TestFetchTool:
         )
 
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     "fetch",
                     {"url": "https://example.com/note.md", "path": "fetched.md"},
@@ -1167,8 +1175,15 @@ class TestFetchTool:
         mock_client = self._mock_httpx_stream(raw, {"content-type": "image/png"})
 
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     "fetch",
                     {
@@ -1192,7 +1207,7 @@ class TestFetchTool:
     ) -> None:
         """file:// URLs are rejected (SSRF protection)."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError, match="http and https"):
                 await client.call_tool(
                     "fetch",
@@ -1204,7 +1219,7 @@ class TestFetchTool:
     ) -> None:
         """ftp:// URLs are rejected."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError, match="http and https"):
                 await client.call_tool(
                     "fetch",
@@ -1227,8 +1242,15 @@ class TestFetchTool:
         )
 
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 with pytest.raises(ToolError, match="exceeded"):
                     await client.call_tool(
                         "fetch",
@@ -1254,7 +1276,7 @@ class TestFetchTool:
         monkeypatch.setattr(builtins, "__import__", mock_import)
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError, match="httpx"):
                 await client.call_tool(
                     "fetch",
@@ -1273,8 +1295,15 @@ class TestFetchTool:
         mock_client = self._mock_httpx_stream(body, {"content-type": "text/markdown"})
 
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool(
                     "fetch",
                     {
@@ -1323,8 +1352,15 @@ class TestFetchTool:
         mock_client_instance.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(httpx, "AsyncClient", return_value=mock_client_instance):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 with pytest.raises(ToolError, match="Not Found"):
                     await client.call_tool(
                         "fetch",
@@ -1339,7 +1375,7 @@ class TestFetchTool:
     ) -> None:
         """Private/loopback IPs are rejected (SSRF protection)."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError, match="private"):
                 await client.call_tool(
                     "fetch",
@@ -1351,7 +1387,7 @@ class TestFetchTool:
     ) -> None:
         """Cloud metadata endpoint IPs are rejected."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError, match="private"):
                 await client.call_tool(
                     "fetch",
@@ -1366,7 +1402,7 @@ class TestFetchTool:
     ) -> None:
         """0.0.0.0 is rejected (routes to localhost on most systems)."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError, match="private"):
                 await client.call_tool(
                     "fetch",
@@ -1385,8 +1421,15 @@ class TestFetchTool:
         mock_client = self._mock_httpx_stream(raw, {"content-type": "image/png"})
 
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 with pytest.raises(ToolError, match="not valid UTF-8"):
                     await client.call_tool(
                         "fetch",
@@ -1400,7 +1443,7 @@ class TestFetchTool:
     async def test_fetch_hidden_in_read_only_mode(self) -> None:
         """fetch tool should not appear when server is read-only."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         tool_names = [t.name for t in tools]
         assert "fetch" not in tool_names
@@ -1419,8 +1462,15 @@ class TestFetchTool:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 with pytest.raises(ToolError, match="timed out"):
                     await client.call_tool(
                         "fetch",
@@ -1435,7 +1485,7 @@ class TestFetchTool:
     ) -> None:
         """Hostname blocklist rejects 'localhost'."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(ToolError, match="private"):
                 await client.call_tool(
                     "fetch",
@@ -1450,7 +1500,7 @@ class TestMCPListDocumentsAttachments:
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("list_documents", {})
         items = _parse_tool_data(result)
         paths = [item["path"] for item in items]
@@ -1460,7 +1510,7 @@ class TestMCPListDocumentsAttachments:
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "list_documents", {"include_attachments": True}
             )
@@ -1478,7 +1528,7 @@ class TestMCPListDocumentsAttachments:
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "list_documents", {"include_attachments": True}
             )
@@ -1496,7 +1546,7 @@ class TestMCPStatsAttachmentExtensions:
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("stats", {})
         data = result.data
         assert "attachment_extensions" in data
@@ -1534,7 +1584,7 @@ class TestLinkTools:
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_backlinks(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_backlinks", {"path": "notes/topic.md"})
         data = _parse_tool_data(result)
         assert len(data) == 1
@@ -1544,14 +1594,14 @@ class TestLinkTools:
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_backlinks_nonexistent_raises(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises((ToolError, McpError)):
                 await client.call_tool("get_backlinks", {"path": "nope.md"})
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_outlinks(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_outlinks", {"path": "index.md"})
         data = _parse_tool_data(result)
         assert len(data) == 2
@@ -1566,14 +1616,14 @@ class TestLinkTools:
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_outlinks_nonexistent_path(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises((ToolError, McpError)):
                 await client.call_tool("get_outlinks", {"path": "nope.md"})
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_broken_links(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_broken_links", {})
         data = _parse_tool_data(result)
         assert len(data) == 1
@@ -1583,7 +1633,7 @@ class TestLinkTools:
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_broken_links_with_folder_filter(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_broken_links", {"folder": "notes"})
         data = _parse_tool_data(result)
         # notes/topic.md links to ../index.md which exists — no broken links
@@ -1593,7 +1643,7 @@ class TestLinkTools:
     async def test_link_tools_available_in_readonly(self) -> None:
         """Link tools are read-only and available even when vault is read-only."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
             names = {t.name for t in tools}
         assert "get_backlinks" in names
@@ -1608,7 +1658,7 @@ class TestSimilarTool:
     async def test_get_similar_no_embeddings_returns_empty(self) -> None:
         """get_similar returns empty list when embeddings not configured."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_similar", {"path": "simple.md"})
         data = _parse_tool_data(result)
         assert data == []
@@ -1616,7 +1666,7 @@ class TestSimilarTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_get_similar_nonexistent_raises(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises((ToolError, McpError)):
                 await client.call_tool("get_similar", {"path": "nonexistent.md"})
 
@@ -1624,7 +1674,7 @@ class TestSimilarTool:
     async def test_get_similar_tool_accepts_chunks_per_file(self) -> None:
         """The `get_similar` MCP tool surfaces the chunks_per_file kwarg."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             # Without embeddings this returns []; the assertion is that the
             # call_tool schema accepts the chunks_per_file kwarg without raising.
             result = await client.call_tool(
@@ -1641,7 +1691,7 @@ class TestRecentTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_get_recent_returns_notes(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_recent", {"limit": 5})
         data = _parse_tool_data(result)
         assert isinstance(data, list)
@@ -1655,7 +1705,7 @@ class TestRecentTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_get_recent_empty_folder(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "get_recent", {"folder": "nonexistent_folder"}
             )
@@ -1665,7 +1715,7 @@ class TestRecentTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_recent_resource(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.read_resource("recent://vault")
         data = json.loads(result[0].text)
         assert isinstance(data, list)
@@ -1711,7 +1761,7 @@ class TestContextTool:
     async def test_get_context_basic_fields(self) -> None:
         """get_context returns expected top-level fields."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_context", {"path": "index.md"})
         data = _parse_tool_data(result)
         assert data["path"] == "index.md"
@@ -1728,7 +1778,7 @@ class TestContextTool:
     async def test_get_context_modified_at_matches_read(self) -> None:
         """modified_at in context matches the value from read()."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             ctx = _parse_tool_data(
                 await client.call_tool("get_context", {"path": "index.md"})
             )
@@ -1739,7 +1789,7 @@ class TestContextTool:
     async def test_get_context_backlinks(self) -> None:
         """notes/topic.md has a backlink from index.md."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_context", {"path": "notes/topic.md"})
         data = _parse_tool_data(result)
         sources = [b["source_path"] for b in data["backlinks"]]
@@ -1749,7 +1799,7 @@ class TestContextTool:
     async def test_get_context_outlinks(self) -> None:
         """index.md has an outlink to notes/topic.md."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_context", {"path": "index.md"})
         data = _parse_tool_data(result)
         targets = [o["target_path"] for o in data["outlinks"]]
@@ -1759,7 +1809,7 @@ class TestContextTool:
     async def test_get_context_folder_notes_excludes_self(self) -> None:
         """folder_notes for notes/topic.md contains peer.md but not topic.md."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_context", {"path": "notes/topic.md"})
         data = _parse_tool_data(result)
         assert "notes/topic.md" not in data["folder_notes"]
@@ -1769,7 +1819,7 @@ class TestContextTool:
     async def test_get_context_tags(self) -> None:
         """Indexed frontmatter tags appear in context.tags."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_context", {"path": "index.md"})
         data = _parse_tool_data(result)
         assert "tags" in data["tags"]
@@ -1780,7 +1830,7 @@ class TestContextTool:
     async def test_get_context_similar_empty_without_embeddings(self) -> None:
         """similar is empty when embeddings are not configured."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_context", {"path": "index.md"})
         data = _parse_tool_data(result)
         assert data["similar"] == []
@@ -1789,7 +1839,7 @@ class TestContextTool:
     async def test_get_context_nonexistent_raises(self) -> None:
         """get_context raises for a path not in the index."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises((ToolError, McpError)):
                 await client.call_tool("get_context", {"path": "nope.md"})
 
@@ -1797,7 +1847,7 @@ class TestContextTool:
     async def test_get_context_in_tool_list(self) -> None:
         """get_context appears in the server tool list."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         names = {t.name for t in tools}
         assert "get_context" in names
@@ -1814,7 +1864,7 @@ class TestResources:
     @pytest.mark.usefixtures("_mcp_env_with_fields")
     async def test_config_resource(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.read_resource("config://vault")
         data = json.loads(result[0].text)
         assert "source_dir" in data
@@ -1829,7 +1879,7 @@ class TestResources:
     @pytest.mark.usefixtures("_mcp_env_with_fields")
     async def test_stats_resource(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resource_result = await client.read_resource("stats://vault")
             tool_result = await client.call_tool("stats", {})
         resource_data = json.loads(resource_result[0].text)
@@ -1840,7 +1890,7 @@ class TestResources:
     @pytest.mark.usefixtures("_mcp_env_with_fields")
     async def test_tags_resource_grouped(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.read_resource("tags://vault")
         data = json.loads(result[0].text)
         # With indexed fields "cluster,tags", both keys should be present.
@@ -1851,7 +1901,7 @@ class TestResources:
     @pytest.mark.usefixtures("_mcp_env_with_fields")
     async def test_tags_resource_by_field(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.read_resource("tags://vault/cluster")
         data = json.loads(result[0].text)
         assert isinstance(data, list)
@@ -1861,7 +1911,7 @@ class TestResources:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_folders_resource(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.read_resource("folders://vault")
         data = json.loads(result[0].text)
         assert isinstance(data, list)
@@ -1871,7 +1921,7 @@ class TestResources:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_toc_resource(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.read_resource("toc://vault/simple.md")
         data = json.loads(result[0].text)
         assert isinstance(data, list)
@@ -1884,7 +1934,7 @@ class TestResources:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_toc_resource_missing_path(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             with pytest.raises(McpError, match="Document not found"):
                 await client.read_resource("toc://vault/does_not_exist.md")
 
@@ -1900,7 +1950,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_summarize_prompt(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("summarize", {"path": "simple.md"})
         text = result.messages[0].content.text
         assert "simple.md" in text
@@ -1909,7 +1959,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_research_prompt(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("research", {"topic": "horror fiction"})
         text = result.messages[0].content.text
         assert "horror fiction" in text
@@ -1919,7 +1969,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_discuss_prompt(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("discuss", {"path": "simple.md"})
         text = result.messages[0].content.text
         assert "simple.md" in text
@@ -1929,7 +1979,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_related_prompt(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("related", {"path": "simple.md"})
         text = result.messages[0].content.text
         assert "simple.md" in text
@@ -1939,7 +1989,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_compare_prompt(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt(
                 "compare", {"path1": "simple.md", "path2": "no_frontmatter.md"}
             )
@@ -1951,7 +2001,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_create_from_template_prompt_with_name(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt(
                 "create_from_template", {"template_name": "meeting.md"}
             )
@@ -1965,7 +2015,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_create_from_template_prompt_sanitizes_template_name(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt(
                 "create_from_template",
                 {"template_name": "/../notes/meeting.md"},
@@ -1980,7 +2030,7 @@ class TestPrompts:
     ) -> None:
         """.. segments collapse into parent rather than being dropped as isolated parts."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt(
                 "create_from_template",
                 {"template_name": "team/../daily.md"},
@@ -1996,7 +2046,7 @@ class TestPrompts:
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER", "Templates\\Notes\\")
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt(
                 "create_from_template",
                 {"template_name": "daily\\standup.md"},
@@ -2008,7 +2058,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_create_from_template_prompt_discovery_mode(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("create_from_template", {})
         text = result.messages[0].content.text
         assert "list_documents" in text
@@ -2020,7 +2070,7 @@ class TestPrompts:
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER", "Templates/")
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.get_prompt("create_from_template", {})
         text = result.messages[0].content.text
         assert "Templates/" not in text
@@ -2029,7 +2079,7 @@ class TestPrompts:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_create_from_template_prompt_registration_schema(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
 
         prompt = next((p for p in prompts if p.name == "create_from_template"), None)
@@ -2053,7 +2103,7 @@ class TestPromptVisibility:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_write_prompts_hidden_when_readonly(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         names = {p.name for p in prompts}
         assert "research" not in names
@@ -2063,7 +2113,7 @@ class TestPromptVisibility:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_write_prompts_visible_when_writable(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         names = {p.name for p in prompts}
         assert "summarize" in names
@@ -2076,7 +2126,7 @@ class TestPromptVisibility:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_readonly_prompts_always_visible(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
         names = {p.name for p in prompts}
         assert "summarize" in names
@@ -2095,7 +2145,7 @@ class TestPromptAndResourceIcons:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_prompts_have_icons(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             prompts = await client.list_prompts()
 
         for prompt in prompts:
@@ -2106,7 +2156,7 @@ class TestPromptAndResourceIcons:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_resources_have_icons(self) -> None:
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             resources = await client.list_resources()
 
         for resource in resources:
@@ -2147,7 +2197,7 @@ class TestIfMatchParameter:
     async def test_write_rejects_stale_if_match(self) -> None:
         """write tool returns an error when if_match does not match."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "write",
                 {
@@ -2182,7 +2232,7 @@ class TestIfMatchParameter:
     async def test_edit_rejects_stale_if_match(self) -> None:
         """edit tool returns an error when if_match does not match."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "edit",
                 {
@@ -2213,7 +2263,7 @@ class TestIfMatchParameter:
     async def test_delete_rejects_stale_if_match(self) -> None:
         """delete tool returns an error when if_match does not match."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "delete",
                 {"path": "simple.md", "if_match": "stale-etag-value"},
@@ -2244,7 +2294,7 @@ class TestIfMatchParameter:
     async def test_rename_rejects_stale_if_match(self) -> None:
         """rename tool returns an error when if_match does not match."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp(
                 "rename",
                 {
@@ -2290,8 +2340,15 @@ class TestLifespanAutoEmbeddings:
             "markdown_vault_mcp.providers.get_embedding_provider",
             return_value=mock_prov,
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 result = await client.call_tool_mcp("embeddings_status", {})
         data = json.loads(result.content[0].text)
         assert data["chunk_count"] > 0
@@ -2320,8 +2377,15 @@ class TestLifespanAutoEmbeddings:
             "markdown_vault_mcp.providers.get_embedding_provider",
             return_value=mock_prov,
         ):
+            from markdown_vault_mcp._server_deps import get_collection_singleton
+            from tests.conftest import wait_for_background_reindex
+
             server = make_server()
+
             async with Client(server) as client:
+                collection = get_collection_singleton()
+
+                await wait_for_background_reindex(collection)
                 r1 = await client.call_tool_mcp("embeddings_status", {})
         count1 = json.loads(r1.content[0].text)["chunk_count"]
         assert count1 > 0
@@ -2360,7 +2424,7 @@ class TestLifespanAutoEmbeddings:
             monkeypatch.delenv(var, raising=False)
 
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool_mcp("stats", {})
         data = json.loads(result.content[0].text)
         assert data["semantic_search_available"] is False
@@ -3094,7 +3158,7 @@ class TestGetHistoryTool:
     async def test_vault_wide_history(self) -> None:
         """get_history with no path returns vault-wide commits."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_history", {})
         data = _parse_tool_data(result)
         assert isinstance(data, dict)
@@ -3109,7 +3173,7 @@ class TestGetHistoryTool:
     async def test_single_note_history(self) -> None:
         """get_history filtered by path returns commits for that note."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_history", {"path": "alpha.md"})
         data = _parse_tool_data(result)
         assert isinstance(data, dict)
@@ -3120,7 +3184,7 @@ class TestGetHistoryTool:
     async def test_history_entry_fields(self) -> None:
         """Each history entry has the expected fields."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_history", {"limit": 1})
         data = _parse_tool_data(result)
         entry = data["commits"][0]
@@ -3134,7 +3198,7 @@ class TestGetHistoryTool:
     async def test_limit_respected(self) -> None:
         """limit parameter restricts the number of results."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_history", {"limit": 1})
         data = _parse_tool_data(result)
         assert len(data["commits"]) == 1
@@ -3152,7 +3216,7 @@ class TestGetHistoryTool:
     async def test_get_history_in_tool_list(self) -> None:
         """get_history appears in the tool list."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         names = [t.name for t in tools]
         assert "get_history" in names
@@ -3160,7 +3224,7 @@ class TestGetHistoryTool:
     async def test_get_diff_in_tool_list(self) -> None:
         """get_diff appears in the tool list."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         names = [t.name for t in tools]
         assert "get_diff" in names
@@ -3169,7 +3233,7 @@ class TestGetHistoryTool:
         """structured_content uses the `commits` envelope, not FastMCP's
         synthetic `result` wrap key."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool("get_history", {})
         assert result.structured_content is not None
         assert "commits" in result.structured_content
@@ -3183,7 +3247,7 @@ class TestGetHistoryTool:
         marker — it appears only when FastMCP auto-wraps a list/primitive
         return under a synthetic `result` key; the dict envelope skips it."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         gh = next(t for t in tools if t.name == "get_history")
         schema = gh.outputSchema
@@ -3214,7 +3278,7 @@ class TestGetDiffTool:
         """get_diff with since_sha returns a unified diff dict."""
         sha = self._first_sha(git_vault)
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "get_diff", {"path": "alpha.md", "since_sha": sha}
             )
@@ -3227,7 +3291,7 @@ class TestGetDiffTool:
         """get_diff with per_commit=True returns a {commits, total} envelope."""
         sha = self._first_sha(git_vault)
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "get_diff",
                 {"path": "alpha.md", "since_sha": sha, "per_commit": True},
@@ -3296,7 +3360,7 @@ class TestGetDiffTool:
             )
         sha = self._first_sha(git_vault)
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "get_diff",
                 {
@@ -3321,7 +3385,7 @@ class TestGetDiffTool:
         synthetic `result` wrap key."""
         sha = self._first_sha(git_vault)
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             result = await client.call_tool(
                 "get_diff",
                 {"path": "alpha.md", "since_sha": sha, "per_commit": True},
@@ -3338,7 +3402,7 @@ class TestGetDiffTool:
         marker — it appears only when FastMCP auto-wraps a list/primitive
         return under a synthetic `result` key; the dict envelope skips it."""
         server = make_server()
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             tools = await client.list_tools()
         gd = next(t for t in tools if t.name == "get_diff")
         schema = gd.outputSchema
@@ -3374,8 +3438,15 @@ async def test_search_tool_accepts_chunks_per_file_and_snippet_words(
     for var in _CLEAR_VARS:
         monkeypatch.delenv(var, raising=False)
 
+    from markdown_vault_mcp._server_deps import get_collection_singleton
+    from tests.conftest import wait_for_background_reindex
+
     server = make_server()
+
     async with Client(server) as client:
+        collection = get_collection_singleton()
+
+        await wait_for_background_reindex(collection)
         result = await client.call_tool(
             "search",
             {
@@ -3417,8 +3488,15 @@ async def test_read_tool_returns_only_named_section(
     for var in _CLEAR_VARS:
         monkeypatch.delenv(var, raising=False)
 
+    from markdown_vault_mcp._server_deps import get_collection_singleton
+    from tests.conftest import wait_for_background_reindex
+
     server = make_server()
+
     async with Client(server) as client:
+        collection = get_collection_singleton()
+
+        await wait_for_background_reindex(collection)
         whole = await client.call_tool("read", {"path": "a.md"})
         assert "first body" in whole.data["content"]
         assert "second body" in whole.data["content"]
@@ -3445,8 +3523,7 @@ class TestGitToolsUntilParam:
         # A far-future cutoff must include both; a far-past cutoff must exclude
         # both. This proves the `until` kwarg is plumbed through to git log.
         server = make_server()
-
-        async with Client(server) as client:
+        async with mcp_client_ready(server) as client:
             future = await client.call_tool(
                 "get_history", {"until": "2099-01-01T00:00:00"}
             )


### PR DESCRIPTION
## Summary

Replaces the abandoned PR #515 with a structurally different approach:
indexing stays in `Collection`, but the public API gains
`start_background_reindex()` (fire-and-forget daemon spawn) and
`index_status()` (read-only snapshot) — and the foreground waiter
`_ensure_initialized()` is **removed entirely** (22 call sites stripped).

The no-foreground-waiter rule that PR #515 violated is now executable:
`test_foreground_reads_never_block_on_background` asserts `search` /
`list` / `stats` / `index_status` each return within 500ms while a
deliberately slow background embedding pass is in flight. Future code
re-introducing a waiter will fail this test.

Spec: `docs/superpowers/specs/2026-05-26-background-indexing-v2-design.md`
Plan: `docs/superpowers/plans/2026-05-26-background-indexing-v2.md`

Closes #513.

## Architecture

| | |
|---|---|
| Sync mode | `build_index()` / `reindex()` — unchanged; used by CLI + `reindex` MCP tool |
| Background mode | `start_background_reindex()` — daemon thread runs `reindex()` then `build_embeddings()` (if provider configured); idempotent; returns immediately |
| Status | Nested in `CollectionStats.index_status` (LLM accesses via `stats` tool) and surfaced under `get_server_info`'s upstream slot |
| Shutdown | `close()` signals shutdown, joins with 30s bounded timeout, daemon-thread fallback; SQLite WAL handles partial uncommitted state on next startup |
| Rule | No public method on `Collection` may block on background indexing state. Empty-during-cold-start is a valid result, not an error to wait out. |

## Local review

Two rounds of the `preflight-circus` skill (5 core lenses + 4 supplementary)
ran before push. All findings at confidence ≥ 80 addressed in commits
`1b4744b` and `b9fe6e0`.

## Deferred follow-ups (filed as comments below or to be split into issues post-merge)

These were surfaced by the local review at sub-threshold or as architectural
deltas, intentionally not bundled:

1. **Type-design**: `CollectionStats.index_status` is typed `dict[str, Any]`
   and `_background_phase` is `str | None` with an implicit
   `{"indexing", "embedding", None}` domain. A frozen `IndexStatus` dataclass
   + `Literal["indexing", "embedding"]` would give compile-time guarantees.
   Separate refactor.
2. **Test coverage**: Concurrent foreground writes during background
   reindex, and `close()` during in-flight writes, are not directly
   exercised. Real production paths; require a slow-callback test
   harness.
3. **Observability**: Categorising specific exception types in the
   daemon worker (`MemoryError`, `sqlite3.DatabaseError`, `OSError`)
   for severity escalation. Currently all go through the broad
   `except Exception` boundary.
4. **`_closed` flag**: `start_background_reindex()` races trivially
   with `close()` — adding a `_closed` flag would harden it. Single-shot
   shutdown in practice, but worth a follow-up if anyone hits it.

## Test plan

- [x] `uv run pytest -x -q` — 1601 passed, 1 skipped
- [x] `uv run mypy src/ tests/` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Foreground reads return < 500ms during slow background embedding (the load-bearing test)
- [x] `_ensure_initialized` removed from collection.py and all 22 call sites
- [x] Bounded `close()` join: 30s timeout, daemon-thread fallback
- [x] `index_status` exposed via both `stats` and `get_server_info`
- [x] Two rounds of preflight-circus (5 core lenses + 4 supplementary) cleared at ≥80 confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)