### PR TITLE
refactor(collection): extract WriteCallbackDispatcher into write_callback.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ src/markdown_vault_mcp/
   providers.py         -- embedding provider ABC + implementations
   tracker.py           -- hash-based change detection
   collection.py        -- thin facade: lifecycle, wiring, delegation (index-write → indexing/coordinator.py)
+  write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
   config.py            -- configuration loading
   server.py            -- generic FastMCP server factory (make_server) with tool annotations
   cli.py               -- CLI entry point

--- a/docs/design.md
+++ b/docs/design.md
@@ -65,6 +65,7 @@ markdown-vault-mcp (new package)
 +-- providers.py      -- Ollama / OpenAI / SentenceTransformers
 +-- tracker.py        -- hash-based change detection
 +-- collection.py     -- thin facade: lifecycle, wiring, delegation (index-write → indexing/coordinator.py)
++-- write_callback.py -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
 +-- config.py         -- configuration loading
 +-- server.py         -- generic FastMCP server
 +-- cli.py            -- CLI entry point

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import queue
 import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal
@@ -41,10 +40,10 @@ from markdown_vault_mcp.types import (
     ReindexResult,
     RenameResult,
     WriteCallback,
-    WriteOperation,
     WriteResult,
 )
 from markdown_vault_mcp.utils import effective_attachment_extensions
+from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -312,6 +311,12 @@ class Collection:
             snippet_words=snippet_words,
             length_downweight_alpha=length_downweight_alpha,
         )
+        # Deferred write callback (issue #175): the git-commit on_write
+        # callback runs on a background worker so write methods return after
+        # the FTS update.  Constructed before DocumentManager, whose
+        # ``on_write_callback`` is wired to ``fire`` (#599).
+        self._write_callback = WriteCallbackDispatcher(self._on_write)
+
         # 4. DocumentManager (mark_paths_dirty routes through the writer)
         self._doc_mgr = DocumentManager(
             fts=self._fts,
@@ -323,18 +328,9 @@ class Collection:
             attachment_extensions=self._attachment_extensions,
             max_attachment_size_mb=self._max_attachment_size_mb,
             max_note_read_bytes=self._max_note_read_bytes,
-            on_write_callback=self._fire_write_callback,
+            on_write_callback=self._write_callback.fire,
             mark_paths_dirty=self._coordinator.mark_paths_dirty,
         )
-
-        # Deferred write callback queue (issue #175).  Git commit (on_write
-        # callback) runs in a background worker thread so write methods
-        # return immediately after the FTS update.
-        self._callback_queue: queue.Queue[tuple[Path, str, WriteOperation] | None] = (
-            queue.Queue()
-        )
-        self._callback_worker: threading.Thread | None = None
-        self._callback_worker_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -436,14 +432,7 @@ class Collection:
         # before its close() returns; no further flush needed here (#559).
 
         # 2. Drain the write-callback queue (git commits).
-        if self._callback_worker is not None and self._callback_worker.is_alive():
-            self._callback_queue.put(None)  # sentinel
-            self._callback_worker.join(timeout=30)
-            if self._callback_worker.is_alive():
-                logger.warning(
-                    "Write-callback worker did not finish within 30 s; "
-                    "pending git commits may be lost."
-                )
+        self._write_callback.close(timeout=30.0)
 
         # 3. Close git strategy (flush push, etc.).
         if self._git_strategy is not None:
@@ -1140,49 +1129,6 @@ class Collection:
     def _validate_attachment_path(self, path: str) -> Path:
         """Resolve and validate a non-.md attachment path."""
         return self._doc_mgr._validate_attachment_path(path)
