### PR TITLE
feat: capture async writer-job failures into get_index_status

### DIFF
--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1243,8 +1243,14 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Returns:
             Dict with ``status: "queued"``. The reindex runs asynchronously on
-            the writer thread; poll ``get_server_info`` or ``get_index_status``
-            for completion.
+            the writer thread. Poll ``get_index_status`` for completion:
+
+            - ``status == "queryable"`` AND ``queue_depth == 0`` AND
+              ``in_flight is None`` → reindex completed.
+            - ``last_reindex_error`` not ``None`` → the most recent async
+              reindex failed on the writer thread; the value is the
+              stringified exception.  Operators can re-run ``reindex`` to
+              retry; a subsequent successful run clears the field.
         """
         collection.reindex_async()
         return {"status": "queued"}
@@ -1276,8 +1282,15 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
 
         Returns:
             Dict with ``status: "queued"``. The build runs asynchronously on
-            the writer thread; poll ``get_server_info`` or
-            ``get_index_status`` for completion.
+            the writer thread. Poll ``get_index_status`` for completion:
+
+            - ``status == "queryable"`` AND ``queue_depth == 0`` AND
+              ``in_flight is None`` → build completed.
+            - ``last_build_embeddings_error`` not ``None`` → the most
+              recent async build failed on the writer thread; the value is
+              the stringified exception.  Operators can re-run
+              ``build_embeddings`` to retry; a subsequent successful run
+              clears the field.
         """
         collection.build_embeddings_async(force=force)
         return {"status": "queued"}

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -624,7 +624,7 @@ class Collection:
     def get_index_status(self) -> dict[str, Any]:
         """Return a non-blocking snapshot of background-build state.
 
-        Returns a dict with ten keys:
+        Returns a dict with nine keys:
 
         - ``status`` (``"queryable"`` | ``"building"`` | ``"failed"``):
           overall state of the FTS index build.
@@ -660,9 +660,9 @@ class Collection:
         - ``queue_depth`` (int): number of jobs awaiting the writer.
         - ``in_flight`` (str | None): the currently running job's name,
           or ``None`` if idle.
-        - ``dirty_paths`` (list[str]): paths queued for reindex.
-        - ``dirty_embeddings`` (bool): True if an embedding build is
-          queued.
+        - ``dirty_paths`` (int): count of paths queued for FTS reindex.
+        - ``dirty_embeddings`` (int): count of paths queued for vector
+          re-embedding.
         """
         if self.is_queryable():
             status = "queryable"

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -274,6 +274,14 @@ class Collection:
         self._background_build_error: BaseException | None = None
         self._background_started: bool = False
 
+        # Per-async-variant error capture (#561). Each async variant of a
+        # writer-routed operation attaches a done-callback that records the
+        # most recent failure. Surfaced via get_index_status() so MCP
+        # clients can detect that a "queued" reindex / build_embeddings
+        # actually failed on the writer thread.
+        self._last_reindex_error: BaseException | None = None
+        self._last_build_embeddings_error: BaseException | None = None
+
         # Lock for file-mutation atomicity only (#559). The IndexWriter
         # thread is the serialization point for index mutations; this lock
         # serialises ONLY the read-modify-write of files in DocumentManager
@@ -616,26 +624,45 @@ class Collection:
     def get_index_status(self) -> dict[str, Any]:
         """Return a non-blocking snapshot of background-build state.
 
-        Shape: ``{"status": "queryable" | "building" | "failed",
-        "documents_indexed": int, "error": str | None}`` merged with
-        :meth:`IndexWriter.get_status` (``queue_depth``, ``in_flight``,
-        ``dirty_paths``, ``dirty_embeddings``).
+        Returns a dict with ten keys:
 
-        - ``"queryable"``: ``_index_built`` is True and the build event is
-          set — a completed build exists; captures an error as diagnostic
-          context in ``error`` but does not demote the status.
-        - ``"failed"``: precondition does not hold AND the build event is
-          set AND ``_background_build_error`` is non-None; ``error`` carries
-          its message.
-        - ``"building"``: anything else — event cleared (writer in flight)
-          OR event set but ``_index_built`` is False (never scheduled).
+        - ``status`` (``"queryable"`` | ``"building"`` | ``"failed"``):
+          overall state of the FTS index build.
 
-        ``documents_indexed`` is taken from :meth:`FTSIndex.list_notes` and
-        so reflects whatever rows are currently committed — progress is
-        observable in the ``"building"`` state as the count rises.
+          - ``"queryable"``: ``_index_built`` is True and the build event is
+            set — a completed build exists; captures an error as diagnostic
+            context in ``error`` but does not demote the status.
+          - ``"failed"``: precondition does not hold AND the build event is
+            set AND ``_background_build_error`` is non-None; ``error``
+            carries its message.
+          - ``"building"``: anything else — event cleared (writer in flight)
+            OR event set but ``_index_built`` is False (never scheduled).
 
-        ``error`` carries the diagnostic message from the last background
-        build attempt that captured an exception, independent of ``status``.
+        - ``documents_indexed`` (int): row count from
+          :meth:`FTSIndex.list_notes`, reflecting whatever rows are
+          currently committed.  Progress is observable in the
+          ``"building"`` state as the count rises.
+        - ``error`` (str | None): diagnostic message from the last
+          background ``build_index`` attempt that captured an exception,
+          independent of ``status``.
+        - ``last_reindex_error`` (str | None): diagnostic message from the
+          most recent async :meth:`reindex_async` invocation that failed
+          on the writer thread, captured via :meth:`_on_reindex_done`
+          (#561).  Cleared by a subsequent successful async reindex.
+        - ``last_build_embeddings_error`` (str | None): diagnostic message
+          from the most recent async :meth:`build_embeddings_async`
+          invocation that failed on the writer thread, captured via
+          :meth:`_on_build_embeddings_done` (#561).  Cleared by a
+          subsequent successful async build_embeddings.
+
+        Merged with :meth:`IndexWriter.get_status`, which adds four keys:
+
+        - ``queue_depth`` (int): number of jobs awaiting the writer.
+        - ``in_flight`` (str | None): the currently running job's name,
+          or ``None`` if idle.
+        - ``dirty_paths`` (list[str]): paths queued for reindex.
+        - ``dirty_embeddings`` (bool): True if an embedding build is
+          queued.
         """
         if self.is_queryable():
             status = "queryable"
