### PR TITLE
feat(git): split commit author from committer for per-user attribution

### DIFF
--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -616,8 +616,14 @@ class GitWriteStrategy:
                     self._git_root,
                     path,
                     operation,
-                    commit_name=effective_name,
-                    commit_email=effective_email,
+                    commit_name=self._commit_name,
+                    commit_email=self._commit_email,
+                    author_name=effective_name
+                    if effective_name != self._commit_name
+                    else None,
+                    author_email=effective_email
+                    if effective_email != self._commit_email
+                    else None,
                 )
             if self._enable_push:
                 self._schedule_push()
@@ -2515,6 +2521,8 @@ def _stage_and_commit(
     operation: Literal["write", "edit", "delete", "rename"],
     commit_name: str = GitWriteStrategy.DEFAULT_COMMIT_NAME,
     commit_email: str = GitWriteStrategy.DEFAULT_COMMIT_EMAIL,
+    author_name: str | None = None,
+    author_email: str | None = None,
 ) -> None:
     """Stage and commit a single file change (no push).
 
@@ -2524,6 +2532,13 @@ def _stage_and_commit(
         operation: The write operation type.
         commit_name: Git committer name (overrides git config).
         commit_email: Git committer email (overrides git config).
+        author_name: Git author name.  When provided and different from
+            *commit_name* (or when *author_email* also differs), the commit
+            is recorded with a separate ``--author`` field so the author and
+            committer identities are distinct.  Falls back to *commit_name*
+            when ``None``.
+        author_email: Git author e-mail.  Same split semantics as
+            *author_name*.  Falls back to *commit_email* when ``None``.
     """
     root = str(git_root)
 
