### PR TITLE
feat(server): non-blocking MCP initialize via BackgroundIndexer (issue #513)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b0c2a392-87fc-41c9-8e2c-d7a596000a80","pid":254519,"procStart":"543893","acquiredAt":1778439832390}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b0c2a392-87fc-41c9-8e2c-d7a596000a80","pid":254519,"procStart":"543893","acquiredAt":1778439832390}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ site/
 .claude/worktrees/
 .claude/settings.local.json
 docs/superpowers/
+.claude/scheduled_tasks.lock

--- a/docs/design.md
+++ b/docs/design.md
@@ -365,10 +365,34 @@ Two methods manage the index:
   adds/modifies/deletes since the last scan and applies only the delta.
   Applies `exclude_patterns` filtering and purges stale excluded documents.
 
-**Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
-`Collection` lazily builds the FTS index from `source_dir` if no pre-built
-`index_path` was provided. `build_index()` can be called explicitly to
-pre-warm the index or to force a rebuild.
+**Explicit initialization**: callers (the MCP lifespan via
+`BackgroundIndexer`, the CLI, tests) call `build_index()` explicitly.
+Tool methods on an unbuilt `Collection` return empty results without
+triggering a scan. `build_index(force=True)` drops existing data and
+rebuilds.
+
+### Background indexer
+
+`BackgroundIndexer` (`src/markdown_vault_mcp/background_indexer.py`)
+owns the daemon thread that runs `Collection.build_index()` and, when
+an embedding provider is configured, `Collection.build_embeddings()`
+after the MCP server lifespan has yielded. The lifespan
+(`_server_deps.py`) constructs the orchestrator, calls `start()`, and
+yields immediately; the MCP `initialize` handshake therefore never
+blocks on indexing work (issue #513).
+
+`Collection` itself is purely synchronous and has no awareness of
+threading. Concurrency lives one layer up in the orchestrator. Teardown
+is linear: the lifespan calls `indexer.stop(timeout=30)` to join the
+daemon, then `Collection.close()` to release the SQLite connection.
+This ordering makes it structurally impossible for the SQLite
+connection to be closed while the worker is mid-write.
+
+Read tools on a collection where the background indexer has not yet
+finished return whatever the FTS database currently contains (possibly
+empty). Operators observe the warmup state via the `get_index_status`
+MCP tool. The daemon thread is WAL-resilient — if the join times out,
+the daemon is abandoned, and the next startup recovers via SQLite WAL.
 
 ### Error Handling
 
@@ -999,9 +1023,11 @@ class Collection:
 - `embeddings_path=None`: semantic search is disabled.
 - `state_path=None`: defaults to `{source_dir}/.markdown_vault_mcp/state.json`.
 
-**Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
-`Collection` lazily builds the FTS index from `source_dir` if no pre-built
-`index_path` was provided.
+**Explicit initialization**: callers (the MCP lifespan via
+`BackgroundIndexer`, the CLI, tests) call `build_index()` explicitly.
+Tool methods on an unbuilt `Collection` return empty results without
+triggering a scan. `build_index(force=True)` drops existing data and
+rebuilds.
 
 **Write operations** (`write`, `edit`, `delete`, `rename`) raise
 `ReadOnlyError` when `read_only=True`.

--- a/docs/design.md
+++ b/docs/design.md
@@ -382,17 +382,24 @@ yields immediately; the MCP `initialize` handshake therefore never
 blocks on indexing work (issue #513).
 
 `Collection` itself is purely synchronous and has no awareness of
-threading. Concurrency lives one layer up in the orchestrator. Teardown
-is linear: the lifespan calls `indexer.stop(timeout=30)` to join the
-daemon, then `Collection.close()` to release the SQLite connection.
-This ordering makes it structurally impossible for the SQLite
-connection to be closed while the worker is mid-write.
+threading. Concurrency lives one layer up in the orchestrator.
+Teardown: the lifespan calls `indexer.stop(timeout=30)` to join the
+daemon, then `Collection.close()`. When the join succeeds (the
+expected case) the SQLite connection is released only after the worker
+has exited. If the join times out — possible on a vault large enough
+that `build_index()` or `build_embeddings()` exceeds 30s and cannot be
+interrupted between phases — `Collection.close()` proceeds regardless;
+any in-flight SQLite write the daemon attempts after close raises
+inside `_run`'s ``except`` and SQLite's WAL recovers any partial state
+on next startup.
 
 Read tools on a collection where the background indexer has not yet
 finished return whatever the FTS database currently contains (possibly
-empty). Operators observe the warmup state via the `get_index_status`
-MCP tool. The daemon thread is WAL-resilient — if the join times out,
-the daemon is abandoned, and the next startup recovers via SQLite WAL.
+empty). The orchestrator's `status` snapshot is reachable to MCP tools
+via `get_indexer(ctx)` in `_server_deps.py`; a dedicated
+`get_index_status` MCP tool that surfaces the snapshot to clients
+lands in a follow-up PR (see
+[issue #513 status-surfacing](superpowers/specs/2026-05-27-issue-513-background-indexer-design.md#status-surfacing--separate-get_index_status-tool)).
 
 ### Error Handling
 

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -77,8 +77,10 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
 
     Returns:
         A FastMCP lifespan coroutine that initialises the
-        :class:`~markdown_vault_mcp.collection.Collection` and yields
-        ``{"collection": collection, "config": config}`` to the lifespan context.
+        :class:`~markdown_vault_mcp.collection.Collection` and the
+        :class:`~markdown_vault_mcp.background_indexer.BackgroundIndexer`,
+        and yields ``{"collection": collection, "config": config, "indexer":
+        indexer}`` to the lifespan context.
     """
 
     @lifespan

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -15,6 +15,7 @@ from fastmcp.dependencies import CurrentContext
 from fastmcp.server.context import Context
 from fastmcp.server.lifespan import lifespan
 
+from markdown_vault_mcp.background_indexer import BackgroundIndexer
 from markdown_vault_mcp.collection import Collection
 
 if TYPE_CHECKING:
@@ -100,22 +101,14 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # build_index() scans the freshest working tree.
         await asyncio.to_thread(collection.sync_from_remote_before_index)
 
-        # Build index eagerly so first tool call is fast.
-        stats = await asyncio.to_thread(collection.build_index)
-        logger.info(
-            "Index built: %d documents, %d chunks",
-            stats.documents_indexed,
-            stats.chunks_indexed,
+        indexer = BackgroundIndexer(
+            collection,
+            has_provider=kwargs.get("embedding_provider") is not None,
         )
+        indexer.start()
+        logger.info("background_indexer_started")
 
-        # Build embeddings eagerly when an embedding provider is configured.
-        # build_embeddings() skips work if the vector index already exists on disk,
-        # so this is safe to call on every startup.
-        if kwargs.get("embedding_provider") is not None:
-            chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
-            logger.info("Embeddings ready: %d chunks", chunks_embedded)
-
-        # Start background tasks (e.g. git pull loop) after index is built.
+        # Start background tasks (e.g. git pull loop).
         collection.start()
 
         # Artifact store singleton is wired in make_server(), not here —
@@ -125,12 +118,15 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # Collection to the HTTP handler.
 
         try:
-            yield {"collection": collection, "config": config}
+            yield {"collection": collection, "config": config, "indexer": indexer}
         finally:
             # Clear the singleton before closing so any in-flight HTTP handler
             # gets a clean RuntimeError instead of touching a Collection
             # mid-close().
             set_collection_singleton(None)
+            joined = indexer.stop(timeout=30.0)
+            if not joined:
+                logger.warning("background_indexer_join_timed_out")
             collection.close()
             logger.info("Collection shut down")
 
@@ -150,3 +146,19 @@ def get_collection(ctx: Context = CurrentContext()) -> Collection:
         msg = "Collection not initialised — server lifespan has not run"
         raise RuntimeError(msg)
     return collection
+
+
+def get_indexer(ctx: Context = CurrentContext()) -> BackgroundIndexer:
+    """Resolve the BackgroundIndexer from lifespan context.
+
+    Used as a ``Depends()`` default in tool signatures that need access
+    to background-index status.
+
+    Raises:
+        RuntimeError: If the server lifespan has not run.
+    """
+    indexer: BackgroundIndexer | None = ctx.lifespan_context.get("indexer")
+    if indexer is None:
+        msg = "BackgroundIndexer not initialised — lifespan did not run."
+        raise RuntimeError(msg)
+    return indexer

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -103,9 +103,16 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # build_index() scans the freshest working tree.
         await asyncio.to_thread(collection.sync_from_remote_before_index)
 
+        # Embedding phase requires BOTH a provider and a sidecar path; if
+        # either is missing, Collection.build_embeddings() raises ValueError.
+        # Gate has_provider on both to avoid `state="failed"` on every startup
+        # when a provider is configured but the path isn't (PR #515 hit this).
         indexer = BackgroundIndexer(
             collection,
-            has_provider=kwargs.get("embedding_provider") is not None,
+            has_provider=(
+                kwargs.get("embedding_provider") is not None
+                and kwargs.get("embeddings_path") is not None
+            ),
         )
         indexer.start()
         logger.info("background_indexer_started")
@@ -128,7 +135,16 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
             set_collection_singleton(None)
             joined = indexer.stop(timeout=30.0)
             if not joined:
-                logger.warning("background_indexer_join_timed_out")
+                # Daemon still mid-write. Closing the SQLite connection here
+                # would race with that write. We accept the race because the
+                # alternative (skipping close) leaks the handle and the next
+                # startup's SQLite WAL recovery handles any partial state. Any
+                # exception the daemon hits post-close is caught by _run's
+                # ``except Exception`` and logged.
+                logger.warning(
+                    "background_indexer_join_timed_out: proceeding with "
+                    "collection.close(); WAL will recover any partial write."
+                )
             collection.close()
             logger.info("Collection shut down")
 

--- a/src/markdown_vault_mcp/background_indexer.py
+++ b/src/markdown_vault_mcp/background_indexer.py
@@ -24,10 +24,22 @@ logger = logging.getLogger(__name__)
 
 
 class IndexStatus(TypedDict):
-    """Snapshot of background index progress."""
+    """Snapshot of background index progress.
+
+    Fields:
+        state: lifecycle state. ``"failed"`` implies ``error`` is set; the
+            other states leave ``error`` as ``None``.
+        error: failure message when ``state == "failed"``, else ``None``.
+        error_type: exception class name when ``state == "failed"``, else
+            ``None``. Lets callers distinguish e.g. a transient
+            ``sqlite3.OperationalError`` from a persistent ``ValueError``.
+        documents_indexed: count populated after ``build_index`` returns.
+        chunks_indexed: count populated after ``build_index`` returns.
+    """
 
     state: Literal["idle", "indexing", "embedding", "ready", "failed"]
     error: str | None
+    error_type: str | None
     documents_indexed: int
     chunks_indexed: int
 
@@ -35,9 +47,13 @@ class IndexStatus(TypedDict):
 class BackgroundIndexer:
     """Drives the post-handshake index build on a daemon thread.
 
+    Single-shot: once :meth:`stop` has been called the indexer cannot be
+    restarted. Construct a new instance to retry.
+
     Args:
         collection: The synchronous :class:`Collection` to drive.
-        has_provider: Whether an embedding provider is configured. When
+        has_provider: Whether the collection is configured for embeddings
+            (both an embedding provider *and* an embeddings path). When
             ``False``, the worker skips the embedding phase.
     """
 
@@ -50,6 +66,7 @@ class BackgroundIndexer:
         self._status: IndexStatus = {
             "state": "idle",
             "error": None,
+            "error_type": None,
             "documents_indexed": 0,
             "chunks_indexed": 0,
         }
@@ -59,6 +76,12 @@ class BackgroundIndexer:
         """Thread-safe snapshot of the current status."""
         with self._lock:
             return dict(self._status)  # type: ignore[return-value]
+
+    @property
+    def is_started(self) -> bool:
+        """``True`` once :meth:`start` has been called at least once."""
+        with self._lock:
+            return self._thread is not None
 
     def start(self) -> None:
         """Spawn the worker thread. Idempotent — a second call is a no-op."""
@@ -75,10 +98,18 @@ class BackgroundIndexer:
     def stop(self, timeout: float = 30.0) -> bool:
         """Signal the worker to stop and join with a bounded wait.
 
+        The stop signal is checked between the indexing and embedding
+        phases. A ``build_index()`` or ``build_embeddings()`` call already
+        in progress cannot be interrupted; the join may therefore time out
+        on a vault large enough that one phase exceeds *timeout*.
+
         Returns:
             ``True`` if the thread exited within the timeout (or was never
             started); ``False`` if the join timed out and the daemon was
-            abandoned.
+            abandoned. When ``False``, the caller should treat any
+            subsequent ``Collection`` shutdown as potentially racing with
+            in-flight SQLite writes; SQLite's WAL recovers any partial
+            write on next startup.
         """
         with self._lock:
             thread = self._thread
@@ -102,6 +133,7 @@ class BackgroundIndexer:
             Literal["idle", "indexing", "embedding", "ready", "failed"] | None
         ) = None,
         error: str | None = None,
+        error_type: str | None = None,
         documents_indexed: int | None = None,
         chunks_indexed: int | None = None,
     ) -> None:
@@ -110,6 +142,8 @@ class BackgroundIndexer:
                 self._status["state"] = state
             if error is not None:
                 self._status["error"] = error
+            if error_type is not None:
+                self._status["error_type"] = error_type
             if documents_indexed is not None:
                 self._status["documents_indexed"] = documents_indexed
             if chunks_indexed is not None:
@@ -137,4 +171,4 @@ class BackgroundIndexer:
             )
         except Exception as exc:
             logger.error("background_indexer_failed", exc_info=True)
-            self._set(state="failed", error=str(exc))
+            self._set(state="failed", error=str(exc), error_type=type(exc).__name__)

--- a/src/markdown_vault_mcp/background_indexer.py
+++ b/src/markdown_vault_mcp/background_indexer.py
@@ -1,0 +1,140 @@
+"""Background index orchestrator for issue #513.
+
+Owns the daemon thread that runs ``Collection.build_index()`` and, when an
+embedding provider is configured, ``Collection.build_embeddings()`` after
+the MCP server lifespan has yielded. ``Collection`` itself stays purely
+synchronous — indexing concurrency lives only here.
+
+Lifecycle: ``start()`` spawns the worker (idempotent), ``stop(timeout)``
+signals it and joins with a bounded wait, ``status`` returns a thread-safe
+snapshot.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING, Literal, TypedDict
+
+if TYPE_CHECKING:
+    from markdown_vault_mcp.collection import Collection
+
+
+logger = logging.getLogger(__name__)
+
+
+class IndexStatus(TypedDict):
+    """Snapshot of background index progress."""
+
+    state: Literal["idle", "indexing", "embedding", "ready", "failed"]
+    error: str | None
+    documents_indexed: int
+    chunks_indexed: int
+
+
+class BackgroundIndexer:
+    """Drives the post-handshake index build on a daemon thread.
+
+    Args:
+        collection: The synchronous :class:`Collection` to drive.
+        has_provider: Whether an embedding provider is configured. When
+            ``False``, the worker skips the embedding phase.
+    """
+
+    def __init__(self, collection: Collection, *, has_provider: bool) -> None:
+        self._collection = collection
+        self._has_provider = has_provider
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._status: IndexStatus = {
+            "state": "idle",
+            "error": None,
+            "documents_indexed": 0,
+            "chunks_indexed": 0,
+        }
+
+    @property
+    def status(self) -> IndexStatus:
+        """Thread-safe snapshot of the current status."""
+        with self._lock:
+            return dict(self._status)  # type: ignore[return-value]
+
+    def start(self) -> None:
+        """Spawn the worker thread. Idempotent — a second call is a no-op."""
+        with self._lock:
+            if self._thread is not None:
+                return
+            self._thread = threading.Thread(
+                target=self._run,
+                name="markdown-vault-background-indexer",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def stop(self, timeout: float = 30.0) -> bool:
+        """Signal the worker to stop and join with a bounded wait.
+
+        Returns:
+            ``True`` if the thread exited within the timeout (or was never
+            started); ``False`` if the join timed out and the daemon was
+            abandoned.
+        """
+        with self._lock:
+            thread = self._thread
+        if thread is None:
+            return True
+        self._stop_event.set()
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            logger.warning("background_indexer_stop_timed_out timeout=%.1f", timeout)
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Worker body
+    # ------------------------------------------------------------------
+
+    def _set(
+        self,
+        *,
+        state: (
+            Literal["idle", "indexing", "embedding", "ready", "failed"] | None
+        ) = None,
+        error: str | None = None,
+        documents_indexed: int | None = None,
+        chunks_indexed: int | None = None,
+    ) -> None:
+        with self._lock:
+            if state is not None:
+                self._status["state"] = state
+            if error is not None:
+                self._status["error"] = error
+            if documents_indexed is not None:
+                self._status["documents_indexed"] = documents_indexed
+            if chunks_indexed is not None:
+                self._status["chunks_indexed"] = chunks_indexed
+
+    def _run(self) -> None:
+        try:
+            self._set(state="indexing")
+            stats = self._collection.build_index()
+            self._set(
+                documents_indexed=stats.documents_indexed,
+                chunks_indexed=stats.chunks_indexed,
+            )
+            if self._stop_event.is_set():
+                logger.info("background_indexer_stopped_after_index")
+                return
+            if self._has_provider:
+                self._set(state="embedding")
+                self._collection.build_embeddings()
+            self._set(state="ready")
+            logger.info(
+                "background_indexer_ready documents=%d chunks=%d",
+                stats.documents_indexed,
+                stats.chunks_indexed,
+            )
+        except Exception as exc:
+            logger.error("background_indexer_failed", exc_info=True)
+            self._set(state="failed", error=str(exc))

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -348,11 +348,13 @@ class Collection:
         self._fts.close()
 
     def _ensure_initialized(self) -> None:
-        """No-op. Retained so the 23 in-class call sites stay stable; the
-        lazy build it used to drive moved out of ``Collection`` into
-        :class:`~markdown_vault_mcp.background_indexer.BackgroundIndexer`.
-
-        See issue #513.
+        """No-op shim. The lazy build it used to drive moved out of
+        ``Collection`` into
+        :class:`~markdown_vault_mcp.background_indexer.BackgroundIndexer`
+        (issue #513). The shim is retained instead of stripped from its
+        in-class call sites to avoid the call-site sweep that contributed
+        to PR #515's failure to converge; future PRs may inline-remove
+        the callers and then this method.
         """
         return
 
@@ -479,14 +481,6 @@ class Collection:
         runs (including the ``exclude_patterns`` purge), and ``_index_built``
         is set to ``True`` on success. ``force=True`` drops all existing
         data and rebuilds unconditionally.
-
-        Called by:
-
-        - :class:`~markdown_vault_mcp.background_indexer.BackgroundIndexer`,
-          which runs this method on a daemon thread after the MCP lifespan
-          yields (issue #513).
-        - The CLI ``markdown-vault-mcp index`` command.
-        - Tests, directly.
 
         Args:
             force: When ``True``, drop and rebuild the index unconditionally.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -86,8 +86,8 @@ def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
 class Collection:
     """Facade over FTS5 index, vector index, and change tracker.
 
-    Instantiate once per collection root.  Call :meth:`build_index` (or let
-    lazy initialisation handle it) before querying.
+    Instantiate once per collection root.  Call :meth:`build_index` before
+    querying.
 
     Args:
         source_dir: Root directory of the markdown collection.
@@ -195,8 +195,7 @@ class Collection:
         )
         self._tracker = ChangeTracker(self._state_path)
 
-        # Lazy initialisation flag.
-        self._initialized = False
+        self._index_built = False
 
         # Serialise concurrent write operations on this instance.
         # Re-entrant: periodic pull tick blocks writes, then reindex() acquires
@@ -348,14 +347,14 @@ class Collection:
         # 4. Close SQLite.
         self._fts.close()
 
-    # ------------------------------------------------------------------
-    # Lazy initialisation
-    # ------------------------------------------------------------------
-
     def _ensure_initialized(self) -> None:
-        """Build the FTS index on first access if it has not been built yet."""
-        if not self._initialized:
-            self.build_index()
+        """No-op. Retained so the 23 in-class call sites stay stable; the
+        lazy build it used to drive moved out of ``Collection`` into
+        :class:`~markdown_vault_mcp.background_indexer.BackgroundIndexer`.
+
+        See issue #513.
+        """
+        return
 
     @property
     def _vectors(self) -> VectorIndex | None:
@@ -475,18 +474,28 @@ class Collection:
     def build_index(self, *, force: bool = False) -> IndexStats:
         """Scan source_dir and build the FTS index.
 
-        If the index already contains documents and *force* is ``False``,
-        this is a no-op.  ``force=True`` drops all existing data and rebuilds
-        from scratch.
+        Returns early when ``force=False`` and ``_index_built`` is ``True``
+        and the FTS database already has rows. Otherwise the underlying scan
+        runs (including the ``exclude_patterns`` purge), and ``_index_built``
+        is set to ``True`` on success. ``force=True`` drops all existing
+        data and rebuilds unconditionally.
+
+        Called by:
+
+        - :class:`~markdown_vault_mcp.background_indexer.BackgroundIndexer`,
+          which runs this method on a daemon thread after the MCP lifespan
+          yields (issue #513).
+        - The CLI ``markdown-vault-mcp index`` command.
+        - Tests, directly.
 
         Args:
             force: When ``True``, drop and rebuild the index unconditionally.
 
         Returns:
-            :class:`~markdown_vault_mcp.types.IndexStats` describing what was indexed.
+            :class:`~markdown_vault_mcp.types.IndexStats` describing what
+            was indexed.
         """
-        # Check if index already has data and we are not forcing.
-        if not force and self._initialized:
+        if not force and self._index_built:
             existing = self._fts.list_notes()
             if existing:
                 logger.debug(
@@ -500,7 +509,7 @@ class Collection:
                 )
 
         result = self._index_mgr.build_index(force=force)
-        self._initialized = True
+        self._index_built = True
         return result
 
     def reindex(self) -> ReindexResult:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -14,6 +16,63 @@ from markdown_vault_mcp.providers import EmbeddingProvider
 # test module without requiring a per-file import (which would trip ruff's
 # F811 redefinition check on the parameter shadowing).
 from tests.fixtures.git import git_repo_pair  # noqa: F401
+
+
+async def wait_for_indexer_ready(client: Any, *, timeout: float = 10.0) -> None:
+    """Poll ``stats`` until the background indexer has indexed at least one document.
+
+    The background indexer (issue #513) runs ``build_index()`` on a daemon
+    thread after the lifespan yields.  MCP tests that call tools expecting
+    indexed data must wait for indexing to complete before asserting results.
+    Polling ``stats`` is sufficient: the tool reads from the same FTS database
+    as all other tools, so a non-zero ``document_count`` means the index is
+    ready for any subsequent tool call within the same lifespan.
+
+    Args:
+        client: An active :class:`fastmcp.Client` connected to the server.
+        timeout: Maximum seconds to wait before raising ``TimeoutError``.
+
+    Raises:
+        TimeoutError: If the indexer does not complete within *timeout* seconds.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        result = await client.call_tool("stats", {})
+        data = result.data
+        if isinstance(data, dict) and data.get("document_count", 0) > 0:
+            return
+        await asyncio.sleep(0.05)
+    msg = f"background indexer did not complete within {timeout}s"
+    raise TimeoutError(msg)
+
+
+async def wait_for_embeddings_ready(client: Any, *, timeout: float = 15.0) -> None:
+    """Poll ``embeddings_status`` until the background indexer has embedded at least
+    one chunk.
+
+    Use this in tests that require the embedding phase to complete (e.g.
+    semantic search or ``include_semantic=True`` graph queries). It implies
+    ``wait_for_indexer_ready`` because the embedding phase runs after the
+    indexing phase.
+
+    Args:
+        client: An active :class:`fastmcp.Client` connected to the server.
+        timeout: Maximum seconds to wait before raising ``TimeoutError``.
+
+    Raises:
+        TimeoutError: If the embedding phase does not complete within *timeout* seconds.
+    """
+    import json
+
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        result = await client.call_tool_mcp("embeddings_status", {})
+        data = json.loads(result.content[0].text)
+        if data.get("chunk_count", 0) > 0:
+            return
+        await asyncio.sleep(0.05)
+    msg = f"background embedding phase did not complete within {timeout}s"
+    raise TimeoutError(msg)
 
 
 class MockEmbeddingProvider(EmbeddingProvider):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,11 @@ async def wait_for_indexer_ready(client: Any, *, timeout: float = 10.0) -> None:
         if isinstance(data, dict) and data.get("document_count", 0) > 0:
             return
         await asyncio.sleep(0.05)
-    msg = f"background indexer did not complete within {timeout}s"
+    msg = (
+        f"background indexer did not complete within {timeout}s "
+        f"(may indicate the indexer transitioned to state='failed' — "
+        f"check server logs for 'background_indexer_failed')"
+    )
     raise TimeoutError(msg)
 
 

--- a/tests/test_background_indexer.py
+++ b/tests/test_background_indexer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import TYPE_CHECKING
 
@@ -11,11 +12,12 @@ from markdown_vault_mcp.background_indexer import BackgroundIndexer
 from markdown_vault_mcp.collection import Collection
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 
 @pytest.fixture
-def small_collection(tmp_path: Path) -> Collection:
+def small_collection(tmp_path: Path) -> Iterator[Collection]:
     (tmp_path / "note.md").write_text("# Hello\n\nWorld.\n", encoding="utf-8")
     col = Collection(
         source_dir=tmp_path,
@@ -26,13 +28,28 @@ def small_collection(tmp_path: Path) -> Collection:
 
 
 def _wait_for_state(
-    indexer: BackgroundIndexer, state: str, *, timeout: float = 5.0
+    indexer: BackgroundIndexer,
+    state: str,
+    *,
+    timeout: float = 5.0,
 ) -> dict:
+    """Poll until *state* is reached, or short-circuit on a different terminal.
+
+    If the indexer reaches ``failed`` while we're waiting for any other state,
+    the test fails with the error rather than running out the clock on a
+    misleading timeout.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         snap = indexer.status
         if snap["state"] == state:
             return snap
+        if snap["state"] == "failed" and state != "failed":
+            pytest.fail(
+                f"indexer transitioned to failed while waiting for "
+                f"state={state!r}: error_type={snap['error_type']!r} "
+                f"error={snap['error']!r}"
+            )
         time.sleep(0.02)
     pytest.fail(f"never reached state={state!r}, last={indexer.status!r}")
 
@@ -42,8 +59,10 @@ def test_status_before_start(small_collection: Collection) -> None:
     s = indexer.status
     assert s["state"] == "idle"
     assert s["error"] is None
+    assert s["error_type"] is None
     assert s["documents_indexed"] == 0
     assert s["chunks_indexed"] == 0
+    assert indexer.is_started is False
 
 
 def test_run_to_ready_without_provider(small_collection: Collection) -> None:
@@ -51,6 +70,7 @@ def test_run_to_ready_without_provider(small_collection: Collection) -> None:
     indexer.start()
     final = _wait_for_state(indexer, "ready")
     assert final["error"] is None
+    assert final["error_type"] is None
     assert final["documents_indexed"] >= 1
     assert indexer.stop(timeout=5.0) is True
 
@@ -66,15 +86,29 @@ def test_failure_sets_failed_state(
     indexer.start()
     final = _wait_for_state(indexer, "failed")
     assert "synthetic build failure" in (final["error"] or "")
+    assert final["error_type"] == "RuntimeError"
     assert indexer.stop(timeout=5.0) is True
 
 
 def test_double_start_is_idempotent(small_collection: Collection) -> None:
     indexer = BackgroundIndexer(small_collection, has_provider=False)
+    assert indexer.is_started is False
     indexer.start()
-    first = indexer._thread
+    assert indexer.is_started is True
+    # Second start must not spawn a second worker thread executing _run.
+    matching = [
+        t
+        for t in threading.enumerate()
+        if t.name == "markdown-vault-background-indexer"
+    ]
+    assert len(matching) == 1
     indexer.start()
-    assert indexer._thread is first
+    matching_after = [
+        t
+        for t in threading.enumerate()
+        if t.name == "markdown-vault-background-indexer"
+    ]
+    assert len(matching_after) == 1
     _wait_for_state(indexer, "ready")
     assert indexer.stop(timeout=5.0) is True
 
@@ -90,3 +124,38 @@ def test_stop_after_ready_is_noop(small_collection: Collection) -> None:
     _wait_for_state(indexer, "ready")
     assert indexer.stop(timeout=5.0) is True
     assert indexer.stop(timeout=1.0) is True
+
+
+def test_stop_signal_observed_between_phases(
+    small_collection: Collection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stop_event is checked after build_index completes and before
+    build_embeddings begins. Setting stop during a slow build_index keeps the
+    worker out of the embedding phase.
+    """
+    original_build_index = small_collection.build_index
+    slow_started = threading.Event()
+
+    def slow_build_index(*args: object, **kwargs: object) -> object:
+        slow_started.set()
+        time.sleep(0.3)
+        return original_build_index(*args, **kwargs)
+
+    def must_not_run(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError(
+            "build_embeddings called despite stop_event set after build_index"
+        )
+
+    monkeypatch.setattr(small_collection, "build_index", slow_build_index)
+    monkeypatch.setattr(small_collection, "build_embeddings", must_not_run)
+
+    indexer = BackgroundIndexer(small_collection, has_provider=True)
+    indexer.start()
+    assert slow_started.wait(timeout=2.0), "slow build_index never started"
+    # Set the stop signal while build_index is mid-sleep. When build_index
+    # returns, _run sees stop_event set and returns before build_embeddings.
+    assert indexer.stop(timeout=5.0) is True
+    # State remains "indexing" — _set(state="embedding") never ran.
+    final = indexer.status
+    assert final["state"] == "indexing"
+    assert final["error"] is None

--- a/tests/test_background_indexer.py
+++ b/tests/test_background_indexer.py
@@ -1,0 +1,92 @@
+"""Tests for the BackgroundIndexer orchestrator (issue #513)."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.background_indexer import BackgroundIndexer
+from markdown_vault_mcp.collection import Collection
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def small_collection(tmp_path: Path) -> Collection:
+    (tmp_path / "note.md").write_text("# Hello\n\nWorld.\n", encoding="utf-8")
+    col = Collection(
+        source_dir=tmp_path,
+        state_path=tmp_path / ".state" / "state.json",
+    )
+    yield col
+    col.close()
+
+
+def _wait_for_state(
+    indexer: BackgroundIndexer, state: str, *, timeout: float = 5.0
+) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snap = indexer.status
+        if snap["state"] == state:
+            return snap
+        time.sleep(0.02)
+    pytest.fail(f"never reached state={state!r}, last={indexer.status!r}")
+
+
+def test_status_before_start(small_collection: Collection) -> None:
+    indexer = BackgroundIndexer(small_collection, has_provider=False)
+    s = indexer.status
+    assert s["state"] == "idle"
+    assert s["error"] is None
+    assert s["documents_indexed"] == 0
+    assert s["chunks_indexed"] == 0
+
+
+def test_run_to_ready_without_provider(small_collection: Collection) -> None:
+    indexer = BackgroundIndexer(small_collection, has_provider=False)
+    indexer.start()
+    final = _wait_for_state(indexer, "ready")
+    assert final["error"] is None
+    assert final["documents_indexed"] >= 1
+    assert indexer.stop(timeout=5.0) is True
+
+
+def test_failure_sets_failed_state(
+    small_collection: Collection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("synthetic build failure")
+
+    monkeypatch.setattr(small_collection, "build_index", boom)
+    indexer = BackgroundIndexer(small_collection, has_provider=False)
+    indexer.start()
+    final = _wait_for_state(indexer, "failed")
+    assert "synthetic build failure" in (final["error"] or "")
+    assert indexer.stop(timeout=5.0) is True
+
+
+def test_double_start_is_idempotent(small_collection: Collection) -> None:
+    indexer = BackgroundIndexer(small_collection, has_provider=False)
+    indexer.start()
+    first = indexer._thread
+    indexer.start()
+    assert indexer._thread is first
+    _wait_for_state(indexer, "ready")
+    assert indexer.stop(timeout=5.0) is True
+
+
+def test_stop_without_start_is_noop(small_collection: Collection) -> None:
+    indexer = BackgroundIndexer(small_collection, has_provider=False)
+    assert indexer.stop(timeout=1.0) is True
+
+
+def test_stop_after_ready_is_noop(small_collection: Collection) -> None:
+    indexer = BackgroundIndexer(small_collection, has_provider=False)
+    indexer.start()
+    _wait_for_state(indexer, "ready")
+    assert indexer.stop(timeout=5.0) is True
+    assert indexer.stop(timeout=1.0) is True

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -264,10 +264,6 @@ class TestBuildIndex:
             index_path=index_path,
             exclude_patterns=[".claude/**"],
         )
-        # Bypass the _ensure_initialized() guard: col2 shares the same
-        # persistent DB as col1, so the index already exists — we want to
-        # test reindex() directly, not build_index().
-        col2._initialized = True
         col2.reindex()
 
         # The stale excluded doc should be purged.
@@ -312,7 +308,6 @@ class TestBuildIndex:
             embedding_provider=mock_provider,
             exclude_patterns=[".claude/**"],
         )
-        col2._initialized = True
         col2.reindex()
 
         paths2 = [row["path"] for row in col2._fts.list_notes()]

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -395,29 +395,26 @@ class TestBuildIndex:
 
 
 # ---------------------------------------------------------------------------
-# Lazy initialisation
+# _ensure_initialized is a no-op (issue #513)
 # ---------------------------------------------------------------------------
 
 
-class TestLazyInitialisation:
-    def test_search_without_build_index(self, vault_path: Path) -> None:
-        """search() triggers lazy initialisation without an explicit build_index()."""
+class TestEnsureInitializedNoOp:
+    def test_search_without_build_index_returns_empty(self, vault_path: Path) -> None:
+        """search() on an unbuilt Collection returns empty results without crashing."""
         col = _make_collection(vault_path)
 
-        # Do NOT call build_index() — search() should initialise automatically.
         results = col.search("simple")
 
-        # Either finds something or returns [] — the key is it does not crash.
-        assert isinstance(results, list)
+        assert results == []
 
-    def test_list_without_build_index(self, vault_path: Path) -> None:
-        """list() triggers lazy initialisation without an explicit build_index()."""
+    def test_list_without_build_index_returns_empty(self, vault_path: Path) -> None:
+        """list() on an unbuilt Collection returns empty results without crashing."""
         col = _make_collection(vault_path)
 
         notes = col.list()
 
-        assert isinstance(notes, list)
-        assert len(notes) == 9
+        assert notes == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -339,9 +339,11 @@ class TestMCPGraphTools:
         from fastmcp import Client
 
         from markdown_vault_mcp.server import make_server
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_orphan_notes", {})
         items = _parse_tool_data(result)
         assert isinstance(items, list)
@@ -354,9 +356,11 @@ class TestMCPGraphTools:
         from fastmcp import Client
 
         from markdown_vault_mcp.server import make_server
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_most_linked", {"limit": 5})
         items = _parse_tool_data(result)
         assert isinstance(items, list)
@@ -369,9 +373,11 @@ class TestMCPGraphTools:
         from fastmcp import Client
 
         from markdown_vault_mcp.server import make_server
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_most_linked", {"limit": 1})
         items = _parse_tool_data(result)
         assert len(items) == 1
@@ -659,9 +665,11 @@ class TestMCPGetConnectionPath:
         from fastmcp import Client
 
         from markdown_vault_mcp.server import make_server
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "get_connection_path", {"source": "a.md", "target": "c.md"}
             )
@@ -675,9 +683,11 @@ class TestMCPGetConnectionPath:
         from fastmcp import Client
 
         from markdown_vault_mcp.server import make_server
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "get_connection_path",
                 {"source": "a.md", "target": "isolated.md"},
@@ -692,9 +702,11 @@ class TestMCPGetConnectionPath:
         from fastmcp import Client
 
         from markdown_vault_mcp.server import make_server
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "get_connection_path", {"source": "a.md", "target": "a.md"}
             )

--- a/tests/test_lifespan_non_blocking.py
+++ b/tests/test_lifespan_non_blocking.py
@@ -1,0 +1,59 @@
+"""Integration test: MCP `initialize` handshake must not block on indexing
+(issue #513)."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+from fastmcp import Client
+
+from markdown_vault_mcp.server import make_server
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_block_on_index_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Handshake completes promptly even on a vault where synchronous
+    indexing would take measurable time."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for i in range(50):
+        (vault / f"note-{i:03d}.md").write_text(
+            f"# Note {i}\n\nBody {i} with some content to index.\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv(
+        "MARKDOWN_VAULT_MCP_STATE_PATH",
+        str(tmp_path / ".state" / "state.json"),
+    )
+    # Strip vars that could pull in unrelated configuration from the host.
+    for var in (
+        "MARKDOWN_VAULT_MCP_READ_ONLY",
+        "MARKDOWN_VAULT_MCP_INDEX_PATH",
+        "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
+        "MARKDOWN_VAULT_MCP_GIT_TOKEN",
+        "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
+        "MARKDOWN_VAULT_MCP_AUTH_MODE",
+        "MARKDOWN_VAULT_MCP_BASE_URL",
+        "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    server = make_server()
+
+    start = time.monotonic()
+    async with Client(server) as client:
+        elapsed = time.monotonic() - start
+        # Handshake should complete in well under a second; a 3s budget
+        # tolerates CI noise without hiding regressions.
+        assert elapsed < 3.0, f"handshake took {elapsed:.2f}s"
+        tools = await client.list_tools()
+        assert any(t.name == "search" for t in tools)

--- a/tests/test_lifespan_non_blocking.py
+++ b/tests/test_lifespan_non_blocking.py
@@ -1,5 +1,5 @@
-"""Integration test: MCP `initialize` handshake must not block on indexing
-(issue #513)."""
+"""Integration tests: MCP lifespan must not block on indexing, and must shut
+down cleanly even if indexing is still in progress (issue #513)."""
 
 from __future__ import annotations
 
@@ -9,32 +9,19 @@ from typing import TYPE_CHECKING
 import pytest
 from fastmcp import Client
 
+from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.server import make_server
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.asyncio
-async def test_initialize_does_not_block_on_index_build(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def _isolate_vault_env(
+    monkeypatch: pytest.MonkeyPatch, vault: Path, state_dir: Path
 ) -> None:
-    """Handshake completes promptly even on a vault where synchronous
-    indexing would take measurable time."""
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    for i in range(50):
-        (vault / f"note-{i:03d}.md").write_text(
-            f"# Note {i}\n\nBody {i} with some content to index.\n",
-            encoding="utf-8",
-        )
-
+    """Point the server config at *vault* and strip unrelated host env vars."""
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
-    monkeypatch.setenv(
-        "MARKDOWN_VAULT_MCP_STATE_PATH",
-        str(tmp_path / ".state" / "state.json"),
-    )
-    # Strip vars that could pull in unrelated configuration from the host.
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(state_dir / "state.json"))
     for var in (
         "MARKDOWN_VAULT_MCP_READ_ONLY",
         "MARKDOWN_VAULT_MCP_INDEX_PATH",
@@ -47,13 +34,78 @@ async def test_initialize_does_not_block_on_index_build(
     ):
         monkeypatch.delenv(var, raising=False)
 
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_block_on_index_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A synthetic delay injected into ``Collection.build_index`` would
+    block the handshake under a synchronous lifespan but does not block it
+    under ``BackgroundIndexer``. The test fails (with a > 3s elapsed time)
+    if the lifespan ever reverts to ``await asyncio.to_thread(build_index)``.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "note.md").write_text("# Note\n\nBody.\n", encoding="utf-8")
+
+    original_build_index = Collection.build_index
+
+    def slow_build_index(self: Collection, *, force: bool = False) -> object:
+        # 4-second synthetic delay: comfortably exceeds the 3s handshake
+        # budget so a synchronous regression is unambiguous on any hardware.
+        time.sleep(4.0)
+        return original_build_index(self, force=force)
+
+    monkeypatch.setattr(Collection, "build_index", slow_build_index)
+
+    _isolate_vault_env(monkeypatch, vault, tmp_path / ".state")
     server = make_server()
 
     start = time.monotonic()
     async with Client(server) as client:
         elapsed = time.monotonic() - start
-        # Handshake should complete in well under a second; a 3s budget
-        # tolerates CI noise without hiding regressions.
-        assert elapsed < 3.0, f"handshake took {elapsed:.2f}s"
+        assert elapsed < 3.0, (
+            f"handshake took {elapsed:.2f}s — lifespan may have reverted to "
+            f"awaiting build_index synchronously"
+        )
+        # Tools are reachable immediately. The index itself may not be
+        # populated yet because the slow build is still running in the
+        # background — that's the point of the non-blocking design.
         tools = await client.list_tools()
         assert any(t.name == "search" for t in tools)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_during_indexing_does_not_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The lifespan teardown is called while ``build_index`` is still
+    running on the daemon thread. The teardown must complete without
+    raising and the warning ``background_indexer_join_timed_out`` does not
+    need to fire (because the join honours the timeout) but the test
+    primarily asserts that we *don't* crash on this path — the exact
+    failure mode PRs #515 and #516 were abandoned over.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "note.md").write_text("# Note\n\nBody.\n", encoding="utf-8")
+
+    original_build_index = Collection.build_index
+
+    def long_build_index(self: Collection, *, force: bool = False) -> object:
+        # Indexing takes a few seconds — long enough that the daemon is
+        # still active when the test's ``async with`` block exits.
+        time.sleep(2.0)
+        return original_build_index(self, force=force)
+
+    monkeypatch.setattr(Collection, "build_index", long_build_index)
+
+    _isolate_vault_env(monkeypatch, vault, tmp_path / ".state")
+    server = make_server()
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        assert any(t.name == "search" for t in tools)
+        # Exit the context immediately, while the daemon is still
+        # mid-build_index. The lifespan finally-block runs here.
+    # If we reach this line without an exception, the shutdown was clean.

--- a/tests/test_mcp_apps_browser.py
+++ b/tests/test_mcp_apps_browser.py
@@ -112,8 +112,11 @@ class TestBrowserDataTools:
     """Verify browser data tools return expected structures."""
 
     async def test_vault_list_root(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(_hashed("vault_list"), {})
             data = _parse_tool_data(result)
             assert "folders" in data
@@ -158,8 +161,11 @@ class TestBrowserDataTools:
             assert len(data["frontmatter"]) > 0
 
     async def test_vault_search_keyword(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 _hashed("vault_search"), {"query": "simple", "mode": "keyword"}
             )

--- a/tests/test_mcp_apps_context.py
+++ b/tests/test_mcp_apps_context.py
@@ -109,8 +109,11 @@ class TestVaultContextToolData:
     """Verify _vault_context returns complete NoteContext fields."""
 
     async def test_all_context_fields_present(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "simple.md"}
             )
@@ -127,8 +130,11 @@ class TestVaultContextToolData:
             assert "tags" in data
 
     async def test_context_with_frontmatter(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "full_frontmatter.md"}
             )
@@ -147,8 +153,11 @@ class TestShowContextTool:
     """Verify show_context primary tool behaviour (AC2)."""
 
     async def test_returns_view_and_summary(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("show_context", {"path": "simple.md"})
             data = _parse_tool_data(result)
             assert data["view"] == "context"
@@ -156,8 +165,11 @@ class TestShowContextTool:
             assert "Backlinks:" in data["summary"]
 
     async def test_summary_contains_relationship_counts(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("show_context", {"path": "simple.md"})
             data = _parse_tool_data(result)
             summary = data["summary"]

--- a/tests/test_mcp_apps_foundation.py
+++ b/tests/test_mcp_apps_foundation.py
@@ -329,8 +329,11 @@ class TestShowContextTool:
             assert "show_context" in names
 
     async def test_returns_context_summary(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("show_context", {"path": "simple.md"})
             data = _parse_tool_data(result)
             assert data["path"] == "simple.md"
@@ -349,8 +352,11 @@ class TestAppOnlyTools:
     """Tests for app-only tools (visibility=["app"])."""
 
     async def test_vault_context_returns_note_context(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "simple.md"}
             )
@@ -437,8 +443,11 @@ class TestAppOnlyTools:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         for var in _CLEAR_VARS:
             monkeypatch.delenv(var, raising=False)
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(_hashed("vault_list"), {})
             data = _parse_tool_data(result)
             # 'ai' must appear even though list_folders() only returns 'ai/llm'
@@ -561,8 +570,11 @@ class TestAppToolData:
             assert "Vault:" in data["summary"]
 
     async def test_show_context_tool(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("show_context", {"path": "simple.md"})
             data = _parse_tool_data(result)
             assert data["path"] == "simple.md"
@@ -653,8 +665,11 @@ class TestAppToolLinkedData:
     """Cover graph traversal paths that require inter-note links."""
 
     async def test_vault_graph_neighborhood_with_links(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"), {"path": "linked_a.md", "depth": 2}
             )
@@ -686,8 +701,11 @@ class TestAppToolLinkedData:
                 assert len(data["edges"]) > 0
 
     async def test_vault_context_with_links(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 _hashed("vault_context"), {"path": "linked_a.md"}
             )
@@ -700,6 +718,8 @@ class TestAppToolLinkedData:
     async def test_show_context_with_tags(
         self, vault_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEXED_FIELDS", "tags")
         for var in _CLEAR_VARS:
@@ -707,6 +727,7 @@ class TestAppToolLinkedData:
                 monkeypatch.delenv(var, raising=False)
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("show_context", {"path": "linked_b.md"})
             data = _parse_tool_data(result)
             assert "Tags:" in data["summary"]

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -178,9 +178,12 @@ class TestGraphDataTools:
             read_paths.append(path)
             return original_read(self, path)
 
+        from tests.conftest import wait_for_indexer_ready
+
         monkeypatch.setattr(Collection, "read", _spy)
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(_hashed("vault_graph_hubs"), {})
             data = _parse_tool_data(result)
         hub_paths = {n["id"] for n in data["nodes"] if n["group"] == "hub"}
@@ -308,6 +311,8 @@ class TestIncludeSemanticEdges:
         embeddings_path = str(tmp_path / "embeddings")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH", embeddings_path)
 
+        from tests.conftest import wait_for_embeddings_ready
+
         mock_prov = MockEmbeddingProvider()
         with patch(
             "markdown_vault_mcp.providers.get_embedding_provider",
@@ -315,6 +320,7 @@ class TestIncludeSemanticEdges:
         ):
             server = make_server()
             async with Client(server) as client:
+                await wait_for_embeddings_ready(client)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "include_semantic": True},
@@ -373,6 +379,8 @@ class TestIncludeSemanticEdges:
         embeddings_path = str(tmp_path / "embeddings")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH", embeddings_path)
 
+        from tests.conftest import wait_for_embeddings_ready
+
         mock_prov = MockEmbeddingProvider()
         with patch(
             "markdown_vault_mcp.providers.get_embedding_provider",
@@ -380,6 +388,7 @@ class TestIncludeSemanticEdges:
         ):
             server = make_server()
             async with Client(server) as client:
+                await wait_for_embeddings_ready(client)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {"path": "simple.md", "depth": 0, "include_semantic": True},
@@ -486,8 +495,11 @@ class TestGraphNeighborhoodMaxNodes:
     """Verify max_nodes caps BFS output and sets the truncated flag."""
 
     async def test_max_nodes_caps_node_count(self, _star_vault: Path) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 _hashed("vault_graph_neighborhood"),
                 {"path": "hub.md", "depth": 2, "max_nodes": 5},
@@ -529,6 +541,8 @@ class TestGraphNeighborhoodMaxNodes:
             if var != "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH":
                 monkeypatch.delenv(var, raising=False)
 
+        from tests.conftest import wait_for_embeddings_ready
+
         mock_prov = MockEmbeddingProvider()
         with patch(
             "markdown_vault_mcp.providers.get_embedding_provider",
@@ -536,6 +550,7 @@ class TestGraphNeighborhoodMaxNodes:
         ):
             server = make_server()
             async with Client(server) as client:
+                await wait_for_embeddings_ready(client)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {
@@ -583,6 +598,8 @@ class TestGraphNeighborhoodMaxNodes:
             if var != "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH":
                 monkeypatch.delenv(var, raising=False)
 
+        from tests.conftest import wait_for_embeddings_ready
+
         mock_prov = MockEmbeddingProvider()
         with patch(
             "markdown_vault_mcp.providers.get_embedding_provider",
@@ -590,6 +607,7 @@ class TestGraphNeighborhoodMaxNodes:
         ):
             server = make_server()
             async with Client(server) as client:
+                await wait_for_embeddings_ready(client)
                 result = await client.call_tool(
                     _hashed("vault_graph_neighborhood"),
                     {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -263,8 +263,11 @@ class TestSearchTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_keyword_search(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "search", {"query": "simple document", "limit": 5}
             )
@@ -276,8 +279,11 @@ class TestSearchTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_search_with_folder_filter(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "search",
                 {"query": "subfolder nested", "folder": "subfolder"},
@@ -339,8 +345,11 @@ class TestListDocumentsTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_list_all(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("list_documents", {})
         data = _parse_tool_data(result)
         assert isinstance(data, list)
@@ -350,8 +359,11 @@ class TestListDocumentsTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_list_by_folder(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("list_documents", {"folder": "subfolder"})
         data = _parse_tool_data(result)
         assert isinstance(data, list)
@@ -363,12 +375,15 @@ class TestListDocumentsTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_list_templates_folder(self, vault_path: Path) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         template_path = vault_path / "_templates" / "daily.md"
         template_path.parent.mkdir(parents=True, exist_ok=True)
         template_path.write_text("# Daily Template\n\n## Highlights\n\n- \n")
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("list_documents", {"folder": "_templates"})
         data = _parse_tool_data(result)
         paths = {doc["path"] for doc in data}
@@ -380,8 +395,11 @@ class TestListFoldersTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_list_folders(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("list_folders", {})
         folders = result.data
         assert isinstance(folders, list)
@@ -393,8 +411,11 @@ class TestListTagsTool:
 
     @pytest.mark.usefixtures("_mcp_env_with_fields")
     async def test_list_tags(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("list_tags", {"field": "cluster"})
         tags = result.data
         assert isinstance(tags, list)
@@ -406,8 +427,11 @@ class TestStatsTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_stats(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("stats", {})
         data = result.data
         assert isinstance(data, dict)
@@ -434,8 +458,11 @@ class TestReindexTool:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_reindex_no_changes(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("reindex", {})
         data = result.data
         assert isinstance(data, dict)
@@ -473,8 +500,11 @@ class TestWriteTool:
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_write_creates_document(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "write", {"path": "new_note.md", "content": "# New\n\nBody.\n"}
             )
@@ -485,8 +515,11 @@ class TestWriteTool:
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_write_overwrites_existing(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "write", {"path": "simple.md", "content": "# Replaced\n"}
             )
@@ -496,8 +529,11 @@ class TestWriteTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_write_with_frontmatter(self) -> None:
         """write tool with frontmatter parameter creates document and returns created=True."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "write",
                 {
@@ -517,8 +553,11 @@ class TestEditTool:
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_edit_patches_document(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "edit",
                 {
@@ -543,8 +582,11 @@ class TestEditTool:
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_edit_conflict_returns_error(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool_mcp(
                 "edit",
                 {"path": "simple.md", "old_text": "missing text", "new_text": "b"},
@@ -554,8 +596,11 @@ class TestEditTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_edit_line_range(self) -> None:
         """MCP edit tool accepts line_start/line_end."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             await client.call_tool(
                 "write",
                 {"path": "lines.md", "content": "line1\nline2\nline3\n"},
@@ -576,8 +621,11 @@ class TestEditTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_edit_normalized_match(self) -> None:
         """MCP edit response includes match_type."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             await client.call_tool(
                 "write",
                 {"path": "norm.md", "content": "hello \u2014 world\n"},
@@ -596,8 +644,11 @@ class TestEditTool:
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_edit_diagnostic_error(self) -> None:
         """MCP edit error includes diagnostic info."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             await client.call_tool(
                 "write",
                 {"path": "diag.md", "content": "the quick brown fox\n"},
@@ -620,8 +671,11 @@ class TestDeleteTool:
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_delete_removes_document(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("delete", {"path": "simple.md"})
         data = result.data
         assert data["path"] == "simple.md"
@@ -639,8 +693,11 @@ class TestRenameTool:
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_rename_moves_document(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "rename", {"old_path": "simple.md", "new_path": "renamed.md"}
             )
@@ -701,8 +758,11 @@ class TestMCPExcludePatterns:
             if var != "MARKDOWN_VAULT_MCP_EXCLUDE":
                 monkeypatch.delenv(var, raising=False)
 
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("list_documents", {})
 
         data = _parse_tool_data(result)
@@ -1459,8 +1519,11 @@ class TestMCPListDocumentsAttachments:
     async def test_list_documents_include_attachments_returns_both(
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "list_documents", {"include_attachments": True}
             )
@@ -1533,8 +1596,11 @@ class TestLinkTools:
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_backlinks(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_backlinks", {"path": "notes/topic.md"})
         data = _parse_tool_data(result)
         assert len(data) == 1
@@ -1550,8 +1616,11 @@ class TestLinkTools:
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_outlinks(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_outlinks", {"path": "index.md"})
         data = _parse_tool_data(result)
         assert len(data) == 2
@@ -1572,8 +1641,11 @@ class TestLinkTools:
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_broken_links(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_broken_links", {})
         data = _parse_tool_data(result)
         assert len(data) == 1
@@ -1607,8 +1679,11 @@ class TestSimilarTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_get_similar_no_embeddings_returns_empty(self) -> None:
         """get_similar returns empty list when embeddings not configured."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_similar", {"path": "simple.md"})
         data = _parse_tool_data(result)
         assert data == []
@@ -1623,8 +1698,11 @@ class TestSimilarTool:
     @pytest.mark.usefixtures("_mcp_env")
     async def test_get_similar_tool_accepts_chunks_per_file(self) -> None:
         """The `get_similar` MCP tool surfaces the chunks_per_file kwarg."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             # Without embeddings this returns []; the assertion is that the
             # call_tool schema accepts the chunks_per_file kwarg without raising.
             result = await client.call_tool(
@@ -1710,8 +1788,11 @@ class TestContextTool:
     @pytest.mark.usefixtures("_mcp_env_context")
     async def test_get_context_basic_fields(self) -> None:
         """get_context returns expected top-level fields."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
         data = _parse_tool_data(result)
         assert data["path"] == "index.md"
@@ -1727,8 +1808,11 @@ class TestContextTool:
     @pytest.mark.usefixtures("_mcp_env_context")
     async def test_get_context_modified_at_matches_read(self) -> None:
         """modified_at in context matches the value from read()."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             ctx = _parse_tool_data(
                 await client.call_tool("get_context", {"path": "index.md"})
             )
@@ -1738,8 +1822,11 @@ class TestContextTool:
     @pytest.mark.usefixtures("_mcp_env_context")
     async def test_get_context_backlinks(self) -> None:
         """notes/topic.md has a backlink from index.md."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_context", {"path": "notes/topic.md"})
         data = _parse_tool_data(result)
         sources = [b["source_path"] for b in data["backlinks"]]
@@ -1748,8 +1835,11 @@ class TestContextTool:
     @pytest.mark.usefixtures("_mcp_env_context")
     async def test_get_context_outlinks(self) -> None:
         """index.md has an outlink to notes/topic.md."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
         data = _parse_tool_data(result)
         targets = [o["target_path"] for o in data["outlinks"]]
@@ -1758,8 +1848,11 @@ class TestContextTool:
     @pytest.mark.usefixtures("_mcp_env_context")
     async def test_get_context_folder_notes_excludes_self(self) -> None:
         """folder_notes for notes/topic.md contains peer.md but not topic.md."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_context", {"path": "notes/topic.md"})
         data = _parse_tool_data(result)
         assert "notes/topic.md" not in data["folder_notes"]
@@ -1768,8 +1861,11 @@ class TestContextTool:
     @pytest.mark.usefixtures("_mcp_env_context")
     async def test_get_context_tags(self) -> None:
         """Indexed frontmatter tags appear in context.tags."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
         data = _parse_tool_data(result)
         assert "tags" in data["tags"]
@@ -1779,8 +1875,11 @@ class TestContextTool:
     @pytest.mark.usefixtures("_mcp_env_context")
     async def test_get_context_similar_empty_without_embeddings(self) -> None:
         """similar is empty when embeddings are not configured."""
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
         data = _parse_tool_data(result)
         assert data["similar"] == []
@@ -1850,8 +1949,11 @@ class TestResources:
 
     @pytest.mark.usefixtures("_mcp_env_with_fields")
     async def test_tags_resource_by_field(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.read_resource("tags://vault/cluster")
         data = json.loads(result[0].text)
         assert isinstance(data, list)
@@ -1860,8 +1962,11 @@ class TestResources:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_folders_resource(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.read_resource("folders://vault")
         data = json.loads(result[0].text)
         assert isinstance(data, list)
@@ -1870,8 +1975,11 @@ class TestResources:
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_toc_resource(self) -> None:
+        from tests.conftest import wait_for_indexer_ready
+
         server = make_server()
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.read_resource("toc://vault/simple.md")
         data = json.loads(result[0].text)
         assert isinstance(data, list)
@@ -2127,10 +2235,12 @@ class TestIfMatchParameter:
     async def test_write_accepts_if_match_when_correct(self, vault_path: Path) -> None:
         """write tool succeeds when if_match matches the current file etag."""
         from markdown_vault_mcp.hashing import compute_file_hash
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         current_etag = compute_file_hash(vault_path / "simple.md")
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "write",
                 {
@@ -2162,10 +2272,12 @@ class TestIfMatchParameter:
     async def test_edit_accepts_if_match_when_correct(self, vault_path: Path) -> None:
         """edit tool succeeds when if_match matches the current file etag."""
         from markdown_vault_mcp.hashing import compute_file_hash
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         current_etag = compute_file_hash(vault_path / "simple.md")
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "edit",
                 {
@@ -2198,10 +2310,12 @@ class TestIfMatchParameter:
     async def test_delete_accepts_if_match_when_correct(self, vault_path: Path) -> None:
         """delete tool succeeds when if_match matches the current file etag."""
         from markdown_vault_mcp.hashing import compute_file_hash
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         current_etag = compute_file_hash(vault_path / "simple.md")
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "delete",
                 {"path": "simple.md", "if_match": current_etag},
@@ -2224,10 +2338,12 @@ class TestIfMatchParameter:
     async def test_rename_accepts_if_match_when_correct(self, vault_path: Path) -> None:
         """rename tool succeeds when if_match matches the current file etag."""
         from markdown_vault_mcp.hashing import compute_file_hash
+        from tests.conftest import wait_for_indexer_ready
 
         server = make_server()
         current_etag = compute_file_hash(vault_path / "simple.md")
         async with Client(server) as client:
+            await wait_for_indexer_ready(client)
             result = await client.call_tool(
                 "rename",
                 {
@@ -2292,8 +2408,15 @@ class TestLifespanAutoEmbeddings:
         ):
             server = make_server()
             async with Client(server) as client:
-                result = await client.call_tool_mcp("embeddings_status", {})
-        data = json.loads(result.content[0].text)
+                import asyncio as _asyncio
+
+                deadline = _asyncio.get_event_loop().time() + 15.0
+                while _asyncio.get_event_loop().time() < deadline:
+                    result = await client.call_tool_mcp("embeddings_status", {})
+                    data = json.loads(result.content[0].text)
+                    if data["chunk_count"] > 0:
+                        break
+                    await _asyncio.sleep(0.05)
         assert data["chunk_count"] > 0
 
     async def test_subsequent_startup_skips_rebuild(
@@ -2322,7 +2445,14 @@ class TestLifespanAutoEmbeddings:
         ):
             server = make_server()
             async with Client(server) as client:
-                r1 = await client.call_tool_mcp("embeddings_status", {})
+                import asyncio as _asyncio
+
+                deadline = _asyncio.get_event_loop().time() + 15.0
+                while _asyncio.get_event_loop().time() < deadline:
+                    r1 = await client.call_tool_mcp("embeddings_status", {})
+                    if json.loads(r1.content[0].text)["chunk_count"] > 0:
+                        break
+                    await _asyncio.sleep(0.05)
         count1 = json.loads(r1.content[0].text)["chunk_count"]
         assert count1 > 0
 


### PR DESCRIPTION
## Summary

Issue #513: the MCP `initialize` handshake blocks on cold-start indexing because the lifespan in `_server_deps.py` awaits `build_index()` and `build_embeddings()` before yielding. This PR fixes that by introducing a `BackgroundIndexer` orchestrator that owns the daemon thread driving the index build, leaving `Collection` purely synchronous.

This is **attempt 4** at issue #513. The three prior attempts (PRs #510, #515, #516) were abandoned. Memory documenting the failure patterns is at `.claude/projects/-mnt-code-markdown-mcp/memory/project_issue_513_failure_pattern.md` and `feedback_background_indexing_abandon.md` — this PR explicitly addresses each documented pitfall.

## What this PR delivers (the architectural unit)

- **New `src/markdown_vault_mcp/background_indexer.py`** — `BackgroundIndexer` class owns the daemon thread (spec section: [Architecture → BackgroundIndexer](docs/superpowers/specs/2026-05-27-issue-513-background-indexer-design.md#backgroundindexer-new-srcmarkdown_vault_mcpbackground_indexerpy)). Single-shot lifecycle: `start()` (idempotent), `stop(timeout)` (joins with bounded wait, returns `bool`), `status` property returning an `IndexStatus` `TypedDict` with `state`, `error`, `error_type`, `documents_indexed`, `chunks_indexed`.
- **`_server_deps.py` lifespan rewire** — swaps the two `await asyncio.to_thread(build_index / build_embeddings)` calls for `indexer.start()` and yields immediately (spec section: [Lifespan rewiring](docs/superpowers/specs/2026-05-27-issue-513-background-indexer-design.md#lifespan-rewiring-server_depspy)). Linear teardown: `indexer.stop(timeout=30)` → `collection.close()`. `has_provider` gated on **both** `embedding_provider` and `embeddings_path` (the PR #515 startup-failure pitfall). The close-after-timeout race is documented honestly: WAL recovers any partial write.
- **Collection invariant fix** — `_initialized` renamed to `_index_built` (single meaning: \"`build_index` completed at least once this process\"). `_ensure_initialized()` becomes a no-op shim retained to avoid the 22-call-site sweep that was a major factor in PR #515's failure to converge. `build_index()` skip gate uses the renamed flag (spec section: [Collection._ensure_initialized() becomes a no-op](docs/superpowers/specs/2026-05-27-issue-513-background-indexer-design.md#collection_ensure_initialized-becomes-a-no-op-_initialized-is-renamed)).
- **`docs/design.md`** updated: two \"Lazy initialization\" paragraphs replaced with \"Explicit initialization\"; new `### Background indexer` subsection describes the orchestrator, the synchronous-`Collection` invariant, and the timeout-race contingency honestly.
- **Tests**:
  - `tests/test_background_indexer.py` — 7 unit tests covering idle/ready/failed transitions, idempotent start, no-op stop variants, and the load-bearing `_stop_event` check between phases.
  - `tests/test_lifespan_non_blocking.py` — 2 integration tests: 4s monkeypatched `build_index` delay confirms handshake completes in <3s (a regression to sync would unambiguously fail), and shutdown-during-indexing exits the client context while the daemon is still mid-build (the exact failure mode #515 and #516 were abandoned over).
  - `tests/conftest.py` — `wait_for_indexer_ready` / `wait_for_embeddings_ready` helpers; timeout message points operators at the `background_indexer_failed` log line.
  - 6 pre-existing MCP test files adjusted to call `wait_for_indexer_ready` where they depend on a populated index at handshake time.

## What this PR does NOT include (anchored follow-ups)

- **`get_index_status` MCP tool** — separate PR. Spec section: [Status surfacing](docs/superpowers/specs/2026-05-27-issue-513-background-indexer-design.md#status-surfacing--separate-get_index_status-tool). The orchestrator's `status` property is exposed via `get_indexer(ctx)` in `_server_deps.py` for `Depends()`-based callers; the follow-up wraps it as an MCP tool for clients. The plan structure is at [`docs/superpowers/plans/2026-05-27-issue-513-background-indexer.md`](docs/superpowers/plans/2026-05-27-issue-513-background-indexer.md).
- **Operator-facing docs** (`claude-desktop.md`, `configuration.md`) — separate PR. Standalone-defensible once the architecture is on `main`.

These follow-ups are not blockers for this PR's review — each is reviewable against the material this PR lands.

## How the abandoned-PR pitfalls are addressed

- **#510 (`exclude_patterns` purge regression):** avoided. `build_index()` skip gate's first-call-per-process path is unchanged; `_index_mgr.build_index()` and its purge run on cold start.
- **#515 (foreground waiter coupling on `_ensure_initialized`):** avoided. `_ensure_initialized` is a no-op shim; no foreground waiter exists.
- **#515 (startup failure when provider configured without sidecar):** addressed. Lifespan gates `has_provider` on both `embedding_provider` and `embeddings_path`.
- **#515 (call-site-sweep churn):** avoided. The 23 in-class `_ensure_initialized` callers are unchanged; the shim documents the retention rationale.
- **#516 (`_closed` flag TOCTOU race):** avoided. `BackgroundIndexer` uses a single `_lock` for `_thread` read/write; `_stop_event` is intrinsically thread-safe. The shutdown race is explicitly documented and the WAL-recovery fallback is named.

## Design caveats documented for any future iteration

Substantive design concerns surfaced during local review are posted to issue #513 as [comment 4553475035](https://github.com/pvliesdonk/markdown-vault-mcp/issues/513#issuecomment-4553475035) so future rounds inherit them up front. Items not blocking this PR but worth noting:

- `collection.start()` (periodic git pull loop) starts concurrently with the initial `build_index()` — latent inconsistency risk if a pull lands mid-scan. No mitigation in this PR; could be addressed if the git-pull loop gains a \"wait for indexer ready\" gate.
- `failed` is a terminal state with no in-process recovery — transient failures (network blip, SQLite lock) leave the indexer permanently degraded until restart. Single-shot lifecycle is documented but not runtime-enforced.
- `_run`'s `except Exception` captures `error_type` for diagnostics but does not discriminate `MemoryError` or `sqlite3.DatabaseError` (corruption) from transient failures. Acceptable given the observability via status, but a future refinement could split severity.

## Test plan

- [x] BackgroundIndexer unit tests: idle, ready, failed (with `error_type`), idempotent start, double stop, stop signal observed between phases.
- [x] Integration test: 4s monkeypatched `build_index` delay confirms handshake completes in <3s.
- [x] Integration test: shutdown during indexing completes without raising (the abandoned-PR failure mode).
- [x] PR #256 `test_build_index_purges_stale_excluded_docs` still passes.
- [x] Full test suite green (1602 passed, 1 pre-existing skip on Python 3.13+ scanner test).
- [x] Local preflight-circus clean (5 core lenses + code-reviewer + comment-analyzer + pr-test-analyzer + silent-failure-hunter; 0 findings at confidence ≥ 80 after one local-iteration round addressing first-round findings).

Refs #513