### PR TITLE
feat(server): cold-start background FTS via tool-layer wait (#513 PR1, attempt 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `stats` | Get collection statistics (document count, chunk count, link health metrics, etc.) |
 | `build_embeddings` | Build or rebuild vector embeddings for semantic search |
 | `embeddings_status` | Check embedding provider and index status |
+| `get_index_status` | Check background FTS build state (`ready` / `building` / `failed`) |
 | `get_backlinks` | Find all documents that link to a given document |
 | `get_outlinks` | Find all links from a document, with existence check |
 | `get_broken_links` | Find all links pointing to non-existent documents |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,19 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER` | string | `_templates` | No | Relative folder path used by the `create_from_template` prompt to discover/read template files |
 | `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | path | — | No | Path to a directory of `.md` prompt files that extend or override built-in prompts |
 
+## Index Readiness
+
+### `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S`
+
+Default: `60` (seconds).
+
+Maximum time the MCP-layer `needs_index_ready` decorator waits for
+the FTS index to become ready before raising `IndexNotReadyError`
+to the client. Applied to bucket-3/4 tool and resource calls during
+a cold-start background FTS build. Increase for very large vaults
+where the initial scan takes longer; decrease for tighter feedback
+on stuck builds.
+
 <!-- DOMAIN-CONFIG-VARS-START -->
 ## Server Identity
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -394,6 +394,31 @@ whatever is currently in the index (empty on cold start).
 raises `IndexNotReadyError` pre-#513; once the background indexer
 (#513) lands it will block on a completion event.
 
+**Cold-start background FTS (issue #513 PR1, tool-layer wait
+boundary)**: when the persisted FTS DB is cold (sentinel absent),
+the MCP server lifespan calls
+`Collection.start_background_build_index()` to spawn a daemon
+thread that runs `build_index()` to completion. Bucket-3/4 calls
+arriving at the MCP layer go through the
+`needs_index_ready` decorator (in
+`src/markdown_vault_mcp/_server_readiness.py`), which blocks via
+`Collection.wait_for_index_ready(timeout)` with a configurable
+default (env `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S`, default 60s).
+A failed background build surfaces to MCP clients as
+`IndexBuildFailedError` (the decorator's `wait_for_index_ready`
+call raises) and to operators as
+`get_index_status` reporting
+`{"status": "failed", "error": "..."}`. Embeddings stay on the
+synchronous lifespan path in PR1 — on cold start
+`build_embeddings()` is skipped with a log entry and semantic
+search returns empty until PR2 backgrounds embeddings or the
+operator runs CLI `index`. Warm starts continue to use PR #526's
+O(1) sentinel short-circuit and never spawn the background thread.
+The library's `_require_index_ready()` is unchanged from PR #525
+— it raises immediately on not-ready, which is what lets the git
+pull loop and lifespan's embeddings path handle "not ready"
+without deadlocking on internal blocking.
+
 To apply a configuration change (e.g. new `exclude_patterns`,
 `required_frontmatter`) to a pre-existing index, call
 `build_index(force=True)` — and, when embeddings are configured,

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -94,6 +94,9 @@ The empty string `""` represents the root folder (top-level documents).
 
 Table of contents (heading outline) for a specific document. This is a URI template — replace `{path}` with the document's relative path.
 
+!!! note "Cold-start blocking"
+    Calls during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
+
 **Example:** `toc://vault/Journal/note.md`
 
 **Response:**
@@ -113,6 +116,9 @@ The TOC prepends a synthetic H1 from the document title and deduplicates if the 
 ## `similar://vault/{path}`
 
 Top 10 semantically similar notes for a document. Requires embeddings to be built. This is a URI template — replace `{path}` with the document's relative path.
+
+!!! note "Cold-start blocking"
+    Calls during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
 
 Results are **grouped per file** — each file appears at most once, with up to `chunks_per_file` (server default `2`) best-matching sections in a `sections` array. Each entry is a `GroupedResult` dict with `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -15,6 +15,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`list_tags`](#list_tags) | Read | List all unique frontmatter tag values |
 | [`stats`](#stats) | Read | Get collection statistics and capabilities |
 | [`embeddings_status`](#embeddings_status) | Read | Check embedding provider and vector index status |
+| [`get_index_status`](#get_index_status) | Read | Check background FTS build state (ready / building / failed) |
 | [`get_backlinks`](#get_backlinks) | Read | Find all documents that link to a given document |
 | [`get_outlinks`](#get_outlinks) | Read | Find all links from a document, with existence check |
 | [`get_broken_links`](#get_broken_links) | Read | Find all links pointing to non-existent documents |
@@ -199,9 +200,28 @@ Check the embedding provider configuration and vector index status. Use this to 
 }
 ```
 
+### `get_index_status`
+
+Returns background-build state of the FTS index. Use this when
+`initialize` returned but bucket-3/4 calls block longer than expected
+or surface `IndexNotReadyError`/`IndexBuildFailedError` — the
+`status` field distinguishes "still building" from "build failed."
+
+**Returns:**
+- `status`: `"ready"`, `"building"`, or `"failed"`.
+- `documents_indexed`: count of documents committed to the FTS index
+  right now (rises during `"building"`).
+- `error`: `null` unless the background build raised; otherwise the
+  exception message.
+
+**Tags:** read-only.
+
 ---
 
 ## Index Management
+
+!!! note "Cold-start blocking"
+    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` (default 60s), the tool returns `IndexNotReadyError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
 
 ### `reindex`
 
@@ -586,6 +606,9 @@ managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` not set).
 ---
 
 ## Link Graph
+
+!!! note "Cold-start blocking"
+    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` (default 60s), the tool returns `IndexNotReadyError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
 
 ### `get_backlinks`
 

--- a/src/markdown_vault_mcp/_icons.py
+++ b/src/markdown_vault_mcp/_icons.py
@@ -65,6 +65,9 @@ _TOOL_ICONS: dict[str, list[Icon]] = {
     ]
 }
 
+# Status tools reuse existing icons rather than introducing new SVG files.
+_TOOL_ICONS["get_index_status"] = _TOOL_ICONS["embeddings_status"]
+
 # App-only tools reuse existing icons rather than introducing new SVG files.
 _TOOL_ICONS["vault_context"] = _TOOL_ICONS["get_context"]
 _TOOL_ICONS["vault_list"] = _TOOL_ICONS["list_documents"]

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -100,20 +100,33 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # build_index() scans the freshest working tree.
         await asyncio.to_thread(collection.sync_from_remote_before_index)
 
-        # Build index eagerly so first tool call is fast.
-        stats = await asyncio.to_thread(collection.build_index)
-        logger.info(
-            "Index built: %d documents, %d chunks",
-            stats.documents_indexed,
-            stats.chunks_indexed,
-        )
+        # PR #526 sentinel: warm on-disk DBs short-circuit in O(1) via
+        # synchronous build_index(); cold on-disk routes to background;
+        # in-memory always synchronous (test scenarios only). See #513 PR1.
+        if collection.should_use_background_build():
+            collection.start_background_build_index()
+            logger.info("Cold start: scheduled background FTS build")
+        else:
+            stats = await asyncio.to_thread(collection.build_index)
+            logger.info(
+                "Index ready: %d documents (synchronous build)",
+                stats.documents_indexed,
+            )
 
-        # Build embeddings eagerly when an embedding provider is configured.
-        # build_embeddings() skips work if the vector index already exists on disk,
-        # so this is safe to call on every startup.
+        # Embeddings stay on the synchronous lifespan path for PR1. On
+        # cold start the FTS is still being built so we skip + log;
+        # PR2 follow-up backgrounds embeddings so semantic search
+        # becomes available without operator-initiated rebuild.
         if kwargs.get("embedding_provider") is not None:
-            chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
-            logger.info("Embeddings ready: %d chunks", chunks_embedded)
+            if collection.is_index_ready():
+                chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
+                logger.info("Embeddings ready: %d chunks", chunks_embedded)
+            else:
+                logger.info(
+                    "Cold start: embeddings deferred; semantic search "
+                    "returns empty until PR2 backgrounds embeddings or "
+                    "operator runs CLI 'index'"
+                )
 
         # Start background tasks (e.g. git pull loop) after index is built.
         collection.start()

--- a/src/markdown_vault_mcp/_server_readiness.py
+++ b/src/markdown_vault_mcp/_server_readiness.py
@@ -47,10 +47,11 @@ def needs_index_ready(
     and injects it via kwargs. The wrapper reads ``collection`` from
     kwargs and passes args/kwargs through unchanged.
 
-    Stacking order: place ``@needs_index_ready(...)`` ABOVE
-    ``@mcp.tool(...)`` (or ``@mcp.resource(...)``). Python applies
-    decorators bottom-up, so ``@mcp.tool`` runs first against the
-    result of ``@needs_index_ready`` — FastMCP registers the
+    Stacking order: place ``@needs_index_ready(...)`` BELOW
+    ``@mcp.tool(...)`` (or ``@mcp.resource(...)``) — that is,
+    closer to ``def``. Python applies decorators bottom-up, so
+    ``@needs_index_ready`` wraps the handler first; then
+    ``@mcp.tool`` runs on the result and FastMCP registers the
     already-wrapped function.
 
     Raises (propagated to MCP client via FastMCP error middleware):

--- a/src/markdown_vault_mcp/_server_readiness.py
+++ b/src/markdown_vault_mcp/_server_readiness.py
@@ -1,0 +1,78 @@
+"""MCP-layer `needs_index_ready` decorator (#513 PR1).
+
+Boundary: the library raises ``IndexNotReadyError`` immediately on
+not-ready (PR #525 contract). Blocking semantics live here at the MCP
+layer, where the caller's intent — "an MCP client is waiting and
+wants to wait" — is unambiguous. Internal callers (lifespan, git
+pull loop, CLI, direct library users) do NOT go through this
+decorator; they handle "not ready" with their own caller-appropriate
+logic (skip, log, retry on next interval).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def _resolve_ready_timeout() -> float:
+    """Read env var at call time so tests can monkeypatch.setenv it."""
+    return float(os.environ.get("MARKDOWN_VAULT_MCP_READY_TIMEOUT_S", "60"))
+
+
+def needs_index_ready(
+    timeout: float | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator for bucket-3/4 MCP tool and resource handlers.
+
+    Before invoking the wrapped handler, blocks on
+    ``Collection.wait_for_index_ready(timeout)``. On the warm path
+    (``is_index_ready`` already True) the wait is skipped — no
+    thread-pool overhead.
+
+    The wrapper does NOT redeclare ``collection`` in its own
+    signature. ``functools.wraps`` preserves the wrapped handler's
+    signature so FastMCP's introspection sees the original
+    ``collection: Collection = Depends(get_collection)`` parameter
+    and injects it via kwargs. The wrapper reads ``collection`` from
+    kwargs and passes args/kwargs through unchanged.
+
+    Stacking order: place ``@needs_index_ready(...)`` ABOVE
+    ``@mcp.tool(...)`` (or ``@mcp.resource(...)``). Python applies
+    decorators bottom-up, so ``@mcp.tool`` runs first against the
+    result of ``@needs_index_ready`` — FastMCP registers the
+    already-wrapped function.
+
+    Raises (propagated to MCP client via FastMCP error middleware):
+        IndexNotReadyError: timeout exceeded; or never scheduled.
+        IndexBuildFailedError: a prior background build raised.
+    """
+
+    def deco(handler: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(handler)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            collection = kwargs.get("collection")
+            if collection is None:
+                raise RuntimeError(
+                    "needs_index_ready: collection was not injected; "
+                    "handler must declare "
+                    "`collection: Collection = Depends(get_collection)`."
+                )
+            if not collection.is_index_ready():
+                effective = timeout if timeout is not None else _resolve_ready_timeout()
+                await asyncio.to_thread(collection.wait_for_index_ready, effective)
+            return await handler(*args, **kwargs)
+
+        return wrapper
+
+    return deco

--- a/src/markdown_vault_mcp/_server_readiness.py
+++ b/src/markdown_vault_mcp/_server_readiness.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import inspect
 import logging
 import os
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -60,9 +61,15 @@ def needs_index_ready(
     """
 
     def deco(handler: Callable[..., Any]) -> Callable[..., Any]:
+        # Capture the handler's signature once at decoration time so
+        # collection can be looked up regardless of whether it was
+        # passed positionally or by keyword.
+        sig = inspect.signature(handler)
+
         @functools.wraps(handler)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
-            collection = kwargs.get("collection")
+            bound = sig.bind_partial(*args, **kwargs)
+            collection = bound.arguments.get("collection")
             if collection is None:
                 raise RuntimeError(
                     "needs_index_ready: collection was not injected; "

--- a/src/markdown_vault_mcp/_server_readiness.py
+++ b/src/markdown_vault_mcp/_server_readiness.py
@@ -16,14 +16,12 @@ import functools
 import inspect
 import logging
 import os
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T")
 
 
 def _resolve_ready_timeout() -> float:

--- a/src/markdown_vault_mcp/_server_resources.py
+++ b/src/markdown_vault_mcp/_server_resources.py
@@ -22,6 +22,7 @@ from markdown_vault_mcp.config import CollectionConfig
 
 from ._icons import _TOOL_ICONS
 from ._server_deps import get_collection
+from ._server_readiness import needs_index_ready
 
 
 def _get_config(ctx: Context) -> CollectionConfig:
@@ -129,6 +130,7 @@ def register_resources(mcp: FastMCP) -> None:
     @mcp.resource(
         "toc://vault/{path}", mime_type="application/json", icons=_TOOL_ICONS["read"]
     )
+    @needs_index_ready()
     async def vault_toc(
         path: str,
         collection: Collection = Depends(get_collection),
@@ -142,6 +144,7 @@ def register_resources(mcp: FastMCP) -> None:
         mime_type="application/json",
         icons=_TOOL_ICONS["get_similar"],
     )
+    @needs_index_ready()
     async def vault_similar(
         path: str,
         collection: Collection = Depends(get_collection),

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -582,6 +582,36 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """
         return await asyncio.to_thread(collection.embeddings_status)
 
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": True,
+            "openWorldHint": False,
+        },
+        icons=_TOOL_ICONS["get_index_status"],
+    )
+    async def get_index_status(
+        collection: Collection = Depends(get_collection),
+    ) -> dict[str, Any]:
+        """Return background-build state of the FTS index.
+
+        Use this when ``initialize`` returned but bucket-3/4 calls
+        block longer than expected or surface
+        ``IndexNotReadyError``/``IndexBuildFailedError`` — the
+        ``status`` field distinguishes "still building" from "build
+        failed."
+
+        Returns:
+            Dict with the following fields:
+
+            - status (str): ``"ready"``, ``"building"``, or
+              ``"failed"``.
+            - documents_indexed (int): Count of documents committed to
+              the FTS index right now (rises during ``"building"``).
+            - error (str | None): ``None`` unless the background build
+              raised.
+        """
+        return await asyncio.to_thread(collection.get_index_status)
+
     # --- Link tools (read-only) ---
 
     @mcp.tool(

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
 from ._icons import _TOOL_ICONS
 from ._server_deps import get_collection
+from ._server_readiness import needs_index_ready
 
 logger = logging.getLogger(__name__)
 
@@ -622,6 +623,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
+    @needs_index_ready()
     async def get_backlinks(
         path: str,
         collection: Collection = Depends(get_collection),

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -670,6 +670,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
+    @needs_index_ready()
     async def get_outlinks(
         path: str,
         collection: Collection = Depends(get_collection),
@@ -756,6 +757,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
+    @needs_index_ready()
     async def get_similar(
         path: str,
         limit: int = 10,
@@ -856,6 +858,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
+    @needs_index_ready()
     async def get_context(
         path: str,
         similar_limit: int = 5,
@@ -1017,6 +1020,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
+    @needs_index_ready()
     async def get_connection_path(
         source: str,
         target: str,
@@ -1217,6 +1221,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
+    @needs_index_ready()
     async def reindex(
         collection: Collection = Depends(get_collection),
     ) -> dict[str, Any]:
@@ -1246,6 +1251,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
+    @needs_index_ready()
     async def build_embeddings(
         force: bool = False,
         collection: Collection = Depends(get_collection),

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -432,6 +432,54 @@ class Collection:
             return False
         return self._background_build_done.is_set()
 
+    def start_background_build_index(self) -> None:
+        """Spawn a daemon thread that runs :meth:`build_index` to completion.
+
+        Idempotent: second call after a successful start, after a
+        clean completion, OR after a failed ``thread.start()`` is a
+        no-op. The method is one-shot per Collection lifetime;
+        operator recovery from a failed start is via CLI
+        ``markdown-vault-mcp index`` or process restart, NOT by
+        calling this method again.
+
+        The worker thread catches ``BaseException`` → captures into
+        ``_background_build_error`` → always sets
+        ``_background_build_done`` in its finally clause.
+
+        If ``thread.start()`` itself raises (system thread exhaustion
+        is the realistic case), the same capture-and-set happens
+        synchronously so callers waiting on the event never hang.
+        """
+
+        def _worker() -> None:
+            try:
+                self.build_index()
+            except BaseException as exc:
+                self._background_build_error = exc
+                logger.exception("Background index build failed")
+            finally:
+                self._background_build_done.set()
+
+        with self._write_lock:
+            if self._background_started:
+                return
+            self._background_started = True
+            self._background_build_error = None
+            self._background_build_done.clear()
+            thread = threading.Thread(
+                target=_worker,
+                name="markdown-vault-mcp.background-build",
+                daemon=True,
+            )
+            self._background_build_thread = thread
+            try:
+                thread.start()
+            except Exception as exc:
+                # Synchronously surface the failure so waiters unblock.
+                self._background_build_error = exc
+                self._background_build_done.set()
+                raise
+
     def wait_for_index_ready(self, timeout: float | None = None) -> None:
         """Block until the FTS index is ready, or raise.
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -765,6 +765,9 @@ class Collection:
                     len(existing),
                 )
                 self._index_built = True
+                # Recovery: clear any captured background error + signal ready.
+                self._background_build_error = None
+                self._background_build_done.set()
                 return IndexStats(
                     documents_indexed=len(existing),
                     chunks_indexed=0,
@@ -780,14 +783,9 @@ class Collection:
         result = self._index_mgr.build_index(force=force)
         self._fts.set_build_completed()
         self._index_built = True
-        # A successful synchronous build is also a recovery path —
-        # clear any captured background-build error so is_index_ready()
-        # returns True and bucket-3/4 calls stop surfacing
-        # IndexBuildFailedError. Reviewers: this is the case where an
-        # operator runs CLI `markdown-vault-mcp index` in the same
-        # process after a background failure, or programmatic callers
-        # use build_index() as a recovery primitive.
+        # Recovery: clear any captured background error + signal ready.
         self._background_build_error = None
+        self._background_build_done.set()
         return result
 
     def reindex(self) -> ReindexResult:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -103,6 +103,21 @@ class Collection:
     returns whatever is currently in the index (empty on cold start).
     See issue #525.
 
+    **Background build (issue #513 PR1).** When the persisted FTS DB
+    is cold (sentinel absent), the MCP server lifespan calls
+    :meth:`start_background_build_index` to spawn a daemon thread
+    that runs :meth:`build_index` to completion. Bucket-3/4 MCP tool
+    *clients* block on the new
+    :class:`markdown_vault_mcp._server_readiness.needs_index_ready`
+    decorator, which calls :meth:`wait_for_index_ready` with a
+    bounded default timeout
+    (``MARKDOWN_VAULT_MCP_READY_TIMEOUT_S``, default 60s). The
+    library stays honest: bucket-3/4 *methods* keep the PR #525
+    raise-immediately contract via :meth:`_require_index_ready`.
+    Internal callers (lifespan, git pull loop, CLI, direct library
+    users) get the raise contract and handle "not ready" with
+    caller-appropriate logic — never block.
+
     **Thread safety (issue #519):** every public method on this class is safe
     to call from any thread, concurrently with other reads and writes from
     any other thread. Writes serialise against each other via the internal

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -13,7 +13,7 @@ import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal
 
-from markdown_vault_mcp.exceptions import IndexNotReadyError
+from markdown_vault_mcp.exceptions import IndexBuildFailedError, IndexNotReadyError
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.scanner import (
     ChunkStrategy,
@@ -435,20 +435,52 @@ class Collection:
     def wait_for_index_ready(self, timeout: float | None = None) -> None:
         """Block until the FTS index is ready, or raise.
 
-        Pre-#513 this is a synchronous readiness check: raises
-        :exc:`IndexNotReadyError` when :meth:`build_index` has not
-        completed. The *timeout* parameter is reserved for the
-        background-indexer variant (#513), which will wait on a
-        completion event with this budget.
+        Control flow (each step in order):
+
+        1. ``_background_build_done.wait(timeout)`` — if False
+           (timed out), raise
+           :exc:`IndexNotReadyError("…timed out…")`.
+        2. If ``_background_build_error`` is not None, raise
+           :exc:`IndexBuildFailedError` with the original as
+           ``__cause__``.
+        3. If ``_index_built`` is False, raise
+           :exc:`IndexNotReadyError("…never scheduled…")` — guards
+           the never-scheduled case (event pre-set, no error, no
+           build, no thread). Without it, callers on a fresh
+           Collection would silently return success.
+        4. Otherwise return.
+
+        This method is opt-in for the MCP-layer `needs_index_ready`
+        decorator and for external callers that explicitly want to
+        wait. Library bucket-3/4 methods do NOT call this — they call
+        :meth:`_require_index_ready` which raises immediately. That
+        separation is the boundary that closed attempt 6's hole.
 
         Args:
-            timeout: Maximum seconds to wait. Currently unused.
+            timeout: Maximum seconds to wait on the completion event.
+                ``None`` (default) blocks indefinitely. MCP tool
+                callers are protected from infinite hangs by the
+                bounded default in the decorator (60s) and by
+                client-side deadlines.
 
         Raises:
-            IndexNotReadyError: If the index has not been built.
+            IndexBuildFailedError: A prior background build raised.
+            IndexNotReadyError: Index not built and either no build
+                was ever scheduled, or the timeout expired.
         """
-        del timeout  # Reserved for #513 — no background build to wait on.
-        self._require_index_ready()
+        if not self._background_build_done.wait(timeout=timeout):
+            raise IndexNotReadyError(
+                f"Index build still in progress; timed out after {timeout}s."
+            )
+        if self._background_build_error is not None:
+            raise IndexBuildFailedError(
+                "Background index build raised; see __cause__ for details."
+            ) from self._background_build_error
+        if not self._index_built:
+            raise IndexNotReadyError(
+                "Index not built; background build was never scheduled. "
+                "Call build_index() or start_background_build_index() first."
+            )
 
     @property
     def _vectors(self) -> VectorIndex | None:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -225,6 +225,18 @@ class Collection:
         # build_embeddings). See issue #525.
         self._index_built = False
 
+        # Background-build coordination (issue #513 PR1 attempt 7). The
+        # event is the blocking primitive `wait_for_index_ready()` waits
+        # on; it is pre-set so a freshly constructed Collection that never
+        # called build_index() does not silently look "ready". The
+        # background path clears the event before spawning the thread
+        # and the worker sets it in its finally clause.
+        self._background_build_thread: threading.Thread | None = None
+        self._background_build_done: threading.Event = threading.Event()
+        self._background_build_done.set()
+        self._background_build_error: BaseException | None = None
+        self._background_started: bool = False
+
         # Serialise concurrent write operations on this instance.
         # Re-entrant: periodic pull tick blocks writes, then reindex() acquires
         # this lock again for its mutation phase.
@@ -392,6 +404,33 @@ class Collection:
             raise IndexNotReadyError(
                 "Index not built. Call build_index() before this method."
             )
+
+    def is_index_ready(self) -> bool:
+        """Return ``True`` iff the FTS index is in a clean ready state.
+
+        Non-blocking. Returns ``True`` only when all three conditions
+        hold simultaneously: ``_index_built`` is True (a build returned
+        cleanly), ``_background_build_error`` is None (no captured
+        background failure), and ``_background_build_done`` is set (no
+        in-flight background). A freshly-constructed Collection
+        (event pre-set, no error, ``_index_built`` False) returns False
+        — the attempt-6 status lie is impossible by construction.
+
+        Lock-free by design: reads ``_index_built`` (plain bool
+        attribute), checks ``_background_build_error is None`` (plain
+        attribute), and calls ``_background_build_done.is_set()``
+        (Event method, no lock). Safe to call on hot tool paths.
+
+        Assumes CPython GIL semantics for cross-thread visibility of
+        the plain attribute reads. Not analyzed for Free-Threaded
+        Python 3.13+ (``python -X gil=0``); revisit if the project
+        moves off CPython GIL.
+        """
+        if not self._index_built:
+            return False
+        if self._background_build_error is not None:
+            return False
+        return self._background_build_done.is_set()
 
     def wait_for_index_ready(self, timeout: float | None = None) -> None:
         """Block until the FTS index is ready, or raise.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -480,6 +480,24 @@ class Collection:
                 self._background_build_done.set()
                 raise
 
+    def should_use_background_build(self) -> bool:
+        """Return True iff the lifespan should route to the background
+        FTS build path.
+
+        Returns True only for cold on-disk DBs (index_path is a real
+        file path AND the FTS completeness sentinel from PR #526 is
+        absent). Returns False for:
+        - warm on-disk DBs (sentinel present — synchronous
+          build_index() short-circuits in O(1));
+        - in-memory DBs (no index_path or ":memory:" — no sentinel
+          possible; full sync scan, acceptable for test scenarios).
+        """
+        # In-memory has no persistent state, so a "warm vs cold" notion
+        # doesn't apply; always synchronous.
+        if self._index_path is None or str(self._index_path) == ":memory:":
+            return False
+        return not self._fts.is_build_completed()
+
     def wait_for_index_ready(self, timeout: float | None = None) -> None:
         """Block until the FTS index is ready, or raise.
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -498,6 +498,49 @@ class Collection:
             return False
         return not self._fts.is_build_completed()
 
+    def get_index_status(self) -> dict[str, Any]:
+        """Return a non-blocking snapshot of background-build state.
+
+        Shape: ``{"status": "ready" | "building" | "failed",
+        "documents_indexed": int, "error": str | None}``.
+
+        - ``"ready"``: ``is_index_ready()`` is True (synchronous build
+          returned cleanly or background build completed cleanly);
+          ``error`` is None.
+        - ``"failed"``: ``_background_build_error`` is non-None;
+          ``error`` carries its message.
+        - ``"building"``: anything else — event cleared (in-flight)
+          OR event set but ``_index_built`` is False (never scheduled).
+          From the operator's perspective both mean "wait or poll."
+
+        ``documents_indexed`` is taken from
+        :meth:`FTSIndex.list_notes` and so reflects whatever rows are
+        currently committed — progress is observable in the
+        ``"building"`` state as the count rises.
+        """
+        if self._background_build_error is not None:
+            status = "failed"
+            error: str | None = str(self._background_build_error)
+        elif self.is_index_ready():
+            status = "ready"
+            error = None
+        else:
+            status = "building"
+            error = None
+        try:
+            documents_indexed = len(self._fts.list_notes())
+        except Exception:
+            logger.debug(
+                "get_index_status: list_notes failed; reporting 0",
+                exc_info=True,
+            )
+            documents_indexed = 0
+        return {
+            "status": status,
+            "documents_indexed": documents_indexed,
+            "error": error,
+        }
+
     def wait_for_index_ready(self, timeout: float | None = None) -> None:
         """Block until the FTS index is ready, or raise.
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -368,6 +368,23 @@ class Collection:
         Flushes deferred embeddings and pending write callbacks, then
         closes the SQLite connection and git strategy.
         """
+        # 0. Join background-build thread before any resource teardown.
+        # Read the thread reference under _write_lock (matches the lock
+        # held when start_background_build_index assigns it).
+        # join() must complete before _fts.close() (step 4) so the
+        # worker isn't writing to a closed FTS. daemon=True keeps a
+        # stuck thread from holding the process; cooperative
+        # cancellation inside _index_mgr.build_index is a follow-up.
+        with self._write_lock:
+            thread = self._background_build_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=30.0)
+            if thread.is_alive():
+                logger.warning(
+                    "close: background build thread did not exit within "
+                    "30s; abandoning (daemon thread does not block process)"
+                )
+
         # 1. Flush any deferred embedding updates.
         self._index_mgr.flush_dirty_embeddings()
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -780,6 +780,14 @@ class Collection:
         result = self._index_mgr.build_index(force=force)
         self._fts.set_build_completed()
         self._index_built = True
+        # A successful synchronous build is also a recovery path —
+        # clear any captured background-build error so is_index_ready()
+        # returns True and bucket-3/4 calls stop surfacing
+        # IndexBuildFailedError. Reviewers: this is the case where an
+        # operator runs CLI `markdown-vault-mcp index` in the same
+        # process after a background failure, or programmatic callers
+        # use build_index() as a recovery primitive.
+        self._background_build_error = None
         return result
 
     def reindex(self) -> ReindexResult:

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -80,4 +80,25 @@ class IndexNotReadyError(MarkdownMCPError):
     methods. Once a background indexer lands (issue #513), the
     :meth:`Collection.wait_for_index_ready` primitive will block on a
     completion event instead of raising.
+
+    See :exc:`IndexBuildFailedError` for the related case where a
+    background build started but then raised.
+    """
+
+
+class IndexBuildFailedError(MarkdownMCPError):
+    """Raised when a background index build failed with an exception.
+
+    The original exception is available via ``__cause__``.
+
+    Distinguishes "build never finished / never started"
+    (:exc:`IndexNotReadyError`) from "build started but raised" — both
+    surface through :meth:`Collection.wait_for_index_ready` and through
+    the MCP-layer `needs_index_ready` decorator. Operator action
+    differs: not-ready means wait or check status; failed means
+    inspect logs and decide whether to retry via CLI
+    ``markdown-vault-mcp index``.
+
+    See :exc:`IndexNotReadyError` for the "never finished / never
+    started" case.
     """

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -121,3 +121,75 @@ def test_wait_for_index_ready_raises_when_never_scheduled(tmp_path: Path) -> Non
     with pytest.raises(IndexNotReadyError, match=r"never scheduled|not built"):
         col.wait_for_index_ready(timeout=0.1)
     col.close()
+
+
+def test_start_background_build_index_eventually_ready(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    for i in range(5):
+        _seed(vault, f"n_{i}.md", f"# N{i}\n\nbody {i}\n")
+    col = Collection(source_dir=vault)
+    col.start_background_build_index()
+    col.wait_for_index_ready(timeout=5.0)
+    assert col.is_index_ready()
+    col.get_backlinks("n_0.md")  # smoke: bucket-3 returns (empty list OK)
+    col.close()
+
+
+def test_start_background_build_index_captures_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+
+    def boom(*_a: object, **_kw: object) -> None:
+        raise RuntimeError("simulated scan failure")
+
+    monkeypatch.setattr(col._index_mgr, "build_index", boom)
+    col.start_background_build_index()
+
+    with pytest.raises(IndexBuildFailedError):
+        col.wait_for_index_ready(timeout=5.0)
+    assert col.is_index_ready() is False
+    col.close()
+
+
+def test_start_background_build_index_idempotent(tmp_path: Path) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+    col.start_background_build_index()
+    first = col._background_build_thread
+    assert first is not None
+    col.start_background_build_index()
+    assert col._background_build_thread is first
+    col.wait_for_index_ready(timeout=5.0)
+    col.start_background_build_index()
+    assert col._background_build_thread is first
+    col.close()
+
+
+def test_start_background_build_index_one_shot_after_thread_start_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If thread.start() itself raises, the captured-error path runs
+    synchronously: event set, error recorded, _background_started True.
+    A retry call is a no-op (one-shot)."""
+    col = Collection(source_dir=_vault(tmp_path))
+
+    def boom_start(_self: threading.Thread) -> None:
+        raise RuntimeError("system thread exhaustion (simulated)")
+
+    monkeypatch.setattr(threading.Thread, "start", boom_start)
+
+    with pytest.raises(RuntimeError, match=r"thread exhaustion"):
+        col.start_background_build_index()
+
+    # Event must be set; error recorded.
+    assert col._background_build_done.is_set()
+    assert isinstance(col._background_build_error, RuntimeError)
+
+    # wait_for_index_ready surfaces it as IndexBuildFailedError.
+    with pytest.raises(IndexBuildFailedError):
+        col.wait_for_index_ready(timeout=0.1)
+
+    # Retry is a no-op (one-shot semantics).
+    monkeypatch.undo()
+    col.start_background_build_index()  # no-op; does NOT spawn a new thread
+    col.close()

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -480,3 +480,67 @@ def test_lifespan_cold_start_with_embeddings_skips_embeddings(
         or "skipping embeddings" in record.message.lower()
         for record in caplog.records
     ), f"expected 'embeddings deferred' log; got: {[r.message for r in caplog.records]}"
+
+
+def test_decorator_preflight_one_tool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """COMMIT-A gate: decorator + applied to get_backlinks only.
+    The tool must be callable end-to-end via Client — proves FastMCP
+    accepted the wrapped handler and injected `collection` correctly."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "a.md").write_text("# A\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    from markdown_vault_mcp.server import make_server
+
+    server = make_server()
+
+    async def _call() -> list[Any]:
+        async with Client(server) as client:
+            res = await client.call_tool("get_backlinks", {"path": "a.md"})
+            return res.structured_content or []
+
+    result = asyncio.run(_call())
+    assert isinstance(result, (list, dict))  # may be wrapped; just must not raise
+
+
+def test_decorator_cold_path_blocks_until_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An MCP-client call to get_backlinks during in-flight background
+    blocks on the decorator's wait, then succeeds when the build finishes.
+    """
+    import time as time_mod
+
+    from markdown_vault_mcp.managers import index as index_mod
+    from markdown_vault_mcp.server import make_server
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for i in range(3):
+        (vault / f"n_{i}.md").write_text(f"# N{i}\n\nbody\n", encoding="utf-8")
+
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    original_build_index = index_mod.IndexManager.build_index
+
+    def slow_build_index(self, *, force: bool = False):  # type: ignore[no-untyped-def]
+        time_mod.sleep(0.3)
+        return original_build_index(self, force=force)
+
+    monkeypatch.setattr(index_mod.IndexManager, "build_index", slow_build_index)
+
+    server = make_server()
+
+    async def _call() -> Any:
+        async with Client(server) as client:
+            return await client.call_tool("get_backlinks", {"path": "n_0.md"})
+
+    result = asyncio.run(_call())
+    assert result is not None  # call succeeded after blocking ~0.3s

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import TYPE_CHECKING
 
+import pytest
+
 from markdown_vault_mcp.collection import Collection
-from markdown_vault_mcp.exceptions import IndexBuildFailedError, MarkdownMCPError
+from markdown_vault_mcp.exceptions import (
+    IndexBuildFailedError,
+    IndexNotReadyError,
+    MarkdownMCPError,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -57,4 +65,59 @@ def test_is_index_ready_false_after_captured_background_error(tmp_path: Path) ->
     col._background_build_error = RuntimeError("simulated")
     col._background_build_done.set()
     assert col.is_index_ready() is False
+    col.close()
+
+
+def test_wait_for_index_ready_returns_when_already_built(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+    col.wait_for_index_ready(timeout=0.1)  # must not raise
+    col.close()
+
+
+def test_wait_for_index_ready_blocks_until_event_set(tmp_path: Path) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+    col._background_build_done.clear()
+    col._index_built = False
+
+    def setter() -> None:
+        time.sleep(0.05)
+        col._index_built = True
+        col._background_build_done.set()
+
+    threading.Thread(target=setter).start()
+    col.wait_for_index_ready(timeout=1.0)  # returns when event fires
+    col.close()
+
+
+def test_wait_for_index_ready_raises_on_timeout(tmp_path: Path) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+    col._background_build_done.clear()
+    col._index_built = False
+    with pytest.raises(IndexNotReadyError, match=r"timed out"):
+        col.wait_for_index_ready(timeout=0.05)
+    col.close()
+
+
+def test_wait_for_index_ready_raises_build_failed_when_error_set(
+    tmp_path: Path,
+) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+    col._background_build_error = RuntimeError("scan exploded")
+    with pytest.raises(IndexBuildFailedError) as excinfo:
+        col.wait_for_index_ready(timeout=0.1)
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    col.close()
+
+
+def test_wait_for_index_ready_raises_when_never_scheduled(tmp_path: Path) -> None:
+    """Pre-set event + no error + _index_built=False + _background_started=False.
+    This is the case the spec calls 'never scheduled' — the pre-set event would
+    let wait() return success without the explicit guard."""
+    col = Collection(source_dir=_vault(tmp_path))
+    # All defaults: event pre-set, no error, _index_built=False, no spawn.
+    with pytest.raises(IndexNotReadyError, match=r"never scheduled|not built"):
+        col.wait_for_index_ready(timeout=0.1)
     col.close()

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -193,3 +193,32 @@ def test_start_background_build_index_one_shot_after_thread_start_failure(
     monkeypatch.undo()
     col.start_background_build_index()  # no-op; does NOT spawn a new thread
     col.close()
+
+
+def test_should_use_background_build_in_memory_false(tmp_path: Path) -> None:
+    col = Collection(source_dir=_vault(tmp_path))  # no index_path → in-memory
+    assert col.should_use_background_build() is False
+    col.close()
+
+
+def test_should_use_background_build_cold_on_disk_true(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault, index_path=tmp_path / "fts.db")
+    # No prior build → sentinel absent → background build required.
+    assert col.should_use_background_build() is True
+    col.close()
+
+
+def test_should_use_background_build_warm_on_disk_false(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    _seed(vault)
+    index_path = tmp_path / "fts.db"
+    # Phase 1: pre-build sets the sentinel.
+    pre = Collection(source_dir=vault, index_path=index_path)
+    pre.build_index()
+    pre.close()
+    # Phase 2: fresh Collection sees the warm sentinel.
+    col = Collection(source_dir=vault, index_path=index_path)
+    assert col.should_use_background_build() is False
+    col.close()

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -332,3 +332,151 @@ def test_close_twice_is_safe(tmp_path: Path) -> None:
     col.build_index()
     col.close()
     col.close()  # idempotent
+
+
+# ---------------------------------------------------------------------------
+# Task 8: Lifespan rewire tests
+# ---------------------------------------------------------------------------
+
+
+def test_lifespan_cold_start_handshake_under_1s(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import time as time_mod
+
+    from markdown_vault_mcp.server import make_server
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for i in range(20):
+        (vault / f"n_{i}.md").write_text(
+            f"# N{i}\n\n" + ("body " * 200) + "\n", encoding="utf-8"
+        )
+
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    server = make_server()
+
+    async def _run() -> tuple[float, dict[str, Any]]:
+        start = time_mod.perf_counter()
+        async with Client(server) as client:
+            handshake_elapsed = time_mod.perf_counter() - start
+            res: Any = None
+            for _ in range(50):
+                res = await client.call_tool("get_index_status", {})
+                if (res.structured_content or {}).get("status") == "ready":
+                    break
+                await asyncio.sleep(0.1)
+            final = res.structured_content or {}
+        return handshake_elapsed, final
+
+    handshake_elapsed, final = asyncio.run(_run())
+    assert handshake_elapsed < 1.0, (
+        f"cold-start handshake took {handshake_elapsed:.3f}s, expected < 1.0s"
+    )
+    assert final["status"] == "ready"
+    assert final["documents_indexed"] == 20
+
+
+def test_lifespan_warm_start_skips_background(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from markdown_vault_mcp.server import make_server
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "n.md").write_text("# N\n\nbody\n", encoding="utf-8")
+    index_path = tmp_path / "fts.db"
+
+    pre = Collection(source_dir=vault, index_path=index_path)
+    pre.build_index()
+    pre.close()
+
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(index_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    server = make_server()
+
+    async def _run() -> dict[str, Any]:
+        async with Client(server) as client:
+            res = await client.call_tool("get_index_status", {})
+            return res.structured_content or {}
+
+    status = asyncio.run(_run())
+    assert status["status"] == "ready"
+    assert status["documents_indexed"] == 1
+
+
+def test_lifespan_cold_start_with_embeddings_skips_embeddings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Provider configured + cold start: lifespan must log the skip and not block.
+
+    Must inject a slow _index_mgr.build_index mock so the background thread is
+    reliably still running when the lifespan checks is_index_ready() — otherwise
+    on a tiny vault the background completes between spawn and check, embeddings
+    runs, and the test asserts the wrong thing.
+    """
+    import logging
+    import time as time_mod
+
+    from markdown_vault_mcp.server import make_server
+    from tests.conftest import MockEmbeddingProvider
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "n.md").write_text("# N\n\nbody\n", encoding="utf-8")
+
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    # Patch IndexManager.build_index globally to sleep before returning,
+    # ensuring the background thread is still running when the lifespan
+    # makes the is_index_ready() decision.
+    from markdown_vault_mcp.managers import index as index_mod
+
+    original_build_index = index_mod.IndexManager.build_index
+
+    def slow_build_index(self, *, force: bool = False):  # type: ignore[no-untyped-def]
+        time_mod.sleep(0.5)
+        return original_build_index(self, force=force)
+
+    monkeypatch.setattr(index_mod.IndexManager, "build_index", slow_build_index)
+
+    # Inject a MockEmbeddingProvider into to_collection_kwargs so that
+    # kwargs["embedding_provider"] is non-None without needing a real provider.
+    # "mock" is not a registered provider name in get_embedding_provider(), so
+    # we patch at the config level instead.
+    from markdown_vault_mcp import config as config_mod
+
+    original_to_kwargs = config_mod.CollectionConfig.to_collection_kwargs
+
+    def patched_to_kwargs(self):  # type: ignore[no-untyped-def]
+        kw = original_to_kwargs(self)
+        kw["embedding_provider"] = MockEmbeddingProvider()
+        # embeddings_path is required when embedding_provider is set.
+        if kw.get("embeddings_path") is None:
+            kw["embeddings_path"] = tmp_path / "vectors"
+        return kw
+
+    monkeypatch.setattr(
+        config_mod.CollectionConfig, "to_collection_kwargs", patched_to_kwargs
+    )
+
+    server = make_server()
+    caplog.set_level(logging.INFO)
+
+    async def _run() -> None:
+        async with Client(server):
+            pass  # lifespan runs
+
+    asyncio.run(_run())
+    assert any(
+        "embeddings deferred" in record.message.lower()
+        or "skipping embeddings" in record.message.lower()
+        for record in caplog.records
+    ), f"expected 'embeddings deferred' log; got: {[r.message for r in caplog.records]}"

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.exceptions import IndexBuildFailedError, MarkdownMCPError
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_index_build_failed_error_subclasses_base() -> None:
@@ -17,3 +23,38 @@ def test_index_build_failed_error_carries_cause() -> None:
         raise IndexBuildFailedError("background build failed") from original
     except IndexBuildFailedError as err:
         assert err.__cause__ is original
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    return vault
+
+
+def _seed(vault: Path, name: str = "n.md", body: str = "# N\n\nbody\n") -> None:
+    (vault / name).write_text(body, encoding="utf-8")
+
+
+def test_is_index_ready_false_after_construction(tmp_path: Path) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+    assert col.is_index_ready() is False
+    col.close()
+
+
+def test_is_index_ready_true_after_synchronous_build(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+    assert col.is_index_ready() is True
+    col.close()
+
+
+def test_is_index_ready_false_after_captured_background_error(tmp_path: Path) -> None:
+    """Direct state poke: simulate a finished-but-failed background by setting
+    the error and the event, leaving _index_built False."""
+    col = Collection(source_dir=_vault(tmp_path))
+    col._background_build_error = RuntimeError("simulated")
+    col._background_build_done.set()
+    assert col.is_index_ready() is False
+    col.close()

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -544,3 +545,135 @@ def test_decorator_cold_path_blocks_until_ready(
 
     result = asyncio.run(_call())
     assert result is not None  # call succeeded after blocking ~0.3s
+
+
+def test_decorator_applied_to_remaining_bucket3_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All seven bucket-3 tools must accept calls end-to-end after lifespan.
+    Sanity coverage — proves the decorator pattern propagates without breakage."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "a.md").write_text("# A\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    from markdown_vault_mcp.server import make_server
+
+    server = make_server()
+
+    async def _calls() -> None:
+        async with Client(server) as client:
+            # Bucket-3 tools that take a path.
+            for tool in ("get_outlinks", "get_context"):
+                await client.call_tool(tool, {"path": "a.md"})
+            # get_similar takes path; may error if no embeddings — accept either
+            with contextlib.suppress(Exception):
+                await client.call_tool("get_similar", {"path": "a.md"})
+            await client.call_tool(
+                "get_connection_path", {"source": "a.md", "target": "a.md"}
+            )
+            # Bucket-4 coordinators (reindex always callable, build_embeddings
+            # may raise ValueError if not configured).
+            await client.call_tool("reindex", {})
+            with contextlib.suppress(Exception):
+                await client.call_tool("build_embeddings", {"force": False})
+
+    asyncio.run(_calls())
+
+
+def test_decorator_applied_to_vault_toc_resource(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """vault_toc resource (toc://vault/{path}) must be decorated; calling
+    via Client returns content after lifespan completes."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "a.md").write_text("# A\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    from markdown_vault_mcp.server import make_server
+
+    server = make_server()
+
+    async def _read() -> Any:
+        async with Client(server) as client:
+            return await client.read_resource("toc://vault/a.md")
+
+    result = asyncio.run(_read())
+    assert result is not None
+
+
+def test_decorator_applied_to_vault_similar_resource(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """vault_similar resource (similar://vault/{path}) — same coverage as vault_toc.
+    Catches the regression where the prior round forgot this one."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "a.md").write_text("# A\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    from markdown_vault_mcp.server import make_server
+
+    server = make_server()
+
+    async def _read() -> Any:
+        async with Client(server) as client:
+            try:
+                return await client.read_resource("similar://vault/a.md")
+            except Exception:
+                # May raise if no embeddings configured — that's fine,
+                # we're testing the decorator wired it correctly.
+                return None
+
+    asyncio.run(_read())
+
+
+def test_decorator_respects_env_timeout_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """monkeypatch.setenv must be visible at call time because
+    _resolve_ready_timeout reads at call time, not import time."""
+    import time as time_mod
+
+    from markdown_vault_mcp.managers import index as index_mod
+    from markdown_vault_mcp.server import make_server
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "a.md").write_text("# A\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READY_TIMEOUT_S", "0.1")
+
+    # Mock build_index to never finish so the timeout fires.
+    original = index_mod.IndexManager.build_index
+
+    def hang(self, *, force: bool = False):  # type: ignore[no-untyped-def]
+        time_mod.sleep(60)
+        return original(self, force=force)
+
+    monkeypatch.setattr(index_mod.IndexManager, "build_index", hang)
+
+    server = make_server()
+
+    async def _call() -> Any:
+        async with Client(server) as client:
+            start = time_mod.perf_counter()
+            try:
+                await client.call_tool("get_backlinks", {"path": "a.md"})
+            except Exception as exc:
+                elapsed = time_mod.perf_counter() - start
+                assert elapsed < 1.0, f"timeout not honored: elapsed {elapsed:.2f}s"
+                return exc
+            raise AssertionError("expected the tool call to raise")
+
+    exc = asyncio.run(_call())
+    assert exc is not None

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -1,0 +1,19 @@
+"""Tests for issue #513 PR1 (attempt 7) — tool-layer wait for cold-start background FTS."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.exceptions import IndexBuildFailedError, MarkdownMCPError
+
+
+def test_index_build_failed_error_subclasses_base() -> None:
+    err = IndexBuildFailedError("scan failed")
+    assert isinstance(err, MarkdownMCPError)
+    assert str(err) == "scan failed"
+
+
+def test_index_build_failed_error_carries_cause() -> None:
+    original = RuntimeError("scan exploded")
+    try:
+        raise IndexBuildFailedError("background build failed") from original
+    except IndexBuildFailedError as err:
+        assert err.__cause__ is original

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -300,3 +300,35 @@ def test_mcp_tool_get_index_status_reports_ready(
     status = asyncio.run(_call())
     assert status["status"] in ("ready", "building")  # depends on lifespan timing
     assert status["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# close() joins background thread (Task 7)
+# ---------------------------------------------------------------------------
+
+
+def test_close_joins_background_thread(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    for i in range(3):
+        _seed(vault, f"n_{i}.md", f"# N{i}\n\nbody {i}\n")
+    col = Collection(source_dir=vault, index_path=tmp_path / "fts.db")
+    col.start_background_build_index()
+    col.close()
+    thread = col._background_build_thread
+    assert thread is not None
+    assert not thread.is_alive()
+
+
+def test_close_before_start_is_safe(tmp_path: Path) -> None:
+    """A Collection that never had a background build can still close cleanly."""
+    col = Collection(source_dir=_vault(tmp_path))
+    col.close()  # must not raise
+
+
+def test_close_twice_is_safe(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+    col.close()
+    col.close()  # idempotent

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -848,3 +848,59 @@ def test_synchronous_build_index_clears_prior_background_error(
     # Bucket-3 call no longer surfaces the prior error.
     col.get_backlinks("n.md")  # must not raise
     col.close()
+
+
+def test_synchronous_build_index_warm_path_clears_prior_background_error(
+    tmp_path: Path,
+) -> None:
+    """Recovery path via the warm-restart short-circuit: a prior background
+    failure left _background_build_error populated; the sentinel from a
+    prior successful build is still present; calling build_index()
+    synchronously must clear the captured error and is_index_ready() must
+    return True."""
+    vault = _vault(tmp_path)
+    _seed(vault)
+    index_path = tmp_path / "fts.db"
+
+    # Phase 1: pre-build to set the sentinel and FTS rows.
+    pre = Collection(source_dir=vault, index_path=index_path)
+    pre.build_index()
+    pre.close()
+
+    # Phase 2: fresh Collection sees the warm sentinel; simulate a prior
+    # background failure.
+    col = Collection(source_dir=vault, index_path=index_path)
+    col._background_build_error = RuntimeError("simulated prior background failure")
+    col._background_build_done.set()
+    col._background_started = True
+    assert col.is_index_ready() is False
+
+    # Warm-restart short-circuit recovery.
+    col.build_index()
+
+    assert col._background_build_error is None
+    assert col.is_index_ready() is True
+    col.close()
+
+
+def test_decorator_works_with_positional_collection_arg(tmp_path: Path) -> None:
+    """The decorator must extract `collection` from positional args
+    via inspect.signature.bind_partial, not just from kwargs.
+    Direct call (no FastMCP) with positional collection must work."""
+    import asyncio
+
+    from markdown_vault_mcp._server_readiness import needs_index_ready
+
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()  # mark ready
+
+    @needs_index_ready()
+    async def handler(path: str, collection: Collection) -> str:  # noqa: ARG001
+        return f"got: {path}"
+
+    # Call positionally (not via kwargs).
+    result = asyncio.run(handler("n.md", col))
+    assert result == "got: n.md"
+    col.close()

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -820,3 +820,31 @@ def test_reindex_after_pull_handler_handles_not_ready(tmp_path: Path) -> None:
         monkeypatch.undo()
         col.wait_for_index_ready(timeout=5.0)
         col.close()
+
+
+def test_synchronous_build_index_clears_prior_background_error(
+    tmp_path: Path,
+) -> None:
+    """Recovery path: after a failed background build, calling build_index()
+    synchronously must clear _background_build_error so is_index_ready()
+    returns True and bucket-3/4 calls stop raising IndexBuildFailedError."""
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault, index_path=tmp_path / "fts.db")
+
+    # Simulate a prior failed background: error captured, event set,
+    # _index_built still False.
+    col._background_build_error = RuntimeError("simulated prior background failure")
+    col._background_build_done.set()
+    col._background_started = True
+    assert col.is_index_ready() is False
+
+    # Synchronous recovery build.
+    col.build_index()
+
+    # Now ready: error cleared, _index_built True, event still set.
+    assert col._background_build_error is None
+    assert col.is_index_ready() is True
+    # Bucket-3 call no longer surfaces the prior error.
+    col.get_backlinks("n.md")  # must not raise
+    col.close()

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -788,3 +788,35 @@ def test_foreground_write_during_background_scan_on_disk(tmp_path: Path) -> None
     rows = {r["path"]: r for r in col._fts.list_notes()}
     assert "racy.md" in rows, "foreground write must end up in FTS"
     col.close()
+
+
+def test_reindex_after_pull_handler_handles_not_ready(tmp_path: Path) -> None:
+    """_reindex_after_pull in _server_tools.py catches IndexNotReadyError
+    and sets reindex_failed=True on the pull payload — does NOT block."""
+    import time as time_mod
+
+    from markdown_vault_mcp._server_tools import _reindex_after_pull
+    from markdown_vault_mcp.managers import index as index_mod
+
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault, index_path=tmp_path / "fts.db", read_only=False)
+
+    original = index_mod.IndexManager.build_index
+
+    def slow(self, *, force: bool = False):  # type: ignore[no-untyped-def]
+        time_mod.sleep(0.5)
+        return original(self, force=force)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(index_mod.IndexManager, "build_index", slow)
+    try:
+        col.start_background_build_index()
+        pull_dict: dict[str, Any] = {}
+        asyncio.run(_reindex_after_pull(col, pull_dict))
+        assert pull_dict.get("reindex_failed") is True
+        assert "reindex_hint" in pull_dict
+    finally:
+        monkeypatch.undo()
+        col.wait_for_index_ready(timeout=5.0)
+        col.close()

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
+from fastmcp import Client
 
 from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.exceptions import (
@@ -222,3 +224,79 @@ def test_should_use_background_build_warm_on_disk_false(tmp_path: Path) -> None:
     col = Collection(source_dir=vault, index_path=index_path)
     assert col.should_use_background_build() is False
     col.close()
+
+
+# ---------------------------------------------------------------------------
+# get_index_status tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_index_status_ready(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+    status = col.get_index_status()
+    assert status["status"] == "ready"
+    assert status["documents_indexed"] == 1
+    assert status["error"] is None
+    col.close()
+
+
+def test_get_index_status_building_in_flight(tmp_path: Path) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+    col._background_build_done.clear()
+    col._background_started = True
+    status = col.get_index_status()
+    assert status["status"] == "building"
+    assert status["error"] is None
+    col._background_build_done.set()
+    col.close()
+
+
+def test_get_index_status_building_never_started(tmp_path: Path) -> None:
+    """Fresh Collection: event pre-set, no error, _index_built=False.
+    Reports 'building' (not 'ready' — the attempt-6 lie is fixed)."""
+    col = Collection(source_dir=_vault(tmp_path))
+    status = col.get_index_status()
+    assert status["status"] == "building"
+    assert status["error"] is None
+    col.close()
+
+
+def test_get_index_status_failed(tmp_path: Path) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+    col._background_build_error = RuntimeError("scan failed for X")
+    status = col.get_index_status()
+    assert status["status"] == "failed"
+    assert "scan failed for X" in status["error"]
+    col.close()
+
+
+# ---------------------------------------------------------------------------
+# MCP integration test for get_index_status
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_tool_get_index_status_reports_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "n.md").write_text("# N\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+    from markdown_vault_mcp.server import make_server
+
+    server = make_server()
+
+    async def _call() -> dict[str, Any]:
+        async with Client(server) as client:
+            res = await client.call_tool("get_index_status", {})
+            return res.structured_content or {}
+
+    status = asyncio.run(_call())
+    assert status["status"] in ("ready", "building")  # depends on lifespan timing
+    assert status["error"] is None

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -677,3 +677,114 @@ def test_decorator_respects_env_timeout_override(
 
     exc = asyncio.run(_call())
     assert exc is not None
+
+
+# ---------------------------------------------------------------------------
+# Task 11: Boundary regression test + git pull loop test + foreground-write test
+# ---------------------------------------------------------------------------
+
+
+def test_require_index_ready_raises_immediately_not_blocks(tmp_path: Path) -> None:
+    """Bucket-3/4 library method called during in-flight background build
+    raises IndexNotReadyError WITHIN 0.1s wall-clock — does NOT block.
+
+    This is the canonical regression test against attempt-6's hole."""
+    import time as time_mod
+
+    from markdown_vault_mcp.managers import index as index_mod
+
+    vault = _vault(tmp_path)
+    for i in range(3):
+        _seed(vault, f"n_{i}.md", f"# N{i}\n\nbody\n")
+    col = Collection(source_dir=vault, index_path=tmp_path / "fts.db")
+
+    original = index_mod.IndexManager.build_index
+
+    def slow(self, *, force: bool = False):  # type: ignore[no-untyped-def]
+        time_mod.sleep(1.0)
+        return original(self, force=force)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(index_mod.IndexManager, "build_index", slow)
+    try:
+        col.start_background_build_index()
+
+        start = time_mod.perf_counter()
+        with pytest.raises(IndexNotReadyError):
+            col.get_backlinks("n_0.md")  # bucket-3 library call
+        elapsed = time_mod.perf_counter() - start
+        assert elapsed < 0.1, (
+            f"library method blocked for {elapsed:.3f}s; should raise immediately"
+        )
+    finally:
+        monkeypatch.undo()
+        col.wait_for_index_ready(timeout=5.0)
+        col.close()
+
+
+def test_git_pull_during_background_does_not_starve_writes(tmp_path: Path) -> None:
+    """The on_pull=reindex callback in the git pull loop must NOT hold
+    _write_lock while blocking on the background build. Reindex raises
+    IndexNotReadyError, git_sync catches it, releases the lock, retries
+    on next interval — no lock starvation."""
+    import time as time_mod
+
+    from markdown_vault_mcp.managers import index as index_mod
+
+    vault = _vault(tmp_path)
+    for i in range(5):
+        _seed(vault, f"n_{i}.md", f"# N{i}\n\nbody\n")
+    col = Collection(source_dir=vault, index_path=tmp_path / "fts.db", read_only=False)
+
+    original = index_mod.IndexManager.build_index
+
+    def slow(self, *, force: bool = False):  # type: ignore[no-untyped-def]
+        time_mod.sleep(0.5)
+        return original(self, force=force)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(index_mod.IndexManager, "build_index", slow)
+    try:
+        col.start_background_build_index()
+
+        # Simulate the on_pull callback (reindex) racing the foreground
+        # write. Both should fast-fail / proceed without lock starvation.
+        with pytest.raises(IndexNotReadyError):
+            col.reindex()  # raises immediately, releases internal locks
+
+        # Foreground write must complete promptly (within 1s, well
+        # under the slow scan's 0.5s sleep).
+        start = time_mod.perf_counter()
+        col.write("racy.md", "# Racy\n\nforeground content\n")
+        elapsed = time_mod.perf_counter() - start
+        assert elapsed < 1.0, (
+            f"foreground write blocked for {elapsed:.3f}s (suggests lock starvation)"
+        )
+    finally:
+        monkeypatch.undo()
+        col.wait_for_index_ready(timeout=5.0)
+        col.close()
+
+
+def test_foreground_write_during_background_scan_on_disk(tmp_path: Path) -> None:
+    """On-disk DB: race a foreground write() against background scan.
+    Assertions per spec I13:
+      1. No SQLite locking error.
+      2. racy.md row exists in FTS.
+      3. NO assertion on which content wins. Last-writer-wins per path
+         is the accepted contract; staleness is corrected by next reindex.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for i in range(30):
+        (vault / f"seed_{i}.md").write_text(
+            f"# Seed {i}\n\n" + ("body " * 300) + "\n", encoding="utf-8"
+        )
+    col = Collection(source_dir=vault, index_path=tmp_path / "fts.db", read_only=False)
+    col.start_background_build_index()
+    col.write("racy.md", "# Racy\n\nFOREGROUND CONTENT\n")
+    col.wait_for_index_ready(timeout=10.0)
+
+    rows = {r["path"]: r for r in col._fts.list_notes()}
+    assert "racy.md" in rows, "foreground write must end up in FTS"
+    col.close()


### PR DESCRIPTION
## Summary

PR1 of three planned PRs closing #513. Supersedes the abandoned PR #528 (attempt 6) which collapsed under the uniform "library delegates to wait" abstraction.

**Corrected boundary:** library raises (`_require_index_ready` stays as PR #525 left it — raise-immediately, no delegation). Blocking semantics live at the MCP tool/resource layer in a `@needs_index_ready` decorator applied to 7 tools + 2 resources. Internal callers (lifespan, git pull loop, CLI, direct library users) handle "not ready" with caller-appropriate logic — never block.

## What changed

- **Lifespan** routes cold on-disk through `start_background_build_index()`; warm on-disk and in-memory through synchronous `build_index()`. Embeddings gated on `is_index_ready()` — skipped + logged on cold start (PR2 backgrounds them).
- **`Collection` additions:** state (4 fields), `is_index_ready()`, `start_background_build_index()`, `should_use_background_build()`, `get_index_status()`. `wait_for_index_ready(timeout)` event-based with 4-step control flow including the never-scheduled guard.
- **`close()`** joins the background thread under `_write_lock`, before any resource teardown.
- **New `IndexBuildFailedError`** in `exceptions.py`. Surfaces at the decorator (not at the library).
- **`needs_index_ready` decorator** in new `_server_readiness.py`. Applied via two-commit split — Commit A applied to `get_backlinks` only + preflight test; Commit B applied to the other 8 surfaces.
- **`get_index_status` MCP tool** for operator polling without making a real bucket-3/4 call.
- **Env var `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S`** (default 60s) configures the decorator's wait.

## Out of scope (PR2 / PR3)

- Embeddings background build → PR2.
- Warm-start drift reindex → PR3.
- Cooperative cancellation inside `IndexManager.build_index` (close relies on daemon + bounded join).

## Failure-mode coverage

Every row in the design's failure-mode table maps to a test in `tests/test_background_fts.py`. The canonical regression test against attempt 6's hole is `test_require_index_ready_raises_immediately_not_blocks` — asserts a bucket-3/4 *library* call during in-flight background raises within 0.1s wall-clock (not blocks).

## Discipline

This attempt was preceded by:
- Closing PR #528 unmerged with a retrospective.
- Memory entries: `feedback_uniform_delegation_design_smell.md` (when "every X behaves the same way" requires per-caller exceptions, the contract is wrong, not the callers) and `project_issue_513_attempt_6_abandon.md`.
- A fresh brainstorm with the corrected boundary as the fixed anchor.
- A spec that went through 4 independent review passes before any code was written.
- Subagent-driven implementation with two-stage review per task and a structurally-enforced commit split (Commit A: decorator preflight on `get_backlinks` only; Commit B: rollout to remaining 8 surfaces) so the decorator pattern was verified end-to-end before broad application.

## Test plan
- [x] `pytest -q` — 1674 passed, 1 skipped
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/ tests/` — clean
- [x] `diff-cover --fail-under=80` — 95% patch coverage
- [x] Verification grep — `_require_index_ready` stays raise-only on main + this branch (no delegation re-introduced)

Refs: #513 (PR2 + PR3 to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)