### PR TITLE
refactor(collection): make _ensure_initialized a fast probe (refs #513)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -365,10 +365,11 @@ Two methods manage the index:
   adds/modifies/deletes since the last scan and applies only the delta.
   Applies `exclude_patterns` filtering and purges stale excluded documents.
 
-**Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
-`Collection` lazily builds the FTS index from `source_dir` if no pre-built
-`index_path` was provided. `build_index()` can be called explicitly to
-pre-warm the index or to force a rebuild.
+**Explicit initialization**: callers (the MCP lifespan, the CLI, tests)
+must call `build_index()` before querying. Tool methods on an unbuilt
+`Collection` return empty results; they do not trigger a filesystem
+scan. `build_index()` can also be called to force a rebuild
+(`force=True`).
 
 ### Error Handling
 
@@ -999,9 +1000,9 @@ class Collection:
 - `embeddings_path=None`: semantic search is disabled.
 - `state_path=None`: defaults to `{source_dir}/.markdown_vault_mcp/state.json`.
 
-**Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
-`Collection` lazily builds the FTS index from `source_dir` if no pre-built
-`index_path` was provided.
+**Explicit initialization**: callers (the MCP lifespan, the CLI, tests)
+must call `build_index()` before querying. Tool methods on an unbuilt
+`Collection` return empty results.
 
 **Write operations** (`write`, `edit`, `delete`, `rename`) raise
 `ReadOnlyError` when `read_only=True`.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -195,7 +195,8 @@ class Collection:
         )
         self._tracker = ChangeTracker(self._state_path)
 
-        # Lazy initialisation flag.
+        # Query-readiness flag — flipped by _ensure_initialized; does not
+        # imply build_index has run.
         self._initialized = False
 
         # Serialise concurrent write operations on this instance.
@@ -349,7 +350,7 @@ class Collection:
         self._fts.close()
 
     # ------------------------------------------------------------------
-    # Lazy initialisation
+    # Query-readiness probe
     # ------------------------------------------------------------------
 
     def _ensure_initialized(self) -> None:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -86,8 +86,8 @@ def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
 class Collection:
     """Facade over FTS5 index, vector index, and change tracker.
 
-    Instantiate once per collection root.  Call :meth:`build_index` (or let
-    lazy initialisation handle it) before querying.
+    Instantiate once per collection root.  Call :meth:`build_index` before
+    querying — queries against an unbuilt index return empty results.
 
     Args:
         source_dir: Root directory of the markdown collection.
@@ -355,13 +355,14 @@ class Collection:
     def _ensure_initialized(self) -> None:
         """Mark the collection as ready for queries without forcing a build.
 
-        Tool methods call this before reading from the index. Originally it
+        Tool methods call this before reading from the index. Previously it
         would synchronously run :meth:`build_index` if the index had not been
-        built yet; that blocked the MCP handshake on cold start. The lifespan
-        now drives the initial build via
-        :class:`~markdown_vault_mcp.background_indexer.BackgroundIndexer`, so
-        this method only flips the flag — tools see whatever the FTS DB
-        currently contains, which may be empty during cold-start indexing.
+        built yet, which blocked the MCP handshake on cold start. It now
+        only flips the ``_initialized`` flag; callers see whatever the FTS
+        database currently contains, which may be empty until
+        :meth:`build_index` runs. Scheduling that initial build is the
+        responsibility of the caller (the MCP lifespan, the CLI, or a test).
+        See issue #513.
         """
         self._initialized = True
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -353,9 +353,17 @@ class Collection:
     # ------------------------------------------------------------------
 
     def _ensure_initialized(self) -> None:
-        """Build the FTS index on first access if it has not been built yet."""
-        if not self._initialized:
-            self.build_index()
+        """Mark the collection as ready for queries without forcing a build.
+
+        Tool methods call this before reading from the index. Originally it
+        would synchronously run :meth:`build_index` if the index had not been
+        built yet; that blocked the MCP handshake on cold start. The lifespan
+        now drives the initial build via
+        :class:`~markdown_vault_mcp.background_indexer.BackgroundIndexer`, so
+        this method only flips the flag — tools see whatever the FTS DB
+        currently contains, which may be empty during cold-start indexing.
+        """
+        self._initialized = True
 
     @property
     def _vectors(self) -> VectorIndex | None:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -395,18 +395,17 @@ class TestBuildIndex:
 
 
 # ---------------------------------------------------------------------------
-# Lazy initialisation
+# Explicit initialisation
 # ---------------------------------------------------------------------------
 
 
-class TestLazyInitialisation:
+class TestExplicitInitialisation:
     def test_search_without_build_index_returns_empty(self, vault_path: Path) -> None:
         """search() on an unbuilt index returns empty list without crashing.
 
