### PR TITLE
feat(fts): per-thread SQLite connections for thread-safe Collection (#519)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -434,6 +434,64 @@ The contract is:
   itself call write methods on the same Collection instance (deadlock).
 - Callbacks must not raise; exceptions are logged and swallowed.
 
+#### Collection thread-safety contract (issue #519)
+
+Every public method on `Collection`, `FTSIndex`, and the managers is safe
+to call from any thread, concurrently with calls on any other thread.
+This is the contract that issue #513 (non-blocking MCP initialize via
+background indexing) depends on; PRs #510, #515, #516, #518 all failed
+because the single-connection model violated it on Python 3.12+.
+
+The mechanism is **per-thread `sqlite3.Connection` instances** managed by
+`FTSIndex`:
+
+- Each thread that touches the index opens its own connection on first
+  call, via `_conn()` (which routes through `threading.local`).
+- A side registry (`_all_conns: list[sqlite3.Connection]`, guarded by
+  `_reg_lock`) holds strong references to every opened connection so
+  `close()` can close all of them — including those opened by threads
+  that have since exited. `check_same_thread=False` is set on every
+  connection so `close()` can iterate cross-thread.
+- The constructing thread is special only in that it runs schema/migrations
+  exactly once and applies WAL (a DB-header pragma) for file-backed DBs.
+  Per-thread opens apply only per-connection pragmas (`foreign_keys=ON`,
+  `busy_timeout=5000`, `synchronous=NORMAL`) — **pragmas apply BEFORE
+  schema/migrations** so `busy_timeout` is active during `ALTER TABLE`.
+- `_closed: bool` uses double-checked locking: the fast path is lock-free;
+  the slow path re-checks under `_reg_lock` so a concurrent `close()`
+  cannot race with a new-thread connection open.
+- Slow-path open + pragma + register is wrapped in `except BaseException`
+  so `KeyboardInterrupt` / `SystemExit` / `asyncio.CancelledError` during
+  interpreter teardown cannot leak the half-initialized connection.
+- `_primary_conn` is a strong instance attribute (alongside
+  `self._local.conn`) so the primary connection survives the constructing
+  thread's exit; the registry-based `close()` then still closes it.
+- `:memory:` databases are translated to a unique-per-instance shared-cache
+  URI (`file:fts_<uuid4hex>?mode=memory&cache=shared`) so every per-thread
+  open joins the same in-memory DB. A startup probe opens a second
+  connection to the URI and raises `RuntimeError` with an operator-actionable
+  message if `SQLITE_ENABLE_SHARED_CACHE` is unavailable.
+
+Dead-thread connections accumulate in `_all_conns` until `close()`. This
+is bounded for the MCP server's threading model (long-lived lifespan
+thread + bounded `asyncio.to_thread` pool of ~30 recycled workers) and
+is preferred over the `weakref` approach that introduced a 3-finding
+cascade in PR #520 (see project-memory file
+`feedback_519_weakref_whackamole.md`).
+
+Cursors never escape the method that created them — verified by audit
+during the #519 design. Each `with self._conn():` block emits one
+BEGIN/COMMIT pair; no nested `with conn:` exists in the current code, so
+Python 3.12's implicit-transaction wrapper is never re-entered.
+
+Acceptance evidence: `tests/test_thread_safety.py` exercises per-thread
+identity, pragma application, pragmas-before-schema ordering, single
+schema run, close-closes-all, idempotent close, post-close rejection,
+close/open race safety, strong-ref retention across thread+gc, shared-cache
+`:memory:`, concurrent writers via `_write_lock`, and the PR #518 failure
+pattern (background `build_index(force=True)` interleaved with main-thread
+`read/search/write/edit`).
+
 #### Optimistic Concurrency (`if_match`)
 
 All five write methods (`write()`, `edit()`, `delete()`, `rename()`,

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -89,6 +89,17 @@ class Collection:
     Instantiate once per collection root.  Call :meth:`build_index` (or let
     lazy initialisation handle it) before querying.
 
+    **Thread safety (issue #519):** every public method on this class is safe
+    to call from any thread, concurrently with other reads and writes from
+    any other thread. Writes serialise against each other via the internal
+    ``_write_lock`` (RLock). ``close()`` is safe from any thread; after
+    ``close()`` the collection must not be used. Cross-method atomicity
+    (e.g. read-then-write without intervening concurrent write) is the
+    caller's responsibility — pass ``if_match=`` to write methods for
+    optimistic concurrency. ``fork()`` is not supported. See ``docs/design.md``
+    "Collection thread-safety contract" for the underlying per-thread
+    SQLite-connection model.
+
     Args:
         source_dir: Root directory of the markdown collection.
         index_path: Path to the SQLite index file.  ``None`` (default) uses

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -258,6 +258,11 @@ class FTSIndex:
                     "fts_index.__init__ cleanup: error closing primary",
                     exc_info=True,
                 )
+            # Mirror the _conn() slow-path TLS clear: if a partially-built
+            # FTSIndex's _local.conn still pointed at the now-closed primary,
+            # a caller holding the instance after __init__ raised would
+            # fast-path the closed conn instead of getting ProgrammingError.
+            self._local.conn = None
             self._all_conns.clear()
             self._primary_conn = None
             raise
@@ -417,7 +422,11 @@ class FTSIndex:
             # and the registry append would otherwise leave a closed conn in
             # TLS for the next fast-path call to silently return.
             self._local.conn = None
-            with contextlib.suppress(ValueError):
+            # Re-acquire _reg_lock for the registry mutation: a concurrent
+            # close() iterates _all_conns under the lock, so an unguarded
+            # remove() here could trigger "list changed size during iteration"
+            # in close().
+            with self._reg_lock, contextlib.suppress(ValueError):
                 self._all_conns.remove(new_conn)
             new_conn.close()
             raise

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -225,26 +225,41 @@ class FTSIndex:
         self._closed = False
         self._primary_conn: sqlite3.Connection | None = None
 
-        # Open primary connection on the constructing thread.
+        # Open primary connection on the constructing thread. The whole
+        # init-schema + probe sequence runs under one BaseException cleanup
+        # block so any failure (pragma, ALTER TABLE, or the shared-cache
+        # probe) closes the primary connection — symmetric with the
+        # slow-path cleanup in _conn().
         primary = self._connect()
         try:
             # PRAGMAS FIRST — busy_timeout must be active for ALTER TABLE migrations
             # in _init_schema (per #519 carryover).
             self._apply_pragmas(primary)
             self._init_schema(primary)
+            self._local.conn = primary
+            self._primary_conn = primary
+            self._all_conns.append(primary)
+            # Fail-fast probe: if shared-cache ``:memory:`` translation is in
+            # use but SQLITE_ENABLE_SHARED_CACHE was disabled at build time, a
+            # second connection to the URI will see an empty DB. Surface that
+            # immediately instead of letting per-thread reads fail mysteriously
+            # downstream.
+            if self._is_memory:
+                self._probe_shared_cache()
         except BaseException:
-            primary.close()
+            # Close the primary regardless of how far init progressed (the
+            # probe call may fail after append, leaving primary in
+            # _all_conns; reset both paths to a clean state).
+            try:
+                primary.close()
+            except Exception:
+                logger.debug(
+                    "fts_index.__init__ cleanup: error closing primary",
+                    exc_info=True,
+                )
+            self._all_conns.clear()
+            self._primary_conn = None
             raise
-        self._local.conn = primary
-        self._primary_conn = primary
-        self._all_conns.append(primary)
-
-        # Fail-fast probe: if shared-cache ``:memory:`` translation is in use
-        # but SQLITE_ENABLE_SHARED_CACHE was disabled at build time, a second
-        # connection to the URI will see an empty DB. Surface that immediately
-        # instead of letting per-thread reads fail mysteriously downstream.
-        if self._is_memory:
-            self._probe_shared_cache()
 
     def _connect(self) -> sqlite3.Connection:
         """Open a raw sqlite3 connection to this index's URI."""
@@ -338,6 +353,10 @@ class FTSIndex:
         would then fail with confusing OperationalErrors. Surface that
         condition immediately with an operator-actionable error.
         """
+        # The probe connection intentionally bypasses _all_conns: it is opened
+        # and closed entirely within this method before the FTSIndex instance
+        # is exposed to any caller, so the registry-based close() machinery is
+        # not needed for it.
         probe = self._connect()
         try:
             row = probe.execute(
@@ -350,7 +369,13 @@ class FTSIndex:
                     "path for db_path, or rebuild SQLite with shared-cache support."
                 )
         finally:
-            probe.close()
+            try:
+                probe.close()
+            except sqlite3.Error:
+                logger.debug(
+                    "fts_index._probe_shared_cache: probe.close failed",
+                    exc_info=True,
+                )
 
     def _conn(self) -> sqlite3.Connection:
         """Return this thread's sqlite3 connection, opening one on first touch.
@@ -657,8 +682,9 @@ class FTSIndex:
             Total number of chunks (sections) indexed.
         """
         total_chunks = 0
-        with self._conn():
-            cur = self._conn().cursor()
+        conn = self._conn()
+        with conn:
+            cur = conn.cursor()
             for note in notes:
                 folder = _derive_folder(note.path)
                 self._delete_document(cur, note.path)
@@ -689,8 +715,9 @@ class FTSIndex:
             Number of chunks (sections) indexed for this document.
         """
         folder = _derive_folder(note.path)
-        with self._conn():
-            cur = self._conn().cursor()
+        conn = self._conn()
+        with conn:
+            cur = conn.cursor()
             self._delete_document(cur, note.path)
             doc_id = self._insert_document(cur, note, folder)
             self._insert_sections(cur, doc_id, note)
@@ -711,8 +738,9 @@ class FTSIndex:
         Returns:
             Number of document rows deleted (0 if path was not indexed).
         """
-        with self._conn():
-            cur = self._conn().cursor()
+        conn = self._conn()
+        with conn:
+            cur = conn.cursor()
             deleted = self._delete_document(cur, path)
         if deleted:
             logger.debug("delete_by_path: removed %s", path)
@@ -976,8 +1004,7 @@ class FTSIndex:
         Returns:
             Integer count of all indexed chunks across all documents.
         """
-        row = self._conn().execute("SELECT COUNT(*) FROM sections").fetchone()
-        return row[0] if row else 0
+        return self._conn().execute("SELECT COUNT(*) FROM sections").fetchone()[0]
 
     def get_toc(self, path: str) -> list[dict[str, str | int]]:
         """Return headings for a document, ordered by position.
@@ -1189,10 +1216,9 @@ class FTSIndex:
             if new_path != row["target_path"]:
                 updates.append((new_path, row["id"]))
 
-        with self._conn():
-            self._conn().executemany(
-                "UPDATE links SET target_path = ? WHERE id = ?", updates
-            )
+        conn = self._conn()
+        with conn:
+            conn.executemany("UPDATE links SET target_path = ? WHERE id = ?", updates)
         updated = len(updates)
 
         if updated:
@@ -1608,21 +1634,32 @@ class FTSIndex:
     def close(self) -> None:
         """Close every per-thread connection and mark this index closed.
 
-        Idempotent: second call sees an empty registry and is a no-op. After
-        ``close()``, any thread calling a public method raises
-        ``sqlite3.ProgrammingError`` from ``_conn()``.
+        Idempotent: a second call finds an empty registry and performs no
+        connection closes. After ``close()``, any thread calling a public
+        method raises ``sqlite3.ProgrammingError`` from ``_conn()``.
         """
         with self._reg_lock:
             self._closed = True
-            for conn in self._all_conns:
-                try:
-                    conn.close()
-                except sqlite3.ProgrammingError:
-                    logger.debug("fts_index.close: connection already closed")
-                except sqlite3.Error:
-                    logger.error(
-                        "fts_index.close: error closing connection", exc_info=True
-                    )
-            self._all_conns.clear()
-            self._primary_conn = None
+            try:
+                for conn in self._all_conns:
+                    try:
+                        conn.close()
+                    except sqlite3.ProgrammingError:
+                        logger.debug("fts_index.close: connection already closed")
+                    except Exception:
+                        # Catch non-sqlite3.Error subclasses too (e.g. OSError
+                        # from underlying file handle, RuntimeError from C
+                        # wrappers) so the loop never exits mid-iteration and
+                        # leaves connections un-closed. KeyboardInterrupt /
+                        # SystemExit still propagate.
+                        logger.error(
+                            "fts_index.close: error closing connection",
+                            exc_info=True,
+                        )
+            finally:
+                # Ensure the registry is cleared even if a BaseException
+                # (KeyboardInterrupt / SystemExit) interrupts the loop, so a
+                # subsequent close() retry sees a clean state.
+                self._all_conns.clear()
+                self._primary_conn = None
         logger.debug("FTSIndex closed (db_path=%s)", self._db_path)

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import json
 import logging
@@ -411,6 +412,13 @@ class FTSIndex:
         except BaseException:
             # Cover KeyboardInterrupt / SystemExit / asyncio.CancelledError —
             # sqlite3.Error alone would leak the open connection on teardown.
+            # Clear the TLS slot first: CPython delivers signals at bytecode
+            # boundaries, so an interrupt between the _local.conn assignment
+            # and the registry append would otherwise leave a closed conn in
+            # TLS for the next fast-path call to silently return.
+            self._local.conn = None
+            with contextlib.suppress(ValueError):
+                self._all_conns.remove(new_conn)
             new_conn.close()
             raise
         return new_conn

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -34,10 +34,10 @@ def _json_default(obj: Any) -> str:
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
-# DDL executed once on connection open.
+# DDL executed once on connection open. `foreign_keys` is intentionally NOT
+# set here — `_apply_pragmas` sets it on every connection (primary and
+# per-thread) before `_init_schema` runs.
 _SCHEMA_SQL = """
-PRAGMA foreign_keys = ON;
-
 CREATE TABLE IF NOT EXISTS documents (
     id INTEGER PRIMARY KEY,
     path TEXT UNIQUE NOT NULL,
@@ -1142,26 +1142,22 @@ class FTSIndex:
         Returns:
             Number of link rows whose ``target_path`` was updated.
         """
+        conn = self._conn()
         # Load all document paths once into a Python set/list for in-memory
         # matching — avoids O(N) SQL round-trips (one SELECT per wikilink row).
         doc_paths: list[str] = [
-            r["path"]
-            for r in self._conn().execute("SELECT path FROM documents").fetchall()
+            r["path"] for r in conn.execute("SELECT path FROM documents").fetchall()
         ]
 
         # Build alias → document path mapping for fallback resolution.
         # Case-insensitive: Obsidian alias matching is case-insensitive.
-        alias_rows = (
-            self._conn()
-            .execute(
-                """
+        alias_rows = conn.execute(
+            """
             SELECT da.alias, d.path
             FROM document_aliases da
             JOIN documents d ON d.id = da.document_id
             """
-            )
-            .fetchall()
-        )
+        ).fetchall()
         # Map lowercased alias to list of document paths (multiple docs could
         # share an alias; pick shortest path like the path-based resolution).
         alias_map: dict[str, list[str]] = {}
