### PR TITLE
feat: drift-aware B3 readers (closes #534)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` pr
 | `MARKDOWN_VAULT_MCP_EXCLUDE` | — | No | Comma-separated glob patterns to exclude from scanning (e.g. `.obsidian/**,.trash/**`) |
 | `MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER` | `_templates` | No | Relative folder path where note templates live (used by the `create_from_template` prompt) |
 | `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | — | No | Path to a directory of `.md` prompt files that extend or override built-in prompts (see [User-defined prompts](#user-defined-prompts)) |
+| `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` | `60` | No | Maximum seconds the B3 reader tools wait for the IndexWriter to drain when called with `wait_for_drain=True`. On timeout the tool returns the result with `stale=True` rather than raising. |
 
 ### Server identity
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,18 @@ a cold-start background FTS build. Increase for very large vaults
 where the initial scan takes longer; decrease for tighter feedback
 on stuck builds.
 
+### `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S`
+
+Default: `60` (seconds).
+
+Maximum time the B3 MCP tools (`get_backlinks`, `get_outlinks`,
+`get_similar`, `get_context`, `get_connection_path`) wait for the
+IndexWriter to drain when called with `wait_for_drain=true`. On
+timeout the tool returns the result with `stale=true` rather than
+raising — best-effort fresh read. Increase for very large vaults
+where reindex / build_embeddings jobs take longer; decrease for
+faster client feedback when the index has chronic backlog.
+
 <!-- DOMAIN-CONFIG-VARS-START -->
 ## Server Identity
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -574,11 +574,13 @@ in-flight work and the `data` payload may not reflect the latest
 committed state.
 
 Each B3 tool accepts an optional `wait_for_drain: bool = false`
-parameter. When `true`, the tool blocks on `Collection.wait_for_drain()`
-(bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S`, default 60s)
-before executing the query. On timeout, the tool returns the
-result with `stale=true` rather than raising — best-effort
-fresh-read semantics.
+parameter. When `true`, the tool layer polls `Collection.is_drained()`
+with `asyncio.sleep` until the writer drains or
+`MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s) elapses, then
+runs the query. On timeout the tool returns the result with
+`stale=true` rather than raising — best-effort fresh-read
+semantics. (`Collection.wait_for_drain()` is the synchronous
+counterpart for in-process callers.)
 
 The drift signal reflects writer-internal state only: paths in
 `dirty_paths`, paths in `dirty_embeddings`, the in-flight job

--- a/docs/design.md
+++ b/docs/design.md
@@ -563,6 +563,30 @@ See `docs/superpowers/specs/2026-05-31-issue-559-single-writer-for-indexes-desig
 for the full design rationale, including the cascade of #513 / #519
 prerequisites that motivated centralising mutations on a single writer.
 
