### PR TITLE
refactor(config): remove dead auth-field duplicates from CollectionConfig

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ ignore = ["E501"]
 # Test fixtures import collection/protocol types only used in annotations.
 "tests/conftest.py" = ["TC002", "TC003"]
 "tests/test_smoke.py" = ["TC002", "TC003"]
+"tests/test_server.py" = ["TC003"]
 # PROJECT-RUFF-IGNORES-END
 
 [tool.ruff.lint.isort]

--- a/src/markdown_vault_mcp/_cli_impl.py
+++ b/src/markdown_vault_mcp/_cli_impl.py
@@ -97,7 +97,7 @@ def _cmd_serve(args: argparse.Namespace) -> None:
         import uvicorn
 
         config = load_config()
-        event_store = build_event_store(config.event_store_url)
+        event_store = build_event_store(config.server.event_store_url)
         # FastMCP's run() doesn't pass event_store through to http_app(),
         # so we build the ASGI app and run uvicorn directly.
         app = server.http_app(

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -8,14 +8,11 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from fastmcp_pvl_core import ServerConfig
-from fastmcp_pvl_core import build_bearer_auth as _core_build_bearer_auth
-from fastmcp_pvl_core import build_oidc_proxy_auth as _core_build_oidc_proxy_auth
-from fastmcp_pvl_core import build_remote_auth as _core_build_remote_auth
 from fastmcp_pvl_core import env as _core_env
 
 # Direct re-exports: parse_bool/parse_list match MV's old call shape (take a
@@ -23,8 +20,6 @@ from fastmcp_pvl_core import env as _core_env
 # ``if raw_xxx is not None`` so no shim wrapper is needed.
 from fastmcp_pvl_core import parse_bool as _parse_bool
 from fastmcp_pvl_core import parse_list as _parse_list
-from fastmcp_pvl_core import parse_scopes as _core_parse_scopes
-from fastmcp_pvl_core import resolve_auth_mode as _core_resolve_auth_mode
 
 logger = logging.getLogger(__name__)
 
@@ -40,18 +35,6 @@ def _env(name: str, default: str | None = None) -> str | None:
     value is treated as unset (returns *default*).
     """
     return _core_env(_ENV_PREFIX, name, default=default)
-
-
-def _parse_scopes(raw: str | None) -> list[str] | None:
-    """Parse a comma- or space-separated OIDC scopes string.
-
-    Routes through :func:`fastmcp_pvl_core.parse_scopes` but preserves MV's
-    historical "blank → ``None``" semantics so existing auth-builder
-    fallbacks (``required_scopes if raw is not None else ["openid"]``)
-    keep working.  Core returns ``[]`` for blank input; MV needs ``None``.
-    """
-    result = _core_parse_scopes(raw)
-    return result or None
 
 
 @dataclass
@@ -120,25 +103,6 @@ class CollectionConfig:
             (default ``"_templates"``).
         prompts_folder: Vault-relative folder from which user-defined MCP
             prompts are loaded at startup.  ``None`` disables user prompts.
-        event_store_url: URL for the FastMCP persistent event store used by
-            the HTTP transport (e.g. ``"file:///data/state/events"``).
-            ``None`` defaults to ``/data/state/events``.
-        auth_mode: Explicit OIDC mode override: ``"oidc-proxy"`` or
-            ``"remote"``.  ``None`` (default) means auto-detect from which
-            OIDC env vars are present.  Bearer and multi-auth are determined
-            automatically by the presence of ``bearer_token`` and OIDC fields.
-        base_url: Public base URL of the server, required for OIDC remote mode.
-        oidc_config_url: OIDC discovery endpoint URL.
-        oidc_client_id: OIDC client identifier.
-        oidc_client_secret: OIDC client secret (logged as set/not set).
-        oidc_audience: Expected ``aud`` claim in OIDC tokens.
-        oidc_required_scopes: Comma-separated OIDC scopes to require.
-        oidc_jwt_signing_key: Key for signing session JWTs (logged as
-            set/not set).
-        oidc_verify_access_token: When ``True``, verify the OIDC access
-            token instead of the id_token (default ``False``).
-        bearer_token: Static bearer token for simple auth (logged as
-            set/not set).
         embedding_provider: Name of the embedding provider to use (e.g.
             ``"ollama"``, ``"openai"``, ``"fastembed"``).  ``None`` disables
             semantic search.
@@ -163,9 +127,7 @@ class CollectionConfig:
         server: Shared server-level configuration (transport, host/port,
             auth, base URL, event store URL, MCP App domain) populated
             from ``MARKDOWN_VAULT_MCP_*`` env vars by
-            :meth:`fastmcp_pvl_core.ServerConfig.from_env`.  Domain-specific
-            duplicates above remain on :class:`CollectionConfig` until
-            MV-PR2/3 migrate consumers to read from ``self.server.*``.
+            :meth:`fastmcp_pvl_core.ServerConfig.from_env`.
 
     Example::
 
@@ -197,23 +159,10 @@ class CollectionConfig:
     max_note_read_bytes: int = 262144  # 256 KB; 0 = unlimited
     templates_folder: str = "_templates"
     prompts_folder: str | None = None
-    event_store_url: str | None = None
 
     # Server identity
     server_name: str = "markdown-vault-mcp"
     instructions: str | None = None
-
-    # Auth
-    auth_mode: str | None = None
-    base_url: str | None = None
-    oidc_config_url: str | None = None
-    oidc_client_id: str | None = None
-    oidc_client_secret: str | None = None
-    oidc_audience: str | None = None
-    oidc_required_scopes: str | None = None
-    oidc_jwt_signing_key: str | None = None
-    oidc_verify_access_token: bool = False
-    bearer_token: str | None = None
 
     # Embedding providers
     embedding_provider: str | None = None
@@ -241,9 +190,6 @@ class CollectionConfig:
     # CONFIG-FIELDS-END
 
     # Universal server fields delegated to fastmcp_pvl_core.ServerConfig.
-    # Domain-specific fields above remain on CollectionConfig; subsequent
-    # MV-PR2/3 will migrate consumers (auth builders, middleware) to read
-    # from ``self.server.*`` instead of the local duplicates.
     server: ServerConfig = field(default_factory=ServerConfig)
 
     def __post_init__(self) -> None:
@@ -425,9 +371,6 @@ def load_config() -> CollectionConfig:
       template markdown files are stored; default ``_templates``.
     - ``MARKDOWN_VAULT_MCP_PROMPTS_FOLDER``: relative folder path where
       user-defined prompt markdown files are stored; default ``None`` (disabled).
-    - ``MARKDOWN_VAULT_MCP_EVENT_STORE_URL``: event store backend for HTTP session
-      persistence; ``file:///path`` (default ``/data/state/events``) or
-      ``memory://`` (in-memory, lost on restart).
 
     **Server identity:**
 
@@ -435,25 +378,6 @@ def load_config() -> CollectionConfig:
       default ``"markdown-vault-mcp"``.
     - ``MARKDOWN_VAULT_MCP_INSTRUCTIONS``: server-level instructions surfaced
       to clients; default ``None``.
-
-    **Authentication:**
-
-    - ``MARKDOWN_VAULT_MCP_AUTH_MODE``: explicit OIDC mode override
-      (``"oidc-proxy"`` or ``"remote"``); default auto-detect.  Bearer and
-      multi-auth are determined by the presence of ``BEARER_TOKEN`` and OIDC
-      fields.
-    - ``MARKDOWN_VAULT_MCP_BASE_URL``: public base URL of the server.
-    - ``MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL``: OIDC discovery endpoint URL.
-    - ``MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID``: OIDC client identifier.
-    - ``MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET``: OIDC client secret.
-    - ``MARKDOWN_VAULT_MCP_OIDC_AUDIENCE``: expected ``aud`` claim in tokens.
-    - ``MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES``: comma-separated required
-      OIDC scopes.
-    - ``MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY``: key for signing session
-      JWTs.
-    - ``MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN``: verify access token
-      instead of id_token; default ``false``.
-    - ``MARKDOWN_VAULT_MCP_BEARER_TOKEN``: static bearer token for simple auth.
 
     **Embedding providers:**
 
@@ -475,6 +399,12 @@ def load_config() -> CollectionConfig:
       ``"BAAI/bge-small-en-v1.5"``.
     - ``MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR``: FastEmbed model cache
       directory; default ``None``.
+
+    Transport and auth variables (``TRANSPORT``, ``HOST``, ``PORT``,
+    ``BASE_URL``, ``AUTH_MODE``, ``OIDC_*``, ``BEARER_TOKEN``,
+    ``EVENT_STORE_URL``, ``APP_DOMAIN``) are read into ``config.server`` by
+    :meth:`fastmcp_pvl_core.ServerConfig.from_env`; see
+    ``docs/configuration.md`` for the full list.
 
     Returns:
         A fully populated :class:`CollectionConfig` instance.
@@ -705,12 +635,6 @@ def load_config() -> CollectionConfig:
         prompts_folder = None
     logger.debug("load_config: prompts_folder=%s", prompts_folder)
 
-    raw_event_store_url = (_env("EVENT_STORE_URL") or "").strip()
-    event_store_url: str | None = raw_event_store_url or None
-    logger.debug(
-        "load_config: event_store_url=%s", event_store_url or "not set (file default)"
-    )
-
     # --- Server identity ---
     raw_server_name = (_env("SERVER_NAME") or "").strip()
     server_name: str = raw_server_name or "markdown-vault-mcp"
@@ -719,59 +643,6 @@ def load_config() -> CollectionConfig:
     raw_instructions = (_env("INSTRUCTIONS") or "").strip()
     instructions: str | None = raw_instructions or None
     logger.debug("load_config: instructions=%s", "set" if instructions else "not set")
-
-    # --- Auth ---
-    raw_auth_mode = (_env("AUTH_MODE") or "").strip()
-    auth_mode: str | None = raw_auth_mode or None
-    logger.debug("load_config: auth_mode=%s", auth_mode or "auto-detect")
-
-    raw_base_url = (_env("BASE_URL") or "").strip()
-    base_url: str | None = raw_base_url or None
-    logger.debug("load_config: base_url=%s", base_url or "not set")
-
-    raw_oidc_config_url = (_env("OIDC_CONFIG_URL") or "").strip()
-    oidc_config_url: str | None = raw_oidc_config_url or None
-    logger.debug("load_config: oidc_config_url=%s", oidc_config_url or "not set")
-
-    raw_oidc_client_id = (_env("OIDC_CLIENT_ID") or "").strip()
-    oidc_client_id: str | None = raw_oidc_client_id or None
-    logger.debug("load_config: oidc_client_id=%s", oidc_client_id or "not set")
-
-    raw_oidc_client_secret = (_env("OIDC_CLIENT_SECRET") or "").strip()
-    oidc_client_secret: str | None = raw_oidc_client_secret or None
-    logger.debug(
-        "load_config: oidc_client_secret=%s",
-        "set" if oidc_client_secret else "not set",
-    )
-
-    raw_oidc_audience = (_env("OIDC_AUDIENCE") or "").strip()
-    oidc_audience: str | None = raw_oidc_audience or None
-    logger.debug("load_config: oidc_audience=%s", oidc_audience or "not set")
-
-    raw_oidc_required_scopes = (_env("OIDC_REQUIRED_SCOPES") or "").strip()
-    oidc_required_scopes: str | None = raw_oidc_required_scopes or None
-    logger.debug(
-        "load_config: oidc_required_scopes=%s", oidc_required_scopes or "not set"
-    )
-
-    raw_oidc_jwt_signing_key = (_env("OIDC_JWT_SIGNING_KEY") or "").strip()
-    oidc_jwt_signing_key: str | None = raw_oidc_jwt_signing_key or None
-    logger.debug(
-        "load_config: oidc_jwt_signing_key=%s",
-        "set" if oidc_jwt_signing_key else "not set",
-    )
-
-    raw_oidc_verify_access_token = _env("OIDC_VERIFY_ACCESS_TOKEN")
-    oidc_verify_access_token: bool = (
-        _parse_bool(raw_oidc_verify_access_token)
-        if raw_oidc_verify_access_token is not None
-        else False
-    )
-    logger.debug("load_config: oidc_verify_access_token=%s", oidc_verify_access_token)
-
-    raw_bearer_token = (_env("BEARER_TOKEN") or "").strip()
-    bearer_token: str | None = raw_bearer_token or None
-    logger.debug("load_config: bearer_token=%s", "set" if bearer_token else "not set")
 
     # --- Embedding providers ---
     raw_embedding_provider = (_env("EMBEDDING_PROVIDER") or "").strip()
@@ -914,19 +785,8 @@ def load_config() -> CollectionConfig:
         max_note_read_bytes=max_note_read_bytes,
         templates_folder=templates_folder,
         prompts_folder=prompts_folder,
-        event_store_url=event_store_url,
         server_name=server_name,
         instructions=instructions,
-        auth_mode=auth_mode,
-        base_url=base_url,
-        oidc_config_url=oidc_config_url,
-        oidc_client_id=oidc_client_id,
-        oidc_client_secret=oidc_client_secret,
-        oidc_audience=oidc_audience,
-        oidc_required_scopes=oidc_required_scopes,
-        oidc_jwt_signing_key=oidc_jwt_signing_key,
-        oidc_verify_access_token=oidc_verify_access_token,
-        bearer_token=bearer_token,
         embedding_provider=embedding_provider,
         ollama_host=ollama_host,
         ollama_model=ollama_model,
@@ -946,97 +806,3 @@ def load_config() -> CollectionConfig:
         # CONFIG-FROM-ENV-END
         server=ServerConfig.from_env(_ENV_PREFIX),
     )
-
-
-# ---------------------------------------------------------------------------
-# Auth builder functions — thin wrappers that delegate to fastmcp-pvl-core.
-#
-# Each wrapper accepts the legacy :class:`CollectionConfig` (which still
-# carries duplicated auth/OIDC fields), constructs a transient
-# :class:`ServerConfig` view via :func:`_server_from_collection`, and
-# delegates to the core implementation.  The duplicates on
-# :class:`CollectionConfig` will be removed in a later PR once consumers
-# (currently :mod:`markdown_vault_mcp.server`) read directly from
-# ``config.server`` instead.
-# ---------------------------------------------------------------------------
-
-
-def _server_from_collection(config: CollectionConfig) -> ServerConfig:
-    """Build a :class:`ServerConfig` view from CollectionConfig duplicates.
-
-    The duplicate auth fields on :class:`CollectionConfig` are still the
-    source of truth for the auth wrappers in this module — until consumers
-    migrate to :attr:`CollectionConfig.server`, we synthesize a transient
-    :class:`ServerConfig` from the same duplicates so ``fastmcp_pvl_core``
-    can do the actual work.
-    """
-    return ServerConfig(
-        base_url=config.base_url,
-        bearer_token=config.bearer_token,
-        oidc_config_url=config.oidc_config_url,
-        oidc_client_id=config.oidc_client_id,
-        oidc_client_secret=config.oidc_client_secret,
-        oidc_audience=config.oidc_audience,
-        oidc_required_scopes=tuple(_parse_scopes(config.oidc_required_scopes) or ()),
-        oidc_jwt_signing_key=config.oidc_jwt_signing_key,
-        oidc_verify_access_token=config.oidc_verify_access_token,
-        auth_mode=config.auth_mode,
-    )
-
-
-def resolve_auth_mode(config: CollectionConfig) -> str | None:
-    """Return the OIDC auth flavor for *config*, or ``None`` for no OIDC.
-
-    Preserved for the test surface that constructs :class:`CollectionConfig`
-    directly with auth fields populated — the wrapper bridges to core's
-    resolver via :func:`_server_from_collection` and hides the ``"multi"``
-    / ``"bearer"`` / ``"none"`` outcomes behind ``None`` so callers that
-    only branch on the OIDC flavor (``"remote"`` / ``"oidc-proxy"``) keep
-    working.  Production code in :mod:`markdown_vault_mcp.server` now calls core's
-    :func:`~fastmcp_pvl_core.resolve_auth_mode` directly on
-    ``config.server``.
-
-    Args:
-        config: Populated configuration object.
-
-    Returns:
-        ``"remote"``, ``"oidc-proxy"``, or ``None``.
-    """
-    server = _server_from_collection(config)
-    mode = _core_resolve_auth_mode(server)
-    if mode == "multi":
-        mode = _core_resolve_auth_mode(replace(server, bearer_token=None))
-    return None if mode in ("none", "bearer") else mode
-
-
-def build_remote_auth(config: CollectionConfig) -> Any:
-    """Build a :class:`RemoteAuthProvider` from OIDC discovery.
-
-    Delegates to :func:`fastmcp_pvl_core.build_remote_auth`.  Returns
-    ``None`` when ``base_url`` / ``oidc_config_url`` are missing.
-    Raises :class:`fastmcp_pvl_core.ConfigurationError` when ``httpx``
-    is not installed, when discovery fails, or when the discovery
-    document is missing required keys (fail-fast at startup, pvl-core
-    2.0 contract).
-    """
-    return _core_build_remote_auth(_server_from_collection(config))
-
-
-def build_bearer_auth(config: CollectionConfig) -> Any:
-    """Build a :class:`StaticTokenVerifier` from ``config.bearer_token``.
-
-    Delegates to :func:`fastmcp_pvl_core.build_bearer_auth`.  Returns
-    ``None`` when the bearer token is absent or blank.
-    """
-    return _core_build_bearer_auth(_server_from_collection(config))
-
-
-def build_oidc_auth(config: CollectionConfig) -> Any:
-    """Build an :class:`OIDCProxy` provider, or return ``None``.
-
-    Delegates to :func:`fastmcp_pvl_core.build_oidc_proxy_auth`.  Returns
-    ``None`` when any of the four required fields (``base_url``,
-    ``oidc_config_url``, ``oidc_client_id``, ``oidc_client_secret``) is
-    missing.
-    """
-    return _core_build_oidc_proxy_auth(_server_from_collection(config))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -283,7 +283,7 @@ class TestCmdServe:
         mock_server = MagicMock()
         mock_create.return_value = mock_server
         mock_config = MagicMock()
-        mock_config.event_store_url = None
+        mock_config.server.event_store_url = None
         mock_load_config.return_value = mock_config
         mock_event_store = MagicMock()
         mock_build_es.return_value = mock_event_store
@@ -323,7 +323,7 @@ class TestCmdServe:
         mock_server = MagicMock()
         mock_create.return_value = mock_server
         mock_config = MagicMock()
-        mock_config.event_store_url = None
+        mock_config.server.event_store_url = None
         mock_load_config.return_value = mock_config
         mock_build_es.return_value = MagicMock()
         mock_server.http_app.return_value = MagicMock()
@@ -352,7 +352,7 @@ class TestCmdServe:
         mock_server = MagicMock()
         mock_create.return_value = mock_server
         mock_config = MagicMock()
-        mock_config.event_store_url = None
+        mock_config.server.event_store_url = None
         mock_load_config.return_value = mock_config
         mock_build_es.return_value = MagicMock()
         mock_server.http_app.return_value = MagicMock()
@@ -381,7 +381,7 @@ class TestCmdServe:
         mock_server = MagicMock()
         mock_create.return_value = mock_server
         mock_config = MagicMock()
-        mock_config.event_store_url = None
+        mock_config.server.event_store_url = None
         mock_load_config.return_value = mock_config
         mock_build_es.return_value = MagicMock()
         mock_server.http_app.return_value = MagicMock()
@@ -409,7 +409,7 @@ class TestCmdServe:
         mock_server = MagicMock()
         mock_create.return_value = mock_server
         mock_config = MagicMock()
-        mock_config.event_store_url = None
+        mock_config.server.event_store_url = None
         mock_load_config.return_value = mock_config
         mock_build_es.return_value = MagicMock()
         mock_server.http_app.return_value = MagicMock()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,20 +1,15 @@
-"""Tests for config.py — env var loading and auth builders."""
+"""Tests for config.py — env var loading."""
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from markdown_vault_mcp.config import (
     CollectionConfig,
-    build_bearer_auth,
-    build_oidc_auth,
-    build_remote_auth,
     load_config,
-    resolve_auth_mode,
 )
 
 
@@ -574,20 +569,6 @@ class TestCollectionConfigDefaults:
         assert config.server_name == "markdown-vault-mcp"
         assert config.instructions is None
 
-    def test_auth_defaults(self) -> None:
-        """All auth fields default to None/False."""
-        config = CollectionConfig(source_dir=Path("/tmp/vault"))
-        assert config.auth_mode is None
-        assert config.base_url is None
-        assert config.oidc_config_url is None
-        assert config.oidc_client_id is None
-        assert config.oidc_client_secret is None
-        assert config.oidc_audience is None
-        assert config.oidc_required_scopes is None
-        assert config.oidc_jwt_signing_key is None
-        assert config.oidc_verify_access_token is False
-        assert config.bearer_token is None
-
     def test_embedding_provider_defaults(self) -> None:
         """Embedding fields have correct defaults."""
         config = CollectionConfig(source_dir=Path("/tmp/vault"))
@@ -607,16 +588,6 @@ class TestCollectionConfigDefaults:
             source_dir=Path("/tmp/vault"),
             server_name="my-server",
             instructions="Be helpful",
-            auth_mode="bearer",
-            base_url="https://example.com",
-            oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
-            oidc_client_id="client-123",
-            oidc_client_secret="secret-456",
-            oidc_audience="my-api",
-            oidc_required_scopes="openid,profile",
-            oidc_jwt_signing_key="signing-key-789",
-            oidc_verify_access_token=True,
-            bearer_token="tok_abc",
             embedding_provider="ollama",
             ollama_host="http://gpu-server:11434",
             ollama_model="mxbai-embed-large",
@@ -629,12 +600,6 @@ class TestCollectionConfigDefaults:
         )
         assert config.server_name == "my-server"
         assert config.instructions == "Be helpful"
-        assert config.auth_mode == "bearer"
-        assert config.base_url == "https://example.com"
-        assert config.oidc_client_id == "client-123"
-        assert config.oidc_client_secret == "secret-456"
-        assert config.oidc_verify_access_token is True
-        assert config.bearer_token == "tok_abc"
         assert config.embedding_provider == "ollama"
         assert config.ollama_host == "http://gpu-server:11434"
         assert config.ollama_model == "mxbai-embed-large"
@@ -684,82 +649,6 @@ class TestLoadConfigServerIdentityFields:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_INSTRUCTIONS", "Be concise")
         config = load_config()
         assert config.instructions == "Be concise"
-
-
-class TestLoadConfigAuthFields:
-    """Verify auth env vars are read correctly by load_config()."""
-
-    @pytest.fixture(autouse=True)
-    def _set_source_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
-
-    def test_auth_mode_default_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """load_config() defaults auth_mode to None (auto-detect)."""
-        monkeypatch.delenv("MARKDOWN_VAULT_MCP_AUTH_MODE", raising=False)
-        config = load_config()
-        assert config.auth_mode is None
-
-    def test_auth_mode_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """load_config() reads MARKDOWN_VAULT_MCP_AUTH_MODE."""
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_AUTH_MODE", "bearer")
-        config = load_config()
-        assert config.auth_mode == "bearer"
-
-    def test_base_url_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """load_config() reads MARKDOWN_VAULT_MCP_BASE_URL."""
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_BASE_URL", "https://vault.example.com")
-        config = load_config()
-        assert config.base_url == "https://vault.example.com"
-
-    def test_oidc_fields_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """load_config() reads all OIDC env vars."""
-        monkeypatch.setenv(
-            "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
-            "https://auth.example.com/.well-known/openid-configuration",
-        )
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID", "my-client")
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET", "s3cret")
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_AUDIENCE", "my-api")
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES", "openid,profile")
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY", "jwt-key-123")
-        config = load_config()
-        assert (
-            config.oidc_config_url
-            == "https://auth.example.com/.well-known/openid-configuration"
-        )
-        assert config.oidc_client_id == "my-client"
-        assert config.oidc_client_secret == "s3cret"
-        assert config.oidc_audience == "my-api"
-        assert config.oidc_required_scopes == "openid,profile"
-        assert config.oidc_jwt_signing_key == "jwt-key-123"
-
-    def test_oidc_verify_access_token_default_false(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """load_config() defaults oidc_verify_access_token to False."""
-        monkeypatch.delenv("MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN", raising=False)
-        config = load_config()
-        assert config.oidc_verify_access_token is False
-
-    def test_oidc_verify_access_token_true(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """load_config() parses OIDC_VERIFY_ACCESS_TOKEN=true."""
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN", "true")
-        config = load_config()
-        assert config.oidc_verify_access_token is True
-
-    def test_bearer_token_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """load_config() reads MARKDOWN_VAULT_MCP_BEARER_TOKEN."""
-        monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "tok_abc123")
-        config = load_config()
-        assert config.bearer_token == "tok_abc123"
-
-    def test_bearer_token_default_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """load_config() defaults bearer_token to None."""
-        monkeypatch.delenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", raising=False)
-        config = load_config()
-        assert config.bearer_token is None
 
 
 class TestLoadConfigEmbeddingFields:
@@ -957,231 +846,6 @@ class TestLoadConfigEmbeddingFields:
         assert config.fastembed_cache_dir is None
 
 
-# ---------------------------------------------------------------------------
-# Auth builder helpers
-# ---------------------------------------------------------------------------
-
-
-def _oidc_config(**overrides: Any) -> CollectionConfig:
-    """Build a CollectionConfig pre-filled with all required OIDC fields."""
-    defaults: dict[str, Any] = {
-        "source_dir": Path("/tmp"),
-        "base_url": "https://mcp.example.com",
-        "oidc_config_url": "https://auth.example.com/.well-known/openid-configuration",
-        "oidc_client_id": "test-client",
-        "oidc_client_secret": "test-secret",
-    }
-    defaults.update(overrides)
-    return CollectionConfig(**defaults)
-
-
-# ---------------------------------------------------------------------------
-# resolve_auth_mode()
-# ---------------------------------------------------------------------------
-
-
-class TestResolveAuthModeConfig:
-    """Tests for resolve_auth_mode() accepting CollectionConfig."""
-
-    def test_explicit_remote(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), auth_mode="remote")
-        assert resolve_auth_mode(config) == "remote"
-
-    def test_explicit_oidc_proxy(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), auth_mode="oidc-proxy")
-        assert resolve_auth_mode(config) == "oidc-proxy"
-
-    def test_auto_detect_oidc_proxy(self) -> None:
-        """All four OIDC fields set -> oidc-proxy."""
-        config = _oidc_config()
-        assert resolve_auth_mode(config) == "oidc-proxy"
-
-    def test_auto_detect_remote(self) -> None:
-        """Only base_url + oidc_config_url -> remote."""
-        config = CollectionConfig(
-            source_dir=Path("/tmp"),
-            base_url="https://mcp.example.com",
-            oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
-        )
-        assert resolve_auth_mode(config) == "remote"
-
-    def test_no_auth_returns_none(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        assert resolve_auth_mode(config) is None
-
-    def test_invalid_mode_returns_none(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), auth_mode="invalid")
-        assert resolve_auth_mode(config) is None
-
-
-# ---------------------------------------------------------------------------
-# build_bearer_auth()
-# ---------------------------------------------------------------------------
-
-
-class TestBuildBearerAuthConfig:
-    """Tests for build_bearer_auth() accepting CollectionConfig."""
-
-    def test_returns_none_when_no_token(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        assert build_bearer_auth(config) is None
-
-    def test_returns_verifier_when_token_set(self) -> None:
-        from fastmcp.server.auth import StaticTokenVerifier
-
-        config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="tok123")
-        result = build_bearer_auth(config)
-        assert isinstance(result, StaticTokenVerifier)
-        assert "tok123" in result.tokens
-
-
-# ---------------------------------------------------------------------------
-# build_oidc_auth()
-# ---------------------------------------------------------------------------
-
-
-class TestBuildOidcAuthConfig:
-    """Tests for build_oidc_auth() accepting CollectionConfig."""
-
-    def test_returns_none_when_missing_fields(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        assert build_oidc_auth(config) is None
-
-    def test_returns_proxy_when_all_fields_present(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            result = build_oidc_auth(config)
-        assert result is not None
-        mock_cls.assert_called_once()
-
-    def test_passes_correct_kwargs(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        kw = mock_cls.call_args.kwargs
-        assert kw["base_url"] == "https://mcp.example.com"
-        assert kw["client_id"] == "test-client"
-        assert kw["client_secret"] == "test-secret"
-        assert kw["required_scopes"] == ["openid"]
-        assert kw["verify_id_token"] is True
-
-    def test_scopes_parsed_from_config(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_required_scopes="openid, profile")
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["required_scopes"] == ["openid", "profile"]
-
-    def test_linux_warning_logged(self, caplog: pytest.LogCaptureFixture) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        # The ephemeral-signing-key warning lives in fastmcp_pvl_core._auth
-        # since MV-PR2; patch sys there, not in markdown_vault_mcp.config.
-        with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
-        ):
-            mock_sys.platform = "linux"
-            build_oidc_auth(config)
-
-        assert any(
-            "JWT_SIGNING_KEY" in r.message and r.levelname == "WARNING"
-            for r in caplog.records
-        )
-
-
-# ---------------------------------------------------------------------------
-# build_remote_auth()
-# ---------------------------------------------------------------------------
-
-
-class TestBuildRemoteAuthConfig:
-    """Tests for build_remote_auth() accepting CollectionConfig."""
-
-    def test_returns_none_when_missing_fields(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        assert build_remote_auth(config) is None
-
-    def test_raises_on_discovery_failure(self) -> None:
-        from unittest.mock import patch
-
-        import httpx
-        from fastmcp_pvl_core import ConfigurationError
-
-        config = CollectionConfig(
-            source_dir=Path("/tmp"),
-            base_url="https://mcp.example.com",
-            oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
-        )
-        # pvl-core 2.0 changed the contract: discovery failures now raise
-        # ConfigurationError instead of returning None — fail-fast at startup
-        # rather than silently disabling auth on a misconfigured deployment.
-        with (
-            patch("httpx.get", side_effect=httpx.ConnectError("fail")),
-            pytest.raises(ConfigurationError, match="OIDC discovery failed"),
-        ):
-            build_remote_auth(config)
-
-    def test_happy_path(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = CollectionConfig(
-            source_dir=Path("/tmp"),
-            base_url="https://mcp.example.com",
-            oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
-        )
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "issuer": "https://auth.example.com",
-        }
-        mock_resp.raise_for_status = MagicMock()
-        with patch("httpx.get", return_value=mock_resp):
-            result = build_remote_auth(config)
-        assert result is not None
-
-    def test_scopes_parsed_from_config(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = CollectionConfig(
-            source_dir=Path("/tmp"),
-            base_url="https://mcp.example.com",
-            oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
-            oidc_required_scopes="openid, profile",
-        )
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "issuer": "https://auth.example.com",
-        }
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_verifier_cls = MagicMock()
-        mock_remote_cls = MagicMock()
-
-        with (
-            patch("httpx.get", return_value=mock_resp),
-            patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
-            patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
-        ):
-            build_remote_auth(config)
-
-        kw = mock_verifier_cls.call_args.kwargs
-        assert kw["required_scopes"] == ["openid", "profile"]
-
-
 class TestEmptyBoolEnvVarsFallToDefault:
     """Empty-string env vars on bool fields fall through to the configured default.
 
@@ -1214,7 +878,7 @@ class TestEmptyBoolEnvVarsFallToDefault:
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN", "")
         config = load_config()
-        assert config.oidc_verify_access_token is False  # default
+        assert config.server.oidc_verify_access_token is False  # default
 
     def test_ollama_cpu_only_empty_falls_through_to_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1249,6 +913,52 @@ class TestServerConfigComposition:
         assert config.server.transport == "http"
         assert config.server.bearer_token == "secret-token"
         assert config.server.base_url == "https://api.example.com"
+
+    def test_load_config_reads_oidc_verify_access_token_true(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """OIDC_VERIFY_ACCESS_TOKEN=true composes to config.server as True."""
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN", "true")
+
+        config = load_config()
+
+        assert config.server.oidc_verify_access_token is True
+
+    def test_load_config_populates_oidc_fields_from_prefixed_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Every MARKDOWN_VAULT_MCP_OIDC_*/AUTH_MODE var reaches config.server.
+
+        Guards the env-prefix wiring for the OIDC/AUTH_MODE portion of the auth
+        surface the deleted TestLoadConfigAuthFields covered (bearer/base_url/
+        verify-token are covered by the sibling tests above), now asserted
+        against the composed ServerConfig.
+        """
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_AUTH_MODE", "oidc-proxy")
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
+            "https://auth.example.com/.well-known/openid-configuration",
+        )
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID", "client-123")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET", "secret-456")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_AUDIENCE", "my-api")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES", "openid,profile")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY", "signing-key")
+
+        config = load_config()
+
+        assert config.server.auth_mode == "oidc-proxy"
+        assert (
+            config.server.oidc_config_url
+            == "https://auth.example.com/.well-known/openid-configuration"
+        )
+        assert config.server.oidc_client_id == "client-123"
+        assert config.server.oidc_client_secret == "secret-456"
+        assert config.server.oidc_audience == "my-api"
+        assert config.server.oidc_required_scopes == ("openid", "profile")
+        assert config.server.oidc_jwt_signing_key == "signing-key"
 
 
 def test_search_ranking_config_rejects_malformed_int(

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -77,21 +77,21 @@ class TestEventStoreConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_EVENT_STORE_URL", raising=False)
         config = load_config()
-        assert config.event_store_url is None
+        assert config.server.event_store_url is None
 
     def test_event_store_url_from_env(self, monkeypatch):
         """EVENT_STORE_URL is read from environment."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_EVENT_STORE_URL", "memory://")
         config = load_config()
-        assert config.event_store_url == "memory://"
+        assert config.server.event_store_url == "memory://"
 
     def test_event_store_url_empty_is_none(self, monkeypatch):
         """Empty EVENT_STORE_URL yields None (file default)."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_EVENT_STORE_URL", "  ")
         config = load_config()
-        assert config.event_store_url is None
+        assert config.server.event_store_url is None
 
     def test_event_store_url_file_path(self, monkeypatch):
         """file:// URL passed through verbatim."""
@@ -100,7 +100,7 @@ class TestEventStoreConfig:
             "MARKDOWN_VAULT_MCP_EVENT_STORE_URL", "file:///data/state/events"
         )
         config = load_config()