@@ -665,6 +692,16 @@ class Collection:
             "status": status,
             "documents_indexed": documents_indexed,
             "error": error,
+            "last_reindex_error": (
+                str(self._last_reindex_error)
+                if self._last_reindex_error is not None
+                else None
+            ),
+            "last_build_embeddings_error": (
+                str(self._last_build_embeddings_error)
+                if self._last_build_embeddings_error is not None
+                else None
+            ),
         }
         result.update(self._writer.get_status())
         return result
@@ -1014,6 +1051,36 @@ class Collection:
         future.add_done_callback(_on_done)
         return future
 
+    def _on_reindex_done(self, fut: Future[ReindexResult]) -> None:
+        """Capture async reindex job outcome for visibility via get_index_status.
+
+        Records the exception into ``_last_reindex_error`` on failure;
+        clears it on success.  Mirrors the done-callback pattern used by
+        :meth:`build_index_async` so writer-thread failures are
+        observable to MCP clients (#561).
+        """
+        try:
+            fut.result()
+            self._last_reindex_error = None
+        except BaseException as exc:
+            self._last_reindex_error = exc
+            logger.exception("Async reindex job failed")
+
+    def _on_build_embeddings_done(self, fut: Future[int]) -> None:
+        """Capture async build_embeddings job outcome for visibility via get_index_status.
+
+        Records the exception into ``_last_build_embeddings_error`` on
+        failure; clears it on success.  Mirrors the done-callback pattern
+        used by :meth:`build_index_async` so writer-thread failures are
+        observable to MCP clients (#561).
+        """
+        try:
+            fut.result()
+            self._last_build_embeddings_error = None
+        except BaseException as exc:
+            self._last_build_embeddings_error = exc
+            logger.exception("Async build_embeddings job failed")
+
     def reindex_async(self) -> Future[ReindexResult]:
         """Submit an incremental FTS reindex and return the Future.
 
@@ -1025,8 +1092,17 @@ class Collection:
         :meth:`build_index_async`) runs before this :class:`ReindexAll`,
         so the writer thread sees a built index when it dequeues the
         job.
+
+        Attaches :meth:`_on_reindex_done` as a done-callback so any
+        writer-thread failure is captured into
+        ``_last_reindex_error`` and surfaced through
+        :meth:`get_index_status` (#561).  This lets MCP clients that
+        fired-and-forgot the returned Future still detect async
+        failures.
         """
-        return self._writer.submit(ReindexAll())
+        fut = self._writer.submit(ReindexAll())
+        fut.add_done_callback(self._on_reindex_done)
+        return fut
 
     def build_embeddings_async(self, *, force: bool = False) -> Future[int]:
         """Submit a vector index build and return the Future.
@@ -1039,8 +1115,17 @@ class Collection:
         :meth:`build_index_async`) runs before this
         :class:`BuildEmbeddings`, so the writer thread sees a built
         index when it dequeues the job.
+
+        Attaches :meth:`_on_build_embeddings_done` as a done-callback
+        so any writer-thread failure is captured into
+        ``_last_build_embeddings_error`` and surfaced through
+        :meth:`get_index_status` (#561).  This lets MCP clients that
+        fired-and-forgot the returned Future still detect async
+        failures.
         """