+#### Drift signals on B3 readers (#534)
+
+B3 MCP tools (`get_backlinks`, `get_outlinks`, `get_similar`,
+`get_context`, `get_connection_path`) wrap their response in a
+`{"stale": bool, "data": ...}` envelope. `stale` is `true` when
+`Collection.is_drained()` returns `false` at the moment the
+response is constructed — i.e. the IndexWriter has pending or
+in-flight work and the `data` payload may not reflect the latest
+committed state.
+
+Each B3 tool accepts an optional `wait_for_drain: bool = false`
+parameter. When `true`, the tool blocks on `Collection.wait_for_drain()`
+(bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S`, default 60s)
+before executing the query. On timeout, the tool returns the
+result with `stale=true` rather than raising — best-effort
+fresh-read semantics.
+
+The drift signal reflects writer-internal state only: paths in
+`dirty_paths`, paths in `dirty_embeddings`, the in-flight job
+kind, and the queue depth. **External file changes on disk** —
+files modified outside the MCP server with no `write` tool call
+and no git pull — are not covered by this signal; that drift mode
+is tracked separately in #558.
+
 #### Collection thread-safety contract (issue #519)
 
 Every public method on `Collection`, `FTSIndex`, and the managers is safe

--- a/docs/design.md
+++ b/docs/design.md
@@ -568,13 +568,15 @@ prerequisites that motivated centralising mutations on a single writer.
 B3 MCP tools (`get_backlinks`, `get_outlinks`, `get_similar`,
 `get_context`, `get_connection_path`) wrap their response in a
 `{"stale": bool, "data": ...}` envelope. `stale` is the OR of three
-snapshots: the writer was busy before the optional `wait_for_drain`
-returned (or the wait timed out), the writer was busy at the moment
-the read began, or the writer is busy at response-construction time.
-The writer can still slip a write entirely inside the read window
-between the pre-read and post-read snapshots — `stale` is conservative
-about writes arriving on either side of the read, not strictly
-linearizable.
+signals: the optional `wait_for_drain` timed out (writer never went
+idle within the budget), the writer's monotonic `write_generation`
+counter advanced during the read (a write cycle completed inside the
+read window), or `is_drained()` reports a non-idle writer at
+response-construction time (a write is in flight). The
+`write_generation` counter — incremented under `_in_flight_lock`
+once per completed job — closes the case the pre/post `is_drained()`
+pair could not detect: a write that started and finished entirely
+between two snapshots.
 
 Each B3 tool accepts an optional `wait_for_drain: bool = false`
 parameter. When `true`, the tool layer polls `Collection.is_drained()`

--- a/docs/design.md
+++ b/docs/design.md
@@ -567,11 +567,14 @@ prerequisites that motivated centralising mutations on a single writer.
 
 B3 MCP tools (`get_backlinks`, `get_outlinks`, `get_similar`,
 `get_context`, `get_connection_path`) wrap their response in a
-`{"stale": bool, "data": ...}` envelope. `stale` is `true` when
-`Collection.is_drained()` returns `false` at the moment the
-response is constructed — i.e. the IndexWriter has pending or
-in-flight work and the `data` payload may not reflect the latest
-committed state.
+`{"stale": bool, "data": ...}` envelope. `stale` is the OR of three
+snapshots: the writer was busy before the optional `wait_for_drain`
+returned (or the wait timed out), the writer was busy at the moment
+the read began, or the writer is busy at response-construction time.
+The writer can still slip a write entirely inside the read window
+between the pre-read and post-read snapshots — `stale` is conservative
+about writes arriving on either side of the read, not strictly
+linearizable.
 
 Each B3 tool accepts an optional `wait_for_drain: bool = false`
 parameter. When `true`, the tool layer polls `Collection.is_drained()`

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -122,6 +122,9 @@ Top 10 semantically similar notes for a document. Requires embeddings to be buil
 
 Results are **grouped per file** — each file appears at most once, with up to `chunks_per_file` (server default `2`) best-matching sections in a `sections` array. Each entry is a `GroupedResult` dict with `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 
+!!! note "Resource shape differs from `get_similar` tool"
+    This resource returns a flat JSON array. The `get_similar` MCP tool wraps the same data in a `{"stale": bool, "data": [...]}` envelope so callers see a drift signal (#534). Resource handlers do not accept a `wait_for_drain` parameter, so this resource intentionally omits the envelope; clients that need the drift signal should use the tool. Lifting the envelope to resources is tracked as a follow-up — see [`Collection.is_drained()`](https://github.com/pvliesdonk/markdown-vault-mcp/issues/534) for the underlying primitive.
+
 **Example:** `similar://vault/Journal/note.md`
 
 **Response:**

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -619,11 +619,15 @@ Find all documents that link to a given document.
 
 **Parameters:**
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string | Relative path to the target document |
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | string | required | Relative path to the target document |
+| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
 
-**Returns:** List of documents containing links to the given path.
+**Returns:** Dict envelope with two keys:
+
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `data` (list[dict]): List of documents containing links to the given path. Each entry has `source_path`, `source_title`, `link_text`, `link_type`, `fragment`, and `raw_target` fields.
 
 ### `get_outlinks`
 
@@ -631,11 +635,15 @@ Find all links from a document, with existence check.
 
 **Parameters:**
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string | Relative path to the source document |
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | string | required | Relative path to the source document |
+| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
 
-**Returns:** List of link targets with an `exists` field indicating whether the target document is in the vault.
+**Returns:** Dict envelope with two keys:
+
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `data` (list[dict]): List of link targets with an `exists` field indicating whether the target document is in the vault. Each entry has `target_path`, `link_text`, `link_type`, `fragment`, `raw_target`, and `exists` fields.
 
 ### `get_broken_links`
 
@@ -660,8 +668,12 @@ Find semantically similar notes by document path. Requires embeddings to be buil
 | `path` | string | required | Relative path to the document |
 | `limit` | int | `10` | Maximum files to return |
 | `chunks_per_file` | int | server default (`2`) | Maximum number of matching sections returned per file. Overrides `MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE` for this call. `0` is rejected. |
+| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
 
-**Returns:** List of grouped similar-document dicts ranked by cosine similarity, one entry per file with up to `chunks_per_file` best-matching sections. Each entry contains: `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
+**Returns:** Dict envelope with two keys:
+
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `data` (list[dict]): List of grouped similar-document dicts ranked by cosine similarity, one entry per file with up to `chunks_per_file` best-matching sections. Each entry contains: `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 
 !!! note "Grouped result shape"
     Returns one entry per file with up to `chunks_per_file` best-matching sections. Default is 2 sections per file; pass `chunks_per_file=1` for compact dossiers.
@@ -690,8 +702,12 @@ Get a consolidated context dossier for a note. Combines backlinks, outlinks, sim
 | `path` | string | required | Relative path to the document |
 | `similar_limit` | int | `5` | Max similar files to include. Pass `0` to skip the similarity lookup (e.g. when `stats` shows `semantic_search_available=false`) |
 | `link_limit` | int | `10` | Max backlinks and outlinks to include each |
+| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
 
-**Returns:** Object with `path`, `title`, `folder`, `frontmatter`, `modified_at`, `backlinks`, `outlinks`, `similar`, `folder_notes`, and `tags` fields. The `similar` list contains grouped result dicts — one entry per file with up to `chunks_per_file` best-matching sections (default 1 for `get_context` to keep dossiers compact).
+**Returns:** Dict envelope with two keys:
+
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `data` (dict): Object with `path`, `title`, `folder`, `frontmatter`, `modified_at`, `backlinks`, `outlinks`, `similar`, `folder_notes`, and `tags` fields. The `similar` list contains grouped result dicts — one entry per file with up to `chunks_per_file` best-matching sections (default 1 for `get_context` to keep dossiers compact).
 
 !!! note "Grouped similar shape"
     Each `similar` entry contains `path`, `title`, `folder`, `score`, `search_type`, `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts. `get_context` defaults to one section per file for compact dossiers; `search` and `get_similar` default to 2.
@@ -725,8 +741,12 @@ Find the shortest path between two notes via BFS on the undirected link graph (m
 | `source` | string | required | Relative path to the starting document |
 | `target` | string | required | Relative path to the target document |
 | `max_depth` | int | `10` | Maximum hops to search (clamped to [1, 10]) |
+| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
 
-**Returns:** Object with `found` (bool), `path` (ordered list of note paths from source to target), and `hops` (number of edges, or `-1` if not found).
+**Returns:** Dict envelope with two keys:
+
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `data` (dict): Object with `found` (bool), `path` (ordered list of note paths from source to target), and `hops` (number of edges, or `-1` if not found).
 
 ### `get_history`
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -626,7 +626,7 @@ Find all documents that link to a given document.
 
 **Returns:** Dict envelope with two keys:
 
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
 - `data` (list[dict]): List of documents containing links to the given path. Each entry has `source_path`, `source_title`, `link_text`, `link_type`, `fragment`, and `raw_target` fields.
 
 ### `get_outlinks`
@@ -642,7 +642,7 @@ Find all links from a document, with existence check.
 
 **Returns:** Dict envelope with two keys:
 
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
 - `data` (list[dict]): List of link targets with an `exists` field indicating whether the target document is in the vault. Each entry has `target_path`, `link_text`, `link_type`, `fragment`, `raw_target`, and `exists` fields.
 
 ### `get_broken_links`
@@ -672,7 +672,7 @@ Find semantically similar notes by document path. Requires embeddings to be buil
 
 **Returns:** Dict envelope with two keys:
 
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
 - `data` (list[dict]): List of grouped similar-document dicts ranked by cosine similarity, one entry per file with up to `chunks_per_file` best-matching sections. Each entry contains: `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 
 !!! note "Grouped result shape"
@@ -706,7 +706,7 @@ Get a consolidated context dossier for a note. Combines backlinks, outlinks, sim
 
 **Returns:** Dict envelope with two keys:
 
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
 - `data` (dict): Object with `path`, `title`, `folder`, `frontmatter`, `modified_at`, `backlinks`, `outlinks`, `similar`, `folder_notes`, and `tags` fields. The `similar` list contains grouped result dicts — one entry per file with up to `chunks_per_file` best-matching sections (default 1 for `get_context` to keep dossiers compact).
 
 !!! note "Grouped similar shape"
@@ -745,7 +745,7 @@ Find the shortest path between two notes via BFS on the undirected link graph (m
 
 **Returns:** Dict envelope with two keys:
 
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at response time; the `data` payload may not reflect the latest committed state.
+- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
 - `data` (dict): Object with `found` (bool), `path` (ordered list of note paths from source to target), and `hops` (number of edges, or `-1` if not found).
 
 ### `get_history`

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -700,10 +700,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Returns:
             Dict envelope with two keys:
 
-            - stale (bool): True when the IndexWriter had pending work
-              at the moment this response was constructed. The data
-              below may not reflect the latest committed state. False
-              when the writer was idle at response time.
+            - stale (bool): True when the IndexWriter had pending or
+              in-flight work at any of three observation points (the
+              optional ``wait_for_drain`` timing out, a completed
+              write cycle inside the read window, or non-idle at
+              response construction). False when none of those
+              conditions held — the data is current as of response
+              time.
             - data (list[dict]): The backlinks list. Each entry has:
 
               - source_path (str): Path of the document containing the link.
@@ -722,12 +725,12 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_backlinks"
         )
-        drained_before_read = collection.is_drained()
+        gen_before = collection.write_generation()
         results = await asyncio.to_thread(collection.get_backlinks, path)
         return {
             "stale": (
                 (not drained_on_request)
-                or (not drained_before_read)
+                or (collection.write_generation() != gen_before)
                 or (not collection.is_drained())
             ),
             "data": [asdict(r) for r in results],
@@ -770,10 +773,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Returns:
             Dict envelope with two keys:
 
-            - stale (bool): True when the IndexWriter had pending work
-              at the moment this response was constructed. The data
-              below may not reflect the latest committed state. False
-              when the writer was idle at response time.
+            - stale (bool): True when the IndexWriter had pending or
+              in-flight work at any of three observation points (the
+              optional ``wait_for_drain`` timing out, a completed
+              write cycle inside the read window, or non-idle at
+              response construction). False when none of those
+              conditions held — the data is current as of response
+              time.
             - data (list[dict]): The outlinks list. Each entry has:
 
               - target_path (str): Path of the linked document.
@@ -792,12 +798,12 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_outlinks"
         )
-        drained_before_read = collection.is_drained()
+        gen_before = collection.write_generation()
         results = await asyncio.to_thread(collection.get_outlinks, path)
         return {
             "stale": (
                 (not drained_on_request)
-                or (not drained_before_read)
+                or (collection.write_generation() != gen_before)
                 or (not collection.is_drained())
             ),
             "data": [asdict(r) for r in results],
@@ -888,8 +894,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Returns:
             Dict envelope with two keys:
 
-            - stale (bool): True when the IndexWriter had pending work
-              at response time.
+            - stale (bool): True when the IndexWriter had pending or
+              in-flight work at any of three observation points (wait
+              timed out, write completed inside the read window, or
+              non-idle at response time). False otherwise.
             - data (list[dict]): Result dicts ranked by file similarity.
               Each entry contains:
 
@@ -917,7 +925,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_similar"
         )
-        drained_before_read = collection.is_drained()
+        gen_before = collection.write_generation()
         results = await asyncio.to_thread(
             collection.get_similar,
             path,
@@ -927,7 +935,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         return {
             "stale": (
                 (not drained_on_request)
-                or (not drained_before_read)
+                or (collection.write_generation() != gen_before)
                 or (not collection.is_drained())
             ),
             "data": [asdict(r) for r in results],
@@ -1019,8 +1027,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Returns:
             Dict envelope with two keys:
 
-            - stale (bool): True when the IndexWriter had pending work
-              at response time.
+            - stale (bool): True when the IndexWriter had pending or
+              in-flight work at any of three observation points (wait
+              timed out, write completed inside the read window, or
+              non-idle at response time). False otherwise.
             - data (dict): The note context. Inner fields:
 
               - path (str): Relative path of the document.
@@ -1077,7 +1087,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_context"
         )
-        drained_before_read = collection.is_drained()
+        gen_before = collection.write_generation()
         result = await asyncio.to_thread(
             collection.get_context,
             path,
@@ -1087,7 +1097,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         return {
             "stale": (
                 (not drained_on_request)
-                or (not drained_before_read)
+                or (collection.write_generation() != gen_before)
                 or (not collection.is_drained())
             ),
             "data": asdict(result),
@@ -1196,8 +1206,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Returns:
             Dict envelope with two keys:
 
-            - stale (bool): True when the IndexWriter had pending work
-              at response time.
+            - stale (bool): True when the IndexWriter had pending or
+              in-flight work at any of three observation points (wait
+              timed out, write completed inside the read window, or
+              non-idle at response time). False otherwise.
             - data (dict): The connection-path result. Inner fields:
 
               - `found` (bool): Whether a path was found within `max_depth` hops.
@@ -1209,7 +1221,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_connection_path"
         )
-        drained_before_read = collection.is_drained()
+        gen_before = collection.write_generation()
         result: list[str] | None = await asyncio.to_thread(
             collection.get_connection_path, source, target, max_depth
         )
@@ -1221,7 +1233,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         return {
             "stale": (
                 (not drained_on_request)
-                or (not drained_before_read)
+                or (collection.write_generation() != gen_before)
                 or (not collection.is_drained())
             ),
             "data": inner,

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -722,9 +722,14 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_backlinks"
         )
+        drained_before_read = collection.is_drained()
         results = await asyncio.to_thread(collection.get_backlinks, path)
         return {
-            "stale": (not drained_on_request) or (not collection.is_drained()),
+            "stale": (
+                (not drained_on_request)
+                or (not drained_before_read)
+                or (not collection.is_drained())
+            ),
             "data": [asdict(r) for r in results],
         }
 
@@ -787,9 +792,14 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_outlinks"
         )
+        drained_before_read = collection.is_drained()
         results = await asyncio.to_thread(collection.get_outlinks, path)
         return {
-            "stale": (not drained_on_request) or (not collection.is_drained()),
+            "stale": (
+                (not drained_on_request)
+                or (not drained_before_read)
+                or (not collection.is_drained())
+            ),
             "data": [asdict(r) for r in results],
         }
 
@@ -907,6 +917,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_similar"
         )
+        drained_before_read = collection.is_drained()
         results = await asyncio.to_thread(
             collection.get_similar,
             path,
@@ -914,7 +925,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             chunks_per_file=chunks_per_file,
         )
         return {
-            "stale": (not drained_on_request) or (not collection.is_drained()),
+            "stale": (
+                (not drained_on_request)
+                or (not drained_before_read)
+                or (not collection.is_drained())
+            ),
             "data": [asdict(r) for r in results],
         }
 
@@ -1062,6 +1077,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_context"
         )
+        drained_before_read = collection.is_drained()
         result = await asyncio.to_thread(
             collection.get_context,
             path,
@@ -1069,7 +1085,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             link_limit=link_limit,
         )
         return {
-            "stale": (not drained_on_request) or (not collection.is_drained()),
+            "stale": (
+                (not drained_on_request)
+                or (not drained_before_read)
+                or (not collection.is_drained())
+            ),
             "data": asdict(result),
         }
 
@@ -1189,6 +1209,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_connection_path"
         )
