### PR TITLE
refactor(managers): move stats() into SearchManager + extract GitQueryManager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,10 @@ src/markdown_vault_mcp/
     links.py           -- link target computation and replacement
   managers/
     link.py            -- LinkManager: backlinks, outlinks, broken, orphans, hubs, paths
-    search.py          -- SearchManager: keyword/semantic/hybrid search, list, context
+    search.py          -- SearchManager: keyword/semantic/hybrid search, list, context, stats
     index.py           -- IndexManager: build_index, reindex, embeddings, flush
     document.py        -- DocumentManager: CRUD, attachments, path validation, backlinks
+    git_query.py       -- GitQueryManager: git history/diff reads (#610)
   indexing/
     index_writer.py    -- IndexWriter: single-owner FIFO writer thread + job dataclasses/runners
     readiness.py       -- ReadinessState: build-readiness state machine (#576)

--- a/docs/design.md
+++ b/docs/design.md
@@ -74,9 +74,10 @@ markdown-vault-mcp (new package)
 |   +-- links.py      -- link target computation and replacement
 +-- managers/
 |   +-- link.py       -- LinkManager: backlinks, outlinks, broken, orphans, hubs, paths
-|   +-- search.py     -- SearchManager: keyword/semantic/hybrid search, list, context
+|   +-- search.py     -- SearchManager: keyword/semantic/hybrid search, list, context, stats
 |   +-- index.py      -- IndexManager: build_index, reindex, embeddings, flush
 |   +-- document.py   -- DocumentManager: CRUD, attachments, path validation
+|   +-- git_query.py  -- GitQueryManager: git history/diff reads (#610)
 +-- indexing/
 |   +-- index_writer.py -- IndexWriter: single-owner FIFO writer thread + jobs/runners
 |   +-- readiness.py  -- ReadinessState: build-readiness state machine (#576)
@@ -1151,9 +1152,10 @@ operations to them. No manager holds a back-reference to Collection.
 | Manager | Responsibility | Dependencies |
 |---------|---------------|-------------|
 | ``LinkManager`` | Backlinks, outlinks, broken links, orphans, hubs, connection paths | ``FTSIndex``, ``source_dir`` |
-| ``SearchManager`` | Keyword/semantic/hybrid search, list, folders, tags, recent, similar, context | ``FTSIndex``, ``source_dir``, embedding config, ``LinkManager`` |
+| ``SearchManager`` | Keyword/semantic/hybrid search, list, folders, tags, recent, similar, context, stats | ``FTSIndex``, ``source_dir``, embedding config, ``LinkManager`` |
 | ``IndexManager`` | build_index, reindex, build_embeddings, process_dirty_paths, flush_dirty_embeddings | ``FTSIndex``, ``ChangeTracker``, ``source_dir``, chunk strategy (no lock — driven by the single-owner :class:`~markdown_vault_mcp.indexing.IndexWriter`, #559) |
 | ``DocumentManager`` | read, write, edit, delete, rename, attachments, TOC | ``FTSIndex``, ``source_dir``, ``_file_write_lock`` (file-mutation atomicity only — see #559), ``mark_paths_dirty`` hook, callbacks |
+| ``GitQueryManager`` | Git history / diff reads (read-only, #610) | ``GitWriteStrategy`` (or ``None`` when not a git repo), ``source_dir`` |
 
 Each manager receives its dependencies as constructor arguments. This enables
 isolated unit testing and clear dependency boundaries. Pure utility functions

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import re
 import threading
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -20,29 +19,6 @@ from markdown_vault_mcp.scanner import (
     WholeDocumentChunker,
 )
 from markdown_vault_mcp.tracker import ChangeTracker
-from markdown_vault_mcp.types import (
-    AttachmentContent,
-    AttachmentInfo,
-    BacklinkInfo,
-    BrokenLinkInfo,
-    CollectionStats,
-    CommitDiff,
-    DeleteResult,
-    EditResult,
-    GroupedResult,
-    HistoryEntry,
-    IndexStats,
-    MostLinkedNote,
-    NoteContent,
-    NoteContext,
-    NoteInfo,
-    OutlinkInfo,
-    ReindexResult,
-    RenameResult,
-    WriteCallback,
-    WriteResult,
-)
-from markdown_vault_mcp.utils import effective_attachment_extensions
 from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
 
 if TYPE_CHECKING:
@@ -52,6 +28,28 @@ if TYPE_CHECKING:
 
     from markdown_vault_mcp.git import GitWriteStrategy, PullResult
     from markdown_vault_mcp.providers import EmbeddingProvider
+    from markdown_vault_mcp.types import (
+        AttachmentContent,
+        AttachmentInfo,
+        BacklinkInfo,
+        BrokenLinkInfo,
+        CollectionStats,
+        CommitDiff,
+        DeleteResult,
+        EditResult,
+        GroupedResult,
+        HistoryEntry,
+        IndexStats,
+        MostLinkedNote,
+        NoteContent,
+        NoteContext,
+        NoteInfo,
+        OutlinkInfo,
+        ReindexResult,
+        RenameResult,
+        WriteCallback,
+        WriteResult,
+    )
     from markdown_vault_mcp.vector_index import VectorIndex
 
 logger = logging.getLogger(__name__)
@@ -256,12 +254,15 @@ class Collection:
 
         # Manager modules (dependency-injected, no back-reference).
         from markdown_vault_mcp.managers.document import DocumentManager
+        from markdown_vault_mcp.managers.git_query import GitQueryManager
         from markdown_vault_mcp.managers.index import IndexManager
         from markdown_vault_mcp.managers.link import LinkManager
         from markdown_vault_mcp.managers.search import SearchManager
 
         # 1. LinkManager (no deps)
         self._link_mgr = LinkManager(fts=self._fts, source_dir=self._source_dir)
+        # 1b. GitQueryManager (git history/diff reads; needs only git_strategy)
+        self._git_query_mgr = GitQueryManager(self._git_strategy, self._source_dir)
         # 2. IndexManager (needs fts, tracker — NOT search_mgr)
         #    get_vectors/set_vectors use late-binding lambdas that capture
         #    self._search_mgr; they are only called at runtime after all
@@ -992,14 +993,7 @@ class Collection:
         Raises:
             ValueError: If *path* is provided but fails path validation.
         """
-        if self._git_strategy is None:
-            return []
-        abs_path: Path | None = None
-        if path is not None:
-            abs_path = self._validate_path(path)
-        return self._git_strategy.get_file_history(
-            self._source_dir, abs_path, since, limit, until=until
-        )
+        return self._git_query_mgr.get_history(path, since, until, limit)
 
     def get_diff(
         self,
@@ -1046,64 +1040,20 @@ class Collection:
                 not supplied, *since_sha* contains invalid characters, or the
                 resolved ref is not found in history.
         """
-        if self._git_strategy is None:
-            return [] if per_commit else ""
-
-        if (since_sha is None) == (since_timestamp is None):
-            raise ValueError(
-                "Exactly one of 'since_sha' or 'since_timestamp' must be provided"
-            )
-
-        abs_path = self._validate_path(path)
-
-        if since_sha is not None and not re.fullmatch(r"[0-9a-f]{4,40}", since_sha):
-            raise ValueError(
-                f"Invalid SHA {since_sha!r}: must be 4-40 lowercase hex digits"
-            )
-
-        return self._git_strategy.get_file_diff(
-            self._source_dir,
-            abs_path,
-            ref=since_sha,
-            per_commit=per_commit,
+        return self._git_query_mgr.get_diff(
+            path,
+            since_sha=since_sha,
             since_timestamp=since_timestamp,
-            limit=limit if per_commit else None,
+            per_commit=per_commit,
+            limit=limit,
         )
 
     def stats(self) -> CollectionStats:
         """Return collection-wide statistics.
 
-        Returns:
-            :class:`~markdown_vault_mcp.types.CollectionStats` snapshot.
+        Delegates to :meth:`SearchManager.stats`.
         """
-
-        rows = self._fts.list_notes()
-        doc_count = len(rows)
-
-        # Chunk count via the public FTSIndex method.
-        chunk_count = self._fts.count_chunks()
-
-        folders = self._fts.list_folders()
-        folder_count = len(folders)
-
-        semantic_available = (
-            self._embedding_provider is not None and self._embeddings_path is not None
-        )
-
-        exts = effective_attachment_extensions(self._attachment_extensions)
-        attachment_extensions = ["*"] if "*" in exts else sorted(exts)
-
-        return CollectionStats(
-            document_count=doc_count,
-            chunk_count=chunk_count,
-            folder_count=folder_count,
-            semantic_search_available=semantic_available,
-            indexed_frontmatter_fields=list(self._indexed_frontmatter_fields),
-            attachment_extensions=attachment_extensions,
-            link_count=self._fts.count_links(),
-            broken_link_count=self._fts.count_broken_links(),
-            orphan_count=self._fts.count_orphans(),
-        )
+        return self._search_mgr.stats()
 
     # ------------------------------------------------------------------
     # Write operations (delegated to DocumentManager)

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -1,0 +1,156 @@
+"""Git history/diff query manager.
+
+Handles read-only git queries (commit history, diffs) with dependency
+injection — receives a :class:`~markdown_vault_mcp.git.GitWriteStrategy`
+(or ``None`` when the vault is not a git repository) and the ``source_dir``,
+with no back-reference to :class:`Collection`. Sibling to
+:class:`~markdown_vault_mcp.managers.link.LinkManager`. Extracted from
+``Collection`` (#610) so the read facet stays thin.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.utils import validate_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from markdown_vault_mcp.git import GitWriteStrategy
+    from markdown_vault_mcp.types import CommitDiff, HistoryEntry
+
+
+class GitQueryManager:
+    """Read-only git history/diff queries, backed by a ``GitWriteStrategy``.
+
+    Args:
+        git_strategy: The git strategy to query, or ``None`` when the vault's
+            source directory is not inside a git repository (queries then
+            return empty results rather than raising).
+        source_dir: Absolute path to the vault root directory.
+    """
+
+    def __init__(self, git_strategy: GitWriteStrategy | None, source_dir: Path) -> None:
+        self._git_strategy = git_strategy
+        self._source_dir = source_dir
+
+    def get_history(
+        self,
+        path: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 20,
+    ) -> list[HistoryEntry]:
+        """Return commits that touched a note or the whole vault.
+
+        When *path* is ``None``, queries the full vault history.  Returns an
+        empty list for vaults whose source directory is not inside a git
+        repository.
+
+        Args:
+            path: Vault-relative path of the note to filter on (e.g.
+                ``"notes/alpha.md"``).  Must end with ``.md``.  ``None``
+                returns vault-wide history.
+            since: ISO 8601 datetime string or git date expression (e.g.
+                ``"1 week ago"``).  Passed as ``--since`` to ``git log``.
+                ``None`` disables the filter.
+            until: ISO 8601 datetime string or git date expression, passed as
+                ``--until`` to ``git log``.  ``None`` disables the filter.
+                Both ``since`` and ``until`` boundaries are **inclusive**: a
+                commit whose committer date equals either endpoint is included
+                in the result.
+            limit: Maximum number of commits to return.  Clamped to
+                ``[1, 100]``.  Defaults to ``20``.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.HistoryEntry` ordered
+            newest-first.  Empty list when the vault has no git history or
+            the note has no commits in the given range.  The
+            ``paths_changed`` field on each entry is populated for vault-wide
+            queries (``path=None``); it is always empty for single-note
+            queries, since the path is already determined by the query
+            arguments — callers know which file the commit touched without
+            needing it echoed back.
+
+        Raises:
+            ValueError: If *path* is provided but fails path validation.
+        """
+        if self._git_strategy is None:
+            return []
+        abs_path: Path | None = None
+        if path is not None:
+            abs_path = validate_path(path, self._source_dir)
+        return self._git_strategy.get_file_history(
+            self._source_dir, abs_path, since, limit, until=until
+        )
+
+    def get_diff(
+        self,
+        path: str,
+        since_sha: str | None = None,
+        since_timestamp: str | None = None,
+        per_commit: bool = False,
+        limit: int | None = None,
+    ) -> str | list[CommitDiff]:
+        """Return the diff of a note between a reference point and HEAD.
+
+        Exactly one of *since_sha* or *since_timestamp* must be supplied.
+
+        Args:
+            path: Vault-relative path of the note to diff.  Must end with
+                ``.md``.
+            since_sha: A commit SHA (full or abbreviated, at least 4 hex
+                digits) to diff from.  Mutually exclusive with
+                *since_timestamp*.
+            since_timestamp: ISO 8601 datetime string, resolved via
+                ``git rev-list --before=<ts> -1 HEAD`` to the most recent
+                commit at or before that instant.  Boundary is
+                **inclusive**: a commit whose committer date equals
+                *since_timestamp* IS the resolved ref.  Mutually exclusive
+                with *since_sha*.
+            per_commit: When ``False`` (default), return a single unified diff
+                string from the reference point to HEAD.  When ``True``,
+                return one :class:`~markdown_vault_mcp.types.CommitDiff` per
+                intervening commit.
+            limit: When *per_commit* is ``True``, cap the number of
+                intervening commits returned to the *limit* most recent ones.
+                Clamped to ``[1, 100]``.  ``None`` (the default) means
+                unbounded (still bounded by the underlying ``since..HEAD``
+                range).  Silently ignored when *per_commit* is ``False``.
+
+        Returns:
+            A unified diff string when *per_commit* is ``False``, or a list of
+            :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
+            ``True``.  Returns an empty string / empty list when the note has
+            no changes in the given range.
+
+        Raises:
+            ValueError: If exactly one of *since_sha* / *since_timestamp* is
+                not supplied, *since_sha* contains invalid characters, or the
+                resolved ref is not found in history.
+        """
+        if self._git_strategy is None:
+            return [] if per_commit else ""
+
+        if (since_sha is None) == (since_timestamp is None):
+            raise ValueError(
+                "Exactly one of 'since_sha' or 'since_timestamp' must be provided"
+            )
+
+        abs_path = validate_path(path, self._source_dir)
+
+        if since_sha is not None and not re.fullmatch(r"[0-9a-f]{4,40}", since_sha):
+            raise ValueError(
+                f"Invalid SHA {since_sha!r}: must be 4-40 lowercase hex digits"
+            )
+
+        return self._git_strategy.get_file_diff(
+            self._source_dir,
+            abs_path,
+            ref=since_sha,
+            per_commit=per_commit,
+            since_timestamp=since_timestamp,
+            limit=limit if per_commit else None,
+        )

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 from markdown_vault_mcp.types import (
     AttachmentInfo,
     BacklinkInfo,
+    CollectionStats,
     GroupedResult,
     NoteContext,
     NoteInfo,
@@ -1092,6 +1093,40 @@ class SearchManager:
             Sorted list of distinct value strings.
         """
         return self._fts.list_field_values(field)
+
+    def stats(self) -> CollectionStats:
+        """Return collection-wide statistics.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.CollectionStats` snapshot.
+        """
+        rows = self._fts.list_notes()
+        doc_count = len(rows)
+
+        # Chunk count via the public FTSIndex method.
+        chunk_count = self._fts.count_chunks()
+
+        folders = self._fts.list_folders()
+        folder_count = len(folders)
+
+        semantic_available = (
+            self._embedding_provider is not None and self._embeddings_path is not None
+        )
+
+        exts = self._effective_attachment_extensions()
+        attachment_extensions = ["*"] if "*" in exts else sorted(exts)
+
+        return CollectionStats(
+            document_count=doc_count,
+            chunk_count=chunk_count,
+            folder_count=folder_count,
+            semantic_search_available=semantic_available,
+            indexed_frontmatter_fields=list(self._indexed_frontmatter_fields),
+            attachment_extensions=attachment_extensions,
+            link_count=self._fts.count_links(),
+            broken_link_count=self._fts.count_broken_links(),
+            orphan_count=self._fts.count_orphans(),
+        )
 
     # ------------------------------------------------------------------
     # Recent / similar / context

--- a/tests/test_git_query.py
+++ b/tests/test_git_query.py
@@ -1,0 +1,123 @@
+"""Unit tests for GitQueryManager (#610).
+
+Covers the git-strategy-None fallbacks, the get_diff argument validation
+branches (exactly-one-of since_sha/since_timestamp, SHA format) — previously
+only reachable via the MCP tool layer — and the forwarding contract, using a
+recording fake strategy so no real git repo is needed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from markdown_vault_mcp.managers.git_query import GitQueryManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _RecordingStrategy:
+    """Fake GitWriteStrategy that records calls and returns sentinels."""
+
+    def __init__(self) -> None:
+        self.history_calls: list[tuple[Any, ...]] = []
+        self.diff_calls: list[tuple[Any, ...]] = []
+
+    def get_file_history(
+        self,
+        source_dir: Path,
+        abs_path: Path | None,
+        since: str | None,
+        limit: int,
+        until: str | None = None,
+    ) -> list[str]:
+        self.history_calls.append((source_dir, abs_path, since, limit, until))
+        return ["HIST"]
+
+    def get_file_diff(
+        self,
+        source_dir: Path,
+        abs_path: Path,
+        ref: str | None,
+        per_commit: bool,
+        since_timestamp: str | None = None,
+        limit: int | None = None,
+    ) -> str | list[str]:
+        self.diff_calls.append(
+            (source_dir, abs_path, ref, per_commit, since_timestamp, limit)
+        )
+        return ["CD"] if per_commit else "DIFF"
+
+
+class TestNoGitStrategy:
+    def test_get_history_returns_empty(self, tmp_path: Path) -> None:
+        mgr = GitQueryManager(None, tmp_path)
+        assert mgr.get_history() == []
+        assert mgr.get_history("note.md") == []
+
+    def test_get_diff_returns_empty(self, tmp_path: Path) -> None:
+        mgr = GitQueryManager(None, tmp_path)
+        assert mgr.get_diff("note.md") == ""
+        assert mgr.get_diff("note.md", per_commit=True) == []
+
+
+class TestGetDiffValidation:
+    def test_neither_reference_raises(self, tmp_path: Path) -> None:
+        mgr = GitQueryManager(_RecordingStrategy(), tmp_path)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="Exactly one"):
+            mgr.get_diff("note.md")
+
+    def test_both_references_raise(self, tmp_path: Path) -> None:
+        mgr = GitQueryManager(_RecordingStrategy(), tmp_path)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="Exactly one"):
+            mgr.get_diff("note.md", since_sha="abcd", since_timestamp="2026-01-01")
+
+    def test_malformed_sha_raises(self, tmp_path: Path) -> None:
+        mgr = GitQueryManager(_RecordingStrategy(), tmp_path)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="Invalid SHA"):
+            mgr.get_diff("note.md", since_sha="XYZ!")
+
+
+class TestForwarding:
+    def test_get_history_forwards_args(self, tmp_path: Path) -> None:
+        strat = _RecordingStrategy()
+        mgr = GitQueryManager(strat, tmp_path)  # type: ignore[arg-type]
+        result = mgr.get_history("note.md", since="1 week ago", until="now", limit=5)
+        assert result == ["HIST"]
+        source_dir, abs_path, since, limit, until = strat.history_calls[0]
+        assert source_dir == tmp_path
+        assert abs_path == tmp_path / "note.md"
+        assert (since, until, limit) == ("1 week ago", "now", 5)
+
+    def test_get_history_vault_wide_passes_none_path(self, tmp_path: Path) -> None:
+        strat = _RecordingStrategy()
+        mgr = GitQueryManager(strat, tmp_path)  # type: ignore[arg-type]
+        mgr.get_history()
+        assert strat.history_calls[0][1] is None  # abs_path
+
+    def test_get_diff_limit_gated_on_per_commit(self, tmp_path: Path) -> None:
+        strat = _RecordingStrategy()
+        mgr = GitQueryManager(strat, tmp_path)  # type: ignore[arg-type]
+        # per_commit=False -> caller's limit is suppressed to None (no clamp here;
+        # the [1, 100] clamp lives downstream in GitWriteStrategy.get_file_diff)
+        mgr.get_diff("note.md", since_sha="abcd", limit=5)
+        assert strat.diff_calls[0] == (
+            tmp_path,
+            tmp_path / "note.md",
+            "abcd",
+            False,
+            None,
+            None,
+        )
+        # per_commit=True -> caller limit forwarded
+        mgr.get_diff("note.md", since_timestamp="2026-01-01", per_commit=True, limit=5)
+        assert strat.diff_calls[1] == (
+            tmp_path,
+            tmp_path / "note.md",
+            None,
+            True,
+            "2026-01-01",
+            5,
+        )

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -83,6 +83,17 @@ def search_mgr(search_vault: Path) -> SearchManager:
     )
 
 
+class TestStats:
+    def test_stats_reports_collection_snapshot(self, search_mgr: SearchManager) -> None:
+        stats = search_mgr.stats()
+        assert stats.document_count == 4  # alpha, beta, notes/gamma, notes/delta
+        assert stats.indexed_frontmatter_fields == ["tags"]
+        assert "png" in stats.attachment_extensions
+        assert stats.semantic_search_available is False  # no provider configured
+        assert stats.link_count >= 2  # alpha <-> beta
+        assert stats.chunk_count >= 4
+
+
 # ---------------------------------------------------------------------------
 # keyword search
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #610. Refs #576.

The **manager-boundary prerequisite** for the `collection.py` facet decomposition — sequenced *before* the facet extraction this time (the prior attempt, PR #608, was discarded because extracting facets first forced a fat `ReaderFacet` with manager-bypassing logic and duplicated config state). **Behaviour-preserving**, on the flat `Collection`.

## What

- **`SearchManager.stats() -> CollectionStats`** — `Collection.stats()`'s body moved verbatim. `SearchManager` already holds `fts` + the embedding / attachment / frontmatter config and the `_effective_attachment_extensions()` helper, so this adds **no constructor params**. `Collection.stats()` delegates.
- **New `managers/git_query.py` → `GitQueryManager(git_strategy, source_dir)`** — a read-only git-query manager (sibling to `LinkManager`) holding `get_history` / `get_diff`, moved verbatim (the `git_strategy`-None fallbacks, the exactly-one `since_sha`/`since_timestamp` check, the SHA-format validation, and the `limit if per_commit else None` gate). It calls the module-level `validate_path` directly. `Collection.get_history`/`get_diff` delegate.
- Dropped the now-unused `re` + `effective_attachment_extensions` imports from `collection.py`; the type imports it no longer constructs at runtime moved into `TYPE_CHECKING`.

## Why this unblocks the facets

With `stats` and the git-query logic owned by managers, the upcoming `ReaderFacet` (PR3a′) drops from a 12-param fat constructor to ~4 params (all four facets thin), with **no duplicated config state**. The discarded #608's reusable facet code is preserved as tag `pr3a-discarded-608`.

## Tests

New `tests/test_git_query.py` unit-tests `GitQueryManager` via a recording fake strategy (signatures mirror the real `GitWriteStrategy`), including the `get_diff` exactly-one + SHA-format validation branches **directly** — closing the gap where those were previously only reachable through the MCP tool layer. `SearchManager.stats()` is unit-tested in `test_managers_search.py`. The pre-existing `Collection.stats`/`get_history`/`get_diff` tests (incl. real-git in `test_git.py` and the tool layer in `test_server.py`) stay green via delegation. Full suite: 1912 passed.

## Follow-up (deferred, not in this PR)

Narrowing `GitQueryManager`'s `GitWriteStrategy | None` to a read-only Protocol (so "read-only" is a compile-time guarantee) — ties into the `GitWriteStrategy` decomposition tracked in #577.

## Docs

`CLAUDE.md` Project Structure + `docs/design.md` (both the directory tree **and** the "Internal Manager Architecture" table) gain `GitQueryManager` and `stats` on `SearchManager`. Internal-only change — no README / tools / config surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)