### PR TITLE
refactor: type fts_index, vector_index, providers, collection (closes #575)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1436,8 +1436,10 @@ pattern). Each tool is annotated with MCP `ToolAnnotations`:
 | `create_download_link` | Generate a one-time download URL for a vault file (HTTP/SSE only) | `True` | `False` | `False` |
 
 **Tool name note**: the MCP tool is registered as `list_documents` (not `list`)
-to avoid shadowing Python's built-in `list`. The underlying `Collection.list()`
-method is unchanged.
+to avoid shadowing Python's built-in `list`. The underlying
+`Collection.list_documents()` method matches the MCP name; both deliberately
+avoid the bare name `list` so type annotations like `list[NoteInfo]` are not
+mis-resolved against the method in class scope.
 
 **Transport-conditional tools**: `create_download_link` is only registered when
 the server runs with `--transport http` or `--transport sse` (not `stdio`),

--- a/docs/design.md
+++ b/docs/design.md
@@ -1194,8 +1194,8 @@ class Collection:
     def rename(self, old_path: str, new_path: str,
                if_match: str | None = None, *,
                update_links: bool = False) -> RenameResult: ...
-    def list(self, *, folder: str | None = None,
-             pattern: str | None = None) -> list[NoteInfo]: ...
+    def list_documents(self, *, folder: str | None = None,
+                       pattern: str | None = None) -> list[NoteInfo]: ...
 
     # --- Index management ---
     def build_index(self, *, force: bool = False) -> IndexStats: ...
@@ -1224,9 +1224,9 @@ class Collection:
 - `embeddings_path=None`: semantic search is disabled.
 - `state_path=None`: defaults to `{source_dir}/.markdown_vault_mcp/state.json`.
 
-**Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
-`Collection` lazily builds the FTS index from `source_dir` if no pre-built
-`index_path` was provided.
+**Lazy initialization**: on first call to `search()`, `list_documents()`, or
+`read()`, `Collection` lazily builds the FTS index from `source_dir` if no
+pre-built `index_path` was provided.
 
 **Write operations** (`write`, `edit`, `delete`, `rename`) raise
 `ReadOnlyError` when `read_only=True`.
@@ -1277,8 +1277,8 @@ source-directory-relative links (e.g. `../notes/target.md`) are rewritten
 with the correct new relative path from the source file's directory.
 `update_links` is silently ignored for attachments (non-`.md` files).
 
-**`list()` pattern parameter**: if provided, `pattern` is a Unix glob matched
-against the relative path using `fnmatch.fnmatch()`. Example:
+**`list_documents()` pattern parameter**: if provided, `pattern` is a Unix glob
+matched against the relative path using `fnmatch.fnmatch()`. Example:
 `pattern="Journal/*.md"` returns only documents in the Journal folder.
 
 **`list_tags(field)` behavior**: queries only the `document_tags` table. If

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,17 +171,6 @@ module = ["frontmatter", "frontmatter.*", "yaml", "yaml.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = [
-    "markdown_vault_mcp.fts_index",
-    "markdown_vault_mcp.vector_index",
-    "markdown_vault_mcp.providers",
-    "markdown_vault_mcp.collection",
-]
-# Phase 1 modules have structural type issues (FTSResult used as dict,
-# numpy dtype mismatches).  TODO: fix in a dedicated type-safety PR.
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 # Tests pre-date the template's `mypy src/ tests/` requirement (added in
 # template v1.2.0).  Typing the full test suite is tracked separately.
 module = ["tests.*"]

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -711,7 +711,7 @@ def register_apps(mcp: FastMCP) -> None:
               - kind (str): "note" or "attachment".
         """
         docs = await asyncio.to_thread(
-            collection.list, folder=folder, include_attachments=True
+            collection.list_documents, folder=folder, include_attachments=True
         )
         folders = await asyncio.to_thread(collection.list_folders)
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -492,7 +492,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             Body content is not included in either case.
         """
         results = await asyncio.to_thread(
-            collection.list,
+            collection.list_documents,
             folder=folder,
             pattern=pattern,
             include_attachments=include_attachments,

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -43,6 +43,7 @@ from markdown_vault_mcp.types import (
     ReindexResult,
     RenameResult,
     WriteCallback,
+    WriteOperation,
     WriteResult,
 )
 from markdown_vault_mcp.utils import effective_attachment_extensions
@@ -371,7 +372,9 @@ class Collection:
         # Deferred write callback queue (issue #175).  Git commit (on_write
         # callback) runs in a background worker thread so write methods
         # return immediately after the FTS update.
-        self._callback_queue: queue.Queue[tuple[Path, str, str] | None] = queue.Queue()
+        self._callback_queue: queue.Queue[tuple[Path, str, WriteOperation] | None] = (
+            queue.Queue()
+        )
         self._callback_worker: threading.Thread | None = None
         self._callback_worker_lock = threading.Lock()
 
@@ -517,7 +520,7 @@ class Collection:
             and self._on_write is not self._git_strategy
             and hasattr(self._on_write, "close")
         ):
-            self._on_write.close()  # type: ignore[union-attr]
+            self._on_write.close()
 
         # 4. Close SQLite.
         self._fts.close()
@@ -932,7 +935,7 @@ class Collection:
         """
         return self._doc_mgr.read(path, section=section)
 
-    def list(
+    def list_documents(
         self,
         *,
         folder: str | None = None,
@@ -1011,7 +1014,7 @@ class Collection:
         self._fts.clear_build_completed()
         # Route the actual scan through the IndexWriter so all index
         # mutations are serialised on the single writer thread (#559).
-        result = self._writer.submit(BuildIndex(force=force)).result()
+        result: IndexStats = self._writer.submit(BuildIndex(force=force)).result()
         self._fts.set_build_completed()
         self._index_built = True
         # Recovery: clear any captured background error + signal queryable.
@@ -1030,7 +1033,8 @@ class Collection:
             IndexUnavailableError: If :meth:`build_index` has not been called.
         """
         self._require_built()
-        return self._writer.submit(ReindexAll()).result()
+        result: ReindexResult = self._writer.submit(ReindexAll()).result()
+        return result
 
     def build_embeddings(self, *, force: bool = False) -> int:
         """Build the vector index from all chunks currently in the FTS index.
@@ -1048,7 +1052,8 @@ class Collection:
                 not configured.
         """
         self._require_built()
-        return self._writer.submit(BuildEmbeddings(force=force)).result()
+        count: int = self._writer.submit(BuildEmbeddings(force=force)).result()
+        return count
 
     def build_index_async(self, *, force: bool = False) -> Future[IndexStats]:
         """Submit a full FTS index build and return the Future.
@@ -1218,7 +1223,7 @@ class Collection:
         fut.add_done_callback(self._on_build_embeddings_done)
         return fut
 
-    def embeddings_status(self) -> dict:
+    def embeddings_status(self) -> dict[str, Any]:
         """Return status information about the vector index.
 
         Returns:
@@ -1671,7 +1676,7 @@ class Collection:
             self._callback_worker.start()
 
     def _fire_write_callback(
-        self, abs_path: Path, content: str, operation: str
+        self, abs_path: Path, content: str, operation: WriteOperation
     ) -> None:
         """Submit a write callback to the background worker thread."""
         if self._on_write is None:
@@ -1746,7 +1751,7 @@ class Collection:
         self,
         path: str,
         content: str,
-        frontmatter: dict | None = None,
+        frontmatter: dict[str, Any] | None = None,
         if_match: str | None = None,
     ) -> WriteResult:
         """Create or overwrite a document.

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -495,7 +495,7 @@ class FTSIndex:
         """
         if self._closed:
             raise sqlite3.ProgrammingError("Cannot operate on a closed FTSIndex")