-        After the fast-probe change, _ensure_initialized() only sets the
-        _initialized flag — it does not call build_index(). Tool methods
-        therefore see an empty index on first call if build_index() was
-        never invoked.
+        _ensure_initialized() only sets the _initialized flag — it does not
+        call build_index(). Tool methods see an empty index until
+        build_index() is invoked explicitly.
         """
         col = _make_collection(vault_path)
 
@@ -417,9 +416,9 @@ class TestLazyInitialisation:
     def test_list_without_build_index_returns_empty(self, vault_path: Path) -> None:
         """list() on an unbuilt index returns empty list without crashing.
 
-        After the fast-probe change, _ensure_initialized() only sets the
-        _initialized flag — it does not call build_index(). Callers that
-        need documents must invoke build_index() explicitly.
+        _ensure_initialized() only sets the _initialized flag — it does not
+        call build_index(). Callers that need documents must invoke
+        build_index() explicitly.
         """
         col = _make_collection(vault_path)
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -400,19 +400,38 @@ class TestBuildIndex:
 
 
 class TestLazyInitialisation:
-    def test_search_without_build_index(self, vault_path: Path) -> None:
-        """search() triggers lazy initialisation without an explicit build_index()."""
+    def test_search_without_build_index_returns_empty(self, vault_path: Path) -> None:
+        """search() on an unbuilt index returns empty list without crashing.
+
+        After the fast-probe change, _ensure_initialized() only sets the
+        _initialized flag — it does not call build_index(). Tool methods
+        therefore see an empty index on first call if build_index() was
+        never invoked.
+        """
         col = _make_collection(vault_path)
 
-        # Do NOT call build_index() — search() should initialise automatically.
         results = col.search("simple")
 
-        # Either finds something or returns [] — the key is it does not crash.
-        assert isinstance(results, list)
+        assert results == []
 
-    def test_list_without_build_index(self, vault_path: Path) -> None:
-        """list() triggers lazy initialisation without an explicit build_index()."""
+    def test_list_without_build_index_returns_empty(self, vault_path: Path) -> None:
+        """list() on an unbuilt index returns empty list without crashing.
+
+        After the fast-probe change, _ensure_initialized() only sets the
+        _initialized flag — it does not call build_index(). Callers that
+        need documents must invoke build_index() explicitly.
+        """
         col = _make_collection(vault_path)
+
+        notes = col.list()
+
+        assert isinstance(notes, list)
+        assert len(notes) == 0
+
+    def test_list_after_explicit_build_index(self, vault_path: Path) -> None:
+        """list() returns all documents when build_index() is called first."""
+        col = _make_collection(vault_path)
+        col.build_index()
 
         notes = col.list()
 

--- a/tests/test_collection_initialization.py
+++ b/tests/test_collection_initialization.py
@@ -1,4 +1,4 @@
-"""Tests for Collection lazy-initialization semantics."""
+"""Tests for Collection initialization semantics (issue #513)."""
 
 from __future__ import annotations
 
@@ -9,15 +9,19 @@ from markdown_vault_mcp.collection import Collection
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
 
-def test_ensure_initialized_does_not_build_index(tmp_path: Path) -> None:
-    """Calling a tool method before build_index() must not trigger a scan.
 
-    The `_ensure_initialized` method historically called `build_index()` when
-    the index had not been built yet. After the fast-probe change, it must
-    only mark the collection as initialized so tool calls operate on
-    whatever the DB currently has (possibly empty), never triggering a
-    filesystem scan.
+def test_ensure_initialized_does_not_build_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`_ensure_initialized()` must only flip the flag, not call `build_index()`.
+
+    Previously `_ensure_initialized` called `build_index` on first access,
+    which blocked the MCP handshake on cold start. The new contract: it
+    flips ``_initialized`` and nothing else; callers see whatever the FTS
+    DB currently contains, which may be empty. A monkeypatched
+    `build_index` raising on call directly proves the invariant.
     """
     (tmp_path / "note.md").write_text("# Title\n\nSome body.\n", encoding="utf-8")
 
@@ -26,6 +30,13 @@ def test_ensure_initialized_does_not_build_index(tmp_path: Path) -> None:
     )
     try:
         assert collection._initialized is False
