### PR TITLE
docs(claude): drop bot-reviewer merge-gate language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,12 +51,12 @@ This project is extracted from [`pvliesdonk/if-craft-corpus`](https://github.com
 
 ## Hard PR Acceptance Gates
 
-Every PR must pass **all** of the following before merge. Do not open or push a PR until these are green locally:
+Every PR must pass **all** of the following locally before push. These are mechanical preconditions:
 
-1. **CI passes** — `uv run pytest -x -q` all tests pass
+1. **Tests pass** — `uv run pytest -x -q` all tests pass
 2. **Lint passes** — run in this exact order: `uv run ruff check --fix .` then `uv run ruff format .` then verify with `uv run ruff format --check .`. Always run format *after* check --fix because check --fix can leave files needing reformatting.
 3. **Type-check passes** — `uv run mypy src/ tests/` reports no errors
-4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
+4. **Patch coverage ≥ 80%** — Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
 5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
 6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically, but if you manually touch any of them, update all three.
 
@@ -75,17 +75,6 @@ The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, ya
 **Every PR must have at least one associated issue.** If the work doesn't have one yet — a bug found in the wild, an opportunistic cleanup, a small improvement — create the issue first, then open the PR with `Closes #N` (or `Refs #N`) in the body. A single PR may close multiple issues (`Closes #A, closes #B`) — bundling related fixes is fine; the rule is "no orphan PRs", not "one PR per issue". This keeps the changelog, release notes, and cross-repo history coherent.
 
 Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
-
-**Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
-
-## GitHub Review Types
-
-GitHub has two distinct review mechanisms — **both must be read and addressed**:
-
-- **Inline review comments** (`get_review_comments`): attached to specific lines of the diff. Appear in the "Files changed" tab. Use `get_review_comments` to fetch these.
-- **PR-level comments** (`get_comments`): posted on the Conversation tab, not tied to a line. Review summary posts, bot analysis, and blocking issues are often posted here. Use `get_comments` to fetch these.
-
-Always fetch both before declaring a review round complete.
 
 ## Documentation Discipline
 
@@ -199,7 +188,7 @@ subsequent template updates.
 Shared infrastructure (auth providers, middleware stack, logging bootstrap, event store factory, CLI scaffolding, release pipeline, Docker entrypoint, nfpm packaging, mcpb bundle) lives upstream in two places:
 
 - [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, MCP File Exchange (`register_file_exchange` + `register_file_exchange_upload`), and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
-- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, `.gemini/config.yaml` (gemini-code-assist scope control), and this very section of CLAUDE.md.
+- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, and this very section of CLAUDE.md.
 
 Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `README.md`, `CHANGELOG.md`, `LICENSE`, `.env.example`) are written once and require manual reconciliation on template updates — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` and `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels) stays in this repo.
 


### PR DESCRIPTION
## Summary
- Reframes 'Hard PR Acceptance Gates' as mechanical pre-push preconditions (was: 'before merge / CI passes').
- Removes the 'Bot reviewers are merge gates' clause from PR Discipline.
- Drops the 'GitHub Review Types' section entirely.
- Drops the gemini-code-assist / `.gemini/config.yaml` mention from the Shared Infrastructure section.

Mirrors the global `~/.claude/CLAUDE.md` shift to TDD-first discipline (no review-gate infrastructure).

## Test plan
- [x] Doc-only change — no code, no tests.
- [x] Pre-commit hooks green.

Closes #521