### PR TITLE
feat(git): use OIDC claim values as git commit identity per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Backward compatibility: `MARKDOWN_VAULT_MCP_GIT_TOKEN` without `GIT_REPO_URL` st
 | `MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S` | `30` | Seconds of write-idle time before pushing; `0` = push only on shutdown |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME` | `markdown-vault-mcp` | Git committer name for auto-commits; **set this in Docker** where `git config user.name` is empty |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL` | `noreply@markdown-vault-mcp` | Git committer email for auto-commits |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` | — | OIDC claim key to use as the commit author name (e.g. `name`); overrides `GIT_COMMIT_NAME` per-request when an OIDC token is present |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM` | — | OIDC claim key to use as the commit author e-mail (e.g. `email`); overrides `GIT_COMMIT_EMAIL` per-request when an OIDC token is present |
 | `MARKDOWN_VAULT_MCP_GIT_LFS` | `true` | Enable Git LFS — runs `git lfs pull` on startup to fetch LFS-tracked attachments (PDFs, images). Set to `false` for repos without LFS. |
 
 ### Attachments

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,8 @@ Backward compatibility: `GIT_TOKEN` without `GIT_REPO_URL` still works (legacy b
 | `MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S`` | float | `30` | Seconds of write-idle time before pushing; `0` = push only on shutdown |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME` | string | `markdown-vault-mcp` | Git committer name for auto-commits; **set this in Docker** where `git config user.name` is empty |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL` | string | `noreply@markdown-vault-mcp` | Git committer email for auto-commits |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` | string | — | OIDC claim key to use as the commit author name when a token is present (e.g. `name`); falls back to `GIT_COMMIT_NAME` when absent |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM` | string | — | OIDC claim key to use as the commit author e-mail when a token is present (e.g. `email`); falls back to `GIT_COMMIT_EMAIL` when absent |
 | `MARKDOWN_VAULT_MCP_GIT_LFS` | bool | `true` | Run `git lfs pull` on startup to resolve LFS pointers; set to `false` if git-lfs is not installed |
 
 !!! tip "Push delay"

--- a/examples/obsidian-readwrite.env
+++ b/examples/obsidian-readwrite.env
@@ -19,6 +19,9 @@ MARKDOWN_VAULT_MCP_GIT_TOKEN=ghp_your_token_here
 # Required in Docker where git config user.name is unset:
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
+# OIDC per-user attribution (set to the claim key, e.g. "name" / "email"):
+# MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=name
+# MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=email
 
 # Attachments: default list allows common document and image formats.
 # Uncomment to restrict to specific extensions, or use * for all non-.md files.

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -92,6 +92,14 @@ class CollectionConfig:
             ``"markdown-vault-mcp"``).
         git_commit_email: Git committer e-mail for auto-commits (default
             ``"noreply@markdown-vault-mcp"``).
+        git_commit_name_claim: OIDC claim key to use as the commit author name
+            (e.g. ``"name"``).  When set and the current request carries an
+            OIDC access token with this claim, the claim value overrides
+            *git_commit_name* for that commit.  ``None`` (default) disables
+            the override.
+        git_commit_email_claim: OIDC claim key to use as the commit author
+            e-mail (e.g. ``"email"``).  Same override semantics as
+            *git_commit_name_claim*.  ``None`` (default) disables the override.
         git_lfs: When ``True`` (default), run ``git lfs pull`` during git
             strategy initialisation so LFS pointers are resolved before reads.
         git_pull_interval_s: Interval in seconds for periodic git fetch +
@@ -180,6 +188,8 @@ class CollectionConfig:
     git_push_delay_s: float = 30.0
     git_commit_name: str = "markdown-vault-mcp"
     git_commit_email: str = "noreply@markdown-vault-mcp"
+    git_commit_name_claim: str | None = None
+    git_commit_email_claim: str | None = None
     git_lfs: bool = True
     git_pull_interval_s: int = 600
     attachment_extensions: list[str] | None = None
@@ -296,6 +306,8 @@ class CollectionConfig:
                 push_delay_s=self.git_push_delay_s,
                 commit_name=self.git_commit_name,
                 commit_email=self.git_commit_email,
+                commit_name_claim=self.git_commit_name_claim,
+                commit_email_claim=self.git_commit_email_claim,
                 git_lfs=self.git_lfs,
                 repo_path=self.source_dir,
             )
@@ -316,6 +328,8 @@ class CollectionConfig:
                 push_delay_s=self.git_push_delay_s,
                 commit_name=self.git_commit_name,
                 commit_email=self.git_commit_email,
+                commit_name_claim=self.git_commit_name_claim,
+                commit_email_claim=self.git_commit_email_claim,
                 git_lfs=self.git_lfs,
                 repo_path=self.source_dir,
             )
@@ -334,6 +348,8 @@ class CollectionConfig:
             push_delay_s=self.git_push_delay_s,
             commit_name=self.git_commit_name,
             commit_email=self.git_commit_email,
+            commit_name_claim=self.git_commit_name_claim,
+            commit_email_claim=self.git_commit_email_claim,
             git_lfs=self.git_lfs,
             repo_path=self.source_dir,
         )
@@ -377,6 +393,12 @@ def load_config() -> CollectionConfig:
       auto-commits; default ``markdown-vault-mcp``.
     - ``MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL``: git committer email for
       auto-commits; default ``noreply@markdown-vault-mcp``.
+    - ``MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM``: OIDC claim key whose value
+      overrides the commit author name when an OIDC access token is present
+      (e.g. ``name``).  Unset by default (static name used for all commits).
+    - ``MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM``: OIDC claim key whose value
+      overrides the commit author e-mail when an OIDC access token is present
+      (e.g. ``email``).  Unset by default.
     - ``MARKDOWN_VAULT_MCP_GIT_LFS``: run ``git lfs pull`` during git strategy
       init to resolve LFS pointers; default ``true``.
     - ``MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S``: seconds between periodic
@@ -529,6 +551,14 @@ def load_config() -> CollectionConfig:
     raw_commit_email = (_env("GIT_COMMIT_EMAIL") or "").strip()
     git_commit_email: str = raw_commit_email or "noreply@markdown-vault-mcp"
     logger.debug("load_config: git_commit_email=%s", git_commit_email)
+
+    raw_commit_name_claim = (_env("GIT_COMMIT_NAME_CLAIM") or "").strip()
+    git_commit_name_claim: str | None = raw_commit_name_claim or None
+    logger.debug("load_config: git_commit_name_claim=%s", git_commit_name_claim)
+
+    raw_commit_email_claim = (_env("GIT_COMMIT_EMAIL_CLAIM") or "").strip()
+    git_commit_email_claim: str | None = raw_commit_email_claim or None
+    logger.debug("load_config: git_commit_email_claim=%s", git_commit_email_claim)
 
     raw_push_delay = (_env("GIT_PUSH_DELAY_S") or "").strip()
     if raw_push_delay:
@@ -836,6 +866,8 @@ def load_config() -> CollectionConfig:
         git_push_delay_s=git_push_delay_s,
         git_commit_name=git_commit_name,
         git_commit_email=git_commit_email,
+        git_commit_name_claim=git_commit_name_claim,
+        git_commit_email_claim=git_commit_email_claim,
         git_lfs=git_lfs,
         git_pull_interval_s=git_pull_interval_s,
         attachment_extensions=attachment_extensions,

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -24,6 +24,8 @@ import frontmatter
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+from fastmcp.server.dependencies import get_access_token as _get_access_token
+
 from markdown_vault_mcp.exceptions import ConfigurationError
 from markdown_vault_mcp.types import CommitDiff, HistoryEntry
 
@@ -259,6 +261,25 @@ class PushResult:
     hint: str | None = None
 
 
+def _extract_claim(claim_key: str | None) -> str | None:
+    """Return the string value of an OIDC claim from the current request token.
+
+    Returns ``None`` when *claim_key* is ``None``, no access token is present,
+    the key is absent from the token's claims, or the value is not a non-empty
+    string.
+    """
+    if claim_key is None:
+        return None
+    token = _get_access_token()
+    if token is None:
+        return None
+    claims = getattr(token, "claims", None)
+    if not isinstance(claims, dict):
+        return None
+    value = claims.get(claim_key)
+    return value if isinstance(value, str) and value else None
+
+
 class GitWriteStrategy:
     """Stateful git strategy: commit per write, deferred push.
 
@@ -324,6 +345,8 @@ class GitWriteStrategy:
         push_delay_s: float = 30.0,
         commit_name: str | None = None,
         commit_email: str | None = None,
+        commit_name_claim: str | None = None,
+        commit_email_claim: str | None = None,
         git_lfs: bool = True,
         repo_path: Path | None = None,
     ) -> None:
@@ -338,6 +361,8 @@ class GitWriteStrategy:
         self._push_delay_s = push_delay_s
         self._commit_name = commit_name or self.DEFAULT_COMMIT_NAME
         self._commit_email = commit_email or self.DEFAULT_COMMIT_EMAIL
+        self._commit_name_claim = commit_name_claim
+        self._commit_email_claim = commit_email_claim
         self._git_lfs = git_lfs
         # Retain the configured repo_path so methods invoked after construction
         # (e.g. force_pull / force_push) can reach the working tree without
@@ -571,13 +596,19 @@ class GitWriteStrategy:
             return
 
         try:
+            effective_name = (
+                _extract_claim(self._commit_name_claim) or self._commit_name
+            )
+            effective_email = (
+                _extract_claim(self._commit_email_claim) or self._commit_email
+            )
             with self._lock:
                 _stage_and_commit(
                     self._git_root,
                     path,
                     operation,
-                    commit_name=self._commit_name,
-                    commit_email=self._commit_email,
+                    commit_name=effective_name,
+                    commit_email=effective_email,
                 )
             if self._enable_push:
                 self._schedule_push()

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -602,6 +602,15 @@ class GitWriteStrategy:
             effective_email = (
                 _extract_claim(self._commit_email_claim) or self._commit_email
             )
+            logger.debug(
+                "git_identity_resolved name=%s email=%s name_from_claim=%s email_from_claim=%s",
+                effective_name,
+                effective_email,
+                self._commit_name_claim is not None
+                and effective_name != self._commit_name,
+                self._commit_email_claim is not None
+                and effective_email != self._commit_email,
+            )
             with self._lock:
                 _stage_and_commit(
                     self._git_root,
@@ -1185,6 +1194,9 @@ class GitWriteStrategy:
 
         n = len(written)
         file_list = ", ".join(written)
+        # Conflict resolution runs on the pull background thread, not inside a
+        # request context, so _extract_claim would return None.  Use the static
+        # server identity directly — per-user attribution does not apply here.
         commit_result = subprocess.run(
             [
                 "git",

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3222,3 +3222,275 @@ class TestCollectionGitHistoryMethods:
         out = col.get_diff("note.md", since_sha=oldest, per_commit=True, limit=500)
         assert isinstance(out, list)
         assert len(out) == 2
+
+
+class TestExtractClaim:
+    """Unit tests for _extract_claim — reads a named claim from the current access token."""
+
+    def test_returns_claim_value_when_token_has_claim(self) -> None:
+        """Returns the string claim value when the token carries it."""
+        from unittest.mock import MagicMock, patch
+
+        from markdown_vault_mcp.git import _extract_claim
+
+        token = MagicMock()
+        token.claims = {"name": "Alice"}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            assert _extract_claim("name") == "Alice"
+
+    def test_returns_none_when_no_token(self) -> None:
+        """Returns None when get_access_token() returns None (no-auth / local mode)."""
+        from unittest.mock import patch
+
+        from markdown_vault_mcp.git import _extract_claim
+
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=None):
+            assert _extract_claim("name") is None
+
+    def test_returns_none_when_claim_absent(self) -> None:
+        """Returns None when the named claim is not in the token."""
+        from unittest.mock import MagicMock, patch
+
+        from markdown_vault_mcp.git import _extract_claim
+
+        token = MagicMock()
+        token.claims = {"sub": "user123"}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            assert _extract_claim("name") is None
+
+    def test_returns_none_when_claim_is_empty_string(self) -> None:
+        """Returns None when the claim value is an empty string."""
+        from unittest.mock import MagicMock, patch
+
+        from markdown_vault_mcp.git import _extract_claim
+
+        token = MagicMock()
+        token.claims = {"name": ""}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            assert _extract_claim("name") is None
+
+    def test_returns_none_when_claim_is_not_string(self) -> None:
+        """Returns None when the claim value is not a string (e.g. boolean, int)."""
+        from unittest.mock import MagicMock, patch
+
+        from markdown_vault_mcp.git import _extract_claim
+
+        token = MagicMock()
+        token.claims = {"email_verified": True}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            assert _extract_claim("email_verified") is None
+
+    def test_returns_none_when_claims_is_not_dict(self) -> None:
+        """Returns None when token.claims is not a dict."""
+        from unittest.mock import MagicMock, patch
+
+        from markdown_vault_mcp.git import _extract_claim
+
+        token = MagicMock()
+        token.claims = None
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            assert _extract_claim("name") is None
+
+    def test_returns_none_when_claim_key_is_none(self) -> None:
+        """Returns None immediately when claim_key is None (claim not configured)."""
+        from unittest.mock import MagicMock, patch
+
+        from markdown_vault_mcp.git import _extract_claim
+
+        token = MagicMock()
+        token.claims = {"name": "Alice"}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            assert _extract_claim(None) is None
+
+
+class TestOidcClaimGitIdentity:
+    """Integration tests for OIDC claim-based git author attribution in GitWriteStrategy."""
+
+    def _get_commit_identity(self, repo: Path) -> tuple[str, str]:
+        """Return (author_name, author_email) of the most recent commit."""
+        name = subprocess.run(
+            ["git", "-C", str(repo), "log", "-1", "--format=%aN"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        email = subprocess.run(
+            ["git", "-C", str(repo), "log", "-1", "--format=%aE"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        return name, email
+
+    def test_name_claim_used_when_token_has_claim(self, git_repo: Path) -> None:
+        """When commit_name_claim is set and token has the claim, commit uses claim value."""
+        from unittest.mock import MagicMock, patch
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@example.com",
+            commit_name_claim="name",
+        )
+        test_file = git_repo / "note.md"
+        test_file.write_text("# Note\n")
+
+        token = MagicMock()
+        token.claims = {"name": "Alice Human"}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            strategy(test_file, "# Note\n", "write")
+
+        name, email = self._get_commit_identity(git_repo)
+        assert name == "Alice Human"
+        assert email == "bot@example.com"
+
+    def test_email_claim_used_when_token_has_claim(self, git_repo: Path) -> None:
+        """When commit_email_claim is set and token has the claim, commit uses claim value."""
+        from unittest.mock import MagicMock, patch
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@example.com",
+            commit_email_claim="email",
+        )
+        test_file = git_repo / "note.md"
+        test_file.write_text("# Note\n")
+
+        token = MagicMock()
+        token.claims = {"email": "alice@humans.org"}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            strategy(test_file, "# Note\n", "write")
+
+        name, email = self._get_commit_identity(git_repo)
+        assert name == "bot"
+        assert email == "alice@humans.org"
+
+    def test_both_claims_used_when_token_has_both(self, git_repo: Path) -> None:
+        """Both name and email come from claims when both are configured and present."""
+        from unittest.mock import MagicMock, patch
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@example.com",
+            commit_name_claim="name",
+            commit_email_claim="email",
+        )
+        test_file = git_repo / "note.md"
+        test_file.write_text("# Note\n")
+
+        token = MagicMock()
+        token.claims = {"name": "Alice Human", "email": "alice@humans.org"}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            strategy(test_file, "# Note\n", "write")
+
+        name, email = self._get_commit_identity(git_repo)
+        assert name == "Alice Human"
+        assert email == "alice@humans.org"
+
+    def test_falls_back_to_configured_when_no_token(self, git_repo: Path) -> None:
+        """When no access token, configured name and email are used."""
+        from unittest.mock import patch
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@example.com",
+            commit_name_claim="name",
+            commit_email_claim="email",
+        )
+        test_file = git_repo / "note.md"
+        test_file.write_text("# Note\n")
+
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=None):
+            strategy(test_file, "# Note\n", "write")
+
+        name, email = self._get_commit_identity(git_repo)
+        assert name == "bot"
+        assert email == "bot@example.com"
+
+    def test_falls_back_when_claim_absent_from_token(self, git_repo: Path) -> None:
+        """When the named claim is not in the token, configured value is used."""
+        from unittest.mock import MagicMock, patch
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@example.com",
+            commit_name_claim="name",
+        )
+        test_file = git_repo / "note.md"
+        test_file.write_text("# Note\n")
+
+        token = MagicMock()
+        token.claims = {"sub": "user123"}  # has sub but not name
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            strategy(test_file, "# Note\n", "write")
+
+        name, _email = self._get_commit_identity(git_repo)
+        assert name == "bot"
+
+    def test_no_claim_config_is_backward_compatible(self, git_repo: Path) -> None:
+        """Without claim config, strategy uses static name/email as before."""
+        strategy = GitWriteStrategy(
+            commit_name="my-bot",
+            commit_email="mybot@example.com",
+        )
+        test_file = git_repo / "note.md"
+        test_file.write_text("# Note\n")
+        strategy(test_file, "# Note\n", "write")
+
+        name, email = self._get_commit_identity(git_repo)
+        assert name == "my-bot"
+        assert email == "mybot@example.com"
+
+
+class TestGitClaimConfig:
+    """Tests for GIT_COMMIT_NAME_CLAIM and GIT_COMMIT_EMAIL_CLAIM config loading."""
+
+    def test_load_config_reads_name_claim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() reads GIT_COMMIT_NAME_CLAIM from the environment."""
+        from markdown_vault_mcp.config import load_config
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM", "name")
+        config = load_config()
+        assert config.git_commit_name_claim == "name"
+
+    def test_load_config_reads_email_claim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() reads GIT_COMMIT_EMAIL_CLAIM from the environment."""
+        from markdown_vault_mcp.config import load_config
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM", "email")
+        config = load_config()
+        assert config.git_commit_email_claim == "email"
+
+    def test_load_config_claim_defaults_to_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Claim env vars default to None when not set."""
+        from markdown_vault_mcp.config import load_config
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM", raising=False)
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM", raising=False)
+        config = load_config()
+        assert config.git_commit_name_claim is None
+        assert config.git_commit_email_claim is None
+
+    def test_claim_config_passed_to_strategy(self, tmp_path: Path) -> None:
+        """CollectionConfig.to_collection_kwargs() passes claim keys to GitWriteStrategy."""
+        from markdown_vault_mcp.config import CollectionConfig
+
+        config = CollectionConfig(
+            source_dir=tmp_path,
+            read_only=False,
+            git_commit_name_claim="name",
+            git_commit_email_claim="email",
+        )
+        kwargs = config.to_collection_kwargs()
+        strategy = kwargs["on_write"]
+        assert isinstance(strategy, GitWriteStrategy)
+        assert strategy._commit_name_claim == "name"
+        assert strategy._commit_email_claim == "email"


### PR DESCRIPTION
## Summary

- Adds `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` and `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM` env vars
- When set (e.g. `name`, `email`), each commit reads those OIDC claim keys from the current request's access token and uses the values as the git author name/email for that commit
- Falls back to the static `GIT_COMMIT_NAME` / `GIT_COMMIT_EMAIL` values when no token is present, the claim is absent, or the claim value is not a non-empty string
- Non-OIDC deployments (no claim env vars set) are completely unaffected — backward-compatible by design

Simpler alternative to the YAML mapping approach proposed in #524. Closes #565.

## How it works

`_extract_claim(claim_key)` reads `fastmcp.server.dependencies.get_access_token()`, which is a `contextvars.ContextVar` that propagates correctly into the `WriteCallback` thread spawned by `asyncio.to_thread()`. No new dependency or pvl-core version bump required.

## Test plan

- [x] `TestExtractClaim` (7 unit tests): all `_extract_claim` failure modes — no token, absent claim, empty string, non-string value, non-dict claims, `None` key
- [x] `TestOidcClaimGitIdentity` (6 integration tests): actual git commits verified via `git log --format=%aN/%aE` — name claim, email claim, both claims, no-token fallback, absent-claim fallback, backward-compat (no claim config)
- [x] `TestGitClaimConfig` (4 tests): env var loading, None defaults, claim keys passed to `GitWriteStrategy`
- [x] Full suite: 1747 passed, 1 pre-existing skip, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)