@@ -2588,6 +2603,13 @@ def _stage_and_commit(
 
     commit_msg = f"{operation}: {rel_path}"
 
+    # Build author string when per-request identity differs from committer.
+    eff_author_name = author_name or commit_name
+    eff_author_email = author_email or commit_email
+    author_args: list[str] = []
+    if eff_author_name != commit_name or eff_author_email != commit_email:
+        author_args = ["--author", f"{eff_author_name} <{eff_author_email}>"]
+
     subprocess.run(
         [
             "git",
@@ -2600,6 +2622,7 @@ def _stage_and_commit(
             "commit",
             "-m",
             commit_msg,
+            *author_args,
         ],
         capture_output=True,
         text=True,

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -2621,15 +2621,32 @@ def _stage_and_commit(
     commit_msg = f"{operation}: {rel_path}"
 
     # Build author string when per-request identity differs from committer.
-    # Sanitize OIDC claim values to prevent commit-object header injection.
+    # Sanitize both sides of the comparison so a commit_name that itself
+    # contains stripped chars (e.g. angle brackets) doesn't trigger a
+    # spurious --author when no OIDC author is configured, and so a claim
+    # that sanitizes to the same value as the committer is treated as equal.
     eff_author_name = _sanitize_git_identity(
         author_name if author_name is not None else commit_name
     )
     eff_author_email = _sanitize_git_identity(
         author_email if author_email is not None else commit_email
     )
+    san_commit_name = _sanitize_git_identity(commit_name)
+    san_commit_email = _sanitize_git_identity(commit_email)
+    if author_name is not None and eff_author_name != author_name:
+        logger.debug(
+            "git_identity_sanitized field=author_name original=%s sanitized=%s",
+            author_name,
+            eff_author_name,
+        )
+    if author_email is not None and eff_author_email != author_email:
+        logger.debug(
+            "git_identity_sanitized field=author_email original=%s sanitized=%s",
+            author_email,
+            eff_author_email,
+        )
     author_args: list[str] = []
-    if eff_author_name != commit_name or eff_author_email != commit_email:
+    if eff_author_name != san_commit_name or eff_author_email != san_commit_email:
         author_args = ["--author", f"{eff_author_name} <{eff_author_email}>"]
 
     subprocess.run(

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -11,6 +11,7 @@ import contextlib
 import datetime
 import logging
 import os
+import re
 import stat
 import subprocess
 import tempfile
@@ -2515,6 +2516,21 @@ def git_write_strategy(
     return GitWriteStrategy(token=token, push_delay_s=push_delay_s, git_lfs=git_lfs)
 
 
+_GIT_IDENTITY_UNSAFE = re.compile(r"[\r\n<>]")
+
+
+def _sanitize_git_identity(value: str) -> str:
+    """Strip characters that break git commit-object header parsing.
+
+    Git commit objects use line-based headers; a newline or carriage return in
+    an author/committer field can inject additional header lines.  Angle
+    brackets break the ``Name <email>`` format git expects.  OIDC claim values
+    are user-influenceable at the IdP, so sanitization is required before
+    interpolating them into the ``--author`` string.
+    """
+    return _GIT_IDENTITY_UNSAFE.sub("", value)
+
+
 def _stage_and_commit(
     git_root: Path,
     path: Path,
@@ -2532,13 +2548,14 @@ def _stage_and_commit(
         operation: The write operation type.
         commit_name: Git committer name (overrides git config).
         commit_email: Git committer email (overrides git config).
-        author_name: Git author name.  When provided and different from
-            *commit_name* (or when *author_email* also differs), the commit
-            is recorded with a separate ``--author`` field so the author and
-            committer identities are distinct.  Falls back to *commit_name*
-            when ``None``.
-        author_email: Git author e-mail.  Same split semantics as
-            *author_name*.  Falls back to *commit_email* when ``None``.
+        author_name: Git author name override.  Falls back to *commit_name*
+            when ``None``.  Evaluated independently of *author_email*: when
+            only one field is provided, the other is taken from the committer
+            identity, producing a mixed ``--author`` string.
+        author_email: Git author e-mail override.  Falls back to *commit_email*
+            when ``None``.  Both values are sanitized (``\\r``, ``\\n``,
+            ``<``, ``>`` stripped) before being interpolated into the
+            ``--author`` string to prevent commit-object header injection.
     """
     root = str(git_root)
 
@@ -2604,8 +2621,13 @@ def _stage_and_commit(
     commit_msg = f"{operation}: {rel_path}"
 
     # Build author string when per-request identity differs from committer.
-    eff_author_name = author_name or commit_name
-    eff_author_email = author_email or commit_email
+    # Sanitize OIDC claim values to prevent commit-object header injection.
+    eff_author_name = _sanitize_git_identity(
+        author_name if author_name is not None else commit_name
+    )
+    eff_author_email = _sanitize_git_identity(
+        author_email if author_email is not None else commit_email
+    )
     author_args: list[str] = []
     if eff_author_name != commit_name or eff_author_email != commit_email:
         author_args = ["--author", f"{eff_author_name} <{eff_author_email}>"]

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1215,7 +1215,12 @@ class TestCommitterIdentityInCommit:
         recorded_calls: list[tuple] = []
 
         def recording_stage_and_commit(
-            git_root, path, operation, commit_name="default", commit_email="default"
+            git_root,
+            path,
+            operation,
+            commit_name="default",
+            commit_email="default",
+            **_kwargs,
         ):
             recorded_calls.append(
                 (git_root, path, operation, commit_name, commit_email)
@@ -3494,3 +3499,211 @@ class TestGitClaimConfig:
         assert isinstance(strategy, GitWriteStrategy)
         assert strategy._commit_name_claim == "name"
         assert strategy._commit_email_claim == "email"
+
+
+class TestStageAndCommitAuthorSplit:
+    """_stage_and_commit sets --author separately from the committer when provided."""
+
+    def _get_log(self, repo: Path, fmt: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), "log", "-1", f"--format={fmt}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    def test_both_author_fields_differ_from_committer(self, git_repo: Path) -> None:
+        """When author_name/email differ, git records separate author and committer."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            author_name="Alice",
+            author_email="alice@humans.org",
+        )
+
+        assert self._get_log(git_repo, "%aN") == "Alice"
+        assert self._get_log(git_repo, "%aE") == "alice@humans.org"
+        assert self._get_log(git_repo, "%cN") == "bot"
+        assert self._get_log(git_repo, "%cE") == "bot@srv.com"
+
+    def test_only_author_name_differs(self, git_repo: Path) -> None:
+        """When only author_name differs, author email falls back to committer email."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            author_name="Alice",
+            author_email=None,
+        )
+
+        assert self._get_log(git_repo, "%aN") == "Alice"
+        assert self._get_log(git_repo, "%aE") == "bot@srv.com"  # email unchanged
+        assert self._get_log(git_repo, "%cN") == "bot"
+
+    def test_only_author_email_differs(self, git_repo: Path) -> None:
+        """When only author_email differs, author name falls back to committer name."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            author_name=None,
+            author_email="alice@humans.org",
+        )
+
+        assert self._get_log(git_repo, "%aN") == "bot"  # name unchanged
+        assert self._get_log(git_repo, "%aE") == "alice@humans.org"
+        assert self._get_log(git_repo, "%cE") == "bot@srv.com"
+
+    def test_no_author_fields_author_equals_committer(self, git_repo: Path) -> None:
+        """Without author_name/email, author and committer are identical (backward compat)."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="bot",
+            commit_email="bot@srv.com",
+        )
+
+        assert self._get_log(git_repo, "%aN") == self._get_log(git_repo, "%cN")
+        assert self._get_log(git_repo, "%aE") == self._get_log(git_repo, "%cE")
+
+    def test_author_same_as_committer_no_author_flag(self, git_repo: Path) -> None:
+        """When author_name/email match committer, no --author flag: author == committer."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            author_name="bot",
+            author_email="bot@srv.com",
+        )
+
+        assert self._get_log(git_repo, "%aN") == "bot"
+        assert self._get_log(git_repo, "%cN") == "bot"
+        assert self._get_log(git_repo, "%aE") == self._get_log(git_repo, "%cE")
+
+
+class TestOidcClaimAuthorCommitterSplit:
+    """GitWriteStrategy uses OIDC claims for author only; committer stays static."""
+
+    def _get_identity(self, repo: Path) -> tuple[str, str, str, str]:
+        """Return (author_name, author_email, committer_name, committer_email)."""
+
+        def _log(fmt: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(repo), "log", "-1", f"--format={fmt}"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+
+        return _log("%aN"), _log("%aE"), _log("%cN"), _log("%cE")
+
+    def test_claim_sets_author_committer_stays_static(self, git_repo: Path) -> None:
+        """When claim is configured and token present, author = claim, committer = static."""
+        from unittest.mock import MagicMock, patch
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            commit_name_claim="name",
+            commit_email_claim="email",
+        )
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+
+        token = MagicMock()
+        token.claims = {"name": "Alice Human", "email": "alice@humans.org"}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            strategy(f, "# hi\n", "write")
+
+        a_name, a_email, c_name, c_email = self._get_identity(git_repo)
+        assert a_name == "Alice Human"
+        assert a_email == "alice@humans.org"
+        assert c_name == "bot"
+        assert c_email == "bot@srv.com"
+
+    def test_no_claim_config_author_equals_committer(self, git_repo: Path) -> None:
+        """Without claim config, author and committer are both the static identity."""
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@srv.com",
+        )
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        strategy(f, "# hi\n", "write")
+
+        a_name, a_email, c_name, c_email = self._get_identity(git_repo)
+        assert a_name == c_name == "bot"
+        assert a_email == c_email == "bot@srv.com"
+
+    def test_no_token_falls_back_author_equals_committer(self, git_repo: Path) -> None:
+        """When claim is configured but no token, author falls back to static identity."""
+        from unittest.mock import patch
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            commit_name_claim="name",
+            commit_email_claim="email",
+        )
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=None):
+            strategy(f, "# hi\n", "write")
+
+        a_name, a_email, c_name, c_email = self._get_identity(git_repo)
+        assert a_name == c_name == "bot"
+        assert a_email == c_email == "bot@srv.com"
+
+    def test_only_name_claim_committer_email_unchanged(self, git_repo: Path) -> None:
+        """When only name_claim is configured, author name = claim, email = static for both."""
+        from unittest.mock import MagicMock, patch
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            commit_name_claim="name",
+        )
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+
+        token = MagicMock()
+        token.claims = {"name": "Alice Human"}
+        with patch("markdown_vault_mcp.git._get_access_token", return_value=token):
+            strategy(f, "# hi\n", "write")
+
+        a_name, a_email, c_name, c_email = self._get_identity(git_repo)
+        assert a_name == "Alice Human"
+        assert a_email == "bot@srv.com"
+        assert c_name == "bot"
+        assert c_email == "bot@srv.com"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3653,6 +3653,50 @@ class TestStageAndCommitAuthorSplit:
         assert ">" not in author_name
         assert "Alice" in author_name
 
+    def test_commit_name_with_angle_brackets_no_spurious_author(
+        self, git_repo: Path
+    ) -> None:
+        """commit_name containing angle brackets does not trigger spurious --author."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        # commit_name has angle brackets — same content as what _sanitize would produce
+        # when no author override is configured.  No --author flag should be added.
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="Vault Bot <bot@srv>",
+            commit_email="bot@srv.com",
+        )
+
+        # author == committer (no --author flag spuriously added)
+        assert self._get_log(git_repo, "%aN") == self._get_log(git_repo, "%cN")
+        assert self._get_log(git_repo, "%aE") == self._get_log(git_repo, "%cE")
+
+    def test_sanitized_claim_matching_committer_not_added_as_author(
+        self, git_repo: Path
+    ) -> None:
+        """OIDC claim that sanitizes to the committer value is not added as --author."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        # claim "bot\n" sanitizes to "bot" == commit_name — no attribution split expected
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            author_name="bot\n",
+            author_email="bot@srv.com",
+        )
+
+        assert self._get_log(git_repo, "%aN") == self._get_log(git_repo, "%cN")
+        assert self._get_log(git_repo, "%aE") == self._get_log(git_repo, "%cE")
+
 
 class TestOidcClaimAuthorCommitterSplit:
     """GitWriteStrategy uses OIDC claims for author only; committer stays static."""

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3610,6 +3610,49 @@ class TestStageAndCommitAuthorSplit:
         assert self._get_log(git_repo, "%cN") == "bot"
         assert self._get_log(git_repo, "%aE") == self._get_log(git_repo, "%cE")
 