-        assert config.event_store_url == "file:///data/state/events"
+        assert config.server.event_store_url == "file:///data/state/events"
 
 
 class TestFileEventStorePersistence:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,13 +16,6 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from mcp.shared.exceptions import McpError
 
-from markdown_vault_mcp.config import (
-    CollectionConfig,
-    build_bearer_auth,
-    build_oidc_auth,
-    build_remote_auth,
-    resolve_auth_mode,
-)
 from markdown_vault_mcp.server import make_server
 from tests.conftest import wait_for_mcp_writer_drain
 
@@ -758,261 +751,6 @@ _OIDC_REQUIRED = {
     "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID": "test-client",
     "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET": "test-secret",
 }
-
-
-def _oidc_config(**overrides: Any) -> CollectionConfig:
-    """Build a CollectionConfig pre-filled with all required OIDC fields.
-
-    Keyword arguments override any field on the config.
-    """
-    defaults: dict[str, Any] = {
-        "source_dir": Path("/tmp"),
-        "base_url": "https://mcp.example.com",
-        "oidc_config_url": "https://auth.example.com/.well-known/openid-configuration",
-        "oidc_client_id": "test-client",
-        "oidc_client_secret": "test-secret",
-    }
-    defaults.update(overrides)
-    return CollectionConfig(**defaults)
-
-
-class TestBuildOidcAuth:
-    """Unit tests for build_oidc_auth()."""
-
-    def test_returns_none_when_no_vars_set(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        assert build_oidc_auth(config) is None
-
-    @pytest.mark.parametrize(
-        "missing_field",
-        ["base_url", "oidc_config_url", "oidc_client_id", "oidc_client_secret"],
-    )
-    def test_returns_none_when_one_required_var_missing(
-        self, missing_field: str
-    ) -> None:
-        """Any one missing required field disables auth."""
-        config = _oidc_config(**{missing_field: None})
-        assert build_oidc_auth(config) is None
-
-    def test_returns_non_none_when_all_required_vars_set(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            result = build_oidc_auth(config)
-
-        assert result is not None
-        mock_cls.assert_called_once()
-
-    def test_passes_required_kwargs_to_oidc_proxy(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        kw = mock_cls.call_args.kwargs
-        assert kw["base_url"] == "https://mcp.example.com"
-        assert (
-            kw["config_url"]
-            == "https://auth.example.com/.well-known/openid-configuration"
-        )
-        assert kw["client_id"] == "test-client"
-        assert kw["client_secret"] == "test-secret"
-
-    def test_default_required_scopes_is_openid(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["required_scopes"] == ["openid"]
-
-    def test_empty_required_scopes_falls_back_to_openid(self) -> None:
-        """Explicitly empty REQUIRED_SCOPES falls back to ['openid'], not []."""
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_required_scopes="")
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["required_scopes"] == ["openid"]
-
-    def test_custom_required_scopes_parsed(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_required_scopes="openid, profile, email")
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["required_scopes"] == [
-            "openid",
-            "profile",
-            "email",
-        ]
-
-    def test_audience_forwarded_when_set(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_audience="my-api")
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["audience"] == "my-api"
-
-    def test_audience_is_none_when_not_set(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["audience"] is None
-
-    def test_jwt_signing_key_forwarded_when_set(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_jwt_signing_key="deadbeef1234")
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["jwt_signing_key"] == "deadbeef1234"
-
-    def test_jwt_signing_key_is_none_when_not_set(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["jwt_signing_key"] is None
-
-    def test_linux_warning_when_jwt_key_absent(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
-        ):
-            mock_sys.platform = "linux"
-            build_oidc_auth(config)
-
-        assert any(
-            "JWT_SIGNING_KEY" in r.message and r.levelname == "WARNING"
-            for r in caplog.records
-        )
-
-    def test_no_warning_when_jwt_key_present_on_linux(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_jwt_signing_key="some-key")
-        mock_cls = MagicMock()
-        with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
-        ):
-            mock_sys.platform = "linux"
-            build_oidc_auth(config)
-
-        assert not any(
-            "JWT_SIGNING_KEY" in r.message and r.levelname == "WARNING"
-            for r in caplog.records
-        )
-
-    def test_no_warning_on_non_linux_without_jwt_key(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
-        ):
-            mock_sys.platform = "darwin"
-            build_oidc_auth(config)
-
-        assert not any(
-            "JWT_SIGNING_KEY" in r.message and r.levelname == "WARNING"
-            for r in caplog.records
-        )
-
-    def test_default_verify_id_token_is_true(self) -> None:
-        """By default, verify_id_token=True (works with opaque access tokens)."""
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["verify_id_token"] is True
-
-    def test_verify_access_token_disables_verify_id_token(self) -> None:
-        """OIDC_VERIFY_ACCESS_TOKEN=true reverts to access-token verification."""
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_verify_access_token=True)
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert mock_cls.call_args.kwargs["verify_id_token"] is False
-
-    # Note: the previous test_verify_id_token_log_message /
-    # test_verify_access_token_log_message tests asserted MV-specific INFO
-    # log strings ("verifying upstream id_token") that fastmcp_pvl_core
-    # replaced with structured key=value logging.  The behavioural
-    # assertion they backed (verify_id_token kwarg flips correctly) is
-    # already covered by test_default_verify_id_token and
-    # test_verify_access_token_disables_verify_id_token above.
-
-    def test_warning_when_openid_scope_missing_with_verify_id_token(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Warn when verify_id_token=True but 'openid' is not in scopes."""
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config(oidc_required_scopes="profile,email")
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert any(
-            "openid" in r.message and r.levelname == "WARNING" for r in caplog.records
-        )
-
-    def test_no_warning_when_openid_scope_present(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """No warning when 'openid' is in scopes (default)."""
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
-            build_oidc_auth(config)
-
-        assert not any(
-            "openid" in r.message and r.levelname == "WARNING" for r in caplog.records
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -2510,65 +2248,15 @@ class TestLifespanAutoEmbeddings:
 _BEARER_VARS = ("MARKDOWN_VAULT_MCP_BEARER_TOKEN",)
 
 
-class TestBuildBearerAuth:
-    """Unit tests for build_bearer_auth()."""
-
-    def test_returns_none_when_no_var_set(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        assert build_bearer_auth(config) is None
-
-    def test_returns_none_when_empty_string(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="")
-        assert build_bearer_auth(config) is None
-
-    def test_returns_none_when_whitespace_only(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="   ")
-        assert build_bearer_auth(config) is None
-
-    def test_returns_static_token_verifier_when_set(self) -> None:
-        from fastmcp.server.auth import StaticTokenVerifier
-
-        config = CollectionConfig(
-            source_dir=Path("/tmp"), bearer_token="test-secret-123"
-        )
-        result = build_bearer_auth(config)
-        assert isinstance(result, StaticTokenVerifier)
-
-    def test_token_dict_has_correct_structure(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="my-token")
-        result = build_bearer_auth(config)
-        assert "my-token" in result.tokens
-        entry = result.tokens["my-token"]
-        assert entry["client_id"] == "bearer-anon"
-        assert entry["scopes"] == ["read", "write"]
-
-    async def test_verify_correct_token_returns_access_token(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="good-token")
-        verifier = build_bearer_auth(config)
-        access = await verifier.verify_token("good-token")
-        assert access is not None
-        assert access.client_id == "bearer-anon"
-        assert access.scopes == ["read", "write"]
-
-    async def test_verify_wrong_token_returns_none(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="good-token")
-        verifier = build_bearer_auth(config)
-        access = await verifier.verify_token("wrong-token")
-        assert access is None
-
-    async def test_verify_empty_token_returns_none(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="good-token")
-        verifier = build_bearer_auth(config)
-        access = await verifier.verify_token("")
-        assert access is None
-
-
 class TestAuthModeSelection:
     """Tests for auth mode selection in make_server().
 
-    These tests call ``make_server()`` directly so the real assembly
-    logic is exercised — not just the individual builder functions.
-    Covers all four modes: multi (both), bearer-only, OIDC-only, none.
+    Exercises the real make_server() assembly for the modes MV is
+    responsible for wiring: multi, bearer-only, oidc-proxy, and none, plus
+    the OIDC security defaults (blank scopes -> ["openid"], verify_id_token).
+    Remote-mode discovery and RemoteAuthProvider assembly are pvl-core-owned
+    (tested upstream); MV's only remote responsibility — the OIDC env vars
+    reaching config.server — is covered by TestServerConfigComposition.
     """
 
     @pytest.fixture(autouse=True)
@@ -2682,6 +2370,73 @@ class TestAuthModeSelection:
         assert server.auth is not None
         assert server.auth is mock_cls.return_value
 
+    def test_bearer_only_when_no_oidc(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Only BEARER_TOKEN set (no OIDC) -> server.auth is a StaticTokenVerifier."""
+        from fastmcp.server.auth import StaticTokenVerifier
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_BEARER_TOKEN", "secret")
+
+        server = make_server()
+
+        assert isinstance(server.auth, StaticTokenVerifier)
+
+    def test_oidc_blank_required_scopes_defaults_to_openid(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Blank OIDC_REQUIRED_SCOPES -> OIDCProxy enforces ["openid"].
+
+        Security default: leaving scopes unset must still enforce openid
+        (core maps the empty tuple to ["openid"]); the assembled server must
+        not silently accept any-scope tokens.
+        """
+        from unittest.mock import MagicMock, patch
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+        for var, val in _OIDC_REQUIRED.items():
+            monkeypatch.setenv(var, val)
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES", "")
+
+        mock_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            make_server()
+
+        assert mock_cls.call_args.kwargs["required_scopes"] == ["openid"]
+
+    def test_oidc_verify_id_token_follows_verify_access_token(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """OIDCProxy verifies the id_token by default; verify_access_token flips it.
+
+        Security default: unset OIDC_VERIFY_ACCESS_TOKEN must verify the
+        id_token (verify_id_token=True); setting it true switches verification
+        to the access token (verify_id_token=False).
+        """
+        from unittest.mock import MagicMock, patch
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+        for var, val in _OIDC_REQUIRED.items():
+            monkeypatch.setenv(var, val)
+
+        mock_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            make_server()
+        assert mock_cls.call_args.kwargs["verify_id_token"] is True
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN", "true")
+        mock_cls.reset_mock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            make_server()
+        assert mock_cls.call_args.kwargs["verify_id_token"] is False
+
     def test_no_auth_when_nothing_configured(
         self,
         vault_path: Path,
@@ -2710,7 +2465,7 @@ class TestAuthModeSelection:
         """If build_auth returns None despite OIDC config, log ``mode=none``.
 
         Guards against the log drifting from reality when e.g. OIDC
-        discovery fails: ``resolve_auth_mode`` would still report
+        discovery fails: core's ``resolve_auth_mode`` would still report
         ``oidc-proxy`` from field presence, but the actual auth object
         is ``None`` so the startup summary must say ``none``.
         """
@@ -2733,64 +2488,13 @@ class TestAuthModeSelection:
         assert "Auth enabled" not in caplog.text
 
 
-class TestAuthDebugLogging:
-    """Tests for auth DEBUG logging (issue #181).
+class TestStartupSummaryLogging:
+    """Tests for the make_server() startup-summary log line.
 
-    The literal log strings asserted here were updated when MV-PR2
-    delegated auth builders to fastmcp_pvl_core, which uses structured
-    ``key=value`` logging instead of MV's old prose strings.  The
-    security-relevant property — secrets never appearing in logs — is
-    preserved verbatim.
+    The two remaining cases assert the INFO startup summary (which
+    reports auth mode, version, and read-only state) and the version
+    fallback when the package metadata is unavailable.
     """
-
-    def test_bearer_debug_logs_presence(self, caplog: pytest.LogCaptureFixture) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), bearer_token="secret-token")
-        with caplog.at_level(logging.DEBUG):
-            build_bearer_auth(config)
-        assert "bearer_auth_enabled" in caplog.text
-        assert "<redacted>" in caplog.text
-        assert "secret-token" not in caplog.text
-
-    def test_bearer_debug_logs_absence(self, caplog: pytest.LogCaptureFixture) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        with caplog.at_level(logging.DEBUG):
-            build_bearer_auth(config)
-        assert "bearer_auth_skipped" in caplog.text
-
-    def test_oidc_debug_does_not_leak_secret(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """OIDC builder invokes OIDCProxy and never logs the client_secret.
-
-        The positive leg (``mock_cls.assert_called_once()``) guards against
-        a regression where this test would silently pass if build_oidc_auth
-        bailed out before reaching the proxy construction.
-        """
-        from unittest.mock import MagicMock, patch
-
-        config = _oidc_config()
-        mock_cls = MagicMock()
-        with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            caplog.at_level(logging.DEBUG),
-        ):
-            build_oidc_auth(config)
-
-        mock_cls.assert_called_once()
-        assert "test-secret" not in caplog.text
-
-    def test_oidc_debug_logs_missing_vars(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        # Only set BASE_URL, leave others missing
-        config = CollectionConfig(
-            source_dir=Path("/tmp"), base_url="https://example.com"
-        )
-        with caplog.at_level(logging.DEBUG):
-            result = build_oidc_auth(config)
-        assert result is None
-        assert "oidc_proxy_auth_skipped" in caplog.text
-        assert "missing=" in caplog.text
 
     def test_startup_summary_logged(
         self,
@@ -2823,298 +2527,6 @@ class TestAuthDebugLogging:
         with caplog.at_level(logging.INFO):
             make_server()
         assert "version=unknown" in caplog.text
-
-
-# ---------------------------------------------------------------------------
-# _resolve_auth_mode() — OIDC mode detection
-# ---------------------------------------------------------------------------
-
-
-class TestResolveAuthMode:
-    """Tests for resolve_auth_mode()."""
-
-    def test_explicit_remote(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), auth_mode="remote")
-        assert resolve_auth_mode(config) == "remote"
-
-    def test_explicit_oidc_proxy(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), auth_mode="oidc-proxy")
-        assert resolve_auth_mode(config) == "oidc-proxy"
-
-    def test_explicit_case_insensitive(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), auth_mode="REMOTE")
-        assert resolve_auth_mode(config) == "remote"
-
-    def test_auto_detect_oidc_proxy(self) -> None:
-        """All four OIDC fields set -> oidc-proxy."""
-        config = _oidc_config()
-        assert resolve_auth_mode(config) == "oidc-proxy"
-
-    def test_auto_detect_remote(self) -> None:
-        """Only base_url + oidc_config_url -> remote."""
-        config = CollectionConfig(
-            source_dir=Path("/tmp"),
-            base_url="https://mcp.example.com",
-            oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
-        )
-        assert resolve_auth_mode(config) == "remote"
-
-    def test_no_vars_returns_none(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        assert resolve_auth_mode(config) is None
-
-    def test_invalid_mode_ignored(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"), auth_mode="invalid")
-        assert resolve_auth_mode(config) is None
-
-    def test_invalid_mode_warns_and_falls_through(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Invalid AUTH_MODE with auto-detect fields logs warning, falls to remote."""
-        config = CollectionConfig(
-            source_dir=Path("/tmp"),
-            auth_mode="typo",
-            base_url="https://mcp.example.com",
-            oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
-        )
-        with caplog.at_level(logging.WARNING):
-            result = resolve_auth_mode(config)
-        assert result == "remote"
-        # Core's structured warning replaces MV's old "Unknown AUTH_MODE 'X'".
-        assert "auth_mode_unknown" in caplog.text
-        assert "'typo'" in caplog.text
-
-    def test_only_base_url_returns_none(self) -> None:
-        """base_url alone is not enough for any OIDC mode."""
-        config = CollectionConfig(
-            source_dir=Path("/tmp"), base_url="https://mcp.example.com"
-        )
-        assert resolve_auth_mode(config) is None
-
-    def test_explicit_overrides_auto_detection(self) -> None:
-        """AUTH_MODE=remote forces remote even when all four fields are set."""
-        config = _oidc_config(auth_mode="remote")
-        assert resolve_auth_mode(config) == "remote"
-
-
-# ---------------------------------------------------------------------------
-# _build_remote_auth() — RemoteAuthProvider construction
-# ---------------------------------------------------------------------------
-
-
-class TestBuildRemoteAuth:
-    """Tests for build_remote_auth()."""
-
-    def _remote_config(self, **overrides: Any) -> CollectionConfig:
-        """Build a CollectionConfig with base_url + oidc_config_url."""
-        defaults: dict[str, Any] = {
-            "source_dir": Path("/tmp"),
-            "base_url": "https://mcp.example.com",
-            "oidc_config_url": "https://auth.example.com/.well-known/openid-configuration",
-        }
-        defaults.update(overrides)
-        return CollectionConfig(**defaults)
-
-    def test_missing_env_vars_returns_none(self) -> None:
-        config = CollectionConfig(source_dir=Path("/tmp"))
-        assert build_remote_auth(config) is None
-
-    def test_missing_config_url_returns_none(self) -> None:
-        config = CollectionConfig(
-            source_dir=Path("/tmp"), base_url="https://mcp.example.com"
-        )
-        assert build_remote_auth(config) is None
-
-    def test_missing_base_url_returns_none(self) -> None:
-        config = CollectionConfig(
-            source_dir=Path("/tmp"),
-            oidc_config_url="https://auth.example.com/.well-known/openid-configuration",
-        )
-        assert build_remote_auth(config) is None
-
-    def test_discovery_fetch_failure_raises(self) -> None:
-        from unittest.mock import patch
-
-        import httpx
-        from fastmcp_pvl_core import ConfigurationError
-
-        config = self._remote_config()
-        # pvl-core 2.0 raises ConfigurationError on discovery failure
-        # (fail-fast at startup) instead of returning None.
-        with (
-            patch("httpx.get", side_effect=httpx.ConnectError("connection failed")),
-            pytest.raises(ConfigurationError, match="OIDC discovery failed"),
-        ):
-            build_remote_auth(config)
-
-    def test_httpx_import_error_raises(self) -> None:
-        """Missing httpx aborts startup with ConfigurationError (pvl-core 2.0 contract)."""
-        import sys as _sys
-        from unittest.mock import patch
-
-        from fastmcp_pvl_core import ConfigurationError
-
-        config = self._remote_config()
-        with (
-            patch.dict(_sys.modules, {"httpx": None}),
-            pytest.raises(ConfigurationError, match="remote-auth"),
-        ):
-            build_remote_auth(config)
-
-    def test_happy_path_returns_non_none(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = self._remote_config()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "issuer": "https://auth.example.com",
-        }
-        mock_resp.raise_for_status = MagicMock()
-        with patch("httpx.get", return_value=mock_resp):
-            result = build_remote_auth(config)
-        assert result is not None
-
-    def test_missing_jwks_uri_raises(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        from fastmcp_pvl_core import ConfigurationError
-
-        config = self._remote_config()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"issuer": "https://auth.example.com"}
-        mock_resp.raise_for_status = MagicMock()
-        # pvl-core 2.0: incomplete discovery doc aborts startup.
-        with (
-            patch("httpx.get", return_value=mock_resp),
-            pytest.raises(ConfigurationError, match="incomplete"),
-        ):
-            build_remote_auth(config)
-
-    def test_missing_issuer_raises(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        from fastmcp_pvl_core import ConfigurationError
-
-        config = self._remote_config()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json"
-        }
-        mock_resp.raise_for_status = MagicMock()
-        with (
-            patch("httpx.get", return_value=mock_resp),
-            pytest.raises(ConfigurationError, match="incomplete"),
-        ):
-            build_remote_auth(config)
-
-    def test_audience_forwarded_when_set(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = self._remote_config(oidc_audience="my-api")
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "issuer": "https://auth.example.com",
-        }
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_jwt_verifier = MagicMock()
-        mock_verifier_cls = MagicMock(return_value=mock_jwt_verifier)
-        mock_remote_cls = MagicMock()
-
-        with (
-            patch("httpx.get", return_value=mock_resp),
-            patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
-            patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
-        ):
-            build_remote_auth(config)
-
-        kw = mock_verifier_cls.call_args.kwargs
-        assert kw["audience"] == "my-api"
-
-    def test_audience_is_none_when_not_set(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = self._remote_config()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "issuer": "https://auth.example.com",
-        }
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_jwt_verifier = MagicMock()
-        mock_verifier_cls = MagicMock(return_value=mock_jwt_verifier)
-        mock_remote_cls = MagicMock()
-
-        with (
-            patch("httpx.get", return_value=mock_resp),
-            patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
-            patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
-        ):
-            build_remote_auth(config)
-
-        kw = mock_verifier_cls.call_args.kwargs
-        assert kw["audience"] is None
-
-    def test_required_scopes_parsed(self) -> None:
-        from unittest.mock import MagicMock, patch
-
-        config = self._remote_config(oidc_required_scopes="openid, profile, email")
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "issuer": "https://auth.example.com",
-        }
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_jwt_verifier = MagicMock()
-        mock_verifier_cls = MagicMock(return_value=mock_jwt_verifier)
-        mock_remote_cls = MagicMock()
-
-        with (
-            patch("httpx.get", return_value=mock_resp),
-            patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
-            patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
-        ):
-            build_remote_auth(config)
-
-        kw = mock_verifier_cls.call_args.kwargs
-        assert kw["required_scopes"] == ["openid", "profile", "email"]
-
-    def test_empty_required_scopes_results_in_none(self) -> None:
-        """Empty REQUIRED_SCOPES results in None (no scope enforcement)."""
-        from unittest.mock import MagicMock, patch
-
-        config = self._remote_config(oidc_required_scopes="")
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "issuer": "https://auth.example.com",
-        }
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_jwt_verifier = MagicMock()
-        mock_verifier_cls = MagicMock(return_value=mock_jwt_verifier)
-        mock_remote_cls = MagicMock()
-
-        with (
-            patch("httpx.get", return_value=mock_resp),
-            patch("fastmcp.server.auth.JWTVerifier", mock_verifier_cls),
-            patch("fastmcp.server.auth.RemoteAuthProvider", mock_remote_cls),
-        ):
-            build_remote_auth(config)
-
-        kw = mock_verifier_cls.call_args.kwargs
-        assert kw["required_scopes"] is None
-
-    # Removed test_debug_logging_on_success: it asserted MV's verbose
-    # "Remote auth config:" multi-line debug dump, which fastmcp_pvl_core
-    # doesn't emit (core uses structured key=value logging only on
-    # skip/failure paths).  The behavioural property (success builds a
-    # RemoteAuthProvider) is already covered by test_happy_path_returns_non_none
-    # above.
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1266,7 +1266,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.3" },
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "fastmcp-pvl-core", specifier = ">=2.1.0,<3" },
+    { name = "fastmcp-pvl-core", specifier = ">=2.1.0,<4" },
     { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25" },
     { name = "httpx", marker = "extra == 'embeddings-api'", specifier = ">=0.25" },


### PR DESCRIPTION
Closes #600. Supersedes #603 (discarded — that branch became sediment from reactively redesigning the auth test surface through the review loop; this is the clean single-pass reauthor with the design done up front).

## What
Removes the 11 auth/OIDC/bearer fields + `event_store_url` duplicate from `CollectionConfig`, the four MV auth-builder wrappers (`resolve_auth_mode`/`build_remote_auth`/`build_bearer_auth`/`build_oidc_auth`), the `_server_from_collection` adapter, and `_parse_scopes`. Production already reads `config.server.*` via `fastmcp_pvl_core` (`server.py`: `build_auth`/`resolve_auth_mode` on `config.server`), so these were dead. `_cli_impl.py` reads `config.server.event_store_url`.

**No behaviour change:** every `MARKDOWN_VAULT_MCP_*` auth/event-store var is still read into `config.server` by `ServerConfig.from_env`. No env-var renames.

## Test-surface redesign (designed up front from a full audit of the deleted set)
The wrapper unit tests can't survive the wrapper removal, so MV's post-delegation auth-test contract is:
- **Dropped** (fastmcp_pvl_core internals, tested upstream): OIDCProxy/RemoteAuth value forwarding, `verify_id_token` flip, scope parsing, `StaticTokenVerifier` internals, discovery `ConfigurationError`, `resolve_auth_mode` mode-string selection, debug-log redaction.
- **Restored as MV-observable tests** at integration/composition altitude:
  - `make_server()` wiring: bearer-only→`StaticTokenVerifier`; oidc-proxy→`OIDCProxy`; multi→`MultiAuth` (`required_scopes=[]`, verifier composition); none→`None`.
  - security defaults via `make_server()`: blank `OIDC_REQUIRED_SCOPES`→`["openid"]`; `OIDC_VERIFY_ACCESS_TOKEN` unset→`verify_id_token=True` / true→`False`.
  - `config.server` composition: all `MARKDOWN_VAULT_MCP_OIDC_*`/`AUTH_MODE` + bearer/base_url/transport/verify_access_token + `event_store_url` reach `config.server`.

**Scope decision (pre-declared):** remote-mode selection and its discovery-based `RemoteAuthProvider` assembly are pvl-core-owned (testing them at MV level would re-test core's discovery internals — the boundary this audit deliberately drew). MV's only remote responsibility — OIDC env vars reaching `config.server` — is covered by the composition tests.

## Notes
- First commit re-locks `uv.lock` to match `pyproject` `fastmcp-pvl-core<4` (a pre-existing #557 drift the pre-commit `uv` step surfaces), isolated from the refactor.
- Out of scope (pre-existing): #609 (double `load_config` on the HTTP serve path); minor test-hygiene in `_CLEAR_VARS`/`_BEARER_VARS`.

## Verification
1827 passed / 1 skipped / 1 xpassed; mypy + ruff clean. Full five-lens preflight + pr-test-analyzer/code-reviewer/comment-analyzer run before this first push — clean at the ≥80 bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)