### PR TITLE
chore(deps): bump pyjwt to 2.13.0 to clear audit advisories

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2418,11 +2418,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #593.

The CI `Dependency Audit` job fails on four PYSEC advisories (PYSEC-2026-175/177/178/179) against `pyjwt` 2.12.1, all fixed in **2.13.0**. `pyjwt` is transitive (`mcp[crypto]` → `fastmcp` → `fastmcp-pvl-core`); no direct pin or upper bound constrains it.

**Lockfile-only** — the published package's declared deps (pyproject) are unaffected; this only updates the dev/CI resolution.

**Verified locally** with the CI-equivalent command:
`uv export --all-extras --no-default-groups --frozen --no-emit-project --no-hashes` then `pip-audit --strict --ignore-vuln CVE-2026-25990 --ignore-vuln CVE-2026-4539` → `No known vulnerabilities found`. Full suite: 1885 passed.

Note: python-multipart (#441) is already at 0.0.28 in the lock, so that advisory no longer fires.