### PR TITLE
feat!(server): rename status ready->queryable + remove 'ready' vocabulary (#538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed (BREAKING)
+
+- `Collection.get_index_status` `status` field value renamed from
+  `"ready"` to `"queryable"`. MCP clients pattern-matching on the
+  old value will silently treat the new value as unknown until
+  updated.
+- `Collection.get_index_status` priority order flipped: a built
+  index with a captured background error from a prior attempt now
+  reports `status="queryable"` (with the diagnostic in `error`),
+  not `status="failed"`. `"failed"` now means "preconditions do not
+  hold AND a captured error exists" — i.e., the index is not
+  readable.
+- `Collection.is_index_ready()` renamed to `Collection.is_queryable()`.
+- `Collection._require_index_ready()` (private) renamed to
+  `Collection._require_built()` — matches what it actually checks
+  (only `_index_built`, single field).
+- `Collection.wait_for_index_ready()` renamed to
+  `Collection.wait_until_queryable()`.
+- MCP decorator `needs_index_ready` renamed to `needs_queryable`.
+  Module `_server_readiness.py` renamed to `_server_queryable.py`.
+- Public exception `IndexNotReadyError` renamed to
+  `IndexUnavailableError`.
+- Environment variable `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` renamed
+  to `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`. Running deployments that
+  set the old variable will silently fall back to the 60-second
+  default after upgrading; update operator configs (compose files,
+  systemd units, `.env` files) accordingly.
+
+External consumers that previously imported `IndexNotReadyError`,
+called `is_index_ready()`/`wait_for_index_ready()`, or set the old
+env var must rename their references. No deprecation shims ship.

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `stats` | Get collection statistics (document count, chunk count, link health metrics, etc.) |
 | `build_embeddings` | Build or rebuild vector embeddings for semantic search |
 | `embeddings_status` | Check embedding provider and index status |
-| `get_index_status` | Check background FTS build state (`ready` / `building` / `failed`) |
+| `get_index_status` | Check background FTS build state (`queryable` / `building` / `failed`) |
 | `get_backlinks` | Find all documents that link to a given document |
 | `get_outlinks` | Find all links from a document, with existence check |
 | `get_broken_links` | Find all links pointing to non-existent documents |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,14 +17,14 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 | `MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER` | string | `_templates` | No | Relative folder path used by the `create_from_template` prompt to discover/read template files |
 | `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | path | — | No | Path to a directory of `.md` prompt files that extend or override built-in prompts |
 
-## Index Readiness
+## Index Build Timeout
 
-### `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S`
+### `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`
 
 Default: `60` (seconds).
 
-Maximum time the MCP-layer `needs_index_ready` decorator waits for
-the FTS index to become ready before raising `IndexNotReadyError`
+Maximum time the MCP-layer `needs_queryable` decorator waits for
+the FTS index to become queryable before raising `IndexUnavailableError`
 to the client. Applied to bucket-3/4 tool and resource calls during
 a cold-start background FTS build. Increase for very large vaults
 where the initial scan takes longer; decrease for tighter feedback

--- a/docs/design.md
+++ b/docs/design.md
@@ -381,7 +381,7 @@ populate the index. Callers must invoke `build_index()` explicitly
 before bucket-3 relational/FTS-backed queries (`get_backlinks`,
 `get_outlinks`, `get_similar`, `get_context`, `get_connection_path`,
 `get_toc`) or the bucket-4 coordinators (`reindex`,
-`build_embeddings`); otherwise `IndexNotReadyError` is raised.
+`build_embeddings`); otherwise `IndexUnavailableError` is raised.
 `start()` must also be called after `build_index()` because its git
 pull loop wires `reindex` as the `on_pull` callback. Bucket-1 file
 operations (`read`, `write`, `edit`, `delete`, `rename`,
@@ -390,8 +390,8 @@ operations (`read`, `write`, `edit`, `delete`, `rename`,
 `get_orphan_notes`, `get_most_linked`, `get_broken_links`) work on an
 unbuilt index — bucket-1 hits disk directly; bucket-2 queries
 whatever is currently in the index (empty on cold start).
-`wait_for_index_ready(timeout=None)` is the readiness primitive: it
-raises `IndexNotReadyError` pre-#513; once the background indexer
+`wait_until_queryable(timeout=None)` is the readiness primitive: it
+raises `IndexUnavailableError` pre-#513; once the background indexer
 (#513) lands it will block on a completion event.
 
 **Cold-start background FTS (issue #513 PR1, tool-layer wait
@@ -400,12 +400,12 @@ the MCP server lifespan calls
 `Collection.start_background_build_index()` to spawn a daemon
 thread that runs `build_index()` to completion. Bucket-3/4 calls
 arriving at the MCP layer go through the
-`needs_index_ready` decorator (in
-`src/markdown_vault_mcp/_server_readiness.py`), which blocks via
-`Collection.wait_for_index_ready(timeout)` with a configurable
-default (env `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S`, default 60s).
+`needs_queryable` decorator (in
+`src/markdown_vault_mcp/_server_queryable.py`), which blocks via
+`Collection.wait_until_queryable(timeout)` with a configurable
+default (env `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`, default 60s).
 A failed background build surfaces to MCP clients as
-`IndexBuildFailedError` (the decorator's `wait_for_index_ready`
+`IndexBuildFailedError` (the decorator's `wait_until_queryable`
 call raises) and to operators as
 `get_index_status` reporting
 `{"status": "failed", "error": "..."}`. Embeddings stay on the
@@ -414,10 +414,17 @@ synchronous lifespan path in PR1 — on cold start
 search returns empty until PR2 backgrounds embeddings or the
 operator runs CLI `index`. Warm starts continue to use PR #526's
 O(1) sentinel short-circuit and never spawn the background thread.
-The library's `_require_index_ready()` is unchanged from PR #525
+The library's `_require_built()` is unchanged from PR #525
 — it raises immediately on not-ready, which is what lets the git
 pull loop and lifespan's embeddings path handle "not ready"
 without deadlocking on internal blocking.
+
+The `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` env var bounds the
+`@needs_queryable` decorator's wait, which calls
+`Collection.wait_until_queryable`. The env var and the method name
+describe the same wait from different angles — operators tune the
+timeout in seconds; the method describes what predicate the wait
+resolves to.
 
 To apply a configuration change (e.g. new `exclude_patterns`,
 `required_frontmatter`) to a pre-existing index, call

--- a/docs/design.md
+++ b/docs/design.md
@@ -391,8 +391,9 @@ operations (`read`, `write`, `edit`, `delete`, `rename`,
 unbuilt index — bucket-1 hits disk directly; bucket-2 queries
 whatever is currently in the index (empty on cold start).
 `wait_until_queryable(timeout=None)` is the readiness primitive: it
-raises `IndexUnavailableError` pre-#513; once the background indexer
-(#513) lands it will block on a completion event.
+blocks on the background-build completion event with a bounded
+timeout and raises `IndexUnavailableError` on timeout or when no
+build was ever scheduled.
 
 **Cold-start background FTS (issue #513 PR1, tool-layer wait
 boundary)**: when the persisted FTS DB is cold (sentinel absent),

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -95,7 +95,7 @@ The empty string `""` represents the root folder (top-level documents).
 Table of contents (heading outline) for a specific document. This is a URI template — replace `{path}` with the document's relative path.
 
 !!! note "Cold-start blocking"
-    Calls during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
+    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
 
 **Example:** `toc://vault/Journal/note.md`
 
@@ -118,7 +118,7 @@ The TOC prepends a synthetic H1 from the document title and deduplicates if the 
 Top 10 semantically similar notes for a document. Requires embeddings to be built. This is a URI template — replace `{path}` with the document's relative path.
 
 !!! note "Cold-start blocking"
-    Calls during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
+    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
 
 Results are **grouped per file** — each file appears at most once, with up to `chunks_per_file` (server default `2`) best-matching sections in a `sections` array. Each entry is a `GroupedResult` dict with `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -15,7 +15,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`list_tags`](#list_tags) | Read | List all unique frontmatter tag values |
 | [`stats`](#stats) | Read | Get collection statistics and capabilities |
 | [`embeddings_status`](#embeddings_status) | Read | Check embedding provider and vector index status |
-| [`get_index_status`](#get_index_status) | Read | Check background FTS build state (ready / building / failed) |
+| [`get_index_status`](#get_index_status) | Read | Check background FTS build state (queryable / building / failed) |
 | [`get_backlinks`](#get_backlinks) | Read | Find all documents that link to a given document |
 | [`get_outlinks`](#get_outlinks) | Read | Find all links from a document, with existence check |
 | [`get_broken_links`](#get_broken_links) | Read | Find all links pointing to non-existent documents |
@@ -208,7 +208,7 @@ or surface `IndexNotReadyError`/`IndexBuildFailedError` — the
 `status` field distinguishes "still building" from "build failed."
 
 **Returns:**
-- `status`: `"ready"`, `"building"`, or `"failed"`.
+- `status`: `"queryable"`, `"building"`, or `"failed"`.
 - `documents_indexed`: count of documents committed to the FTS index
   right now (rises during `"building"`).
 - `error`: `null` unless the background build raised; otherwise the
@@ -221,7 +221,7 @@ or surface `IndexNotReadyError`/`IndexBuildFailedError` — the
 ## Index Management
 
 !!! note "Cold-start blocking"
-    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` (default 60s), the tool returns `IndexNotReadyError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
+    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
 
 ### `reindex`
 
@@ -608,7 +608,7 @@ managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` not set).
 ## Link Graph
 
 !!! note "Cold-start blocking"