-        return self._writer.submit(BuildEmbeddings(force=force))
+        fut = self._writer.submit(BuildEmbeddings(force=force))
+        fut.add_done_callback(self._on_build_embeddings_done)
+        return fut
 
     def embeddings_status(self) -> dict:
         """Return status information about the vector index.

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4073,3 +4073,109 @@ def test_collection_build_embeddings_async_returns_future(tmp_path):
         future.result(timeout=10)
     finally:
         col.close()
+
+
+def test_reindex_async_failure_recorded_in_status(tmp_path, monkeypatch):
+    """If the writer-thread reindex job raises, the exception is captured
+    into get_index_status['last_reindex_error'] (#561)."""
+    import time
+
+    from markdown_vault_mcp.collection import Collection
+    from markdown_vault_mcp.managers import index as index_module
+
+    col = Collection(source_dir=tmp_path, read_only=False)
+    try:
+        col.build_index()
+
+        # Patch IndexManager.reindex to raise so we can verify capture.
+        def boom(self):  # noqa: ARG001
+            raise RuntimeError("simulated reindex failure")
+
+        monkeypatch.setattr(index_module.IndexManager, "reindex", boom)
+
+        fut = col.reindex_async()
+        # Future will resolve with the exception.
+        with pytest.raises(RuntimeError, match="simulated reindex failure"):
+            fut.result(timeout=5)
+
+        # Wait for the done-callback to run.  The callback ordering
+        # relative to .result() can race — give it a tick.
+        for _ in range(50):
+            if col._last_reindex_error is not None:
+                break
+            time.sleep(0.01)
+
+        assert col._last_reindex_error is not None
+        assert "simulated reindex failure" in str(col._last_reindex_error)
+
+        status = col.get_index_status()
+        assert "last_reindex_error" in status
+        assert status["last_reindex_error"] is not None
+        assert "simulated reindex failure" in status["last_reindex_error"]
+    finally:
+        col.close()
+
+
+def test_reindex_async_success_clears_prior_error(tmp_path):
+    """A successful async reindex clears any prior captured error (#561)."""
+    import time
+
+    from markdown_vault_mcp.collection import Collection
+
+    col = Collection(source_dir=tmp_path, read_only=False)
+    try:
+        col.build_index()
+        # Seed a prior error.
+        col._last_reindex_error = RuntimeError("prior")
+
+        fut = col.reindex_async()
+        fut.result(timeout=5)
+
+        for _ in range(50):
+            if col._last_reindex_error is None:
+                break
+            time.sleep(0.01)
+        assert col._last_reindex_error is None
+        assert col.get_index_status()["last_reindex_error"] is None
+    finally:
+        col.close()
+
+
+def test_build_embeddings_async_failure_recorded_in_status(tmp_path, monkeypatch):
+    """If the writer-thread build_embeddings job raises, the exception is
+    captured into get_index_status['last_build_embeddings_error'] (#561)."""
+    import time
+
+    from markdown_vault_mcp.collection import Collection
+    from markdown_vault_mcp.managers import index as index_module
+    from tests.conftest import MockEmbeddingProvider
+
+    col = Collection(
+        source_dir=tmp_path,
+        read_only=False,
+        embeddings_path=tmp_path / "vec",
+        embedding_provider=MockEmbeddingProvider(),
+    )
+    try:
+        col.build_index()
+
+        def boom(self, *, force=False):  # noqa: ARG001
+            raise RuntimeError("simulated embeddings failure")
+
+        monkeypatch.setattr(index_module.IndexManager, "build_embeddings", boom)
+
+        fut = col.build_embeddings_async()
+        with pytest.raises(RuntimeError, match="simulated embeddings failure"):
+            fut.result(timeout=5)
+
+        for _ in range(50):
+            if col._last_build_embeddings_error is not None:
+                break
+            time.sleep(0.01)
+
+        assert col._last_build_embeddings_error is not None
+        status = col.get_index_status()
+        assert status["last_build_embeddings_error"] is not None
+        assert "simulated embeddings failure" in status["last_build_embeddings_error"]
+    finally:
+        col.close()


### PR DESCRIPTION
## Summary

Closes #561. Stacked on top of #562.

`reindex_async()` and `build_embeddings_async()` previously returned the writer's Future without an `add_done_callback`. The MCP tool handlers called them and discarded the Future, so writer-thread job failures (sqlite3.OperationalError, embedding-provider failures, etc.) were captured in the orphaned Future, logged once on the writer thread, and never surfaced to MCP clients.

## Fix

Mirror the `build_index_async` pattern: attach `_on_reindex_done` and `_on_build_embeddings_done` callbacks that capture exceptions into `_last_reindex_error` / `_last_build_embeddings_error` on `Collection`. Expose via `get_index_status()` as stringified messages. Update MCP tool docstrings to point clients at the new fields.

## Why stacked on #562

Both async variants and `get_index_status` exist in #562. This fix builds directly on that surface; once #562 merges, this PR auto-rebases to main.

## Test plan

- New tests in `tests/test_collection.py`:
  - `test_reindex_async_failure_recorded_in_status` — patches `IndexManager.reindex` to raise; verifies the exception is captured.
  - `test_reindex_async_success_clears_prior_error` — verifies success clears any prior captured error.
  - `test_build_embeddings_async_failure_recorded_in_status` — same for build_embeddings.
- Full suite green, lint/format/mypy clean.

Generated with [Claude Code](https://claude.com/claude-code)