-        existing = getattr(self._local, "conn", None)
+        existing: sqlite3.Connection | None = getattr(self._local, "conn", None)
         if existing is not None:
             return existing
         new_conn = self._connect()
@@ -1075,7 +1075,7 @@ class FTSIndex:
         return results
 
     @_retry_on_locked
-    def get_note(self, path: str) -> dict | None:
+    def get_note(self, path: str) -> dict[str, Any] | None:
         """Return document metadata for a single note.
 
         Args:
@@ -1101,7 +1101,7 @@ class FTSIndex:
         return dict(row)
 
     @_retry_on_locked
-    def list_notes(self, *, folder: str | None = None) -> list[dict]:
+    def list_notes(self, *, folder: str | None = None) -> list[dict[str, Any]]:
         """List all indexed documents, optionally filtered by folder.
 
         Args:
@@ -1179,7 +1179,8 @@ class FTSIndex:
         Returns:
             Integer count of all indexed chunks across all documents.
         """
-        return self._conn().execute("SELECT COUNT(*) FROM sections").fetchone()[0]
+        row = self._conn().execute("SELECT COUNT(*) FROM sections").fetchone()
+        return int(row[0])
 
     @_retry_on_locked
     def get_toc(self, path: str) -> list[dict[str, str | int]]:
@@ -1213,7 +1214,9 @@ class FTSIndex:
         ]
 
     @_retry_on_locked
-    def get_backlinks(self, path: str, *, limit: int | None = None) -> list[dict]:
+    def get_backlinks(
+        self, path: str, *, limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Return all documents that link TO the given path.
 
         Args:
@@ -1226,7 +1229,7 @@ class FTSIndex:
             ``link_text``, ``link_type``, ``fragment``, ``raw_target``.
         """
         limit_clause = "" if limit is None else "LIMIT ?"