+        drained_before_read = collection.is_drained()
         result: list[str] | None = await asyncio.to_thread(
             collection.get_connection_path, source, target, max_depth
         )
@@ -1198,7 +1219,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         else:
             inner = {"found": True, "path": result, "hops": len(result) - 1}
         return {
-            "stale": (not drained_on_request) or (not collection.is_drained()),
+            "stale": (
+                (not drained_on_request)
+                or (not drained_before_read)
+                or (not collection.is_drained())
+            ),
             "data": inner,
         }
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -44,6 +44,11 @@ async def _maybe_wait_for_drain(
 ) -> bool:
     """Wait for the writer to drain when requested. Log on timeout.
 
+    Polls :meth:`Collection.is_drained` directly with ``asyncio.sleep``
+    so concurrent waiters yield to the event loop instead of occupying
+    ``asyncio.to_thread`` slots for the full timeout (would starve the
+    default thread pool at moderate concurrency).
+
     Returns True when the writer was drained at the point of asking
     (or when no wait was requested), False when the bounded wait
     timed out. Callers OR the negation into the response envelope's
@@ -52,12 +57,20 @@ async def _maybe_wait_for_drain(
     if not wait_for_drain:
         return True
     timeout = _resolve_drain_timeout()
-    drained = await asyncio.to_thread(collection.wait_for_drain, timeout=timeout)
-    if not drained:
-        logger.warning(
-            "wait_for_drain_timeout tool=%s timeout_s=%s", tool_name, timeout
-        )
-    return drained
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    poll_interval = 0.05
+    while True:
+        if collection.is_drained():
+            return True
+        if loop.time() >= deadline:
+            logger.warning(
+                "wait_for_drain_timeout tool=%s timeout_s=%s",
+                tool_name,
+                timeout,
+            )
+            return False
+        await asyncio.sleep(poll_interval)
 
 
 _ALLOWED_FETCH_SCHEMES = frozenset({"http", "https"})

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -39,6 +39,27 @@ def _resolve_drain_timeout() -> float:
     return float(os.environ.get("MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S", "60"))
 
 
+async def _maybe_wait_for_drain(
+    collection: Collection, wait_for_drain: bool, tool_name: str
+) -> bool:
+    """Wait for the writer to drain when requested. Log on timeout.
+
+    Returns True when the writer was drained at the point of asking
+    (or when no wait was requested), False when the bounded wait
+    timed out. Callers OR the negation into the response envelope's
+    ``stale`` field so a timed-out wait reliably reports ``stale=True``.
+    """
+    if not wait_for_drain:
+        return True
+    timeout = _resolve_drain_timeout()
+    drained = await asyncio.to_thread(collection.wait_for_drain, timeout=timeout)
+    if not drained:
+        logger.warning(
+            "wait_for_drain_timeout tool=%s timeout_s=%s", tool_name, timeout
+        )
+    return drained
+
+
 _ALLOWED_FETCH_SCHEMES = frozenset({"http", "https"})
 
 # SSRF protection: block private/reserved IP ranges.
@@ -685,13 +706,12 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        if wait_for_drain:
-            await asyncio.to_thread(
-                collection.wait_for_drain, timeout=_resolve_drain_timeout()
-            )
+        drained_on_request = await _maybe_wait_for_drain(
+            collection, wait_for_drain, "get_backlinks"
+        )
         results = await asyncio.to_thread(collection.get_backlinks, path)
         return {
-            "stale": not collection.is_drained(),
+            "stale": (not drained_on_request) or (not collection.is_drained()),
             "data": [asdict(r) for r in results],
         }
 
@@ -751,13 +771,12 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        if wait_for_drain:
-            await asyncio.to_thread(
-                collection.wait_for_drain, timeout=_resolve_drain_timeout()
-            )
+        drained_on_request = await _maybe_wait_for_drain(
+            collection, wait_for_drain, "get_outlinks"
+        )
         results = await asyncio.to_thread(collection.get_outlinks, path)
         return {
-            "stale": not collection.is_drained(),
+            "stale": (not drained_on_request) or (not collection.is_drained()),
             "data": [asdict(r) for r in results],
         }
 
@@ -872,10 +891,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        if wait_for_drain:
-            await asyncio.to_thread(
-                collection.wait_for_drain, timeout=_resolve_drain_timeout()
-            )
+        drained_on_request = await _maybe_wait_for_drain(
+            collection, wait_for_drain, "get_similar"
+        )
         results = await asyncio.to_thread(
             collection.get_similar,
             path,
@@ -883,7 +901,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             chunks_per_file=chunks_per_file,
         )
         return {
-            "stale": not collection.is_drained(),
+            "stale": (not drained_on_request) or (not collection.is_drained()),
             "data": [asdict(r) for r in results],
         }
 
@@ -1028,10 +1046,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        if wait_for_drain:
-            await asyncio.to_thread(
-                collection.wait_for_drain, timeout=_resolve_drain_timeout()
-            )
+        drained_on_request = await _maybe_wait_for_drain(
+            collection, wait_for_drain, "get_context"
+        )
         result = await asyncio.to_thread(
             collection.get_context,
             path,
@@ -1039,7 +1056,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             link_limit=link_limit,
         )
         return {
-            "stale": not collection.is_drained(),
+            "stale": (not drained_on_request) or (not collection.is_drained()),
             "data": asdict(result),
         }
 
@@ -1156,10 +1173,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
               - `hops` (int): Number of edges in the path (`len(path) - 1`), or -1 if
                 not found.
         """
-        if wait_for_drain:
-            await asyncio.to_thread(
-                collection.wait_for_drain, timeout=_resolve_drain_timeout()
-            )
+        drained_on_request = await _maybe_wait_for_drain(
+            collection, wait_for_drain, "get_connection_path"
+        )
         result: list[str] | None = await asyncio.to_thread(
             collection.get_connection_path, source, target, max_depth
         )
@@ -1169,7 +1185,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         else:
             inner = {"found": True, "path": result, "hops": len(result) - 1}
         return {
-            "stale": not collection.is_drained(),
+            "stale": (not drained_on_request) or (not collection.is_drained()),
             "data": inner,
         }
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1111,6 +1111,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         source: str,
         target: str,
         max_depth: int = 10,
+        wait_for_drain: bool = False,
         collection: Collection = Depends(get_collection),
     ) -> dict[str, Any]:
         """Find the shortest connection path between two notes in the link graph.
@@ -1126,9 +1127,20 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             source: Vault-relative path of the starting note (e.g. 'Ideas/spark.md').
             target: Vault-relative path of the destination note.
             max_depth: Maximum number of hops to search. Default 10, max 10.
+            wait_for_drain: When True, block until the IndexWriter has
+                no pending or in-flight work before answering. Bounded
+                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
+                On timeout, returns the result with `stale=True` rather
+                than raising — best-effort fresh read. Default False
+                returns immediately and reports staleness via the
+                envelope's `stale` field.
 
         Returns:
-            A dict with the following fields:
+            Dict envelope with two keys:
+
+            - stale (bool): True when the IndexWriter had pending work
+              at response time.
+            - data (dict): The connection-path result. Inner fields:
 
             - `found` (bool): Whether a path was found within `max_depth` hops.
             - `path` (list[str]): Ordered list of note paths from source to target,
@@ -1136,13 +1148,20 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - `hops` (int): Number of edges in the path (`len(path) - 1`), or -1 if
               not found.
         """
+        if wait_for_drain:
+            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
         result: list[str] | None = await asyncio.to_thread(
             collection.get_connection_path, source, target, max_depth
         )
 
         if result is None:
