### PR TITLE
feat(collection): per-thread SQLite connections (closes #519)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -537,6 +537,75 @@ unless overridden by `-v` (sets both app and FastMCP to `DEBUG`). When
 configuration details (secrets redacted). At `INFO`, only the auth mode
 decision and a startup summary line are emitted.
 
+## Collection thread-safety contract
+
+`Collection` and its `FTSIndex` use per-thread SQLite connections. Each
+thread that calls a method on `FTSIndex` gets its own `sqlite3.Connection`,
+opened lazily on first touch via `_conn()`, stored in `threading.local`,
+and registered in `_all_conns` for deterministic cleanup at `close()`.
+
+### Why per-thread connections
+
+Python's stdlib `sqlite3` reports `threadsafety=1` ("threads may share
+the module, but not connections"). SQLite's own documentation says:
+"no single database connection nor any object derived from database
+connection, such as a prepared statement, is used in two or more
+threads at the same time" ([sqlite.org/threadsafe.html](https://www.sqlite.org/threadsafe.html)).
+
+Python 3.12 tightened enforcement of these rules; sharing one connection
+across threads (which earlier versions of this codebase did) deterministically
+raises `sqlite3.OperationalError` or `InterfaceError` on 3.12+. Issue #519
+introduced the per-thread connection model that resolves this.
+
+### Connection lifecycle
+
+- **Constructing thread** (the thread that creates `Collection`):
+  `FTSIndex.__init__` opens the primary connection, runs schema DDL and
+  all migrations, sets WAL (one-time DB-header pragma), applies per-connection
+  pragmas (`foreign_keys=ON`, `busy_timeout=5000`, `synchronous=NORMAL`),
+  stores in `threading.local`, and appends to `_all_conns`.
+- **Subsequent threads** (any thread that later calls a method): on first
+  call to `_conn()`, opens a new connection, applies per-connection
+  pragmas only (schema DDL skipped — already persisted in the DB file),
+  stores in TLS, appends to `_all_conns`.
+- **`close()`**: iterates `_all_conns` from whichever thread invokes it
+  and closes every registered connection. Safe cross-thread because
+  `check_same_thread=False`. After `close()`, every per-thread connection
+  raises `ProgrammingError` on next access.
+
+### Why `check_same_thread=False`
+
+Python's `sqlite3` enforces `check_same_thread` on `Connection.close()`
+too. With `check_same_thread=True`, `Collection.close()` would be unable
+to close connections opened on other threads — defeating the registry's
+entire purpose. TLS routing in `_conn()` is the actual safety mechanism:
+each thread only ever receives its own connection.
+
+### Concurrent writers
+
+WAL mode permits unlimited concurrent readers with one writer at a time
+at the SQLite level. `Collection._write_lock` (RLock) serialises writers
+at the Python layer, so concurrent in-process writes queue cleanly
+without ever hitting `SQLITE_BUSY`. The `busy_timeout=5000ms`
+per-connection pragma is the safety net for the rare case where an
+out-of-process holder (e.g. a sidecar tool) holds a lock.
+
+### In-memory databases
+
+`sqlite3.connect(":memory:")` opens a fresh, empty database per
+connection. To make `:memory:` (the production default when
+`MARKDOWN_VAULT_MCP_INDEX_PATH` is unset) usable under the per-thread
+model, `FTSIndex` transparently translates `:memory:` to a unique
+shared-cache URI of the form `file:fts_<uuid4hex>?mode=memory&cache=shared`
+on construction. All per-thread connections opened by the same
+`FTSIndex` instance see the same in-memory database; different
+`FTSIndex` instances stay isolated.
+
+### References
+
+- Issue [#519](https://github.com/pvliesdonk/markdown-vault-mcp/issues/519) — the refactor that introduced this model, including a verified-baseline comment summarising official SQLite / Python sqlite3 docs.
+- Issue [#513](https://github.com/pvliesdonk/markdown-vault-mcp/issues/513) — the original consumer (non-blocking MCP initialise via background indexing) that requires this prerequisite.
+
 ## Data Types
 
 All public return types and major internal structures:

--- a/docs/design.md
+++ b/docs/design.md
@@ -590,6 +590,12 @@ without ever hitting `SQLITE_BUSY`. The `busy_timeout=5000ms`
 per-connection pragma is the safety net for the rare case where an
 out-of-process holder (e.g. a sidecar tool) holds a lock.
 
+The `synchronous = NORMAL` pragma trades durability for write throughput:
+an OS crash (not process crash) may lose the last committed transaction.
+This is acceptable here because the index is derived from the source
+markdown files — a crash rebuild is safe and the source files are the
+source of truth.
+
 ### In-memory databases
 
 `sqlite3.connect(":memory:")` opens a fresh, empty database per

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ dev = [
     "mypy>=1.0",
     "pre-commit>=3.0",
     "pip-audit>=2.7",
+    "tox>=4.0",
+    "tox-uv>=1.0",
 ]
 docs = [
     "mkdocs-material>=9.7.6",
@@ -138,6 +140,9 @@ indent-style = "space"
 testpaths = ["tests"]
 addopts = ["--strict-markers", "-ra"]
 asyncio_mode = "auto"
+markers = [
+    "benchmark: micro-benchmark tests (excluded from default runs)",
+]
 
 [tool.coverage.run]
 source = ["src/markdown_vault_mcp"]

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -125,6 +125,28 @@ class Collection:
             ``0`` disables the limit (default ``1.0``).
         max_note_read_bytes: Maximum bytes returned by full-document reads.
             ``0`` disables the limit (default ``262144``, i.e. 256 KB).
+
+    Thread-safety:
+        All public methods are safe to call from any thread.
+
+        - Read methods (``read``, ``search``, ``list``, ``get_backlinks``,
+          ``get_outlinks``, ``get_similar``, ``get_context``, etc.) may
+          run concurrently with other reads and with writes from any
+          other thread.
+        - Write methods (``write``, ``edit``, ``delete``, ``rename``)
+          serialise against each other via the internal ``_write_lock``
+          (RLock).
+        - :meth:`close` is safe to call from any thread. After
+          :meth:`close`, the Collection must not be used.
+        - Cross-method atomicity is the caller's responsibility:
+          ``_write_lock`` is per-method, not per-logical-operation.
+          Calling ``write()`` then ``edit()`` from one thread does NOT
+          guarantee another thread sees neither or both — only that
+          each individual call is internally atomic.
+        - ``fork()`` is not supported. The connection model assumes a
+          threaded server.
+
+        See issue #519 for the SQLite connection model details.
     """
 
     def __init__(

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -403,26 +403,46 @@ class FTSIndex:
             sqlite3.ProgrammingError: If :meth:`close` has already been
                 called on this instance.
         """
-        # The _closed check is intentionally outside _reg_lock: it's a cheap
-        # boolean read written exactly once, holding _reg_lock here would
-        # deadlock against close()'s own with-block, and the contract is
-        # already "callers stop using the collection before close()".
+        # Fast path: lock-free read of the cached per-thread connection. The
+        # _closed check here is an early-rejection optimisation — the slow
+        # path re-checks under _reg_lock to close the TOCTOU window with
+        # close().
         if self._closed:
             raise sqlite3.ProgrammingError("Cannot operate on a closed FTSIndex")
         conn = getattr(self._local, "conn", None)
-        if conn is None:
-            conn = sqlite3.connect(
-                self._connect_string,
-                check_same_thread=False,
-                uri=self._connect_uri,
-                factory=_WeakRefableConnection,
-            )
-            conn.row_factory = sqlite3.Row
-            _apply_pragmas(conn)
-            self._local.conn = conn
-            with self._reg_lock:
-                self._all_conns.append(weakref.ref(conn))
-        return conn
+        if conn is not None:
+            return conn
+
+        # Slow path: open a new connection. Re-check _closed under _reg_lock
+        # so a concurrent close() cannot leave us with a live connection
+        # outside the registry. Holding _reg_lock here does NOT deadlock —
+        # close() runs from a separate call stack, not nested within _conn().
+        new_conn = sqlite3.connect(
+            self._connect_string,
+            check_same_thread=False,
+            uri=self._connect_uri,
+            factory=_WeakRefableConnection,
+        )
+        new_conn.row_factory = sqlite3.Row
+        try:
+            _apply_pragmas(new_conn)
+        except sqlite3.Error:
+            # Failure-path cleanup: don't leak the freshly-opened connection
+            # if pragma application failed (disk full, locked DB beyond
+            # busy_timeout, etc.). Caller sees the OperationalError.
+            new_conn.close()
+            raise
+
+        with self._reg_lock:
+            if self._closed:
+                # close() ran while we were opening. Drop the new connection
+                # and raise — caller should not see a live conn on a closed
+                # index.
+                new_conn.close()
+                raise sqlite3.ProgrammingError("Cannot operate on a closed FTSIndex")
+            self._local.conn = new_conn
+            self._all_conns.append(weakref.ref(new_conn))
+        return new_conn
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -8,6 +8,7 @@ import logging
 import sqlite3
 import threading
 import uuid
+import weakref
 from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -157,6 +158,17 @@ def _normalize_heading(heading: str) -> str:
     return " ".join(heading.split())
 
 
+class _WeakRefableConnection(sqlite3.Connection):
+    """``sqlite3.Connection`` subclass that supports :mod:`weakref`.
+
+    CPython's built-in ``sqlite3.Connection`` does not implement
+    ``__weakref__``, so :func:`weakref.ref` raises ``TypeError``. Subclassing
+    adds the slot. Used via ``sqlite3.connect(..., factory=...)`` so the
+    per-thread connection registry can hold weak references — dead-thread
+    connections are GC'd naturally rather than leaking until :meth:`close`.
+    """
+
+
 def _apply_pragmas(conn: sqlite3.Connection) -> None:
     """Apply per-connection pragmas. MUST be called on every new connection.
 
@@ -281,10 +293,18 @@ def _open_connection(
     DB file for file-backed DBs; for ``":memory:"`` the shared-cache URI
     ensures per-thread connections see the same schema).
     """
-    conn = sqlite3.connect(connect_string, check_same_thread=False, uri=uri)
+    conn = sqlite3.connect(
+        connect_string,
+        check_same_thread=False,
+        uri=uri,
+        factory=_WeakRefableConnection,
+    )
     conn.row_factory = sqlite3.Row
-    _init_schema(conn, db_path)
+    # Pragmas (notably busy_timeout=5000) MUST be applied before schema
+    # initialisation so the ALTER TABLE / CREATE INDEX migration statements
+    # wait on a concurrent-process lock rather than failing immediately.
     _apply_pragmas(conn)
+    _init_schema(conn, db_path)
     return conn
 
 
@@ -346,15 +366,18 @@ class FTSIndex:
         self._connect_string, self._connect_uri = _resolve_connect_uri(db_path)
         self._indexed_fields: list[str] = indexed_frontmatter_fields or []
         # Per-thread connections: thread-local slot + side registry for close().
+        # Weak refs so connections from threads that have exited are GC'd
+        # naturally; close() skips weakrefs whose referent is already gone.
         self._local = threading.local()
-        self._all_conns: list[sqlite3.Connection] = []
+        self._all_conns: list[weakref.ref[sqlite3.Connection]] = []
         self._reg_lock = threading.Lock()
+        self._closed = False
         # Primary connection: runs schema + migrations + pragmas, then
         # registers itself so close() can clean it up like any other.
         primary = _open_connection(db_path, self._connect_string, self._connect_uri)
         self._local.conn = primary
         with self._reg_lock:
-            self._all_conns.append(primary)
+            self._all_conns.append(weakref.ref(primary))
 
     def _conn(self) -> sqlite3.Connection:
         """Return the calling thread's SQLite connection, opening one on first touch.
@@ -369,26 +392,36 @@ class FTSIndex:
         ``check_same_thread=False`` is required — :meth:`close` runs from
         one thread and must close connections opened on other threads).
 
-        Connections opened by threads that have since exited remain in
-        ``_all_conns`` until :meth:`close` is called; intentional for the
-        long-lived MCP server use case but worth knowing for callers that
-        spawn unbounded short-lived threads.
+        Per-thread connections are tracked via :mod:`weakref`, so connections
+        from threads that have exited are garbage-collected automatically;
+        :meth:`close` will skip already-gone references.
 
         Returns:
             The Connection owned by the calling thread.
+
+        Raises:
+            sqlite3.ProgrammingError: If :meth:`close` has already been
+                called on this instance.
         """
+        # The _closed check is intentionally outside _reg_lock: it's a cheap
+        # boolean read written exactly once, holding _reg_lock here would
+        # deadlock against close()'s own with-block, and the contract is
+        # already "callers stop using the collection before close()".
+        if self._closed:
+            raise sqlite3.ProgrammingError("Cannot operate on a closed FTSIndex")
         conn = getattr(self._local, "conn", None)
         if conn is None:
             conn = sqlite3.connect(
                 self._connect_string,
                 check_same_thread=False,
                 uri=self._connect_uri,
+                factory=_WeakRefableConnection,
             )
             conn.row_factory = sqlite3.Row
             _apply_pragmas(conn)
             self._local.conn = conn
             with self._reg_lock:
-                self._all_conns.append(conn)
+                self._all_conns.append(weakref.ref(conn))
         return conn
 
     # ------------------------------------------------------------------
@@ -1622,10 +1655,23 @@ class FTSIndex:
         ("Cannot operate on a closed database") on their next access.
         """
         with self._reg_lock:
-            for conn in self._all_conns:
+            self._closed = True
+            for conn_ref in self._all_conns:
+                conn = conn_ref()
+                if conn is None:
+                    # Owning thread has exited; the connection was GC'd.
+                    continue
                 try:
                     conn.close()
-                except sqlite3.Error as exc:
-                    logger.warning("FTSIndex.close: error closing connection: %s", exc)
+                except sqlite3.ProgrammingError:
+                    # Benign: connection already closed (idempotent close).
+                    logger.debug("FTSIndex.close: connection already closed")
+                except sqlite3.Error:
+                    logger.error(
+                        "FTSIndex.close: failed to close connection (db_path=%s)",
+                        self._db_path,
+                        exc_info=True,
+                    )
+                    # Continue — don't strand other connections.
             self._all_conns.clear()
         logger.debug("FTSIndex closed (db_path=%s)", self._db_path)

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -155,31 +155,37 @@ def _normalize_heading(heading: str) -> str:
     return " ".join(heading.split())
 
 
-def _open_connection(db_path: Path | str) -> sqlite3.Connection:
-    """Open an SQLite connection with required pragmas and schema applied.
+def _apply_pragmas(conn: sqlite3.Connection) -> None:
+    """Apply per-connection pragmas. MUST be called on every new connection.
 
-    Args:
-        db_path: Filesystem path or ``":memory:"`` for an in-memory database.
-
-    Returns:
-        An open :class:`sqlite3.Connection` with the schema applied and
-        ``foreign_keys`` enforcement active.
+    These pragmas are connection-scoped (not persisted in the DB header) so
+    every ``sqlite3.connect()`` must re-apply them. See SQLite docs on
+    ``PRAGMA foreign_keys``, ``PRAGMA busy_timeout``, ``PRAGMA synchronous``.
     """
-    conn = sqlite3.connect(str(db_path), check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    # Apply schema; executescript commits implicitly.
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA busy_timeout = 5000")
+    conn.execute("PRAGMA synchronous = NORMAL")
+
+
+def _init_schema(conn: sqlite3.Connection, db_path: Path | str) -> None:
+    """Run schema DDL, migrations, and one-time DB-header pragmas.
+
+    Called exactly once per :class:`FTSIndex` instance, on the constructing
+    thread, before any per-thread connections are opened. Subsequent
+    per-thread opens (via :meth:`FTSIndex._conn`) must NOT re-run this.
+    """
+    # Base schema (idempotent via CREATE TABLE IF NOT EXISTS).
     conn.executescript(_SCHEMA_SQL)
-    # Migrate existing databases: add columns introduced after initial schema.
-    # ALTER TABLE ADD COLUMN is idempotent-guarded via try/except because
-    # SQLite only supports ADD COLUMN IF NOT EXISTS from version 3.35 onwards.
+
+    # Migration: links.raw_target column.
     try:
         conn.execute("ALTER TABLE links ADD COLUMN raw_target TEXT NOT NULL DEFAULT ''")
         conn.commit()
     except sqlite3.OperationalError as e:
         if "duplicate column name" not in str(e).lower():
-            raise  # Unexpected error — re-raise.
-    # Migrate: create document_aliases table if it does not exist (added for
-    # Obsidian-style alias resolution in wikilinks).
+            raise
+
+    # Migration: document_aliases table (added for Obsidian alias resolution).
     conn.executescript(
         """
         CREATE TABLE IF NOT EXISTS document_aliases (
@@ -193,9 +199,8 @@ def _open_connection(db_path: Path | str) -> sqlite3.Connection:
         CREATE INDEX IF NOT EXISTS idx_aliases_docid ON document_aliases(document_id);
         """
     )
-    # Migration: chunk_count was added 2026-04-30. ALTER TABLE is a no-op
-    # if the column already exists, but SQLite has no IF NOT EXISTS for
-    # columns, so we probe PRAGMA first.
+
+    # Migration: documents.chunk_count column (added 2026-04-30).
     cols = {r["name"] for r in conn.execute("PRAGMA table_info(documents)").fetchall()}
     if "chunk_count" not in cols:
         try:
@@ -209,25 +214,18 @@ def _open_connection(db_path: Path | str) -> sqlite3.Connection:
         except sqlite3.OperationalError as exc:
             if "duplicate column name" not in str(exc).lower():
                 raise
-            # Another process beat us to it; column now exists.
             logger.debug(
                 "fts_index: chunk_count column already added by concurrent process"
             )
-    # Migration: idx_sections_docid was added 2026-05-12 to back the
-    # correlated subquery on sections(document_id) used in keyword search
-    # for start_line propagation. CREATE INDEX IF NOT EXISTS is idempotent.
+
+    # Migration: idx_sections_docid index (added 2026-05-12).
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_sections_docid ON sections(document_id)"
     )
     conn.commit()
-    # Ensure foreign_keys stays ON for subsequent statements (executescript
-    # does not guarantee this survives across statement boundaries in all
-    # SQLite versions).
-    conn.execute("PRAGMA foreign_keys = ON")
-    # WAL mode allows concurrent readers during writes — essential for
-    # search queries running while reindex or write operations update the DB.
-    # In-memory databases do not support WAL; skip the pragma to avoid a
-    # spurious warning (SQLite silently uses 'memory' journal mode).
+
+    # WAL is a one-time DB-header pragma — persists across opens. Skip for
+    # in-memory DBs (no WAL support; would emit a noisy warning).
     if str(db_path) != ":memory:":
         result = conn.execute("PRAGMA journal_mode = WAL").fetchone()
         if result is None or result[0].lower() != "wal":
@@ -237,6 +235,21 @@ def _open_connection(db_path: Path | str) -> sqlite3.Connection:
                 result[0] if result else "no result",
             )
     conn.commit()
+
+
+def _open_connection(db_path: Path | str) -> sqlite3.Connection:
+    """Open the PRIMARY connection: schema + migrations + pragmas.
+
+    Used only by :meth:`FTSIndex.__init__` for the constructing-thread
+    connection. Subsequent per-thread connections are opened by
+    :meth:`FTSIndex._conn` and apply pragmas only (schema persists in the
+    DB file for file-backed DBs; ``:memory:`` is single-thread by contract —
+    see design spec).
+    """
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    _init_schema(conn, db_path)
+    _apply_pragmas(conn)
     return conn
 
 

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -6,6 +6,8 @@ import datetime
 import json
 import logging
 import sqlite3
+import threading
+import uuid
 from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -237,16 +239,49 @@ def _init_schema(conn: sqlite3.Connection, db_path: Path | str) -> None:
     conn.commit()
 
 
-def _open_connection(db_path: Path | str) -> sqlite3.Connection:
+def _resolve_connect_uri(db_path: Path | str) -> tuple[str, bool]:
+    """Translate db_path to the connection string + uri flag for sqlite3.connect.
+
+    For ``":memory:"``, returns a unique shared-cache URI so that per-thread
+    connections opened by :meth:`FTSIndex._conn` all see the SAME in-memory
+    database. A plain ``sqlite3.connect(":memory:")`` from a second thread
+    would open a fresh empty DB — breaking schema visibility and the
+    per-thread model.
+
+    For file paths, returns the path string unchanged with ``uri=False``.
+
+    Args:
+        db_path: User-facing database path (``":memory:"`` or a filesystem
+            path).
+
+    Returns:
+        ``(connect_string, uri_flag)`` suitable for
+        ``sqlite3.connect(..., uri=...)``.
+    """
+    if str(db_path) == ":memory:":
+        # uuid4 gives a unique cache name per FTSIndex instance — multiple
+        # FTSIndex instances do not share state, matching the prior per-instance
+        # ``:memory:`` isolation. All connections opened against this URI from
+        # any thread see the SAME database (shared cache).
+        cache_name = f"fts_{uuid.uuid4().hex}"
+        return (f"file:{cache_name}?mode=memory&cache=shared", True)
+    return (str(db_path), False)
+
+
+def _open_connection(
+    db_path: Path | str,
+    connect_string: str,
+    uri: bool,
+) -> sqlite3.Connection:
     """Open the PRIMARY connection: schema + migrations + pragmas.
 
     Used only by :meth:`FTSIndex.__init__` for the constructing-thread
     connection. Subsequent per-thread connections are opened by
     :meth:`FTSIndex._conn` and apply pragmas only (schema persists in the
-    DB file for file-backed DBs; ``:memory:`` is single-thread by contract —
-    see design spec).
+    DB file for file-backed DBs; for ``":memory:"`` the shared-cache URI
+    ensures per-thread connections see the same schema).
     """
-    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn = sqlite3.connect(connect_string, check_same_thread=False, uri=uri)
     conn.row_factory = sqlite3.Row
     _init_schema(conn, db_path)
     _apply_pragmas(conn)
@@ -267,6 +302,12 @@ class FTSIndex:
     types (nested dicts, objects) are stored in the raw JSON blob only and
     are not indexed.
 
+    In-memory databases (``db_path=":memory:"``) are transparently mapped to
+    a unique shared-cache URI per :class:`FTSIndex` instance, so per-thread
+    connections all see the same database. This makes ``":memory:"`` safe
+    for multi-threaded callers including the MCP server's
+    ``asyncio.to_thread`` dispatch.
+
     Args:
         db_path: Path to the SQLite database file.  Pass ``":memory:"`` (the
             default) for a transient in-memory database.
@@ -281,8 +322,48 @@ class FTSIndex:
         indexed_frontmatter_fields: list[str] | None = None,
     ) -> None:
         self._db_path = db_path
+        self._connect_string, self._connect_uri = _resolve_connect_uri(db_path)
         self._indexed_fields: list[str] = indexed_frontmatter_fields or []
-        self._conn = _open_connection(db_path)
+        # Per-thread connections: thread-local slot + side registry for close().
+        self._local = threading.local()
+        self._all_conns: list[sqlite3.Connection] = []
+        self._reg_lock = threading.Lock()
+        # Primary connection: runs schema + migrations + pragmas, then
+        # registers itself so close() can clean it up like any other.
+        primary = _open_connection(db_path, self._connect_string, self._connect_uri)
+        self._local.conn = primary
+        with self._reg_lock:
+            self._all_conns.append(primary)
+
+    def _conn(self) -> sqlite3.Connection:
+        """Return the calling thread's SQLite connection, opening one on first touch.
+
+        Per-thread connections are the only safe pattern for multi-threaded
+        SQLite use (see sqlite.org/threadsafe.html and issue #519). Subsequent
+        calls from the same thread return the same Connection object;
+        different threads see different connections.
+
+        The connection is registered in ``self._all_conns`` so :meth:`close`
+        can deterministically close all per-thread connections (which is why
+        ``check_same_thread=False`` is required — :meth:`close` runs from
+        one thread and must close connections opened on other threads).
+
+        Returns:
+            The Connection owned by the calling thread.
+        """
+        conn = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(
+                self._connect_string,
+                check_same_thread=False,
+                uri=self._connect_uri,
+            )
+            conn.row_factory = sqlite3.Row
+            _apply_pragmas(conn)
+            self._local.conn = conn
+            with self._reg_lock:
+                self._all_conns.append(conn)
+        return conn
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -551,8 +632,8 @@ class FTSIndex:
             Total number of chunks (sections) indexed.
         """
         total_chunks = 0
-        with self._conn:
-            cur = self._conn.cursor()
+        with self._conn():
+            cur = self._conn().cursor()
             for note in notes:
                 folder = _derive_folder(note.path)
                 self._delete_document(cur, note.path)
@@ -583,8 +664,8 @@ class FTSIndex:
             Number of chunks (sections) indexed for this document.
         """
         folder = _derive_folder(note.path)
-        with self._conn:
-            cur = self._conn.cursor()
+        with self._conn():
+            cur = self._conn().cursor()
             self._delete_document(cur, note.path)
             doc_id = self._insert_document(cur, note, folder)
             self._insert_sections(cur, doc_id, note)
@@ -605,8 +686,8 @@ class FTSIndex:
         Returns:
             Number of document rows deleted (0 if path was not indexed).
         """
-        with self._conn:
-            cur = self._conn.cursor()
+        with self._conn():
+            cur = self._conn().cursor()
             deleted = self._delete_document(cur, path)
         if deleted:
             logger.debug("delete_by_path: removed %s", path)
@@ -738,7 +819,7 @@ class FTSIndex:
             snippet_words,
         )
         try:
-            cur = self._conn.execute(sql, params)
+            cur = self._conn().execute(sql, params)
         except sqlite3.OperationalError as exc:
             msg = str(exc).lower()
             if (
@@ -781,7 +862,7 @@ class FTSIndex:
             ``frontmatter_json``, ``content_hash``, ``modified_at``, or
             ``None`` if the document is not indexed.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT path, title, folder, frontmatter_json,
                    content_hash, modified_at
@@ -809,7 +890,7 @@ class FTSIndex:
             # Escape LIKE wildcards in the user-supplied folder value so that
             # literal '%' and '_' characters are matched as-is.
             escaped = _escape_like(folder)
-            cur = self._conn.execute(
+            cur = self._conn().execute(
                 """
                 SELECT path, title, folder, frontmatter_json,
                        content_hash, modified_at
@@ -820,7 +901,7 @@ class FTSIndex:
                 (folder, escaped + "/%"),
             )
         else:
-            cur = self._conn.execute(
+            cur = self._conn().execute(
                 """
                 SELECT path, title, folder, frontmatter_json,
                        content_hash, modified_at
@@ -836,7 +917,7 @@ class FTSIndex:
         Returns:
             Sorted list of folder strings (including ``""`` for the root).
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             "SELECT DISTINCT folder FROM documents ORDER BY folder"
         )
         return [row[0] for row in cur.fetchall()]
@@ -853,7 +934,7 @@ class FTSIndex:
         Returns:
             Sorted list of distinct value strings.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT DISTINCT tag_value
             FROM document_tags
@@ -870,7 +951,7 @@ class FTSIndex:
         Returns:
             Integer count of all indexed chunks across all documents.
         """
-        row = self._conn.execute("SELECT COUNT(*) FROM sections").fetchone()
+        row = self._conn().execute("SELECT COUNT(*) FROM sections").fetchone()
         return row[0] if row else 0
 
     def get_toc(self, path: str) -> list[dict[str, str | int]]:
@@ -887,7 +968,7 @@ class FTSIndex:
             first appearance.  Empty list if the document is not found or
             has no headings.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT heading, heading_level
             FROM sections
@@ -917,7 +998,7 @@ class FTSIndex:
         """
         limit_clause = "" if limit is None else "LIMIT ?"
         params: tuple = (path,) if limit is None else (path, limit)
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             f"""
             SELECT d.path AS source_path,
                    d.title AS source_title,
@@ -952,7 +1033,7 @@ class FTSIndex:
         """
         limit_clause = "" if limit is None else "LIMIT ?"
         params: tuple = (path,) if limit is None else (path, limit)
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             f"""
             SELECT l.target_path,
                    l.link_text,
@@ -1013,18 +1094,22 @@ class FTSIndex:
         # matching — avoids O(N) SQL round-trips (one SELECT per wikilink row).
         doc_paths: list[str] = [
             r["path"]
-            for r in self._conn.execute("SELECT path FROM documents").fetchall()
+            for r in self._conn().execute("SELECT path FROM documents").fetchall()
         ]
 
         # Build alias → document path mapping for fallback resolution.
         # Case-insensitive: Obsidian alias matching is case-insensitive.
-        alias_rows = self._conn.execute(
-            """
+        alias_rows = (
+            self._conn()
+            .execute(
+                """
             SELECT da.alias, d.path
             FROM document_aliases da
             JOIN documents d ON d.id = da.document_id
             """
-        ).fetchall()
+            )
+            .fetchall()
+        )
         # Map lowercased alias to list of document paths (multiple docs could
         # share an alias; pick shortest path like the path-based resolution).
         alias_map: dict[str, list[str]] = {}
@@ -1034,15 +1119,19 @@ class FTSIndex:
         # Fetch all wikilinks eligible for vault-wide resolution.
         # Explicit relative prefixes (./  ../) are excluded — those were
         # resolved at scan time and must not be overwritten.
-        rows = self._conn.execute(
-            """
+        rows = (
+            self._conn()
+            .execute(
+                """
             SELECT id, raw_target, target_path
             FROM links
             WHERE link_type = 'wikilink'
               AND raw_target NOT LIKE './%'
               AND raw_target NOT LIKE '../%'
             """
-        ).fetchall()
+            )
+            .fetchall()
+        )
 
         # Resolve each wikilink in Python, then batch-UPDATE.
         updates: list[tuple[str, int]] = []
@@ -1075,8 +1164,8 @@ class FTSIndex:
             if new_path != row["target_path"]:
                 updates.append((new_path, row["id"]))
 
-        with self._conn:
-            self._conn.executemany(
+        with self._conn():
+            self._conn().executemany(
                 "UPDATE links SET target_path = ? WHERE id = ?", updates
             )
         updated = len(updates)
@@ -1120,7 +1209,7 @@ class FTSIndex:
               {folder_clause}
             ORDER BY d.path, l.rowid
         """
-        cur = self._conn.execute(sql, params)
+        cur = self._conn().execute(sql, params)
         return [dict(row) for row in cur.fetchall()]
 
     def get_recent(self, *, limit: int = 20, folder: str | None = None) -> list[dict]:
@@ -1137,7 +1226,7 @@ class FTSIndex:
         """
         if folder is not None:
             escaped = _escape_like(folder)
-            cur = self._conn.execute(
+            cur = self._conn().execute(
                 """
                 SELECT path, title, folder, frontmatter_json,
                        modified_at
@@ -1149,7 +1238,7 @@ class FTSIndex:
                 (folder, escaped + "/%", limit),
             )
         else:
-            cur = self._conn.execute(
+            cur = self._conn().execute(
                 """
                 SELECT path, title, folder, frontmatter_json,
                        modified_at
@@ -1172,7 +1261,7 @@ class FTSIndex:
             List of dicts with keys ``path``, ``title``, ``folder``,
             ``frontmatter_json``, and ``modified_at``, ordered by path.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT path, title, folder, frontmatter_json, modified_at
             FROM documents d
@@ -1193,7 +1282,7 @@ class FTSIndex:
             List of dicts with keys ``path``, ``title``, ``folder``,
             ``backlink_count``, ordered by backlink_count descending.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT d.path,
                    d.title,
@@ -1237,9 +1326,11 @@ class FTSIndex:
 
         # Validate both endpoints exist.
         for path in (source_path, target_path):
-            row = self._conn.execute(
-                "SELECT 1 FROM documents WHERE path = ?", (path,)
-            ).fetchone()
+            row = (
+                self._conn()
+                .execute("SELECT 1 FROM documents WHERE path = ?", (path,))
+                .fetchone()
+            )
             if row is None:
                 raise ValueError(f"Path not found in index: {path!r}")
 
@@ -1249,7 +1340,7 @@ class FTSIndex:
 
         # Load all edges into an undirected adjacency dict.
         adj: dict[str, set[str]] = {}
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             "SELECT d1.path, d2.path FROM links l"
             " JOIN documents d1 ON d1.id = l.source_id"
             " JOIN documents d2 ON d2.path = l.target_path"
@@ -1305,7 +1396,7 @@ class FTSIndex:
                 missing links table.
         """
         try:
-            row = self._conn.execute(sql).fetchone()
+            row = self._conn().execute(sql).fetchone()
             return int(row[0])
         except sqlite3.OperationalError as e:
             if "no such table: links" in str(e).lower():
@@ -1361,9 +1452,11 @@ class FTSIndex:
             The ``chunk_count`` stored in the documents table, or ``1`` if
             the document is not found.
         """
-        row = self._conn.execute(
-            "SELECT chunk_count FROM documents WHERE path = ?", (path,)
-        ).fetchone()
+        row = (
+            self._conn()
+            .execute("SELECT chunk_count FROM documents WHERE path = ?", (path,))
+            .fetchone()
+        )
         return int(row["chunk_count"]) if row else 1
 
     def get_chunk_counts(self, paths: Iterable[str]) -> dict[str, int]:
@@ -1381,10 +1474,14 @@ class FTSIndex:
         if not paths_list:
             return {}
         placeholders = ",".join("?" * len(paths_list))
-        rows = self._conn.execute(
-            f"SELECT path, chunk_count FROM documents WHERE path IN ({placeholders})",
-            paths_list,
-        ).fetchall()
+        rows = (
+            self._conn()
+            .execute(
+                f"SELECT path, chunk_count FROM documents WHERE path IN ({placeholders})",
+                paths_list,
+            )
+            .fetchall()
+        )
         return {r["path"]: int(r["chunk_count"]) for r in rows}
 
     def get_section(self, path: str, heading: str) -> dict[str, Any] | None:
@@ -1426,16 +1523,20 @@ class FTSIndex:
         norm_query = _normalize_heading(heading)
         if not norm_query:
             return None
-        rows = self._conn.execute(
-            """
+        rows = (
+            self._conn()
+            .execute(
+                """
             SELECT s.content, s.heading, s.heading_level
             FROM sections s
             JOIN documents d ON d.id = s.document_id
             WHERE d.path = ? AND s.heading IS NOT NULL
             ORDER BY s.start_line ASC
             """,
-            (path,),
-        ).fetchall()
+                (path,),
+            )
+            .fetchall()
+        )
         for row in rows:
             if _normalize_heading(row["heading"]) == norm_query:
                 return {
@@ -1461,8 +1562,10 @@ class FTSIndex:
             List of heading strings in document order, deduplicated while
             preserving the first-occurrence order.
         """
-        rows = self._conn.execute(
-            """
+        rows = (
+            self._conn()
+            .execute(
+                """
             SELECT s.heading
             FROM sections s
             JOIN documents d ON d.id = s.document_id
@@ -1471,14 +1574,30 @@ class FTSIndex:
             ORDER BY MIN(s.start_line) ASC
             LIMIT ?
             """,
-            (path, limit),
-        ).fetchall()
+                (path, limit),
+            )
+            .fetchall()
+        )
         return [row["heading"] for row in rows]
 
     def close(self) -> None:
-        """Close the underlying database connection.
+        """Close every per-thread database connection.
 
-        After calling this method, the index must not be used.
+        Iterates the registry of connections opened by all threads that
+        touched this :class:`FTSIndex` and closes each. Safe to call from
+        any thread (cross-thread close is enabled by
+        ``check_same_thread=False``). Idempotent: subsequent calls find
+        an empty registry and do nothing.
+
+        After calling this method, the index must not be used. Subsequent
+        operations from any thread will raise :class:`sqlite3.ProgrammingError`
+        ("Cannot operate on a closed database") on their next access.
         """
-        self._conn.close()
+        with self._reg_lock:
+            for conn in self._all_conns:
+                try:
+                    conn.close()
+                except sqlite3.Error as exc:
+                    logger.warning("FTSIndex.close: error closing connection: %s", exc)
+            self._all_conns.clear()
         logger.debug("FTSIndex closed (db_path=%s)", self._db_path)

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -369,6 +369,11 @@ class FTSIndex:
         ``check_same_thread=False`` is required — :meth:`close` runs from
         one thread and must close connections opened on other threads).
 
+        Connections opened by threads that have since exited remain in
+        ``_all_conns`` until :meth:`close` is called; intentional for the
+        long-lived MCP server use case but worth knowing for callers that
+        spawn unbounded short-lived threads.
+
         Returns:
             The Connection owned by the calling thread.
         """
@@ -653,8 +658,9 @@ class FTSIndex:
             Total number of chunks (sections) indexed.
         """
         total_chunks = 0
-        with self._conn():
-            cur = self._conn().cursor()
+        conn = self._conn()
+        with conn:
+            cur = conn.cursor()
             for note in notes:
                 folder = _derive_folder(note.path)
                 self._delete_document(cur, note.path)
@@ -685,8 +691,9 @@ class FTSIndex:
             Number of chunks (sections) indexed for this document.
         """
         folder = _derive_folder(note.path)
-        with self._conn():
-            cur = self._conn().cursor()
+        conn = self._conn()
+        with conn:
+            cur = conn.cursor()
             self._delete_document(cur, note.path)
             doc_id = self._insert_document(cur, note, folder)
             self._insert_sections(cur, doc_id, note)
@@ -707,8 +714,9 @@ class FTSIndex:
         Returns:
             Number of document rows deleted (0 if path was not indexed).
         """
-        with self._conn():
-            cur = self._conn().cursor()
+        conn = self._conn()
+        with conn:
+            cur = conn.cursor()
             deleted = self._delete_document(cur, path)
         if deleted:
             logger.debug("delete_by_path: removed %s", path)
@@ -1185,10 +1193,9 @@ class FTSIndex:
             if new_path != row["target_path"]:
                 updates.append((new_path, row["id"]))
 
-        with self._conn():
-            self._conn().executemany(
-                "UPDATE links SET target_path = ? WHERE id = ?", updates
-            )
+        conn = self._conn()
+        with conn:
+            conn.executemany("UPDATE links SET target_path = ? WHERE id = ?", updates)
         updated = len(updates)
 
         if updated:

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -291,9 +291,35 @@ def _open_connection(
 class FTSIndex:
     """SQLite FTS5 index providing BM25 search and tag filtering.
 
-    Wraps a single SQLite database file (or in-memory database) and exposes
-    CRUD operations and full-text search over a collection of markdown
-    documents.
+    Wraps a SQLite database file (or in-memory database) and exposes CRUD
+    operations and full-text search over a collection of markdown documents.
+
+    Thread-safety:
+        Each thread that calls a method on this class gets its own
+        ``sqlite3.Connection`` (lazily opened on first touch via
+        :meth:`_conn`, stored in ``threading.local``, registered in
+        ``_all_conns`` for cleanup). Connections are never shared across
+        threads. Sequential operations from the same thread reuse the
+        same connection.
+
+        :meth:`close` is safe to call from any thread; it iterates the
+        registry and closes every per-thread connection. After
+        :meth:`close`, subsequent operations on any thread raise
+        ``sqlite3.ProgrammingError``.
+
+        Concurrent writers are serialised at the application layer by
+        :attr:`Collection._write_lock` (an RLock). This class does NOT
+        serialise concurrent writers itself; callers that don't hold
+        ``_write_lock`` and write concurrently from multiple threads may
+        see ``sqlite3.OperationalError`` (SQLITE_BUSY) on contending
+        writes (the per-connection ``busy_timeout=5000ms`` mitigates this
+        for short transactions).
+
+        In-memory databases (``db_path=":memory:"``) are transparently
+        mapped to a unique shared-cache URI per ``FTSIndex`` instance so
+        that all per-thread connections see the same database. Per-thread
+        access to ``:memory:`` is therefore safe, including from the MCP
+        server's ``asyncio.to_thread`` dispatch path.
 
     Tag indexing behaviour is controlled by ``indexed_frontmatter_fields``:
     only the listed frontmatter keys are promoted into the ``document_tags``
@@ -302,15 +328,10 @@ class FTSIndex:
     types (nested dicts, objects) are stored in the raw JSON blob only and
     are not indexed.
 
-    In-memory databases (``db_path=":memory:"``) are transparently mapped to
-    a unique shared-cache URI per :class:`FTSIndex` instance, so per-thread
-    connections all see the same database. This makes ``":memory:"`` safe
-    for multi-threaded callers including the MCP server's
-    ``asyncio.to_thread`` dispatch.
-
     Args:
         db_path: Path to the SQLite database file.  Pass ``":memory:"`` (the
-            default) for a transient in-memory database.
+            default) for a transient in-memory database (transparently
+            shared across threads via a per-instance shared-cache URI).
         indexed_frontmatter_fields: Frontmatter keys whose values are
             promoted to the ``document_tags`` table.  ``None`` means no tag
             indexing.

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -187,6 +187,8 @@ class IndexManager:
         Returns:
             :class:`~markdown_vault_mcp.types.IndexStats` describing what
             was indexed.
+
+        Thread-safety: safe to call from any thread, including a background daemon thread (motivation for issue #519). Acquires ``_write_lock`` for the bulk-write phase; concurrent readers may interleave under WAL.
         """
         if force:
             logger.info("build_index(force=True): dropping and rebuilding index")
@@ -287,14 +289,11 @@ class IndexManager:
         matching ``exclude_patterns`` are skipped, and any previously indexed
         documents that now match the patterns are purged.
 
-        Thread-safety: the filesystem scan runs without holding
-        ``_write_lock`` (read-only), then the mutation phase acquires the
-        lock to prevent races with concurrent write/edit/delete/rename
-        operations.
-
         Returns:
             :class:`~markdown_vault_mcp.types.ReindexResult` with counts
             of changes applied.
+
+        Thread-safety: safe to call from any thread. Acquires ``_write_lock`` for the bulk-write phase; concurrent readers may interleave under WAL.
         """
         # Phase 1: scan (outside lock — read-only filesystem walk + hashing).
         changes = self._tracker.detect_changes(self._source_dir)

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -188,7 +188,13 @@ class IndexManager:
             :class:`~markdown_vault_mcp.types.IndexStats` describing what
             was indexed.
 
-        Thread-safety: safe to call from any thread, including a background daemon thread (motivation for issue #519). Acquires ``_write_lock`` for the bulk-write phase; concurrent readers may interleave under WAL.
+        Thread-safety: safe to call from any thread, including from a
+        background daemon thread (motivation for issue #519). Does NOT
+        acquire ``_write_lock``; callers that build the index
+        concurrently with write/edit/delete/rename operations must
+        coordinate at a higher layer (the BackgroundIndexer design in
+        issue #513 will own that coordination). Concurrent readers may
+        interleave under WAL.
         """
         if force:
             logger.info("build_index(force=True): dropping and rebuilding index")
@@ -293,7 +299,11 @@ class IndexManager:
             :class:`~markdown_vault_mcp.types.ReindexResult` with counts
             of changes applied.
 
-        Thread-safety: safe to call from any thread. Acquires ``_write_lock`` for the bulk-write phase; concurrent readers may interleave under WAL.
+        Thread-safety: safe to call from any thread, including from a
+        background daemon thread. The filesystem scan runs without holding
+        ``_write_lock`` (read-only), then the mutation phase acquires the
+        lock to prevent races with concurrent write/edit/delete/rename
+        operations. Concurrent readers may interleave under WAL.
         """
         # Phase 1: scan (outside lock — read-only filesystem walk + hashing).
         changes = self._tracker.detect_changes(self._source_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,13 +113,7 @@ def tmp_collection_path(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def tmp_collection(tmp_collection_path: Path):
-    """Tempfile-backed Collection. Safe for multi-threaded tests, unlike :memory:.
-
-    ``:memory:`` SQLite databases are connection-scoped — every per-thread
-    connection sees a fresh empty DB. Multi-thread tests MUST use this
-    fixture (or the dedicated multi_thread_collection fixture). See
-    ``docs/superpowers/specs/2026-05-27-issue-519-...md`` for rationale.
-    """
+    """Tempfile-backed Collection; safe for multi-threaded tests unlike :memory: (issue #519)."""
     from markdown_vault_mcp.collection import Collection
 
     coll = Collection(source_dir=tmp_collection_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,31 @@ def populated_collection(tmp_path: Path):
     return col
 
 
+@pytest.fixture
+def tmp_collection_path(tmp_path: Path) -> Path:
+    """Tempdir path suitable for a file-backed Collection."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    return vault
+
+
+@pytest.fixture
+def tmp_collection(tmp_collection_path: Path):
+    """Tempfile-backed Collection. Safe for multi-threaded tests, unlike :memory:.
+
+    ``:memory:`` SQLite databases are connection-scoped — every per-thread
+    connection sees a fresh empty DB. Multi-thread tests MUST use this
+    fixture (or the dedicated multi_thread_collection fixture). See
+    ``docs/superpowers/specs/2026-05-27-issue-519-...md`` for rationale.
+    """
+    from markdown_vault_mcp.collection import Collection
+
+    coll = Collection(source_dir=tmp_collection_path)
+    coll.build_index()
+    yield coll
+    coll.close()
+
+
 async def get_app_html() -> str:
     """Spin up a fresh server and fetch the SPA HTML resource."""
     from fastmcp import Client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def tmp_collection_path(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def tmp_collection(tmp_collection_path: Path):
-    """Tempfile-backed Collection; safe for multi-threaded tests unlike :memory: (issue #519)."""
+    """Tempfile-backed Collection with a file-on-disk DB (enables WAL pragma for realistic perf)."""
     from markdown_vault_mcp.collection import Collection
 
     coll = Collection(source_dir=tmp_collection_path)

--- a/tests/test_fts_chunk_count.py
+++ b/tests/test_fts_chunk_count.py
@@ -25,9 +25,11 @@ def test_chunk_count_populated_on_upsert(tmp_path):
     note = _make_note(tmp_path, "doc.md", body)
     fts.upsert_note(note)
 
-    row = fts._conn.execute(
-        "SELECT chunk_count FROM documents WHERE path = ?", (note.path,)
-    ).fetchone()
+    row = (
+        fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = ?", (note.path,))
+        .fetchone()
+    )
     assert row is not None
     assert row["chunk_count"] == len(note.chunks)
     # Sanity: the helper bypasses the 30-line short-doc rule so this fixture
@@ -45,7 +47,7 @@ def test_chunk_count_populated_on_build_from_notes(tmp_path):
     fts.build_from_notes(notes)
 
     counts = dict(
-        fts._conn.execute("SELECT path, chunk_count FROM documents").fetchall()
+        fts._conn().execute("SELECT path, chunk_count FROM documents").fetchall()
     )
     assert counts["a.md"] == len(notes[0].chunks)
     assert counts["b.md"] == len(notes[1].chunks)
@@ -56,9 +58,11 @@ def test_chunk_count_updates_on_reupsert(tmp_path):
     fts = FTSIndex(db_path=":memory:")
     note_v1 = _make_note(tmp_path, "doc.md", "# A\nbody\n")
     fts.upsert_note(note_v1)
-    v1_count = fts._conn.execute(
-        "SELECT chunk_count FROM documents WHERE path = ?", (note_v1.path,)
-    ).fetchone()["chunk_count"]
+    v1_count = (
+        fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = ?", (note_v1.path,))
+        .fetchone()["chunk_count"]
+    )
 
     note_v2 = _make_note(
         tmp_path,
@@ -66,9 +70,11 @@ def test_chunk_count_updates_on_reupsert(tmp_path):
         "# A\nbody\n## B\nmore\n## C\neven more\n",
     )
     fts.upsert_note(note_v2)
-    v2_count = fts._conn.execute(
-        "SELECT chunk_count FROM documents WHERE path = ?", (note_v2.path,)
-    ).fetchone()["chunk_count"]
+    v2_count = (
+        fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = ?", (note_v2.path,))
+        .fetchone()["chunk_count"]
+    )
 
     assert v2_count != v1_count
     assert v2_count == len(note_v2.chunks)
@@ -124,11 +130,14 @@ def test_migration_adds_column_to_pre_existing_db(tmp_path):
 
     fts = FTSIndex(db_path=db_path)
     cols = [
-        r["name"] for r in fts._conn.execute("PRAGMA table_info(documents)").fetchall()
+        r["name"]
+        for r in fts._conn().execute("PRAGMA table_info(documents)").fetchall()
     ]
     assert "chunk_count" in cols
     # Existing legacy row gets the default value.
-    row = fts._conn.execute(
-        "SELECT chunk_count FROM documents WHERE path = 'legacy.md'"
-    ).fetchone()
+    row = (
+        fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = 'legacy.md'")
+        .fetchone()
+    )
     assert row["chunk_count"] == 1

--- a/tests/test_fts_index.py
+++ b/tests/test_fts_index.py
@@ -360,7 +360,7 @@ class TestSearch:
         # Replace the real connection with a mock that raises a non-FTS5 DB error.
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = sqlite3.OperationalError("database is locked")
-        idx._conn = mock_conn
+        idx._conn = lambda: mock_conn  # type: ignore[method-assign]
 
         with pytest.raises(sqlite3.OperationalError, match="database is locked"):
             idx.search("hello")
@@ -463,7 +463,7 @@ class TestSearch:
         gap on ``sections`` was a perf regression flagged by local review.
         """
         idx = FTSIndex(":memory:")
-        cur = idx._conn.execute(
+        cur = idx._conn().execute(
             "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='sections'"
         )
         index_names = {row[0] for row in cur.fetchall()}
@@ -599,7 +599,7 @@ class TestDelete:
         )
 
         # Verify sections and tags exist before deletion.
-        conn = idx._conn
+        conn = idx._conn()
         sec_count = conn.execute(
             "SELECT COUNT(*) FROM sections WHERE document_id IN "
             "(SELECT id FROM documents WHERE path = ?)",
@@ -673,9 +673,11 @@ class TestTagIndexing:
         """A scalar frontmatter value produces exactly one document_tags row."""
         idx = _tagged_index()
         idx.upsert_note(make_note("scalar.md", frontmatter={"cluster": "fiction"}))
-        rows = idx._conn.execute(
-            "SELECT tag_value FROM document_tags WHERE tag_key = 'cluster'"
-        ).fetchall()
+        rows = (
+            idx._conn()
+            .execute("SELECT tag_value FROM document_tags WHERE tag_key = 'cluster'")
+            .fetchall()
+        )
         assert len(rows) == 1
         assert rows[0][0] == "fiction"
 
@@ -683,10 +685,14 @@ class TestTagIndexing:
         """A list frontmatter value creates one row per distinct item."""
         idx = _tagged_index()
         idx.upsert_note(make_note("list.md", frontmatter={"topics": ["a", "b", "a"]}))
-        rows = idx._conn.execute(
-            "SELECT tag_value FROM document_tags WHERE tag_key = 'topics' "
-            "ORDER BY tag_value"
-        ).fetchall()
+        rows = (
+            idx._conn()
+            .execute(
+                "SELECT tag_value FROM document_tags WHERE tag_key = 'topics' "
+                "ORDER BY tag_value"
+            )
+            .fetchall()
+        )
         assert len(rows) == 2
         assert rows[0][0] == "a"
         assert rows[1][0] == "b"
@@ -697,9 +703,11 @@ class TestTagIndexing:
         idx.upsert_note(
             make_note("complex.md", frontmatter={"cluster": {"key": "val"}})
         )
-        rows = idx._conn.execute(
-            "SELECT COUNT(*) FROM document_tags WHERE tag_key = 'cluster'"
-        ).fetchone()
+        rows = (
+            idx._conn()
+            .execute("SELECT COUNT(*) FROM document_tags WHERE tag_key = 'cluster'")
+            .fetchone()
+        )
         assert rows[0] == 0
 
 
@@ -757,13 +765,13 @@ class TestWALMode:
         """File-based FTSIndex uses WAL journal mode for concurrent reads."""
         db_path = tmp_path / "test.db"
         idx = FTSIndex(str(db_path))
-        mode = idx._conn.execute("PRAGMA journal_mode").fetchone()[0]
+        mode = idx._conn().execute("PRAGMA journal_mode").fetchone()[0]
         assert mode.lower() == "wal"
 
     def test_in_memory_index_uses_memory_journal_mode(self) -> None:
         """In-memory FTSIndex skips WAL and retains SQLite default 'memory' mode."""
         idx = FTSIndex(":memory:")
-        mode = idx._conn.execute("PRAGMA journal_mode").fetchone()[0]
+        mode = idx._conn().execute("PRAGMA journal_mode").fetchone()[0]
         # WAL pragma is skipped for :memory: databases; SQLite uses 'memory' mode.
         assert mode.lower() == "memory"
 
@@ -788,7 +796,7 @@ class TestWALMode:
             ),
             caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.fts_index"),
         ):
-            _open_connection(db_path)
+            _open_connection(db_path, str(db_path), False)
 
         assert any(
             "Could not enable WAL journal mode" in r.message for r in caplog.records

--- a/tests/test_fts_snippet.py
+++ b/tests/test_fts_snippet.py
@@ -55,7 +55,7 @@ def test_chunk_count_populated_on_fts_result(tmp_path):
     assert results[0].chunk_count >= 1
     assert (
         results[0].chunk_count
-        == fts._conn.execute(
-            "SELECT chunk_count FROM documents WHERE path = 'doc.md'"
-        ).fetchone()["chunk_count"]
+        == fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = 'doc.md'")
+        .fetchone()["chunk_count"]
     )

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1394,7 +1394,7 @@ class TestStatsLinkCounts:
         """
         idx = FTSIndex(":memory:")
         # Simulate an old index file that predates link tracking.
-        idx._conn.execute("DROP TABLE links")
+        idx._conn().execute("DROP TABLE links")
         assert idx.count_links() == 0
         assert idx.count_broken_links() == 0
         assert idx.count_orphans() == 0

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -186,6 +186,52 @@ def test_closed_index_rejects_new_thread_access(tmp_collection_path):
     )
 
 
+def test_concurrent_close_and_new_thread_conn_open_is_safe(tmp_collection_path):
+    """close() racing with a new thread's _conn() must not leave live conns outside the registry — issue #519, preflight TOCTOU finding."""
+    from markdown_vault_mcp.collection import Collection
+
+    coll = Collection(source_dir=tmp_collection_path)
+    coll.build_index()
+    fts = coll._fts
+
+    # Both threads block on the barrier so they hit _conn()/close() as
+    # close to simultaneously as possible.
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+    opened: list[object] = []
+
+    def opener() -> None:
+        try:
+            barrier.wait()
+            opened.append(fts._conn())
+        except sqlite3.ProgrammingError:
+            # Acceptable: close() won the race; new conn correctly rejected.
+            pass
+        except BaseException as exc:
+            errors.append(exc)
+
+    def closer() -> None:
+        try:
+            barrier.wait()
+            coll.close()
+        except BaseException as exc:
+            errors.append(exc)
+
+    t_open = threading.Thread(target=opener)
+    t_close = threading.Thread(target=closer)
+    t_open.start()
+    t_close.start()
+    t_open.join(timeout=10)
+    t_close.join(timeout=10)
+
+    assert errors == [], f"unexpected errors: {errors}"
+    # After close(), _closed is True, so a fresh _conn() from this thread
+    # must raise — confirms the index is fully closed regardless of which
+    # thread won the race.
+    with pytest.raises(sqlite3.ProgrammingError):
+        fts._conn()
+
+
 def test_concurrent_build_and_reads_pr518_pattern(multi_thread_collection):
     """PR #518 failure pattern: background reindex + main thread mixed ops, no errors (issue #519)."""
     coll = multi_thread_collection

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -222,3 +222,33 @@ def test_concurrent_writers_serialize_via_write_lock(multi_thread_collection):
     docs = {d.path for d in coll.list()}
     expected = {f"a_{i}.md" for i in range(20)} | {f"b_{i}.md" for i in range(20)}
     assert expected.issubset(docs), f"missing writes: {expected - docs}"
+
+
+@pytest.mark.benchmark
+def test_perf_1000_searches_on_1k_docs(tmp_path):
+    """1000 search() calls on a 1k-doc vault, single thread. Manual perf gate for #519."""
+    import time
+
+    from markdown_vault_mcp.collection import Collection
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for i in range(1000):
+        (vault / f"doc_{i:04d}.md").write_text(
+            f"# Doc {i}\n\nQuick brown fox jumps over lazy dog {i}.\n"
+        )
+
+    coll = Collection(source_dir=vault, read_only=False)
+    coll.build_index()
+
+    # Warm-up.
+    for _ in range(10):
+        coll.search("brown fox", limit=10)
+
+    start = time.perf_counter()
+    for _ in range(1000):
+        coll.search("brown fox", limit=10)
+    elapsed = time.perf_counter() - start
+
+    coll.close()
+    print(f"\n1000 searches on 1k docs: {elapsed:.3f}s")

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,35 @@
+"""Thread-safety tests for Collection / FTSIndex.
+
+Per issue #519: verifies the per-thread connection model. These tests MUST
+pass on Python 3.11, 3.12, 3.13, and 3.14 (run via tox; see tox.ini).
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+def test_conn_is_per_thread(tmp_collection):
+    """index._conn() returns a different Connection object per thread.
+
+    Same thread → same connection (identity). Different threads → different
+    connections. This is the load-bearing invariant of the per-thread
+    connection model.
+    """
+    fts = tmp_collection._fts  # FTSIndex instance
+    main_conn_1 = fts._conn()
+    main_conn_2 = fts._conn()
+    assert main_conn_1 is main_conn_2, "same thread should reuse one connection"
+
+    captured: dict[str, object] = {}
+
+    def worker() -> None:
+        captured["worker_conn"] = fts._conn()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert captured["worker_conn"] is not main_conn_1, (
+        "worker thread should get a distinct connection"
+    )

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -8,21 +8,14 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+from typing import Any
 
 import pytest
 
 
 @pytest.fixture
 def multi_thread_collection(tmp_collection_path):
-    """Tempfile-backed Collection for tests that exercise cross-thread access.
-
-    Use this fixture (NOT the default :memory: fixtures) for any test
-    that opens FTSIndex connections from multiple threads. SQLite
-    :memory: databases are connection-scoped: each per-thread connection
-    sees a fresh, EMPTY database. This fixture forces a file-backed DB
-    so all per-thread connections see the same data. See issue #519
-    design spec.
-    """
+    """Tempfile-backed Collection for multi-thread tests (:memory: is per-connection; issue #519)."""
     from markdown_vault_mcp.collection import Collection
 
     coll = Collection(
@@ -39,18 +32,13 @@ def multi_thread_collection(tmp_collection_path):
 
 
 def test_conn_is_per_thread(tmp_collection):
-    """index._conn() returns a different Connection object per thread.
-
-    Same thread → same connection (identity). Different threads → different
-    connections. This is the load-bearing invariant of the per-thread
-    connection model.
-    """
+    """_conn() returns identical connection within a thread, distinct across threads."""
     fts = tmp_collection._fts  # FTSIndex instance
     main_conn_1 = fts._conn()
     main_conn_2 = fts._conn()
     assert main_conn_1 is main_conn_2, "same thread should reuse one connection"
 
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     def worker() -> None:
         captured["worker_conn"] = fts._conn()
@@ -82,14 +70,9 @@ def test_registry_tracks_per_thread_connections(tmp_collection):
 
 
 def test_pragmas_applied_per_connection(multi_thread_collection):
-    """Worker-thread connections see foreign_keys, busy_timeout, synchronous,
-    AND the persisted WAL journal mode (without re-applying it).
-
-    Uses the file-backed fixture because :memory: DBs skip WAL by design
-    (SQLite emits a noisy warning and falls back to ``memory`` journal).
-    """
+    """Worker-thread connections see foreign_keys, busy_timeout, synchronous, and persisted WAL."""
     fts = multi_thread_collection._fts
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     def worker() -> None:
         conn = fts._conn()
@@ -109,12 +92,7 @@ def test_pragmas_applied_per_connection(multi_thread_collection):
 
 
 def test_migrations_dont_rerun_on_per_thread_open(tmp_collection):
-    """sqlite3 trace callback on a worker-thread connection sees no ALTER TABLE.
-
-    Schema DDL runs once on the constructing thread; per-thread opens
-    apply pragmas only. Catches accidental re-introduction of migration
-    logic into the per-thread open path.
-    """
+    """Per-thread open applies pragmas only — no ALTER/CREATE TABLE on worker connections."""
     fts = tmp_collection._fts
     traced: list[str] = []
 
@@ -176,13 +154,7 @@ def test_close_is_idempotent(tmp_collection_path):
 
 
 def test_concurrent_build_and_reads_pr518_pattern(multi_thread_collection):
-    """Background thread builds index repeatedly while main thread does mixed ops.
-
-    Acceptance criterion for issue #519. Reproduces the exact failure
-    pattern from PR #518 (sqlite3.OperationalError / InterfaceError on
-    Python 3.12+ from cross-thread connection sharing). Must pass on
-    3.11, 3.12, 3.13, and 3.14 (see tox.ini).
-    """
+    """PR #518 failure pattern: background reindex + main thread mixed ops, no errors (issue #519)."""
     coll = multi_thread_collection
     errors: list[BaseException] = []
     stop = threading.Event()

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -160,6 +160,32 @@ def test_close_is_idempotent(tmp_collection_path):
     coll.close()  # must not raise
 
 
+def test_closed_index_rejects_new_thread_access(tmp_collection_path):
+    """After close(), _conn() from a NEW thread raises ProgrammingError (issue #519)."""
+    from markdown_vault_mcp.collection import Collection
+
+    coll = Collection(source_dir=tmp_collection_path)
+    coll.build_index()
+    coll.close()
+
+    error: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            coll._fts._conn()
+        except BaseException as exc:
+            error.append(exc)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert len(error) == 1, "worker should have raised exactly one exception"
+    assert isinstance(error[0], sqlite3.ProgrammingError), (
+        f"expected ProgrammingError, got {type(error[0]).__name__}: {error[0]}"
+    )
+
+
 def test_concurrent_build_and_reads_pr518_pattern(multi_thread_collection):
     """PR #518 failure pattern: background reindex + main thread mixed ops, no errors (issue #519)."""
     coll = multi_thread_collection

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -15,7 +15,7 @@ import pytest
 
 @pytest.fixture
 def multi_thread_collection(tmp_collection_path):
-    """Tempfile-backed Collection for multi-thread tests (:memory: is per-connection; issue #519)."""
+    """File-backed Collection with seed docs (WAL pragma requires file DB; issue #519)."""
     from markdown_vault_mcp.collection import Collection
 
     coll = Collection(
@@ -91,28 +91,35 @@ def test_pragmas_applied_per_connection(multi_thread_collection):
     assert captured["journal_mode"].lower() == "wal", "WAL must persist across opens"
 
 
-def test_migrations_dont_rerun_on_per_thread_open(tmp_collection):
-    """Per-thread open applies pragmas only — no ALTER/CREATE TABLE on worker connections."""
-    fts = tmp_collection._fts
-    traced: list[str] = []
+def test_init_schema_runs_once_across_all_threads(tmp_collection_path):
+    """`_init_schema` is called exactly once (primary connection); per-thread opens skip it (issue #519)."""
+    from unittest.mock import patch
 
-    def worker() -> None:
-        conn = fts._conn()
-        conn.set_trace_callback(traced.append)
-        conn.execute("SELECT 1").fetchone()
-        conn.set_trace_callback(None)
+    from markdown_vault_mcp import fts_index as fts_module
+    from markdown_vault_mcp.collection import Collection
 
-    t = threading.Thread(target=worker)
-    t.start()
-    t.join()
+    original = fts_module._init_schema
+    with patch.object(fts_module, "_init_schema", wraps=original) as spy:
+        coll = Collection(source_dir=tmp_collection_path)
+        coll.build_index()
+        fts = coll._fts
 
-    for stmt in traced:
-        assert "ALTER TABLE" not in stmt.upper(), (
-            f"per-thread open must not re-run migrations; saw: {stmt!r}"
+        def worker() -> None:
+            fts._conn()
+
+        threads = [threading.Thread(target=worker) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Primary connection ran schema once at __init__; worker threads must not.
+        assert spy.call_count == 1, (
+            f"_init_schema must run exactly once across all threads; "
+            f"got {spy.call_count} calls (worker threads re-ran schema)"
         )
-        assert "CREATE TABLE" not in stmt.upper(), (
-            f"per-thread open must not re-run schema; saw: {stmt!r}"
-        )
+
+    coll.close()
 
 
 def test_close_closes_all_per_thread_connections(tmp_collection_path):

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -6,7 +6,36 @@ pass on Python 3.11, 3.12, 3.13, and 3.14 (run via tox; see tox.ini).
 
 from __future__ import annotations
 
+import sqlite3
 import threading
+
+import pytest
+
+
+@pytest.fixture
+def multi_thread_collection(tmp_collection_path):
+    """Tempfile-backed Collection for tests that exercise cross-thread access.
+
+    Use this fixture (NOT the default :memory: fixtures) for any test
+    that opens FTSIndex connections from multiple threads. SQLite
+    :memory: databases are connection-scoped: each per-thread connection
+    sees a fresh, EMPTY database. This fixture forces a file-backed DB
+    so all per-thread connections see the same data. See issue #519
+    design spec.
+    """
+    from markdown_vault_mcp.collection import Collection
+
+    coll = Collection(
+        source_dir=tmp_collection_path,
+        index_path=tmp_collection_path.parent / "index.db",
+        read_only=False,
+    )
+    coll.build_index()
+    for i in range(5):
+        (tmp_collection_path / f"seed_{i}.md").write_text(f"# Seed {i}\n\nbody {i}\n")
+    coll.reindex()
+    yield coll
+    coll.close()
 
 
 def test_conn_is_per_thread(tmp_collection):
@@ -33,3 +62,191 @@ def test_conn_is_per_thread(tmp_collection):
     assert captured["worker_conn"] is not main_conn_1, (
         "worker thread should get a distinct connection"
     )
+
+
+def test_registry_tracks_per_thread_connections(tmp_collection):
+    """_all_conns contains one entry per thread that touched _conn()."""
+    fts = tmp_collection._fts
+    initial = len(fts._all_conns)
+
+    def worker() -> None:
+        fts._conn()
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(fts._all_conns) == initial + 3
+
+
+def test_pragmas_applied_per_connection(multi_thread_collection):
+    """Worker-thread connections see foreign_keys, busy_timeout, synchronous,
+    AND the persisted WAL journal mode (without re-applying it).
+
+    Uses the file-backed fixture because :memory: DBs skip WAL by design
+    (SQLite emits a noisy warning and falls back to ``memory`` journal).
+    """
+    fts = multi_thread_collection._fts
+    captured: dict[str, object] = {}
+
+    def worker() -> None:
+        conn = fts._conn()
+        captured["foreign_keys"] = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+        captured["busy_timeout"] = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        captured["synchronous"] = conn.execute("PRAGMA synchronous").fetchone()[0]
+        captured["journal_mode"] = conn.execute("PRAGMA journal_mode").fetchone()[0]
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert captured["foreign_keys"] == 1, "foreign_keys must be ON"
+    assert captured["busy_timeout"] == 5000, "busy_timeout must be 5000ms"
+    assert captured["synchronous"] == 1, "synchronous must be NORMAL (1)"
+    assert captured["journal_mode"].lower() == "wal", "WAL must persist across opens"
+
+
+def test_migrations_dont_rerun_on_per_thread_open(tmp_collection):
+    """sqlite3 trace callback on a worker-thread connection sees no ALTER TABLE.
+
+    Schema DDL runs once on the constructing thread; per-thread opens
+    apply pragmas only. Catches accidental re-introduction of migration
+    logic into the per-thread open path.
+    """
+    fts = tmp_collection._fts
+    traced: list[str] = []
+
+    def worker() -> None:
+        conn = fts._conn()
+        conn.set_trace_callback(traced.append)
+        conn.execute("SELECT 1").fetchone()
+        conn.set_trace_callback(None)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    for stmt in traced:
+        assert "ALTER TABLE" not in stmt.upper(), (
+            f"per-thread open must not re-run migrations; saw: {stmt!r}"
+        )
+        assert "CREATE TABLE" not in stmt.upper(), (
+            f"per-thread open must not re-run schema; saw: {stmt!r}"
+        )
+
+
+def test_close_closes_all_per_thread_connections(tmp_collection_path):
+    """After close(), every per-thread connection raises on next op."""
+    from markdown_vault_mcp.collection import Collection
+
+    coll = Collection(source_dir=tmp_collection_path)
+    coll.build_index()
+    fts = coll._fts
+
+    captured: dict[str, sqlite3.Connection] = {}
+
+    def worker() -> None:
+        captured["worker_conn"] = fts._conn()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    main_conn = fts._conn()
+    coll.close()
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        main_conn.execute("SELECT 1")
+    with pytest.raises(sqlite3.ProgrammingError):
+        captured["worker_conn"].execute("SELECT 1")
+
+    assert fts._all_conns == []
+
+
+def test_close_is_idempotent(tmp_collection_path):
+    """Calling close() twice is safe."""
+    from markdown_vault_mcp.collection import Collection
+
+    coll = Collection(source_dir=tmp_collection_path)
+    coll.build_index()
+    coll.close()
+    coll.close()  # must not raise
+
+
+def test_concurrent_build_and_reads_pr518_pattern(multi_thread_collection):
+    """Background thread builds index repeatedly while main thread does mixed ops.
+
+    Acceptance criterion for issue #519. Reproduces the exact failure
+    pattern from PR #518 (sqlite3.OperationalError / InterfaceError on
+    Python 3.12+ from cross-thread connection sharing). Must pass on
+    3.11, 3.12, 3.13, and 3.14 (see tox.ini).
+    """
+    coll = multi_thread_collection
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def background_indexer() -> None:
+        try:
+            for _ in range(10):
+                if stop.is_set():
+                    return
+                coll.reindex()
+        except BaseException as exc:
+            errors.append(exc)
+
+    def main_thread_ops() -> None:
+        try:
+            for i in range(100):
+                coll.search("seed", limit=5)
+                coll.list()
+                if i % 10 == 0:
+                    path = f"main_{i}.md"
+                    coll.write(path, f"# main {i}\n\ncontent\n")
+                if i % 20 == 10 and i > 10:
+                    # Edit a path we wrote earlier this run.
+                    coll.edit(
+                        f"main_{i - 10}.md",
+                        old_text="content",
+                        new_text=f"content {i}",
+                    )
+        except BaseException as exc:
+            errors.append(exc)
+
+    t_bg = threading.Thread(target=background_indexer)
+    t_main = threading.Thread(target=main_thread_ops)
+    t_bg.start()
+    t_main.start()
+    t_main.join(timeout=60)
+    stop.set()
+    t_bg.join(timeout=30)
+
+    assert not t_bg.is_alive(), "background indexer thread did not terminate"
+    assert not t_main.is_alive(), "main-ops thread did not terminate"
+    assert errors == [], f"concurrent ops raised errors: {errors}"
+
+
+def test_concurrent_writers_serialize_via_write_lock(multi_thread_collection):
+    """Two worker threads writing distinct paths concurrently — no losses, no errors."""
+    coll = multi_thread_collection
+    errors: list[BaseException] = []
+
+    def writer(prefix: str, n: int) -> None:
+        try:
+            for i in range(n):
+                coll.write(f"{prefix}_{i}.md", f"# {prefix} {i}\n\nbody\n")
+        except BaseException as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=writer, args=("a", 20))
+    t2 = threading.Thread(target=writer, args=("b", 20))
+    t1.start()
+    t2.start()
+    t1.join(timeout=60)
+    t2.join(timeout=60)
+
+    assert errors == [], f"concurrent writes raised: {errors}"
+    docs = {d.path for d in coll.list()}
+    expected = {f"a_{i}.md" for i in range(20)} | {f"b_{i}.md" for i in range(20)}
+    assert expected.issubset(docs), f"missing writes: {expected - docs}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+requires =
+    tox>=4.0
+    tox-uv>=1.0
+envlist = py311, py312, py313
+isolated_build = true
+
+[testenv]
+description = Run the full test suite on a specific Python version
+runner = uv-venv-lock-runner
+allowlist_externals = uv
+extras = all
+dependency_groups = dev
+commands =
+    pytest -x -q -m "not benchmark" {posargs}
+
+[testenv:py314]
+description = Python 3.14 — may not be GA at run time; allowed to fail
+ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,12 @@
 requires =
     tox>=4.0
     tox-uv>=1.0
-envlist = py311, py312, py313
+envlist = py311, py312, py313, py314
 isolated_build = true
 
 [testenv]
 description = Run the full test suite on a specific Python version
 runner = uv-venv-lock-runner
-allowlist_externals = uv
 extras = all
 dependency_groups = dev
 commands =

--- a/uv.lock
+++ b/uv.lock
@@ -1247,6 +1247,8 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "tox" },
+    { name = "tox-uv" },
 ]
 docs = [
     { name = "mkdocs-llmstxt" },
@@ -1283,6 +1285,8 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.21" },
     { name = "pytest-cov", specifier = ">=4.0" },
     { name = "ruff", specifier = ">=0.1" },
+    { name = "tox", specifier = ">=4.0" },
+    { name = "tox-uv", specifier = ">=1.0" },
 ]
 docs = [
     { name = "mkdocs-llmstxt", specifier = ">=0.5" },
@@ -2454,6 +2458,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyproject-api"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/7b/c0e1333b61d41c69e59e5366e727b18c4992688caf0de1be10b3e5265f6b/pyproject_api-1.10.0.tar.gz", hash = "sha256:40c6f2d82eebdc4afee61c773ed208c04c19db4c4a60d97f8d7be3ebc0bbb330", size = 22785, upload-time = "2025-10-09T19:12:27.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/cc/cecf97be298bee2b2a37dd360618c819a2a7fd95251d8e480c1f0eb88f3b/pyproject_api-1.10.0-py3-none-any.whl", hash = "sha256:8757c41a79c0f4ab71b99abed52b97ecf66bd20b04fa59da43b5840bac105a09", size = 13218, upload-time = "2025-10-09T19:12:24.428Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2510,15 +2526,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.1.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/67/09765eacf4e44413c4f8943ba5a317fcb9c7b447c3b8b0b7fce7e3090b0b/python_discovery-1.1.1.tar.gz", hash = "sha256:584c08b141c5b7029f206b4e8b78b1a1764b22121e21519b89dec56936e95b0a", size = 56016, upload-time = "2026-03-07T00:00:56.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/0f/2bf7e3b5a4a65f623cb820feb5793e243fad58ae561015ee15a6152f67a2/python_discovery-1.1.1-py3-none-any.whl", hash = "sha256:69f11073fa2392251e405d4e847d60ffffd25fd762a0dc4d1a7d6b9c3f79f1a3", size = 30732, upload-time = "2026-03-07T00:00:55.143Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
 ]
 
 [[package]]
@@ -3011,6 +3027,52 @@ wheels = [
 ]
 
 [[package]]
+name = "tox"
+version = "4.54.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "colorama" },
+    { name = "filelock" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pluggy" },
+    { name = "pyproject-api" },
+    { name = "python-discovery" },
+    { name = "tomli-w" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/2c/7ca5edb5ecd6bcc5cc926fe87e62a84dcd3cbd03a32f9d0bee98d2bee7cf/tox-4.54.0.tar.gz", hash = "sha256:21e36fd8256590379620848d0b03b52f4d541b65b749de1a17c3e616978dad58", size = 279256, upload-time = "2026-05-12T19:13:05.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/18/20cf56a76c5d6117547179db9b5d31cc56e3e90507d1b0b748da74aa95c5/tox-4.54.0-py3-none-any.whl", hash = "sha256:a2d7c1177242ae9c3d9e404039e9f945ce16a3e5dfc66972c643e27d7e764f4b", size = 214527, upload-time = "2026-05-12T19:13:04.334Z" },
+]
+
+[[package]]
+name = "tox-uv"
+version = "1.35.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tox-uv-bare" },
+    { name = "uv" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/dc/6e9994c799bdbb309f829dd6b8d98764dd0757302f3433c380438a3a127b/tox_uv-1.35.2-py3-none-any.whl", hash = "sha256:2d99b0e3c782ba49e7cbe521c8d344758595961b17a3633738d67096641c1bde", size = 6565, upload-time = "2026-05-05T01:34:16.07Z" },
+]
+
+[[package]]
+name = "tox-uv-bare"
+version = "1.35.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tox" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/cb/168dc1ccf24e4065a9a0a33df55709ed2b5eb73bd2b13ddd53187e5dffb8/tox_uv_bare-1.35.2.tar.gz", hash = "sha256:49e28a804c97f23ea17e25859960c0fa78f35bccb7e14344cfd840e89a9aade9", size = 32333, upload-time = "2026-05-05T01:34:18.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/4a33dc81da39db7b31e5622333df361e8fe055b7ec636bd5fea762c9182d/tox_uv_bare-1.35.2-py3-none-any.whl", hash = "sha256:c0d590a41d1054a1ad0874e9e5943ff52402786e3d4599d8f8d37a65b566ef53", size = 22307, upload-time = "2026-05-05T01:34:17.681Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3074,6 +3136,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/99/025154611a4bd97a23851574c15d73bb71ada09d35f092d6972f9ac87f70/uv-0.11.16.tar.gz", hash = "sha256:4b435fcb0af8f34833dcc1903a8a223856437efd0d515c2160a2871def221238", size = 4177038, upload-time = "2026-05-21T22:10:01.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e3/8b8cfc802bc476c67e31a39725538193265cf3a19585b4a60c232659f919/uv-0.11.16-py3-none-linux_armv6l.whl", hash = "sha256:c9e9d9cb73ee8cd2ad696dbf1bc3232abaac363270557684b6b85a2bdb8eb276", size = 23508087, upload-time = "2026-05-21T22:10:06.227Z" },
+    { url = "https://files.pythonhosted.org/packages/45/78/d5ca91c636ac88e902b6b3ff31ad32d2d02663232d844aff871467a323d2/uv-0.11.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:01172238a75e42a5a55d12555cd9ec98bee24249f3645b98a4b32eb5f1ff5e43", size = 23028989, upload-time = "2026-05-21T22:09:50.127Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/26/c84580dfec5a87c36fb1218eac17c5194fa3e58e2a9232cf085d69eb6bed/uv-0.11.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c75f9b5bac49b97131973910c220feac60fe47b10a333941b237ff0ae4b36721", size = 21572023, upload-time = "2026-05-21T22:09:58.703Z" },
+    { url = "https://files.pythonhosted.org/packages/84/68/ba2bdc64fea96ef8c9796a991f244541b65bb9d31c661b322cc724857a4e/uv-0.11.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a801484f4507b6c2133e557350f3143b61b8f8b61dddb01ff7b84a74cdfab1fb", size = 23289936, upload-time = "2026-05-21T22:10:15.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/81/74922f693d5804a77d009338ca8dc709eff871fb60d9f2c263dede8d77d1/uv-0.11.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:eb538069e768b042cf870be700a210518ce628e36d99d9a83b85acaf484d7f6a", size = 23020906, upload-time = "2026-05-21T22:10:24.242Z" },
+    { url = "https://files.pythonhosted.org/packages/60/81/cda8886f5df4dd28854a9b97bcc3ee6a7d1b5b5b23aaaccfbf1ed3e5e2bf/uv-0.11.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d7cdb23457a4d1bc76bf1016638ea1d1ada0e8e032f656168e933d4d17c47e72", size = 23004220, upload-time = "2026-05-21T22:10:32.847Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/65837e07de23f0a40ab860bc6601f7c022d4bcf4b97ca79b6c35a2e72e65/uv-0.11.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:451327388d59ac3041cbda474296f3ceeafac5b1f645476198e7b95f504fcfd5", size = 24319651, upload-time = "2026-05-21T22:10:21.492Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/9d364542bf118433b60ed71422e47d2c8c470aca7d3aef0df9449a5f726a/uv-0.11.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e7992b8276149b3ffaf35ce9434702d3e16bae6ec393e99df209b870a7e19eb0", size = 25359517, upload-time = "2026-05-21T22:09:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b4/650896e8cff5a3289cee860c41fd9876da83ca628c5871f9a61d5fc75c72/uv-0.11.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:83a8db9b3314d900e7a240105afce43f806c9e04c59ea10a40bdbdca84c6d0c5", size = 24563421, upload-time = "2026-05-21T22:10:35.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7d/184711a8c02466e1486d57efdc9394ce09cbf43ee2c5794da70bd25db3fb/uv-0.11.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b10086165189c39c53142a0e2f34e0b8889ef681886f589ed17be45a1a774c7", size = 24676607, upload-time = "2026-05-21T22:10:39.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/3f/5b338df6505f77f73c20eae38cb29f57d14dba56dac835386e3dc6e2a5d6/uv-0.11.16-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:cfe1f06fb8f135a735a961065d5ee90f99cccf41749fb1f964edb5b3c3dae19b", size = 23401615, upload-time = "2026-05-21T22:10:30.124Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f9/54bbcbc77443dc76468f09a49cc9f4f92ca49b4159a011c6010d223de4ea/uv-0.11.16-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:2454f80d8b548fb2e246151578809b14ad4395b3f357d738bae1af11918e91af", size = 24104468, upload-time = "2026-05-21T22:09:53.323Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0a/b5f105514fddea5110fe3947cd18a9f199ff93dbad78e5e5a08e1b5d0ea2/uv-0.11.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:4249d57a563165d368050680deeb722f9c0053a0dbf3244b11cca3e6d85a3c7d", size = 24164861, upload-time = "2026-05-21T22:10:09.458Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/01/15d4ca2be7257862b077a9077ac31ce81c419f35ef7994e76356a317716b/uv-0.11.16-py3-none-musllinux_1_1_i686.whl", hash = "sha256:374c30126483ce95675c5de49e54c2454ddedb01c17b8321417fe4eb9da83406", size = 23644919, upload-time = "2026-05-21T22:10:03.129Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bf/9de3e262e6ff93aec2e0a4c238857293fd2c616dd79f25bb440f126bf32c/uv-0.11.16-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:746edfc9d1d8cd03dd58739989f634d3580648048d09f81a9c68da74c4eb9d62", size = 24973746, upload-time = "2026-05-21T22:10:18.413Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/7d/f4126dce104f1b5d0b451ce3ca41c4db69b963c2e78c3465fcda6440de31/uv-0.11.16-py3-none-win32.whl", hash = "sha256:50299b20aab2d28c05ff27d781ce2af3f5af2102bc304dc07a4ad54b05e2af8a", size = 22400991, upload-time = "2026-05-21T22:10:27.119Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/38/99627cb995a03389b227ce4b12b08e770565d0aa7850cd0420973194a638/uv-0.11.16-py3-none-win_amd64.whl", hash = "sha256:e901aafa5007beffafe57bfa44e5e248d99fb5d97036a3718fd65cf9723c5cd3", size = 25067163, upload-time = "2026-05-21T22:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/68/3ed1c0bdfb4bec501e5cde73419b4f39c8a125ef905a85fc0f239f19eb9b/uv-0.11.16-py3-none-win_arm64.whl", hash = "sha256:d777cb29661cdfa7f90dae77406c85fb5b729bf8bc13941dc237958a1ea1ba00", size = 23502015, upload-time = "2026-05-21T22:09:56.014Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Refactors `FTSIndex` to per-thread `sqlite3.Connection` objects via `threading.local` + side registry for deterministic cleanup. Closes #519, prerequisite for #513.
- Splits `_open_connection` into `_init_schema` (once, constructing thread) + `_apply_pragmas` (every open).
- Adds `PRAGMA busy_timeout = 5000` and `PRAGMA synchronous = NORMAL` on every connection (WAL + multi-thread best practice; see [verified-baseline comment on #519](https://github.com/pvliesdonk/markdown-vault-mcp/issues/519#issuecomment-4554038489) for the SQLite/Python docs sourcing).
- Keeps `check_same_thread=False` (current value) — TLS routing is the safety mechanism; the C-level flag would break cross-thread `close()`.
- `:memory:` is transparently mapped to a unique shared-cache URI per `FTSIndex` instance so per-thread connections see the same DB. Required because `:memory:` is the production default when `INDEX_PATH` is unset, and the MCP server's `asyncio.to_thread` dispatch routinely crosses thread boundaries.
- Adds `tox` + `tox-uv` for local Python 3.11–3.14 matrix testing, running the FULL suite per env (not just the new test file — restricting scope recreates PR #518's trap).
- New `tests/test_thread_safety.py` (9 tests): per-thread identity, registry tracking, pragmas + WAL persistence, no-rerun migrations, close + idempotency, PR #518's failure-pattern integration test, concurrent writers, 1k-search benchmark (marker-gated).
- Documents the thread-safety contract in `docs/design.md` (new H2 section), `Collection` + `FTSIndex` class docstrings, and `IndexManager.build_index`/`reindex` docstrings.

Four prior PRs (#510, #515, #516, #518) failed at #513 because they layered concurrency above this non-thread-safe domain object. This PR fixes the foundation; #513 can be re-attempted on top.

## Test plan

- [x] Full suite passes on Python 3.11 locally (`uv run pytest -x -q`): 1601 passed, 1 skipped
- [x] Full suite passes on Python 3.12 (`uv run tox -e py312`) — the version PR #518 failed on: 1601 passed, 1 skipped
- [x] Full suite passes on Python 3.13 (`uv run tox -e py313`): 1602 passed
- [x] Full suite passes on Python 3.14 (`uv run tox -e py314`): 1602 passed (3.14.5 via uv)
- [x] `tests/test_thread_safety.py` covers per-thread identity, registry tracking, pragma application incl. WAL persistence, no-rerun-of-migrations, cross-thread close + idempotency, PR #518's failure pattern, concurrent writers
- [x] `pytest -m benchmark`: 1000-search/1k-doc benchmark — ratio 1.007 vs main (median of 3 runs; well under the 10% gate)
- [x] `mypy src/ tests/` clean (81 source files)
- [x] `ruff check`/`ruff format` clean
- [x] `diff-cover` 94% patch coverage on changed lines (≥80% gate)
- [x] `preflight-circus` (local five-lens review + 4 supplementary lenses): CLEAN at confidence ≥80

## Documentation

- `docs/design.md` — new "Collection thread-safety contract" section with subsections (Why per-thread, Connection lifecycle, Why `check_same_thread=False`, Concurrent writers, In-memory databases).
- `Collection` class docstring — Thread-safety section listing read/write method semantics, close safety, per-method (not per-operation) atomicity, no fork support.
- `FTSIndex` class docstring — Thread-safety section + updated `:memory:` note reflecting the shared-cache URI translation.
- `IndexManager.build_index` / `reindex` — one-line cross-thread safety notes (build_index does NOT acquire `_write_lock`; reindex does, for the mutation phase only).

## Spec

Local-only design spec (gitignored at `docs/superpowers/specs/`) drove this work. The public anchor for rationale is issue #519's [verified-baseline comment](https://github.com/pvliesdonk/markdown-vault-mcp/issues/519#issuecomment-4554038489) summarising the official SQLite / Python sqlite3 docs sourcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)