### PR TITLE
refactor: drop IndexBuildFailedError, simplify queryable contract

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -405,11 +405,14 @@ arriving at the MCP layer go through the
 `src/markdown_vault_mcp/_server_queryable.py`), which blocks via
 `Collection.wait_until_queryable(timeout)` with a configurable
 default (env `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`, default 60s).
-A failed background build surfaces to MCP clients as
-`IndexBuildFailedError` (the decorator's `wait_until_queryable`
-call raises) and to operators as
+A failed background build surfaces to operators as
 `get_index_status` reporting
-`{"status": "failed", "error": "..."}`. Embeddings stay on the
+`{"status": "failed", "error": "..."}`. MCP clients see
+`IndexUnavailableError` from the decorator's
+`wait_until_queryable` call (the never-scheduled guard fires
+because the worker resets `_index_built=False` before recording the
+error); the captured error message itself is read via
+`get_index_status`. Embeddings stay on the
 synchronous lifespan path in PR1 — on cold start
 `build_embeddings()` is skipped with a log entry and semantic
 search returns empty until PR2 backgrounds embeddings or the

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -95,7 +95,7 @@ The empty string `""` represents the root folder (top-level documents).
 Table of contents (heading outline) for a specific document. This is a URI template — replace `{path}` with the document's relative path.
 
 !!! note "Cold-start blocking"
-    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
+    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexUnavailableError` if the background build did not complete successfully (the captured error message is available via `get_index_status`'s `error` field). Poll `get_index_status` to observe build state without blocking.
 
 **Example:** `toc://vault/Journal/note.md`
 
@@ -118,7 +118,7 @@ The TOC prepends a synthetic H1 from the document title and deduplicates if the 
 Top 10 semantically similar notes for a document. Requires embeddings to be built. This is a URI template — replace `{path}` with the document's relative path.
 
 !!! note "Cold-start blocking"