-            return {"found": False, "path": [], "hops": -1}
-        return {"found": True, "path": result, "hops": len(result) - 1}
+            inner: dict[str, Any] = {"found": False, "path": [], "hops": -1}
+        else:
+            inner = {"found": True, "path": result, "hops": len(result) - 1}
+        return {
+            "stale": not collection.is_drained(),
+            "data": inner,
+        }
 
     # --- Git history tools ---
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -824,9 +824,10 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Uses stored embedding vectors — no re-embedding needed. The
         reference document is excluded from results. Requires semantic
         search to be configured (check 'stats' for
-        semantic_search_available). Returns an empty list if embeddings
-        are not configured (check 'embeddings_status') or the document has
-        no stored vectors (call 'build_embeddings' to embed missing chunks).
+        semantic_search_available). The envelope's ``data`` field is an
+        empty list if embeddings are not configured (check
+        'embeddings_status') or the document has no stored vectors (call
+        'build_embeddings' to embed missing chunks).
 
         Args:
             path: Relative path of the reference document (e.g.

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -34,11 +34,10 @@ from ._server_queryable import needs_queryable
 logger = logging.getLogger(__name__)
 
 
-# Drift-aware B3 reader timeout (#534). Bounds wait_for_drain=True calls
-# on the five B3 tools (get_backlinks, get_outlinks, get_similar,
-# get_context, get_connection_path). Default 60s matches the existing
-# BUILD_TIMEOUT_S precedent.
-_DRAIN_TIMEOUT_S = float(os.environ.get("MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S", "60"))
+def _resolve_drain_timeout() -> float:
+    """Read env var at call time so tests can monkeypatch.setenv it."""
+    return float(os.environ.get("MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S", "60"))
+
 
 _ALLOWED_FETCH_SCHEMES = frozenset({"http", "https"})
 
@@ -687,7 +686,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             ValueError: If no document exists at the given path.
         """
         if wait_for_drain:
-            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
+            await asyncio.to_thread(
+                collection.wait_for_drain, timeout=_resolve_drain_timeout()
+            )
         results = await asyncio.to_thread(collection.get_backlinks, path)
         return {
             "stale": not collection.is_drained(),
@@ -751,7 +752,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             ValueError: If no document exists at the given path.
         """
         if wait_for_drain:
-            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
+            await asyncio.to_thread(
+                collection.wait_for_drain, timeout=_resolve_drain_timeout()
+            )
         results = await asyncio.to_thread(collection.get_outlinks, path)
         return {
             "stale": not collection.is_drained(),
@@ -847,19 +850,19 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - data (list[dict]): Result dicts ranked by file similarity.
               Each entry contains:
 
-            - path (str): Relative path of the similar document.
-            - title (str): Document title.
-            - folder (str): Parent folder path.
-            - score (float): File-level cosine similarity (max of section
-              scores), 0.0-1.0; higher = more similar.
-            - search_type (str): Always "semantic".
-            - frontmatter (dict): Parsed YAML frontmatter.
-            - sections (list[dict]): Up to chunks_per_file best-matching
-              sections, each with:
+              - path (str): Relative path of the similar document.
+              - title (str): Document title.
+              - folder (str): Parent folder path.
+              - score (float): File-level cosine similarity (max of section
+                scores), 0.0-1.0; higher = more similar.
+              - search_type (str): Always "semantic".
+              - frontmatter (dict): Parsed YAML frontmatter.
+              - sections (list[dict]): Up to chunks_per_file best-matching
+                sections, each with:
 
-              - heading (str | None): Section heading or null for intro.
-              - content (str): Matched chunk text.
-              - score (float): Chunk-level score for this section.
+                - heading (str | None): Section heading or null for intro.
+                - content (str): Matched chunk text.
+                - score (float): Chunk-level score for this section.
 
         Useful for finding link candidates that aren't yet wikilinked — the
         vault's organic graph is almost always denser than its explicit one.
@@ -869,7 +872,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             ValueError: If no document exists at the given path.
         """
         if wait_for_drain:
-            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
+            await asyncio.to_thread(
+                collection.wait_for_drain, timeout=_resolve_drain_timeout()
+            )
         results = await asyncio.to_thread(
             collection.get_similar,
             path,
@@ -971,49 +976,49 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
               at response time.
             - data (dict): The note context. Inner fields:
 
-            - path (str): Relative path of the document.
-            - title (str): Document title.
-            - folder (str): Parent folder path.
-            - frontmatter (dict): Parsed YAML frontmatter.
-            - modified_at (float): Unix timestamp of last modification.
-            - backlinks (list): Documents linking to this note. List of dicts,
-              each with:
-
-              - source_path (str): Path of the document containing the link.
-              - source_title (str): Title of the source document.
-              - link_text (str): The clickable text of the link.
-              - link_type (str): One of "markdown", "wikilink", or "reference".
-              - fragment (str | None): Heading anchor (e.g. "#section"), or null.
-              - raw_target (str): Literal link target as written in the source.
-
-            - outlinks (list): Links from this note. List of dicts, each with:
-
-              - target_path (str): Path of the linked document.
-              - link_text (str): The clickable text of the link.
-              - link_type (str): One of "markdown", "wikilink", or "reference".
-              - fragment (str | None): Heading anchor (e.g. "#section"), or null.
-              - raw_target (str): Literal link target as written in the source.
-              - exists (bool): True if the target document is indexed.
-
-            - similar (list): Semantically similar notes, field-collapsed by
-              file (chunks_per_file=1 for compact dossiers).  List of dicts,
-              each with:
-
-              - path (str): Relative path of the similar document.
+              - path (str): Relative path of the document.
               - title (str): Document title.
               - folder (str): Parent folder path.
-              - score (float): File-level cosine similarity 0.0-1.0 = score
-                of the best matching section.
-              - search_type (str): Always "semantic".
               - frontmatter (dict): Parsed YAML frontmatter.
-              - sections (list): Single best-matching section, each with
-                heading (str|null), content (str), score (float).
-                Call get_similar(path, chunks_per_file=N) for more sections.
+              - modified_at (float): Unix timestamp of last modification.
+              - backlinks (list): Documents linking to this note. List of dicts,
+                each with:
 
-            - folder_notes (list[str]): Paths of other notes in the same
-              folder (up to 20). Plain strings, not dicts.
-            - tags (dict[str, list[str]]): Indexed frontmatter field →
-              distinct values for this note.
+                - source_path (str): Path of the document containing the link.
+                - source_title (str): Title of the source document.
+                - link_text (str): The clickable text of the link.
+                - link_type (str): One of "markdown", "wikilink", or "reference".
+                - fragment (str | None): Heading anchor (e.g. "#section"), or null.
+                - raw_target (str): Literal link target as written in the source.
+
+              - outlinks (list): Links from this note. List of dicts, each with:
+
+                - target_path (str): Path of the linked document.
+                - link_text (str): The clickable text of the link.
+                - link_type (str): One of "markdown", "wikilink", or "reference".
+                - fragment (str | None): Heading anchor (e.g. "#section"), or null.
+                - raw_target (str): Literal link target as written in the source.
+                - exists (bool): True if the target document is indexed.
+
+              - similar (list): Semantically similar notes, field-collapsed by
+                file (chunks_per_file=1 for compact dossiers).  List of dicts,
+                each with:
+
+                - path (str): Relative path of the similar document.
+                - title (str): Document title.
+                - folder (str): Parent folder path.
+                - score (float): File-level cosine similarity 0.0-1.0 = score
+                  of the best matching section.
+                - search_type (str): Always "semantic".
+                - frontmatter (dict): Parsed YAML frontmatter.
+                - sections (list): Single best-matching section, each with
+                  heading (str|null), content (str), score (float).
+                  Call get_similar(path, chunks_per_file=N) for more sections.
+
+              - folder_notes (list[str]): Paths of other notes in the same
+                folder (up to 20). Plain strings, not dicts.
+              - tags (dict[str, list[str]]): Indexed frontmatter field →
+                distinct values for this note.
 
         The ``similar`` field in the response surfaces notes that may warrant
         explicit links to the context note but don't yet — a common input to
@@ -1023,7 +1028,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             ValueError: If no document exists at the given path.
         """
         if wait_for_drain:
-            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
+            await asyncio.to_thread(
+                collection.wait_for_drain, timeout=_resolve_drain_timeout()
+            )
         result = await asyncio.to_thread(
             collection.get_context,
             path,
@@ -1142,14 +1149,16 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
               at response time.
             - data (dict): The connection-path result. Inner fields:
 
-            - `found` (bool): Whether a path was found within `max_depth` hops.
-            - `path` (list[str]): Ordered list of note paths from source to target,
-              or an empty list if not found.
-            - `hops` (int): Number of edges in the path (`len(path) - 1`), or -1 if
-              not found.
+              - `found` (bool): Whether a path was found within `max_depth` hops.
+              - `path` (list[str]): Ordered list of note paths from source to target,
+                or an empty list if not found.
+              - `hops` (int): Number of edges in the path (`len(path) - 1`), or -1 if
+                not found.
         """
         if wait_for_drain:
-            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
+            await asyncio.to_thread(
+                collection.wait_for_drain, timeout=_resolve_drain_timeout()
+            )
         result: list[str] | None = await asyncio.to_thread(
             collection.get_connection_path, source, target, max_depth
         )

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -705,8 +705,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     @needs_queryable()
     async def get_outlinks(
         path: str,
+        wait_for_drain: bool = False,
         collection: Collection = Depends(get_collection),
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """Find all links FROM the given document to other documents (outlinks).
 
         Use this to see what a document references. For a full picture of
@@ -719,16 +720,29 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Args:
             path: Relative path of the source document (e.g.
                 "notes/topic.md"). Case-sensitive.
+            wait_for_drain: When True, block until the IndexWriter has
+                no pending or in-flight work before answering. Bounded
+                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
+                On timeout, returns the result with `stale=True` rather
+                than raising — best-effort fresh read. Default False
+                returns immediately and reports staleness via the
+                envelope's `stale` field.
 
         Returns:
-            List of dicts, each with:
+            Dict envelope with two keys:
 
-            - target_path (str): Path of the linked document.
-            - link_text (str): The clickable text of the link.
-            - link_type (str): One of "markdown", "wikilink", or "reference".
-            - fragment (str | None): Heading anchor (e.g. "#section"), or null.
-            - raw_target (str): Literal link target as written in the source.
-            - exists (bool): True if the target document is indexed.
+            - stale (bool): True when the IndexWriter had pending work
+              at the moment this response was constructed. The data
+              below may not reflect the latest committed state. False
+              when the writer was idle at response time.
+            - data (list[dict]): The outlinks list. Each entry has:
+
+              - target_path (str): Path of the linked document.
+              - link_text (str): The clickable text of the link.
+              - link_type (str): One of "markdown", "wikilink", or "reference".
+              - fragment (str | None): Heading anchor (e.g. "#section"), or null.
+              - raw_target (str): Literal link target as written in the source.
+              - exists (bool): True if the target document is indexed.
 
         Combine with ``get_similar`` to find connection gaps — notes the
         source is semantically close to but hasn't linked yet.
@@ -736,8 +750,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
+        if wait_for_drain:
+            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
         results = await asyncio.to_thread(collection.get_outlinks, path)
-        return [asdict(r) for r in results]
+        return {
+            "stale": not collection.is_drained(),
+            "data": [asdict(r) for r in results],
+        }
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_broken_links"],

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -932,6 +932,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         path: str,
         similar_limit: int = 5,
         link_limit: int = 10,
+        wait_for_drain: bool = False,
         collection: Collection = Depends(get_collection),
     ) -> dict[str, Any]:
         """Get a consolidated context dossier for a document.
@@ -955,9 +956,20 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 are not configured).
             link_limit: Maximum number of backlinks and outlinks to include
                 each (default 10).
+            wait_for_drain: When True, block until the IndexWriter has
+                no pending or in-flight work before answering. Bounded
+                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
+                On timeout, returns the result with `stale=True` rather
+                than raising — best-effort fresh read. Default False
+                returns immediately and reports staleness via the
+                envelope's `stale` field.
 
         Returns:
-            Dict with the following fields:
+            Dict envelope with two keys:
+
+            - stale (bool): True when the IndexWriter had pending work
+              at response time.
+            - data (dict): The note context. Inner fields:
 
             - path (str): Relative path of the document.
             - title (str): Document title.
@@ -1010,13 +1022,18 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
+        if wait_for_drain:
+            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
         result = await asyncio.to_thread(
             collection.get_context,
             path,
             similar_limit=similar_limit,
             link_limit=link_limit,
         )
-        return asdict(result)
+        return {
+            "stale": not collection.is_drained(),
+            "data": asdict(result),
+        }
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_orphan_notes"],

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -10,6 +10,7 @@ import asyncio
 import base64
 import ipaddress
 import logging
+import os
 import subprocess
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Literal
@@ -31,6 +32,13 @@ from ._server_deps import get_collection
 from ._server_queryable import needs_queryable
 
 logger = logging.getLogger(__name__)
+
+
+# Drift-aware B3 reader timeout (#534). Bounds wait_for_drain=True calls
+# on the five B3 tools (get_backlinks, get_outlinks, get_similar,
+# get_context, get_connection_path). Default 60s matches the existing
+# BUILD_TIMEOUT_S precedent.
+_DRAIN_TIMEOUT_S = float(os.environ.get("MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S", "60"))
 
 _ALLOWED_FETCH_SCHEMES = frozenset({"http", "https"})
 
@@ -631,8 +639,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     @needs_queryable()
     async def get_backlinks(
         path: str,
+        wait_for_drain: bool = False,
         collection: Collection = Depends(get_collection),
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """Find all documents that link TO the given document (backlinks).
 
         Use this to discover which notes reference a particular document.
@@ -647,16 +656,29 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Args:
             path: Relative path of the target document (e.g.
                 "notes/topic.md"). Case-sensitive.
+            wait_for_drain: When True, block until the IndexWriter has
+                no pending or in-flight work before answering. Bounded
+                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
+                On timeout, returns the result with `stale=True` rather
+                than raising — best-effort fresh read. Default False
+                returns immediately and reports staleness via the
+                envelope's `stale` field.
 
         Returns:
-            List of dicts, each with:
+            Dict envelope with two keys:
 
-            - source_path (str): Path of the document containing the link.
-            - source_title (str): Title of the source document.
-            - link_text (str): The clickable text of the link.
-            - link_type (str): One of "markdown", "wikilink", or "reference".
-            - fragment (str | None): Heading anchor (e.g. "#section"), or null.
-            - raw_target (str): Literal link target as written in the source.
+            - stale (bool): True when the IndexWriter had pending work
+              at the moment this response was constructed. The data
+              below may not reflect the latest committed state. False
+              when the writer was idle at response time.
+            - data (list[dict]): The backlinks list. Each entry has:
+
+              - source_path (str): Path of the document containing the link.
+              - source_title (str): Title of the source document.
+              - link_text (str): The clickable text of the link.
+              - link_type (str): One of "markdown", "wikilink", or "reference".
+              - fragment (str | None): Heading anchor (e.g. "#section"), or null.
+              - raw_target (str): Literal link target as written in the source.
 
         Combine with ``get_similar`` to find connection gaps — notes that are
         semantically close to the target but not yet linked.
@@ -664,8 +686,13 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
+        if wait_for_drain:
+            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
         results = await asyncio.to_thread(collection.get_backlinks, path)
-        return [asdict(r) for r in results]
+        return {
+            "stale": not collection.is_drained(),
+            "data": [asdict(r) for r in results],
+        }
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_outlinks"],

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -813,8 +813,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         path: str,
         limit: int = 10,
         chunks_per_file: int | None = None,
+        wait_for_drain: bool = False,
         collection: Collection = Depends(get_collection),
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """Find notes most semantically similar to the given document.
 
         Uses stored embedding vectors — no re-embedding needed. The
@@ -830,9 +831,21 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             limit: Maximum number of similar notes to return (default 10).
             chunks_per_file: Maximum sections returned per file (default 2).
                 Set to 1 for one best section per file.  Must be >= 1.
+            wait_for_drain: When True, block until the IndexWriter has
+                no pending or in-flight work before answering. Bounded
+                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
+                On timeout, returns the result with `stale=True` rather
+                than raising — best-effort fresh read. Default False
+                returns immediately and reports staleness via the
+                envelope's `stale` field.
 
         Returns:
-            List of result dicts ranked by file similarity. Each contains:
+            Dict envelope with two keys:
+
+            - stale (bool): True when the IndexWriter had pending work
+              at response time.
+            - data (list[dict]): Result dicts ranked by file similarity.
+              Each entry contains:
 
             - path (str): Relative path of the similar document.
             - title (str): Document title.
@@ -855,13 +868,18 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
+        if wait_for_drain:
+            await asyncio.to_thread(collection.wait_for_drain, timeout=_DRAIN_TIMEOUT_S)
         results = await asyncio.to_thread(
             collection.get_similar,
             path,
             limit=limit,
             chunks_per_file=chunks_per_file,
         )
-        return [asdict(r) for r in results]
+        return {
+            "stale": not collection.is_drained(),
+            "data": [asdict(r) for r in results],
+        }
 
     # --- Recently modified ---
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -625,11 +625,14 @@ class Collection:
     def is_drained(self) -> bool:
         """Return True iff the IndexWriter has no pending or in-flight work.
 
-        Cheap, non-blocking. A snapshot of the writer's current state —
-        the four indicators are sampled under the writer's per-field
-        locks (queue depth via ``Queue.qsize()`` is lock-free), not a
-        single cross-field lock, so the writer can transition briefly
-        between sample points.
+        Cheap (microsecond-scale). Acquires the writer's per-field
+        ``threading.Lock``s briefly to sample state — not technically
+        non-blocking from an asyncio perspective, but the lock-hold
+        durations are bounded by the writer's own short critical
+        sections. The four indicators (queue depth, in-flight kind,
+        FTS-dirty count, vector-dirty count) are sampled under
+        per-field locks rather than a single cross-field lock, so the
+        writer can transition briefly between sample points.
 
         Returns:
             True when ``queue_depth == 0``, ``in_flight is None``, the

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -625,7 +625,11 @@ class Collection:
     def is_drained(self) -> bool:
         """Return True iff the IndexWriter has no pending or in-flight work.
 
-        Cheap, non-blocking. A snapshot of the writer's current state.
+        Cheap, non-blocking. A snapshot of the writer's current state —
+        the four indicators are sampled under the writer's per-field
+        locks (queue depth via ``Queue.qsize()`` is lock-free), not a
+        single cross-field lock, so the writer can transition briefly
+        between sample points.
 
         Returns:
             True when ``queue_depth == 0``, ``in_flight is None``, the

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -638,11 +638,9 @@ class Collection:
             True when ``queue_depth == 0``, ``in_flight is None``, the
             FTS-dirty set is empty, and the vector-dirty set is empty.
             Reflects the moment of call only; the writer can transition
-            in or out of "drained" the moment this returns. In
-            particular, a complete write cycle (enqueue → run → clear)
-            that fits between two consecutive ``is_drained()`` samples
-            is invisible to a caller comparing the two snapshots; the
-            drift-signal callsites accept this as best-effort.
+            in or out of "drained" the moment this returns. Callers
+            that need to detect a complete write cycle inside a window
+            should pair this with :meth:`write_generation`.
         """
         status = self._writer.get_status()
         return (
@@ -651,6 +649,17 @@ class Collection:
             and status["dirty_paths"] == 0
             and status["dirty_embeddings"] == 0
         )
+
+    def write_generation(self) -> int:
+        """Return the writer's monotonic completion counter.
+
+        Increments once per completed job (success or exception).
+        Pair with :meth:`is_drained`: snapshot the counter before and
+        after a read; if it changes, a write cycle completed inside
+        the read window even if :meth:`is_drained` was True at both
+        ends.
+        """
+        return int(self._writer.get_status()["write_generation"])
 
     def wait_for_drain(self, timeout: float | None = None) -> bool:
         """Block until :meth:`is_drained` returns True, or until *timeout*.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -11,6 +11,7 @@ import logging
 import queue
 import re
 import threading
+import time
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -643,9 +644,10 @@ class Collection:
     def wait_for_drain(self, timeout: float | None = None) -> bool:
         """Block until :meth:`is_drained` returns True, or until *timeout*.
 
-        Polls writer state with a 50ms interval. Does not hold any lock
-        during the wait; the writer is free to process jobs while a
-        caller waits.
+        Polls writer state every 50ms. Does not hold any lock during the
+        wait; the writer is free to process jobs while a caller waits.
+        Because the deadline is only re-checked after each sleep, the
+        actual maximum wait is ``timeout + 0.05`` seconds.
 
         Args:
             timeout: Maximum seconds to wait. ``None`` blocks indefinitely;
@@ -656,8 +658,6 @@ class Collection:
             timeout. Does not raise on timeout — best-effort semantics
             so callers can fall through to a stale read.
         """
-        import time
-
         deadline = None if timeout is None else time.monotonic() + timeout
         poll_interval = 0.05
         while True:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -640,6 +640,33 @@ class Collection:
             and status["dirty_embeddings"] == 0
         )
 
+    def wait_for_drain(self, timeout: float | None = None) -> bool:
+        """Block until :meth:`is_drained` returns True, or until *timeout*.
+
+        Polls writer state with a 50ms interval. Does not hold any lock
+        during the wait; the writer is free to process jobs while a
+        caller waits.
+
+        Args:
+            timeout: Maximum seconds to wait. ``None`` blocks indefinitely;
+                production callers should always pass a finite timeout.
+
+        Returns:
+            True if the writer drained within the budget; False on
+            timeout. Does not raise on timeout — best-effort semantics
+            so callers can fall through to a stale read.
+        """
+        import time
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        poll_interval = 0.05
+        while True:
+            if self.is_drained():
+                return True
+            if deadline is not None and time.monotonic() >= deadline:
+                return False
+            time.sleep(poll_interval)
+
     def get_index_status(self) -> dict[str, Any]:
         """Return a non-blocking snapshot of background-build state.
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -621,6 +621,25 @@ class Collection:
             return False
         return not self._fts.is_build_completed()
 
+    def is_drained(self) -> bool:
+        """Return True iff the IndexWriter has no pending or in-flight work.
+
+        Cheap, non-blocking. A snapshot of the writer's current state.
+
+        Returns:
+            True when ``queue_depth == 0``, ``in_flight is None``, the
+            FTS-dirty set is empty, and the vector-dirty set is empty.
+            Reflects the moment of call only; the writer can transition
+            in or out of "drained" the moment this returns.
+        """
+        status = self._writer.get_status()
+        return (
+            status["queue_depth"] == 0
+            and status["in_flight"] is None
+            and status["dirty_paths"] == 0
+            and status["dirty_embeddings"] == 0
+        )
+
     def get_index_status(self) -> dict[str, Any]:
         """Return a non-blocking snapshot of background-build state.
 

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -638,7 +638,11 @@ class Collection:
             True when ``queue_depth == 0``, ``in_flight is None``, the
             FTS-dirty set is empty, and the vector-dirty set is empty.
             Reflects the moment of call only; the writer can transition
-            in or out of "drained" the moment this returns.
+            in or out of "drained" the moment this returns. In
+            particular, a complete write cycle (enqueue → run → clear)
+            that fits between two consecutive ``is_drained()`` samples
+            is invisible to a caller comparing the two snapshots; the
+            drift-signal callsites accept this as best-effort.
         """
         status = self._writer.get_status()
         return (

--- a/src/markdown_vault_mcp/static/prompts/propose-links.md
+++ b/src/markdown_vault_mcp/static/prompts/propose-links.md
@@ -28,12 +28,12 @@ If the resolved set contains more than 100 notes, pause and ask the user whether
 
 For each note in scope:
 
-1. Call `get_similar(path=<note path>, limit=$per_note_limit)` (default limit: 5).
-2. If `get_similar` returns an empty list (no embeddings configured), fall back to `search(query=<note title>, mode='keyword', limit=$per_note_limit)` and drop the note itself from the result.
+1. Call `get_similar(path=<note path>, limit=$per_note_limit)` (default limit: 5). The tool returns a `{"stale": bool, "data": [...]}` envelope — use the `data` list for the candidates.
+2. If `get_similar`'s `data` list is empty (no embeddings configured), fall back to `search(query=<note title>, mode='keyword', limit=$per_note_limit)` and drop the note itself from the result.
 
 ## Step 3: Filter out already-linked pairs
 
-For each scanned note, call `get_outlinks(path=<note>)` once. For each candidate pair (A, B), drop the candidate if A already links to B — compare the candidate path `B` against each outlink's `target_path` (the resolved vault-relative path of the link target, which is what you want for equality checks). `raw_target` is the literal link text as written (and may be a wikilink without `.md`) — only fall back to comparing against `raw_target` when `target_path` is empty (e.g., the link hasn't been resolved).
+For each scanned note, call `get_outlinks(path=<note>)` once. The tool returns a `{"stale": bool, "data": [...]}` envelope; iterate `data` for the outlink dicts. For each candidate pair (A, B), drop the candidate if A already links to B — compare the candidate path `B` against each outlink's `target_path` (the resolved vault-relative path of the link target, which is what you want for equality checks). `raw_target` is the literal link text as written (and may be a wikilink without `.md`) — only fall back to comparing against `raw_target` when `target_path` is empty (e.g., the link hasn't been resolved).
 
 ## Step 4: Apply LLM judgment
 

--- a/src/markdown_vault_mcp/static/prompts/related.md
+++ b/src/markdown_vault_mcp/static/prompts/related.md
@@ -7,7 +7,7 @@ arguments:
 icons: search
 ---
 Step 1: Call `read` with path='$path'. Extract the main topics and key terms.
-Step 2: Call `get_context` with path='$path' — this returns backlinks, outlinks, and similar notes in one call. Also call `search` using the main topic terms to surface additional documents not captured by direct links or overall document similarity.
+Step 2: Call `get_context` with path='$path' — this returns a `{"stale": bool, "data": {...}}` envelope; the `data` dict contains backlinks, outlinks, and similar notes in one call. Also call `search` using the main topic terms to surface additional documents not captured by direct links or overall document similarity.
 Step 3: Present a list of the most relevant related documents. For each, include: the document title, its path, and one sentence explaining the connection.
 Format suggested cross-references as: [title](relative/path.md)
 Do not edit any documents — this prompt is read-only.

--- a/src/markdown_vault_mcp/writer.py
+++ b/src/markdown_vault_mcp/writer.py
@@ -114,6 +114,12 @@ class IndexWriter:
         self._dirty_embeddings: set[str] = set()
         self._in_flight_lock = threading.Lock()
         self._in_flight_kind: str | None = None
+        # Monotonically increments each time a job finishes. Read under
+        # _in_flight_lock alongside _in_flight_kind so callers can pair
+        # the snapshot with the state. Used by drift-aware B3 readers
+        # (#534) to detect write cycles that fit entirely inside a
+        # tool's read window.
+        self._write_generation: int = 0
 
     def start(self) -> None:
         """Spawn the worker thread. Idempotent and thread-safe.
@@ -226,6 +232,7 @@ class IndexWriter:
         """Return non-blocking snapshot of writer state."""
         with self._in_flight_lock:
             in_flight = self._in_flight_kind
+            write_generation = self._write_generation
         with self._dirty_lock:
             dirty_paths = len(self._dirty_paths)
             dirty_embeddings = len(self._dirty_embeddings)
@@ -234,6 +241,7 @@ class IndexWriter:
             "in_flight": in_flight,
             "dirty_paths": dirty_paths,
             "dirty_embeddings": dirty_embeddings,
+            "write_generation": write_generation,
         }
 
     def _run(self) -> None:
@@ -328,6 +336,7 @@ class IndexWriter:
             finally:
                 with self._in_flight_lock:
                     self._in_flight_kind = None
+                    self._write_generation += 1
 
 
 @dataclass

--- a/src/markdown_vault_mcp/writer.py
+++ b/src/markdown_vault_mcp/writer.py
@@ -257,10 +257,15 @@ class IndexWriter:
                 sentinel_seen = True
                 continue
             job, future = cast("tuple[Any, Future[Any]]", item)
-            if not future.set_running_or_notify_cancel():
-                continue
+            # Claim in_flight BEFORE notifying the future, so a
+            # concurrent get_status() cannot observe queue_depth=0
+            # together with in_flight=None during dispatch (#534/#573).
             with self._in_flight_lock:
                 self._in_flight_kind = job.kind
+            if not future.set_running_or_notify_cancel():
+                with self._in_flight_lock:
+                    self._in_flight_kind = None
+                continue
             try:
                 runner = self._runners[job.kind]
                 result = runner(job, self._ctx)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,6 +209,7 @@ async def wait_for_mcp_writer_drain(client: object, timeout: float = 5.0) -> Non
             and status.get("queue_depth", 0) == 0
             and status.get("in_flight") is None
             and status.get("dirty_paths", 0) == 0
+            and status.get("dirty_embeddings", 0) == 0
         ):
             return
         await _asyncio.sleep(0.05)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4244,3 +4244,79 @@ class TestIsDrained:
                 fut.result(timeout=5)
         finally:
             col.close()
+
+
+class TestWaitForDrain:
+    """Tests for Collection.wait_for_drain() (#534)."""
+
+    def test_returns_true_immediately_when_already_drained(
+        self, tmp_path: Path
+    ) -> None:
+        import time
+
+        from markdown_vault_mcp.collection import Collection
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            start = time.monotonic()
+            drained = col.wait_for_drain(timeout=1.0)
+            elapsed = time.monotonic() - start
+            assert drained is True
+            assert elapsed < 0.2
+        finally:
+            col.close()
+
+    def test_returns_true_after_writer_drains(self, tmp_path: Path) -> None:
+        import threading
+
+        from markdown_vault_mcp.collection import Collection
+        from markdown_vault_mcp.writer import BuildIndex
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            release = threading.Event()
+            started = threading.Event()
+            original_runner = col._writer._runners["build_index"]
+
+            def _blocking_runner(job, ctx):
+                started.set()
+                release.wait(timeout=5)
+                return original_runner(job, ctx)
+
+            col._writer._runners["build_index"] = _blocking_runner
+            fut = col._writer.submit(BuildIndex())
+            started.wait(timeout=5)
+            threading.Timer(0.1, release.set).start()
+            assert col.wait_for_drain(timeout=5.0) is True
+            fut.result(timeout=5)
+        finally:
+            col.close()
+
+    def test_returns_false_on_timeout(self, tmp_path: Path) -> None:
+        import threading
+
+        from markdown_vault_mcp.collection import Collection
+        from markdown_vault_mcp.writer import BuildIndex
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            release = threading.Event()
+            started = threading.Event()
+            original_runner = col._writer._runners["build_index"]
+
+            def _blocking_runner(job, ctx):
+                started.set()
+                release.wait(timeout=5)
+                return original_runner(job, ctx)
+
+            col._writer._runners["build_index"] = _blocking_runner
+            fut = col._writer.submit(BuildIndex())
+            started.wait(timeout=5)
+            assert col.wait_for_drain(timeout=0.1) is False
+            release.set()
+            fut.result(timeout=5)
+        finally:
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4179,3 +4179,68 @@ def test_build_embeddings_async_failure_recorded_in_status(tmp_path, monkeypatch
         assert "simulated embeddings failure" in status["last_build_embeddings_error"]
     finally:
         col.close()
+
+
+class TestIsDrained:
+    """Tests for Collection.is_drained() (#534)."""
+
+    def test_returns_true_on_idle_writer(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.collection import Collection
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            assert col.is_drained() is True
+        finally:
+            col.close()
+
+    def test_returns_false_when_dirty_paths_present(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.collection import Collection
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            col._writer.mark_dirty(["fake.md"])
+            assert col.is_drained() is False
+        finally:
+            col.close()
+
+    def test_returns_false_when_dirty_embeddings_present(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.collection import Collection
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            col._writer.mark_embedding_dirty(["fake.md"])
+            assert col.is_drained() is False
+        finally:
+            col.close()
+
+    def test_returns_false_during_in_flight_job(self, tmp_path: Path) -> None:
+        import threading
+
+        from markdown_vault_mcp.collection import Collection
+        from markdown_vault_mcp.writer import BuildIndex
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            release = threading.Event()
+            started = threading.Event()
+            original_runner = col._writer._runners["build_index"]
+
+            def _blocking_runner(job, ctx):
+                started.set()
+                release.wait(timeout=5)
+                return original_runner(job, ctx)
+
+            col._writer._runners["build_index"] = _blocking_runner
+            try:
+                fut = col._writer.submit(BuildIndex())
+                started.wait(timeout=5)
+                assert col.is_drained() is False
+            finally:
+                release.set()
+                fut.result(timeout=5)
+        finally:
+            col.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4246,6 +4246,46 @@ class TestIsDrained:
             col.close()
 
 
+class TestWriteGeneration:
+    """Tests for Collection.write_generation() (#534)."""
+
+    def test_increments_on_job_completion(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.collection import Collection
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            gen_before = col.write_generation()
+            # Submit a no-op write (mark + flush dirty paths) so a job
+            # cycle completes through the writer.
+            col._writer.mark_dirty(["sentinel.md"])
+            col._writer.drain_dirty_paths()
+            from markdown_vault_mcp.writer import BuildIndex
+
+            col._writer.submit(BuildIndex()).result(timeout=5)
+            assert col.write_generation() > gen_before
+        finally:
+            col.close()
+
+    def test_monotonic_across_multiple_jobs(self, tmp_path: Path) -> None:
+        from itertools import pairwise
+
+        from markdown_vault_mcp.collection import Collection
+        from markdown_vault_mcp.writer import BuildIndex
+
+        col = Collection(source_dir=tmp_path, read_only=False)
+        try:
+            col.build_index()
+            samples = [col.write_generation()]
+            for _ in range(3):
+                col._writer.submit(BuildIndex()).result(timeout=5)
+                samples.append(col.write_generation())
+            for prev, cur in pairwise(samples):
+                assert cur > prev
+        finally:
+            col.close()
+
+
 class TestWaitForDrain:
     """Tests for Collection.wait_for_drain() (#534)."""
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -666,10 +666,13 @@ class TestMCPGetConnectionPath:
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 "get_connection_path", {"source": "a.md", "target": "c.md"}
             )
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert data["found"] is True
         assert data["path"] == ["a.md", "b.md", "c.md"]
         assert data["hops"] == 2
@@ -682,11 +685,14 @@ class TestMCPGetConnectionPath:
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 "get_connection_path",
                 {"source": "a.md", "target": "isolated.md"},
             )
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert data["found"] is False
         assert data["path"] == []
         assert data["hops"] == -1
@@ -699,10 +705,13 @@ class TestMCPGetConnectionPath:
 
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 "get_connection_path", {"source": "a.md", "target": "a.md"}
             )
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert data["found"] is True
         assert data["path"] == ["a.md"]
         assert data["hops"] == 0
@@ -721,3 +730,26 @@ class TestMCPGetConnectionPath:
                     "get_connection_path",
                     {"source": "nonexistent.md", "target": "a.md"},
                 )
+
+    async def test_get_connection_path_with_wait_for_drain(
+        self, _mcp_env_path: None
+    ) -> None:
+        """wait_for_drain=True blocks until writer drained, then returns envelope."""
+        from fastmcp import Client
+
+        from markdown_vault_mcp.server import make_server
+
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "get_connection_path",
+                {
+                    "source": "a.md",
+                    "target": "c.md",
+                    "wait_for_drain": True,
+                },
+            )
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        assert envelope["data"]["found"] is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3600,3 +3600,67 @@ class TestGitToolsUntilParam:
         past_data = _parse_tool_data(past)
         assert past_data["commits"] == []
         assert past_data["total"] == 0
+
+
+class TestB3StaleSignal:
+    """Tests for the writer-state staleness signal on B3 tools (#534)."""
+
+    @pytest.fixture
+    def _mcp_env_linked(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Create a vault with interlinked notes for B3 tool stale-signal tests."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "index.md").write_text(
+            "# Index\n\nSee [Topic](notes/topic.md) and [Ghost](ghost.md).\n",
+            encoding="utf-8",
+        )
+        (vault / "notes").mkdir()
+        (vault / "notes" / "topic.md").write_text(
+            "# Topic\n\nBack to [Index](../index.md).\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
+        for var in _CLEAR_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+    @pytest.mark.usefixtures("_mcp_env_linked")
+    async def test_stale_true_when_writer_has_pending_dirty_paths(
+        self,
+    ) -> None:
+        from markdown_vault_mcp._server_deps import get_collection_singleton
+
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            # Make the writer non-idle by marking a path dirty directly
+            # on the writer (no submit, so no in-flight job, just a
+            # non-empty dirty-paths set — that alone should set stale=True).
+            col = get_collection_singleton()
+            col._writer.mark_dirty(["sentinel.md"])
+            try:
+                result = await client.call_tool(
+                    "get_backlinks", {"path": "notes/topic.md"}
+                )
+            finally:
+                # Clear the sentinel so subsequent tests are not affected
+                # by leaked dirty-set state.
+                col._writer.drain_dirty_paths()
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is True
+        # The data is still returned despite stale=True.
+        assert isinstance(envelope["data"], list)
+
+    @pytest.mark.usefixtures("_mcp_env_linked")
+    async def test_wait_for_drain_clears_stale_when_writer_idle(
+        self,
+    ) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "get_backlinks",
+                {"path": "notes/topic.md", "wait_for_drain": True},
+            )
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1668,8 +1668,11 @@ class TestSimilarTool:
         """get_similar returns empty list when embeddings not configured."""
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_similar", {"path": "simple.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert data == []
 
     @pytest.mark.usefixtures("_mcp_env")
@@ -1684,14 +1687,30 @@ class TestSimilarTool:
         """The `get_similar` MCP tool surfaces the chunks_per_file kwarg."""
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             # Without embeddings this returns []; the assertion is that the
             # call_tool schema accepts the chunks_per_file kwarg without raising.
             result = await client.call_tool(
                 "get_similar",
                 {"path": "simple.md", "limit": 5, "chunks_per_file": 1},
             )
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert isinstance(data, list)
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_get_similar_with_wait_for_drain(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "get_similar",
+                {"path": "simple.md", "wait_for_drain": True},
+            )
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        assert isinstance(envelope["data"], list)
 
 
 class TestRecentTool:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3664,3 +3664,26 @@ class TestB3StaleSignal:
             )
         envelope = _parse_tool_data(result)
         assert envelope["stale"] is False
+
+    @pytest.mark.usefixtures("_mcp_env_linked")
+    async def test_wait_for_drain_timeout_reports_stale_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp._server_deps import get_collection_singleton
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S", "0.05")
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            col = get_collection_singleton()
+            col._writer.mark_dirty(["sentinel.md"])
+            try:
+                result = await client.call_tool(
+                    "get_backlinks",
+                    {"path": "notes/topic.md", "wait_for_drain": True},
+                )
+            finally:
+                col._writer.drain_dirty_paths()
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is True
+        assert isinstance(envelope["data"], list)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3687,3 +3687,36 @@ class TestB3StaleSignal:
         envelope = _parse_tool_data(result)
         assert envelope["stale"] is True
         assert isinstance(envelope["data"], list)
+
+    @pytest.mark.usefixtures("_mcp_env_linked")
+    @pytest.mark.parametrize(
+        ("tool_name", "tool_args"),
+        [
+            ("get_backlinks", {"path": "notes/topic.md"}),
+            ("get_outlinks", {"path": "notes/topic.md"}),
+            ("get_similar", {"path": "notes/topic.md"}),
+            ("get_context", {"path": "notes/topic.md"}),
+            (
+                "get_connection_path",
+                {"source": "notes/topic.md", "target": "index.md"},
+            ),
+        ],
+    )
+    async def test_stale_true_uniform_across_b3_tools(
+        self, tool_name: str, tool_args: dict[str, str]
+    ) -> None:
+        """Each B3 tool independently ORs stale; catch copy-paste regressions."""
+        from markdown_vault_mcp._server_deps import get_collection_singleton
+
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            col = get_collection_singleton()
+            col._writer.mark_dirty(["sentinel.md"])
+            try:
+                result = await client.call_tool(tool_name, tool_args)
+            finally:
+                col._writer.drain_dirty_paths()
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is True
+        assert "data" in envelope

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1790,8 +1790,11 @@ class TestContextTool:
         """get_context returns expected top-level fields."""
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert data["path"] == "index.md"
         assert data["title"] == "Index"
         assert "modified_at" in data
@@ -1807,10 +1810,13 @@ class TestContextTool:
         """modified_at in context matches the value from read()."""
         server = make_server()
         async with Client(server) as client:
-            ctx = _parse_tool_data(
+            await wait_for_mcp_writer_drain(client)
+            envelope = _parse_tool_data(
                 await client.call_tool("get_context", {"path": "index.md"})
             )
             read = (await client.call_tool("read", {"path": "index.md"})).data
+        assert envelope["stale"] is False
+        ctx = envelope["data"]
         assert ctx["modified_at"] == read["modified_at"]
 
     @pytest.mark.usefixtures("_mcp_env_context")
@@ -1818,8 +1824,11 @@ class TestContextTool:
         """notes/topic.md has a backlink from index.md."""
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "notes/topic.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         sources = [b["source_path"] for b in data["backlinks"]]
         assert "index.md" in sources
 
@@ -1828,8 +1837,11 @@ class TestContextTool:
         """index.md has an outlink to notes/topic.md."""
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         targets = [o["target_path"] for o in data["outlinks"]]
         assert "notes/topic.md" in targets
 
@@ -1838,8 +1850,11 @@ class TestContextTool:
         """folder_notes for notes/topic.md contains peer.md but not topic.md."""
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "notes/topic.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert "notes/topic.md" not in data["folder_notes"]
         assert "notes/peer.md" in data["folder_notes"]
 
@@ -1848,8 +1863,11 @@ class TestContextTool:
         """Indexed frontmatter tags appear in context.tags."""
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert "tags" in data["tags"]
         assert "ai" in data["tags"]["tags"]
         assert "research" in data["tags"]["tags"]
@@ -1859,8 +1877,11 @@ class TestContextTool:
         """similar is empty when embeddings are not configured."""
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert data["similar"] == []
 
     @pytest.mark.usefixtures("_mcp_env_context")
@@ -1879,6 +1900,19 @@ class TestContextTool:
             tools = await client.list_tools()
         names = {t.name for t in tools}
         assert "get_context" in names
+
+    @pytest.mark.usefixtures("_mcp_env_context")
+    async def test_get_context_with_wait_for_drain(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "get_context",
+                {"path": "index.md", "wait_for_drain": True},
+            )
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        assert envelope["data"]["path"] == "index.md"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1593,8 +1593,11 @@ class TestLinkTools:
     async def test_get_outlinks(self) -> None:
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_outlinks", {"path": "index.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert len(data) == 2
         targets = {d["target_path"] for d in data}
         assert "notes/topic.md" in targets
@@ -1603,6 +1606,19 @@ class TestLinkTools:
         by_target = {d["target_path"]: d for d in data}
         assert by_target["notes/topic.md"]["exists"] is True
         assert by_target["ghost.md"]["exists"] is False
+
+    @pytest.mark.usefixtures("_mcp_env_linked")
+    async def test_get_outlinks_with_wait_for_drain(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "get_outlinks",
+                {"path": "index.md", "wait_for_drain": True},
+            )
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        assert len(envelope["data"]) == 2
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_outlinks_nonexistent_path(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1560,11 +1560,27 @@ class TestLinkTools:
     async def test_get_backlinks(self) -> None:
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_backlinks", {"path": "notes/topic.md"})
-        data = _parse_tool_data(result)
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        data = envelope["data"]
         assert len(data) == 1
         assert data[0]["source_path"] == "index.md"
         assert data[0]["link_text"] == "Topic"
+
+    @pytest.mark.usefixtures("_mcp_env_linked")
+    async def test_get_backlinks_with_wait_for_drain(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "get_backlinks",
+                {"path": "notes/topic.md", "wait_for_drain": True},
+            )
+        envelope = _parse_tool_data(result)
+        assert envelope["stale"] is False
+        assert len(envelope["data"]) == 1
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_backlinks_nonexistent_raises(self) -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -245,7 +245,39 @@ def test_get_status_empty_writer():
         "in_flight": None,
         "dirty_paths": 0,
         "dirty_embeddings": 0,
+        "write_generation": 0,
     }
+
+
+def test_write_generation_advances_per_completed_job():
+    def runner(job, ctx):  # noqa: ARG001
+        return None
+
+    writer = IndexWriter(runners={"build_index": runner}, ctx=None)
+    writer.start()
+    try:
+        assert writer.get_status()["write_generation"] == 0
+        writer.submit(BuildIndex()).result(timeout=5)
+        assert writer.get_status()["write_generation"] == 1
+        writer.submit(BuildIndex()).result(timeout=5)
+        assert writer.get_status()["write_generation"] == 2
+    finally:
+        writer.close(timeout=5)
+
+
+def test_write_generation_advances_when_runner_raises():
+    def raising_runner(job, ctx):  # noqa: ARG001
+        raise RuntimeError("boom")
+
+    writer = IndexWriter(runners={"build_index": raising_runner}, ctx=None)
+    writer.start()
+    future = writer.submit(BuildIndex())
+    with pytest.raises(RuntimeError, match="boom"):
+        future.result(timeout=5)
+    # close() joins the worker, ensuring the finally block (which
+    # increments _write_generation) has completed before we observe it.
+    writer.close(timeout=5)
+    assert writer.get_status()["write_generation"] == 1
 
 
 def test_get_status_reports_dirty_counts():


### PR DESCRIPTION
## Summary

- Adds `Collection.is_drained()` and `Collection.wait_for_drain(timeout)` primitives that snapshot the IndexWriter's drainedness across `queue_depth`, `in_flight`, `dirty_paths`, and `dirty_embeddings`.
- Adds an optional `wait_for_drain: bool = False` parameter to five B3 MCP tools (`get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, `get_connection_path`). When true the tool blocks (bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S`, default 60s) until the writer drains.
- Wraps each B3 tool response in `{"stale": bool, "data": <previous-payload>}`. `stale` is `True` if the writer had any pending work at request time, even when `wait_for_drain=True` timed out (the bound is honored as a strict contract via a `_maybe_wait_for_drain` helper that logs `WARNING` on timeout per the project's logging standard).
- Test helper `wait_for_mcp_writer_drain` is updated to gate on `dirty_embeddings == 0` so it stays in sync with `is_drained()`.

Closes #534. Out of scope: external on-disk drift (tracked separately in #558).

## Test plan

- [x] `uv run pytest -x -q` — 1775 passed
- [x] `uv run ruff check --fix . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/ tests/` — no issues
- [x] `uv run pre-commit run --all-files` — green
- [x] New test pins `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=0.05` and verifies `stale=True` on timeout with `wait_for_drain=True`
- [x] Docs updated: `docs/configuration.md`, `docs/design.md`, `docs/tools/index.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)