-        params: tuple = (path,) if limit is None else (path, limit)
+        params: tuple[str | int, ...] = (path,) if limit is None else (path, limit)
         cur = self._conn().execute(
             f"""
             SELECT d.path AS source_path,
@@ -1246,7 +1249,9 @@ class FTSIndex:
         return [dict(row) for row in cur.fetchall()]
 
     @_retry_on_locked
-    def get_outlinks(self, path: str, *, limit: int | None = None) -> list[dict]:
+    def get_outlinks(
+        self, path: str, *, limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Return all links FROM the given document.
 
         Uses a LEFT JOIN to check target existence in a single query,
@@ -1262,7 +1267,7 @@ class FTSIndex:
             ``link_type``, ``fragment``, ``raw_target``, ``exists`` (bool).
         """
         limit_clause = "" if limit is None else "LIMIT ?"
-        params: tuple = (path,) if limit is None else (path, limit)
+        params: tuple[str | int, ...] = (path,) if limit is None else (path, limit)
         cur = self._conn().execute(
             f"""
             SELECT l.target_path,
@@ -1396,7 +1401,7 @@ class FTSIndex:
         return updated
 
     @_retry_on_locked
-    def get_broken_links(self, *, folder: str | None = None) -> list[dict]:
+    def get_broken_links(self, *, folder: str | None = None) -> list[dict[str, Any]]:
         """Return all links whose target does not exist as an indexed document.
 
         Args:
@@ -1435,7 +1440,9 @@ class FTSIndex:
         return [dict(row) for row in cur.fetchall()]
 
     @_retry_on_locked
-    def get_recent(self, *, limit: int = 20, folder: str | None = None) -> list[dict]:
+    def get_recent(
+        self, *, limit: int = 20, folder: str | None = None
+    ) -> list[dict[str, Any]]:
         """Return the most recently modified documents.
 
         Args:
@@ -1474,7 +1481,7 @@ class FTSIndex:
         return [dict(row) for row in cur.fetchall()]
 
     @_retry_on_locked
-    def get_orphan_notes(self) -> list[dict]:
+    def get_orphan_notes(self) -> list[dict[str, Any]]:
         """Return all documents with no inbound or outbound links.
 
         A document is an orphan if it has zero rows in ``links`` as either
@@ -1497,7 +1504,7 @@ class FTSIndex:
         return [dict(row) for row in cur.fetchall()]
 
     @_retry_on_locked
-    def get_most_linked(self, limit: int = 10) -> list[dict]:
+    def get_most_linked(self, limit: int = 10) -> list[dict[str, Any]]:
         """Return the documents with the most distinct source documents linking to them.
 
         Args:
@@ -1581,13 +1588,13 @@ class FTSIndex:
         visited: set[str] = {source_path}
 
         while queue:
-            current, path = queue.popleft()
-            if len(path) - 1 >= max_depth:
+            current, current_path = queue.popleft()
+            if len(current_path) - 1 >= max_depth:
                 continue
             for neighbour in adj.get(current, set()):
                 if neighbour in visited:
                     continue
-                new_path = [*path, neighbour]
+                new_path = [*current_path, neighbour]
                 if neighbour == target_path:
                     logger.debug(
                         "get_connection_path: found path %s → %s in %d hops",

--- a/src/markdown_vault_mcp/git.py
+++ b/src/markdown_vault_mcp/git.py
@@ -384,7 +384,7 @@ class GitWriteStrategy:
         self._pause_writes: (
             Callable[[], contextlib.AbstractContextManager[None]] | None
         ) = None
-        self._on_pull: Callable[[], None] | None = None
+        self._on_pull: Callable[[], object] | None = None
         if repo_path is not None:
             if self._managed:
                 self._ensure_managed_repo(repo_path)
@@ -1965,7 +1965,7 @@ class GitWriteStrategy:
         pull_interval_s: int,
         pause_writes: Callable[[], contextlib.AbstractContextManager[None]]
         | None = None,
-        on_pull: Callable[[], None] | None = None,
+        on_pull: Callable[[], object] | None = None,
     ) -> None:
         """Start a periodic fetch + ff-only update loop in a daemon thread."""
         if self._closed or not self._enable_pull or pull_interval_s <= 0:

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -34,6 +34,7 @@ from markdown_vault_mcp.types import (
     EditResult,
     NoteContent,
     RenameResult,
+    WriteOperation,
     WriteResult,
 )
 from markdown_vault_mcp.utils import (
@@ -108,7 +109,7 @@ class DocumentManager:
         attachment_extensions: list[str] | None = None,
         max_attachment_size_mb: float = 1.0,
         max_note_read_bytes: int = 262144,
-        on_write_callback: Callable[[Path, str, str], None] | None = None,
+        on_write_callback: Callable[[Path, str, WriteOperation], None] | None = None,
         mark_paths_dirty: Callable[[Iterable[str]], None] | None = None,
     ) -> None:
         self._fts = fts

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from markdown_vault_mcp.config import CollectionConfig
@@ -259,7 +259,7 @@ class OpenAIProvider(EmbeddingProvider):
 
         data = response.json()
         # Sort by index to guarantee input order is preserved.
-        items: list[dict] = sorted(data["data"], key=lambda d: d["index"])
+        items: list[dict[str, Any]] = sorted(data["data"], key=lambda d: d["index"])
         embeddings: list[list[float]] = [item["embedding"] for item in items]
 
         # Cache dimension from first successful call.
@@ -326,10 +326,12 @@ class FastEmbedProvider(EmbeddingProvider):
 
         self._model_name = model_name
         self._cache_dir = cache_dir
-        kwargs: dict[str, object] = {"model_name": self._model_name}
         if self._cache_dir:
-            kwargs["cache_dir"] = self._cache_dir
-        self._model = TextEmbedding(**kwargs)
+            self._model = TextEmbedding(
+                model_name=self._model_name, cache_dir=self._cache_dir
+            )
+        else:
+            self._model = TextEmbedding(model_name=self._model_name)
         self._dimension: int | None = None
         logger.debug(
             "FastEmbedProvider initialised: model=%s cache_dir=%s",

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -553,9 +553,9 @@ class CommitDiff:
     diff: str
 
 
-WriteCallback = Callable[
-    [Path, str, Literal["write", "edit", "delete", "rename"]], None
-]
+WriteOperation = Literal["write", "edit", "delete", "rename"]
+
+WriteCallback = Callable[[Path, str, WriteOperation], None]
 
 # Default set of allowed attachment extensions (without leading dot, lower-case).
 # .md is always excluded — it is always handled as a markdown note.

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -205,7 +205,7 @@ class NoteContent:
 
 @dataclass
 class NoteInfo:
-    """Summary info for a document, returned by :meth:`~markdown_vault_mcp.collection.Collection.list`.
+    """Summary info for a document, returned by :meth:`~markdown_vault_mcp.collection.Collection.list_documents`.
 
     Attributes:
         path: Relative path from the vault root.
@@ -333,7 +333,7 @@ class AttachmentContent:
 
 @dataclass
 class AttachmentInfo:
-    """Summary info for an attachment, returned by :meth:`~markdown_vault_mcp.collection.Collection.list` when ``include_attachments=True``.
+    """Summary info for an attachment, returned by :meth:`~markdown_vault_mcp.collection.Collection.list_documents` when ``include_attachments=True``.
 
     Attributes:
         path: Relative path from the vault root.

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -30,7 +30,7 @@ class VectorIndex:
 
     Stores embedding vectors as a 2-D numpy array (shape ``[n, dim]``)
     with normalised rows so that similarity queries reduce to a dot-product.
-    A parallel ``list[dict]`` holds the per-row metadata.
+    A parallel ``list[dict[str, Any]]`` holds the per-row metadata.
 
     The index is serialised as two sidecar files:
 
@@ -62,7 +62,7 @@ class VectorIndex:
         self._provider = provider
         # Shape: (0, dim) — will grow with each add() call.
         self._embeddings: np.ndarray = np.empty((0, 0), dtype=np.float32)
-        self._metadata: list[dict] = []
+        self._metadata: list[dict[str, Any]] = []
 
     # ------------------------------------------------------------------
     # Class-method constructor
@@ -98,7 +98,7 @@ class VectorIndex:
         with json_path.open("r", encoding="utf-8") as fh:
             payload = json.load(fh)
 
-        metadata: list[dict]
+        metadata: list[dict[str, Any]]
         expected_provider = provider.provider_name
         expected_model = provider.model_name
         if isinstance(payload, list):
@@ -148,7 +148,7 @@ class VectorIndex:
         """
         return len(self._metadata)
 
-    def add(self, texts: list[str], metadata: list[dict]) -> int:
+    def add(self, texts: list[str], metadata: list[dict[str, Any]]) -> int:
         """Embed ``texts`` and append rows to the index.
 
         Vectors are L2-normalised before storage so that similarity
@@ -185,7 +185,9 @@ class VectorIndex:
         raw: list[list[float]] = self._provider.embed(texts)
         return self.add_vectors(raw, metadata)
 
-    def add_vectors(self, raw_vectors: list[list[float]], metadata: list[dict]) -> int:
+    def add_vectors(
+        self, raw_vectors: list[list[float]], metadata: list[dict[str, Any]]
+    ) -> int:
         """Append pre-computed embedding vectors to the index.
 
         Accepts raw (un-normalised) float vectors as returned by
@@ -227,7 +229,9 @@ class VectorIndex:
         norms = np.linalg.norm(vectors, axis=1, keepdims=True)
         # Avoid division by zero for zero-magnitude vectors.
         norms = np.where(norms == 0, 1.0, norms)
-        vectors = vectors / norms
+        # np.linalg.norm + np.where(..., 1.0, ...) widen to float64; cast back
+        # to float32 so _embeddings keeps its declared dtype invariant.
+        vectors = (vectors / norms).astype(np.float32, copy=False)
 
         if self._embeddings.size == 0:
             self._embeddings = vectors
@@ -251,7 +255,7 @@ class VectorIndex:
         )
         return len(raw_vectors)
 
-    def search(self, query: str, *, limit: int = 10) -> list[dict]:
+    def search(self, query: str, *, limit: int = 10) -> list[dict[str, Any]]:
         """Return the top-k most similar chunks for ``query``.
 
         Args:
@@ -291,7 +295,7 @@ class VectorIndex:
         # argsort descending, then take the top-k indices.
         top_indices = np.argsort(scores)[::-1][:k]
 
-        results: list[dict] = []
+        results: list[dict[str, Any]] = []
         for idx in top_indices:
             entry = dict(self._metadata[int(idx)])
             entry["score"] = float(scores[int(idx)])
@@ -300,7 +304,7 @@ class VectorIndex:
         logger.debug("VectorIndex.search: returning %d results", len(results))
         return results
 
-    def search_by_path(self, path: str, *, limit: int = 10) -> list[dict]:
+    def search_by_path(self, path: str, *, limit: int = 10) -> list[dict[str, Any]]:
         """Return the top-k most similar chunks from *other* documents.
 
         Looks up the stored embedding vectors for ``path``, averages them
@@ -345,7 +349,7 @@ class VectorIndex:
         candidates.sort(key=lambda x: x[0], reverse=True)
         top = candidates[: min(limit, len(candidates))]
 
-        results: list[dict] = []
+        results: list[dict[str, Any]] = []
         for score, idx in top:
             entry = dict(self._metadata[idx])
             entry["score"] = score

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -228,12 +228,10 @@ class VectorIndex:
         # L2-normalise each row.
         norms = np.linalg.norm(vectors, axis=1, keepdims=True)
         # Avoid division by zero for zero-magnitude vectors.
-        # In-place assignment auto-casts the scalar to norms's dtype so the
-        # float32 invariant survives; the np.where(..., 1.0, ...) form would
-        # widen to float64 under pre-NEP-50 numpy because the Python literal
-        # 1.0 promotes the array.
-        norms[norms == 0] = 1.0
-        vectors = vectors / norms
+        norms = np.where(norms == 0, 1.0, norms)
+        # np.linalg.norm + np.where(..., 1.0, ...) widen to float64; cast back
+        # to float32 so _embeddings keeps its declared dtype invariant.
+        vectors = (vectors / norms).astype(np.float32, copy=False)
 
         if self._embeddings.size == 0:
             self._embeddings = vectors

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -228,10 +228,12 @@ class VectorIndex:
         # L2-normalise each row.
         norms = np.linalg.norm(vectors, axis=1, keepdims=True)
         # Avoid division by zero for zero-magnitude vectors.
-        norms = np.where(norms == 0, 1.0, norms)
-        # np.linalg.norm + np.where(..., 1.0, ...) widen to float64; cast back
-        # to float32 so _embeddings keeps its declared dtype invariant.
-        vectors = (vectors / norms).astype(np.float32, copy=False)
+        # In-place assignment auto-casts the scalar to norms's dtype so the
+        # float32 invariant survives; the np.where(..., 1.0, ...) form would
+        # widen to float64 under pre-NEP-50 numpy because the Python literal
+        # 1.0 promotes the array.
+        norms[norms == 0] = 1.0
+        vectors = vectors / norms
 
         if self._embeddings.size == 0:
             self._embeddings = vectors

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -418,7 +418,7 @@ class TestLazyInitialisation:
         """list() on an unbuilt index returns [] (bucket 2 — no implicit build)."""
         col = _make_collection(vault_path)
 
-        notes = col.list()
+        notes = col.list_documents()
 
         assert notes == []
 
@@ -533,7 +533,7 @@ class TestSearch:
         col = _make_collection(vault)
         col.build_index()
 
-        notes = col.list()
+        notes = col.list_documents()
         paths = [n.path for n in notes]
         assert "alpha/note.md" in paths
         assert "beta/note.md" in paths
@@ -624,14 +624,14 @@ class TestRead:
 class TestList:
     def test_list_all(self, collection: Collection) -> None:
         """list() returns all indexed documents."""
-        notes = collection.list()
+        notes = collection.list_documents()
 
         assert len(notes) == 9
         assert all(isinstance(n, NoteInfo) for n in notes)
 
     def test_list_with_folder(self, collection: Collection) -> None:
         """list(folder=...) returns only documents in that folder."""
-        notes = collection.list(folder="subfolder")
+        notes = collection.list_documents(folder="subfolder")
 
         assert len(notes) >= 1
         assert all("subfolder" in n.folder for n in notes)
@@ -642,7 +642,7 @@ class TestList:
         ``fnmatch`` treats ``*`` as matching path separators, so
         ``subfolder/*.md`` also matches ``subfolder/deep/doc.md``.
         """
-        notes = collection.list(pattern="subfolder/*.md")
+        notes = collection.list_documents(pattern="subfolder/*.md")
 
         paths = [n.path for n in notes]
         assert "subfolder/nested.md" in paths
@@ -653,7 +653,7 @@ class TestList:
 
     def test_list_subfolder_deep_pattern(self, collection: Collection) -> None:
         """list() with a deep glob pattern returns deeply nested documents."""
-        notes = collection.list(pattern="subfolder/**/*.md")
+        notes = collection.list_documents(pattern="subfolder/**/*.md")
 
         paths = [n.path for n in notes]
         assert "subfolder/deep/doc.md" in paths
@@ -1590,7 +1590,7 @@ class TestRename:
         writable.rename("simple.md", "new_folder/simple.md")
         wait_for_writer_drain(writable)
 
-        notes = writable.list(folder="new_folder")
+        notes = writable.list_documents(folder="new_folder")
         paths = [n.path for n in notes]
         assert "new_folder/simple.md" in paths
 
@@ -2218,7 +2218,7 @@ class TestListWithAttachments:
         """list() without include_attachments does not return attachment files."""
         col = Collection(source_dir=vault_with_attachment)
         col.build_index()
-        results = col.list()
+        results = col.list_documents()
 
         paths = [r.path for r in results]
         assert not any(p.endswith(".pdf") or p.endswith(".png") for p in paths)
@@ -2229,7 +2229,7 @@ class TestListWithAttachments:
         """list(include_attachments=True) returns notes and attachments."""
         col = Collection(source_dir=vault_with_attachment)
         col.build_index()
-        results = col.list(include_attachments=True)
+        results = col.list_documents(include_attachments=True)
 
         kinds = {type(r).__name__ for r in results}
         assert "NoteInfo" in kinds
@@ -2239,7 +2239,7 @@ class TestListWithAttachments:
         """AttachmentInfo entries have the correct fields."""
         col = Collection(source_dir=vault_with_attachment)
         col.build_index()
-        results = col.list(include_attachments=True)
+        results = col.list_documents(include_attachments=True)
 
         attachments = [r for r in results if isinstance(r, AttachmentInfo)]
         assert len(attachments) >= 1
@@ -2257,7 +2257,7 @@ class TestListWithAttachments:
         (vault_with_attachment / "assets" / "data.xyz").write_bytes(b"unknown")
         col = Collection(source_dir=vault_with_attachment)
         col.build_index()
-        results = col.list(include_attachments=True)
+        results = col.list_documents(include_attachments=True)
 
         paths = [r.path for r in results]
         assert not any(p.endswith(".xyz") for p in paths)
@@ -2269,7 +2269,7 @@ class TestListWithAttachments:
         (vault_with_attachment / "assets" / "data.xyz").write_bytes(b"unknown")
         col = Collection(source_dir=vault_with_attachment, attachment_extensions=["*"])
         col.build_index()
-        results = col.list(include_attachments=True)
+        results = col.list_documents(include_attachments=True)
 
         paths = [r.path for r in results]
         assert any(p.endswith(".xyz") for p in paths)
@@ -2278,7 +2278,7 @@ class TestListWithAttachments:
         """list(include_attachments=True, folder=...) filters attachments by folder."""
         col = Collection(source_dir=vault_with_attachment)
         col.build_index()
-        results = col.list(include_attachments=True, folder="assets")
+        results = col.list_documents(include_attachments=True, folder="assets")
 
         for r in results:
             assert r.folder == "assets" or r.folder.startswith("assets/")
@@ -3285,7 +3285,7 @@ class TestListAttachmentEdgeCases:
         """Attachments at the vault root have folder='' (not '.' or '/')."""
         col = Collection(source_dir=vault_with_root_attachment)
         col.build_index()
-        results = col.list(include_attachments=True)
+        results = col.list_documents(include_attachments=True)
 
         attachments = [r for r in results if isinstance(r, AttachmentInfo)]
         root_json = next((a for a in attachments if a.path == "diagram.json"), None)
@@ -3298,7 +3298,7 @@ class TestListAttachmentEdgeCases:
         """list(include_attachments=True, pattern='*.json') returns only .json files."""
         col = Collection(source_dir=vault_with_root_attachment)
         col.build_index()
-        results = col.list(include_attachments=True, pattern="*.json")
+        results = col.list_documents(include_attachments=True, pattern="*.json")
 
         attachment_paths = [r.path for r in results if isinstance(r, AttachmentInfo)]
         assert all(p.endswith(".json") for p in attachment_paths)
@@ -3311,7 +3311,7 @@ class TestListAttachmentEdgeCases:
         """list(include_attachments=True, folder='notes') only returns notes/ attachments."""
         col = Collection(source_dir=vault_with_root_attachment)
         col.build_index()
-        results = col.list(include_attachments=True, folder="notes")
+        results = col.list_documents(include_attachments=True, folder="notes")
 
         for r in results:
             assert r.folder == "notes" or r.folder.startswith("notes/")
@@ -3381,7 +3381,7 @@ class TestListAttachmentHiddenDirFiltering:
 
         col = Collection(source_dir=vault, attachment_extensions=["pdf", "json"])
         col.build_index()
-        results = col.list(include_attachments=True)
+        results = col.list_documents(include_attachments=True)
 
         attachment_paths = {
             r.path
@@ -3402,7 +3402,7 @@ class TestListAttachmentHiddenDirFiltering:
 
         col = Collection(source_dir=vault, attachment_extensions=["json"])
         col.build_index()
-        results = col.list(include_attachments=True)
+        results = col.list_documents(include_attachments=True)
 
         attachment_paths = {r.path for r in results if hasattr(r, "mime_type")}
         assert ".hidden_config.json" not in attachment_paths
@@ -3428,7 +3428,7 @@ class TestListAttachmentHiddenDirFiltering:
             exclude_patterns=["archived/**", "trash/**"],
         )
         col.build_index()
-        results = col.list(include_attachments=True)
+        results = col.list_documents(include_attachments=True)
 
         attachment_paths = {r.path for r in results if hasattr(r, "mime_type")}
         assert "assets/chart.pdf" in attachment_paths
@@ -3932,7 +3932,7 @@ class TestLoggingAuditSilentPaths:
             patch.object(_Path, "stat", stat_that_fails),
             patch.object(_Path, "is_file", is_file_override),
         ):
