### PR TITLE
feat!: add IndexUnavailableReason Literal + required reason field

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,8 +24,8 @@ All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP
 Default: `60` (seconds).
 
 Maximum time the MCP-layer `needs_queryable` decorator waits for
-the FTS index to become queryable before raising `IndexUnavailableError`
-to the client. Applied to bucket-3/4 tool and resource calls during
+the FTS index to become queryable before raising
+`IndexUnavailableError(reason="timeout")` to the client. Applied to bucket-3/4 tool and resource calls during
 a cold-start background FTS build. Increase for very large vaults
 where the initial scan takes longer; decrease for tighter feedback
 on stuck builds.

--- a/docs/design.md
+++ b/docs/design.md
@@ -381,7 +381,8 @@ populate the index. Callers must invoke `build_index()` explicitly
 before bucket-3 relational/FTS-backed queries (`get_backlinks`,
 `get_outlinks`, `get_similar`, `get_context`, `get_connection_path`,
 `get_toc`) or the bucket-4 coordinators (`reindex`,
-`build_embeddings`); otherwise `IndexUnavailableError` is raised.
+`build_embeddings`); otherwise `IndexUnavailableError(reason="never_built")`
+is raised.
 `start()` must also be called after `build_index()` because its git
 pull loop wires `reindex` as the `on_pull` callback. Bucket-1 file
 operations (`read`, `write`, `edit`, `delete`, `rename`,
@@ -392,8 +393,11 @@ unbuilt index — bucket-1 hits disk directly; bucket-2 queries
 whatever is currently in the index (empty on cold start).
 `wait_until_queryable(timeout=None)` is the readiness primitive: it
 blocks on the background-build completion event with a bounded
-timeout and raises `IndexUnavailableError` on timeout or when no
-build was ever scheduled.
+timeout and raises `IndexUnavailableError(reason="timeout")` on
+timeout or `IndexUnavailableError(reason="never_built")` when no
+build was ever scheduled (the latter also covers the case where a
+background build started and raised — see the errors-as-events
+section).
 
 **Cold-start background FTS (issue #513 PR1, tool-layer wait
 boundary)**: when the persisted FTS DB is cold (sentinel absent),
@@ -408,11 +412,12 @@ default (env `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`, default 60s).
 A failed background build surfaces to operators as
 `get_index_status` reporting
 `{"status": "failed", "error": "..."}`. MCP clients see
-`IndexUnavailableError` from the decorator's
-`wait_until_queryable` call (the never-scheduled guard fires
-because the worker resets `_index_built=False` before recording the
-error); the captured error message itself is read via
-`get_index_status`. Embeddings stay on the
+`IndexUnavailableError` with `reason="never_built"` (or
+`reason="timeout"` if the decorator's bounded wait elapsed first)
+from the decorator's `wait_until_queryable` call. The
+never-scheduled guard fires because the worker resets
+`_index_built=False` before recording the error; the captured
+error message itself is read via `get_index_status`. Embeddings stay on the
 synchronous lifespan path in PR1 — on cold start
 `build_embeddings()` is skipped with a log entry and semantic
 search returns empty until PR2 backgrounds embeddings or the

--- a/docs/design.md
+++ b/docs/design.md
@@ -395,9 +395,11 @@ whatever is currently in the index (empty on cold start).
 blocks on the background-build completion event with a bounded
 timeout and raises `IndexUnavailableError(reason="timeout")` on
 timeout or `IndexUnavailableError(reason="never_built")` when no
-build was ever scheduled (the latter also covers the case where a
-background build started and raised — see the errors-as-events
-section).
+build was ever scheduled. The `never_built` branch also fires when
+a background build started and then raised — the worker resets
+`_index_built=False` before the destructive rebuild, so a failed
+build leaves `_index_built=False` and `wait_until_queryable`'s
+never-scheduled guard catches it.
 
 **Cold-start background FTS (issue #513 PR1, tool-layer wait
 boundary)**: when the persisted FTS DB is cold (sentinel absent),

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -95,7 +95,7 @@ The empty string `""` represents the root folder (top-level documents).
 Table of contents (heading outline) for a specific document. This is a URI template — replace `{path}` with the document's relative path.
 
 !!! note "Cold-start blocking"
-    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexUnavailableError` if the background build did not complete successfully (the captured error message is available via `get_index_status`'s `error` field). Poll `get_index_status` to observe build state without blocking.
+    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexUnavailableError(reason="never_built")` if the background build did not complete successfully (the captured error message is available via `get_index_status`'s `error` field), or `IndexUnavailableError(reason="timeout")` if the decorator's bounded wait elapsed first. Poll `get_index_status` to observe build state without blocking.
 
 **Example:** `toc://vault/Journal/note.md`
 
@@ -118,7 +118,7 @@ The TOC prepends a synthetic H1 from the document title and deduplicates if the 
 Top 10 semantically similar notes for a document. Requires embeddings to be built. This is a URI template — replace `{path}` with the document's relative path.
 
 !!! note "Cold-start blocking"
-    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexUnavailableError` if the background build did not complete successfully (the captured error message is available via `get_index_status`'s `error` field). Poll `get_index_status` to observe build state without blocking.
+    Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexUnavailableError(reason="never_built")` if the background build did not complete successfully (the captured error message is available via `get_index_status`'s `error` field), or `IndexUnavailableError(reason="timeout")` if the decorator's bounded wait elapsed first. Poll `get_index_status` to observe build state without blocking.
 
 Results are **grouped per file** — each file appears at most once, with up to `chunks_per_file` (server default `2`) best-matching sections in a `sections` array. Each entry is a `GroupedResult` dict with `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -204,9 +204,10 @@ Check the embedding provider configuration and vector index status. Use this to 
 
 Returns background-build state of the FTS index. Use this when
 `initialize` returned but bucket-3/4 calls block longer than expected
-or surface `IndexUnavailableError` — the `status` field distinguishes
-"still building" from "build failed," and the `error` field carries
-the diagnostic message from the last failed background build attempt.
+or surface `IndexUnavailableError` (with `reason` of `"never_built"`
+or `"timeout"`) — the `status` field distinguishes "still building"
+from "build failed," and the `error` field carries the diagnostic
+message from the last failed background build attempt.
 
 **Returns:**
 - `status`: `"queryable"`, `"building"`, or `"failed"`.
@@ -222,7 +223,7 @@ the diagnostic message from the last failed background build attempt.
 ## Index Management
 
 !!! note "Cold-start blocking"
-    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError`. The same exception fires if the background build did not complete successfully — read `get_index_status`'s `error` field for the captured diagnostic. Poll `get_index_status` to observe build state without blocking.
+    Calls to `reindex` and `build_embeddings` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError(reason="timeout")`. The same exception fires with `reason="never_built"` if the background build did not complete successfully — read `get_index_status`'s `error` field for the captured diagnostic. Poll `get_index_status` to observe build state without blocking.
 
 ### `reindex`
 
@@ -609,7 +610,7 @@ managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` not set).
 ## Link Graph
 
 !!! note "Cold-start blocking"
-    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError`. The same exception fires if the background build did not complete successfully — read `get_index_status`'s `error` field for the captured diagnostic. Poll `get_index_status` to observe build state without blocking.
+    Calls to `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, and `get_connection_path` during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator. If the build takes longer than `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` (default 60s), the tool returns `IndexUnavailableError(reason="timeout")`. The same exception fires with `reason="never_built"` if the background build did not complete successfully — read `get_index_status`'s `error` field for the captured diagnostic. Poll `get_index_status` to observe build state without blocking.
 
 ### `get_backlinks`
 

--- a/src/markdown_vault_mcp/__init__.py
+++ b/src/markdown_vault_mcp/__init__.py
@@ -8,6 +8,8 @@ from markdown_vault_mcp.exceptions import (
     DocumentExistsError,
     DocumentNotFoundError,
     EditConflictError,
+    IndexUnavailableError,
+    IndexUnavailableReason,
     MarkdownMCPError,
     ReadOnlyError,
 )
@@ -65,6 +67,8 @@ __all__ = [
     "GroupedResult",
     "HistoryEntry",
     "IndexStats",
+    "IndexUnavailableError",
+    "IndexUnavailableReason",
     "LinkInfo",
     "MarkdownMCPError",
     "MostLinkedNote",

--- a/src/markdown_vault_mcp/_server_queryable.py
+++ b/src/markdown_vault_mcp/_server_queryable.py
@@ -54,11 +54,12 @@ def needs_queryable(
     already-wrapped function.
 
     Raises (propagated to MCP client via FastMCP error middleware):
-        IndexUnavailableError: timeout exceeded, or never scheduled,
-            or build did not complete successfully (a captured
-            background-build error surfaces here via the
-            never-scheduled guard; the error message itself is
-            available via get_index_status).
+        IndexUnavailableError: ``reason="timeout"`` when the bounded
+            wait elapsed, or ``reason="never_built"`` when no build
+            was ever scheduled or a background build did not complete
+            successfully (the never-scheduled guard fires for both
+            cold-collection and failed-rebuild cases; the captured
+            error message itself is available via get_index_status).
     """
 
     def deco(handler: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -434,7 +434,8 @@ class Collection:
         """Raise :exc:`IndexUnavailableError` if :meth:`build_index` has not run."""
         if not self._index_built:
             raise IndexUnavailableError(
-                "Index not built. Call build_index() before this method."
+                "Index not built. Call build_index() before this method.",
+                reason="never_built",
             )
 
     def is_queryable(self) -> bool:
@@ -614,19 +615,22 @@ class Collection:
 
         Raises:
             IndexUnavailableError: Either the timeout expired before
-                the build event was set, or the build did not complete
-                successfully (``_index_built`` remained False).
+                the build event was set (``reason="timeout"``), or the
+                build did not complete successfully and ``_index_built``
+                remained False (``reason="never_built"``).
         """
         if not self._background_build_done.wait(timeout=timeout):
             raise IndexUnavailableError(
-                f"Index build still in progress; timed out after {timeout}s."
+                f"Index build still in progress; timed out after {timeout}s.",
+                reason="timeout",
             )
         if not self._index_built:
             raise IndexUnavailableError(
                 "Index not built: background build was never scheduled "
                 "or did not complete successfully. "
                 "Check get_index_status() for diagnostic details, or call "
-                "build_index() / start_background_build_index() to retry."
+                "build_index() / start_background_build_index() to retry.",
+                reason="never_built",
             )
 
     @property

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -1,5 +1,7 @@
 """Exception types for markdown-vault-mcp."""
 
+from typing import Literal
+
 
 class MarkdownMCPError(Exception):
     """Base exception for all markdown-vault-mcp errors."""
@@ -66,18 +68,34 @@ class ConfigurationError(MarkdownMCPError):
     """Raised for invalid or unsupported configuration at startup."""
 
 
+IndexUnavailableReason = Literal["never_built", "timeout"]
+"""Discriminator for IndexUnavailableError's cause.
+
+- ``"never_built"`` — the index has not been built (cold collection, or
+  background build was scheduled but did not complete successfully).
+- ``"timeout"`` — caller waited via ``wait_until_queryable()`` and the
+  bounded timeout elapsed before the build event was set.
+"""
+
+
 class IndexUnavailableError(MarkdownMCPError):
     """Raised when the FTS index is not in a state to serve a query.
 
+    Attributes:
+        reason: One of ``"never_built"``, ``"timeout"`` — disambiguates
+            which of the operational situations below fired. See the
+            :data:`IndexUnavailableReason` Literal for definitions.
+
     Covers the following operational situations:
 
-    - **Never built.** The Collection has never had
-      ``build_index()`` complete (cold collection on a fresh process).
-    - **Build did not complete successfully.** A previous background
-      build raised and was not retried (``_index_built`` remained
-      False; the captured error is available via
-      :meth:`Collection.get_index_status`'s ``error`` field).
-    - **Timeout.** A caller waited via
+    - **Never built** (``reason="never_built"``). The Collection has
+      never had ``build_index()`` complete (cold collection on a fresh
+      process).
+    - **Build did not complete successfully** (``reason="never_built"``).
+      A previous background build raised and was not retried
+      (``_index_built`` remained False; the captured error is available
+      via :meth:`Collection.get_index_status`'s ``error`` field).
+    - **Timeout** (``reason="timeout"``). A caller waited via
       :meth:`Collection.wait_until_queryable` and the bounded timeout
       elapsed before the background build signaled completion.
 
@@ -85,3 +103,7 @@ class IndexUnavailableError(MarkdownMCPError):
     class: it is diagnostic state surfaced via
     :meth:`Collection.get_index_status`'s ``error`` field.
     """
+
+    def __init__(self, message: str, *, reason: IndexUnavailableReason) -> None:
+        super().__init__(message)
+        self.reason: IndexUnavailableReason = reason

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -96,8 +96,9 @@ def test_wait_until_queryable_raises_on_timeout(tmp_path: Path) -> None:
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_done.clear()
     col._index_built = False
-    with pytest.raises(IndexUnavailableError, match=r"timed out"):
+    with pytest.raises(IndexUnavailableError) as excinfo:
         col.wait_until_queryable(timeout=0.05)
+    assert excinfo.value.reason == "timeout"
     col.close()
 
 
@@ -110,8 +111,9 @@ def test_wait_until_queryable_raises_unavailable_when_error_set_and_not_built(
     read get_index_status() for the diagnostic."""
     col = Collection(source_dir=_vault(tmp_path))
     col._background_build_error = RuntimeError("scan exploded")
-    with pytest.raises(IndexUnavailableError, match=r"never scheduled|not built"):
+    with pytest.raises(IndexUnavailableError) as excinfo:
         col.wait_until_queryable(timeout=0.1)
+    assert excinfo.value.reason == "never_built"
     col.close()
 
 
@@ -121,8 +123,9 @@ def test_wait_until_queryable_raises_when_never_scheduled(tmp_path: Path) -> Non
     let wait() return success without the explicit guard."""
     col = Collection(source_dir=_vault(tmp_path))
     # All defaults: event pre-set, no error, _index_built=False, no spawn.
-    with pytest.raises(IndexUnavailableError, match=r"never scheduled|not built"):
+    with pytest.raises(IndexUnavailableError) as excinfo:
         col.wait_until_queryable(timeout=0.1)
+    assert excinfo.value.reason == "never_built"
     col.close()
 
 
@@ -163,8 +166,9 @@ def test_start_background_build_index_captures_error(
     monkeypatch.setattr(col._index_mgr, "build_index", boom)
     col.start_background_build_index()
 
-    with pytest.raises(IndexUnavailableError):
+    with pytest.raises(IndexUnavailableError) as excinfo:
         col.wait_until_queryable(timeout=5.0)
+    assert excinfo.value.reason == "never_built"
     assert col.is_queryable() is False
     col.close()
 
@@ -205,8 +209,9 @@ def test_start_background_build_index_one_shot_after_thread_start_failure(
     # wait_until_queryable surfaces this state via the never-scheduled
     # guard (step 2): event set + _index_built=False → IndexUnavailableError.
     # The captured error is diagnostic only, readable via get_index_status().
-    with pytest.raises(IndexUnavailableError):
+    with pytest.raises(IndexUnavailableError) as excinfo:
         col.wait_until_queryable(timeout=0.1)
+    assert excinfo.value.reason == "never_built"
 
     # Retry is a no-op (one-shot semantics).
     monkeypatch.undo()
@@ -748,8 +753,9 @@ def test_require_built_raises_immediately_not_blocks(tmp_path: Path) -> None:
         col.start_background_build_index()
 
         start = time_mod.perf_counter()
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_backlinks("n_0.md")  # bucket-3 library call
+        assert excinfo.value.reason == "never_built"
         elapsed = time_mod.perf_counter() - start
         assert elapsed < 0.1, (
             f"library method blocked for {elapsed:.3f}s; should raise immediately"
@@ -787,8 +793,9 @@ def test_git_pull_during_background_does_not_starve_writes(tmp_path: Path) -> No
 
         # Simulate the on_pull callback (reindex) racing the foreground
         # write. Both should fast-fail / proceed without lock starvation.
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.reindex()  # raises immediately, releases internal locks
+        assert excinfo.value.reason == "never_built"
 
         # Foreground write must complete promptly (within 1s, well
         # under the slow scan's 0.5s sleep).

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,57 @@
+"""Tests for markdown_vault_mcp.exceptions — constructor contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from markdown_vault_mcp.exceptions import (
+    IndexUnavailableError,
+    MarkdownMCPError,
+)
+
+
+class TestIndexUnavailableError:
+    def test_constructs_with_never_built_reason(self) -> None:
+        err = IndexUnavailableError("not built", reason="never_built")
+        assert err.reason == "never_built"
+        assert str(err) == "not built"
+        assert isinstance(err, MarkdownMCPError)
+
+    def test_constructs_with_timeout_reason(self) -> None:
+        err = IndexUnavailableError("timed out", reason="timeout")
+        assert err.reason == "timeout"
+        assert str(err) == "timed out"
+
+    def test_reason_is_keyword_only(self) -> None:
+        """Positional second arg must fail — reason must be passed by keyword."""
+        with pytest.raises(TypeError):
+            IndexUnavailableError("msg", "timeout")  # type: ignore[misc]
+
+    def test_reason_is_required(self) -> None:
+        """No default — must pass reason explicitly."""
+        with pytest.raises(TypeError):
+            IndexUnavailableError("msg")  # type: ignore[call-arg]
+
+    def test_message_is_required(self) -> None:
+        """Message remains the first positional argument."""
+        with pytest.raises(TypeError):
+            IndexUnavailableError(reason="never_built")  # type: ignore[call-arg]
+
+    def test_reason_attribute_survives_raise_catch(self) -> None:
+        """The attribute is preserved through the raise/catch cycle."""
+        try:
+            raise IndexUnavailableError("oops", reason="timeout")
+        except IndexUnavailableError as e:
+            assert e.reason == "timeout"
+
+
+def test_index_unavailable_reason_literal_values() -> None:
+    """The Literal type carries the two expected discriminator values.
+
+    Validates by attempting to construct with each. Direct introspection of
+    typing.Literal at runtime is implementation-dependent; the constructor
+    round-trip is the contract that matters.
+    """
+    for value in ("never_built", "timeout"):
+        err = IndexUnavailableError("x", reason=value)  # type: ignore[arg-type]
+        assert err.reason == value

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -160,16 +160,18 @@ class TestBucket3Block:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_backlinks("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_outlinks_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_outlinks("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_similar_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
@@ -180,16 +182,18 @@ class TestBucket3Block:
             embeddings_path=tmp_path / "vectors",
         )
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_similar("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_context_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_context("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_connection_path_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
@@ -197,8 +201,9 @@ class TestBucket3Block:
         _seed(vault, "b.md")
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_connection_path("a.md", "b.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_get_toc_on_unbuilt_raises(self, tmp_path: Path) -> None:
         """get_toc reads from FTS so cold-start must raise readiness, not a
@@ -208,8 +213,9 @@ class TestBucket3Block:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_toc("note.md")
+        assert excinfo.value.reason == "never_built"
 
 
 # ---------------------------------------------------------------------------
@@ -224,8 +230,9 @@ class TestBucket4Coordinate:
         _seed(vault)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.reindex()
+        assert excinfo.value.reason == "never_built"
 
     def test_build_embeddings_on_unbuilt_raises(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
@@ -236,8 +243,9 @@ class TestBucket4Coordinate:
             embeddings_path=tmp_path / "vectors",
         )
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.build_embeddings()
+        assert excinfo.value.reason == "never_built"
 
     def test_build_index_short_circuits_on_warm_restart(self, tmp_path: Path) -> None:
         """A second Collection on the same persistent FTS DB short-circuits.
@@ -276,8 +284,9 @@ class TestWaitUntilQueryable:
         vault = _vault(tmp_path)
         col = Collection(source_dir=vault)
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.wait_until_queryable(timeout=0.1)
+        assert excinfo.value.reason == "never_built"
 
     def test_after_build_returns(self, tmp_path: Path) -> None:
         vault = _vault(tmp_path)
@@ -375,8 +384,9 @@ class TestReadinessFlagSemantics:
         with pytest.raises(RuntimeError):
             col.build_index(force=True)
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_backlinks("note.md")
+        assert excinfo.value.reason == "never_built"
 
     def test_failed_build_index_leaves_unready(self, tmp_path: Path) -> None:
         """If build_index() raises, subsequent bucket-3 calls still raise."""
@@ -393,5 +403,6 @@ class TestReadinessFlagSemantics:
         with pytest.raises(RuntimeError):
             col.build_index()
 
-        with pytest.raises(IndexUnavailableError):
+        with pytest.raises(IndexUnavailableError) as excinfo:
             col.get_backlinks("note.md")
+        assert excinfo.value.reason == "never_built"


### PR DESCRIPTION
Closes #540.

Adds `IndexUnavailableReason = Literal["never_built", "timeout"]` and a required keyword-only `reason: IndexUnavailableReason` field on `IndexUnavailableError`. Sweeps three raise sites in `collection.py` to pass `reason=` explicitly. Updates 18 raise-catch test sites to assert on `.reason` (and migrates three `match=r"..."` regexes to `.reason` for tighter typed contract). Adds `tests/test_exceptions.py` for the constructor contract. Documents the discriminator inline at every existing `IndexUnavailableError` mention across 4 user-facing doc surfaces and the decorator docstring.

## Breaking change

For library consumers that construct `IndexUnavailableError` directly: `reason=` is now a required keyword-only argument. In-tree raise sites are all updated; the rewritten class docstring + new `Attributes:` section + per-bullet `reason="..."` parentheticals enumerate the current two discriminator values.

## Commits

1. `feat!: add IndexUnavailableReason Literal + reason field on IndexUnavailableError` (5f64156)
2. `test: assert .reason at every raise-catch site for IndexUnavailableError` (1722a64)
3. `docs: document reason discriminator in IndexUnavailableError surfaces` (4a4fc14)
4. `docs: drop dangling errors-as-events pointer from design.md` (ca17b5a — preflight follow-up)
5. `docs: name reason discriminator in needs_queryable decorator docstring` (0bae999 — whole-PR review follow-up)

## Test plan

- [x] `uv run pytest -x -q` — 1685 passed, 1 skipped
- [x] `uv run ruff check --fix . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/ tests/` — clean
- [x] `uv run diff-cover coverage.xml --compare-branch origin/main --fail-under=80` — 100% (6 lines / 0 missing)
- [x] `grep -nE 'raise IndexUnavailableError\b' src/ -r | grep -v 'reason='` — 0 matches
- [x] `grep -nE 'pytest.raises\(IndexUnavailableError, match' tests/` — 0 matches
- [x] `grep -rn '"broken"\|#541' src/ tests/ docs/design.md docs/configuration.md docs/tools/ docs/resources.md` — 0 matches (no forward references in shipped artifacts)
- [x] Preflight-circus: 5 core lenses + 5 supplementary lenses, clean at ≥80 calibration

🤖 Generated with [Claude Code](https://claude.com/claude-code)