### PR TITLE
feat(server): MARKDOWN_VAULT_MCP_DISABLE_APPS_UI env var to hide MCP-Apps tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` pr
 | `MARKDOWN_VAULT_MCP_HTTP_PATH` | `/mcp` | HTTP endpoint path for streamable HTTP transport (used by `serve --transport http`) |
 | `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | `file:///data/state/events` | Event store backend for HTTP session persistence. `file:///path` (default) survives restarts; `memory://` for dev (lost on restart). |
 | `MARKDOWN_VAULT_MCP_APP_DOMAIN` | (auto) | Override the Claude app domain used for MCP Apps iframe sandboxing. Auto-computed from `BASE_URL` when not set. |
+| `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` | `false` | Hide MCP-Apps UI tools (`browse_vault`, `show_context`) from the tool listing for clients that don't render MCP Apps panels. |
 | `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). App loggers default to `INFO`. `-v` overrides both to `DEBUG`. |
 | `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `MARKDOWN_VAULT_MCP_BASE_URL` | url | — | Public base URL of the server (e.g. `https://mcp.example.com`). Required for OIDC auth, `create_download_link` tool, and MCP Apps domain computation |
 | `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | url | `file:///data/state/events` | Event store backend for HTTP session persistence. `file:///path` survives restarts; `memory://` for dev (lost on restart) |
 | `MARKDOWN_VAULT_MCP_APP_DOMAIN` | string | (auto) | Override the Claude app domain used for MCP Apps iframe sandboxing. Auto-computed from `BASE_URL` when not set |