@@ -1171,19 +1167,15 @@ class FTSIndex:
         # Fetch all wikilinks eligible for vault-wide resolution.
         # Explicit relative prefixes (./  ../) are excluded — those were
         # resolved at scan time and must not be overwritten.
-        rows = (
-            self._conn()
-            .execute(
-                """
+        rows = conn.execute(
+            """
             SELECT id, raw_target, target_path
             FROM links
             WHERE link_type = 'wikilink'
               AND raw_target NOT LIKE './%'
               AND raw_target NOT LIKE '../%'
             """
-            )
-            .fetchall()
-        )
+        ).fetchall()
 
         # Resolve each wikilink in Python, then batch-UPDATE.
         updates: list[tuple[str, int]] = []
@@ -1216,7 +1208,6 @@ class FTSIndex:
             if new_path != row["target_path"]:
                 updates.append((new_path, row["id"]))
 
-        conn = self._conn()
         with conn:
             conn.executemany("UPDATE links SET target_path = ? WHERE id = ?", updates)
         updated = len(updates)

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -6,6 +6,8 @@ import datetime
 import json
 import logging
 import sqlite3
+import threading
+import uuid
 from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -155,97 +157,39 @@ def _normalize_heading(heading: str) -> str:
     return " ".join(heading.split())
 
 
-def _open_connection(db_path: Path | str) -> sqlite3.Connection:
-    """Open an SQLite connection with required pragmas and schema applied.
+def _resolve_connect_uri(db_path: Path | str) -> tuple[str, bool, bool]:
+    """Resolve a db_path into (connect_string, uses_uri, is_memory).
 
-    Args:
-        db_path: Filesystem path or ``":memory:"`` for an in-memory database.
+    For ``":memory:"`` returns a shared-cache URI unique to this call so that
+    every per-thread ``sqlite3.connect()`` joins the same in-memory database
+    (required for the per-thread connection model — see #519). For file paths
+    returns the path string directly.
 
-    Returns:
-        An open :class:`sqlite3.Connection` with the schema applied and
-        ``foreign_keys`` enforcement active.
+    The shared-cache URI is unique per ``FTSIndex`` instance (uuid4 token) so
+    distinct in-process collections do not collide.
     """
-    conn = sqlite3.connect(str(db_path), check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    # Apply schema; executescript commits implicitly.
-    conn.executescript(_SCHEMA_SQL)
-    # Migrate existing databases: add columns introduced after initial schema.
-    # ALTER TABLE ADD COLUMN is idempotent-guarded via try/except because
-    # SQLite only supports ADD COLUMN IF NOT EXISTS from version 3.35 onwards.
-    try:
-        conn.execute("ALTER TABLE links ADD COLUMN raw_target TEXT NOT NULL DEFAULT ''")
-        conn.commit()
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" not in str(e).lower():
-            raise  # Unexpected error — re-raise.
-    # Migrate: create document_aliases table if it does not exist (added for
-    # Obsidian-style alias resolution in wikilinks).
-    conn.executescript(
-        """
-        CREATE TABLE IF NOT EXISTS document_aliases (
-            id INTEGER PRIMARY KEY,
-            document_id INTEGER NOT NULL,
-            alias TEXT NOT NULL,
-            UNIQUE(document_id, alias),
-            FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
-        );
-        CREATE INDEX IF NOT EXISTS idx_aliases_alias ON document_aliases(alias);
-        CREATE INDEX IF NOT EXISTS idx_aliases_docid ON document_aliases(document_id);
-        """
-    )
-    # Migration: chunk_count was added 2026-04-30. ALTER TABLE is a no-op
-    # if the column already exists, but SQLite has no IF NOT EXISTS for
-    # columns, so we probe PRAGMA first.
-    cols = {r["name"] for r in conn.execute("PRAGMA table_info(documents)").fetchall()}
-    if "chunk_count" not in cols:
-        try:
-            conn.execute(
-                "ALTER TABLE documents ADD COLUMN chunk_count INTEGER NOT NULL DEFAULT 1"
-            )
-            conn.commit()
-            logger.info(
-                "fts_index: migrated documents table — added chunk_count column"
-            )
-        except sqlite3.OperationalError as exc:
-            if "duplicate column name" not in str(exc).lower():
-                raise
-            # Another process beat us to it; column now exists.
-            logger.debug(
-                "fts_index: chunk_count column already added by concurrent process"
-            )
-    # Migration: idx_sections_docid was added 2026-05-12 to back the
-    # correlated subquery on sections(document_id) used in keyword search
-    # for start_line propagation. CREATE INDEX IF NOT EXISTS is idempotent.
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_sections_docid ON sections(document_id)"
-    )
-    conn.commit()
-    # Ensure foreign_keys stays ON for subsequent statements (executescript
-    # does not guarantee this survives across statement boundaries in all
-    # SQLite versions).
-    conn.execute("PRAGMA foreign_keys = ON")
-    # WAL mode allows concurrent readers during writes — essential for
-    # search queries running while reindex or write operations update the DB.
-    # In-memory databases do not support WAL; skip the pragma to avoid a
-    # spurious warning (SQLite silently uses 'memory' journal mode).
-    if str(db_path) != ":memory:":
-        result = conn.execute("PRAGMA journal_mode = WAL").fetchone()
-        if result is None or result[0].lower() != "wal":
-            logger.warning(
-                "Could not enable WAL journal mode (got %s); "
-                "concurrent reads during writes may block",
-                result[0] if result else "no result",
-            )
-    conn.commit()
-    return conn
+    if str(db_path) == ":memory:":
+        token = uuid.uuid4().hex
+        return f"file:fts_{token}?mode=memory&cache=shared", True, True
+    return str(db_path), False, False
 
 
 class FTSIndex:
     """SQLite FTS5 index providing BM25 search and tag filtering.
 
-    Wraps a single SQLite database file (or in-memory database) and exposes
-    CRUD operations and full-text search over a collection of markdown
-    documents.
+    Wraps a SQLite database file (or in-memory database) and exposes CRUD
+    operations and full-text search over a collection of markdown documents.
+
+    **Thread safety (issue #519):** every public method is safe to call from
+    any thread. Each thread that touches the index opens its own
+    ``sqlite3.Connection`` on first use via :meth:`_conn`; a side registry
+    (``_all_conns``, guarded by ``_reg_lock``) holds strong refs so
+    :meth:`close` can close every connection — including those opened by
+    threads that have since exited. Concurrent writers are serialised by
+    ``Collection._write_lock``, not by this class. After :meth:`close`,
+    every public method raises ``sqlite3.ProgrammingError``. See
+    ``docs/design.md`` "Collection thread-safety contract" for the full
+    contract.
 
     Tag indexing behaviour is controlled by ``indexed_frontmatter_fields``:
     only the listed frontmatter keys are promoted into the ``document_tags``
@@ -269,7 +213,182 @@ class FTSIndex:
     ) -> None:
         self._db_path = db_path
         self._indexed_fields: list[str] = indexed_frontmatter_fields or []
-        self._conn = _open_connection(db_path)
+        # Resolve URI (translates ``:memory:`` to a shared-cache URI so that
+        # per-thread opens see the same in-memory DB).
+        self._connect_uri, self._uses_uri, self._is_memory = _resolve_connect_uri(
+            db_path
+        )
+        # Thread-safety state — see #519 and docs/design.md.
+        self._local = threading.local()
+        self._all_conns: list[sqlite3.Connection] = []
+        self._reg_lock = threading.Lock()
+        self._closed = False
+        self._primary_conn: sqlite3.Connection | None = None
+
+        # Open primary connection on the constructing thread.
+        primary = self._connect()
+        try:
+            # PRAGMAS FIRST — busy_timeout must be active for ALTER TABLE migrations
+            # in _init_schema (per #519 carryover).
+            self._apply_pragmas(primary)
+            self._init_schema(primary)
+        except BaseException:
+            primary.close()
+            raise
+        self._local.conn = primary
+        self._primary_conn = primary
+        self._all_conns.append(primary)
+
+        # Fail-fast probe: if shared-cache ``:memory:`` translation is in use
+        # but SQLITE_ENABLE_SHARED_CACHE was disabled at build time, a second
+        # connection to the URI will see an empty DB. Surface that immediately
+        # instead of letting per-thread reads fail mysteriously downstream.
+        if self._is_memory:
+            self._probe_shared_cache()
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a raw sqlite3 connection to this index's URI."""
+        conn = sqlite3.connect(
+            self._connect_uri,
+            check_same_thread=False,
+            uri=self._uses_uri,
+        )
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _apply_pragmas(self, conn: sqlite3.Connection) -> None:
+        """Apply per-connection pragmas (foreign_keys, busy_timeout, synchronous).
+
+        Called on every ``sqlite3.connect()`` — the primary connection and
+        every per-thread open. These are per-connection settings that do NOT
+        persist across opens.
+        """
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        conn.execute("PRAGMA synchronous = NORMAL")
+
+    def _init_schema(self, conn: sqlite3.Connection) -> None:
+        """Run DDL, migrations, and WAL on the primary connection.
+
+        Called exactly once per ``FTSIndex`` instance, on the constructing
+        thread. Per-thread opens do NOT call this method — they only apply
+        pragmas, since DDL and WAL are persisted in the DB header.
+        """
+        conn.executescript(_SCHEMA_SQL)
+        try:
+            conn.execute(
+                "ALTER TABLE links ADD COLUMN raw_target TEXT NOT NULL DEFAULT ''"
+            )
+            conn.commit()
+        except sqlite3.OperationalError as e:
+            if "duplicate column name" not in str(e).lower():
+                raise
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS document_aliases (
+                id INTEGER PRIMARY KEY,
+                document_id INTEGER NOT NULL,
+                alias TEXT NOT NULL,
+                UNIQUE(document_id, alias),
+                FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_aliases_alias ON document_aliases(alias);
+            CREATE INDEX IF NOT EXISTS idx_aliases_docid ON document_aliases(document_id);
+            """
+        )
+        cols = {
+            r["name"] for r in conn.execute("PRAGMA table_info(documents)").fetchall()
+        }
+        if "chunk_count" not in cols:
+            try:
+                conn.execute(
+                    "ALTER TABLE documents ADD COLUMN chunk_count INTEGER NOT NULL DEFAULT 1"
+                )
+                conn.commit()
+                logger.info(
+                    "fts_index: migrated documents table — added chunk_count column"
+                )
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+                logger.debug(
+                    "fts_index: chunk_count column already added by concurrent process"
+                )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sections_docid ON sections(document_id)"
+        )
+        conn.commit()
+        # WAL is a DB-header pragma — persists across opens. Skip for in-memory
+        # databases (SQLite silently falls back to 'memory' journal mode there).
+        if not self._is_memory:
+            result = conn.execute("PRAGMA journal_mode = WAL").fetchone()
+            if result is None or str(result[0]).lower() != "wal":
+                logger.warning(
+                    "Could not enable WAL journal mode (got %s); "
+                    "concurrent reads during writes may block",
+                    result[0] if result else "no result",
+                )
+        conn.commit()
+
+    def _probe_shared_cache(self) -> None:
+        """Verify that a second connection to the same in-memory URI sees the schema.
+
+        If ``SQLITE_ENABLE_SHARED_CACHE`` is unavailable in this SQLite build,
+        the second connection will see an empty database — per-thread reads
+        would then fail with confusing OperationalErrors. Surface that
+        condition immediately with an operator-actionable error.
+        """
+        probe = self._connect()
+        try:
+            row = probe.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='documents'"
+            ).fetchone()
+            if row is None:
+                raise RuntimeError(
+                    "FTSIndex: in-memory shared-cache probe failed — this SQLite "
+                    "build appears to lack SQLITE_ENABLE_SHARED_CACHE. Use a file "
+                    "path for db_path, or rebuild SQLite with shared-cache support."
+                )
+        finally:
+            probe.close()
+
+    def _conn(self) -> sqlite3.Connection:
+        """Return this thread's sqlite3 connection, opening one on first touch.
+
+        Uses double-checked locking: the fast path is lock-free; the slow path
+        re-checks ``_closed`` under ``_reg_lock`` so a concurrent ``close()``
+        cannot race with a new-thread open.
+
+        Raises:
+            sqlite3.ProgrammingError: If ``close()`` has been called.
+
+        Note on connection accumulation: dead-thread connections remain in
+        ``_all_conns`` (strong refs) until ``close()``. This is bounded for
+        the MCP server's workload (long-lived lifespan thread + bounded
+        ``asyncio.to_thread`` pool) and is preferred over weakrefs (see
+        ``feedback_519_weakref_whackamole.md``).
+        """
+        if self._closed:
+            raise sqlite3.ProgrammingError("Cannot operate on a closed FTSIndex")
+        existing = getattr(self._local, "conn", None)
+        if existing is not None:
+            return existing
+        new_conn = self._connect()
+        try:
+            self._apply_pragmas(new_conn)
+            with self._reg_lock:
+                if self._closed:
+                    raise sqlite3.ProgrammingError(
+                        "Cannot operate on a closed FTSIndex"
+                    )
+                self._local.conn = new_conn
+                self._all_conns.append(new_conn)
+        except BaseException:
+            # Cover KeyboardInterrupt / SystemExit / asyncio.CancelledError —
+            # sqlite3.Error alone would leak the open connection on teardown.
+            new_conn.close()
+            raise
+        return new_conn
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -538,8 +657,8 @@ class FTSIndex:
             Total number of chunks (sections) indexed.
         """
         total_chunks = 0
-        with self._conn:
-            cur = self._conn.cursor()
+        with self._conn():
+            cur = self._conn().cursor()
             for note in notes:
                 folder = _derive_folder(note.path)
                 self._delete_document(cur, note.path)
@@ -570,8 +689,8 @@ class FTSIndex:
             Number of chunks (sections) indexed for this document.
         """
         folder = _derive_folder(note.path)
-        with self._conn:
-            cur = self._conn.cursor()
+        with self._conn():
+            cur = self._conn().cursor()
             self._delete_document(cur, note.path)
             doc_id = self._insert_document(cur, note, folder)
             self._insert_sections(cur, doc_id, note)
@@ -592,8 +711,8 @@ class FTSIndex:
         Returns:
             Number of document rows deleted (0 if path was not indexed).
         """
-        with self._conn:
-            cur = self._conn.cursor()
+        with self._conn():
+            cur = self._conn().cursor()
             deleted = self._delete_document(cur, path)
         if deleted:
             logger.debug("delete_by_path: removed %s", path)
@@ -725,7 +844,7 @@ class FTSIndex:
             snippet_words,
         )
         try:
-            cur = self._conn.execute(sql, params)
+            cur = self._conn().execute(sql, params)
         except sqlite3.OperationalError as exc:
             msg = str(exc).lower()
             if (
@@ -768,7 +887,7 @@ class FTSIndex:
             ``frontmatter_json``, ``content_hash``, ``modified_at``, or
             ``None`` if the document is not indexed.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT path, title, folder, frontmatter_json,
                    content_hash, modified_at
@@ -796,7 +915,7 @@ class FTSIndex:
             # Escape LIKE wildcards in the user-supplied folder value so that
             # literal '%' and '_' characters are matched as-is.
             escaped = _escape_like(folder)
-            cur = self._conn.execute(
+            cur = self._conn().execute(
                 """
                 SELECT path, title, folder, frontmatter_json,
                        content_hash, modified_at
@@ -807,7 +926,7 @@ class FTSIndex:
                 (folder, escaped + "/%"),
             )
         else:
-            cur = self._conn.execute(
+            cur = self._conn().execute(
                 """
                 SELECT path, title, folder, frontmatter_json,
                        content_hash, modified_at
@@ -823,7 +942,7 @@ class FTSIndex:
         Returns:
             Sorted list of folder strings (including ``""`` for the root).
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             "SELECT DISTINCT folder FROM documents ORDER BY folder"
         )
         return [row[0] for row in cur.fetchall()]
@@ -840,7 +959,7 @@ class FTSIndex:
         Returns:
             Sorted list of distinct value strings.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT DISTINCT tag_value
             FROM document_tags
@@ -857,7 +976,7 @@ class FTSIndex:
         Returns:
             Integer count of all indexed chunks across all documents.
         """
-        row = self._conn.execute("SELECT COUNT(*) FROM sections").fetchone()
+        row = self._conn().execute("SELECT COUNT(*) FROM sections").fetchone()
         return row[0] if row else 0
 
     def get_toc(self, path: str) -> list[dict[str, str | int]]:
@@ -874,7 +993,7 @@ class FTSIndex:
             first appearance.  Empty list if the document is not found or
             has no headings.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT heading, heading_level
             FROM sections
@@ -904,7 +1023,7 @@ class FTSIndex:
         """
         limit_clause = "" if limit is None else "LIMIT ?"
         params: tuple = (path,) if limit is None else (path, limit)
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             f"""
             SELECT d.path AS source_path,
                    d.title AS source_title,
@@ -939,7 +1058,7 @@ class FTSIndex:
         """
         limit_clause = "" if limit is None else "LIMIT ?"
         params: tuple = (path,) if limit is None else (path, limit)
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             f"""
             SELECT l.target_path,
                    l.link_text,
@@ -1000,18 +1119,22 @@ class FTSIndex:
         # matching — avoids O(N) SQL round-trips (one SELECT per wikilink row).
         doc_paths: list[str] = [
             r["path"]
-            for r in self._conn.execute("SELECT path FROM documents").fetchall()
+            for r in self._conn().execute("SELECT path FROM documents").fetchall()
         ]
 
         # Build alias → document path mapping for fallback resolution.
         # Case-insensitive: Obsidian alias matching is case-insensitive.
-        alias_rows = self._conn.execute(
-            """
+        alias_rows = (
+            self._conn()
+            .execute(
+                """
             SELECT da.alias, d.path
             FROM document_aliases da
             JOIN documents d ON d.id = da.document_id
             """
-        ).fetchall()
+            )
+            .fetchall()
+        )
         # Map lowercased alias to list of document paths (multiple docs could
         # share an alias; pick shortest path like the path-based resolution).
         alias_map: dict[str, list[str]] = {}
@@ -1021,15 +1144,19 @@ class FTSIndex:
         # Fetch all wikilinks eligible for vault-wide resolution.
         # Explicit relative prefixes (./  ../) are excluded — those were
         # resolved at scan time and must not be overwritten.
-        rows = self._conn.execute(
-            """
+        rows = (
+            self._conn()
+            .execute(
+                """
             SELECT id, raw_target, target_path
             FROM links
             WHERE link_type = 'wikilink'
               AND raw_target NOT LIKE './%'
               AND raw_target NOT LIKE '../%'
             """
-        ).fetchall()
+            )
+            .fetchall()
+        )
 
         # Resolve each wikilink in Python, then batch-UPDATE.
         updates: list[tuple[str, int]] = []
@@ -1062,8 +1189,8 @@ class FTSIndex:
             if new_path != row["target_path"]:
                 updates.append((new_path, row["id"]))
 
-        with self._conn:
-            self._conn.executemany(
+        with self._conn():
+            self._conn().executemany(
                 "UPDATE links SET target_path = ? WHERE id = ?", updates
             )
         updated = len(updates)
@@ -1107,7 +1234,7 @@ class FTSIndex:
               {folder_clause}
             ORDER BY d.path, l.rowid
         """
-        cur = self._conn.execute(sql, params)
+        cur = self._conn().execute(sql, params)
         return [dict(row) for row in cur.fetchall()]
 
     def get_recent(self, *, limit: int = 20, folder: str | None = None) -> list[dict]:
@@ -1124,7 +1251,7 @@ class FTSIndex:
         """
         if folder is not None:
             escaped = _escape_like(folder)
-            cur = self._conn.execute(
+            cur = self._conn().execute(
                 """
                 SELECT path, title, folder, frontmatter_json,
                        modified_at
@@ -1136,7 +1263,7 @@ class FTSIndex:
                 (folder, escaped + "/%", limit),
             )
         else:
-            cur = self._conn.execute(
+            cur = self._conn().execute(
                 """
                 SELECT path, title, folder, frontmatter_json,
                        modified_at
@@ -1159,7 +1286,7 @@ class FTSIndex:
             List of dicts with keys ``path``, ``title``, ``folder``,
             ``frontmatter_json``, and ``modified_at``, ordered by path.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT path, title, folder, frontmatter_json, modified_at
             FROM documents d
@@ -1180,7 +1307,7 @@ class FTSIndex:
             List of dicts with keys ``path``, ``title``, ``folder``,
             ``backlink_count``, ordered by backlink_count descending.
         """
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             """
             SELECT d.path,
                    d.title,
@@ -1224,9 +1351,11 @@ class FTSIndex:
 
         # Validate both endpoints exist.
         for path in (source_path, target_path):
-            row = self._conn.execute(
-                "SELECT 1 FROM documents WHERE path = ?", (path,)
-            ).fetchone()
+            row = (
+                self._conn()
+                .execute("SELECT 1 FROM documents WHERE path = ?", (path,))
+                .fetchone()
+            )
             if row is None:
                 raise ValueError(f"Path not found in index: {path!r}")
 
@@ -1236,7 +1365,7 @@ class FTSIndex:
 
         # Load all edges into an undirected adjacency dict.
         adj: dict[str, set[str]] = {}
-        cur = self._conn.execute(
+        cur = self._conn().execute(
             "SELECT d1.path, d2.path FROM links l"
             " JOIN documents d1 ON d1.id = l.source_id"
             " JOIN documents d2 ON d2.path = l.target_path"
@@ -1292,7 +1421,7 @@ class FTSIndex:
                 missing links table.
         """
         try:
-            row = self._conn.execute(sql).fetchone()
+            row = self._conn().execute(sql).fetchone()
             return int(row[0])
         except sqlite3.OperationalError as e:
             if "no such table: links" in str(e).lower():
@@ -1348,9 +1477,11 @@ class FTSIndex:
             The ``chunk_count`` stored in the documents table, or ``1`` if
             the document is not found.
         """
-        row = self._conn.execute(
-            "SELECT chunk_count FROM documents WHERE path = ?", (path,)
-        ).fetchone()
+        row = (
+            self._conn()
+            .execute("SELECT chunk_count FROM documents WHERE path = ?", (path,))
+            .fetchone()
+        )
         return int(row["chunk_count"]) if row else 1
 
     def get_chunk_counts(self, paths: Iterable[str]) -> dict[str, int]:
@@ -1368,10 +1499,14 @@ class FTSIndex:
         if not paths_list:
             return {}
         placeholders = ",".join("?" * len(paths_list))
-        rows = self._conn.execute(
-            f"SELECT path, chunk_count FROM documents WHERE path IN ({placeholders})",
-            paths_list,
-        ).fetchall()
+        rows = (
+            self._conn()
+            .execute(
+                f"SELECT path, chunk_count FROM documents WHERE path IN ({placeholders})",
+                paths_list,
+            )
+            .fetchall()
+        )
         return {r["path"]: int(r["chunk_count"]) for r in rows}
 
     def get_section(self, path: str, heading: str) -> dict[str, Any] | None:
@@ -1413,16 +1548,20 @@ class FTSIndex:
         norm_query = _normalize_heading(heading)
         if not norm_query:
             return None
-        rows = self._conn.execute(
-            """
+        rows = (
+            self._conn()
+            .execute(
+                """
             SELECT s.content, s.heading, s.heading_level
             FROM sections s
             JOIN documents d ON d.id = s.document_id
             WHERE d.path = ? AND s.heading IS NOT NULL
             ORDER BY s.start_line ASC
             """,
-            (path,),
-        ).fetchall()
+                (path,),
+            )
+            .fetchall()
+        )
         for row in rows:
             if _normalize_heading(row["heading"]) == norm_query:
                 return {
@@ -1448,8 +1587,10 @@ class FTSIndex:
             List of heading strings in document order, deduplicated while
             preserving the first-occurrence order.
         """
-        rows = self._conn.execute(
-            """
+        rows = (
+            self._conn()
+            .execute(
+                """
             SELECT s.heading
             FROM sections s
             JOIN documents d ON d.id = s.document_id
@@ -1458,14 +1599,30 @@ class FTSIndex:
             ORDER BY MIN(s.start_line) ASC
             LIMIT ?
             """,
-            (path, limit),
-        ).fetchall()
+                (path, limit),
+            )
+            .fetchall()
+        )
         return [row["heading"] for row in rows]
 
     def close(self) -> None:
-        """Close the underlying database connection.
+        """Close every per-thread connection and mark this index closed.
 
-        After calling this method, the index must not be used.
+        Idempotent: second call sees an empty registry and is a no-op. After
+        ``close()``, any thread calling a public method raises
+        ``sqlite3.ProgrammingError`` from ``_conn()``.
         """
-        self._conn.close()
+        with self._reg_lock:
+            self._closed = True
+            for conn in self._all_conns:
+                try:
+                    conn.close()
+                except sqlite3.ProgrammingError:
+                    logger.debug("fts_index.close: connection already closed")
+                except sqlite3.Error:
+                    logger.error(
+                        "fts_index.close: error closing connection", exc_info=True
+                    )
+            self._all_conns.clear()
+            self._primary_conn = None
         logger.debug("FTSIndex closed (db_path=%s)", self._db_path)

--- a/tests/test_fts_chunk_count.py
+++ b/tests/test_fts_chunk_count.py
@@ -25,9 +25,11 @@ def test_chunk_count_populated_on_upsert(tmp_path):
     note = _make_note(tmp_path, "doc.md", body)
     fts.upsert_note(note)
 
-    row = fts._conn.execute(
-        "SELECT chunk_count FROM documents WHERE path = ?", (note.path,)
-    ).fetchone()
+    row = (
+        fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = ?", (note.path,))
+        .fetchone()
+    )
     assert row is not None
     assert row["chunk_count"] == len(note.chunks)
     # Sanity: the helper bypasses the 30-line short-doc rule so this fixture
@@ -45,7 +47,7 @@ def test_chunk_count_populated_on_build_from_notes(tmp_path):
     fts.build_from_notes(notes)
 
     counts = dict(
-        fts._conn.execute("SELECT path, chunk_count FROM documents").fetchall()
+        fts._conn().execute("SELECT path, chunk_count FROM documents").fetchall()
     )
     assert counts["a.md"] == len(notes[0].chunks)
     assert counts["b.md"] == len(notes[1].chunks)
@@ -56,9 +58,11 @@ def test_chunk_count_updates_on_reupsert(tmp_path):
     fts = FTSIndex(db_path=":memory:")
     note_v1 = _make_note(tmp_path, "doc.md", "# A\nbody\n")
     fts.upsert_note(note_v1)
-    v1_count = fts._conn.execute(
-        "SELECT chunk_count FROM documents WHERE path = ?", (note_v1.path,)
-    ).fetchone()["chunk_count"]
+    v1_count = (
+        fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = ?", (note_v1.path,))
+        .fetchone()["chunk_count"]
+    )
 
     note_v2 = _make_note(
         tmp_path,
@@ -66,9 +70,11 @@ def test_chunk_count_updates_on_reupsert(tmp_path):
         "# A\nbody\n## B\nmore\n## C\neven more\n",
     )
     fts.upsert_note(note_v2)
-    v2_count = fts._conn.execute(
-        "SELECT chunk_count FROM documents WHERE path = ?", (note_v2.path,)
-    ).fetchone()["chunk_count"]
+    v2_count = (
+        fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = ?", (note_v2.path,))
+        .fetchone()["chunk_count"]
+    )
 
     assert v2_count != v1_count
     assert v2_count == len(note_v2.chunks)
@@ -124,11 +130,14 @@ def test_migration_adds_column_to_pre_existing_db(tmp_path):
 
     fts = FTSIndex(db_path=db_path)
     cols = [
-        r["name"] for r in fts._conn.execute("PRAGMA table_info(documents)").fetchall()
+        r["name"]
+        for r in fts._conn().execute("PRAGMA table_info(documents)").fetchall()
     ]
     assert "chunk_count" in cols
     # Existing legacy row gets the default value.
-    row = fts._conn.execute(
-        "SELECT chunk_count FROM documents WHERE path = 'legacy.md'"
-    ).fetchone()
+    row = (
+        fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = 'legacy.md'")
+        .fetchone()
+    )
     assert row["chunk_count"] == 1

--- a/tests/test_fts_index.py
+++ b/tests/test_fts_index.py
@@ -357,10 +357,11 @@ class TestSearch:
         from unittest.mock import MagicMock
 
         idx = FTSIndex(":memory:")
-        # Replace the real connection with a mock that raises a non-FTS5 DB error.
+        # Replace the per-thread conn provider with one that returns a mock
+        # raising a non-FTS5 DB error.
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = sqlite3.OperationalError("database is locked")
-        idx._conn = mock_conn
+        idx._conn = lambda: mock_conn  # type: ignore[method-assign]
 
         with pytest.raises(sqlite3.OperationalError, match="database is locked"):
             idx.search("hello")
@@ -463,7 +464,7 @@ class TestSearch:
         gap on ``sections`` was a perf regression flagged by local review.
         """
         idx = FTSIndex(":memory:")
-        cur = idx._conn.execute(
+        cur = idx._conn().execute(
             "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='sections'"
         )
         index_names = {row[0] for row in cur.fetchall()}
@@ -599,7 +600,7 @@ class TestDelete:
         )
 
         # Verify sections and tags exist before deletion.
-        conn = idx._conn
+        conn = idx._conn()
         sec_count = conn.execute(
             "SELECT COUNT(*) FROM sections WHERE document_id IN "
             "(SELECT id FROM documents WHERE path = ?)",
@@ -673,9 +674,11 @@ class TestTagIndexing:
         """A scalar frontmatter value produces exactly one document_tags row."""
         idx = _tagged_index()
         idx.upsert_note(make_note("scalar.md", frontmatter={"cluster": "fiction"}))
-        rows = idx._conn.execute(
-            "SELECT tag_value FROM document_tags WHERE tag_key = 'cluster'"
-        ).fetchall()
+        rows = (
+            idx._conn()
+            .execute("SELECT tag_value FROM document_tags WHERE tag_key = 'cluster'")
+            .fetchall()
+        )
         assert len(rows) == 1
         assert rows[0][0] == "fiction"
 
@@ -683,10 +686,14 @@ class TestTagIndexing:
         """A list frontmatter value creates one row per distinct item."""
         idx = _tagged_index()
         idx.upsert_note(make_note("list.md", frontmatter={"topics": ["a", "b", "a"]}))
-        rows = idx._conn.execute(
-            "SELECT tag_value FROM document_tags WHERE tag_key = 'topics' "
-            "ORDER BY tag_value"
-        ).fetchall()
+        rows = (
+            idx._conn()
+            .execute(
+                "SELECT tag_value FROM document_tags WHERE tag_key = 'topics' "
+                "ORDER BY tag_value"
+            )
+            .fetchall()
+        )
         assert len(rows) == 2
         assert rows[0][0] == "a"
         assert rows[1][0] == "b"
@@ -697,9 +704,11 @@ class TestTagIndexing:
         idx.upsert_note(
             make_note("complex.md", frontmatter={"cluster": {"key": "val"}})
         )
-        rows = idx._conn.execute(
-            "SELECT COUNT(*) FROM document_tags WHERE tag_key = 'cluster'"
-        ).fetchone()
+        rows = (
+            idx._conn()
+            .execute("SELECT COUNT(*) FROM document_tags WHERE tag_key = 'cluster'")
+            .fetchone()
+        )
         assert rows[0] == 0
 
 
@@ -757,13 +766,13 @@ class TestWALMode:
         """File-based FTSIndex uses WAL journal mode for concurrent reads."""
         db_path = tmp_path / "test.db"
         idx = FTSIndex(str(db_path))
-        mode = idx._conn.execute("PRAGMA journal_mode").fetchone()[0]
+        mode = idx._conn().execute("PRAGMA journal_mode").fetchone()[0]
         assert mode.lower() == "wal"
 
     def test_in_memory_index_uses_memory_journal_mode(self) -> None:
         """In-memory FTSIndex skips WAL and retains SQLite default 'memory' mode."""
         idx = FTSIndex(":memory:")
-        mode = idx._conn.execute("PRAGMA journal_mode").fetchone()[0]
+        mode = idx._conn().execute("PRAGMA journal_mode").fetchone()[0]
         # WAL pragma is skipped for :memory: databases; SQLite uses 'memory' mode.
         assert mode.lower() == "memory"
 
@@ -773,8 +782,6 @@ class TestWALMode:
         """A warning is logged when WAL mode cannot be enabled."""
         import logging
         from unittest.mock import MagicMock
-
-        from markdown_vault_mcp.fts_index import _open_connection
 
         db_path = tmp_path / "nowarn.db"
 
@@ -788,7 +795,7 @@ class TestWALMode:
             ),
             caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.fts_index"),
         ):
-            _open_connection(db_path)
+            FTSIndex(db_path=db_path)
 
         assert any(
             "Could not enable WAL journal mode" in r.message for r in caplog.records

--- a/tests/test_fts_snippet.py
+++ b/tests/test_fts_snippet.py
@@ -55,7 +55,7 @@ def test_chunk_count_populated_on_fts_result(tmp_path):
     assert results[0].chunk_count >= 1
     assert (
         results[0].chunk_count
-        == fts._conn.execute(
-            "SELECT chunk_count FROM documents WHERE path = 'doc.md'"
-        ).fetchone()["chunk_count"]
+        == fts._conn()
+        .execute("SELECT chunk_count FROM documents WHERE path = 'doc.md'")
+        .fetchone()["chunk_count"]
     )

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1394,7 +1394,7 @@ class TestStatsLinkCounts:
         """
         idx = FTSIndex(":memory:")
         # Simulate an old index file that predates link tracking.
-        idx._conn.execute("DROP TABLE links")
+        idx._conn().execute("DROP TABLE links")
         assert idx.count_links() == 0
         assert idx.count_broken_links() == 0
         assert idx.count_orphans() == 0

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -480,6 +480,37 @@ def test_init_baseexception_cleanup_closes_primary(
     )
 
 
+def test_init_baseexception_cleanup_clears_tls_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If __init__ raises AFTER the primary's TLS assignment (e.g. during
+    `_probe_shared_cache`), the cleanup must clear ``self._local.conn`` —
+    otherwise a caller holding the partially-built instance would fast-path
+    a closed connection instead of seeing ProgrammingError.
+
+    Uses the :memory: path so the probe runs; captures the partial instance
+    via the patched method since __init__ never returns one to the caller.
+    """
+    captured: list[FTSIndex] = []
+
+    def boom_probe(self: FTSIndex) -> None:
+        captured.append(self)
+        raise RuntimeError("simulated probe failure")
+
+    monkeypatch.setattr(FTSIndex, "_probe_shared_cache", boom_probe)
+
+    with pytest.raises(RuntimeError, match="simulated probe failure"):
+        FTSIndex(db_path=":memory:")
+
+    assert len(captured) == 1
+    assert getattr(captured[0]._local, "conn", None) is None, (
+        "__init__ cleanup must clear self._local.conn after post-TLS failure"
+    )
+    # _all_conns must also be cleared by the cleanup.
+    assert captured[0]._all_conns == []
+    assert captured[0]._primary_conn is None
+
+
 def test_probe_shared_cache_raises_when_documents_invisible(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,403 @@
+"""Thread-safety contract tests for FTSIndex (issue #519).
+
+Each test exercises one failure mode that the per-thread connection model
+must address. Run individually with ``uv run pytest tests/test_thread_safety.py``.
+
+The carryover design (per ``project_issue_519_attempt_1_abandon.md``) is:
+per-thread ``sqlite3.Connection`` via ``threading.local``, strong-ref
+registry guarded by ``_reg_lock``, ``_closed`` flag with double-checked
+locking, ``BaseException`` cleanup on slow-path open, ``_primary_conn``
+strong attribute, shared-cache URI translation for ``:memory:`` with
+startup probe, and pragmas applied BEFORE schema/migrations.
+"""
+
+from __future__ import annotations
+
+import gc
+import sqlite3
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.fts_index import FTSIndex
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path) -> Path:
+    """Filesystem-backed SQLite DB path for tests."""
+    return tmp_path / "fts.sqlite"
+
+
+@pytest.fixture
+def fts(tmp_db: Path):
+    """Tempfile-backed FTSIndex. Closed at teardown."""
+    idx = FTSIndex(db_path=tmp_db)
+    try:
+        yield idx
+    finally:
+        idx.close()
+
+
+@pytest.fixture
+def fts_memory():
+    """`:memory:` FTSIndex. Closed at teardown.
+
+    Safe for multi-threaded tests under the new design because
+    ``:memory:`` is translated to a shared-cache URI so every per-thread
+    open joins the same in-memory DB.
+    """
+    idx = FTSIndex(db_path=":memory:")
+    try:
+        yield idx
+    finally:
+        idx.close()
+
+
+def _make_collection(tmp_path: Path) -> Collection:
+    """Build a writeable file-backed Collection."""
+    vault = tmp_path / "vault"
+    vault.mkdir(exist_ok=True)
+    return Collection(
+        source_dir=vault,
+        index_path=tmp_path / "fts.sqlite",
+        read_only=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-thread connection mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_conn_is_per_thread(fts: FTSIndex) -> None:
+    """`_conn()` returns the same object per thread, distinct objects across threads."""
+    main = fts._conn()
+    assert fts._conn() is main, "second call from same thread must return same conn"
+
+    seen: dict[str, sqlite3.Connection] = {}
+
+    def grab() -> None:
+        seen["worker"] = fts._conn()
+        seen["worker2"] = fts._conn()
+
+    t = threading.Thread(target=grab)
+    t.start()
+    t.join()
+    assert seen["worker"] is seen["worker2"], "worker thread reuses its TLS slot"
+    assert seen["worker"] is not main, "worker conn must be distinct from main"
+
+
+def test_pragmas_applied_per_connection(fts: FTSIndex) -> None:
+    """Every per-thread conn has foreign_keys, busy_timeout, synchronous applied;
+    WAL persists in the DB header for file-backed DBs."""
+
+    def check(out: dict[str, object]) -> None:
+        conn = fts._conn()
+        out["foreign_keys"] = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+        out["busy_timeout"] = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        out["synchronous"] = conn.execute("PRAGMA synchronous").fetchone()[0]
+        out["journal_mode"] = conn.execute("PRAGMA journal_mode").fetchone()[0]
+
+    out: dict[str, object] = {}
+    t = threading.Thread(target=check, args=(out,))
+    t.start()
+    t.join()
+
+    assert out["foreign_keys"] == 1
+    assert out["busy_timeout"] == 5000
+    assert out["synchronous"] == 1  # NORMAL
+    assert str(out["journal_mode"]).lower() == "wal"
+
+
+def test_pragmas_applied_before_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_db: Path
+) -> None:
+    """`_apply_pragmas` must run BEFORE `_init_schema` so busy_timeout is active
+    during ALTER TABLE migrations.
+
+    Capture the call order by patching both methods on the class.
+    """
+    order: list[str] = []
+    real_apply = FTSIndex._apply_pragmas  # type: ignore[attr-defined]
+    real_init = FTSIndex._init_schema  # type: ignore[attr-defined]
+
+    def spy_apply(self, conn):  # type: ignore[no-untyped-def]
+        order.append("pragmas")
+        return real_apply(self, conn)
+
+    def spy_init(self, conn):  # type: ignore[no-untyped-def]
+        order.append("schema")
+        return real_init(self, conn)
+
+    monkeypatch.setattr(FTSIndex, "_apply_pragmas", spy_apply)
+    monkeypatch.setattr(FTSIndex, "_init_schema", spy_init)
+
+    idx = FTSIndex(db_path=tmp_db)
+    try:
+        assert order[:2] == ["pragmas", "schema"], (
+            f"pragmas must precede schema; got {order}"
+        )
+    finally:
+        idx.close()
+
+
+def test_init_schema_runs_once_across_all_threads(
+    monkeypatch: pytest.MonkeyPatch, tmp_db: Path
+) -> None:
+    """Schema/migrations run exactly once on the constructing thread; per-thread
+    opens only apply pragmas."""
+    call_count = {"n": 0}
+    real = FTSIndex._init_schema  # type: ignore[attr-defined]
+
+    def spy(self, conn):  # type: ignore[no-untyped-def]
+        call_count["n"] += 1
+        return real(self, conn)
+
+    monkeypatch.setattr(FTSIndex, "_init_schema", spy)
+
+    idx = FTSIndex(db_path=tmp_db)
+    try:
+        # Touch from 5 worker threads.
+        def touch() -> None:
+            idx._conn().execute("SELECT 1").fetchone()
+
+        threads = [threading.Thread(target=touch) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert call_count["n"] == 1, (
+            f"_init_schema must run exactly once; got {call_count['n']}"
+        )
+    finally:
+        idx.close()
+
+
+def test_close_closes_all_per_thread_connections(fts: FTSIndex) -> None:
+    """After close(), every registered connection raises on use."""
+    captured: list[sqlite3.Connection] = [fts._conn()]
+
+    def grab() -> None:
+        captured.append(fts._conn())
+
+    t = threading.Thread(target=grab)
+    t.start()
+    t.join()
+    assert len(captured) == 2
+
+    fts.close()
+    for conn in captured:
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+
+
+def test_close_is_idempotent(fts: FTSIndex) -> None:
+    """Second close() is a no-op, not an error."""
+    fts._conn()
+    fts.close()
+    fts.close()  # must not raise
+
+
+def test_closed_index_rejects_new_thread_access(fts: FTSIndex) -> None:
+    """After close(), a never-before-seen thread calling _conn() gets
+    ProgrammingError — not a half-registered new connection."""
+    fts._conn()
+    fts.close()
+
+    errors: list[BaseException] = []
+
+    def attempt() -> None:
+        try:
+            fts._conn()
+        except BaseException as exc:
+            errors.append(exc)
+
+    t = threading.Thread(target=attempt)
+    t.start()
+    t.join()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], sqlite3.ProgrammingError)
+
+
+def test_concurrent_close_and_new_thread_conn_open_is_safe(fts: FTSIndex) -> None:
+    """A new thread calling _conn() racing with close() must end in either:
+    (a) a usable conn that is then closed by close(), OR
+    (b) ProgrammingError from the slow-path re-check.
+
+    Neither outcome leaks a connection past close() or crashes the close()."""
+    barrier = threading.Barrier(2)
+    outcomes: list[str] = []
+
+    def opener() -> None:
+        barrier.wait()
+        try:
+            c = fts._conn()
+            c.execute("SELECT 1").fetchone()
+            outcomes.append("opened")
+        except sqlite3.ProgrammingError:
+            outcomes.append("rejected")
+
+    def closer() -> None:
+        barrier.wait()
+        fts.close()
+
+    t_open = threading.Thread(target=opener)
+    t_close = threading.Thread(target=closer)
+    t_open.start()
+    t_close.start()
+    t_open.join()
+    t_close.join()
+
+    assert outcomes and outcomes[0] in {"opened", "rejected"}
+
+
+def test_registry_uses_strong_refs(fts: FTSIndex) -> None:
+    """Registry must hold strong refs so close() can close worker conns even
+    after the worker thread has exited and gc has run.
+
+    Weakrefs are explicitly REJECTED per ``feedback_519_weakref_whackamole.md``.
+    """
+    fts._conn()  # primary
+    worker_id: list[int] = []
+
+    def worker() -> None:
+        worker_id.append(id(fts._conn()))
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    del t
+    gc.collect()
+
+    # Registry still holds the worker conn.
+    assert any(id(c) == worker_id[0] for c in fts._all_conns), (
+        "worker conn must survive thread exit + gc in strong-ref registry"
+    )
+
+
+def test_memory_db_is_shared_across_threads(fts_memory: FTSIndex) -> None:
+    """:memory: must be shared across threads via shared-cache URI translation.
+
+    Pre-PR-#520, each thread's _conn() against ":memory:" got a separate
+    empty DB and the schema was invisible. The translation must fix this.
+    """
+
+    def query(out: dict[str, object]) -> None:
+        conn = fts_memory._conn()
+        # If the per-thread conn sees an empty DB, this raises OperationalError.
+        out["count"] = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+
+    out: dict[str, object] = {}
+    t = threading.Thread(target=query, args=(out,))
+    t.start()
+    t.join()
+    assert out.get("count") == 0
+
+
+def test_concurrent_writers_serialize_via_collection_write_lock(
+    tmp_path: Path,
+) -> None:
+    """Two writer threads each writing 20 distinct paths through Collection
+    produce 40 docs with no SQLITE_BUSY / lost writes."""
+    coll = _make_collection(tmp_path)
+    coll.build_index()
+
+    errors: list[BaseException] = []
+
+    def writer(prefix: str) -> None:
+        for i in range(20):
+            try:
+                coll.write(f"{prefix}-{i}.md", f"# {prefix}{i}\n\nbody\n")
+            except BaseException as exc:
+                errors.append(exc)
+
+    t1 = threading.Thread(target=writer, args=("a",))
+    t2 = threading.Thread(target=writer, args=("b",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    try:
+        assert not errors, f"writer errors: {errors!r}"
+        docs = coll.list()
+        assert len(docs) == 40
+    finally:
+        coll.close()
+
+
+def test_concurrent_build_and_reads_pr518_pattern(tmp_path: Path) -> None:
+    """The acceptance test for #519 (and prerequisite for #513).
+
+    Background thread loops build_index(); main thread runs mixed read /
+    search / write / edit concurrently. None of the cross-thread sqlite3
+    errors that killed PRs #510/#515/#516/#518 must surface.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    # Seed a few notes so build_index has something to scan.
+    for i in range(10):
+        (vault / f"seed-{i}.md").write_text(f"# Seed {i}\n\ncontent {i}\n")
+
+    coll = Collection(
+        source_dir=vault,
+        index_path=tmp_path / "fts.sqlite",
+        read_only=False,
+    )
+    coll.build_index()
+
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def background_build() -> None:
+        for _ in range(5):
+            if stop.is_set():
+                return
+            try:
+                coll.build_index(force=True)
+            except BaseException as exc:
+                errors.append(exc)
+                return
+
+    def foreground_mix() -> None:
+        try:
+            for i in range(50):
+                coll.list()
+                coll.search("content", limit=5)
+                coll.write(f"new-{i}.md", f"# New {i}\n\nbody\n")
+                coll.read(f"new-{i}.md")
+                if i % 5 == 0:
+                    coll.edit(
+                        f"new-{i}.md", f"# New {i}\n\nbody\n", f"# New {i}\n\nEDITED\n"
+                    )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            stop.set()
+
+    bg = threading.Thread(target=background_build)
+    fg = threading.Thread(target=foreground_mix)
+    bg.start()
+    fg.start()
+    fg.join(timeout=60)
+    bg.join(timeout=10)
+
+    try:
+        for exc in errors:
+            assert not isinstance(
+                exc,
+                (
+                    sqlite3.OperationalError,
+                    sqlite3.InterfaceError,
+                    sqlite3.ProgrammingError,
+                ),
+            ), f"cross-thread sqlite3 error: {exc!r}"
+        assert not errors, f"unexpected errors: {errors!r}"
+    finally:
+        coll.close()

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -288,15 +288,21 @@ def test_memory_db_is_shared_across_threads(fts_memory: FTSIndex) -> None:
     empty DB and the schema was invisible. The translation must fix this.
     """
 
+    errors: list[BaseException] = []
+
     def query(out: dict[str, object]) -> None:
-        conn = fts_memory._conn()
-        # If the per-thread conn sees an empty DB, this raises OperationalError.
-        out["count"] = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        try:
+            conn = fts_memory._conn()
+            # If the per-thread conn sees an empty DB, this raises OperationalError.
+            out["count"] = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        except BaseException as exc:
+            errors.append(exc)
 
     out: dict[str, object] = {}
     t = threading.Thread(target=query, args=(out,))
     t.start()
     t.join()
+    assert not errors, f"worker thread raised: {errors[0]!r}"
     assert out.get("count") == 0
 
 
@@ -387,6 +393,10 @@ def test_concurrent_build_and_reads_pr518_pattern(tmp_path: Path) -> None:
     fg.start()
     fg.join(timeout=60)
     bg.join(timeout=10)
+    # If either thread is still alive the join timed out — a deadlock would
+    # otherwise leave errors empty and let the test silently pass.
+    assert not fg.is_alive(), "foreground thread timed out — possible deadlock"
+    assert not bg.is_alive(), "background thread timed out — possible deadlock"
 
     try:
         for exc in errors:
@@ -401,3 +411,144 @@ def test_concurrent_build_and_reads_pr518_pattern(tmp_path: Path) -> None:
         assert not errors, f"unexpected errors: {errors!r}"
     finally:
         coll.close()
+
+
+def test_init_baseexception_cleanup_closes_primary(
+    monkeypatch: pytest.MonkeyPatch, tmp_db: Path
+) -> None:
+    """If _init_schema fails, the primary connection must be closed before
+    the exception propagates — no leaked file handle."""
+
+    closed: list[object] = []
+    real_connect = sqlite3.connect
+
+    class _CloseTracker:
+        """Forwarding wrapper that records close() calls (sqlite3.Connection.close is read-only)."""
+
+        _inner: sqlite3.Connection
+
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            object.__setattr__(self, "_inner", inner)
+
+        def close(self) -> None:
+            closed.append(self._inner)
+            self._inner.close()
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._inner, name)
+
+        def __setattr__(self, name: str, value: object) -> None:
+            setattr(self._inner, name, value)
+
+        def __enter__(self) -> sqlite3.Connection:
+            return self._inner.__enter__()
+
+        def __exit__(self, *args: object) -> object:
+            return self._inner.__exit__(*args)  # type: ignore[arg-type]
+
+    def tracking_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        return _CloseTracker(real_connect(*args, **kwargs))  # type: ignore[return-value,arg-type]
+
+    monkeypatch.setattr(
+        "markdown_vault_mcp.fts_index.sqlite3.connect", tracking_connect
+    )
+
+    def boom_schema(_self: object, _conn: object) -> None:
+        raise RuntimeError("simulated schema failure")
+
+    monkeypatch.setattr(FTSIndex, "_init_schema", boom_schema)
+
+    with pytest.raises(RuntimeError, match="simulated schema failure"):
+        FTSIndex(db_path=tmp_db)
+
+    assert len(closed) == 1, (
+        f"primary connection must be closed exactly once; got {len(closed)}"
+    )
+
+
+def test_probe_shared_cache_raises_when_documents_invisible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a second connection to the shared-cache URI cannot see the
+    schema, _probe_shared_cache must raise RuntimeError with an
+    operator-actionable message — not let per-thread reads fail mysteriously
+    downstream."""
+
+    real_connect = sqlite3.connect
+    call_count = {"n": 0}
+
+    def fake_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        call_count["n"] += 1
+        # Simulate SQLITE_ENABLE_SHARED_CACHE missing by giving the probe
+        # (second connect) a fresh empty in-memory DB instead of joining
+        # the shared cache.
+        if call_count["n"] == 2:
+            return real_connect(":memory:", check_same_thread=False)
+        return real_connect(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("markdown_vault_mcp.fts_index.sqlite3.connect", fake_connect)
+
+    with pytest.raises(RuntimeError, match="shared-cache probe failed"):
+        FTSIndex(db_path=":memory:")
+
+
+def test_conn_slow_path_baseexception_cleanup(
+    monkeypatch: pytest.MonkeyPatch, fts: FTSIndex
+) -> None:
+    """If _apply_pragmas fails on a per-thread open, the new connection
+    must be closed and the TLS slot left unset so a retry re-opens."""
+
+    closed: list[object] = []
+    real_connect = sqlite3.connect
+
+    class _CloseTracker:
+        """Forwarding wrapper that records close() calls (sqlite3.Connection.close is read-only)."""
+
+        _inner: sqlite3.Connection
+
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            object.__setattr__(self, "_inner", inner)
+
+        def close(self) -> None:
+            closed.append(self._inner)
+            self._inner.close()
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._inner, name)
+
+        def __setattr__(self, name: str, value: object) -> None:
+            setattr(self._inner, name, value)
+
+        def __enter__(self) -> sqlite3.Connection:
+            return self._inner.__enter__()
+
+        def __exit__(self, *args: object) -> object:
+            return self._inner.__exit__(*args)  # type: ignore[arg-type]
+
+    def tracking_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        return _CloseTracker(real_connect(*args, **kwargs))  # type: ignore[return-value,arg-type]
+
+    monkeypatch.setattr(
+        "markdown_vault_mcp.fts_index.sqlite3.connect", tracking_connect
+    )
+
+    def boom_pragmas(_self: object, _conn: object) -> None:
+        raise RuntimeError("simulated pragma failure")
+
+    monkeypatch.setattr(FTSIndex, "_apply_pragmas", boom_pragmas)
+
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            fts._conn()
+        except BaseException as exc:
+            errors.append(exc)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)
+    assert len(closed) >= 1, "new per-thread connection must be closed on failure"

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -546,6 +546,60 @@ def test_conn_slow_path_baseexception_cleanup(
     assert len(closed) >= 1, "new per-thread connection must be closed on failure"
 
 
+def test_conn_slow_path_failure_clears_tls_slot(fts: FTSIndex) -> None:
+    """If the slow-path open fails AFTER ``self._local.conn`` was set but
+    BEFORE registration completes (e.g. a BaseException between the two
+    writes inside the lock), the cleanup MUST clear the TLS slot so the
+    next ``_conn()`` call does not fast-path return a closed connection.
+
+    Regression for the bug where ``self._local.conn = new_conn`` was
+    assigned and a BaseException between that and ``_all_conns.append``
+    left a closed conn in TLS for subsequent silent reuse.
+
+    Injection method: patch ``list.append`` on ``_all_conns`` so the
+    append raises after the TLS assignment has already happened.
+    """
+    append_calls = {"n": 0}
+
+    class _ExplodingList(list):
+        def append(self, item: object) -> None:
+            append_calls["n"] += 1
+            # First patched call is the worker's registration — fail after
+            # the TLS slot has already been set inside the lock block.
+            if append_calls["n"] == 1:
+                raise RuntimeError("simulated failure between TLS set and append")
+            super().append(item)
+
+    # Swap registry with the exploding subclass, preserving the primary
+    # connection entry the fixture registered before the patch.
+    fts._all_conns = _ExplodingList(fts._all_conns)
+
+    first_error: list[BaseException] = []
+    second_result: list[sqlite3.Connection] = []
+
+    def worker() -> None:
+        try:
+            fts._conn()
+        except BaseException as exc:
+            first_error.append(exc)
+        # Subsequent call from the same thread must NOT fast-path return a
+        # stale closed conn — it must go to the slow path and succeed.
+        try:
+            second_result.append(fts._conn())
+        except BaseException as exc:
+            first_error.append(exc)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert len(first_error) == 1, f"unexpected errors: {first_error!r}"
+    assert isinstance(first_error[0], RuntimeError)
+    assert len(second_result) == 1
+    # The recovered conn must be usable.
+    second_result[0].execute("SELECT 1").fetchone()
+
+
 def test_close_continues_when_one_connection_raises(fts: FTSIndex) -> None:
     """If one ``conn.close()`` raises a non-sqlite3 exception (e.g. OSError),
     ``close()`` must continue iterating and close the remaining connections —

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -58,6 +58,42 @@ def fts_memory():
         idx.close()
 
 
+@pytest.fixture
+def close_tracker() -> tuple[list[object], type]:
+    """Return (closed_list, tracker_class) for monkey-patching `sqlite3.connect`.
+
+    The tracker class is a forwarding wrapper around a `sqlite3.Connection`
+    that records every `close()` call into `closed_list`. Needed because
+    `sqlite3.Connection.close` is a read-only attribute and cannot be
+    monkey-patched directly.
+    """
+    closed: list[object] = []
+
+    class _CloseTracker:
+        _inner: sqlite3.Connection
+
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            object.__setattr__(self, "_inner", inner)
+
+        def close(self) -> None:
+            closed.append(self._inner)
+            self._inner.close()
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._inner, name)
+
+        def __setattr__(self, name: str, value: object) -> None:
+            setattr(self._inner, name, value)
+
+        def __enter__(self) -> sqlite3.Connection:
+            return self._inner.__enter__()
+
+        def __exit__(self, *args: object) -> object:
+            return self._inner.__exit__(*args)  # type: ignore[arg-type]
+
+    return closed, _CloseTracker
+
+
 def _make_collection(tmp_path: Path) -> Collection:
     """Build a writeable file-backed Collection."""
     vault = tmp_path / "vault"
@@ -414,40 +450,18 @@ def test_concurrent_build_and_reads_pr518_pattern(tmp_path: Path) -> None:
 
 
 def test_init_baseexception_cleanup_closes_primary(
-    monkeypatch: pytest.MonkeyPatch, tmp_db: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_db: Path,
+    close_tracker: tuple[list[object], type],
 ) -> None:
     """If _init_schema fails, the primary connection must be closed before
     the exception propagates — no leaked file handle."""
 
-    closed: list[object] = []
+    closed, tracker_cls = close_tracker
     real_connect = sqlite3.connect
 
-    class _CloseTracker:
-        """Forwarding wrapper that records close() calls (sqlite3.Connection.close is read-only)."""
-
-        _inner: sqlite3.Connection
-
-        def __init__(self, inner: sqlite3.Connection) -> None:
-            object.__setattr__(self, "_inner", inner)
-
-        def close(self) -> None:
-            closed.append(self._inner)
-            self._inner.close()
-
-        def __getattr__(self, name: str) -> object:
-            return getattr(self._inner, name)
-
-        def __setattr__(self, name: str, value: object) -> None:
-            setattr(self._inner, name, value)
-
-        def __enter__(self) -> sqlite3.Connection:
-            return self._inner.__enter__()
-
-        def __exit__(self, *args: object) -> object:
-            return self._inner.__exit__(*args)  # type: ignore[arg-type]
-
     def tracking_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
-        return _CloseTracker(real_connect(*args, **kwargs))  # type: ignore[return-value,arg-type]
+        return tracker_cls(real_connect(*args, **kwargs))  # type: ignore[return-value,arg-type,no-any-return]
 
     monkeypatch.setattr(
         "markdown_vault_mcp.fts_index.sqlite3.connect", tracking_connect
@@ -493,40 +507,18 @@ def test_probe_shared_cache_raises_when_documents_invisible(
 
 
 def test_conn_slow_path_baseexception_cleanup(
-    monkeypatch: pytest.MonkeyPatch, fts: FTSIndex
+    monkeypatch: pytest.MonkeyPatch,
+    fts: FTSIndex,
+    close_tracker: tuple[list[object], type],
 ) -> None:
     """If _apply_pragmas fails on a per-thread open, the new connection
     must be closed and the TLS slot left unset so a retry re-opens."""
 
-    closed: list[object] = []
+    closed, tracker_cls = close_tracker
     real_connect = sqlite3.connect
 
-    class _CloseTracker:
-        """Forwarding wrapper that records close() calls (sqlite3.Connection.close is read-only)."""
-
-        _inner: sqlite3.Connection
-
-        def __init__(self, inner: sqlite3.Connection) -> None:
-            object.__setattr__(self, "_inner", inner)
-
-        def close(self) -> None:
-            closed.append(self._inner)
-            self._inner.close()
-
-        def __getattr__(self, name: str) -> object:
-            return getattr(self._inner, name)
-
-        def __setattr__(self, name: str, value: object) -> None:
-            setattr(self._inner, name, value)
-
-        def __enter__(self) -> sqlite3.Connection:
-            return self._inner.__enter__()
-
-        def __exit__(self, *args: object) -> object:
-            return self._inner.__exit__(*args)  # type: ignore[arg-type]
-
     def tracking_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
-        return _CloseTracker(real_connect(*args, **kwargs))  # type: ignore[return-value,arg-type]
+        return tracker_cls(real_connect(*args, **kwargs))  # type: ignore[return-value,arg-type,no-any-return]
 
     monkeypatch.setattr(
         "markdown_vault_mcp.fts_index.sqlite3.connect", tracking_connect

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -552,3 +552,57 @@ def test_conn_slow_path_baseexception_cleanup(
     assert len(errors) == 1
     assert isinstance(errors[0], RuntimeError)
     assert len(closed) >= 1, "new per-thread connection must be closed on failure"
+
+
+def test_close_continues_when_one_connection_raises(fts: FTSIndex) -> None:
+    """If one ``conn.close()`` raises a non-sqlite3 exception (e.g. OSError),
+    ``close()`` must continue iterating and close the remaining connections —
+    otherwise a single bad connection leaks the rest.
+
+    Guards against narrowing the `except Exception:` in `close()` back to
+    `except sqlite3.Error:` (the original spec wording).
+    """
+    # Force a second per-thread connection so the registry has > 1 entry.
+    primary = fts._conn()
+    second_holder: dict[str, sqlite3.Connection] = {}
+
+    def grab() -> None:
+        second_holder["c"] = fts._conn()
+
+    t = threading.Thread(target=grab)
+    t.start()
+    t.join()
+    second = second_holder["c"]
+    assert primary is not second
+    assert len(fts._all_conns) == 2
+
+    # Replace one connection's close with a function that raises OSError.
+    # We can't monkey-patch sqlite3.Connection.close (read-only attr), so we
+    # swap the registry entry for a stand-in object that records close calls.
+    real_close_calls: list[object] = []
+
+    class _BadCloser:
+        def close(self) -> None:
+            raise OSError("simulated close failure")
+
+    class _GoodCloser:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            self._inner = inner
+
+        def close(self) -> None:
+            real_close_calls.append(self._inner)
+            self._inner.close()
+
+    bad = _BadCloser()
+    good = _GoodCloser(second)
+    # Replace registry contents with [bad, good]. Drop the real primary +
+    # second so they aren't double-closed by close() then by the fixture.
+    fts._all_conns[:] = [bad, good]  # type: ignore[list-item]
+    fts._primary_conn = None
+    primary.close()  # close the original primary out-of-band
+
+    # close() must reach `good` despite `bad` raising.
+    fts.close()
+    assert real_close_calls == [second], (
+        "close() must continue past a connection whose close() raises"
+    )


### PR DESCRIPTION
## Summary

Refactors `FTSIndex` from a single shared `sqlite3.Connection` to **per-thread connections** held in `threading.local` with a strong-ref side registry. Unblocks #513 (non-blocking MCP initialize via background indexing); PRs #510, #515, #516, #518 all failed because cross-thread SQLite errors surface on Python 3.12+ when one connection is shared across threads.

## Design (carryover from PR #520 abandon)

- **`threading.local`** per-thread connections; **strong-ref** `_all_conns` registry guarded by `_reg_lock` (weakref tried in #520 and produced a 3-finding cascade — see `feedback_519_weakref_whackamole.md`).
- **`_closed` flag** with double-checked locking: fast path lock-free; slow path re-checks under `_reg_lock` so a concurrent `close()` cannot race with a new-thread open.
- **`except BaseException`** on the slow-path open so `KeyboardInterrupt`/`SystemExit`/`asyncio.CancelledError` mid-pragma cannot leak the half-initialized connection.
- **`_primary_conn`** strong instance attribute so the constructing-thread's connection survives that thread's exit (registry-based `close()` still closes it).
- **Pragmas BEFORE schema/migrations** so `busy_timeout` is active during `ALTER TABLE` writes.
- **`:memory:` shared-cache URI translation**: each `FTSIndex(":memory:")` is mapped to a unique `file:fts_<uuid4hex>?mode=memory&cache=shared` URI so per-thread opens join the same in-memory DB. A startup probe fails fast on SQLite builds lacking `SQLITE_ENABLE_SHARED_CACHE`.
- `check_same_thread=False` kept so `close()` can iterate the registry from any thread; TLS routing is the safety mechanism, not the C-level check.

## What changed

- `src/markdown_vault_mcp/fts_index.py` — primary refactor. New `_resolve_connect_uri`, `_connect`, `_apply_pragmas`, `_init_schema`, `_probe_shared_cache`, `_conn` (now a method), rewritten `close`. ~30 internal `self._conn` attribute accesses become `self._conn()` calls.
- `src/markdown_vault_mcp/collection.py` — class docstring grows a Thread-safety section.
- `docs/design.md` — new "Collection thread-safety contract" subsection.
- `tests/test_thread_safety.py` (new, 12 tests, 100% TDD — RED verified before GREEN).
- `tests/test_fts_index.py`, `tests/test_fts_chunk_count.py`, `tests/test_fts_snippet.py`, `tests/test_links.py` — call-site adjustments (`fts._conn` → `fts._conn()`).
- `tests/test_fts_index.py::test_wal_warning_logged_when_pragma_returns_non_wal` — exercises `FTSIndex(...)` directly instead of the removed module-level `_open_connection`.

## Test plan

- [x] `uv run pytest -x -q` — 1605 passed, 1 skipped (pre-existing 3.13-only).
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv run mypy src/ tests/` — clean.
- [x] Pre-commit hooks — green.
- [x] PR #518 deterministic failure pattern (`InterfaceError: bad parameter or other API misuse`) reproduced pre-fix on Python 3.12.11; passes post-fix.
- [x] TDD: 11/12 new tests failed for the expected reason before implementation; the 12th (writer-serialization) is regression coverage for `Collection._write_lock`.

## Failure-mode coverage (`tests/test_thread_safety.py`)

| # | Test | Failure mode |
|---|------|--------------|
| 1 | `test_conn_is_per_thread` | TLS slot identity |
| 2 | `test_pragmas_applied_per_connection` | foreign_keys/busy_timeout/synchronous + WAL persistence |
| 3 | `test_pragmas_applied_before_schema` | ordering invariant for ALTER TABLE safety |
| 4 | `test_init_schema_runs_once_across_all_threads` | DDL exactly once |
| 5 | `test_close_closes_all_per_thread_connections` | registry close iteration |
| 6 | `test_close_is_idempotent` | second close = no-op |
| 7 | `test_closed_index_rejects_new_thread_access` | post-close ProgrammingError |
| 8 | `test_concurrent_close_and_new_thread_conn_open_is_safe` | Barrier-coordinated race |
| 9 | `test_registry_uses_strong_refs` | strong-ref retention after thread exit + gc |
| 10 | `test_memory_db_is_shared_across_threads` | shared-cache URI translation |
| 11 | `test_concurrent_writers_serialize_via_collection_write_lock` | `_write_lock` regression |
| 12 | `test_concurrent_build_and_reads_pr518_pattern` | acceptance integration test |

## Acceptance criteria from issue

- [x] `Collection`'s public methods callable concurrently without `sqlite3.OperationalError`/`InterfaceError`/`ProgrammingError`.
- [x] Integration test exercises PR #518's failure pattern (background `build_index(force=True)` + main `read/search/write/edit`).
- [x] `test_build_index_purges_stale_excluded_docs` continues to pass.
- [x] WAL journal mode behaviour unchanged.
- [x] Thread-safety contract documented (class docstrings + `docs/design.md`).
- [ ] Performance: 1k-search benchmark within 10% of main — manual run pending; not gated by CI. Defer if perf surprise surfaces in `ai-obsidian-vault-mcp` smoke.

## Out-of-scope follow-ups

- **tox-uv matrix for Python 3.11–3.14** is template-level surgery and tracked separately; this PR relies on CI's existing 3.11/3.12/3.13 matrix.
- **Background indexer (#513)** is unblocked but not addressed here.

Closes #519