+
+        def fail_build_index(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError(
+                "build_index must not be called by _ensure_initialized"
+            )
+
+        monkeypatch.setattr(collection, "build_index", fail_build_index)
 
         results = collection.search("Title")
 

--- a/tests/test_collection_initialization.py
+++ b/tests/test_collection_initialization.py
@@ -1,0 +1,35 @@
+"""Tests for Collection lazy-initialization semantics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.collection import Collection
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_ensure_initialized_does_not_build_index(tmp_path: Path) -> None:
+    """Calling a tool method before build_index() must not trigger a scan.
+
+    The `_ensure_initialized` method historically called `build_index()` when
+    the index had not been built yet. After the fast-probe change, it must
+    only mark the collection as initialized so tool calls operate on
+    whatever the DB currently has (possibly empty), never triggering a
+    filesystem scan.
+    """
+    (tmp_path / "note.md").write_text("# Title\n\nSome body.\n", encoding="utf-8")
+
+    collection = Collection(
+        source_dir=tmp_path, state_path=tmp_path / ".state" / "state.json"
+    )
+    try:
+        assert collection._initialized is False
+
+        results = collection.search("Title")
+
+        assert collection._initialized is True
+        assert results == []
+    finally:
+        collection.close()


### PR DESCRIPTION
## Summary

`Collection._ensure_initialized()` no longer triggers `build_index()`. It now only flips `self._initialized = True`. The 22 existing call sites remain unchanged.

**Production behavior is unchanged today** because the lifespan in `_server_deps.py` still eagerly awaits `build_index()` (and `build_embeddings()`) before yielding, so the lazy fallback in `_ensure_initialized` was already dead. This PR is a **safety predicate** for the upcoming `BackgroundIndexer` landing (issue #513, attempt 4): without it, a tool call landing while a future background daemon is mid-`build_index()` would trigger a concurrent second `build_index()` race.

## Why ship this alone

The four-PR sequence for issue #513 (spec at `docs/superpowers/specs/2026-05-27-issue-513-background-indexer-design.md`):
1. **This PR** — `_ensure_initialized` fast probe.
2. `BackgroundIndexer` + lifespan switch (the actual handshake unblock).
3. `get_index_status` MCP tool.
4. Docs reframe; closes #513.

Each PR has one reviewer surface. The first three attempts at #513 (PRs #510, #515, #516) were abandoned because each tried to land 5–7 changes at once.

## Scope discipline

Not in this PR:
- Stripping `_ensure_initialized` from the 22 call sites (this was a major factor in PR #515 failing to converge).
- Any threading, `IndexStatus`, or lifespan changes.

Doc rot caught locally before push (pitfall #6 from PR #516's abandon notes): the `Collection` class docstring, two adjacent inline comments, the section banner, two `docs/design.md` paragraphs, and the test class name `TestLazyInitialisation` all still referenced the now-defunct lazy-build contract and have been updated in this PR.

## Test plan

- [x] New `test_ensure_initialized_does_not_build_index` monkeypatches `Collection.build_index` to raise — directly proves the invariant (not just that the method returned).
- [x] `TestExplicitInitialisation` (renamed from `TestLazyInitialisation`) — tightened assertions: `search()` and `list()` on an unbuilt index return empty, and a positive control test verifies `list()` returns documents after explicit `build_index()`.
- [x] Full suite green: 1595 passed, 1 skipped (pre-existing Python 3.13+ skip).
- [x] Lint, format, mypy clean.
- [x] Local preflight-circus clean (5 lenses + supplementary code-reviewer + comment-analyzer; 0 findings at ≥80 confidence).

Refs #513