### PR TITLE
chore(deps): refresh uv.lock to address starlette PYSEC-2026-161

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2898,15 +2898,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #551.

## Summary

CI's `Dependency Audit` job has been failing on recent PRs (e.g. #550) due to a transitive-dependency CVE: `starlette 0.52.1 → PYSEC-2026-161` (fix in 1.0.1). `starlette` is pulled transitively via `fastmcp` → `sse-starlette` / FastAPI.

Bumps `starlette 0.52.1 → 1.2.0` via `uv sync --upgrade-package starlette`. Single-file diff in `uv.lock`; only `starlette` changes, no other transitive bumps.

## Test plan

- [x] `uv sync --all-extras` — succeeds
- [x] `uv run pytest -x -q` — 1678 passed, 1 skipped (same as main)
- [x] `uv run ruff check --fix . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/ tests/` — clean
- [x] Local `pip-audit` against the regenerated lockfile (with CI's existing `CVE-2026-25990` / `CVE-2026-4539` ignore flags) — `No known vulnerabilities found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)