### PR TITLE
test(config): xfail test_includes_all_collection_params on flaky HuggingFace download

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -248,6 +248,13 @@ class TestToCollectionKwargs:
         kwargs = config.to_collection_kwargs()
         assert "git_token" not in kwargs
 
+    @pytest.mark.xfail(
+        raises=ValueError,
+        reason="embeddings_path set without a provider resolves FastEmbedProvider, "
+        "which downloads BAAI/bge-small-en-v1.5 from HuggingFace — flaky/unavailable "
+        "in CI (#595)",
+        strict=False,
+    )
     def test_includes_all_collection_params(self) -> None:
         config = CollectionConfig(
             source_dir=Path("/tmp/vault"),


### PR DESCRIPTION
Closes #595.

`test_includes_all_collection_params` sets `embeddings_path` without an explicit provider, so `to_collection_kwargs()` resolves `FastEmbedProvider`, which downloads `BAAI/bge-small-en-v1.5` from HuggingFace. When the HF CDN is flaky/unavailable in CI, fastembed raises `ValueError: Could not load model ... from any source` — and `to_collection_kwargs` only guards that call with `(ImportError, RuntimeError)`, so the `ValueError` propagated and red CI on unrelated PRs (#589 on Python 3.11, #592 on 3.12/3.14).

**Fix:** `@pytest.mark.xfail(raises=ValueError, strict=False)`. The test passes (xpass) when the model is available and xfails — not errors — when the download fails, so CI is no longer gated on third-party model availability. `raises=ValueError` scopes the xfail to the download failure; a genuine assertion regression still fails.

A deeper fix (don't trigger a network model download in a config→kwargs passthrough unit test) is noted as an open question on #595 but is out of scope for this minimal change.