-
-    def _ensure_callback_worker(self) -> None:
-        """Start the background write-callback worker if not running."""
-        with self._callback_worker_lock:
-            if self._callback_worker is not None and self._callback_worker.is_alive():
-                return
-
-            def _worker() -> None:
-                while True:
-                    item = self._callback_queue.get()
-                    if item is None:
-                        break
-                    abs_path, content, operation = item
-                    try:
-                        if self._on_write is None:
-                            logger.error(
-                                "Write callback is None in worker; dropping %s (%s)",
-                                abs_path,
-                                operation,
-                            )
-                            continue
-                        self._on_write(abs_path, content, operation)
-                    except Exception:
-                        logger.error(
-                            "Write callback failed for %s (%s)",
-                            abs_path,
-                            operation,
-                            exc_info=True,
-                        )
-
-            self._callback_worker = threading.Thread(
-                target=_worker, daemon=True, name="write-callback"
-            )
-            self._callback_worker.start()
-
-    def _fire_write_callback(
-        self, abs_path: Path, content: str, operation: WriteOperation
-    ) -> None:
-        """Submit a write callback to the background worker thread."""
-        if self._on_write is None:
-            return
-        self._ensure_callback_worker()
-        self._callback_queue.put((abs_path, content, operation))
 
     def read_attachment(self, path: str) -> AttachmentContent:
         """Read the binary content of a non-.md attachment.

--- a/src/markdown_vault_mcp/write_callback.py
+++ b/src/markdown_vault_mcp/write_callback.py
@@ -1,0 +1,117 @@
+"""Background dispatcher for deferred write callbacks (issue #175).
+
+Extracted from :class:`~markdown_vault_mcp.collection.Collection` (issue #599)
+so the git-commit dispatch concern lives apart from the index-write machinery
+in :mod:`markdown_vault_mcp.indexing`.
+
+A single daemon worker thread drains a FIFO queue, invoking the configured
+``on_write`` callback (typically a git commit) off the write path, so write
+methods return as soon as the FTS update lands.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from markdown_vault_mcp.types import WriteCallback, WriteOperation
+
+logger = logging.getLogger(__name__)
+
+
+class WriteCallbackDispatcher:
+    """Run write callbacks on a single background thread, in FIFO order.
+
+    The worker starts lazily on the first :meth:`fire` (only when a callback
+    is configured) and is joined by :meth:`close`. A ``None`` callback makes
+    :meth:`fire` a no-op. A callback that raises is logged and skipped; the
+    worker keeps processing subsequent items.
+    """
+
+    def __init__(self, on_write: WriteCallback | None) -> None:
+        """Store the callback; the worker is started lazily by :meth:`fire`.
+
+        Args:
+            on_write: Invoked as ``on_write(abs_path, content, operation)`` for
+                each fired write, or ``None`` to disable dispatch entirely.
+        """
+        self._on_write = on_write
+        self._queue: queue.Queue[tuple[Path, str, WriteOperation] | None] = (
+            queue.Queue()
+        )
+        self._worker: threading.Thread | None = None
+        self._worker_lock = threading.Lock()
+
+    def fire(self, abs_path: Path, content: str, operation: WriteOperation) -> None:
+        """Queue a callback invocation, starting the worker if needed.
+
+        No-op when no callback is configured.
+
+        Args:
+            abs_path: Absolute path of the written file.
+            content: File content at write time (empty for deletes).
+            operation: The kind of write that occurred.
+        """
+        if self._on_write is None:
+            return
+        self._ensure_worker()
+        self._queue.put((abs_path, content, operation))
+
+    def _ensure_worker(self) -> None:
+        """Start the background worker if it is not already running."""
+        with self._worker_lock:
+            if self._worker is not None and self._worker.is_alive():
+                return
+            self._worker = threading.Thread(
+                target=self._run, daemon=True, name="write-callback"
+            )
+            self._worker.start()
+
+    def _run(self) -> None:
+        """Worker loop: drain the queue until the sentinel is dequeued."""
+        while True:
+            item = self._queue.get()
+            if item is None:
+                break
+            abs_path, content, operation = item
+            on_write = self._on_write
+            try:
+                if on_write is None:
+                    logger.error(
+                        "Write callback is None in worker; dropping %s (%s)",
+                        abs_path,
+                        operation,
+                    )
+                    continue
+                on_write(abs_path, content, operation)
+            except Exception:
+                logger.error(
+                    "Write callback failed for %s (%s)",
+                    abs_path,
+                    operation,
+                    exc_info=True,
+                )
+
+    def close(self, timeout: float = 30.0) -> None:
+        """Drain pending callbacks and join the worker (bounded by ``timeout``).
+
+        Safe to call when the worker was never started, and idempotent on a
+        second call. Logs a warning if the worker does not finish in time.
+
+        Args:
+            timeout: Seconds to wait for the worker to drain and exit.
+        """
+        if self._worker is not None and self._worker.is_alive():
+            self._queue.put(None)  # sentinel
+            self._worker.join(timeout=timeout)
+            if self._worker.is_alive():
+                logger.warning(
+                    "Write-callback worker did not finish within %s s; "
+                    "pending git commits may be lost.",
+                    timeout,
+                )

--- a/tests/test_write_callback.py
+++ b/tests/test_write_callback.py
@@ -1,0 +1,115 @@
+"""Unit tests for WriteCallbackDispatcher (issue #599).
+
+Pins the six behavioural invariants the dispatcher inherits from the former
+Collection callback worker (#175): on_write=None no-op, lazy+idempotent single
+worker, FIFO order, callback-exception isolation, bounded draining close, and
+the daemon worker identity.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+
+from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
+
+
+def _recorder() -> tuple[list[tuple[Path, str, str]], object]:
+    calls: list[tuple[Path, str, str]] = []
+
+    def cb(abs_path: Path, content: str, operation: str) -> None:
+        calls.append((abs_path, content, operation))
+
+    return calls, cb
+
+
+class TestFire:
+    def test_fire_invokes_callback(self) -> None:
+        calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.fire(Path("a.md"), "body", "write")
+        dispatcher.close()  # drains + joins -> callback has run
+        assert calls == [(Path("a.md"), "body", "write")]
+
+    def test_fires_in_submission_order(self) -> None:
+        calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        for i in range(5):
+            dispatcher.fire(Path(f"{i}.md"), str(i), "write")
+        dispatcher.close()
+        assert [content for _, content, _ in calls] == ["0", "1", "2", "3", "4"]
+
+    def test_noop_when_on_write_none(self) -> None:
+        dispatcher = WriteCallbackDispatcher(None)
+        dispatcher.fire(Path("a.md"), "body", "write")
+        assert dispatcher._worker is None  # no worker started
+        dispatcher.close()  # safe with no worker
+
+    def test_worker_is_daemon_named(self) -> None:
+        _calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.fire(Path("a.md"), "body", "write")
+        assert dispatcher._worker is not None
+        assert dispatcher._worker.daemon is True
+        assert dispatcher._worker.name == "write-callback"
+        dispatcher.close()
+
+    def test_idempotent_worker_start(self) -> None:
+        _calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.fire(Path("a.md"), "x", "write")
+        first = dispatcher._worker
+        dispatcher.fire(Path("b.md"), "y", "write")
+        assert dispatcher._worker is first  # not restarted
+        dispatcher.close()
+
+
+class TestCallbackException:
+    def test_worker_continues_after_exception(self, caplog) -> None:
+        calls: list[str] = []
+
+        def cb(_abs_path: Path, content: str, _operation: str) -> None:
+            if content == "bad":
+                raise RuntimeError("boom")
+            calls.append(content)
+
+        dispatcher = WriteCallbackDispatcher(cb)
+        with caplog.at_level(logging.ERROR):
+            dispatcher.fire(Path("a.md"), "bad", "write")
+            dispatcher.fire(Path("b.md"), "good", "write")
+            dispatcher.close()
+        assert calls == ["good"]  # second item processed despite first raising
+        assert any("Write callback failed" in r.getMessage() for r in caplog.records)
+
+
+class TestClose:
+    def test_close_when_worker_never_started(self) -> None:
+        _calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.close()  # no fire -> no worker; must not error or hang
+        assert dispatcher._worker is None
+
+    def test_close_is_idempotent(self) -> None:
+        calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.fire(Path("a.md"), "body", "write")
+        dispatcher.close()
+        dispatcher.close()  # second close safe
+        assert calls == [(Path("a.md"), "body", "write")]
+
+    def test_close_warns_when_worker_hangs(self, caplog) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def cb(_abs_path: Path, _content: str, _operation: str) -> None:
+            started.set()
+            release.wait(5)  # block the worker
+
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.fire(Path("a.md"), "body", "write")
+        assert started.wait(2)  # worker is now blocked inside the callback
+        with caplog.at_level(logging.WARNING):
+            dispatcher.close(timeout=0.05)  # join times out -> warn
+        assert any("did not finish" in r.getMessage() for r in caplog.records)
+        release.set()  # let the daemon worker exit


### PR DESCRIPTION
Closes #599. Refs #576.

PR2 of the `collection.py` facade-decomposition epic (PR1 was #582, which extracted the `indexing/` package).

## What

Moves the deferred git-commit write-callback worker (originally #175) out of the `Collection` god-facade into a focused, separately-testable `WriteCallbackDispatcher` in `src/markdown_vault_mcp/write_callback.py`. **Behaviour-preserving** — no public surface change.

- `WriteCallbackDispatcher(on_write)` owns the daemon worker thread, the FIFO queue, and the start-lock.
- `.fire(abs_path, content, operation)` replaces `_fire_write_callback` + `_ensure_callback_worker`.
- `.close(timeout=30.0)` is the former `close()` step-2 drain (sentinel → join → warn-on-timeout).
- `Collection` constructs the dispatcher **before** `DocumentManager` (so `on_write_callback=self._write_callback.fire` captures a live reference), and calls `.close(timeout=30.0)` in the same teardown slot. It removes the three `_callback_*` attributes, the two private methods, and the now-unused `import queue`; it keeps `self._on_write` for the separate `_on_write.close()` resource teardown.

## Invariants preserved (verbatim move)

`on_write=None` → `fire` no-op; lazy + idempotent single worker (start-race lock); FIFO; a raising callback is logged (`exc_info=True`) and the worker continues; `close()` drains then joins (≤30 s), warns on timeout, is safe when never started and on a second call; daemon thread named `write-callback`.

## Tests

New `tests/test_write_callback.py` unit-pins all six invariants directly (deterministic — `threading.Event` + `close()`-join, no sleeps). The pre-existing Collection-facade callback tests (`test_collection.py`, `test_thread_safety.py`, `test_managers_document.py`, `test_git.py`) remain green as integration coverage. Full suite: 1903 passed, 1 skipped, 1 xpassed. `write_callback.py` patch coverage 95% (the one uncovered branch is a provably-dead defensive guard, carried over verbatim).

## Deferred

Latent thread-contract/lifecycle hardening for the dispatcher (close/fire lock discipline, use-after-close guard, removing the dead guard, quantifying the timeout warning) is **pre-existing** (carried verbatim from `Collection`) and tracked in #601 — out of scope for this behaviour-preserving move, per the #582 verbatim-move contract.

## Docs

`CLAUDE.md` and `docs/design.md` module maps gain `write_callback.py`. Internal-only change — no README / tools / config / resource surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)