-            results = col.list(include_attachments=True)
+            results = col.list_documents(include_attachments=True)
         attachment_paths = [r.path for r in results if isinstance(r, AttachmentInfo)]
         assert "data.csv" not in attachment_paths
         assert any("stat error" in rec.message for rec in caplog.records)

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -135,7 +135,7 @@ class TestBucket2PartialReport:
         _seed(vault, "b.md")
         col = Collection(source_dir=vault)
 
-        notes = col.list()
+        notes = col.list_documents()
 
         assert notes == []
 

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -370,7 +370,7 @@ def test_concurrent_writers_serialize_via_collection_write_lock(
     try:
         assert not errors, f"writer errors: {errors!r}"
         wait_for_writer_drain(coll)
-        docs = coll.list()
+        docs = coll.list_documents()
         assert len(docs) == 40
     finally:
         coll.close()
@@ -412,7 +412,7 @@ def test_concurrent_build_and_reads_pr518_pattern(tmp_path: Path) -> None:
     def foreground_mix() -> None:
         try:
             for i in range(50):
-                coll.list()
+                coll.list_documents()
                 coll.search("content", limit=5)
                 coll.write(f"new-{i}.md", f"# New {i}\n\nbody\n")
                 coll.read(f"new-{i}.md")

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 
 from markdown_vault_mcp.vector_index import VectorIndex, VectorIndexCompatibilityError
@@ -165,6 +166,29 @@ class TestVectorIndexAddVectors:
         results_add_vectors = index_via_add_vectors.search("hello world")
         assert len(results_add) == len(results_add_vectors) == 1
         assert results_add[0]["path"] == results_add_vectors[0]["path"]
+
+    def test_add_vectors_preserves_float32_dtype(
+        self, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        # Pins the cast at vector_index.add_vectors that prevents
+        # np.linalg.norm + np.where(..., 1.0, ...) from widening _embeddings
+        # to float64.  Without the cast, on-disk sidecar doubles in size.
+        index = VectorIndex(mock_provider)
+        raw = mock_provider.embed(["alpha", "beta"])
+        index.add_vectors(raw, [_make_meta("a.md"), _make_meta("b.md")])
+        assert index._embeddings.dtype == np.float32
+
+    def test_add_vectors_zero_magnitude_preserves_float32(
+        self, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        # The np.where(norms == 0, 1.0, norms) branch in add_vectors is where
+        # float64 leaks in — a literal 1.0 widens norms even when the input
+        # is float32.  Exercise the zero-magnitude path explicitly.
+        index = VectorIndex(mock_provider)
+        dim = mock_provider.dimension
+        raw = [[0.0] * dim, [1.0] + [0.0] * (dim - 1)]
+        index.add_vectors(raw, [_make_meta("zero.md"), _make_meta("unit.md")])
+        assert index._embeddings.dtype == np.float32
 
 
 class TestVectorIndexSearch:

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -170,9 +170,12 @@ class TestVectorIndexAddVectors:
     def test_add_vectors_preserves_float32_dtype(
         self, mock_provider: MockEmbeddingProvider
     ) -> None:
-        # Pins the cast at vector_index.add_vectors that prevents
-        # np.linalg.norm + np.where(..., 1.0, ...) from widening _embeddings
-        # to float64.  Without the cast, on-disk sidecar doubles in size.
+        # Pins the float32 invariant on _embeddings.  The primary regression
+        # guard is mypy (the numpy stub for np.where returns float64, so any
+        # revert that drops the trailing .astype(np.float32) fails type
+        # checking); this runtime assertion additionally protects pre-NEP-50
+        # numpy environments (numpy<2.0) where the widening would happen at
+        # runtime too.
         index = VectorIndex(mock_provider)
         raw = mock_provider.embed(["alpha", "beta"])
         index.add_vectors(raw, [_make_meta("a.md"), _make_meta("b.md")])
@@ -181,9 +184,9 @@ class TestVectorIndexAddVectors:
     def test_add_vectors_zero_magnitude_preserves_float32(
         self, mock_provider: MockEmbeddingProvider
     ) -> None:
-        # The np.where(norms == 0, 1.0, norms) branch in add_vectors is where
-        # float64 leaks in — a literal 1.0 widens norms even when the input
-        # is float32.  Exercise the zero-magnitude path explicitly.
+        # Exercises the zero-magnitude branch (np.where substituting 1.0 for
+        # zero norms) so the float32 invariant is checked on the path where
+        # pre-NEP-50 numpy would widen via the Python scalar 1.0.
         index = VectorIndex(mock_provider)
         dim = mock_provider.dimension
         raw = [[0.0] * dim, [1.0] + [0.0] * (dim - 1)]


### PR DESCRIPTION
## Summary

Removes the `pyproject.toml` mypy `ignore_errors=true` override that exempted four hot modules (`fts_index`, `vector_index`, `providers`, `collection`) from strict typing, and applies the real fixes the original TODO comment ("FTSResult used as dict, numpy dtype mismatches") gestured at.

51 → 0 mypy errors. 1853 tests passing. 100% patch coverage.

Closes #575.

## Notable changes

- **`Collection.list` → `Collection.list_documents`.** The method `list` shadowed the `list` builtin in class-scope annotations, causing 13 of the 51 mypy errors (`list[NoteInfo]` mis-resolved against the method). The MCP tool wrapping it was already named `list_documents`, and the class has sibling methods `list_folders` / `list_tags`. All 25 callsites (2 in `src/`, 23 in `tests/`) and Sphinx `:meth:` cross-refs in `NoteInfo` / `AttachmentInfo` updated.
- **`vector_index.add_vectors`** now `.astype(np.float32, copy=False)` after L2 normalisation so `_embeddings`'s declared float32 invariant holds — the literal `1.0` in `np.where(norms == 0, 1.0, norms)` widens to float64 under pre-NEP-50 numpy. Two regression tests pin the invariant (happy path + zero-magnitude branch).
- **`providers.FastEmbedProvider.__init__`** calls `TextEmbedding` directly in an `if/else` instead of via a `**dict[str, object]` unpack, restoring kwargs-level signature checking.
- **`WriteOperation = Literal["write", "edit", "delete", "rename"]`** alias extracted in `types.py`; threaded through `Collection._fire_write_callback`, `_callback_queue`, and `DocumentManager.on_write_callback` so the worker no longer hits a `str` → `Literal[…]` mismatch.
- **`GitWriteStrategy.start.on_pull`** widened from `Callable[[], None]` to `Callable[[], object]` so `Collection.reindex` (returns `ReindexResult`) can be passed without a discarding-wrapper lambda.
- Various `dict` / `tuple` annotations parameterised; `getattr(self._local, "conn", None)` typed at the binding; `count_chunks` no longer returns `Any` from `fetchone()[0]`.
- Stale `# type: ignore[union-attr]` removed; BFS local variable rename to stop shadowing the loop variable in `get_connection_path`.
- `docs/design.md` updated: spec block signature + prose references + tool-name-note rationale.

## Test plan

- [x] `uv run mypy src/` — clean across 37 files (was 51 errors with override removed)
- [x] `uv run pytest -x -q` — 1853 passed (was 1851 baseline; +2 dtype-invariant tests)
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean
- [x] `uv run diff-cover coverage.xml --compare-branch=main --fail-under=80` — 100% patch coverage
- [x] Mutation-tested: removing the `.astype(...)` cast causes the mypy gate to fail on numpy 2.x stubs; pre-NEP-50 numpy would also fail the runtime dtype assertion.
- [x] Preflight code-review circus run; one round of fixes for surviving ≥80 findings; second round clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)