+    def test_newline_in_author_name_is_stripped(self, git_repo: Path) -> None:
+        """Newlines in author_name are stripped to prevent commit-object header injection."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            author_name="Alice\ngpgsig: injected",
+            author_email="alice@humans.org",
+        )
+
+        author_name = self._get_log(git_repo, "%aN")
+        # The newline is stripped, preventing header injection; the remaining
+        # text is stored as part of the author name (harmless).
+        assert "\n" not in author_name
+        assert "Alice" in author_name
+
+    def test_angle_brackets_in_author_name_are_stripped(self, git_repo: Path) -> None:
+        """Angle brackets in author_name are stripped so the Name <email> format is not broken."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+        _stage_and_commit(
+            git_repo,
+            f,
+            "write",
+            commit_name="bot",
+            commit_email="bot@srv.com",
+            author_name="Alice <injected@evil.com>",
+            author_email="alice@humans.org",
+        )
+
+        author_name = self._get_log(git_repo, "%aN")
+        assert "<" not in author_name
+        assert ">" not in author_name
+        assert "Alice" in author_name
+
 
 class TestOidcClaimAuthorCommitterSplit:
     """GitWriteStrategy uses OIDC claims for author only; committer stays static."""


### PR DESCRIPTION
## Summary

- `_stage_and_commit` gains `author_name` / `author_email` optional parameters
- When provided and different from `commit_name` / `commit_email`, a `--author "Name <email>"` flag is added to `git commit` so git records separate author and committer fields
- `GitWriteStrategy.__call__` now routes the static configured identity to the committer and the OIDC-claim-resolved effective identity to the author only
- Backward-compatible: when no claim is configured, `author_name`/`author_email` are `None`, no `--author` flag is added, and `%aN == %cN` as before

Closes #568. Builds on #567.

## Behavior change from #567

#567 replaced **both** author and committer with the claim values. This PR corrects that: the committer stays as the static server identity (`GIT_COMMIT_NAME` / `GIT_COMMIT_EMAIL`) and only the author field reflects the per-request OIDC identity. This is the standard "authored by human, committed by bot" git pattern.

## Test plan

- [x] `TestStageAndCommitAuthorSplit` (5 tests): both fields differ, only name differs, only email differs, no author args (backward compat), author == committer (no `--author` flag added)
- [x] `TestOidcClaimAuthorCommitterSplit` (4 tests): claim → author=claim/committer=static; no claim → author==committer==static; no token → fallback; asymmetric name-only claim
- [x] Existing `TestCommitterIdentityInCommit` stub updated to accept new kwargs — assertions unchanged
- [x] Full suite: 1769 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)