### PR TITLE
fix(indexing): distinguish failing list_notes from empty index + clear stale sync-build error

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -548,7 +548,12 @@ file-mutation lock.
 **Status surface.** `Collection.get_index_status()` merges the writer's
 non-blocking snapshot (`queue_depth`, `in_flight`, `dirty_paths`,
 `dirty_embeddings`) into its response shape, so operators can observe
-exactly what the writer is doing without taking any lock.
+exactly what the writer is doing without taking any lock. The document
+count is read from `FTSIndex.list_notes()`; a `sqlite3.Error` there
+(locked / corrupt / closed DB) is not an empty index, so `get_index_status`
+keeps `documents_indexed` at `0` and surfaces the reason in a separate
+`documents_indexed_error` field (logged at `WARNING`) rather than masking
+the failure as a clean zero (#583).
 
 The contract is:
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -213,7 +213,12 @@ build attempt.
 **Returns:**
 - `status`: `"queryable"`, `"building"`, or `"failed"`.
 - `documents_indexed`: count of documents committed to the FTS index
-  right now (rises during `"building"`).
+  right now (rises during `"building"`). `0` both for an empty index
+  and when the count could not be read — check `documents_indexed_error`
+  to tell them apart.
+- `documents_indexed_error`: `null` on a normal read; the SQLite error
+  message when the document count could not be read (e.g. a locked or
+  closed database), in which case `documents_indexed` is `0`.
 - `error`: `null` unless the background build raised; otherwise the
   exception message.
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -654,6 +654,12 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
               ``"failed"``.
             - documents_indexed (int): Count of documents committed to
               the FTS index right now (rises during ``"building"``).
+              ``0`` both for an empty index and when the count could not
+              be read — see ``documents_indexed_error`` to tell them apart.
+            - documents_indexed_error (str | None): ``None`` on a normal
+              read; the SQLite error message when the document count
+              could not be read (e.g. a locked or closed database), in
+              which case ``documents_indexed`` is ``0``.
             - error (str | None): ``None`` unless the background build
               raised.
         """

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -511,14 +511,16 @@ class Collection:
         return self._coordinator.wait_for_drain(timeout)
 
     def get_index_status(self) -> dict[str, Any]:
-        """Return a non-blocking ten-key snapshot of build + writer state.
+        """Return a non-blocking eleven-key snapshot of build + writer state.
 
         Keys: ``status`` (``"queryable"`` | ``"building"`` | ``"failed"``),
-        ``documents_indexed``, ``error``, ``last_reindex_error``,
-        ``last_build_embeddings_error``, plus ``queue_depth``, ``in_flight``,
-        ``dirty_paths``, ``dirty_embeddings``, ``write_generation`` merged from
-        the writer. A captured build error appears in ``error`` as diagnostic
-        context without demoting a ``queryable`` status.
+        ``documents_indexed``, ``documents_indexed_error``, ``error``,
+        ``last_reindex_error``, ``last_build_embeddings_error``, plus
+        ``queue_depth``, ``in_flight``, ``dirty_paths``, ``dirty_embeddings``,
+        ``write_generation`` merged from the writer. A captured build error
+        appears in ``error`` as diagnostic context without demoting a
+        ``queryable`` status; ``documents_indexed_error`` carries a SQLite
+        read failure (``documents_indexed`` stays ``0``) (#583).
         """
         return self._coordinator.get_index_status()
 

--- a/src/markdown_vault_mcp/indexing/coordinator.py
+++ b/src/markdown_vault_mcp/indexing/coordinator.py
@@ -12,6 +12,7 @@ coordinator constructs, starts, and closes the single-owner
 from __future__ import annotations
 
 import logging
+import sqlite3
 import threading
 import time
 from concurrent.futures import CancelledError, Future
@@ -127,19 +128,20 @@ class IndexWriteCoordinator:
             )
 
     def get_index_status(self) -> dict[str, Any]:
-        """Return a non-blocking snapshot of build + writer state (ten keys)."""
+        """Return a non-blocking snapshot of build + writer state (eleven keys)."""
         fields = self._readiness.status_fields()
+        documents_indexed_error: str | None = None
         try:
             documents_indexed = len(self._fts.list_notes())
-        except Exception:
-            logger.debug(
-                "get_index_status: list_notes failed; reporting 0",
-                exc_info=True,
-            )
+        except sqlite3.Error as exc:
+            # Failed FTS read (locked/corrupt/closed) != empty index — surface why (#583).
+            logger.warning("get_index_status_list_notes_failed", exc_info=True)
             documents_indexed = 0
