### PR TITLE
refactor!: unwind error-as-state layer; IndexBuildFailedError deleted (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed (BREAKING)
+
+- `IndexBuildFailedError` removed from the public exception surface
+  (#533). Captured background-build errors are now diagnostic events
+  surfaced via `Collection.get_index_status` instead of raised from
+  the read path. The MCP `@needs_index_ready` decorator catches
+  `sqlite3.OperationalError` from handlers and remaps to
+  `IndexNotReadyError(reason="broken")` — the new structured
+  `reason` discriminator on `IndexNotReadyError` distinguishes
+  `"never_built"`, `"timeout"`, and `"broken"`. External consumers
+  that previously caught `IndexBuildFailedError` should remove that
+  catch arm.
+- `Collection.get_index_status` renames `status="ready"` to
+  `status="queryable"` and flips the priority so a previously-built
+  index with a captured rebuild error reports `"queryable"` (with the
+  diagnostic in `error`) rather than `"failed"`. `"failed"` now means
+  not queryable AND a build attempt errored. Issue #534 will further
+  subdivide `"queryable"` into `"up_to_date"` / `"degraded"` once
+  drift detection lands.

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `stats` | Get collection statistics (document count, chunk count, link health metrics, etc.) |
 | `build_embeddings` | Build or rebuild vector embeddings for semantic search |
 | `embeddings_status` | Check embedding provider and index status |
-| `get_index_status` | Check background FTS build state (`ready` / `building` / `failed`) |
+| `get_index_status` | Check background FTS build state (`queryable` / `building` / `failed`) |
 | `get_backlinks` | Find all documents that link to a given document |
 | `get_outlinks` | Find all links from a document, with existence check |
 | `get_broken_links` | Find all links pointing to non-existent documents |

--- a/docs/design.md
+++ b/docs/design.md
@@ -404,11 +404,17 @@ arriving at the MCP layer go through the
 `src/markdown_vault_mcp/_server_readiness.py`), which blocks via
 `Collection.wait_for_index_ready(timeout)` with a configurable
 default (env `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S`, default 60s).
-A failed background build surfaces to MCP clients as
-`IndexBuildFailedError` (the decorator's `wait_for_index_ready`
-call raises) and to operators as
-`get_index_status` reporting
-`{"status": "failed", "error": "..."}`. Embeddings stay on the
+A failed background build is a diagnostic event, not a gate on the
+read path. It surfaces to operators via `get_index_status` reporting
+`{"status": "failed", "error": "..."}` when the index is not
+queryable, or `{"status": "queryable", "error": "..."}` when a
+prior rebuild attempt errored but an older index remains usable.
+The `needs_index_ready` decorator raises `IndexNotReadyError` with a
+structured `reason` discriminator: `"never_built"` (build never
+scheduled), `"timeout"` (wait exceeded `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S`),
+or `"broken"` (sqlite3.OperationalError caught at the decorator
+boundary). Issue #534 will further subdivide `"queryable"` into
+`"up_to_date"` and `"degraded"` once drift detection lands. Embeddings stay on the
 synchronous lifespan path in PR1 — on cold start
 `build_embeddings()` is skipped with a log entry and semantic
 search returns empty until PR2 backgrounds embeddings or the

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -95,7 +95,7 @@ The empty string `""` represents the root folder (top-level documents).
 Table of contents (heading outline) for a specific document. This is a URI template — replace `{path}` with the document's relative path.
 
 !!! note "Cold-start blocking"
-    Calls during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
+    Calls during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than the configured timeout, the resource raises `IndexNotReadyError(reason="timeout")`. The `reason` field also takes values `"never_built"` (build never scheduled) and `"broken"` (sqlite3.OperationalError caught at the decorator boundary). A captured background-build error does not gate this read; it is surfaced via the `error` field of `get_index_status`. Poll `get_index_status` to observe build state without blocking.
 
 **Example:** `toc://vault/Journal/note.md`
 
@@ -118,7 +118,7 @@ The TOC prepends a synthetic H1 from the document title and deduplicates if the 
 Top 10 semantically similar notes for a document. Requires embeddings to be built. This is a URI template — replace `{path}` with the document's relative path.
 
 !!! note "Cold-start blocking"
-    Calls during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
+    Calls during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than the configured timeout, the resource raises `IndexNotReadyError(reason="timeout")`. The `reason` field also takes values `"never_built"` (build never scheduled) and `"broken"` (sqlite3.OperationalError caught at the decorator boundary). A captured background-build error does not gate this read; it is surfaced via the `error` field of `get_index_status`. Poll `get_index_status` to observe build state without blocking.
 
 Results are **grouped per file** — each file appears at most once, with up to `chunks_per_file` (server default `2`) best-matching sections in a `sections` array. Each entry is a `GroupedResult` dict with `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -15,7 +15,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`list_tags`](#list_tags) | Read | List all unique frontmatter tag values |
 | [`stats`](#stats) | Read | Get collection statistics and capabilities |
 | [`embeddings_status`](#embeddings_status) | Read | Check embedding provider and vector index status |
-| [`get_index_status`](#get_index_status) | Read | Check background FTS build state (ready / building / failed) |
+| [`get_index_status`](#get_index_status) | Read | Check background FTS build state (queryable / building / failed) |
 | [`get_backlinks`](#get_backlinks) | Read | Find all documents that link to a given document |
 | [`get_outlinks`](#get_outlinks) | Read | Find all links from a document, with existence check |
 | [`get_broken_links`](#get_broken_links) | Read | Find all links pointing to non-existent documents |
@@ -204,11 +204,11 @@ Check the embedding provider configuration and vector index status. Use this to 
 
 Returns background-build state of the FTS index. Use this when
 `initialize` returned but bucket-3/4 calls block longer than expected
-or surface `IndexNotReadyError`/`IndexBuildFailedError` — the
+or surface `IndexNotReadyError` — the
 `status` field distinguishes "still building" from "build failed."
 
 **Returns:**
-- `status`: `"ready"`, `"building"`, or `"failed"`.
+- `status`: `"queryable"`, `"building"`, or `"failed"`.
 - `documents_indexed`: count of documents committed to the FTS index
   right now (rises during `"building"`).
 - `error`: `null` unless the background build raised; otherwise the
@@ -221,7 +221,7 @@ or surface `IndexNotReadyError`/`IndexBuildFailedError` — the
 ## Index Management
 
 !!! note "Cold-start blocking"
-    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` (default 60s), the tool returns `IndexNotReadyError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
+    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` (default 60s), the tool raises `IndexNotReadyError(reason="timeout")`. A captured background-build error does not gate this read; it is surfaced via the `error` field of `get_index_status`. Poll `get_index_status` to observe build state without blocking.
 
 ### `reindex`
 
@@ -608,7 +608,7 @@ managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` not set).
 ## Link Graph
 
 !!! note "Cold-start blocking"
-    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` (default 60s), the tool returns `IndexNotReadyError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
+    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` (default 60s), the tool raises `IndexNotReadyError(reason="timeout")`. A captured background-build error does not gate this read; it is surfaced via the `error` field of `get_index_status`. Poll `get_index_status` to observe build state without blocking.
 
 ### `get_backlinks`
 

--- a/src/markdown_vault_mcp/_server_readiness.py
+++ b/src/markdown_vault_mcp/_server_readiness.py
@@ -16,7 +16,10 @@ import functools
 import inspect
 import logging
 import os
+import sqlite3
 from typing import TYPE_CHECKING, Any
+
+from markdown_vault_mcp.exceptions import IndexNotReadyError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -54,8 +57,12 @@ def needs_index_ready(
     already-wrapped function.
 
     Raises (propagated to MCP client via FastMCP error middleware):
-        IndexNotReadyError: timeout exceeded; or never scheduled.
-        IndexBuildFailedError: a prior background build raised.
+        IndexNotReadyError: with ``reason="timeout"`` if the bounded
+            wait elapsed before the background build completed;
+            ``reason="never_built"`` if the build was never scheduled;
+            ``reason="broken"`` if the wrapped handler raised
+            ``sqlite3.OperationalError`` (reactive broken-detection
+            boundary — issue #533).
     """
 
     def deco(handler: Callable[..., Any]) -> Callable[..., Any]:
@@ -77,7 +84,13 @@ def needs_index_ready(
             if not collection.is_index_ready():
                 effective = timeout if timeout is not None else _resolve_ready_timeout()
                 await asyncio.to_thread(collection.wait_for_index_ready, effective)
-            return await handler(*args, **kwargs)
+            try:
+                return await handler(*args, **kwargs)
+            except sqlite3.OperationalError as exc:
+                raise IndexNotReadyError(
+                    "Index appears broken; operation could not complete.",
+                    reason="broken",
+                ) from exc
 
         return wrapper
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -596,20 +596,29 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """Return background-build state of the FTS index.
 
         Use this when ``initialize`` returned but bucket-3/4 calls
-        block longer than expected or raise ``IndexNotReadyError``. The
-        ``status`` field distinguishes "still building" from "build
-        failed," and the ``error`` field surfaces any captured background
-        build exception.
+        block longer than expected or raise ``IndexNotReadyError``.
+        ``status`` reports whether the index is readable right now;
+        ``error`` is the diagnostic exit code of the last background
+        build attempt and may be populated even when ``status`` is
+        ``"queryable"`` (a previously successful build left readable
+        data and a subsequent attempt errored).
 
         Returns:
             Dict with the following fields:
 
-            - status (str): ``"ready"``, ``"building"``, or
-              ``"failed"``.
+            - status (str): ``"queryable"`` (index is readable now),
+              ``"building"`` (in-flight or never scheduled), or
+              ``"failed"`` (not readable AND a build attempt errored).
+              Issue #534 will further subdivide ``"queryable"`` into
+              ``"up_to_date"`` and ``"degraded"`` once drift detection
+              lands; clients should treat unknown queryable-like values
+              as queryable.
             - documents_indexed (int): Count of documents committed to
               the FTS index right now (rises during ``"building"``).
-            - error (str | None): ``None`` unless the background build
-              raised.
+            - error (str | None): Diagnostic message from the most
+              recent build attempt that raised, if any. Always check
+              this field — ``status == "queryable"`` does NOT imply
+              the most recent build succeeded.
         """
         return await asyncio.to_thread(collection.get_index_status)
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -598,27 +598,30 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Use this when ``initialize`` returned but bucket-3/4 calls
         block longer than expected or raise ``IndexNotReadyError``.
         ``status`` reports whether the index is readable right now;
-        ``error`` is the diagnostic exit code of the last background
-        build attempt and may be populated even when ``status`` is
-        ``"queryable"`` (a previously successful build left readable
-        data and a subsequent attempt errored).
+        ``error`` carries the diagnostic message from the last
+        background-build attempt that raised.
 
         Returns:
             Dict with the following fields:
 
             - status (str): ``"queryable"`` (index is readable now),
               ``"building"`` (in-flight or never scheduled), or
-              ``"failed"`` (not readable AND a build attempt errored).
+              ``"failed"`` (a background build raised AND the index is
+              not currently readable; only the background ``_worker``
+              path populates the captured error — a foreground
+              :meth:`build_index` failure raises to its caller and
+              leaves status as ``"building"``).
               Issue #534 will further subdivide ``"queryable"`` into
               ``"up_to_date"`` and ``"degraded"`` once drift detection
               lands; clients should treat unknown queryable-like values
               as queryable.
             - documents_indexed (int): Count of documents committed to
               the FTS index right now (rises during ``"building"``).
-            - error (str | None): Diagnostic message from the most
-              recent build attempt that raised, if any. Always check
-              this field — ``status == "queryable"`` does NOT imply
-              the most recent build succeeded.
+            - error (str | None): Diagnostic message from the last
+              background-build attempt that raised, if any. In
+              production flows this is ``None`` when status is
+              ``"queryable"`` because every successful
+              :meth:`build_index` clears the captured error.
         """
         return await asyncio.to_thread(collection.get_index_status)
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -596,10 +596,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """Return background-build state of the FTS index.
 
         Use this when ``initialize`` returned but bucket-3/4 calls
-        block longer than expected or surface
-        ``IndexNotReadyError``/``IndexBuildFailedError`` — the
+        block longer than expected or raise ``IndexNotReadyError``. The
         ``status`` field distinguishes "still building" from "build
-        failed."
+        failed," and the ``error`` field surfaces any captured background
+        build exception.
 
         Returns:
             Dict with the following fields:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -603,8 +603,7 @@ class Collection:
 
         A captured ``_background_build_error`` no longer gates this
         method (#533 unwind). The captured exception is surfaced via
-        :meth:`get_index_status` as a diagnostic event, not as a raised
-        ``IndexBuildFailedError`` — the class is gone.
+        :meth:`get_index_status` as a diagnostic event.
 
         This method is opt-in for the MCP-layer
         :func:`needs_index_ready` decorator and for external callers that

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -439,29 +439,23 @@ class Collection:
             )
 
     def is_index_ready(self) -> bool:
-        """Return ``True`` iff the FTS index is in a clean ready state.
+        """Return ``True`` iff the FTS index is queryable right now.
 
-        Non-blocking. Returns ``True`` only when all three conditions
-        hold simultaneously: ``_index_built`` is True (a build returned
-        cleanly), ``_background_build_error`` is None (no captured
-        background failure), and ``_background_build_done`` is set (no
-        in-flight background). A freshly-constructed Collection
-        (event pre-set, no error, ``_index_built`` False) returns False
-        — the attempt-6 status lie is impossible by construction.
+        Two-field check after issue #533: ``_index_built`` is True AND
+        ``_background_build_done`` is set. The captured
+        ``_background_build_error`` no longer participates — it's a
+        diagnostic event surfaced via :meth:`get_index_status`, not a
+        gate on the read path.
 
-        Lock-free by design: reads ``_index_built`` (plain bool
-        attribute), checks ``_background_build_error is None`` (plain
-        attribute), and calls ``_background_build_done.is_set()``
-        (Event method, no lock). Safe to call on hot tool paths.
+        A previously-built index whose subsequent rebuild captured an
+        error is still queryable: the on-disk index has the previously
+        ingested data; the next read uses it.
 
-        Assumes CPython GIL semantics for cross-thread visibility of
-        the plain attribute reads. Not analyzed for Free-Threaded
-        Python 3.13+ (``python -X gil=0``); revisit if the project
-        moves off CPython GIL.
+        Lock-free by design: plain attribute read of ``_index_built``
+        + ``Event.is_set()``. Assumes CPython GIL semantics for
+        cross-thread visibility; not analyzed for Free-Threaded Python.
         """
         if not self._index_built:
-            return False
-        if self._background_build_error is not None:
             return False
         return self._background_build_done.is_set()
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -434,7 +434,8 @@ class Collection:
         """Raise :exc:`IndexNotReadyError` if :meth:`build_index` has not run."""
         if not self._index_built:
             raise IndexNotReadyError(
-                "Index not built. Call build_index() before this method."
+                "Index not built. Call build_index() before this method.",
+                reason="never_built",
             )
 
     def is_index_ready(self) -> bool:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -447,16 +447,22 @@ class Collection:
         diagnostic event surfaced via :meth:`get_index_status`, not a
         gate on the read path.
 
-        Note that under the current implementation
-        :meth:`build_index` resets ``_index_built = False`` before
-        rebuilding (so a mid-rebuild crash leaves the Collection
-        visibly not-ready — see issue #525). A queryable index whose
-        *subsequent* rebuild fails therefore transitions through
-        not-ready while the rebuild is in flight, and the failure
-        leaves it not-ready until the next successful build. The
-        "errors are events" principle is realised at the read-time
-        boundary: once :meth:`build_index` succeeds the captured
-        background error is cleared (see line 778).
+        Production-path note: every successful :meth:`build_index`
+        clears ``_background_build_error`` (both the warm-restart
+        short-circuit and the full-rebuild success path), so an index
+        that is queryable also has ``error=None`` in
+        :meth:`get_index_status` under normal flows. The defensive
+        priority in :meth:`get_index_status` that allows
+        ``status="queryable"`` to win over ``status="failed"`` is for
+        test scenarios and externally-injected state, not a state the
+        Collection produces on its own. :meth:`build_index` also
+        resets ``_index_built = False`` before rebuilding so a
+        mid-rebuild crash leaves the Collection visibly not-ready
+        (see #525); the synchronous path does not capture the
+        exception into ``_background_build_error`` (only the
+        background ``_worker`` does that), so a foreground rebuild
+        failure ends in ``status="building"`` with ``error=None``,
+        not ``"failed"``.
 
         Lock-free by design: plain attribute read of ``_index_built``
         + ``Event.is_set()``. Assumes CPython GIL semantics for
@@ -543,15 +549,14 @@ class Collection:
         outcome.
 
         - ``"queryable"`` (#533 rename from ``"ready"``): the FTS index
-          is readable right now. ``error`` may still be non-None when
-          a warm-restart short-circuit (:meth:`build_index` finding a
-          completeness sentinel + existing docs) flips the Collection
-          to ready while a captured background error from a prior
-          attempt is still surfaced. Readers proceed normally;
-          operators see the diagnostic in ``error``. (Under the
-          current implementation a *foreground* failed rebuild
-          transitions through not-ready and lands in ``"failed"``, not
-          ``"queryable"`` — see :meth:`is_index_ready` and #525.)
+          is readable right now. In production flows ``error`` is
+          ``None`` here — every successful :meth:`build_index` clears
+          the captured background error. The fact that the branch
+          still tolerates a non-None ``error`` is defensive: test
+          scenarios poke ``_background_build_error`` directly to
+          verify the priority flip (queryable wins over failed),
+          and a future change that lets a captured error outlive a
+          successful build would still be readable.
         - ``"failed"``: NOT queryable AND a build attempt errored.
           Operator action: inspect ``error``, rebuild via CLI
           ``markdown-vault-mcp index`` or restart.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -526,31 +526,50 @@ class Collection:
         return not self._fts.is_build_completed()
 
     def get_index_status(self) -> dict[str, Any]:
-        """Return a non-blocking snapshot of background-build state.
+        """Return a non-blocking snapshot of FTS background-build state.
 
-        Shape: ``{"status": "ready" | "building" | "failed",
+        Shape: ``{"status": "queryable" | "building" | "failed",
         "documents_indexed": int, "error": str | None}``.
 
-        - ``"ready"``: ``is_index_ready()`` is True (synchronous build
-          returned cleanly or background build completed cleanly);
-          ``error`` is None.
-        - ``"failed"``: ``_background_build_error`` is non-None;
-          ``error`` carries its message.
+        Issue #533 reframed the meaning. Status is a present-tense
+        capability check; ``error`` is the diagnostic last-attempt
+        outcome.
+
+        - ``"queryable"`` (#533 rename from ``"ready"``): the FTS index
+          is readable right now. ``error`` may still be non-None —
+          a previously successful build left readable data on disk and
+          a subsequent rebuild captured an exception. Readers proceed
+          normally; operators see the diagnostic in ``error``.
+        - ``"failed"``: NOT queryable AND a build attempt errored.
+          Operator action: inspect ``error``, rebuild via CLI
+          ``markdown-vault-mcp index`` or restart.
         - ``"building"``: anything else — event cleared (in-flight)
-          OR event set but ``_index_built`` is False (never scheduled).
-          From the operator's perspective both mean "wait or poll."
+          or event set but ``_index_built`` False (never scheduled).
+
+        Forward-pointer (issue #534): the ``"queryable"`` value will
+        subdivide into ``"up_to_date"`` and ``"degraded"`` when drift
+        detection lands. Clients that haven't learned the new values
+        should treat any unknown queryable-like value as queryable
+        (graceful degradation).
 
         ``documents_indexed`` is taken from
         :meth:`FTSIndex.list_notes` and so reflects whatever rows are
-        currently committed — progress is observable in the
+        currently committed; progress is observable in the
         ``"building"`` state as the count rises.
         """
-        if self._background_build_error is not None:
+        if self.is_index_ready():
+            status = "queryable"
+            error: str | None = (
+                str(self._background_build_error)
+                if self._background_build_error is not None
+                else None
+            )
+        elif (
+            self._background_build_done.is_set()
+            and self._background_build_error is not None
+        ):
             status = "failed"
-            error: str | None = str(self._background_build_error)
-        elif self.is_index_ready():
-            status = "ready"
-            error = None
+            error = str(self._background_build_error)
         else:
             status = "building"
             error = None

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -447,9 +447,16 @@ class Collection:
         diagnostic event surfaced via :meth:`get_index_status`, not a
         gate on the read path.
 
-        A previously-built index whose subsequent rebuild captured an
-        error is still queryable: the on-disk index has the previously
-        ingested data; the next read uses it.
+        Note that under the current implementation
+        :meth:`build_index` resets ``_index_built = False`` before
+        rebuilding (so a mid-rebuild crash leaves the Collection
+        visibly not-ready — see issue #525). A queryable index whose
+        *subsequent* rebuild fails therefore transitions through
+        not-ready while the rebuild is in flight, and the failure
+        leaves it not-ready until the next successful build. The
+        "errors are events" principle is realised at the read-time
+        boundary: once :meth:`build_index` succeeds the captured
+        background error is cleared (see line 778).
 
         Lock-free by design: plain attribute read of ``_index_built``
         + ``Event.is_set()``. Assumes CPython GIL semantics for
@@ -536,10 +543,15 @@ class Collection:
         outcome.
 
         - ``"queryable"`` (#533 rename from ``"ready"``): the FTS index
-          is readable right now. ``error`` may still be non-None —
-          a previously successful build left readable data on disk and
-          a subsequent rebuild captured an exception. Readers proceed
-          normally; operators see the diagnostic in ``error``.
+          is readable right now. ``error`` may still be non-None when
+          a warm-restart short-circuit (:meth:`build_index` finding a
+          completeness sentinel + existing docs) flips the Collection
+          to ready while a captured background error from a prior
+          attempt is still surfaced. Readers proceed normally;
+          operators see the diagnostic in ``error``. (Under the
+          current implementation a *foreground* failed rebuild
+          transitions through not-ready and lands in ``"failed"``, not
+          ``"queryable"`` — see :meth:`is_index_ready` and #525.)
         - ``"failed"``: NOT queryable AND a build attempt errored.
           Operator action: inspect ``error``, rebuild via CLI
           ``markdown-vault-mcp index`` or restart.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -13,7 +13,7 @@ import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal
 
-from markdown_vault_mcp.exceptions import IndexBuildFailedError, IndexNotReadyError
+from markdown_vault_mcp.exceptions import IndexNotReadyError
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.scanner import (
     ChunkStrategy,
@@ -575,53 +575,49 @@ class Collection:
         }
 
     def wait_for_index_ready(self, timeout: float | None = None) -> None:
-        """Block until the FTS index is ready, or raise.
+        """Block until the FTS index is queryable, or raise.
 
         Control flow (each step in order):
 
-        1. ``_background_build_done.wait(timeout)`` — if False
-           (timed out), raise
-           :exc:`IndexNotReadyError("…timed out…")`.
-        2. If ``_background_build_error`` is not None, raise
-           :exc:`IndexBuildFailedError` with the original as
-           ``__cause__``.
-        3. If ``_index_built`` is False, raise
-           :exc:`IndexNotReadyError("…never scheduled…")` — guards
-           the never-scheduled case (event pre-set, no error, no
-           build, no thread). Without it, callers on a fresh
-           Collection would silently return success.
-        4. Otherwise return.
+        1. ``_background_build_done.wait(timeout)`` — if False (timed
+           out), raise :exc:`IndexNotReadyError(reason="timeout")`.
+        2. If ``_index_built`` is False, raise
+           :exc:`IndexNotReadyError(reason="never_built")` — guards
+           the never-scheduled case (event pre-set, no build, no thread).
+           Without it, callers on a fresh Collection would silently
+           return success.
+        3. Otherwise return.
 
-        This method is opt-in for the MCP-layer `needs_index_ready`
-        decorator and for external callers that explicitly want to
-        wait. Library bucket-3/4 methods do NOT call this — they call
-        :meth:`_require_index_ready` which raises immediately. That
-        separation is the boundary that closed attempt 6's hole.
+        A captured ``_background_build_error`` no longer gates this
+        method (#533 unwind). The captured exception is surfaced via
+        :meth:`get_index_status` as a diagnostic event, not as a raised
+        ``IndexBuildFailedError`` — the class is gone.
+
+        This method is opt-in for the MCP-layer
+        :func:`needs_index_ready` decorator and for external callers that
+        explicitly want to wait. Library bucket-3/4 methods do NOT call
+        this — they call :meth:`_require_index_ready` which raises
+        immediately. That separation is the boundary that closed attempt
+        6's hole.
 
         Args:
             timeout: Maximum seconds to wait on the completion event.
-                ``None`` (default) blocks indefinitely. MCP tool
-                callers are protected from infinite hangs by the
-                bounded default in the decorator (60s) and by
-                client-side deadlines.
+                ``None`` (default) blocks indefinitely.
 
         Raises:
-            IndexBuildFailedError: A prior background build raised.
-            IndexNotReadyError: Index not built and either no build
-                was ever scheduled, or the timeout expired.
+            IndexNotReadyError: with ``reason="timeout"`` on timeout, or
+                ``reason="never_built"`` if the build was never scheduled.
         """
         if not self._background_build_done.wait(timeout=timeout):
             raise IndexNotReadyError(
-                f"Index build still in progress; timed out after {timeout}s."
+                f"Index build still in progress; timed out after {timeout}s.",
+                reason="timeout",
             )
-        if self._background_build_error is not None:
-            raise IndexBuildFailedError(
-                "Background index build raised; see __cause__ for details."
-            ) from self._background_build_error
         if not self._index_built:
             raise IndexNotReadyError(
                 "Index not built; background build was never scheduled. "
-                "Call build_index() or start_background_build_index() first."
+                "Call build_index() or start_background_build_index() first.",
+                reason="never_built",
             )
 
     @property

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -102,21 +102,3 @@ class IndexNotReadyError(MarkdownMCPError):
     def __init__(self, message: str, *, reason: IndexNotReadyReason) -> None:
         super().__init__(message)
         self.reason = reason
-
-
-class IndexBuildFailedError(MarkdownMCPError):
-    """Raised when a background index build failed with an exception.
-
-    The original exception is available via ``__cause__``.
-
-    Distinguishes "build never finished / never started"
-    (:exc:`IndexNotReadyError`) from "build started but raised" — both
-    surface through :meth:`Collection.wait_for_index_ready` and through
-    the MCP-layer `needs_index_ready` decorator. Operator action
-    differs: not-ready means wait or check status; failed means
-    inspect logs and decide whether to retry via CLI
-    ``markdown-vault-mcp index``.
-
-    See :exc:`IndexNotReadyError` for the "never finished / never
-    started" case.
-    """

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -1,5 +1,9 @@
 """Exception types for markdown-vault-mcp."""
 
+from __future__ import annotations
+
+from typing import Literal
+
 
 class MarkdownMCPError(Exception):
     """Base exception for all markdown-vault-mcp errors."""
@@ -66,24 +70,38 @@ class ConfigurationError(MarkdownMCPError):
     """Raised for invalid or unsupported configuration at startup."""
 
 
+IndexNotReadyReason = Literal["never_built", "timeout", "broken"]
+
+
 class IndexNotReadyError(MarkdownMCPError):
-    """Raised when a method requires a built FTS index and none exists.
+    """Raised when a method requires a built FTS index that is not currently usable.
 
-    Bucket-3 relational / FTS-backed queries (``get_backlinks``,
-    ``get_outlinks``, ``get_similar``, ``get_context``,
-    ``get_connection_path``, ``get_toc``) and bucket-4 coordinators
-    (``reindex``, ``build_embeddings``) cannot produce correct results
-    against an empty / never-built index. They raise this rather than
-    silently return wrong answers.
+    Carries a structured ``reason`` discriminator so callers (notably the
+    MCP layer and operators reading status output) can tell apart the
+    three not-ready cases without parsing exception messages:
 
-    Callers must call :meth:`Collection.build_index` before these
-    methods. Once a background indexer lands (issue #513), the
-    :meth:`Collection.wait_for_index_ready` primitive will block on a
-    completion event instead of raising.
+    - ``"never_built"``: ``Collection.build_index`` has not produced a
+      usable FTS DB yet (cold collection, in-flight first build, or a
+      previously-broken DB never recovered).
+    - ``"timeout"``: caller waited via
+      :meth:`Collection.wait_for_index_ready` and the bounded timeout
+      elapsed before the background build signaled completion.
+    - ``"broken"``: a ``sqlite3.OperationalError`` surfaced from the FTS
+      layer during the operation. Set only by the MCP-layer
+      :func:`needs_index_ready` decorator boundary — never by library
+      code.
 
-    See :exc:`IndexBuildFailedError` for the related case where a
-    background build started but then raised.
+    The previous PR #529 companion class ``IndexBuildFailedError`` was
+    deleted in issue #533: captured background-build errors are now
+    diagnostic events (surfaced via ``Collection.get_index_status``) and
+    no longer raised from the read path.
     """
+
+    reason: IndexNotReadyReason
+
+    def __init__(self, message: str, *, reason: IndexNotReadyReason) -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 class IndexBuildFailedError(MarkdownMCPError):

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -99,19 +99,23 @@ def test_wait_for_index_ready_raises_on_timeout(tmp_path: Path) -> None:
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_done.clear()
     col._index_built = False
-    with pytest.raises(IndexNotReadyError, match=r"timed out"):
+    with pytest.raises(IndexNotReadyError) as excinfo:
         col.wait_for_index_ready(timeout=0.05)
+    assert excinfo.value.reason == "timeout"
     col.close()
 
 
-def test_wait_for_index_ready_raises_build_failed_when_error_set(
+def test_wait_for_index_ready_returns_when_built_with_captured_error(
     tmp_path: Path,
 ) -> None:
+    """The 'errors are events not states' rule (#533): a captured background
+    error on a previously-built index must NOT gate the read path.
+    wait_for_index_ready returns normally; the error is diagnostic-only."""
     col = Collection(source_dir=_vault(tmp_path))
-    col._background_build_error = RuntimeError("scan exploded")
-    with pytest.raises(IndexBuildFailedError) as excinfo:
-        col.wait_for_index_ready(timeout=0.1)
-    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    col._index_built = True
+    col._background_build_done.set()
+    col._background_build_error = RuntimeError("prior scan exploded")
+    col.wait_for_index_ready(timeout=0.1)  # must not raise
     col.close()
 
 
@@ -121,8 +125,9 @@ def test_wait_for_index_ready_raises_when_never_scheduled(tmp_path: Path) -> Non
     let wait() return success without the explicit guard."""
     col = Collection(source_dir=_vault(tmp_path))
     # All defaults: event pre-set, no error, _index_built=False, no spawn.
-    with pytest.raises(IndexNotReadyError, match=r"never scheduled|not built"):
+    with pytest.raises(IndexNotReadyError) as excinfo:
         col.wait_for_index_ready(timeout=0.1)
+    assert excinfo.value.reason == "never_built"
     col.close()
 
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -264,13 +264,13 @@ def test_should_use_background_build_warm_on_disk_false(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_get_index_status_ready(tmp_path: Path) -> None:
+def test_get_index_status_queryable(tmp_path: Path) -> None:
     vault = _vault(tmp_path)
     _seed(vault)
     col = Collection(source_dir=vault)
     col.build_index()
     status = col.get_index_status()
-    assert status["status"] == "ready"
+    assert status["status"] == "queryable"
     assert status["documents_indexed"] == 1
     assert status["error"] is None
     col.close()
@@ -289,7 +289,8 @@ def test_get_index_status_building_in_flight(tmp_path: Path) -> None:
 
 def test_get_index_status_building_never_started(tmp_path: Path) -> None:
     """Fresh Collection: event pre-set, no error, _index_built=False.
-    Reports 'building' (not 'ready' — the attempt-6 lie is fixed)."""
+    Reports 'building' (the never-scheduled case behaves the same as
+    in-flight from the operator's perspective)."""
     col = Collection(source_dir=_vault(tmp_path))
     status = col.get_index_status()
     assert status["status"] == "building"
@@ -297,12 +298,37 @@ def test_get_index_status_building_never_started(tmp_path: Path) -> None:
     col.close()
 
 
-def test_get_index_status_failed(tmp_path: Path) -> None:
+def test_get_index_status_failed_when_not_queryable_with_captured_error(
+    tmp_path: Path,
+) -> None:
+    """status='failed' only when NOT queryable AND error captured AND
+    event set. After #533 priority flip, a *built* index with a captured
+    error reports 'queryable'; only the never-built-plus-errored case
+    is 'failed'."""
     col = Collection(source_dir=_vault(tmp_path))
+    # _index_built False; event already pre-set; explicitly set error.
     col._background_build_error = RuntimeError("scan failed for X")
     status = col.get_index_status()
     assert status["status"] == "failed"
     assert "scan failed for X" in status["error"]
+    col.close()
+
+
+def test_get_index_status_queryable_when_built_with_captured_error(
+    tmp_path: Path,
+) -> None:
+    """The #533 priority flip: a built+done index with a captured error
+    reports 'queryable' (not 'failed'). The error field carries the
+    last-attempt message as diagnostic context."""
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()  # sets _index_built True and clears _background_build_error
+    col._background_build_error = RuntimeError("subsequent rebuild blew up")
+    status = col.get_index_status()
+    assert status["status"] == "queryable"
+    assert status["documents_indexed"] == 1
+    assert "subsequent rebuild blew up" in (status["error"] or "")
     col.close()
 
 
@@ -311,7 +337,7 @@ def test_get_index_status_failed(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_tool_get_index_status_reports_ready(
+def test_mcp_tool_get_index_status_reports_queryable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     vault = tmp_path / "vault"
@@ -331,7 +357,7 @@ def test_mcp_tool_get_index_status_reports_ready(
             return res.structured_content or {}
 
     status = asyncio.run(_call())
-    assert status["status"] in ("ready", "building")  # depends on lifespan timing
+    assert status["status"] in ("queryable", "building")  # depends on lifespan timing
     assert status["error"] is None
 
 
@@ -399,7 +425,7 @@ def test_lifespan_cold_start_handshake_under_1s(
             res: Any = None
             for _ in range(50):
                 res = await client.call_tool("get_index_status", {})
-                if (res.structured_content or {}).get("status") == "ready":
+                if (res.structured_content or {}).get("status") == "queryable":
                     break
                 await asyncio.sleep(0.1)
             final = res.structured_content or {}
@@ -409,7 +435,7 @@ def test_lifespan_cold_start_handshake_under_1s(
     assert handshake_elapsed < 1.0, (
         f"cold-start handshake took {handshake_elapsed:.3f}s, expected < 1.0s"
     )
-    assert final["status"] == "ready"
+    assert final["status"] == "queryable"
     assert final["documents_indexed"] == 20
 
 
@@ -439,7 +465,7 @@ def test_lifespan_warm_start_skips_background(
             return res.structured_content or {}
 
     status = asyncio.run(_run())
-    assert status["status"] == "ready"
+    assert status["status"] == "queryable"
     assert status["documents_indexed"] == 1
 
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -13,28 +13,10 @@ import pytest
 from fastmcp import Client
 
 from markdown_vault_mcp.collection import Collection
-from markdown_vault_mcp.exceptions import (
-    IndexBuildFailedError,
-    IndexNotReadyError,
-    MarkdownMCPError,
-)
+from markdown_vault_mcp.exceptions import IndexNotReadyError
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def test_index_build_failed_error_subclasses_base() -> None:
-    err = IndexBuildFailedError("scan failed")
-    assert isinstance(err, MarkdownMCPError)
-    assert str(err) == "scan failed"
-
-
-def test_index_build_failed_error_carries_cause() -> None:
-    original = RuntimeError("scan exploded")
-    try:
-        raise IndexBuildFailedError("background build failed") from original
-    except IndexBuildFailedError as err:
-        assert err.__cause__ is original
 
 
 def _vault(tmp_path: Path) -> Path:
@@ -170,9 +152,13 @@ def test_start_background_build_index_eventually_ready(tmp_path: Path) -> None:
     col.close()
 
 
-def test_start_background_build_index_captures_error(
+def test_start_background_build_index_captures_error_diagnostically(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """After #533, a captured background build error does NOT raise from
+    wait_for_index_ready. The error becomes a diagnostic event visible
+    via _background_build_error and get_index_status. The index stays
+    not-ready because _index_built was never set."""
     col = Collection(source_dir=_vault(tmp_path))
 
     def boom(*_a: object, **_kw: object) -> None:
@@ -181,9 +167,16 @@ def test_start_background_build_index_captures_error(
     monkeypatch.setattr(col._index_mgr, "build_index", boom)
     col.start_background_build_index()
 
-    with pytest.raises(IndexBuildFailedError):
+    # wait_for_index_ready raises 'never_built' (not 'IndexBuildFailedError').
+    with pytest.raises(IndexNotReadyError) as excinfo:
         col.wait_for_index_ready(timeout=5.0)
+    assert excinfo.value.reason == "never_built"
     assert col.is_index_ready() is False
+    # Diagnostic: captured error is visible.
+    assert isinstance(col._background_build_error, RuntimeError)
+    status = col.get_index_status()
+    assert status["status"] == "failed"
+    assert "simulated scan failure" in (status["error"] or "")
     col.close()
 
 
@@ -220,9 +213,10 @@ def test_start_background_build_index_one_shot_after_thread_start_failure(
     assert col._background_build_done.is_set()
     assert isinstance(col._background_build_error, RuntimeError)
 
-    # wait_for_index_ready surfaces it as IndexBuildFailedError.
-    with pytest.raises(IndexBuildFailedError):
+    # wait_for_index_ready raises 'never_built' (no IndexBuildFailedError).
+    with pytest.raises(IndexNotReadyError) as excinfo:
         col.wait_for_index_ready(timeout=0.1)
+    assert excinfo.value.reason == "never_built"
 
     # Retry is a no-op (one-shot semantics).
     monkeypatch.undo()
@@ -885,7 +879,7 @@ def test_synchronous_build_index_clears_prior_background_error(
 ) -> None:
     """Recovery path: after a failed background build, calling build_index()
     synchronously must clear _background_build_error so is_index_ready()
-    returns True and bucket-3/4 calls stop raising IndexBuildFailedError."""
+    returns True after build completion and bucket-3/4 calls operate normally."""
     vault = _vault(tmp_path)
     _seed(vault)
     col = Collection(source_dir=vault, index_path=tmp_path / "fts.db")

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import sqlite3
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -934,4 +935,114 @@ def test_decorator_works_with_positional_collection_arg(tmp_path: Path) -> None:
     # Call positionally (not via kwargs).
     result = asyncio.run(handler("n.md", col))
     assert result == "got: n.md"
+    col.close()
+
+
+def test_decorator_catches_sqlite_operational_error_and_remaps_to_broken(
+    tmp_path: Path,
+) -> None:
+    """Issue #533 reactive broken detection: when a handler bubbles a
+    sqlite3.OperationalError up through the decorator, the MCP boundary
+    remaps it to IndexNotReadyError(reason='broken') with __cause__ set
+    to the original."""
+    import asyncio
+
+    from markdown_vault_mcp._server_readiness import needs_index_ready
+
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+
+    @needs_index_ready()
+    async def fake_handler(collection: Collection) -> None:  # noqa: ARG001
+        raise sqlite3.OperationalError("database disk image is malformed")
+
+    async def _call() -> Any:
+        try:
+            await fake_handler(col)  # type: ignore[arg-type]
+        except IndexNotReadyError as exc:
+            return exc
+        raise AssertionError("expected IndexNotReadyError")
+
+    err = asyncio.run(_call())
+    assert err.reason == "broken"
+    assert isinstance(err.__cause__, sqlite3.OperationalError)
+    col.close()
+
+
+def test_decorator_does_not_remap_sqlite_programming_error(
+    tmp_path: Path,
+) -> None:
+    """Narrow scope: only sqlite3.OperationalError is remapped. Other
+    sqlite3 subclasses (IntegrityError, ProgrammingError) bubble up
+    unwrapped because they indicate distinct caller-actionable bugs."""
+    import asyncio
+
+    from markdown_vault_mcp._server_readiness import needs_index_ready
+
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+
+    @needs_index_ready()
+    async def fake_handler(collection: Collection) -> None:  # noqa: ARG001
+        raise sqlite3.ProgrammingError("bad statement binding")
+
+    async def _call() -> Any:
+        return await fake_handler(col)  # type: ignore[arg-type]
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        asyncio.run(_call())
+    col.close()
+
+
+def test_decorator_does_not_remap_os_error(
+    tmp_path: Path,
+) -> None:
+    """OSError is out of scope for the decorator catch (#533 narrow
+    scope) — it bubbles up unwrapped."""
+    import asyncio
+
+    from markdown_vault_mcp._server_readiness import needs_index_ready
+
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+
+    @needs_index_ready()
+    async def fake_handler(collection: Collection) -> None:  # noqa: ARG001
+        raise OSError("disk gone")
+
+    async def _call() -> Any:
+        return await fake_handler(col)  # type: ignore[arg-type]
+
+    with pytest.raises(OSError, match=r"disk gone"):
+        asyncio.run(_call())
+    col.close()
+
+
+def test_decorator_does_not_remap_generic_exception(
+    tmp_path: Path,
+) -> None:
+    import asyncio
+
+    from markdown_vault_mcp._server_readiness import needs_index_ready
+
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+
+    @needs_index_ready()
+    async def fake_handler(collection: Collection) -> None:  # noqa: ARG001
+        raise ValueError("handler-level value error")
+
+    async def _call() -> Any:
+        return await fake_handler(col)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match=r"handler-level"):
+        asyncio.run(_call())
     col.close()

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -958,6 +958,58 @@ def test_decorator_works_with_positional_collection_arg(tmp_path: Path) -> None:
     col.close()
 
 
+def test_decorator_surfaces_wait_for_index_ready_timeout_reason(
+    tmp_path: Path,
+) -> None:
+    """Issue #533: the decorator propagates ``reason="timeout"`` from
+    Collection.wait_for_index_ready through the asyncio.to_thread
+    boundary to the awaiting caller. Pins the reason discriminator
+    end-to-end on the cold path."""
+    import asyncio
+
+    from markdown_vault_mcp._server_readiness import needs_index_ready
+
+    col = Collection(source_dir=_vault(tmp_path))
+    # Clear the pre-set event so wait_for_index_ready blocks until
+    # the bounded timeout elapses.
+    col._background_build_done.clear()
+
+    @needs_index_ready(timeout=0.05)
+    async def handler(collection: Collection) -> str:  # noqa: ARG001
+        return "should never get here"
+
+    with pytest.raises(IndexNotReadyError) as excinfo:
+        asyncio.run(handler(col))
+    assert excinfo.value.reason == "timeout"
+    # Restore so col.close() doesn't deadlock on shutdown.
+    col._background_build_done.set()
+    col.close()
+
+
+def test_decorator_surfaces_wait_for_index_ready_never_built_reason(
+    tmp_path: Path,
+) -> None:
+    """Issue #533: the decorator propagates ``reason="never_built"``
+    when the event is pre-set but the Collection was never built. Pins
+    the reason discriminator end-to-end on the never-scheduled path."""
+    import asyncio
+
+    from markdown_vault_mcp._server_readiness import needs_index_ready
+
+    col = Collection(source_dir=_vault(tmp_path))
+    # Default state: _background_build_done pre-set, _index_built False,
+    # no error captured. wait_for_index_ready raises reason="never_built".
+
+    @needs_index_ready(timeout=1.0)
+    async def handler(collection: Collection) -> str:  # noqa: ARG001
+        return "should never get here"
+
+    with pytest.raises(IndexNotReadyError) as excinfo:
+        asyncio.run(handler(col))
+    assert excinfo.value.reason == "never_built"
+    col.close()
+
+
 def test_decorator_catches_sqlite_operational_error_and_remaps_to_broken(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -61,12 +61,38 @@ def test_is_index_ready_true_after_synchronous_build(tmp_path: Path) -> None:
     col.close()
 
 
-def test_is_index_ready_false_after_captured_background_error(tmp_path: Path) -> None:
-    """Direct state poke: simulate a finished-but-failed background by setting
-    the error and the event, leaving _index_built False."""
+def test_is_index_ready_true_after_captured_background_error_on_built_index(
+    tmp_path: Path,
+) -> None:
+    """Issue #533 meaning shift: a captured background error on a
+    previously-built index does NOT make the index unreadable. The
+    captured error is diagnostic only; is_index_ready stays True."""
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+    col._background_build_error = RuntimeError("subsequent rebuild blew up")
+    assert col.is_index_ready() is True
+    col.close()
+
+
+def test_is_index_ready_false_when_not_built_regardless_of_error(
+    tmp_path: Path,
+) -> None:
     col = Collection(source_dir=_vault(tmp_path))
-    col._background_build_error = RuntimeError("simulated")
     col._background_build_done.set()
+    col._background_build_error = None
+    # _index_built is False by construction.
+    assert col.is_index_ready() is False
+    col.close()
+
+
+def test_is_index_ready_false_when_event_cleared_regardless_of_built(
+    tmp_path: Path,
+) -> None:
+    col = Collection(source_dir=_vault(tmp_path))
+    col._index_built = True
+    col._background_build_done.clear()
     assert col.is_index_ready() is False
     col.close()
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -958,6 +958,42 @@ def test_decorator_works_with_positional_collection_arg(tmp_path: Path) -> None:
     col.close()
 
 
+def test_get_index_status_foreground_rebuild_failure_reports_building(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the foreground-rebuild failure transition (preflight gap PTA.1).
+
+    A previously-queryable index whose synchronous build_index(force=True)
+    raises mid-flight lands in ``status="building"`` with ``error=None``,
+    NOT in ``"failed"``: build_index resets ``_index_built=False`` at the
+    start of the rebuild, then the IndexManager exception propagates to the
+    caller without populating ``_background_build_error`` (only the
+    background worker except block writes that field). Documents the
+    actually-reachable behavior so a future docstring or refactor doesn't
+    drift from the code."""
+    from markdown_vault_mcp.managers import index as index_mod
+
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+    assert col.is_index_ready() is True
+
+    def boom(self, *, force: bool = False):  # type: ignore[no-untyped-def]  # noqa: ARG001
+        raise RuntimeError("simulated mid-rebuild crash")
+
+    monkeypatch.setattr(index_mod.IndexManager, "build_index", boom)
+    with pytest.raises(RuntimeError, match="mid-rebuild crash"):
+        col.build_index(force=True)
+
+    assert col.is_index_ready() is False
+    assert col._background_build_error is None
+    status = col.get_index_status()
+    assert status["status"] == "building"
+    assert status["error"] is None
+    col.close()
+
+
 def test_decorator_surfaces_wait_for_index_ready_timeout_reason(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,32 @@
+"""Tests for the exception taxonomy after issue #533."""
+
+from __future__ import annotations
+
+import pytest
+
+from markdown_vault_mcp.exceptions import (
+    IndexNotReadyError,
+    MarkdownMCPError,
+)
+
+
+def test_index_not_ready_error_carries_reason_field() -> None:
+    err = IndexNotReadyError("not built", reason="never_built")
+    assert err.reason == "never_built"
+    assert str(err) == "not built"
+    assert isinstance(err, MarkdownMCPError)
+
+
+def test_index_not_ready_error_requires_reason_kwarg() -> None:
+    with pytest.raises(TypeError):
+        IndexNotReadyError("missing reason")  # type: ignore[call-arg]
+
+
+def test_index_not_ready_reason_alias_is_a_literal_string() -> None:
+    """IndexNotReadyReason is a Literal alias — we don't introspect the
+    literal at runtime (PEP 586 makes that awkward); we instead verify that
+    the documented values construct successfully and unexpected values can
+    still be passed (it's a static type, not a runtime guard)."""
+    for reason in ("never_built", "timeout", "broken"):
+        err = IndexNotReadyError("x", reason=reason)
+        assert err.reason == reason

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,3 +30,13 @@ def test_index_not_ready_reason_alias_is_a_literal_string() -> None:
     for reason in ("never_built", "timeout", "broken"):
         err = IndexNotReadyError("x", reason=reason)
         assert err.reason == reason
+
+
+def test_index_build_failed_error_class_is_deleted() -> None:
+    """Regression-protect the #533 deletion against accidental
+    re-introduction in a future PR. Captured background errors are
+    diagnostic events (surfaced via Collection.get_index_status), not
+    exceptions raised from the read path."""
+    import markdown_vault_mcp.exceptions as exc_module
+
+    assert not hasattr(exc_module, "IndexBuildFailedError")

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -160,16 +160,18 @@ class TestBucket3Block:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.get_backlinks("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_outlinks_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.get_outlinks("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_similar_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
@@ -180,16 +182,18 @@ class TestBucket3Block:
             embeddings_path=tmp_path / "vectors",
         )
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.get_similar("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_context_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.get_context("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_connection_path_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
@@ -197,8 +201,9 @@ class TestBucket3Block:
         _seed(vault, "b.md")
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.get_connection_path("a.md", "b.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_toc_on_unbuilt_raises(self, tmp_path: Path) -> None:
         """get_toc reads from FTS so cold-start must raise readiness, not a
@@ -208,8 +213,9 @@ class TestBucket3Block:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.get_toc("note.md")
+        assert excinfo.value.reason == "never_built"
 
 
 # ---------------------------------------------------------------------------
@@ -224,8 +230,9 @@ class TestBucket4Coordinate:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.reindex()
+        assert excinfo.value.reason == "never_built"
 
     def test_build_embeddings_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
@@ -236,8 +243,9 @@ class TestBucket4Coordinate:
             embeddings_path=tmp_path / "vectors",
         )
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.build_embeddings()
+        assert excinfo.value.reason == "never_built"
 
     def test_build_index_short_circuits_on_warm_restart(self, tmp_path: Path) -> None:
         """A second Collection on the same persistent FTS DB short-circuits.
@@ -375,8 +383,9 @@ class TestReadinessFlagSemantics:
         with pytest.raises(RuntimeError):
             col.build_index(force=True)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.get_backlinks("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_failed_build_index_leaves_unready(self, tmp_path: Path) -> None:
         """If build_index() raises, subsequent bucket-3 calls still raise."""
@@ -393,5 +402,6 @@ class TestReadinessFlagSemantics:
         with pytest.raises(RuntimeError):
             col.build_index()
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.get_backlinks("note.md")
+        assert excinfo.value.reason == "never_built"

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -284,8 +284,9 @@ class TestWaitForIndexReady:
         vault = _vault(tmp_path)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexNotReadyError) as excinfo:
             col.wait_for_index_ready(timeout=0.1)
+        assert excinfo.value.reason == "never_built"
 
     def test_after_build_returns(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)


### PR DESCRIPTION
## Summary

Closes #533.

Unwinds PR #529's error-as-state gating layer. `IndexBuildFailedError`
is deleted; `IndexNotReadyError` gains a required
`reason: Literal["never_built", "timeout", "broken"]` discriminator;
captured background-build errors become diagnostic-only via
`get_index_status`. The MCP `@needs_index_ready` decorator catches
`sqlite3.OperationalError` from handlers and remaps to
`IndexNotReadyError(reason="broken")`. `get_index_status` renames
`status="ready"` to `"queryable"` and flips priority so a built
index with a captured subsequent-rebuild error reports `"queryable"`
with the diagnostic in the `error` field.

Design: `docs/superpowers/specs/2026-05-29-issue-533-unwind-error-as-state-design.md`
(local-only, gitignored).
Memory: `feedback_errors_are_events_not_states`.

## Breaking changes

- `IndexBuildFailedError` removed from public exception surface.
- `IndexNotReadyError` now requires the `reason=` kwarg.
- `get_index_status` status word renamed `ready → queryable`.
- `get_index_status` "failed" semantics narrowed to "not queryable AND
  error captured." A built+errored index now reports "queryable."

## Test plan

- [x] All 26 failure modes from spec Section 5 covered.
- [x] Verification greps in Task 11 Step 1 all clean.
- [x] CI hard gates (pytest -x, ruff, mypy, diff-cover) all green
      locally.
- [x] Patch coverage ≥ 80% on changed modules.

## Follow-ups

This PR is #1 of 4 in the chain that supersedes #513:
- #533 (this PR) — unwind error-as-state. *Lands first.*
- #534 — drift-aware B2/B3 readers (subdivides "queryable" into
  "up_to_date"/"degraded").
- #535 — B4 writers fire-and-forget.
- #536 — cold-start background embeddings build (supersedes #513).