+| `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` | bool | `false` | Hide MCP-Apps UI tools (`browse_vault`, `show_context`) from the tool listing for clients that don't render MCP Apps panels |
 | `FASTMCP_LOG_LEVEL` | string | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `-v` CLI flag overrides both app and FastMCP loggers to `DEBUG` |
 | `FASTMCP_ENABLE_RICH_LOGGING` | bool | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output |
 

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -238,6 +238,7 @@ def register_apps(mcp: FastMCP) -> None:
     # -- Primary tool: browse_vault -----------------------------------------
 
     @mcp.tool(
+        tags={"apps-ui"},
         icons=_TOOL_ICONS["browse_vault"],
         annotations={
             "readOnlyHint": True,
@@ -338,6 +339,7 @@ def register_apps(mcp: FastMCP) -> None:
         return asdict(ctx)
 
     @mcp.tool(
+        tags={"apps-ui"},
         icons=_TOOL_ICONS["show_context"],
         annotations={
             "readOnlyHint": True,

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -115,6 +115,10 @@ class CollectionConfig:
         event_store_url: URL for the FastMCP persistent event store used by
             the HTTP transport (e.g. ``"file:///data/state/events"``).
             ``None`` defaults to ``/data/state/events``.
+        disable_apps_ui: When ``True``, hides MCP-Apps UI tools
+            (``browse_vault``, ``show_context``) from the tool listing so
+            clients that don't render MCP Apps panels don't see them
+            (default ``False``).
         auth_mode: Explicit OIDC mode override: ``"oidc-proxy"`` or
             ``"remote"``.  ``None`` (default) means auto-detect from which
             OIDC env vars are present.  Bearer and multi-auth are determined
@@ -188,6 +192,7 @@ class CollectionConfig:
     templates_folder: str = "_templates"
     prompts_folder: str | None = None
     event_store_url: str | None = None
+    disable_apps_ui: bool = False
 
     # Server identity
     server_name: str = "markdown-vault-mcp"
@@ -399,6 +404,9 @@ def load_config() -> CollectionConfig:
     - ``MARKDOWN_VAULT_MCP_EVENT_STORE_URL``: event store backend for HTTP session
       persistence; ``file:///path`` (default ``/data/state/events``) or
       ``memory://`` (in-memory, lost on restart).
+    - ``MARKDOWN_VAULT_MCP_DISABLE_APPS_UI``: hide MCP-Apps UI tools
+      (``browse_vault``, ``show_context``) from the tool listing; default
+      ``false``.
 
     **Server identity:**
 
@@ -642,6 +650,14 @@ def load_config() -> CollectionConfig:
         "load_config: event_store_url=%s", event_store_url or "not set (file default)"
     )
 
+    raw_disable_apps_ui = _env("DISABLE_APPS_UI")
+    disable_apps_ui: bool = (
+        _parse_bool(raw_disable_apps_ui) if raw_disable_apps_ui is not None else False
+    )
+    logger.debug(
+        "load_config: disable_apps_ui=%s (raw=%r)", disable_apps_ui, raw_disable_apps_ui
+    )
+
     # --- Server identity ---
     raw_server_name = (_env("SERVER_NAME") or "").strip()
     server_name: str = raw_server_name or "markdown-vault-mcp"
@@ -844,6 +860,7 @@ def load_config() -> CollectionConfig:
         templates_folder=templates_folder,
         prompts_folder=prompts_folder,
         event_store_url=event_store_url,
+        disable_apps_ui=disable_apps_ui,
         server_name=server_name,
         instructions=instructions,
         auth_mode=auth_mode,

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -326,7 +326,7 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # does not render the MCP Apps panels. Set
     # MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=true to remove them from the tool
     # listing (saves a few tokens; the LLM cannot call them anyway).
-    if os.environ.get("MARKDOWN_VAULT_MCP_DISABLE_APPS_UI", "").strip().lower() in {
+    if os.environ.get(f"{_ENV_PREFIX}_DISABLE_APPS_UI", "").strip().lower() in {
         "1",
         "true",
         "yes",

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -12,6 +12,7 @@ configured :class:`~fastmcp.FastMCP` instance.
 from __future__ import annotations
 
 import logging
+import os
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import TYPE_CHECKING
@@ -320,5 +321,17 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # the broader cleanup of duplicate ``to_collection_kwargs`` calls.
     if config.git_repo_url is None:
         mcp.disable(tags={"git-managed"})
+
+    # Hide MCP-Apps UI tools (browse_vault, show_context) when the client
+    # does not render the MCP Apps panels. Set
+    # MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=true to remove them from the tool
+    # listing (saves a few tokens; the LLM cannot call them anyway).
+    if os.environ.get("MARKDOWN_VAULT_MCP_DISABLE_APPS_UI", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        mcp.disable(tags={"apps-ui"})
 
     return mcp

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -12,7 +12,6 @@ configured :class:`~fastmcp.FastMCP` instance.
 from __future__ import annotations
 
 import logging
-import os
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import TYPE_CHECKING
@@ -326,12 +325,7 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # does not render the MCP Apps panels. Set
     # MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=true to remove them from the tool
     # listing (saves a few tokens; the LLM cannot call them anyway).
-    if os.environ.get(f"{_ENV_PREFIX}_DISABLE_APPS_UI", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }:
+    if config.disable_apps_ui:
         mcp.disable(tags={"apps-ui"})
 
     return mcp


### PR DESCRIPTION
## Summary

Adds an `apps-ui` tag to the `browse_vault` and `show_context` tools and a tag-based disable pass in `make_server` that fires when `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` is truthy (`1`/`true`/`yes`/`on`).

Composes with the existing `write` and `git-managed` disable passes — set-union on disabled tags. No behavior change when the env var is unset.

## Motivation

Both tools are designed to open an interactive MCP Apps panel for the user. Their docstrings already tell the LLM not to call them when no UI is rendered (preferring `search` / `read` / `list_documents` / `get_context` instead) — but they still appear in `tools/list`, costing tokens in every session.

Some clients (e.g. a CLI-only consumer) cannot render MCP Apps panels at all. For those, hiding the two tools entirely is cleaner than keeping them and relying on the docstring guidance.

## Changes

- `_server_apps.py`: add `tags={"apps-ui"}` to `browse_vault` and `show_context` decorators.
- `server.py`: read `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI`; call `mcp.disable(tags={"apps-ui"})` when truthy. Documented inline.

## Test plan

- [x] Container build + run with the env var **unset** → both tools listed.
- [x] Container run with `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=true` → `tools/list` returns neither.
- [x] Runtime check inside the container confirms 27 tools visible vs. 29 without the var (delta = `browse_vault` + `show_context`).