+            documents_indexed_error = str(exc)
         result = {
             "status": fields["status"],
             "documents_indexed": documents_indexed,
+            "documents_indexed_error": documents_indexed_error,
             "error": fields["error"],
             "last_reindex_error": (
                 str(self._last_reindex_error)
@@ -206,13 +208,28 @@ class IndexWriteCoordinator:
         self._readiness.begin_sync_build()
         self._fts.clear_build_completed()
         try:
-            result: IndexStats = self._writer.submit(BuildIndex(force=force)).result()
-            self._fts.set_build_completed()
-        except Exception as exc:
-            self._readiness.fail_build(exc)
-            raise
-        self._readiness.mark_built()
-        return result
+            try:
+                result: IndexStats = self._writer.submit(
+                    BuildIndex(force=force)
+                ).result()
+            except CancelledError:
+                # Drain cancellation (writer shutdown) is not a build failure — skip fail_build (#590).
+                logger.debug("sync_build_index_cancelled")
+                raise
+            except BaseException as exc:
+                # Record a build-job failure (incl. BaseException) as "failed", re-raise (#591).
+                self._readiness.fail_build(exc)
+                raise
+            try:
+                self._fts.set_build_completed()
+            except Exception as exc:
+                self._readiness.fail_build(exc)
+                raise
+            self._readiness.mark_built()
+            return result
+        finally:
+            # Always re-set the done-event begin_sync_build cleared, so waiters never hang (#587).
+            self._readiness.mark_done()
 
     def reindex(self) -> ReindexResult:
         """Incrementally update the index based on file changes.

--- a/src/markdown_vault_mcp/indexing/readiness.py
+++ b/src/markdown_vault_mcp/indexing/readiness.py
@@ -30,8 +30,10 @@ class ReadinessState:
     # -- transitions (each mirrors one former Collection mutation set) --
 
     def begin_sync_build(self) -> None:
-        """Sync build_index cold path: clears built only."""
+        """Sync build_index cold path: clears built + error + done (#587)."""
         self._index_built = False
+        self._error = None
+        self._done.clear()
 
     def begin_async_build(self) -> None:
         """Async build_index_async cold path: clears built + error + done."""

--- a/tests/test_index_coordinator.py
+++ b/tests/test_index_coordinator.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+import sqlite3
 import threading
-from concurrent.futures import Future
+from concurrent.futures import CancelledError, Future
 from typing import TYPE_CHECKING
 
 import pytest
@@ -59,6 +61,7 @@ def test_build_index_makes_queryable(tmp_path: Path) -> None:
         assert set(status) >= {
             "status",
             "documents_indexed",
+            "documents_indexed_error",
             "error",
             "last_reindex_error",
             "last_build_embeddings_error",
@@ -429,5 +432,177 @@ def test_on_build_index_done_cancellation_unblocks_waiters(tmp_path: Path) -> No
             coord.wait_until_queryable(timeout=2)
         assert ei.value.reason == "never_built"
         assert coord.get_index_status()["status"] != "failed"
+    finally:
+        coord.close(timeout=5)
+
+
+def _raise_locked(*args: object, **kwargs: object) -> list[dict[str, object]]:  # noqa: ARG001
+    raise sqlite3.OperationalError("database is locked")
+
+
+def test_get_index_status_list_notes_failure_surfaces_error(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # #583: when list_notes() raises a sqlite3 error, the count stays 0 but
+    # documents_indexed_error carries the reason (distinguishing empty from a
+    # failing/locked DB), logged at WARNING (visible at the default level).
+    coord = make_coordinator(tmp_path)
+    try:
+        coord.build_index()
+        coord._fts.list_notes = _raise_locked  # type: ignore[method-assign]
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.indexing.coordinator"
+        ):
+            status = coord.get_index_status()
+        assert status["documents_indexed"] == 0
+        assert status["documents_indexed_error"] is not None
+        assert "database is locked" in status["documents_indexed_error"]
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+    finally:
+        coord.close(timeout=5)
+
+
+def test_get_index_status_documents_indexed_error_none_on_success(
+    tmp_path: Path,
+) -> None:
+    # #583: a successful list_notes() read leaves documents_indexed_error None,
+    # so an empty/normal index is distinguishable from a failing query.
+    coord = make_coordinator(tmp_path)
+    try:
+        coord.build_index()
+        status = coord.get_index_status()
+        assert status["documents_indexed_error"] is None
+    finally:
+        coord.close(timeout=5)
+
+
+def _raise_value_error(*args: object, **kwargs: object) -> list[dict[str, object]]:  # noqa: ARG001
+    raise ValueError("unexpected bug")
+
+
+def test_get_index_status_non_sqlite_error_propagates(tmp_path: Path) -> None:
+    # #583: only sqlite3 errors are tolerated as "count unavailable". A
+    # non-sqlite exception signals a bug and must propagate, not be swallowed.
+    coord = make_coordinator(tmp_path)
+    try:
+        coord.build_index()
+        coord._fts.list_notes = _raise_value_error  # type: ignore[method-assign]
+        with pytest.raises(ValueError, match="unexpected bug"):
+            coord.get_index_status()
+    finally:
+        coord.close(timeout=5)
+
+
+def test_build_index_clears_stale_error_during_sync_rebuild(tmp_path: Path) -> None:
+    # #587: a prior failed build leaves a stale _error; a sync build_index()
+    # retry must report "building" (not the stale "failed") to a concurrent
+    # status reader mid-rebuild. Pins the fix through the public build_index
+    # entry point — the unit test exercises only ReadinessState directly.
+    coord = make_coordinator(tmp_path)
+    try:
+        coord._readiness.fail_build(RuntimeError("stale async failure"))
+        assert coord.get_index_status()["status"] == "failed"
+
+        started = threading.Event()
+        proceed = threading.Event()
+        original = coord.writer._runners["build_index"]
+
+        def _gated(job: object, ctx: object) -> object:
+            started.set()
+            proceed.wait(timeout=5)
+            return original(job, ctx)
+
+        coord.writer._runners["build_index"] = _gated
+        builder = threading.Thread(target=coord.build_index)
+        builder.start()
+        try:
+            assert started.wait(timeout=5)
+            # begin_sync_build has run: stale error cleared, done-event cleared.
+            assert coord.get_index_status()["status"] == "building"
+            # a concurrent waiter blocks for the active build (not a premature
+            # never_built) because _done is cleared (#587, Gemini HIGH finding).
+            with pytest.raises(IndexUnavailableError) as ei:
+                coord.wait_until_queryable(timeout=0.1)
+            assert ei.value.reason == "timeout"
+        finally:
+            proceed.set()
+            builder.join(timeout=5)
+        assert coord.get_index_status()["status"] == "queryable"
+    finally:
+        coord.close(timeout=5)
+
+
+@pytest.mark.filterwarnings(
+    # The propagating BaseException intentionally terminates the writer thread.
+    "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+)
+def test_build_index_records_job_baseexception_as_failed(tmp_path: Path) -> None:
+    # #591: a BaseException from the build job is recorded as "failed" and
+    # re-raised; fail_build sets the done-event so a waiter unblocks (never hangs).
+    coord = make_coordinator(tmp_path)
+    try:
+
+        def _base_runner(job: object, ctx: object) -> object:  # noqa: ARG001
+            raise _BaseBoom("sync job base boom")
+
+        coord.writer._runners["build_index"] = _base_runner
+        with pytest.raises(_BaseBoom, match="sync job base boom"):
+            coord.build_index()
+        status = coord.get_index_status()
+        assert status["status"] == "failed"
+        assert status["error"] is not None and "sync job base boom" in status["error"]
+        assert coord.is_queryable() is False
+        # fail_build set the done-event, so a waiter unblocks immediately (to
+        # never_built, not hang). timeout=0 is a non-blocking state check.
+        with pytest.raises(IndexUnavailableError) as ei:
+            coord.wait_until_queryable(timeout=0)
+        assert ei.value.reason == "never_built"
+    finally:
+        coord.close(timeout=5)
+
+
+def test_build_index_set_completed_baseexception_does_not_strand(
+    tmp_path: Path,
+) -> None:
+    # #591: a BaseException from set_build_completed (the job already succeeded)
+    # is NOT recorded as failed and propagates, but the finally sets the
+    # done-event so waiters unblock to never_built (symmetric with async #585).
+    coord = make_coordinator(tmp_path)
+    try:
+
+        def _boom() -> None:
+            raise _BaseBoom("sync set_completed base boom")
+
+        coord._fts.set_build_completed = _boom  # type: ignore[method-assign]
+        with pytest.raises(_BaseBoom):
+            coord.build_index()
+        # not recorded as failed; the finally re-set the cleared done-event, so a
+        # waiter unblocks to never_built (the build never completed). timeout=0 is
+        # a non-blocking state check.
+        assert coord.get_index_status()["status"] == "building"
+        with pytest.raises(IndexUnavailableError) as ei:
+            coord.wait_until_queryable(timeout=0)
+        assert ei.value.reason == "never_built"
+    finally:
+        coord.close(timeout=5)
+
+
+def test_build_index_drain_cancellation_not_recorded_as_failed(tmp_path: Path) -> None:
+    # #590/#591: a drain CancelledError on the sync BuildIndex future (the writer
+    # cancelled a queued build during shutdown) is NOT a build failure — skip
+    # fail_build and re-raise, mirroring the async _on_build_index_done carve-out.
+    coord = make_coordinator(tmp_path)
+    try:
+        cancelled: Future[object] = Future()
+        cancelled.cancel()
+        coord.writer.submit = lambda job: cancelled  # type: ignore[method-assign]  # noqa: ARG005
+        with pytest.raises(CancelledError):
+            coord.build_index()
+        # not recorded as failed; the finally re-set the cleared done-event, so a
+        # waiter unblocks to never_built (timeout=0 is a non-blocking state check).
+        assert coord.get_index_status()["status"] == "building"
+        with pytest.raises(IndexUnavailableError) as ei:
+            coord.wait_until_queryable(timeout=0)
+        assert ei.value.reason == "never_built"
     finally:
         coord.close(timeout=5)

--- a/tests/test_index_readiness.py
+++ b/tests/test_index_readiness.py
@@ -25,16 +25,29 @@ def test_mark_built_makes_queryable_and_clears_error() -> None:
     assert r.error is None
 
 
-def test_begin_sync_build_only_clears_built() -> None:
+def test_begin_sync_build_clears_built_error_and_done() -> None:
+    # #587: sync begin clears the stale error (a fresh build supersedes a prior
+    # failure) AND clears the done-event so a concurrent reader blocks/waits for
+    # the active build instead of prematurely raising never_built.
     r = ReadinessState()
     r.mark_built()  # built=True, done set, error None
-    prior_error = RuntimeError("kept")
-    r._error = prior_error  # simulate a leftover error
+    r._error = RuntimeError("stale")  # leftover error from a prior failure
     r.begin_sync_build()
     assert r.is_built is False
-    # sync begin does NOT clear the error nor the done-event
-    assert r.error is prior_error
-    assert r.wait(timeout=0) is True
+    assert r.error is None  # stale error cleared
+    assert r.wait(timeout=0) is False  # done-event cleared so waiters block
+
+
+def test_status_building_after_begin_sync_build_with_stale_error() -> None:
+    # #587: a stale error from a prior failed async build must not make
+    # status report "failed" once a fresh sync build has begun.
+    r = ReadinessState()
+    r.fail_build(RuntimeError("old async failure"))  # error + done set
+    assert r.status_fields()["status"] == "failed"
+    r.begin_sync_build()
+    fields = r.status_fields()
+    assert fields["status"] == "building"
+    assert fields["error"] is None
 
 
 def test_begin_async_build_clears_built_error_and_done() -> None:


### PR DESCRIPTION
Closes #583, closes #587, closes #591.

Three status-surface bugs in the indexing readiness path (all pre-existing — moved verbatim from `collection.py` during the #576 extraction).

## #583 — failing `list_notes()` masked as an empty index

`get_index_status()` wrapped the document count in a broad `except Exception` that reported `documents_indexed=0` and logged at **DEBUG** whenever `list_notes()` raised — masking a locked/corrupt/closed FTS DB (`sqlite3.Error`) as a clean, empty index. Narrowed to `except sqlite3.Error`, log **WARNING**, keep `documents_indexed: 0`, and add a **`documents_indexed_error: str | None`** field so callers can tell an empty index from a failed read. Non-sqlite exceptions now propagate.

## #587 — stale `"failed"` + premature `never_built` during a sync rebuild

`begin_sync_build()` cleared only `_index_built`, so a stale `_error` from a prior failed async build made `get_index_status()` report `status="failed"` during an active sync rebuild. It now also clears `_error` **and the done-event**.

Clearing the done-event addresses @gemini-code-assist's HIGH finding: with `_done` left set, a concurrent `wait_until_queryable()` returned `never_built` immediately instead of blocking for the active build (inconsistent with the `"building"` the same state reports). Now a concurrent reader blocks correctly.

## #591 — sync `BaseException` no longer strands status

With the done-event cleared at begin, a `BaseException` escaping the sync build would strand it. Restructured `build_index`'s cold path to **fully mirror the async `_on_build_index_done`**:
- drain `CancelledError` → **not** recorded as a failure (skip `fail_build`, re-raise) — mirrors #590;
- build-job `BaseException` → recorded `"failed"`, re-raised;
- `set_build_completed` `BaseException` → propagates without being recorded (mirrors #585's `except Exception`);
- `finally: mark_done()` re-sets the done-event on every exit so waiters never hang.

## Tests

Symmetric, mutation-verified coverage: #583 (sqlite-error / success / non-sqlite-propagate); #587 (readiness unit clears built+error+done; a threaded integration test asserting a concurrent reader sees `"building"` AND blocks — `wait_until_queryable` times out, not `never_built`); #591 (job `BaseException` → "failed"; `set_completed` `BaseException` → `never_built`, no strand; drain `CancelledError` → not failed). All four load-bearing pieces (done-clear, CancelledError carve-out, `except BaseException`, `finally`) are individually mutation-pinned. Full suite: 1893 passed.

## Docs

`get_index_status` tool docstring, the `Collection.get_index_status` facade docstring (now "eleven-key"), `docs/tools/index.md`, and the `docs/design.md` status-surface paragraph document the new field.