-    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_index_ready` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` (default 60s), the tool returns `IndexNotReadyError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
+    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
 
 ### `get_backlinks`
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -204,7 +204,7 @@ Check the embedding provider configuration and vector index status. Use this to 
 
 Returns background-build state of the FTS index. Use this when
 `initialize` returned but bucket-3/4 calls block longer than expected
-or surface `IndexNotReadyError`/`IndexBuildFailedError` — the
+or surface `IndexUnavailableError`/`IndexBuildFailedError` — the
 `status` field distinguishes "still building" from "build failed."
 
 **Returns:**

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -118,7 +118,7 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # PR2 follow-up backgrounds embeddings so semantic search
         # becomes available without operator-initiated rebuild.
         if kwargs.get("embedding_provider") is not None:
-            if collection.is_index_ready():
+            if collection.is_queryable():
                 chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
                 logger.info("Embeddings ready: %d chunks", chunks_embedded)
             else:

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -109,7 +109,7 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         else:
             stats = await asyncio.to_thread(collection.build_index)
             logger.info(
-                "Index ready: %d documents (synchronous build)",
+                "Index built: %d documents (synchronous build)",
                 stats.documents_indexed,
             )
 

--- a/src/markdown_vault_mcp/_server_queryable.py
+++ b/src/markdown_vault_mcp/_server_queryable.py
@@ -1,11 +1,11 @@
 """MCP-layer `needs_queryable` decorator (#513 PR1).
 
-Boundary: the library raises ``IndexNotReadyError`` immediately on
-not-ready (PR #525 contract). Blocking semantics live here at the MCP
+Boundary: the library raises ``IndexUnavailableError`` immediately on
+not-queryable (PR #525 contract). Blocking semantics live here at the MCP
 layer, where the caller's intent — "an MCP client is waiting and
 wants to wait" — is unambiguous. Internal callers (lifespan, git
 pull loop, CLI, direct library users) do NOT go through this
-decorator; they handle "not ready" with their own caller-appropriate
+decorator; they handle "not queryable" with their own caller-appropriate
 logic (skip, log, retry on next interval).
 """
 
@@ -54,7 +54,7 @@ def needs_queryable(
     already-wrapped function.
 
     Raises (propagated to MCP client via FastMCP error middleware):
-        IndexNotReadyError: timeout exceeded; or never scheduled.
+        IndexUnavailableError: timeout exceeded; or never scheduled.
         IndexBuildFailedError: a prior background build raised.
     """
 

--- a/src/markdown_vault_mcp/_server_queryable.py
+++ b/src/markdown_vault_mcp/_server_queryable.py
@@ -1,4 +1,4 @@
-"""MCP-layer `needs_index_ready` decorator (#513 PR1).
+"""MCP-layer `needs_queryable` decorator (#513 PR1).
 
 Boundary: the library raises ``IndexNotReadyError`` immediately on
 not-ready (PR #525 contract). Blocking semantics live here at the MCP
@@ -24,12 +24,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _resolve_ready_timeout() -> float:
+def _resolve_build_timeout() -> float:
     """Read env var at call time so tests can monkeypatch.setenv it."""
-    return float(os.environ.get("MARKDOWN_VAULT_MCP_READY_TIMEOUT_S", "60"))
+    return float(os.environ.get("MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S", "60"))
 
 
-def needs_index_ready(
+def needs_queryable(
     timeout: float | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator for bucket-3/4 MCP tool and resource handlers.
@@ -46,10 +46,10 @@ def needs_index_ready(
     and injects it via kwargs. The wrapper reads ``collection`` from
     kwargs and passes args/kwargs through unchanged.
 
-    Stacking order: place ``@needs_index_ready(...)`` BELOW
+    Stacking order: place ``@needs_queryable(...)`` BELOW
     ``@mcp.tool(...)`` (or ``@mcp.resource(...)``) — that is,
     closer to ``def``. Python applies decorators bottom-up, so
-    ``@needs_index_ready`` wraps the handler first; then
+    ``@needs_queryable`` wraps the handler first; then
     ``@mcp.tool`` runs on the result and FastMCP registers the
     already-wrapped function.
 
@@ -70,12 +70,12 @@ def needs_index_ready(
             collection = bound.arguments.get("collection")
             if collection is None:
                 raise RuntimeError(
-                    "needs_index_ready: collection was not injected; "
+                    "needs_queryable: collection was not injected; "
                     "handler must declare "
                     "`collection: Collection = Depends(get_collection)`."
                 )
             if not collection.is_queryable():
-                effective = timeout if timeout is not None else _resolve_ready_timeout()
+                effective = timeout if timeout is not None else _resolve_build_timeout()
                 await asyncio.to_thread(collection.wait_until_queryable, effective)
             return await handler(*args, **kwargs)
 

--- a/src/markdown_vault_mcp/_server_readiness.py
+++ b/src/markdown_vault_mcp/_server_readiness.py
@@ -36,7 +36,7 @@ def needs_index_ready(
 
     Before invoking the wrapped handler, blocks on
     ``Collection.wait_for_index_ready(timeout)``. On the warm path
-    (``is_index_ready`` already True) the wait is skipped — no
+    (``is_queryable`` already True) the wait is skipped — no
     thread-pool overhead.
 
     The wrapper does NOT redeclare ``collection`` in its own
@@ -74,7 +74,7 @@ def needs_index_ready(
                     "handler must declare "
                     "`collection: Collection = Depends(get_collection)`."
                 )
-            if not collection.is_index_ready():
+            if not collection.is_queryable():
                 effective = timeout if timeout is not None else _resolve_ready_timeout()
                 await asyncio.to_thread(collection.wait_for_index_ready, effective)
             return await handler(*args, **kwargs)

--- a/src/markdown_vault_mcp/_server_readiness.py
+++ b/src/markdown_vault_mcp/_server_readiness.py
@@ -35,7 +35,7 @@ def needs_index_ready(
     """Decorator for bucket-3/4 MCP tool and resource handlers.
 
     Before invoking the wrapped handler, blocks on
-    ``Collection.wait_for_index_ready(timeout)``. On the warm path
+    ``Collection.wait_until_queryable(timeout)``. On the warm path
     (``is_queryable`` already True) the wait is skipped — no
     thread-pool overhead.
 
@@ -76,7 +76,7 @@ def needs_index_ready(
                 )
             if not collection.is_queryable():
                 effective = timeout if timeout is not None else _resolve_ready_timeout()
-                await asyncio.to_thread(collection.wait_for_index_ready, effective)
+                await asyncio.to_thread(collection.wait_until_queryable, effective)
             return await handler(*args, **kwargs)
 
         return wrapper

--- a/src/markdown_vault_mcp/_server_resources.py
+++ b/src/markdown_vault_mcp/_server_resources.py
@@ -22,7 +22,7 @@ from markdown_vault_mcp.config import CollectionConfig
 
 from ._icons import _TOOL_ICONS
 from ._server_deps import get_collection
-from ._server_readiness import needs_index_ready
+from ._server_queryable import needs_queryable
 
 
 def _get_config(ctx: Context) -> CollectionConfig:
@@ -130,7 +130,7 @@ def register_resources(mcp: FastMCP) -> None:
     @mcp.resource(
         "toc://vault/{path}", mime_type="application/json", icons=_TOOL_ICONS["read"]
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def vault_toc(
         path: str,
         collection: Collection = Depends(get_collection),
@@ -144,7 +144,7 @@ def register_resources(mcp: FastMCP) -> None:
         mime_type="application/json",
         icons=_TOOL_ICONS["get_similar"],
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def vault_similar(
         path: str,
         collection: Collection = Depends(get_collection),

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -597,7 +597,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Use this when ``initialize`` returned but bucket-3/4 calls
         block longer than expected or surface
-        ``IndexNotReadyError``/``IndexBuildFailedError`` — the
+        ``IndexUnavailableError``/``IndexBuildFailedError`` — the
         ``status`` field distinguishes "still building" from "build
         failed."
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 from ._icons import _TOOL_ICONS
 from ._server_deps import get_collection
-from ._server_readiness import needs_index_ready
+from ._server_queryable import needs_queryable
 
 logger = logging.getLogger(__name__)
 
@@ -623,7 +623,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def get_backlinks(
         path: str,
         collection: Collection = Depends(get_collection),
@@ -670,7 +670,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def get_outlinks(
         path: str,
         collection: Collection = Depends(get_collection),
@@ -757,7 +757,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def get_similar(
         path: str,
         limit: int = 10,
@@ -858,7 +858,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def get_context(
         path: str,
         similar_limit: int = 5,
@@ -1020,7 +1020,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def get_connection_path(
         source: str,
         target: str,
@@ -1221,7 +1221,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def reindex(
         collection: Collection = Depends(get_collection),
     ) -> dict[str, Any]:
@@ -1251,7 +1251,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             "idempotentHint": True,
         },
     )
-    @needs_index_ready()
+    @needs_queryable()
     async def build_embeddings(
         force: bool = False,
         collection: Collection = Depends(get_collection),

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -604,7 +604,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Returns:
             Dict with the following fields:
 
-            - status (str): ``"ready"``, ``"building"``, or
+            - status (str): ``"queryable"``, ``"building"``, or
               ``"failed"``.
             - documents_indexed (int): Count of documents committed to
               the FTS index right now (rises during ``"building"``).

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -533,29 +533,38 @@ class Collection:
     def get_index_status(self) -> dict[str, Any]:
         """Return a non-blocking snapshot of background-build state.
 
-        Shape: ``{"status": "ready" | "building" | "failed",
+        Shape: ``{"status": "queryable" | "building" | "failed",
         "documents_indexed": int, "error": str | None}``.
 
-        - ``"ready"``: ``is_index_ready()`` is True (synchronous build
-          returned cleanly or background build completed cleanly);
-          ``error`` is None.
-        - ``"failed"``: ``_background_build_error`` is non-None;
-          ``error`` carries its message.
-        - ``"building"``: anything else — event cleared (in-flight)
+        - ``"queryable"``: ``_index_built`` is True and the build event is
+          set — a completed build exists; captures an error as diagnostic
+          context in ``error`` but does not demote the status.
+        - ``"failed"``: precondition does not hold AND the build event is
+          set AND ``_background_build_error`` is non-None; ``error`` carries
+          its message.
+        - ``"building"``: anything else — event cleared (writer in flight)
           OR event set but ``_index_built`` is False (never scheduled).
-          From the operator's perspective both mean "wait or poll."
 
-        ``documents_indexed`` is taken from
-        :meth:`FTSIndex.list_notes` and so reflects whatever rows are
-        currently committed — progress is observable in the
-        ``"building"`` state as the count rises.
+        ``documents_indexed`` is taken from :meth:`FTSIndex.list_notes` and
+        so reflects whatever rows are currently committed — progress is
+        observable in the ``"building"`` state as the count rises.
+
+        ``error`` carries the diagnostic message from the last background
+        build attempt that captured an exception, independent of ``status``.
         """
-        if self._background_build_error is not None:
+        if self._index_built and self._background_build_done.is_set():
+            status = "queryable"
+            error: str | None = (
+                str(self._background_build_error)
+                if self._background_build_error is not None
+                else None
+            )
+        elif (
+            self._background_build_done.is_set()
+            and self._background_build_error is not None
+        ):
             status = "failed"
-            error: str | None = str(self._background_build_error)
-        elif self.is_index_ready():
-            status = "ready"
-            error = None
+            error = str(self._background_build_error)
         else:
             status = "building"
             error = None

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -113,7 +113,7 @@ class Collection:
     bounded default timeout
     (``MARKDOWN_VAULT_MCP_READY_TIMEOUT_S``, default 60s). The
     library stays honest: bucket-3/4 *methods* keep the PR #525
-    raise-immediately contract via :meth:`_require_index_ready`.
+    raise-immediately contract via :meth:`_require_built`.
     Internal callers (lifespan, git pull loop, CLI, direct library
     users) get the raise contract and handle "not ready" with
     caller-appropriate logic — never block.
@@ -430,7 +430,7 @@ class Collection:
     # Indexing readiness (issue #525)
     # ------------------------------------------------------------------
 
-    def _require_index_ready(self) -> None:
+    def _require_built(self) -> None:
         """Raise :exc:`IndexNotReadyError` if :meth:`build_index` has not run."""
         if not self._index_built:
             raise IndexNotReadyError(
@@ -595,7 +595,7 @@ class Collection:
         This method is opt-in for the MCP-layer `needs_index_ready`
         decorator and for external callers that explicitly want to
         wait. Library bucket-3/4 methods do NOT call this — they call
-        :meth:`_require_index_ready` which raises immediately. That
+        :meth:`_require_built` which raises immediately. That
         separation is the boundary that closed attempt 6's hole.
 
         Args:
@@ -799,7 +799,7 @@ class Collection:
         Raises:
             IndexNotReadyError: If :meth:`build_index` has not been called.
         """
-        self._require_index_ready()
+        self._require_built()
         return self._index_mgr.reindex()
 
     def build_embeddings(self, *, force: bool = False) -> int:
@@ -817,7 +817,7 @@ class Collection:
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is
                 not configured.
         """
-        self._require_index_ready()
+        self._require_built()
         return self._index_mgr.build_embeddings(force=force)
 
     def embeddings_status(self) -> dict:
@@ -872,7 +872,7 @@ class Collection:
             IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
-        self._require_index_ready()
+        self._require_built()
         return self._doc_mgr.get_toc(path)
 
     def get_backlinks(self, path: str) -> list[BacklinkInfo]:
@@ -890,7 +890,7 @@ class Collection:
             IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
-        self._require_index_ready()
+        self._require_built()
         return self._link_mgr.get_backlinks(path)
 
     def get_outlinks(self, path: str) -> list[OutlinkInfo]:
@@ -911,7 +911,7 @@ class Collection:
             IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
-        self._require_index_ready()
+        self._require_built()
         return self._link_mgr.get_outlinks(path)
 
     def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
@@ -951,7 +951,7 @@ class Collection:
         Raises:
             IndexNotReadyError: If :meth:`build_index` has not been called.
         """
-        self._require_index_ready()
+        self._require_built()
         return self._search_mgr.get_similar(
             path, limit=limit, chunks_per_file=chunks_per_file
         )
@@ -1001,7 +1001,7 @@ class Collection:
             IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
-        self._require_index_ready()
+        self._require_built()
         return self._search_mgr.get_context(
             path, similar_limit=similar_limit, link_limit=link_limit
         )
@@ -1052,7 +1052,7 @@ class Collection:
             IndexNotReadyError: If :meth:`build_index` has not been called.
             ValueError: If *source* or *target* is not found in the index.
         """
-        self._require_index_ready()
+        self._require_built()
         return self._link_mgr.get_connection_path(source, target, max_depth=max_depth)
 
     # ------------------------------------------------------------------

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -243,7 +243,7 @@ class Collection:
         # Background-build coordination (issue #513 PR1 attempt 7). The
         # event is the blocking primitive `wait_until_queryable()` waits
         # on; it is pre-set so a freshly constructed Collection that never
-        # called build_index() does not silently look "ready". The
+        # called build_index() does not silently look "queryable". The
         # background path clears the event before spawning the thread
         # and the worker sets it in its finally clause.
         self._background_build_thread: threading.Thread | None = None
@@ -766,7 +766,7 @@ class Collection:
                     len(existing),
                 )
                 self._index_built = True
-                # Recovery: clear any captured background error + signal ready.
+                # Recovery: clear any captured background error + signal queryable.
                 self._background_build_error = None
                 self._background_build_done.set()
                 return IndexStats(
@@ -776,7 +776,7 @@ class Collection:
                 )
 
         # Reset before the (potentially destructive) rebuild so a mid-build
-        # exception leaves the Collection visibly not-ready. The sentinel
+        # exception leaves the Collection visibly not-queryable. The sentinel
         # is cleared too so a crash mid-loop is detectable by the next
         # process (rows without sentinel = partial — see issue #525).
         self._index_built = False
@@ -784,7 +784,7 @@ class Collection:
         result = self._index_mgr.build_index(force=force)
         self._fts.set_build_completed()
         self._index_built = True
-        # Recovery: clear any captured background error + signal ready.
+        # Recovery: clear any captured background error + signal queryable.
         self._background_build_error = None
         self._background_build_done.set()
         return result

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -437,26 +437,18 @@ class Collection:
                 "Index not built. Call build_index() before this method."
             )
 
-    def is_index_ready(self) -> bool:
-        """Return ``True`` iff the FTS index is in a clean ready state.
+    def is_queryable(self) -> bool:
+        """Return True when the structural preconditions for serving FTS
+        queries are met (in-process precondition snapshot).
 
-        Non-blocking. Returns ``True`` only when all three conditions
-        hold simultaneously: ``_index_built`` is True (a build returned
-        cleanly), ``_background_build_error`` is None (no captured
-        background failure), and ``_background_build_done`` is set (no
-        in-flight background). A freshly-constructed Collection
-        (event pre-set, no error, ``_index_built`` False) returns False
-        — the attempt-6 status lie is impossible by construction.
+        Checks ``_index_built`` is True, ``_background_build_error`` is
+        None, and ``_background_build_done`` is set. Necessary but not
+        sufficient — actual queryability is determined at use time (a
+        corrupted on-disk database satisfies these preconditions but
+        queries still fail).
 
-        Lock-free by design: reads ``_index_built`` (plain bool
-        attribute), checks ``_background_build_error is None`` (plain
-        attribute), and calls ``_background_build_done.is_set()``
-        (Event method, no lock). Safe to call on hot tool paths.
-
-        Assumes CPython GIL semantics for cross-thread visibility of
-        the plain attribute reads. Not analyzed for Free-Threaded
-        Python 3.13+ (``python -X gil=0``); revisit if the project
-        moves off CPython GIL.
+        Lock-free by design: plain attribute reads + Event.is_set().
+        Assumes CPython GIL semantics for cross-thread visibility.
         """
         if not self._index_built:
             return False

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -13,7 +13,7 @@ import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal
 
-from markdown_vault_mcp.exceptions import IndexBuildFailedError, IndexNotReadyError
+from markdown_vault_mcp.exceptions import IndexBuildFailedError, IndexUnavailableError
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.scanner import (
     ChunkStrategy,
@@ -93,7 +93,7 @@ class Collection:
     :meth:`get_context`, :meth:`get_connection_path`, :meth:`get_toc`)
     or the bucket-4 coordinators :meth:`reindex` and
     :meth:`build_embeddings`; otherwise
-    :exc:`~markdown_vault_mcp.exceptions.IndexNotReadyError` is raised.
+    :exc:`~markdown_vault_mcp.exceptions.IndexUnavailableError` is raised.
     :meth:`build_index` must also precede :meth:`start` — see
     :meth:`start` for the rationale.
     Bucket-1 file operations (:meth:`read`, :meth:`write`, :meth:`edit`,
@@ -354,7 +354,7 @@ class Collection:
 
         Call :meth:`build_index` **before** :meth:`start`. The git pull
         loop wires :meth:`reindex` (bucket 4) as its ``on_pull`` callback,
-        and ``reindex`` raises :exc:`IndexNotReadyError` on an unbuilt
+        and ``reindex`` raises :exc:`IndexUnavailableError` on an unbuilt
         index — so a pull event firing before the initial build would
         crash the loop thread.
         """
@@ -431,9 +431,9 @@ class Collection:
     # ------------------------------------------------------------------
 
     def _require_built(self) -> None:
-        """Raise :exc:`IndexNotReadyError` if :meth:`build_index` has not run."""
+        """Raise :exc:`IndexUnavailableError` if :meth:`build_index` has not run."""
         if not self._index_built:
-            raise IndexNotReadyError(
+            raise IndexUnavailableError(
                 "Index not built. Call build_index() before this method."
             )
 
@@ -581,12 +581,12 @@ class Collection:
 
         1. ``_background_build_done.wait(timeout)`` — if False
            (timed out), raise
-           :exc:`IndexNotReadyError("…timed out…")`.
+           :exc:`IndexUnavailableError("…timed out…")`.
         2. If ``_background_build_error`` is not None, raise
            :exc:`IndexBuildFailedError` with the original as
            ``__cause__``.
         3. If ``_index_built`` is False, raise
-           :exc:`IndexNotReadyError("…never scheduled…")` — guards
+           :exc:`IndexUnavailableError("…never scheduled…")` — guards
            the never-scheduled case (event pre-set, no error, no
            build, no thread). Without it, callers on a fresh
            Collection would silently return success.
@@ -607,11 +607,11 @@ class Collection:
 
         Raises:
             IndexBuildFailedError: A prior background build raised.
-            IndexNotReadyError: Index not built and either no build
+            IndexUnavailableError: Index not built and either no build
                 was ever scheduled, or the timeout expired.
         """
         if not self._background_build_done.wait(timeout=timeout):
-            raise IndexNotReadyError(
+            raise IndexUnavailableError(
                 f"Index build still in progress; timed out after {timeout}s."
             )
         if self._background_build_error is not None:
@@ -619,7 +619,7 @@ class Collection:
                 "Background index build raised; see __cause__ for details."
             ) from self._background_build_error
         if not self._index_built:
-            raise IndexNotReadyError(
+            raise IndexUnavailableError(
                 "Index not built; background build was never scheduled. "
                 "Call build_index() or start_background_build_index() first."
             )
@@ -797,7 +797,7 @@ class Collection:
             applied.
 
         Raises:
-            IndexNotReadyError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`build_index` has not been called.
         """
         self._require_built()
         return self._index_mgr.reindex()
@@ -813,7 +813,7 @@ class Collection:
             Total number of chunks embedded.
 
         Raises:
-            IndexNotReadyError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is
                 not configured.
         """
@@ -869,7 +869,7 @@ class Collection:
             position, with the document title prepended as level 1.
 
         Raises:
-            IndexNotReadyError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_built()
@@ -887,7 +887,7 @@ class Collection:
             for each document that contains a link pointing to ``path``.
 
         Raises:
-            IndexNotReadyError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_built()
@@ -908,7 +908,7 @@ class Collection:
             each link originating from ``path``.
 
         Raises:
-            IndexNotReadyError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_built()
@@ -949,7 +949,7 @@ class Collection:
             List of grouped results.
 
         Raises:
-            IndexNotReadyError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`build_index` has not been called.
         """
         self._require_built()
         return self._search_mgr.get_similar(
@@ -998,7 +998,7 @@ class Collection:
             stays compact.
 
         Raises:
-            IndexNotReadyError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_built()
@@ -1049,7 +1049,7 @@ class Collection:
             (inclusive), or ``None`` if unreachable within *max_depth* hops.
 
         Raises:
-            IndexNotReadyError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If *source* or *target* is not found in the index.
         """
         self._require_built()

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -109,7 +109,7 @@ class Collection:
     that runs :meth:`build_index` to completion. Bucket-3/4 MCP tool
     *clients* block on the new
     :class:`markdown_vault_mcp._server_readiness.needs_index_ready`
-    decorator, which calls :meth:`wait_for_index_ready` with a
+    decorator, which calls :meth:`wait_until_queryable` with a
     bounded default timeout
     (``MARKDOWN_VAULT_MCP_READY_TIMEOUT_S``, default 60s). The
     library stays honest: bucket-3/4 *methods* keep the PR #525
@@ -241,7 +241,7 @@ class Collection:
         self._index_built = False
 
         # Background-build coordination (issue #513 PR1 attempt 7). The
-        # event is the blocking primitive `wait_for_index_ready()` waits
+        # event is the blocking primitive `wait_until_queryable()` waits
         # on; it is pre-set so a freshly constructed Collection that never
         # called build_index() does not silently look "ready". The
         # background path clears the event before spawning the thread
@@ -574,8 +574,8 @@ class Collection:
             "error": error,
         }
 
-    def wait_for_index_ready(self, timeout: float | None = None) -> None:
-        """Block until the FTS index is ready, or raise.
+    def wait_until_queryable(self, timeout: float | None = None) -> None:
+        """Block until the FTS index is queryable per :meth:`is_queryable`, or raise.
 
         Control flow (each step in order):
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -580,7 +580,7 @@ class Collection:
         }
 
     def wait_until_queryable(self, timeout: float | None = None) -> None:
-        """Block until the FTS index is queryable per :meth:`is_queryable`, or raise.
+        """Block until the FTS index is queryable, or raise.
 
         Control flow (each step in order):
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -108,10 +108,10 @@ class Collection:
     :meth:`start_background_build_index` to spawn a daemon thread
     that runs :meth:`build_index` to completion. Bucket-3/4 MCP tool
     *clients* block on the new
-    :class:`markdown_vault_mcp._server_readiness.needs_index_ready`
+    :class:`markdown_vault_mcp._server_queryable.needs_queryable`
     decorator, which calls :meth:`wait_until_queryable` with a
     bounded default timeout
-    (``MARKDOWN_VAULT_MCP_READY_TIMEOUT_S``, default 60s). The
+    (``MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S``, default 60s). The
     library stays honest: bucket-3/4 *methods* keep the PR #525
     raise-immediately contract via :meth:`_require_built`.
     Internal callers (lifespan, git pull loop, CLI, direct library
@@ -592,7 +592,7 @@ class Collection:
            Collection would silently return success.
         4. Otherwise return.
 
-        This method is opt-in for the MCP-layer `needs_index_ready`
+        This method is opt-in for the MCP-layer `needs_queryable`
         decorator and for external callers that explicitly want to
         wait. Library bucket-3/4 methods do NOT call this — they call
         :meth:`_require_built` which raises immediately. That

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -544,6 +544,11 @@ class Collection:
         ``error`` carries the diagnostic message from the last background
         build attempt that captured an exception, independent of ``status``.
         """
+        # Intentionally does not call is_queryable() — that method also
+        # gates on _background_build_error is None. Here a captured error
+        # is diagnostic context only (surfaced via the error field),
+        # not a reason to hide a queryable index. The two predicates
+        # converge once is_queryable()'s body is simplified.
         if self._index_built and self._background_build_done.is_set():
             status = "queryable"
             error: str | None = (

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -78,7 +78,7 @@ class IndexNotReadyError(MarkdownMCPError):
 
     Callers must call :meth:`Collection.build_index` before these
     methods. Once a background indexer lands (issue #513), the
-    :meth:`Collection.wait_for_index_ready` primitive will block on a
+    :meth:`Collection.wait_until_queryable` primitive will block on a
     completion event instead of raising.
 
     See :exc:`IndexBuildFailedError` for the related case where a
@@ -93,7 +93,7 @@ class IndexBuildFailedError(MarkdownMCPError):
 
     Distinguishes "build never finished / never started"
     (:exc:`IndexNotReadyError`) from "build started but raised" — both
-    surface through :meth:`Collection.wait_for_index_ready` and through
+    surface through :meth:`Collection.wait_until_queryable` and through
     the MCP-layer `needs_index_ready` decorator. Operator action
     differs: not-ready means wait or check status; failed means
     inspect logs and decide whether to retry via CLI

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -66,20 +66,16 @@ class ConfigurationError(MarkdownMCPError):
     """Raised for invalid or unsupported configuration at startup."""
 
 
-class IndexNotReadyError(MarkdownMCPError):
-    """Raised when a method requires a built FTS index and none exists.
+class IndexUnavailableError(MarkdownMCPError):
+    """Raised when the FTS index is not in a state to serve a query.
 
-    Bucket-3 relational / FTS-backed queries (``get_backlinks``,
-    ``get_outlinks``, ``get_similar``, ``get_context``,
-    ``get_connection_path``, ``get_toc``) and bucket-4 coordinators
-    (``reindex``, ``build_embeddings``) cannot produce correct results
-    against an empty / never-built index. They raise this rather than
-    silently return wrong answers.
+    Covers two operational situations today:
 
-    Callers must call :meth:`Collection.build_index` before these
-    methods. Once a background indexer lands (issue #513), the
-    :meth:`Collection.wait_until_queryable` primitive will block on a
-    completion event instead of raising.
+    - The Collection has never had ``build_index()`` complete (cold
+      collection, or a previously-failed build never retried).
+    - A caller waited via :meth:`Collection.wait_until_queryable` and
+      the bounded timeout elapsed before the background build
+      signaled completion.
 
     See :exc:`IndexBuildFailedError` for the related case where a
     background build started but then raised.
@@ -92,13 +88,10 @@ class IndexBuildFailedError(MarkdownMCPError):
     The original exception is available via ``__cause__``.
 
     Distinguishes "build never finished / never started"
-    (:exc:`IndexNotReadyError`) from "build started but raised" — both
-    surface through :meth:`Collection.wait_until_queryable` and through
-    the MCP-layer `needs_queryable` decorator. Operator action
-    differs: not-ready means wait or check status; failed means
-    inspect logs and decide whether to retry via CLI
+    (:exc:`IndexUnavailableError`) from "build started but raised" —
+    both surface through :meth:`Collection.wait_until_queryable` and
+    through the MCP-layer ``needs_queryable`` decorator. Operator
+    action differs: unavailable means wait or check status; failed
+    means inspect logs and decide whether to retry via CLI
     ``markdown-vault-mcp index``.
-
-    See :exc:`IndexNotReadyError` for the "never finished / never
-    started" case.
     """

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -94,7 +94,7 @@ class IndexBuildFailedError(MarkdownMCPError):
     Distinguishes "build never finished / never started"
     (:exc:`IndexNotReadyError`) from "build started but raised" — both
     surface through :meth:`Collection.wait_until_queryable` and through
-    the MCP-layer `needs_index_ready` decorator. Operator action
+    the MCP-layer `needs_queryable` decorator. Operator action
     differs: not-ready means wait or check status; failed means
     inspect logs and decide whether to retry via CLI
     ``markdown-vault-mcp index``.

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -232,15 +232,34 @@ def test_should_use_background_build_warm_on_disk_false(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_get_index_status_ready(tmp_path: Path) -> None:
+def test_get_index_status_queryable(tmp_path: Path) -> None:
     vault = _vault(tmp_path)
     _seed(vault)
     col = Collection(source_dir=vault)
     col.build_index()
     status = col.get_index_status()
-    assert status["status"] == "ready"
+    assert status["status"] == "queryable"
     assert status["documents_indexed"] == 1
     assert status["error"] is None
+    col.close()
+
+
+def test_get_index_status_queryable_when_built_with_captured_error(
+    tmp_path: Path,
+) -> None:
+    """Priority flip: a built index with a captured background error
+    reports 'queryable' (not 'failed'). The error field carries the
+    last-attempt message as diagnostic context, independent of status."""
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()  # _index_built True, error cleared
+    col._background_build_error = RuntimeError("subsequent rebuild blew up")
+    status = col.get_index_status()
+    assert status["status"] == "queryable"
+    assert status["documents_indexed"] == 1
+    assert status["error"] is not None
+    assert "subsequent rebuild blew up" in status["error"]
     col.close()
 
 
@@ -265,11 +284,14 @@ def test_get_index_status_building_never_started(tmp_path: Path) -> None:
     col.close()
 
 
-def test_get_index_status_failed(tmp_path: Path) -> None:
+def test_get_index_status_failed_when_not_queryable_with_captured_error(
+    tmp_path: Path,
+) -> None:
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_error = RuntimeError("scan failed for X")
     status = col.get_index_status()
     assert status["status"] == "failed"
+    assert status["error"] is not None
     assert "scan failed for X" in status["error"]
     col.close()
 
@@ -279,7 +301,7 @@ def test_get_index_status_failed(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_tool_get_index_status_reports_ready(
+def test_mcp_tool_get_index_status_reports_queryable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     vault = tmp_path / "vault"
@@ -299,7 +321,7 @@ def test_mcp_tool_get_index_status_reports_ready(
             return res.structured_content or {}
 
     status = asyncio.run(_call())
-    assert status["status"] in ("ready", "building")  # depends on lifespan timing
+    assert status["status"] in ("queryable", "building")  # depends on lifespan timing
     assert status["error"] is None
 
 
@@ -367,7 +389,7 @@ def test_lifespan_cold_start_handshake_under_1s(
             res: Any = None
             for _ in range(50):
                 res = await client.call_tool("get_index_status", {})
-                if (res.structured_content or {}).get("status") == "ready":
+                if (res.structured_content or {}).get("status") == "queryable":
                     break
                 await asyncio.sleep(0.1)
             final = res.structured_content or {}
@@ -377,7 +399,7 @@ def test_lifespan_cold_start_handshake_under_1s(
     assert handshake_elapsed < 1.0, (
         f"cold-start handshake took {handshake_elapsed:.3f}s, expected < 1.0s"
     )
-    assert final["status"] == "ready"
+    assert final["status"] == "queryable"
     assert final["documents_indexed"] == 20
 
 
@@ -407,7 +429,7 @@ def test_lifespan_warm_start_skips_background(
             return res.structured_content or {}
 
     status = asyncio.run(_run())
-    assert status["status"] == "ready"
+    assert status["status"] == "queryable"
     assert status["documents_indexed"] == 1
 
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -661,7 +661,7 @@ def test_decorator_respects_env_timeout_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """monkeypatch.setenv must be visible at call time because
-    _resolve_ready_timeout reads at call time, not import time."""
+    _resolve_build_timeout reads at call time, not import time."""
     import time as time_mod
 
     from markdown_vault_mcp.managers import index as index_mod
@@ -673,7 +673,7 @@ def test_decorator_respects_env_timeout_override(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
-    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READY_TIMEOUT_S", "0.1")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S", "0.1")
 
     # Mock build_index to never finish so the timeout fires.
     original = index_mod.IndexManager.build_index
@@ -911,14 +911,14 @@ def test_decorator_works_with_positional_collection_arg(tmp_path: Path) -> None:
     Direct call (no FastMCP) with positional collection must work."""
     import asyncio
 
-    from markdown_vault_mcp._server_readiness import needs_index_ready
+    from markdown_vault_mcp._server_queryable import needs_queryable
 
     vault = _vault(tmp_path)
     _seed(vault)
     col = Collection(source_dir=vault)
     col.build_index()  # mark ready
 
-    @needs_index_ready()
+    @needs_queryable()
     async def handler(path: str, collection: Collection) -> str:  # noqa: ARG001
         return f"got: {path}"
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -706,7 +706,7 @@ def test_decorator_respects_env_timeout_override(
 # ---------------------------------------------------------------------------
 
 
-def test_require_index_ready_raises_immediately_not_blocks(tmp_path: Path) -> None:
+def test_require_built_raises_immediately_not_blocks(tmp_path: Path) -> None:
     """Bucket-3/4 library method called during in-flight background build
     raises IndexNotReadyError WITHIN 0.1s wall-clock — does NOT block.
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -46,28 +46,28 @@ def _seed(vault: Path, name: str = "n.md", body: str = "# N\n\nbody\n") -> None:
     (vault / name).write_text(body, encoding="utf-8")
 
 
-def test_is_index_ready_false_after_construction(tmp_path: Path) -> None:
+def test_is_queryable_false_after_construction(tmp_path: Path) -> None:
     col = Collection(source_dir=_vault(tmp_path))
-    assert col.is_index_ready() is False
+    assert col.is_queryable() is False
     col.close()
 
 
-def test_is_index_ready_true_after_synchronous_build(tmp_path: Path) -> None:
+def test_is_queryable_true_after_synchronous_build(tmp_path: Path) -> None:
     vault = _vault(tmp_path)
     _seed(vault)
     col = Collection(source_dir=vault)
     col.build_index()
-    assert col.is_index_ready() is True
+    assert col.is_queryable() is True
     col.close()
 
 
-def test_is_index_ready_false_after_captured_background_error(tmp_path: Path) -> None:
+def test_is_queryable_false_after_captured_background_error(tmp_path: Path) -> None:
     """Direct state poke: simulate a finished-but-failed background by setting
     the error and the event, leaving _index_built False."""
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_error = RuntimeError("simulated")
     col._background_build_done.set()
-    assert col.is_index_ready() is False
+    assert col.is_queryable() is False
     col.close()
 
 
@@ -133,7 +133,7 @@ def test_start_background_build_index_eventually_ready(tmp_path: Path) -> None:
     col = Collection(source_dir=vault)
     col.start_background_build_index()
     col.wait_for_index_ready(timeout=5.0)
-    assert col.is_index_ready()
+    assert col.is_queryable()
     col.get_backlinks("n_0.md")  # smoke: bucket-3 returns (empty list OK)
     col.close()
 
@@ -151,7 +151,7 @@ def test_start_background_build_index_captures_error(
 
     with pytest.raises(IndexBuildFailedError):
         col.wait_for_index_ready(timeout=5.0)
-    assert col.is_index_ready() is False
+    assert col.is_queryable() is False
     col.close()
 
 
@@ -439,7 +439,7 @@ def test_lifespan_cold_start_with_embeddings_skips_embeddings(
     """Provider configured + cold start: lifespan must log the skip and not block.
 
     Must inject a slow _index_mgr.build_index mock so the background thread is
-    reliably still running when the lifespan checks is_index_ready() — otherwise
+    reliably still running when the lifespan checks is_queryable() — otherwise
     on a tiny vault the background completes between spawn and check, embeddings
     runs, and the test asserts the wrong thing.
     """
@@ -459,7 +459,7 @@ def test_lifespan_cold_start_with_embeddings_skips_embeddings(
 
     # Patch IndexManager.build_index globally to sleep before returning,
     # ensuring the background thread is still running when the lifespan
-    # makes the is_index_ready() decision.
+    # makes the is_queryable() decision.
     from markdown_vault_mcp.managers import index as index_mod
 
     original_build_index = index_mod.IndexManager.build_index
@@ -848,7 +848,7 @@ def test_synchronous_build_index_clears_prior_background_error(
     tmp_path: Path,
 ) -> None:
     """Recovery path: after a failed background build, calling build_index()
-    synchronously must clear _background_build_error so is_index_ready()
+    synchronously must clear _background_build_error so is_queryable()
     returns True and bucket-3/4 calls stop raising IndexBuildFailedError."""
     vault = _vault(tmp_path)
     _seed(vault)
@@ -859,14 +859,14 @@ def test_synchronous_build_index_clears_prior_background_error(
     col._background_build_error = RuntimeError("simulated prior background failure")
     col._background_build_done.set()
     col._background_started = True
-    assert col.is_index_ready() is False
+    assert col.is_queryable() is False
 
     # Synchronous recovery build.
     col.build_index()
 
     # Now ready: error cleared, _index_built True, event still set.
     assert col._background_build_error is None
-    assert col.is_index_ready() is True
+    assert col.is_queryable() is True
     # Bucket-3 call no longer surfaces the prior error.
     col.get_backlinks("n.md")  # must not raise
     col.close()
@@ -878,7 +878,7 @@ def test_synchronous_build_index_warm_path_clears_prior_background_error(
     """Recovery path via the warm-restart short-circuit: a prior background
     failure left _background_build_error populated; the sentinel from a
     prior successful build is still present; calling build_index()
-    synchronously must clear the captured error and is_index_ready() must
+    synchronously must clear the captured error and is_queryable() must
     return True."""
     vault = _vault(tmp_path)
     _seed(vault)
@@ -895,13 +895,13 @@ def test_synchronous_build_index_warm_path_clears_prior_background_error(
     col._background_build_error = RuntimeError("simulated prior background failure")
     col._background_build_done.set()
     col._background_started = True
-    assert col.is_index_ready() is False
+    assert col.is_queryable() is False
 
     # Warm-restart short-circuit recovery.
     col.build_index()
 
     assert col._background_build_error is None
-    assert col.is_index_ready() is True
+    assert col.is_queryable() is True
     col.close()
 
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -260,6 +260,12 @@ def test_get_index_status_queryable_when_built_with_captured_error(
     assert status["documents_indexed"] == 1
     assert status["error"] is not None
     assert "subsequent rebuild blew up" in status["error"]
+    # is_queryable() and get_index_status()'s "queryable" branch disagree
+    # in this state: is_queryable still gates on _background_build_error
+    # being None, while get_index_status applies the priority flip and
+    # treats the captured error as diagnostic context. The asymmetry is
+    # intentional and documented in get_index_status's body comment.
+    assert col.is_queryable() is False
     col.close()
 
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -14,7 +14,7 @@ from fastmcp import Client
 from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.exceptions import (
     IndexBuildFailedError,
-    IndexNotReadyError,
+    IndexUnavailableError,
     MarkdownMCPError,
 )
 
@@ -99,7 +99,7 @@ def test_wait_until_queryable_raises_on_timeout(tmp_path: Path) -> None:
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_done.clear()
     col._index_built = False
-    with pytest.raises(IndexNotReadyError, match=r"timed out"):
+    with pytest.raises(IndexUnavailableError, match=r"timed out"):
         col.wait_until_queryable(timeout=0.05)
     col.close()
 
@@ -121,7 +121,7 @@ def test_wait_until_queryable_raises_when_never_scheduled(tmp_path: Path) -> Non
     let wait() return success without the explicit guard."""
     col = Collection(source_dir=_vault(tmp_path))
     # All defaults: event pre-set, no error, _index_built=False, no spawn.
-    with pytest.raises(IndexNotReadyError, match=r"never scheduled|not built"):
+    with pytest.raises(IndexUnavailableError, match=r"never scheduled|not built"):
         col.wait_until_queryable(timeout=0.1)
     col.close()
 
@@ -708,7 +708,7 @@ def test_decorator_respects_env_timeout_override(
 
 def test_require_built_raises_immediately_not_blocks(tmp_path: Path) -> None:
     """Bucket-3/4 library method called during in-flight background build
-    raises IndexNotReadyError WITHIN 0.1s wall-clock — does NOT block.
+    raises IndexUnavailableError WITHIN 0.1s wall-clock — does NOT block.
 
     This is the canonical regression test against attempt-6's hole."""
     import time as time_mod
@@ -732,7 +732,7 @@ def test_require_built_raises_immediately_not_blocks(tmp_path: Path) -> None:
         col.start_background_build_index()
 
         start = time_mod.perf_counter()
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_backlinks("n_0.md")  # bucket-3 library call
         elapsed = time_mod.perf_counter() - start
         assert elapsed < 0.1, (
@@ -747,7 +747,7 @@ def test_require_built_raises_immediately_not_blocks(tmp_path: Path) -> None:
 def test_git_pull_during_background_does_not_starve_writes(tmp_path: Path) -> None:
     """The on_pull=reindex callback in the git pull loop must NOT hold
     _write_lock while blocking on the background build. Reindex raises
-    IndexNotReadyError, git_sync catches it, releases the lock, retries
+    IndexUnavailableError, git_sync catches it, releases the lock, retries
     on next interval — no lock starvation."""
     import time as time_mod
 
@@ -771,7 +771,7 @@ def test_git_pull_during_background_does_not_starve_writes(tmp_path: Path) -> No
 
         # Simulate the on_pull callback (reindex) racing the foreground
         # write. Both should fast-fail / proceed without lock starvation.
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.reindex()  # raises immediately, releases internal locks
 
         # Foreground write must complete promptly (within 1s, well
@@ -813,7 +813,7 @@ def test_foreground_write_during_background_scan_on_disk(tmp_path: Path) -> None
 
 
 def test_reindex_after_pull_handler_handles_not_ready(tmp_path: Path) -> None:
-    """_reindex_after_pull in _server_tools.py catches IndexNotReadyError
+    """_reindex_after_pull in _server_tools.py catches IndexUnavailableError
     and sets reindex_failed=True on the pull payload — does NOT block."""
     import time as time_mod
 

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -71,16 +71,16 @@ def test_is_queryable_false_after_captured_background_error(tmp_path: Path) -> N
     col.close()
 
 
-def test_wait_for_index_ready_returns_when_already_built(tmp_path: Path) -> None:
+def test_wait_until_queryable_returns_when_already_built(tmp_path: Path) -> None:
     vault = _vault(tmp_path)
     _seed(vault)
     col = Collection(source_dir=vault)
     col.build_index()
-    col.wait_for_index_ready(timeout=0.1)  # must not raise
+    col.wait_until_queryable(timeout=0.1)  # must not raise
     col.close()
 
 
-def test_wait_for_index_ready_blocks_until_event_set(tmp_path: Path) -> None:
+def test_wait_until_queryable_blocks_until_event_set(tmp_path: Path) -> None:
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_done.clear()
     col._index_built = False
@@ -91,38 +91,38 @@ def test_wait_for_index_ready_blocks_until_event_set(tmp_path: Path) -> None:
         col._background_build_done.set()
 
     threading.Thread(target=setter).start()
-    col.wait_for_index_ready(timeout=1.0)  # returns when event fires
+    col.wait_until_queryable(timeout=1.0)  # returns when event fires
     col.close()
 
 
-def test_wait_for_index_ready_raises_on_timeout(tmp_path: Path) -> None:
+def test_wait_until_queryable_raises_on_timeout(tmp_path: Path) -> None:
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_done.clear()
     col._index_built = False
     with pytest.raises(IndexNotReadyError, match=r"timed out"):
-        col.wait_for_index_ready(timeout=0.05)
+        col.wait_until_queryable(timeout=0.05)
     col.close()
 
 
-def test_wait_for_index_ready_raises_build_failed_when_error_set(
+def test_wait_until_queryable_raises_build_failed_when_error_set(
     tmp_path: Path,
 ) -> None:
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_error = RuntimeError("scan exploded")
     with pytest.raises(IndexBuildFailedError) as excinfo:
-        col.wait_for_index_ready(timeout=0.1)
+        col.wait_until_queryable(timeout=0.1)
     assert isinstance(excinfo.value.__cause__, RuntimeError)
     col.close()
 
 
-def test_wait_for_index_ready_raises_when_never_scheduled(tmp_path: Path) -> None:
+def test_wait_until_queryable_raises_when_never_scheduled(tmp_path: Path) -> None:
     """Pre-set event + no error + _index_built=False + _background_started=False.
     This is the case the spec calls 'never scheduled' — the pre-set event would
     let wait() return success without the explicit guard."""
     col = Collection(source_dir=_vault(tmp_path))
     # All defaults: event pre-set, no error, _index_built=False, no spawn.
     with pytest.raises(IndexNotReadyError, match=r"never scheduled|not built"):
-        col.wait_for_index_ready(timeout=0.1)
+        col.wait_until_queryable(timeout=0.1)
     col.close()
 
 
@@ -132,7 +132,7 @@ def test_start_background_build_index_eventually_ready(tmp_path: Path) -> None:
         _seed(vault, f"n_{i}.md", f"# N{i}\n\nbody {i}\n")
     col = Collection(source_dir=vault)
     col.start_background_build_index()
-    col.wait_for_index_ready(timeout=5.0)
+    col.wait_until_queryable(timeout=5.0)
     assert col.is_queryable()
     col.get_backlinks("n_0.md")  # smoke: bucket-3 returns (empty list OK)
     col.close()
@@ -150,7 +150,7 @@ def test_start_background_build_index_captures_error(
     col.start_background_build_index()
 
     with pytest.raises(IndexBuildFailedError):
-        col.wait_for_index_ready(timeout=5.0)
+        col.wait_until_queryable(timeout=5.0)
     assert col.is_queryable() is False
     col.close()
 
@@ -162,7 +162,7 @@ def test_start_background_build_index_idempotent(tmp_path: Path) -> None:
     assert first is not None
     col.start_background_build_index()
     assert col._background_build_thread is first
-    col.wait_for_index_ready(timeout=5.0)
+    col.wait_until_queryable(timeout=5.0)
     col.start_background_build_index()
     assert col._background_build_thread is first
     col.close()
@@ -188,9 +188,9 @@ def test_start_background_build_index_one_shot_after_thread_start_failure(
     assert col._background_build_done.is_set()
     assert isinstance(col._background_build_error, RuntimeError)
 
-    # wait_for_index_ready surfaces it as IndexBuildFailedError.
+    # wait_until_queryable surfaces it as IndexBuildFailedError.
     with pytest.raises(IndexBuildFailedError):
-        col.wait_for_index_ready(timeout=0.1)
+        col.wait_until_queryable(timeout=0.1)
 
     # Retry is a no-op (one-shot semantics).
     monkeypatch.undo()
@@ -740,7 +740,7 @@ def test_require_built_raises_immediately_not_blocks(tmp_path: Path) -> None:
         )
     finally:
         monkeypatch.undo()
-        col.wait_for_index_ready(timeout=5.0)
+        col.wait_until_queryable(timeout=5.0)
         col.close()
 
 
@@ -784,7 +784,7 @@ def test_git_pull_during_background_does_not_starve_writes(tmp_path: Path) -> No
         )
     finally:
         monkeypatch.undo()
-        col.wait_for_index_ready(timeout=5.0)
+        col.wait_until_queryable(timeout=5.0)
         col.close()
 
 
@@ -805,7 +805,7 @@ def test_foreground_write_during_background_scan_on_disk(tmp_path: Path) -> None
     col = Collection(source_dir=vault, index_path=tmp_path / "fts.db", read_only=False)
     col.start_background_build_index()
     col.write("racy.md", "# Racy\n\nFOREGROUND CONTENT\n")
-    col.wait_for_index_ready(timeout=10.0)
+    col.wait_until_queryable(timeout=10.0)
 
     rows = {r["path"]: r for r in col._fts.list_notes()}
     assert "racy.md" in rows, "foreground write must end up in FTS"
@@ -840,7 +840,7 @@ def test_reindex_after_pull_handler_handles_not_ready(tmp_path: Path) -> None:
         assert "reindex_hint" in pull_dict
     finally:
         monkeypatch.undo()
-        col.wait_for_index_ready(timeout=5.0)
+        col.wait_until_queryable(timeout=5.0)
         col.close()
 
 

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -12,13 +12,13 @@ Collection methods fall into four buckets:
 - Bucket 3 (block / raise): ``get_backlinks``, ``get_outlinks``,
   ``get_similar``, ``get_context``, ``get_connection_path``,
   ``get_toc``. Silently wrong on a partial index → raise
-  ``IndexNotReadyError`` pre-#513; block on a background-completion
+  ``IndexUnavailableError`` pre-#513; block on a background-completion
   event post-#513. (``get_toc`` is FTS-backed: on cold start the FTS
   ``documents`` row is absent and the underlying manager would raise
   a misleading ``ValueError("Document not found")``.)
 - Bucket 4 (coordinate): ``reindex``, ``build_embeddings``,
   ``build_index``. ``reindex`` and ``build_embeddings`` require a built
-  index (raise ``IndexNotReadyError`` otherwise). ``build_index`` is
+  index (raise ``IndexUnavailableError`` otherwise). ``build_index`` is
   the bootstrap; its warm-restart short-circuit uses persisted FTS
   state alone (no ``_initialized`` flag).
 """
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from markdown_vault_mcp.collection import Collection
-from markdown_vault_mcp.exceptions import IndexNotReadyError
+from markdown_vault_mcp.exceptions import IndexUnavailableError
 from tests.conftest import MockEmbeddingProvider
 
 if TYPE_CHECKING:
@@ -150,7 +150,7 @@ class TestBucket2PartialReport:
 
 
 # ---------------------------------------------------------------------------
-# Bucket 3 — block (raise IndexNotReadyError on unbuilt pre-#513)
+# Bucket 3 — block (raise IndexUnavailableError on unbuilt pre-#513)
 # ---------------------------------------------------------------------------
 
 
@@ -160,7 +160,7 @@ class TestBucket3Block:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_backlinks("note.md")
 
     def test_get_outlinks_on_unbuilt_raises(self, tmp_path: Path) -> None:
@@ -168,7 +168,7 @@ class TestBucket3Block:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_outlinks("note.md")
 
     def test_get_similar_on_unbuilt_raises(self, tmp_path: Path) -> None:
@@ -180,7 +180,7 @@ class TestBucket3Block:
             embeddings_path=tmp_path / "vectors",
         )
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_similar("note.md")
 
     def test_get_context_on_unbuilt_raises(self, tmp_path: Path) -> None:
@@ -188,7 +188,7 @@ class TestBucket3Block:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_context("note.md")
 
     def test_get_connection_path_on_unbuilt_raises(self, tmp_path: Path) -> None:
@@ -197,7 +197,7 @@ class TestBucket3Block:
         _seed(vault, "b.md")
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_connection_path("a.md", "b.md")
 
     def test_get_toc_on_unbuilt_raises(self, tmp_path: Path) -> None:
@@ -208,7 +208,7 @@ class TestBucket3Block:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_toc("note.md")
 
 
@@ -224,7 +224,7 @@ class TestBucket4Coordinate:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.reindex()
 
     def test_build_embeddings_on_unbuilt_raises(self, tmp_path: Path) -> None:
@@ -236,7 +236,7 @@ class TestBucket4Coordinate:
             embeddings_path=tmp_path / "vectors",
         )
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.build_embeddings()
 
     def test_build_index_short_circuits_on_warm_restart(self, tmp_path: Path) -> None:
@@ -276,7 +276,7 @@ class TestWaitUntilQueryable:
         vault = _vault(tmp_path)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.wait_until_queryable(timeout=0.1)
 
     def test_after_build_returns(self, tmp_path: Path) -> None:
@@ -375,7 +375,7 @@ class TestReadinessFlagSemantics:
         with pytest.raises(RuntimeError):
             col.build_index(force=True)
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_backlinks("note.md")
 
     def test_failed_build_index_leaves_unready(self, tmp_path: Path) -> None:
@@ -393,5 +393,5 @@ class TestReadinessFlagSemantics:
         with pytest.raises(RuntimeError):
             col.build_index()
 
-        with pytest.raises(IndexNotReadyError):
+        with pytest.raises(IndexUnavailableError):
             col.get_backlinks("note.md")

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -267,17 +267,17 @@ class TestBucket4Coordinate:
 
 
 # ---------------------------------------------------------------------------
-# wait_for_index_ready primitive
+# wait_until_queryable primitive
 # ---------------------------------------------------------------------------
 
 
-class TestWaitForIndexReady:
+class TestWaitUntilQueryable:
     def test_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
         col = Collection(source_dir=vault)
 
         with pytest.raises(IndexNotReadyError):
-            col.wait_for_index_ready(timeout=0.1)
+            col.wait_until_queryable(timeout=0.1)
 
     def test_after_build_returns(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
@@ -286,7 +286,7 @@ class TestWaitForIndexReady:
         col.build_index()
 
         # Must return without raising.
-        col.wait_for_index_ready(timeout=0.1)
+        col.wait_until_queryable(timeout=0.1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #538. First of four issues replacing the abandoned #533.

Eliminates the loaded word "ready" from the FTS-index readiness
vocabulary at every load-bearing identifier and prose surface.
Replaces with target words chosen for what they actually describe:

- Status wire value `"ready"` → `"queryable"`
- Method `is_index_ready()` → `is_queryable()`
- Method `_require_index_ready()` → `_require_built()` (it only
  checks `_index_built`)
- Method `wait_for_index_ready()` → `wait_until_queryable()`
- Decorator `needs_index_ready` → `needs_queryable`
- Module `_server_readiness.py` → `_server_queryable.py`
- Exception `IndexNotReadyError` → `IndexUnavailableError`
- Env var `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` →
  `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`

Plus the priority flip in `get_index_status`: a built index with a
captured background error from a prior attempt now reports
`status="queryable"` (with the diagnostic in `error`), not
`status="failed"`.

Design spec: `docs/superpowers/specs/2026-05-30-issue-538-status-rename-design.md` (gitignored, local-only).

## Breaking changes

See CHANGELOG. External consumers must rename references; no
deprecation shims ship (CLAUDE.md "don't build backward-compat
layers for internal refactors"). Running deployments that set the
old env var will silently fall back to the 60-second default;
update operator configs.

## Test plan

- [x] New `test_get_index_status_queryable` (TDD-driven rename of
      `test_get_index_status_ready`).
- [x] New `test_get_index_status_queryable_when_built_with_captured_error`
      (TDD-driven priority-flip test).
- [x] All existing test assertions sweep from `"ready"` to
      `"queryable"`.
- [x] Comprehensive grep verifies no surviving "ready" identifiers
      outside CHANGELOG.
- [x] CI hard gates (pytest, ruff, mypy, pre-commit) all green.
- [x] Patch coverage ≥80% on changed files.

## Follow-ups in chain

This is PR 1 of 4 replacing #533:
- #538 (this PR) — rename + priority flip.
- #539 — delete `IndexBuildFailedError`; simplify
  `wait_until_queryable`; simplify `is_queryable()` to the
  two-field check.
- #540 — add `IndexUnavailableReason` Literal + required `reason`
  field on `IndexUnavailableError`.
- #541 — MCP decorator catches `sqlite3.OperationalError` and adds
  the third `reason` value (`"broken"`).