### PR TITLE
refactor(collection): remove lazy-init; per-bucket readiness policy

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -358,8 +358,15 @@ Two methods manage the index:
 
 - **`build_index(force=False)`**: initial population. Scans `source_dir` and
   builds the FTS index. Short-circuits as a no-op when the persisted FTS
-  database already contains documents (warm restart on the same
-  `index_path`). `force=True` drops and rebuilds from scratch. When a
+  database contains documents **and** carries the completeness sentinel
+  written by a prior clean build (warm restart on the same `index_path`).
+  A database with rows but no sentinel — residue of a process that
+  crashed mid-build, since `IndexManager.build_index` commits per-document
+  in its own transaction — is treated as cold and triggers a full
+  rebuild. The sentinel is the `build_completed_at` row in the FTS
+  `meta` table, cleared by `Collection.build_index` before any
+  destructive rebuild and written only after `_index_mgr.build_index`
+  returns cleanly. `force=True` drops and rebuilds from scratch. When a
   persistent `index_path` contains documents that now match
   `exclude_patterns`, they are purged from the FTS and vector indexes
   after the scan — but only when a scan actually runs (i.e. on a cold

--- a/docs/design.md
+++ b/docs/design.md
@@ -371,19 +371,21 @@ Two methods manage the index:
 
 **Readiness contract (issue #525)**: `Collection.__init__` does not
 populate the index. Callers must invoke `build_index()` explicitly
-before bucket-3 relational queries (`get_backlinks`, `get_outlinks`,
-`get_similar`, `get_context`, `get_connection_path`) or the bucket-4
-coordinators (`reindex`, `build_embeddings`); otherwise
-`IndexNotReadyError` is raised. Bucket-1 file operations (`read`,
-`write`, `edit`, `delete`, `rename`, `write_attachment`) and bucket-2
-aggregate queries (`search`, `list`, `stats`, `list_folders`,
-`list_tags`, `get_recent`, `get_orphan_notes`, `get_most_linked`,
-`get_broken_links`, `get_toc`) work on an unbuilt index — bucket-1
-hits disk directly; bucket-2 queries whatever is currently in the
-index (empty on cold start). `wait_for_index_ready(timeout=None)` is
-the readiness primitive: it raises `IndexNotReadyError` pre-#513;
-once the background indexer (#513) lands it will block on a
-completion event.
+before bucket-3 relational/FTS-backed queries (`get_backlinks`,
+`get_outlinks`, `get_similar`, `get_context`, `get_connection_path`,
+`get_toc`) or the bucket-4 coordinators (`reindex`,
+`build_embeddings`); otherwise `IndexNotReadyError` is raised.
+`start()` must also be called after `build_index()` because its git
+pull loop wires `reindex` as the `on_pull` callback. Bucket-1 file
+operations (`read`, `write`, `edit`, `delete`, `rename`,
+`write_attachment`) and bucket-2 aggregate queries (`search`, `list`,
+`stats`, `list_folders`, `list_tags`, `get_recent`,
+`get_orphan_notes`, `get_most_linked`, `get_broken_links`) work on an
+unbuilt index — bucket-1 hits disk directly; bucket-2 queries
+whatever is currently in the index (empty on cold start).
+`wait_for_index_ready(timeout=None)` is the readiness primitive: it
+raises `IndexNotReadyError` pre-#513; once the background indexer
+(#513) lands it will block on a completion event.
 
 To apply a configuration change (e.g. new `exclude_patterns`,
 `required_frontmatter`) to a pre-existing index, call

--- a/docs/design.md
+++ b/docs/design.md
@@ -357,18 +357,39 @@ its source document path, enabling bulk deletion when a document is reindexed.
 Two methods manage the index:
 
 - **`build_index(force=False)`**: initial population. Scans `source_dir` and
-  builds the FTS index. If the index already has data and `force=False`, this
-  is a no-op. `force=True` drops and rebuilds from scratch. When a persistent
-  `index_path` contains documents that now match `exclude_patterns`, they are
-  purged from the FTS and vector indexes after the scan.
+  builds the FTS index. Short-circuits as a no-op when the persisted FTS
+  database already contains documents (warm restart on the same
+  `index_path`). `force=True` drops and rebuilds from scratch. When a
+  persistent `index_path` contains documents that now match
+  `exclude_patterns`, they are purged from the FTS and vector indexes
+  after the scan — but only when a scan actually runs (i.e. on a cold
+  index or with `force=True`); a warm-restart short-circuit does not
+  apply config changes.
 - **`reindex()`**: incremental update. Uses `ChangeTracker` to detect
   adds/modifies/deletes since the last scan and applies only the delta.
   Applies `exclude_patterns` filtering and purges stale excluded documents.
 
-**Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
-`Collection` lazily builds the FTS index from `source_dir` if no pre-built
-`index_path` was provided. `build_index()` can be called explicitly to
-pre-warm the index or to force a rebuild.
+**Readiness contract (issue #525)**: `Collection.__init__` does not
+populate the index. Callers must invoke `build_index()` explicitly
+before bucket-3 relational queries (`get_backlinks`, `get_outlinks`,
+`get_similar`, `get_context`, `get_connection_path`) or the bucket-4
+coordinators (`reindex`, `build_embeddings`); otherwise
+`IndexNotReadyError` is raised. Bucket-1 file operations (`read`,
+`write`, `edit`, `delete`, `rename`, `write_attachment`) and bucket-2
+aggregate queries (`search`, `list`, `stats`, `list_folders`,
+`list_tags`, `get_recent`, `get_orphan_notes`, `get_most_linked`,
+`get_broken_links`, `get_toc`) work on an unbuilt index — bucket-1
+hits disk directly; bucket-2 queries whatever is currently in the
+index (empty on cold start). `wait_for_index_ready(timeout=None)` is
+the readiness primitive: it raises `IndexNotReadyError` pre-#513;
+once the background indexer (#513) lands it will block on a
+completion event.
+
+To apply a configuration change (e.g. new `exclude_patterns`,
+`required_frontmatter`) to a pre-existing index, call
+`build_index(force=True)` — and, when embeddings are configured,
+`build_embeddings(force=True)` — because the short-circuit is keyed on
+FTS contents alone and does not detect config drift.
 
 ### Error Handling
 

--- a/src/markdown_vault_mcp/_cli_impl.py
+++ b/src/markdown_vault_mcp/_cli_impl.py
@@ -164,6 +164,10 @@ def _cmd_search(args: argparse.Namespace) -> None:
 def _cmd_reindex(args: argparse.Namespace) -> None:
     """Incrementally reindex the collection."""
     collection = _build_collection(args)
+    # reindex() requires a built index (bucket 4 readiness contract,
+    # issue #525). build_index() short-circuits in O(1) on a coherent
+    # persisted DB, so this is free on the warm path and correct on cold.
+    collection.build_index()
     result = collection.reindex()
     logger.info(
         "Reindex complete: %d added, %d modified, %d deleted, %d unchanged",

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -545,7 +545,7 @@ class Collection:
         Returns:
             :class:`~markdown_vault_mcp.types.IndexStats` describing what was indexed.
         """
-        if not force:
+        if not force and self._fts.is_build_completed():
             existing = self._fts.list_notes()
             if existing:
                 logger.debug(
@@ -559,11 +559,14 @@ class Collection:
                     skipped=0,
                 )
 
-        # Reset before the (potentially destructive, force=True) rebuild so a
-        # mid-rebuild exception leaves the Collection visibly not-ready —
-        # otherwise a previously-True flag would mask a cleared/partial index.
+        # Reset before the (potentially destructive) rebuild so a mid-build
+        # exception leaves the Collection visibly not-ready. The sentinel
+        # is cleared too so a crash mid-loop is detectable by the next
+        # process (rows without sentinel = partial — see issue #525).
         self._index_built = False
+        self._fts.clear_build_completed()
         result = self._index_mgr.build_index(force=force)
+        self._fts.set_build_completed()
         self._index_built = True
         return result
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -88,11 +88,14 @@ class Collection:
     """Facade over FTS5 index, vector index, and change tracker.
 
     Instantiate once per collection root.  Callers must invoke
-    :meth:`build_index` before bucket-3 relational queries
+    :meth:`build_index` before bucket-3 relational/FTS-backed queries
     (:meth:`get_backlinks`, :meth:`get_outlinks`, :meth:`get_similar`,
-    :meth:`get_context`, :meth:`get_connection_path`) or the bucket-4
-    coordinators :meth:`reindex` and :meth:`build_embeddings`; otherwise
+    :meth:`get_context`, :meth:`get_connection_path`, :meth:`get_toc`)
+    or the bucket-4 coordinators :meth:`reindex` and
+    :meth:`build_embeddings`; otherwise
     :exc:`~markdown_vault_mcp.exceptions.IndexNotReadyError` is raised.
+    :meth:`build_index` must also precede :meth:`start` — see
+    :meth:`start` for the rationale.
     Bucket-1 file operations (:meth:`read`, :meth:`write`, :meth:`edit`,
     :meth:`delete`, :meth:`rename`, :meth:`write_attachment`) and bucket-2
     aggregate queries (:meth:`search`, :meth:`list`, :meth:`stats`, …)
@@ -320,7 +323,14 @@ class Collection:
         self._git_strategy.sync_once(self._source_dir)
 
     def start(self) -> None:
-        """Start background tasks for this Collection (e.g. git pull loop)."""
+        """Start background tasks for this Collection (e.g. git pull loop).
+
+        Call :meth:`build_index` **before** :meth:`start`. The git pull
+        loop wires :meth:`reindex` (bucket 4) as its ``on_pull`` callback,
+        and ``reindex`` raises :exc:`IndexNotReadyError` on an unbuilt
+        index — so a pull event firing before the initial build would
+        crash the loop thread.
+        """
         if self._git_strategy is None or self._git_pull_interval_s <= 0:
             return
         self._git_strategy.start(
@@ -549,6 +559,10 @@ class Collection:
                     skipped=0,
                 )
 
+        # Reset before the (potentially destructive, force=True) rebuild so a
+        # mid-rebuild exception leaves the Collection visibly not-ready —
+        # otherwise a previously-True flag would mask a cleared/partial index.
+        self._index_built = False
         result = self._index_mgr.build_index(force=force)
         self._index_built = True
         return result
@@ -559,6 +573,9 @@ class Collection:
         Returns:
             :class:`~markdown_vault_mcp.types.ReindexResult` with counts of changes
             applied.
+
+        Raises:
+            IndexNotReadyError: If :meth:`build_index` has not been called.
         """
         self._require_index_ready()
         return self._index_mgr.reindex()
@@ -574,6 +591,7 @@ class Collection:
             Total number of chunks embedded.
 
         Raises:
+            IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is
                 not configured.
         """
@@ -618,7 +636,8 @@ class Collection:
         """Return table of contents for a document.
 
         Queries the FTS sections table for headings and prepends the document
-        title as a synthetic H1 entry.
+        title as a synthetic H1 entry. The result depends on the FTS index, so
+        cold-start callers must build the index first (bucket 3).
 
         Args:
             path: Relative path to the document (e.g. ``"notes/intro.md"``).
@@ -628,8 +647,10 @@ class Collection:
             position, with the document title prepended as level 1.
 
         Raises:
+            IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
+        self._require_index_ready()
         return self._doc_mgr.get_toc(path)
 
     def get_backlinks(self, path: str) -> list[BacklinkInfo]:
@@ -644,6 +665,7 @@ class Collection:
             for each document that contains a link pointing to ``path``.
 
         Raises:
+            IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_index_ready()
@@ -664,6 +686,7 @@ class Collection:
             each link originating from ``path``.
 
         Raises:
+            IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_index_ready()
@@ -702,6 +725,9 @@ class Collection:
 
         Returns:
             List of grouped results.
+
+        Raises:
+            IndexNotReadyError: If :meth:`build_index` has not been called.
         """
         self._require_index_ready()
         return self._search_mgr.get_similar(
@@ -750,6 +776,7 @@ class Collection:
             stays compact.
 
         Raises:
+            IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_index_ready()
@@ -800,6 +827,7 @@ class Collection:
             (inclusive), or ``None`` if unreachable within *max_depth* hops.
 
         Raises:
+            IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If *source* or *target* is not found in the index.
         """
         self._require_index_ready()

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -13,6 +13,7 @@ import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal
 
+from markdown_vault_mcp.exceptions import IndexNotReadyError
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.scanner import (
     ChunkStrategy,
@@ -86,8 +87,18 @@ def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
 class Collection:
     """Facade over FTS5 index, vector index, and change tracker.
 
-    Instantiate once per collection root.  Call :meth:`build_index` (or let
-    lazy initialisation handle it) before querying.
+    Instantiate once per collection root.  Callers must invoke
+    :meth:`build_index` before bucket-3 relational queries
+    (:meth:`get_backlinks`, :meth:`get_outlinks`, :meth:`get_similar`,
+    :meth:`get_context`, :meth:`get_connection_path`) or the bucket-4
+    coordinators :meth:`reindex` and :meth:`build_embeddings`; otherwise
+    :exc:`~markdown_vault_mcp.exceptions.IndexNotReadyError` is raised.
+    Bucket-1 file operations (:meth:`read`, :meth:`write`, :meth:`edit`,
+    :meth:`delete`, :meth:`rename`, :meth:`write_attachment`) and bucket-2
+    aggregate queries (:meth:`search`, :meth:`list`, :meth:`stats`, …)
+    work on an unbuilt index — bucket-1 hits disk directly; bucket-2
+    returns whatever is currently in the index (empty on cold start).
+    See issue #525.
 
     **Thread safety (issue #519):** every public method on this class is safe
     to call from any thread, concurrently with other reads and writes from
@@ -206,8 +217,10 @@ class Collection:
         )
         self._tracker = ChangeTracker(self._state_path)
 
-        # Lazy initialisation flag.
-        self._initialized = False
+        # True once build_index() has completed successfully; gates
+        # bucket-3 (relational queries) and bucket-4 (reindex /
+        # build_embeddings). See issue #525.
+        self._index_built = False
 
         # Serialise concurrent write operations on this instance.
         # Re-entrant: periodic pull tick blocks writes, then reindex() acquires
@@ -360,13 +373,33 @@ class Collection:
         self._fts.close()
 
     # ------------------------------------------------------------------
-    # Lazy initialisation
+    # Indexing readiness (issue #525)
     # ------------------------------------------------------------------
 
-    def _ensure_initialized(self) -> None:
-        """Build the FTS index on first access if it has not been built yet."""
-        if not self._initialized:
-            self.build_index()
+    def _require_index_ready(self) -> None:
+        """Raise :exc:`IndexNotReadyError` if :meth:`build_index` has not run."""
+        if not self._index_built:
+            raise IndexNotReadyError(
+                "Index not built. Call build_index() before this method."
+            )
+
+    def wait_for_index_ready(self, timeout: float | None = None) -> None:
+        """Block until the FTS index is ready, or raise.
+
+        Pre-#513 this is a synchronous readiness check: raises
+        :exc:`IndexNotReadyError` when :meth:`build_index` has not
+        completed. The *timeout* parameter is reserved for the
+        background-indexer variant (#513), which will wait on a
+        completion event with this budget.
+
+        Args:
+            timeout: Maximum seconds to wait. Currently unused.
+
+        Raises:
+            IndexNotReadyError: If the index has not been built.
+        """
+        del timeout  # Reserved for #513 — no background build to wait on.
+        self._require_index_ready()
 
     @property
     def _vectors(self) -> VectorIndex | None:
@@ -417,7 +450,6 @@ class Collection:
             ValueError: If *mode* is ``"semantic"`` or ``"hybrid"`` but no
                 embedding provider or embeddings path is configured.
         """
-        self._ensure_initialized()
         return self._search_mgr.search(
             query,
             limit=limit,
@@ -447,7 +479,6 @@ class Collection:
             A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``
             if the file does not exist.
         """
-        self._ensure_initialized()
         return self._doc_mgr.read(path, section=section)
 
     def list(
@@ -474,7 +505,6 @@ class Collection:
             optionally :class:`~markdown_vault_mcp.types.AttachmentInfo`)
             objects.
         """
-        self._ensure_initialized()
         return self._search_mgr.list(
             folder=folder, pattern=pattern, include_attachments=include_attachments
         )
@@ -486,9 +516,18 @@ class Collection:
     def build_index(self, *, force: bool = False) -> IndexStats:
         """Scan source_dir and build the FTS index.
 
-        If the index already contains documents and *force* is ``False``,
-        this is a no-op.  ``force=True`` drops all existing data and rebuilds
-        from scratch.
+        If the persisted FTS index already contains documents and *force*
+        is ``False``, this is a no-op — the short-circuit is keyed solely
+        on FTS state, so warm restarts (new process, same database file)
+        return immediately rather than re-scanning the vault.
+        ``force=True`` drops all existing data and rebuilds from scratch.
+
+        .. note::
+           Config changes (``exclude_patterns``, ``required_frontmatter``)
+           do not re-trigger a scan on warm restart because they are not
+           part of the short-circuit key. To apply a config change to a
+           pre-existing index, call ``build_index(force=True)``. See
+           issue #525.
 
         Args:
             force: When ``True``, drop and rebuild the index unconditionally.
@@ -496,14 +535,14 @@ class Collection:
         Returns:
             :class:`~markdown_vault_mcp.types.IndexStats` describing what was indexed.
         """
-        # Check if index already has data and we are not forcing.
-        if not force and self._initialized:
+        if not force:
             existing = self._fts.list_notes()
             if existing:
                 logger.debug(
                     "build_index: index already populated (%d docs), skipping",
                     len(existing),
                 )
+                self._index_built = True
                 return IndexStats(
                     documents_indexed=len(existing),
                     chunks_indexed=0,
@@ -511,7 +550,7 @@ class Collection:
                 )
 
         result = self._index_mgr.build_index(force=force)
-        self._initialized = True
+        self._index_built = True
         return result
 
     def reindex(self) -> ReindexResult:
@@ -521,7 +560,7 @@ class Collection:
             :class:`~markdown_vault_mcp.types.ReindexResult` with counts of changes
             applied.
         """
-        self._ensure_initialized()
+        self._require_index_ready()
         return self._index_mgr.reindex()
 
     def build_embeddings(self, *, force: bool = False) -> int:
@@ -538,7 +577,7 @@ class Collection:
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is
                 not configured.
         """
-        self._ensure_initialized()
+        self._require_index_ready()
         return self._index_mgr.build_embeddings(force=force)
 
     def embeddings_status(self) -> dict:
@@ -560,7 +599,6 @@ class Collection:
         Returns:
             Sorted list of folder strings (``""`` for the collection root).
         """
-        self._ensure_initialized()
         return self._search_mgr.list_folders()
 
     def list_tags(self, field: str = "tags") -> list[str]:
@@ -574,7 +612,6 @@ class Collection:
         Returns:
             Sorted list of distinct value strings.
         """
-        self._ensure_initialized()
         return self._search_mgr.list_tags(field)
 
     def get_toc(self, path: str) -> list[dict[str, Any]]:
@@ -593,7 +630,6 @@ class Collection:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        self._ensure_initialized()
         return self._doc_mgr.get_toc(path)
 
     def get_backlinks(self, path: str) -> list[BacklinkInfo]:
@@ -610,7 +646,7 @@ class Collection:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        self._ensure_initialized()
+        self._require_index_ready()
         return self._link_mgr.get_backlinks(path)
 
     def get_outlinks(self, path: str) -> list[OutlinkInfo]:
@@ -630,7 +666,7 @@ class Collection:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        self._ensure_initialized()
+        self._require_index_ready()
         return self._link_mgr.get_outlinks(path)
 
     def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
@@ -643,7 +679,6 @@ class Collection:
         Returns:
             List of :class:`~markdown_vault_mcp.types.BrokenLinkInfo` objects.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_broken_links(folder=folder)
 
     def get_similar(
@@ -668,7 +703,7 @@ class Collection:
         Returns:
             List of grouped results.
         """
-        self._ensure_initialized()
+        self._require_index_ready()
         return self._search_mgr.get_similar(
             path, limit=limit, chunks_per_file=chunks_per_file
         )
@@ -687,7 +722,6 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.NoteInfo` objects
             ordered by modification time (most recent first).
         """
-        self._ensure_initialized()
         return self._search_mgr.get_recent(limit=limit, folder=folder)
 
     def get_context(
@@ -718,7 +752,7 @@ class Collection:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        self._ensure_initialized()
+        self._require_index_ready()
         return self._search_mgr.get_context(
             path, similar_limit=similar_limit, link_limit=link_limit
         )
@@ -733,7 +767,6 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.NoteInfo` objects,
             ordered by path.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_orphan_notes()
 
     def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]:
@@ -746,7 +779,6 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.MostLinkedNote` ordered
             by backlink_count descending.
         """
-        self._ensure_initialized()
         return self._link_mgr.get_most_linked(limit=limit)
 
     def get_connection_path(
@@ -770,7 +802,7 @@ class Collection:
         Raises:
             ValueError: If *source* or *target* is not found in the index.
         """
-        self._ensure_initialized()
+        self._require_index_ready()
         return self._link_mgr.get_connection_path(source, target, max_depth=max_depth)
 
     # ------------------------------------------------------------------
@@ -902,7 +934,6 @@ class Collection:
         Returns:
             :class:`~markdown_vault_mcp.types.CollectionStats` snapshot.
         """
-        self._ensure_initialized()
 
         rows = self._fts.list_notes()
         doc_count = len(rows)
@@ -1023,7 +1054,6 @@ class Collection:
         already validated against ``MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES``);
         leave ``False`` for base64 callers of the MCP ``write`` tool.
         """
-        self._ensure_initialized()
         return self._doc_mgr.write_attachment(
             path, content, if_match=if_match, skip_size_cap=skip_size_cap
         )
@@ -1058,7 +1088,6 @@ class Collection:
                 not match the current file hash.
             ValueError: If *path* escapes the source directory.
         """
-        self._ensure_initialized()
         return self._doc_mgr.write(
             path, content, frontmatter=frontmatter, if_match=if_match
         )
@@ -1099,7 +1128,6 @@ class Collection:
                 not match.
             ValueError: If *path* escapes the source directory.
         """
-        self._ensure_initialized()
         return self._doc_mgr.edit(
             path,
             old_text=old_text,
@@ -1129,7 +1157,6 @@ class Collection:
                 not match.
             DocumentNotFoundError: If *path* does not exist.
         """
-        self._ensure_initialized()
         return self._doc_mgr.delete(path, if_match=if_match)
 
     def rename(
@@ -1165,7 +1192,6 @@ class Collection:
             ValueError: If *old_path* or *new_path* escapes the source
                 directory.
         """
-        self._ensure_initialized()
         return self._doc_mgr.rename(
             old_path, new_path, if_match=if_match, update_links=update_links
         )

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -69,11 +69,12 @@ class ConfigurationError(MarkdownMCPError):
 class IndexNotReadyError(MarkdownMCPError):
     """Raised when a method requires a built FTS index and none exists.
 
-    Bucket-3 relational queries (``get_backlinks``, ``get_outlinks``,
-    ``get_similar``, ``get_context``, ``get_connection_path``) and
-    bucket-4 coordinators (``reindex``, ``build_embeddings``) cannot
-    produce correct results against an empty / never-built index. They
-    raise this rather than silently return wrong answers.
+    Bucket-3 relational / FTS-backed queries (``get_backlinks``,
+    ``get_outlinks``, ``get_similar``, ``get_context``,
+    ``get_connection_path``, ``get_toc``) and bucket-4 coordinators
+    (``reindex``, ``build_embeddings``) cannot produce correct results
+    against an empty / never-built index. They raise this rather than
+    silently return wrong answers.
 
     Callers must call :meth:`Collection.build_index` before these
     methods. Once a background indexer lands (issue #513), the

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -64,3 +64,19 @@ class ConcurrentModificationError(MarkdownMCPError):
 
 class ConfigurationError(MarkdownMCPError):
     """Raised for invalid or unsupported configuration at startup."""
+
+
+class IndexNotReadyError(MarkdownMCPError):
+    """Raised when a method requires a built FTS index and none exists.
+
+    Bucket-3 relational queries (``get_backlinks``, ``get_outlinks``,
+    ``get_similar``, ``get_context``, ``get_connection_path``) and
+    bucket-4 coordinators (``reindex``, ``build_embeddings``) cannot
+    produce correct results against an empty / never-built index. They
+    raise this rather than silently return wrong answers.
+
+    Callers must call :meth:`Collection.build_index` before these
+    methods. Once a background indexer lands (issue #513), the
+    :meth:`Collection.wait_for_index_ready` primitive will block on a
+    completion event instead of raising.
+    """

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -106,7 +106,19 @@ CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
     path, title, folder, heading, content,
     tokenize='porter unicode61'
 );
+
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
 """
+
+# Key written into ``meta`` after :meth:`Collection.build_index` completes
+# a full scan successfully. Warm-restart short-circuits keyed solely on
+# ``documents`` row presence would otherwise treat a partial index (left
+# by a crash mid-build, since per-document upserts each commit in their
+# own transaction) as ready — see issue #525.
+_META_BUILD_COMPLETED_KEY = "build_completed_at"
 
 
 def _escape_like(value: str) -> str:
@@ -762,6 +774,42 @@ class FTSIndex:
         if deleted:
             logger.debug("delete_by_path: removed %s", path)
         return deleted
+
+    # ------------------------------------------------------------------
+    # Build completeness sentinel (issue #525)
+    # ------------------------------------------------------------------
+
+    def is_build_completed(self) -> bool:
+        """Return ``True`` iff a prior ``build_index`` run committed the
+        completeness sentinel into the ``meta`` table.
+
+        Absence of the sentinel — paired with non-empty ``documents`` —
+        signals a partial index left by a crashed prior build, and the
+        caller (``Collection.build_index``) treats it as cold.
+        """
+        conn = self._conn()
+        with conn:
+            row = conn.execute(
+                "SELECT 1 FROM meta WHERE key = ?",
+                (_META_BUILD_COMPLETED_KEY,),
+            ).fetchone()
+        return row is not None
+
+    def set_build_completed(self) -> None:
+        """Mark the FTS index as the result of a clean full build."""
+        conn = self._conn()
+        ts = datetime.datetime.now(tz=datetime.UTC).isoformat()
+        with conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES(?, ?)",
+                (_META_BUILD_COMPLETED_KEY, ts),
+            )
+
+    def clear_build_completed(self) -> None:
+        """Erase the completeness sentinel (before a destructive rebuild)."""
+        conn = self._conn()
+        with conn:
+            conn.execute("DELETE FROM meta WHERE key = ?", (_META_BUILD_COMPLETED_KEY,))
 
     def search(
         self,

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -178,7 +178,7 @@ class IndexManager:
         this is a no-op.  ``force=True`` drops all existing data and rebuilds
         from scratch.
 
-        Note: the caller is responsible for setting any ``_initialized``
+        Note: the caller is responsible for setting any ``_index_built``
         flag after this method returns.
 
         Args:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1009,3 +1009,32 @@ class TestCmdReindex:
             main()
 
         mock_collection.build_embeddings.assert_called_once_with(force=True)
+
+    def test_reindex_against_real_collection(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """End-to-end: ``markdown-vault-mcp reindex`` on a real (unbuilt)
+        Collection must succeed. Pre-fix the bucket-4 readiness guard
+        crashed every invocation because the command jumped straight to
+        ``reindex()`` without first building. Mock-based tests above
+        miss this because they replace Collection wholesale.
+        """
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "a.md").write_text("# A\n\nhello\n")
+        (vault / "b.md").write_text("# B\n\nworld\n")
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "state.json")
+        )
+
+        with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
+            main()
+
+        captured = capsys.readouterr()
+        assert "Reindex" in captured.out

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -264,10 +264,9 @@ class TestBuildIndex:
             index_path=index_path,
             exclude_patterns=[".claude/**"],
         )
-        # Bypass the _ensure_initialized() guard: col2 shares the same
-        # persistent DB as col1, so the index already exists — we want to
-        # test reindex() directly, not build_index().
-        col2._initialized = True
+        # col2 shares the persistent DB; build_index() short-circuits on
+        # populated FTS state alone (issue #525), so this is fast.
+        col2.build_index()
         col2.reindex()
 
         # The stale excluded doc should be purged.
@@ -312,7 +311,7 @@ class TestBuildIndex:
             embedding_provider=mock_provider,
             exclude_patterns=[".claude/**"],
         )
-        col2._initialized = True
+        col2.build_index()
         col2.reindex()
 
         paths2 = [row["path"] for row in col2._fts.list_notes()]
@@ -338,14 +337,16 @@ class TestBuildIndex:
         paths1 = [row["path"] for row in col1._fts.list_notes()]
         assert ".claude/test.md" in paths1
 
-        # Phase 2: new Collection WITH exclude_patterns, build_index() on
-        # the same persistent DB.  The stale doc should be purged.
+        # Phase 2: new Collection WITH exclude_patterns. Per issue #525 the
+        # short-circuit fires on populated FTS state alone, so a plain
+        # build_index() would no-op — config changes (exclude_patterns,
+        # required_frontmatter) need an explicit force=True rebuild.
         col2 = _make_collection(
             vault_path,
             index_path=index_path,
             exclude_patterns=[".claude/**"],
         )
-        col2.build_index()
+        col2.build_index(force=True)
         paths2 = [row["path"] for row in col2._fts.list_notes()]
         assert ".claude/test.md" not in paths2
 
@@ -376,7 +377,10 @@ class TestBuildIndex:
         vec_paths1 = [m["path"] for m in col1._vectors._metadata]
         assert ".claude/test.md" in vec_paths1
 
-        # Phase 2: build_index() WITH exclude_patterns — purges from both.
+        # Phase 2: force=True rebuild applies the new exclude_patterns to
+        # both FTS and embeddings — see the sibling test for the rationale
+        # (issue #525). Vectors need their own force=True because the
+        # short-circuit in build_embeddings is independent.
         col2 = _make_collection(
             vault_path,
             index_path=index_path,
@@ -384,7 +388,8 @@ class TestBuildIndex:
             embedding_provider=mock_provider,
             exclude_patterns=[".claude/**"],
         )
-        col2.build_index()
+        col2.build_index(force=True)
+        col2.build_embeddings(force=True)
 
         paths2 = [row["path"] for row in col2._fts.list_notes()]
         assert ".claude/test.md" not in paths2
@@ -400,24 +405,21 @@ class TestBuildIndex:
 
 
 class TestLazyInitialisation:
-    def test_search_without_build_index(self, vault_path: Path) -> None:
-        """search() triggers lazy initialisation without an explicit build_index()."""
+    def test_search_without_build_index_returns_empty(self, vault_path: Path) -> None:
+        """search() on an unbuilt index returns [] without crashing (bucket 2)."""
         col = _make_collection(vault_path)
 
-        # Do NOT call build_index() — search() should initialise automatically.
         results = col.search("simple")
 
-        # Either finds something or returns [] — the key is it does not crash.
-        assert isinstance(results, list)
+        assert results == []
 
-    def test_list_without_build_index(self, vault_path: Path) -> None:
-        """list() triggers lazy initialisation without an explicit build_index()."""
+    def test_list_without_build_index_returns_empty(self, vault_path: Path) -> None:
+        """list() on an unbuilt index returns [] (bucket 2 — no implicit build)."""
         col = _make_collection(vault_path)
 
         notes = col.list()
 
-        assert isinstance(notes, list)
-        assert len(notes) == 9
+        assert notes == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -10,9 +10,12 @@ Collection methods fall into four buckets:
   ``get_most_linked``, ``get_broken_links``, ``stats``. Query against
   current index state; never implicitly build.
 - Bucket 3 (block / raise): ``get_backlinks``, ``get_outlinks``,
-  ``get_similar``, ``get_context``, ``get_connection_path``. Silently
-  wrong on a partial index → raise ``IndexNotReadyError`` pre-#513;
-  block on a background-completion event post-#513.
+  ``get_similar``, ``get_context``, ``get_connection_path``,
+  ``get_toc``. Silently wrong on a partial index → raise
+  ``IndexNotReadyError`` pre-#513; block on a background-completion
+  event post-#513. (``get_toc`` is FTS-backed: on cold start the FTS
+  ``documents`` row is absent and the underlying manager would raise
+  a misleading ``ValueError("Document not found")``.)
 - Bucket 4 (coordinate): ``reindex``, ``build_embeddings``,
   ``build_index``. ``reindex`` and ``build_embeddings`` require a built
   index (raise ``IndexNotReadyError`` otherwise). ``build_index`` is
@@ -197,6 +200,17 @@ class TestBucket3Block:
         with pytest.raises(IndexNotReadyError):
             col.get_connection_path("a.md", "b.md")
 
+    def test_get_toc_on_unbuilt_raises(self, tmp_path: Path) -> None:
+        """get_toc reads from FTS so cold-start must raise readiness, not a
+        misleading ValueError("Document not found") for a file that exists.
+        """
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+
+        with pytest.raises(IndexNotReadyError):
+            col.get_toc("note.md")
+
 
 # ---------------------------------------------------------------------------
 # Bucket 4 — coordinate (reindex/build_embeddings require built index;
@@ -281,6 +295,27 @@ class TestWaitForIndexReady:
 
 
 class TestReadinessFlagSemantics:
+    def test_failed_force_rebuild_clears_flag(self, tmp_path: Path) -> None:
+        """A failed build_index(force=True) on a previously-built Collection
+        must clear ``_index_built`` — otherwise bucket-3 queries proceed
+        against a cleared / partially rebuilt index.
+        """
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+        col.build_index()  # Sets _index_built = True.
+
+        def boom(*_a: object, **_kw: object) -> None:
+            raise RuntimeError("simulated rebuild failure")
+
+        col._index_mgr.build_index = boom  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError):
+            col.build_index(force=True)
+
+        with pytest.raises(IndexNotReadyError):
+            col.get_backlinks("note.md")
+
     def test_failed_build_index_leaves_unready(self, tmp_path: Path) -> None:
         """If build_index() raises, subsequent bucket-3 calls still raise."""
         vault = _vault(tmp_path)

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -294,6 +294,68 @@ class TestWaitForIndexReady:
 # ---------------------------------------------------------------------------
 
 
+class TestWarmRestartCompletenessSentinel:
+    """Warm-restart short-circuit must require proof of clean prior build,
+    not just "FTS has some rows" (a partial-write crash leaves rows
+    without the proof).
+    """
+
+    def test_warm_restart_with_partial_index_rebuilds(self, tmp_path: Path) -> None:
+        """A persistent FTS with rows but no completeness sentinel — the
+        residue of a process that crashed mid-build_index — must trigger
+        a full rebuild on the next process, not be treated as ready.
+        """
+        from markdown_vault_mcp.fts_index import FTSIndex
+        from markdown_vault_mcp.scanner import scan_directory
+
+        vault = _vault(tmp_path)
+        for i in range(3):
+            _seed(vault, f"n_{i}.md", f"# N{i}\n\nbody {i}\n")
+        index_path = tmp_path / "fts.db"
+
+        # Simulate a crash-mid-build: upsert one note directly into the
+        # FTS DB (so list_notes() is non-empty) without going through
+        # Collection.build_index() (so no sentinel is set).
+        fts = FTSIndex(db_path=index_path)
+        for note in scan_directory(vault):
+            fts.upsert_note(note)
+            break  # Stop after one — simulating a mid-loop crash.
+        fts.close()
+
+        # Next process opens the same DB and calls build_index().
+        col = Collection(source_dir=vault, index_path=index_path)
+        col.build_index()
+
+        # Must have rebuilt fully — not short-circuited on the 1 stale row.
+        assert {row["path"] for row in col._fts.list_notes()} == {
+            "n_0.md",
+            "n_1.md",
+            "n_2.md",
+        }
+        col.close()
+
+    def test_clean_warm_restart_short_circuits(self, tmp_path: Path) -> None:
+        """A persistent FTS that was the result of a successful prior
+        build MUST short-circuit — the perf win the PR is for.
+        """
+        vault = _vault(tmp_path)
+        for i in range(3):
+            _seed(vault, f"n_{i}.md", f"# N{i}\n\nbody {i}\n")
+        index_path = tmp_path / "fts.db"
+
+        col1 = Collection(source_dir=vault, index_path=index_path)
+        col1.build_index()
+        col1.close()
+
+        col2 = Collection(source_dir=vault, index_path=index_path)
+        stats = col2.build_index()
+
+        # Short-circuit: zero chunks reindexed.
+        assert stats.documents_indexed == 3
+        assert stats.chunks_indexed == 0
+        col2.close()
+
+
 class TestReadinessFlagSemantics:
     def test_failed_force_rebuild_clears_flag(self, tmp_path: Path) -> None:
         """A failed build_index(force=True) on a previously-built Collection

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -1,0 +1,300 @@
+"""Tests for the indexing-readiness policy from issue #525.
+
+Collection methods fall into four buckets:
+
+- Bucket 1 (never block): ``read``, ``write``, ``edit``, ``delete``,
+  ``rename``, ``write_attachment``. Disk is the source of truth; the FTS
+  index is a downstream consumer.
+- Bucket 2 (partial + report): ``search``, ``list``, ``list_folders``,
+  ``list_tags``, ``get_recent``, ``get_orphan_notes``,
+  ``get_most_linked``, ``get_broken_links``, ``stats``. Query against
+  current index state; never implicitly build.
+- Bucket 3 (block / raise): ``get_backlinks``, ``get_outlinks``,
+  ``get_similar``, ``get_context``, ``get_connection_path``. Silently
+  wrong on a partial index → raise ``IndexNotReadyError`` pre-#513;
+  block on a background-completion event post-#513.
+- Bucket 4 (coordinate): ``reindex``, ``build_embeddings``,
+  ``build_index``. ``reindex`` and ``build_embeddings`` require a built
+  index (raise ``IndexNotReadyError`` otherwise). ``build_index`` is
+  the bootstrap; its warm-restart short-circuit uses persisted FTS
+  state alone (no ``_initialized`` flag).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.exceptions import IndexNotReadyError
+from tests.conftest import MockEmbeddingProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    return vault
+
+
+def _seed(vault: Path, name: str = "note.md", body: str = "# Note\n\nhello\n") -> Path:
+    f = vault / name
+    f.write_text(body)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Bucket 1 — never block (read/write/edit/delete/rename/write_attachment)
+# ---------------------------------------------------------------------------
+
+
+class TestBucket1NeverBlock:
+    def test_read_on_unbuilt_returns_disk_content(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault, "a.md", "# A\n\nbody\n")
+        col = Collection(source_dir=vault)
+
+        result = col.read("a.md")
+
+        assert result is not None
+        assert "body" in result.content
+
+    def test_write_on_unbuilt_persists_to_disk(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        col = Collection(source_dir=vault, read_only=False)
+
+        col.write("new.md", "# New\n\ncreated\n")
+
+        assert (vault / "new.md").read_text().endswith("created\n")
+
+    def test_edit_on_unbuilt_modifies_disk(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault, "e.md", "# E\n\nfoo\n")
+        col = Collection(source_dir=vault, read_only=False)
+
+        col.edit("e.md", old_text="foo", new_text="bar")
+
+        assert "bar" in (vault / "e.md").read_text()
+
+    def test_delete_on_unbuilt_removes_from_disk(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault, "d.md")
+        col = Collection(source_dir=vault, read_only=False)
+
+        col.delete("d.md")
+
+        assert not (vault / "d.md").exists()
+
+    def test_rename_on_unbuilt_moves_file(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault, "old.md")
+        col = Collection(source_dir=vault, read_only=False)
+
+        col.rename("old.md", "new.md")
+
+        assert not (vault / "old.md").exists()
+        assert (vault / "new.md").exists()
+
+    def test_write_attachment_on_unbuilt_persists(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        col = Collection(
+            source_dir=vault,
+            read_only=False,
+            attachment_extensions=["bin"],
+        )
+
+        col.write_attachment("blob.bin", b"\x00\x01\x02")
+
+        assert (vault / "blob.bin").read_bytes() == b"\x00\x01\x02"
+
+
+# ---------------------------------------------------------------------------
+# Bucket 2 — partial + report (return empty/no-op on unbuilt; no implicit build)
+# ---------------------------------------------------------------------------
+
+
+class TestBucket2PartialReport:
+    def test_search_on_unbuilt_returns_empty(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault, "a.md", "# A\n\nhello world\n")
+        col = Collection(source_dir=vault)
+
+        results = col.search("hello")
+
+        assert results == []
+
+    def test_list_on_unbuilt_returns_empty(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault, "a.md")
+        _seed(vault, "b.md")
+        col = Collection(source_dir=vault)
+
+        notes = col.list()
+
+        assert notes == []
+
+    def test_stats_on_unbuilt_reports_zero_documents(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+
+        result = col.stats()
+
+        assert result.document_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Bucket 3 — block (raise IndexNotReadyError on unbuilt pre-#513)
+# ---------------------------------------------------------------------------
+
+
+class TestBucket3Block:
+    def test_get_backlinks_on_unbuilt_raises(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+
+        with pytest.raises(IndexNotReadyError):
+            col.get_backlinks("note.md")
+
+    def test_get_outlinks_on_unbuilt_raises(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+
+        with pytest.raises(IndexNotReadyError):
+            col.get_outlinks("note.md")
+
+    def test_get_similar_on_unbuilt_raises(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(
+            source_dir=vault,
+            embedding_provider=MockEmbeddingProvider(),
+            embeddings_path=tmp_path / "vectors",
+        )
+
+        with pytest.raises(IndexNotReadyError):
+            col.get_similar("note.md")
+
+    def test_get_context_on_unbuilt_raises(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+
+        with pytest.raises(IndexNotReadyError):
+            col.get_context("note.md")
+
+    def test_get_connection_path_on_unbuilt_raises(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault, "a.md")
+        _seed(vault, "b.md")
+        col = Collection(source_dir=vault)
+
+        with pytest.raises(IndexNotReadyError):
+            col.get_connection_path("a.md", "b.md")
+
+
+# ---------------------------------------------------------------------------
+# Bucket 4 — coordinate (reindex/build_embeddings require built index;
+# build_index short-circuit uses FTS state alone)
+# ---------------------------------------------------------------------------
+
+
+class TestBucket4Coordinate:
+    def test_reindex_on_unbuilt_raises(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+
+        with pytest.raises(IndexNotReadyError):
+            col.reindex()
+
+    def test_build_embeddings_on_unbuilt_raises(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(
+            source_dir=vault,
+            embedding_provider=MockEmbeddingProvider(),
+            embeddings_path=tmp_path / "vectors",
+        )
+
+        with pytest.raises(IndexNotReadyError):
+            col.build_embeddings()
+
+    def test_build_index_short_circuits_on_warm_restart(self, tmp_path: Path) -> None:
+        """A second Collection on the same persistent FTS DB short-circuits.
+
+        Pre-fix: ``_initialized`` resets to False on every process start,
+        so ``build_index()`` re-scans every file even when the FTS DB
+        already holds them. Post-fix: short-circuit checks FTS state
+        alone, so warm restarts are O(1).
+        """
+        vault = _vault(tmp_path)
+        for i in range(5):
+            _seed(vault, f"note_{i}.md", f"# Note {i}\n\nbody {i}\n")
+
+        index_path = tmp_path / "fts.db"
+
+        col1 = Collection(source_dir=vault, index_path=index_path)
+        col1.build_index()
+        col1.close()
+
+        col2 = Collection(source_dir=vault, index_path=index_path)
+        stats = col2.build_index()
+
+        # Short-circuit returns the existing count, indexes zero new chunks.
+        assert stats.documents_indexed == 5
+        assert stats.chunks_indexed == 0
+        col2.close()
+
+
+# ---------------------------------------------------------------------------
+# wait_for_index_ready primitive
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForIndexReady:
+    def test_unbuilt_raises(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        col = Collection(source_dir=vault)
+
+        with pytest.raises(IndexNotReadyError):
+            col.wait_for_index_ready(timeout=0.1)
+
+    def test_after_build_returns(self, tmp_path: Path) -> None:
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+        col.build_index()
+
+        # Must return without raising.
+        col.wait_for_index_ready(timeout=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: readiness flag is only set after a successful build
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessFlagSemantics:
+    def test_failed_build_index_leaves_unready(self, tmp_path: Path) -> None:
+        """If build_index() raises, subsequent bucket-3 calls still raise."""
+        vault = _vault(tmp_path)
+        _seed(vault)
+        col = Collection(source_dir=vault)
+
+        # Force the underlying index manager to fail.
+        def boom(*_a: object, **_kw: object) -> None:
+            raise RuntimeError("simulated build failure")
+
+        col._index_mgr.build_index = boom  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError):
+            col.build_index()
+
+        with pytest.raises(IndexNotReadyError):
+            col.get_backlinks("note.md")


### PR DESCRIPTION
## Summary

Closes #525 (prerequisite for #513).

Drops `Collection._ensure_initialized()` lazy-bootstrap gate and replaces
it with an explicit per-bucket readiness contract derived from the
design discussion on #525:

- **Bucket 1** (`read`, `write`, `edit`, `delete`, `rename`,
  `write_attachment`) — never block. Disk is the source of truth.
- **Bucket 2** (`search`, `list`, `list_folders`, `list_tags`,
  `get_recent`, `get_orphan_notes`, `get_most_linked`,
  `get_broken_links`, `get_toc`, `stats`) — query current index state.
  Return empty on cold start, no implicit build.
- **Bucket 3** (`get_backlinks`, `get_outlinks`, `get_similar`,
  `get_context`, `get_connection_path`) — raise the new
  `IndexNotReadyError` on unbuilt indices, since the answers would
  be silently wrong.
- **Bucket 4** (`reindex`, `build_embeddings`) — raise
  `IndexNotReadyError`. `build_index()` short-circuit now keys on
  FTS state alone, so warm restarts (new process, same DB) are O(1).

The 23 `self._ensure_initialized()` callsites are removed (bucket 1+2)
or replaced with `self._require_index_ready()` (bucket 3+4). New
`Collection.wait_for_index_ready(timeout=None)` primitive raises
pre-#513; the `timeout` parameter is reserved for the
background-indexer variant (#513) where it will block on a completion
event. Internal flag renamed `_initialized` → `_index_built` and is
set only after a successful `build_index()` — a failed build leaves
the Collection not-ready.

## Contract change (callers, take note)

The warm-restart short-circuit is keyed on FTS contents alone and does
**not** detect config drift. To apply a configuration change
(`exclude_patterns`, `required_frontmatter`) to a pre-existing index,
call:

```python
collection.build_index(force=True)
collection.build_embeddings(force=True)  # if embeddings configured
```

Docstring and `docs/design.md` updated accordingly. Two pre-existing
tests (`test_build_index_purges_stale_excluded_docs[_with_embeddings]`)
updated to use `force=True` — they were exercising the lazy-init
re-scan side-effect that no longer fires.

## Verification (per #525)

```
$ grep -rn "_ensure_initialized" src/ tests/   # 0 matches
$ grep -rn "self\._initialized" src/           # 0 matches
$ uv run pytest -x -q                           # 1631 passed, 1 skipped
$ uv run ruff check . && uv run ruff format --check .  # clean
$ uv run mypy src/ tests/                       # 0 errors
$ uv run diff-cover coverage.xml --compare-branch=main --fail-under=80  # 100%
```

## TDD discipline

Failure modes per bucket enumerated up front (issue thread + commit
message). RED phase: 20 tests in `tests/test_indexing_readiness.py`
fail against unchanged code — 15 fail on bucket 2/3/4 + primitive +
cross-cutting contracts; 5 bucket-1 tests pass (regression checks for
the contract that disk ops don't need the index). GREEN phase
flipped all 20 with one set of edits. One missed failure mode
surfaced during full-suite verification (warm-restart purge-on-config-
change side-effect of the old `_initialized` flag) — surfaced as an
explicit contract change rather than patched away.

## Test plan
- [x] All existing tests pass (1631 / 1)
- [x] 20 new tests in `test_indexing_readiness.py` cover all four
      buckets + the readiness primitive + cross-cutting failed-build
      semantics
- [x] Patch coverage 100%
- [x] Verification grep clean (no `_ensure_initialized`, no
      `self._initialized` in src)

🤖 Generated with [Claude Code](https://claude.com/claude-code)