-    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexBuildFailedError` if the background build raised. Poll `get_index_status` to observe build state without blocking.
+    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexUnavailableError` if the background build did not complete successfully (the captured error message is available via `get_index_status`'s `error` field). Poll `get_index_status` to observe build state without blocking.
 
 Results are **grouped per file** — each file appears at most once, with up to `chunks_per_file` (server default `2`) best-matching sections in a `sections` array. Each entry is a `GroupedResult` dict with `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -204,8 +204,9 @@ Check the embedding provider configuration and vector index status. Use this to 
 
 Returns background-build state of the FTS index. Use this when
 `initialize` returned but bucket-3/4 calls block longer than expected
-or surface `IndexUnavailableError`/`IndexBuildFailedError` — the
-`status` field distinguishes "still building" from "build failed."
+or surface `IndexUnavailableError` — the `status` field distinguishes
+"still building" from "build failed," and the `error` field carries
+the diagnostic message from the last failed background build attempt.
 
 **Returns:**
 - `status`: `"queryable"`, `"building"`, or `"failed"`.
@@ -221,7 +222,7 @@ or surface `IndexUnavailableError`/`IndexBuildFailedError` — the
 ## Index Management
 
 !!! note "Cold-start blocking"
-    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
+    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError`. The same exception fires if the background build did not complete successfully — read `get_index_status`'s `error` field for the captured diagnostic. Poll `get_index_status` to observe build state without blocking.
 
 ### `reindex`
 
@@ -608,7 +609,7 @@ managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` not set).
 ## Link Graph
 
 !!! note "Cold-start blocking"
-    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError`. If a prior background build raised, it returns `IndexBuildFailedError`. Poll `get_index_status` to observe build state without blocking.
+    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError`. The same exception fires if the background build did not complete successfully — read `get_index_status`'s `error` field for the captured diagnostic. Poll `get_index_status` to observe build state without blocking.
 
 ### `get_backlinks`
 

--- a/src/markdown_vault_mcp/_server_queryable.py
+++ b/src/markdown_vault_mcp/_server_queryable.py
@@ -54,8 +54,11 @@ def needs_queryable(
     already-wrapped function.
 
     Raises (propagated to MCP client via FastMCP error middleware):
-        IndexUnavailableError: timeout exceeded; or never scheduled.
-        IndexBuildFailedError: a prior background build raised.
+        IndexUnavailableError: timeout exceeded, or never scheduled,
+            or build did not complete successfully (a captured
+            background-build error surfaces here via the
+            never-scheduled guard; the error message itself is
+            available via get_index_status).
     """
 
     def deco(handler: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -597,9 +597,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Use this when ``initialize`` returned but bucket-3/4 calls
         block longer than expected or surface
-        ``IndexUnavailableError``/``IndexBuildFailedError`` — the
-        ``status`` field distinguishes "still building" from "build
-        failed."
+        ``IndexUnavailableError`` — the ``status`` field
+        distinguishes "still building" from "build failed," and the
+        ``error`` field carries the exception message when a build
+        did not complete successfully.
 
         Returns:
             Dict with the following fields:

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -600,10 +600,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         ``IndexUnavailableError`` — the ``status`` field
         distinguishes "still building" from "build failed," and the
         ``error`` field carries the exception message from the last
-        background-build attempt that captured one, independent of
-        ``status`` (a queryable index after a subsequent failed
-        rebuild will report ``status=queryable`` with ``error``
-        populated).
+        background-build attempt that captured one. ``error`` may be
+        populated when ``status`` is ``"queryable"`` (a successful
+        build followed by a later failed rebuild leaves the captured
+        diagnostic in place until the next successful build clears
+        it) and is always ``None`` when ``status`` is ``"building"``.
 
         Returns:
             Dict with the following fields:

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -599,8 +599,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         block longer than expected or surface
         ``IndexUnavailableError`` — the ``status`` field
         distinguishes "still building" from "build failed," and the
-        ``error`` field carries the exception message when a build
-        did not complete successfully.
+        ``error`` field carries the exception message from the last
+        background-build attempt that captured one, independent of
+        ``status`` (a queryable index after a subsequent failed
+        rebuild will report ``status=queryable`` with ``error``
+        populated).
 
         Returns:
             Dict with the following fields:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -547,12 +547,7 @@ class Collection:
         ``error`` carries the diagnostic message from the last background
         build attempt that captured an exception, independent of ``status``.
         """
-        # Intentionally does not call is_queryable() — that method also
-        # gates on _background_build_error is None. Here a captured error
-        # is diagnostic context only (surfaced via the error field),
-        # not a reason to hide a queryable index. The two predicates
-        # converge once is_queryable()'s body is simplified.
-        if self._index_built and self._background_build_done.is_set():
+        if self.is_queryable():
             status = "queryable"
             error: str | None = (
                 str(self._background_build_error)

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -623,8 +623,10 @@ class Collection:
             )
         if not self._index_built:
             raise IndexUnavailableError(
-                "Index not built; background build was never scheduled. "
-                "Call build_index() or start_background_build_index() first."
+                "Index not built: background build was never scheduled "
+                "or did not complete successfully. "
+                "Check get_index_status() for diagnostic details, or call "
+                "build_index() / start_background_build_index() to retry."
             )
 
     @property

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -13,7 +13,7 @@ import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal
 
-from markdown_vault_mcp.exceptions import IndexBuildFailedError, IndexUnavailableError
+from markdown_vault_mcp.exceptions import IndexUnavailableError
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.scanner import (
     ChunkStrategy,
@@ -590,15 +590,19 @@ class Collection:
         1. ``_background_build_done.wait(timeout)`` — if False
            (timed out), raise
            :exc:`IndexUnavailableError("…timed out…")`.
-        2. If ``_background_build_error`` is not None, raise
-           :exc:`IndexBuildFailedError` with the original as
-           ``__cause__``.
-        3. If ``_index_built`` is False, raise
+        2. If ``_index_built`` is False, raise
            :exc:`IndexUnavailableError("…never scheduled…")` — guards
            the never-scheduled case (event pre-set, no error, no
            build, no thread). Without it, callers on a fresh
            Collection would silently return success.
-        4. Otherwise return.
+        3. Otherwise return.
+
+        A captured ``_background_build_error`` from a previous failed
+        attempt does NOT raise: the error is diagnostic state about
+        the most recent build attempt, surfaced via
+        :meth:`get_index_status`'s ``error`` field, not a control-flow
+        gate. Callers needing the diagnostic must read
+        :meth:`get_index_status`.
 
         This method is opt-in for the MCP-layer `needs_queryable`
         decorator and for external callers that explicitly want to
@@ -614,18 +618,14 @@ class Collection:
                 client-side deadlines.
 
         Raises:
-            IndexBuildFailedError: A prior background build raised.
-            IndexUnavailableError: Index not built and either no build
-                was ever scheduled, or the timeout expired.
+            IndexUnavailableError: Either the timeout expired before
+                the build event was set, or the build did not complete
+                successfully (``_index_built`` remained False).
         """
         if not self._background_build_done.wait(timeout=timeout):
             raise IndexUnavailableError(
                 f"Index build still in progress; timed out after {timeout}s."
             )
-        if self._background_build_error is not None:
-            raise IndexBuildFailedError(
-                "Background index build raised; see __cause__ for details."
-            ) from self._background_build_error
         if not self._index_built:
             raise IndexUnavailableError(
                 "Index not built; background build was never scheduled. "

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -441,18 +441,21 @@ class Collection:
         """Return True when the structural preconditions for serving FTS
         queries are met (in-process precondition snapshot).
 
-        Checks ``_index_built`` is True, ``_background_build_error`` is
-        None, and ``_background_build_done`` is set. Necessary but not
-        sufficient — actual queryability is determined at use time (a
-        corrupted on-disk database satisfies these preconditions but
-        queries still fail).
+        Checks ``_index_built`` is True and ``_background_build_done`` is
+        set. Necessary but not sufficient — actual queryability is
+        determined at use time (a corrupted on-disk database satisfies
+        these preconditions but queries still fail).
+
+        A captured ``_background_build_error`` from a previous failed
+        attempt does NOT demote queryability: the error is diagnostic
+        state about the most recent build attempt, surfaced via
+        :meth:`get_index_status`'s ``error`` field, not a control-flow
+        gate.
 
         Lock-free by design: plain attribute reads + Event.is_set().
         Assumes CPython GIL semantics for cross-thread visibility.
         """
         if not self._index_built:
-            return False
-        if self._background_build_error is not None:
             return False
         return self._background_build_done.is_set()
 

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -77,21 +77,7 @@ class IndexUnavailableError(MarkdownMCPError):
       the bounded timeout elapsed before the background build
       signaled completion.
 
-    See :exc:`IndexBuildFailedError` for the related case where a
-    background build started but then raised.
-    """
-
-
-class IndexBuildFailedError(MarkdownMCPError):
-    """Raised when a background index build failed with an exception.
-
-    The original exception is available via ``__cause__``.
-
-    Distinguishes "build never finished / never started"
-    (:exc:`IndexUnavailableError`) from "build started but raised" —
-    both surface through :meth:`Collection.wait_until_queryable` and
-    through the MCP-layer ``needs_queryable`` decorator. Operator
-    action differs: unavailable means wait or check status; failed
-    means inspect logs and decide whether to retry via CLI
-    ``markdown-vault-mcp index``.
+    A captured background-build error is NOT a separate exception
+    class: it is diagnostic state surfaced via
+    :meth:`Collection.get_index_status`'s ``error`` field.
     """

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -69,13 +69,17 @@ class ConfigurationError(MarkdownMCPError):
 class IndexUnavailableError(MarkdownMCPError):
     """Raised when the FTS index is not in a state to serve a query.
 
-    Covers two operational situations today:
+    Covers the following operational situations:
 
-    - The Collection has never had ``build_index()`` complete (cold
-      collection, or a previously-failed build never retried).
-    - A caller waited via :meth:`Collection.wait_until_queryable` and
-      the bounded timeout elapsed before the background build
-      signaled completion.
+    - **Never built.** The Collection has never had
+      ``build_index()`` complete (cold collection on a fresh process).
+    - **Build did not complete successfully.** A previous background
+      build raised and was not retried (``_index_built`` remained
+      False; the captured error is available via
+      :meth:`Collection.get_index_status`'s ``error`` field).
+    - **Timeout.** A caller waited via
+      :meth:`Collection.wait_until_queryable` and the bounded timeout
+      elapsed before the background build signaled completion.
 
     A captured background-build error is NOT a separate exception
     class: it is diagnostic state surfaced via

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -13,27 +13,11 @@ from fastmcp import Client
 
 from markdown_vault_mcp.collection import Collection
 from markdown_vault_mcp.exceptions import (
-    IndexBuildFailedError,
     IndexUnavailableError,
-    MarkdownMCPError,
 )
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def test_index_build_failed_error_subclasses_base() -> None:
-    err = IndexBuildFailedError("scan failed")
-    assert isinstance(err, MarkdownMCPError)
-    assert str(err) == "scan failed"
-
-
-def test_index_build_failed_error_carries_cause() -> None:
-    original = RuntimeError("scan exploded")
-    try:
-        raise IndexBuildFailedError("background build failed") from original
-    except IndexBuildFailedError as err:
-        assert err.__cause__ is original
 
 
 def _vault(tmp_path: Path) -> Path:
@@ -880,8 +864,10 @@ def test_synchronous_build_index_clears_prior_background_error(
     tmp_path: Path,
 ) -> None:
     """Recovery path: after a failed background build, calling build_index()
-    synchronously must clear _background_build_error so is_queryable()
-    returns True and bucket-3/4 calls stop raising IndexBuildFailedError."""
+    synchronously sets _index_built=True so is_queryable() returns True and
+    bucket-3/4 calls succeed. Also clears _background_build_error so the
+    diagnostic field in get_index_status reflects the new successful
+    attempt."""
     vault = _vault(tmp_path)
     _seed(vault)
     col = Collection(source_dir=vault, index_path=tmp_path / "fts.db")

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -117,14 +117,17 @@ def test_wait_until_queryable_raises_on_timeout(tmp_path: Path) -> None:
     col.close()
 
 
-def test_wait_until_queryable_raises_build_failed_when_error_set(
+def test_wait_until_queryable_raises_unavailable_when_error_set_and_not_built(
     tmp_path: Path,
 ) -> None:
+    """Captured error + event set + _index_built=False (default) → raises
+    IndexUnavailableError via step 2 (never-scheduled guard). The captured
+    error is no longer surfaced as a separate exception class; callers
+    read get_index_status() for the diagnostic."""
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_error = RuntimeError("scan exploded")
-    with pytest.raises(IndexBuildFailedError) as excinfo:
+    with pytest.raises(IndexUnavailableError, match=r"never scheduled|not built"):
         col.wait_until_queryable(timeout=0.1)
-    assert isinstance(excinfo.value.__cause__, RuntimeError)
     col.close()
 
 
@@ -136,6 +139,20 @@ def test_wait_until_queryable_raises_when_never_scheduled(tmp_path: Path) -> Non
     # All defaults: event pre-set, no error, _index_built=False, no spawn.
     with pytest.raises(IndexUnavailableError, match=r"never scheduled|not built"):
         col.wait_until_queryable(timeout=0.1)
+    col.close()
+
+
+def test_wait_until_queryable_returns_when_built_with_captured_error(
+    tmp_path: Path,
+) -> None:
+    """Direct state poke: built + done + captured error → returns (no raise).
+    Captured error is diagnostic only, not a control-flow gate."""
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+    col._background_build_error = RuntimeError("subsequent rebuild blew up")
+    col.wait_until_queryable(timeout=0.1)  # must not raise
     col.close()
 
 
@@ -162,7 +179,7 @@ def test_start_background_build_index_captures_error(
     monkeypatch.setattr(col._index_mgr, "build_index", boom)
     col.start_background_build_index()
 
-    with pytest.raises(IndexBuildFailedError):
+    with pytest.raises(IndexUnavailableError):
         col.wait_until_queryable(timeout=5.0)
     assert col.is_queryable() is False
     col.close()
@@ -201,8 +218,10 @@ def test_start_background_build_index_one_shot_after_thread_start_failure(
     assert col._background_build_done.is_set()
     assert isinstance(col._background_build_error, RuntimeError)
 
-    # wait_until_queryable surfaces it as IndexBuildFailedError.
-    with pytest.raises(IndexBuildFailedError):
+    # wait_until_queryable surfaces this state via the never-scheduled
+    # guard (step 2): event set + _index_built=False → IndexUnavailableError.
+    # The captured error is diagnostic only, readable via get_index_status().
+    with pytest.raises(IndexUnavailableError):
         col.wait_until_queryable(timeout=0.1)
 
     # Retry is a no-op (one-shot semantics).

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -71,6 +71,19 @@ def test_is_queryable_false_after_captured_background_error(tmp_path: Path) -> N
     col.close()
 
 
+def test_is_queryable_true_with_captured_error_when_built(tmp_path: Path) -> None:
+    """Direct state poke: built index + done event + captured background
+    error → queryable. The captured error is diagnostic state about the
+    most recent build attempt, not a control-flow gate."""
+    vault = _vault(tmp_path)
+    _seed(vault)
+    col = Collection(source_dir=vault)
+    col.build_index()
+    col._background_build_error = RuntimeError("subsequent rebuild blew up")
+    assert col.is_queryable() is True
+    col.close()
+
+
 def test_wait_until_queryable_returns_when_already_built(tmp_path: Path) -> None:
     vault = _vault(tmp_path)
     _seed(vault)
@@ -260,12 +273,6 @@ def test_get_index_status_queryable_when_built_with_captured_error(
     assert status["documents_indexed"] == 1
     assert status["error"] is not None
     assert "subsequent rebuild blew up" in status["error"]
-    # is_queryable() and get_index_status()'s "queryable" branch disagree
-    # in this state: is_queryable still gates on _background_build_error
-    # being None, while get_index_status applies the priority flip and
-    # treats the captured error as diagnostic context. The asymmetry is
-    # intentional and documented in get_index_status's body comment.
-    assert col.is_queryable() is False
     col.close()
 
 


### PR DESCRIPTION
Closes #539.

Completes the "captured background-build error is diagnostic, not state" realignment that #538 started. Simplifies `Collection.is_queryable()` and `Collection.wait_until_queryable()`, re-aligns `get_index_status` to share the `is_queryable()` predicate, deletes `IndexBuildFailedError`, sweeps prose surfaces.

## Behavior change

In the (test-reachable-only) state `_index_built=True AND _background_build_error is not None AND event_set`, `is_queryable()` now returns `True` and `wait_until_queryable()` returns successfully. `get_index_status`'s "queryable" priority over "failed" (established by #538) is preserved.

Production paths that capture `_background_build_error` also reset `_index_built=False`, so this state is reachable only via direct state poking in tests.

## Commits

1. `refactor: simplify is_queryable() to two-field check` (a42c6af)
2. `refactor: simplify wait_until_queryable() to three-step contract` (34dd99f)
3. `refactor: re-align get_index_status to call is_queryable()` (8004b4a)
4. `refactor: delete IndexBuildFailedError exception class` (2ed1b26)
5. `docs: align IndexUnavailableError docstring with decorator three-trigger framing` (73ee7fa)
6. `docs: drop IndexBuildFailedError references from prose surfaces` (21e1cac)
7. `fix: broaden wait_until_queryable never-built error string` (4a9f473)
8. `docs: clarify get_index_status error field is independent of status` (8e716db)
9. `docs: tighten get_index_status error-field semantics` (b9a820c)

Commits 5, 7, 8, 9 are review-driven follow-ups (per-task spec/quality reviews + post-decomposition whole-PR review + preflight-circus round 2 finding).

## Test plan

- [x] `uv run pytest -x -q` — 1678 passed, 1 skipped
- [x] `uv run ruff check --fix . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/ tests/` — clean
- [x] `uv run diff-cover coverage.xml --compare-branch origin/main --fail-under=80` — 100% (2 lines / 0 missing)
- [x] `grep -rn "IndexBuildFailedError" src/ tests/ docs/design.md docs/tools/ docs/configuration.md docs/resources.md` — 0 matches
- [x] Preflight-circus: 5 core lenses + 5 supplementary lenses, dispatched blind, two full rounds, both clean at ≥80 calibration

Predecessor: #538 (PR #542, merge commit 514e6bc).
Successors: #540 (reason discriminator), #541 (OperationalError catch), then #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)