### PR TITLE
refactor(config): group CollectionConfig fields into config_sections sub-configs

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -67,6 +67,7 @@ markdown-vault-mcp (new package)
 +-- collection.py     -- thin facade: lifecycle, wiring, delegation (index-write → indexing/coordinator.py)
 +-- write_callback.py -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
 +-- config.py         -- configuration loading
++-- config_sections/  -- domain-grouped sub-configs (git/indexing/embeddings/search/sync/content)
 +-- server.py         -- generic FastMCP server
 +-- cli.py            -- CLI entry point
 +-- utils/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,9 @@ ignore = ["E501"]
 "src/markdown_vault_mcp/_server_resources.py" = ["B008", "TC001", "TC002"]
 "src/markdown_vault_mcp/_server_prompts.py" = ["B008", "TC002"]
 "src/markdown_vault_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
+# IndexingConfig needs pathlib.Path at runtime so typing.get_type_hints() works
+# on the public dataclass; keep the import top-level, not behind TYPE_CHECKING.
+"src/markdown_vault_mcp/config_sections/indexing.py" = ["TC003"]
 # Test fixtures import collection/protocol types only used in annotations.
 "tests/conftest.py" = ["TC002", "TC003"]
 "tests/test_smoke.py" = ["TC002", "TC003"]

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -126,16 +126,16 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         )
         from markdown_vault_mcp.exceptions import IndexUnavailableError
 
-        # Use the *resolved* pull interval from kwargs, not config.git_pull_interval_s:
+        # Use the *resolved* pull interval from kwargs, not config.git.pull_interval_s:
         # the config default is 600 even on non-git vaults, but to_collection_kwargs()
         # only passes a non-zero interval through when a git strategy is configured.
         git_pull_active = kwargs.get("git_pull_interval_s", 0) > 0
 
         file_watcher = None
         if should_start_file_watcher(
-            config.file_watcher_enabled,
+            config.sync.file_watcher_enabled,
             git_pull_active,
-            config.github_webhook_secret,
+            config.sync.github_webhook_secret,
         ):
 
             def _on_file_change() -> None:
@@ -152,10 +152,10 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
             file_watcher = VaultFileWatcher(
                 config.source_dir,
                 _on_file_change,
-                debounce_s=config.file_watcher_debounce_s,
+                debounce_s=config.sync.file_watcher_debounce_s,
             )
             file_watcher.start()
-        elif not config.file_watcher_enabled:
+        elif not config.sync.file_watcher_enabled:
             logger.debug("file_watcher: disabled via FILE_WATCHER=false")
         else:
             logger.info(

--- a/src/markdown_vault_mcp/_server_resources.py
+++ b/src/markdown_vault_mcp/_server_resources.py
@@ -62,10 +62,10 @@ def register_resources(mcp: FastMCP) -> None:
             {
                 "source_dir": str(config.source_dir),
                 "read_only": config.read_only,
-                "indexed_fields": config.indexed_frontmatter_fields or [],
-                "required_fields": config.required_frontmatter or [],
-                "exclude_patterns": config.exclude_patterns or [],
-                "templates_folder": config.templates_folder,
+                "indexed_fields": config.indexing.indexed_frontmatter_fields or [],
+                "required_fields": config.indexing.required_frontmatter or [],
+                "exclude_patterns": config.indexing.exclude_patterns or [],
+                "templates_folder": config.content.templates_folder,
                 "semantic_search_available": stats.semantic_search_available,
                 "attachment_extensions": stats.attachment_extensions,
             }

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -10,7 +10,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from fastmcp_pvl_core import ServerConfig
 from fastmcp_pvl_core import env as _core_env
@@ -29,9 +29,7 @@ from markdown_vault_mcp.config_sections import (
     SearchConfig,
     SyncConfig,
 )
-
-if TYPE_CHECKING:
-    from markdown_vault_mcp.git import GitWriteStrategy
+from markdown_vault_mcp.git import GitWriteStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -190,8 +188,6 @@ class CollectionConfig:
         repo_url: str | None = None,
     ) -> GitWriteStrategy:
         """Build a GitWriteStrategy with the kwargs shared across all three git modes."""
-        from markdown_vault_mcp.git import GitWriteStrategy
-
         return GitWriteStrategy(
             token=token,
             repo_url=repo_url,

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -93,8 +93,8 @@ class CollectionConfig:
     def to_collection_kwargs(self) -> dict[str, Any]:
         """Return keyword arguments suitable for ``Collection(**kwargs)``.
 
-        Resolves the embedding provider (when ``embeddings_path`` is set)
-        and creates a :class:`~markdown_vault_mcp.git.GitWriteStrategy`.
+        Resolves the embedding provider (when ``indexing.embeddings_path``
+        is set) and creates a :class:`~markdown_vault_mcp.git.GitWriteStrategy`.
 
         Returns:
             Dict of keyword arguments accepted by
@@ -124,7 +124,8 @@ class CollectionConfig:
             "max_chunk_words": self.search.max_chunk_words,
         }
 
-        # Resolve embedding provider if embeddings_path is configured.
+        # Semantic search is gated by the storage path in config.indexing,
+        # while the provider lives in config.embeddings (cross-section coupling).
         # ValueError propagates — it means the user set an invalid provider
         # name, which is a config mistake that should not be silenced.
         if self.indexing.embeddings_path is not None:

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -10,7 +10,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastmcp_pvl_core import ServerConfig
 from fastmcp_pvl_core import env as _core_env
@@ -29,6 +29,9 @@ from markdown_vault_mcp.config_sections import (
     SearchConfig,
     SyncConfig,
 )
+
+if TYPE_CHECKING:
+    from markdown_vault_mcp.git import GitWriteStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -139,23 +142,13 @@ class CollectionConfig:
                     exc_info=True,
                 )
 
-        from markdown_vault_mcp.git import GitWriteStrategy
-
         if self.git.repo_url is not None:
-            git_strategy = GitWriteStrategy(
+            git_strategy = self._build_git_strategy(
                 token=self.git.token,
-                username=self.git.username,
                 repo_url=self.git.repo_url,
                 managed=True,
                 enable_pull=True,
                 enable_push=True,
-                push_delay_s=self.git.push_delay_s,
-                commit_name=self.git.commit_name,
-                commit_email=self.git.commit_email,
-                commit_name_claim=self.git.commit_name_claim,
-                commit_email_claim=self.git.commit_email_claim,
-                git_lfs=self.git.lfs,
-                repo_path=self.source_dir,
             )
             kwargs["git_pull_interval_s"] = self.git.pull_interval_s
             kwargs["git_strategy"] = git_strategy
@@ -165,19 +158,11 @@ class CollectionConfig:
         # Backward compatibility mode: token without explicit repo URL keeps
         # pull+push semantics, using the existing local checkout's origin.
         if self.git.token is not None:
-            git_strategy = GitWriteStrategy(
+            git_strategy = self._build_git_strategy(
                 token=self.git.token,
-                username=self.git.username,
                 managed=False,
                 enable_pull=True,
                 enable_push=True,
-                push_delay_s=self.git.push_delay_s,
-                commit_name=self.git.commit_name,
-                commit_email=self.git.commit_email,
-                commit_name_claim=self.git.commit_name_claim,
-                commit_email_claim=self.git.commit_email_claim,
-                git_lfs=self.git.lfs,
-                repo_path=self.source_dir,
             )
             kwargs["git_pull_interval_s"] = self.git.pull_interval_s
             kwargs["git_strategy"] = git_strategy
@@ -185,12 +170,35 @@ class CollectionConfig:
             return kwargs
 
         # Unmanaged / commit-only mode: commit locally if repo exists, never pull/push.
-        git_strategy = GitWriteStrategy(
+        git_strategy = self._build_git_strategy(
             token=None,
-            username=self.git.username,
             managed=False,
             enable_pull=False,
             enable_push=False,
+        )
+        kwargs["git_strategy"] = git_strategy
+        kwargs["on_write"] = git_strategy
+        return kwargs
+
+    def _build_git_strategy(
+        self,
+        *,
+        token: str | None,
+        managed: bool,
+        enable_pull: bool,
+        enable_push: bool,
+        repo_url: str | None = None,
+    ) -> GitWriteStrategy:
+        """Build a GitWriteStrategy with the kwargs shared across all three git modes."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        return GitWriteStrategy(
+            token=token,
+            repo_url=repo_url,
+            managed=managed,
+            enable_pull=enable_pull,
+            enable_push=enable_push,
+            username=self.git.username,
             push_delay_s=self.git.push_delay_s,
             commit_name=self.git.commit_name,
             commit_email=self.git.commit_email,
@@ -199,9 +207,6 @@ class CollectionConfig:
             git_lfs=self.git.lfs,
             repo_path=self.source_dir,
         )
-        kwargs["git_strategy"] = git_strategy
-        kwargs["on_write"] = git_strategy
-        return kwargs
 
 
 def load_config() -> CollectionConfig:

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -21,6 +21,15 @@ from fastmcp_pvl_core import env as _core_env
 from fastmcp_pvl_core import parse_bool as _parse_bool
 from fastmcp_pvl_core import parse_list as _parse_list
 
+from markdown_vault_mcp.config_sections import (
+    ContentConfig,
+    EmbeddingsConfig,
+    GitConfig,
+    IndexingConfig,
+    SearchConfig,
+    SyncConfig,
+)
+
 logger = logging.getLogger(__name__)
 
 _ENV_PREFIX = "MARKDOWN_VAULT_MCP"
@@ -45,85 +54,15 @@ class CollectionConfig:
         source_dir: Root directory of the markdown collection.
         read_only: When ``True`` (default), write operations raise
             :exc:`~markdown_vault_mcp.exceptions.ReadOnlyError`.
-        index_path: Path to the persistent SQLite index file.  ``None``
-            (default) uses an in-memory database.
-        embeddings_path: Base path for vector index sidecar files.  ``None``
-            (default) means semantic search is disabled.
-        state_path: Path to the hash-state JSON file used by
-            :class:`~markdown_vault_mcp.tracker.ChangeTracker`.  ``None``
-            defaults to ``{source_dir}/.markdown_vault_mcp/state.json``.
-        indexed_frontmatter_fields: Frontmatter keys whose values are
-            promoted to the ``document_tags`` table for structured filtering.
-            ``None`` means no fields are indexed.
-        required_frontmatter: If set, documents missing any listed field are
-            excluded from the index entirely.  ``None`` means all documents
-            are indexed regardless of frontmatter.
-        exclude_patterns: Glob patterns matched against relative document
-            paths to exclude from scanning (e.g. ``[".obsidian/**"]``).
-            ``None`` means no files are excluded.
-        git_token: Personal access token (PAT) for HTTPS git push/pull
-            authentication.  When set together with *git_repo_url*, the
-            collection is managed in write-through git mode.
-        git_repo_url: Remote git repository URL.  Required when *git_token*
-            is set; the collection will clone or validate the repo on startup.
-        git_username: Username used with token auth (default
-            ``"x-access-token"``, GitHub-compatible).
-        git_push_delay_s: Seconds of write-idle time before flushing local
-            commits to the remote (default ``30.0``).  ``0`` means push only
-            on shutdown.
-        git_commit_name: Git committer name for auto-commits (default
-            ``"markdown-vault-mcp"``).
-        git_commit_email: Git committer e-mail for auto-commits (default
-            ``"noreply@markdown-vault-mcp"``).
-        git_commit_name_claim: OIDC claim key to use as the commit author name
-            (e.g. ``"name"``).  When set and the current request carries an
-            OIDC access token with this claim, the claim value overrides
-            *git_commit_name* for that commit.  ``None`` (default) disables
-            the override.
-        git_commit_email_claim: OIDC claim key to use as the commit author
-            e-mail (e.g. ``"email"``).  Same override semantics as
-            *git_commit_name_claim*.  ``None`` (default) disables the override.
-        git_lfs: When ``True`` (default), run ``git lfs pull`` during git
-            strategy initialisation so LFS pointers are resolved before reads.
-        git_pull_interval_s: Interval in seconds for periodic git fetch +
-            fast-forward-only updates (default ``600``). Set to ``0`` to disable.
         server_name: Display name for the MCP server (default
             ``"markdown-vault-mcp"``).
         instructions: Optional server-level instructions surfaced to clients.
-        attachment_extensions: Allowlist of file extensions (without the
-            leading dot, e.g. ``["pdf", "png"]``) that may be stored as
-            attachments.  ``["*"]`` accepts every extension.  ``None`` uses
-            the built-in default list from
-            :class:`~markdown_vault_mcp.collection.Collection`.
-        max_attachment_size_mb: Maximum attachment file size in megabytes
-            (default ``1.0``).  ``0`` means unlimited.
-        max_note_read_bytes: Maximum note content returned by a single read
-            in bytes (default ``262144``, i.e. 256 KB).  ``0`` means unlimited.
-        templates_folder: Vault-relative folder that holds note templates
-            (default ``"_templates"``).
-        prompts_folder: Vault-relative folder from which user-defined MCP
-            prompts are loaded at startup.  ``None`` disables user prompts.
-        embedding_provider: Name of the embedding provider to use (e.g.
-            ``"ollama"``, ``"openai"``, ``"fastembed"``).  ``None`` disables
-            semantic search.
-        ollama_host: Base URL for the Ollama API (default
-            ``"http://localhost:11434"``).
-        ollama_model: Ollama model name for embeddings (default
-            ``"nomic-embed-text"``).
-        ollama_cpu_only: When ``True``, request CPU-only inference from
-            Ollama (default ``False``).
-        openai_api_key: OpenAI API key for embeddings (logged as set/not
-            set).
-        openai_base_url: OpenAI-compatible API base URL for embeddings
-            (default ``"https://api.openai.com/v1"``).  This can point to
-            providers such as SiliconFlow that expose the OpenAI embeddings
-            API shape.
-        openai_embedding_model: OpenAI-compatible embedding model name
-            (default ``"text-embedding-3-small"``).
-        fastembed_model: FastEmbed model name (default
-            ``"BAAI/bge-small-en-v1.5"``).
-        fastembed_cache_dir: Directory for FastEmbed model cache.  ``None``
-            uses the library default.
+        git: Git auth, identity, and sync cadence settings.
+        indexing: SQLite/vector index paths and frontmatter/exclusion settings.
+        embeddings: Embedding provider selection and per-provider settings.
+        search: Search ranking and snippet-truncation knobs.
+        sync: File-watcher and GitHub-webhook settings.
+        content: Attachment/note-read limits and template/prompt folder paths.
         server: Shared server-level configuration (transport, host/port,
             auth, base URL, event store URL, MCP App domain) populated
             from ``MARKDOWN_VAULT_MCP_*`` env vars by
@@ -138,65 +77,18 @@ class CollectionConfig:
     # CONFIG-FIELDS-START — domain fields; kept across copier update
     source_dir: Path
     read_only: bool = True
-    index_path: Path | None = None
-    embeddings_path: Path | None = None
-    state_path: Path | None = None
-    indexed_frontmatter_fields: list[str] | None = None
-    required_frontmatter: list[str] | None = None
-    exclude_patterns: list[str] | None = None
-    git_token: str | None = None
-    git_repo_url: str | None = None
-    git_username: str = "x-access-token"
-    git_push_delay_s: float = 30.0
-    git_commit_name: str = "markdown-vault-mcp"
-    git_commit_email: str = "noreply@markdown-vault-mcp"
-    git_commit_name_claim: str | None = None
-    git_commit_email_claim: str | None = None
-    git_lfs: bool = True
-    git_pull_interval_s: int = 600
-    attachment_extensions: list[str] | None = None
-    max_attachment_size_mb: float = 1.0  # MB; 0 = unlimited
-    max_note_read_bytes: int = 262144  # 256 KB; 0 = unlimited
-    templates_folder: str = "_templates"
-    prompts_folder: str | None = None
-
-    # Server identity
     server_name: str = "markdown-vault-mcp"
     instructions: str | None = None
-
-    # Embedding providers
-    embedding_provider: str | None = None
-    ollama_host: str = "http://localhost:11434"
-    ollama_model: str = "nomic-embed-text"
-    ollama_cpu_only: bool = False
-    openai_api_key: str | None = None
-    openai_base_url: str = "https://api.openai.com/v1"
-    openai_embedding_model: str = "text-embedding-3-small"
-    fastembed_model: str = "BAAI/bge-small-en-v1.5"
-    fastembed_cache_dir: str | None = None
-
-    # Search ranking and snippet truncation
-    chunks_per_file: int = 2
-    snippet_words: int = 200
-    length_downweight_alpha: float = 0.25
-    max_chunk_words: int = 400
-
-    # GitHub webhook (issue #530)
-    github_webhook_secret: str | None = None
-
-    # File watcher (issue #558) — auto-disabled when git pull or webhook is active
-    file_watcher_enabled: bool = True
-    file_watcher_debounce_s: float = 2.0
+    git: GitConfig = field(default_factory=GitConfig)
+    indexing: IndexingConfig = field(default_factory=IndexingConfig)
+    embeddings: EmbeddingsConfig = field(default_factory=EmbeddingsConfig)
+    search: SearchConfig = field(default_factory=SearchConfig)
+    sync: SyncConfig = field(default_factory=SyncConfig)
+    content: ContentConfig = field(default_factory=ContentConfig)
     # CONFIG-FIELDS-END
 
     # Universal server fields delegated to fastmcp_pvl_core.ServerConfig.
     server: ServerConfig = field(default_factory=ServerConfig)
-
-    def __post_init__(self) -> None:
-        """Normalize fields that must not be empty strings."""
-        if not self.ollama_host:
-            self.ollama_host = "http://localhost:11434"
-        self.ollama_host = self.ollama_host.rstrip("/")
 
     def to_collection_kwargs(self) -> dict[str, Any]:
         """Return keyword arguments suitable for ``Collection(**kwargs)``.
@@ -216,26 +108,26 @@ class CollectionConfig:
         kwargs: dict[str, Any] = {
             "source_dir": self.source_dir,
             "read_only": self.read_only,
-            "index_path": self.index_path,
-            "embeddings_path": self.embeddings_path,
-            "state_path": self.state_path,
-            "indexed_frontmatter_fields": self.indexed_frontmatter_fields,
-            "required_frontmatter": self.required_frontmatter,
-            "exclude_patterns": self.exclude_patterns,
-            "attachment_extensions": self.attachment_extensions,
-            "max_attachment_size_mb": self.max_attachment_size_mb,
-            "max_note_read_bytes": self.max_note_read_bytes,
+            "index_path": self.indexing.index_path,
+            "embeddings_path": self.indexing.embeddings_path,
+            "state_path": self.indexing.state_path,
+            "indexed_frontmatter_fields": self.indexing.indexed_frontmatter_fields,
+            "required_frontmatter": self.indexing.required_frontmatter,
+            "exclude_patterns": self.indexing.exclude_patterns,
+            "attachment_extensions": self.content.attachment_extensions,
+            "max_attachment_size_mb": self.content.max_attachment_size_mb,
+            "max_note_read_bytes": self.content.max_note_read_bytes,
             "git_pull_interval_s": 0,
-            "chunks_per_file": self.chunks_per_file,
-            "snippet_words": self.snippet_words,
-            "length_downweight_alpha": self.length_downweight_alpha,
-            "max_chunk_words": self.max_chunk_words,
+            "chunks_per_file": self.search.chunks_per_file,
+            "snippet_words": self.search.snippet_words,
+            "length_downweight_alpha": self.search.length_downweight_alpha,
+            "max_chunk_words": self.search.max_chunk_words,
         }
 
         # Resolve embedding provider if embeddings_path is configured.
         # ValueError propagates — it means the user set an invalid provider
         # name, which is a config mistake that should not be silenced.
-        if self.embeddings_path is not None:
+        if self.indexing.embeddings_path is not None:
             try:
                 from markdown_vault_mcp.providers import get_embedding_provider
 
@@ -248,45 +140,45 @@ class CollectionConfig:
 
         from markdown_vault_mcp.git import GitWriteStrategy
 
-        if self.git_repo_url is not None:
+        if self.git.repo_url is not None:
             git_strategy = GitWriteStrategy(
-                token=self.git_token,
-                username=self.git_username,
-                repo_url=self.git_repo_url,
+                token=self.git.token,
+                username=self.git.username,
+                repo_url=self.git.repo_url,
                 managed=True,
                 enable_pull=True,
                 enable_push=True,
-                push_delay_s=self.git_push_delay_s,
-                commit_name=self.git_commit_name,
-                commit_email=self.git_commit_email,
-                commit_name_claim=self.git_commit_name_claim,
-                commit_email_claim=self.git_commit_email_claim,
-                git_lfs=self.git_lfs,
+                push_delay_s=self.git.push_delay_s,
+                commit_name=self.git.commit_name,
+                commit_email=self.git.commit_email,
+                commit_name_claim=self.git.commit_name_claim,
+                commit_email_claim=self.git.commit_email_claim,
+                git_lfs=self.git.lfs,
                 repo_path=self.source_dir,
             )
-            kwargs["git_pull_interval_s"] = self.git_pull_interval_s
+            kwargs["git_pull_interval_s"] = self.git.pull_interval_s
             kwargs["git_strategy"] = git_strategy
             kwargs["on_write"] = git_strategy
             return kwargs
 
         # Backward compatibility mode: token without explicit repo URL keeps
         # pull+push semantics, using the existing local checkout's origin.
-        if self.git_token is not None:
+        if self.git.token is not None:
             git_strategy = GitWriteStrategy(
-                token=self.git_token,
-                username=self.git_username,
+                token=self.git.token,
+                username=self.git.username,
                 managed=False,
                 enable_pull=True,
                 enable_push=True,
-                push_delay_s=self.git_push_delay_s,
-                commit_name=self.git_commit_name,
-                commit_email=self.git_commit_email,
-                commit_name_claim=self.git_commit_name_claim,
-                commit_email_claim=self.git_commit_email_claim,
-                git_lfs=self.git_lfs,
+                push_delay_s=self.git.push_delay_s,
+                commit_name=self.git.commit_name,
+                commit_email=self.git.commit_email,
+                commit_name_claim=self.git.commit_name_claim,
+                commit_email_claim=self.git.commit_email_claim,
+                git_lfs=self.git.lfs,
                 repo_path=self.source_dir,
             )
-            kwargs["git_pull_interval_s"] = self.git_pull_interval_s
+            kwargs["git_pull_interval_s"] = self.git.pull_interval_s
             kwargs["git_strategy"] = git_strategy
             kwargs["on_write"] = git_strategy
             return kwargs
@@ -294,16 +186,16 @@ class CollectionConfig:
         # Unmanaged / commit-only mode: commit locally if repo exists, never pull/push.
         git_strategy = GitWriteStrategy(
             token=None,
-            username=self.git_username,
+            username=self.git.username,
             managed=False,
             enable_pull=False,
             enable_push=False,
-            push_delay_s=self.git_push_delay_s,
-            commit_name=self.git_commit_name,
-            commit_email=self.git_commit_email,
-            commit_name_claim=self.git_commit_name_claim,
-            commit_email_claim=self.git_commit_email_claim,
-            git_lfs=self.git_lfs,
+            push_delay_s=self.git.push_delay_s,
+            commit_name=self.git.commit_name,
+            commit_email=self.git.commit_email,
+            commit_name_claim=self.git.commit_name_claim,
+            commit_email_claim=self.git.commit_email_claim,
+            git_lfs=self.git.lfs,
             repo_path=self.source_dir,
         )
         kwargs["git_strategy"] = git_strategy
@@ -764,45 +656,57 @@ def load_config() -> CollectionConfig:
         # CONFIG-FROM-ENV-START — domain fields populated from env; kept across copier update
         source_dir=source_dir,
         read_only=read_only,
-        index_path=index_path,
-        embeddings_path=embeddings_path,
-        state_path=state_path,
-        indexed_frontmatter_fields=indexed_frontmatter_fields,
-        required_frontmatter=required_frontmatter,
-        exclude_patterns=exclude_patterns,
-        git_token=git_token,
-        git_repo_url=git_repo_url,
-        git_username=git_username,
-        git_push_delay_s=git_push_delay_s,
-        git_commit_name=git_commit_name,
-        git_commit_email=git_commit_email,
-        git_commit_name_claim=git_commit_name_claim,
-        git_commit_email_claim=git_commit_email_claim,
-        git_lfs=git_lfs,
-        git_pull_interval_s=git_pull_interval_s,
-        attachment_extensions=attachment_extensions,
-        max_attachment_size_mb=max_attachment_size_mb,
-        max_note_read_bytes=max_note_read_bytes,
-        templates_folder=templates_folder,
-        prompts_folder=prompts_folder,
         server_name=server_name,
         instructions=instructions,
-        embedding_provider=embedding_provider,
-        ollama_host=ollama_host,
-        ollama_model=ollama_model,
-        ollama_cpu_only=ollama_cpu_only,
-        openai_api_key=openai_api_key,
-        openai_base_url=openai_base_url,
-        openai_embedding_model=openai_embedding_model,
-        fastembed_model=fastembed_model,
-        fastembed_cache_dir=fastembed_cache_dir,
-        chunks_per_file=chunks_per_file,
-        snippet_words=snippet_words,
-        length_downweight_alpha=length_downweight_alpha,
-        max_chunk_words=max_chunk_words,
-        github_webhook_secret=github_webhook_secret,
-        file_watcher_enabled=file_watcher_enabled,
-        file_watcher_debounce_s=file_watcher_debounce_s,
+        git=GitConfig(
+            token=git_token,
+            repo_url=git_repo_url,
+            username=git_username,
+            push_delay_s=git_push_delay_s,
+            commit_name=git_commit_name,
+            commit_email=git_commit_email,
+            commit_name_claim=git_commit_name_claim,
+            commit_email_claim=git_commit_email_claim,
+            lfs=git_lfs,
+            pull_interval_s=git_pull_interval_s,
+        ),
+        indexing=IndexingConfig(
+            index_path=index_path,
+            state_path=state_path,
+            embeddings_path=embeddings_path,
+            indexed_frontmatter_fields=indexed_frontmatter_fields,
+            required_frontmatter=required_frontmatter,
+            exclude_patterns=exclude_patterns,
+        ),
+        embeddings=EmbeddingsConfig(
+            provider=embedding_provider,
+            ollama_host=ollama_host,
+            ollama_model=ollama_model,
+            ollama_cpu_only=ollama_cpu_only,
+            openai_api_key=openai_api_key,
+            openai_base_url=openai_base_url,
+            openai_embedding_model=openai_embedding_model,
+            fastembed_model=fastembed_model,
+            fastembed_cache_dir=fastembed_cache_dir,
+        ),
+        search=SearchConfig(
+            chunks_per_file=chunks_per_file,
+            snippet_words=snippet_words,
+            length_downweight_alpha=length_downweight_alpha,
+            max_chunk_words=max_chunk_words,
+        ),
+        sync=SyncConfig(
+            file_watcher_enabled=file_watcher_enabled,
+            file_watcher_debounce_s=file_watcher_debounce_s,
+            github_webhook_secret=github_webhook_secret,
+        ),
+        content=ContentConfig(
+            attachment_extensions=attachment_extensions,
+            max_attachment_size_mb=max_attachment_size_mb,
+            max_note_read_bytes=max_note_read_bytes,
+            templates_folder=templates_folder,
+            prompts_folder=prompts_folder,
+        ),
         # CONFIG-FROM-ENV-END
         server=ServerConfig.from_env(_ENV_PREFIX),
     )

--- a/src/markdown_vault_mcp/config_sections/__init__.py
+++ b/src/markdown_vault_mcp/config_sections/__init__.py
@@ -1,0 +1,19 @@
+"""Domain-grouped sub-configs composed by :class:`CollectionConfig`."""
+
+from __future__ import annotations
+
+from markdown_vault_mcp.config_sections.content import ContentConfig
+from markdown_vault_mcp.config_sections.embeddings import EmbeddingsConfig
+from markdown_vault_mcp.config_sections.git import GitConfig
+from markdown_vault_mcp.config_sections.indexing import IndexingConfig
+from markdown_vault_mcp.config_sections.search import SearchConfig
+from markdown_vault_mcp.config_sections.sync import SyncConfig
+
+__all__ = [
+    "ContentConfig",
+    "EmbeddingsConfig",
+    "GitConfig",
+    "IndexingConfig",
+    "SearchConfig",
+    "SyncConfig",
+]

--- a/src/markdown_vault_mcp/config_sections/content.py
+++ b/src/markdown_vault_mcp/config_sections/content.py
@@ -1,0 +1,16 @@
+"""Content-handling configuration (attachments, read limits, folders)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ContentConfig:
+    """Attachment/note-read limits and template/prompt folder paths."""
+
+    attachment_extensions: list[str] | None = None
+    max_attachment_size_mb: float = 1.0  # MB; 0 = unlimited
+    max_note_read_bytes: int = 262144  # 256 KB; 0 = unlimited
+    templates_folder: str = "_templates"
+    prompts_folder: str | None = None

--- a/src/markdown_vault_mcp/config_sections/embeddings.py
+++ b/src/markdown_vault_mcp/config_sections/embeddings.py
@@ -1,0 +1,26 @@
+"""Embedding-provider configuration for semantic search."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EmbeddingsConfig:
+    """Embedding provider selection + per-provider settings."""
+
+    provider: str | None = None
+    ollama_host: str = "http://localhost:11434"
+    ollama_model: str = "nomic-embed-text"
+    ollama_cpu_only: bool = False
+    openai_api_key: str | None = None
+    openai_base_url: str = "https://api.openai.com/v1"
+    openai_embedding_model: str = "text-embedding-3-small"
+    fastembed_model: str = "BAAI/bge-small-en-v1.5"
+    fastembed_cache_dir: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize ollama_host: non-empty, no trailing slash."""
+        if not self.ollama_host:
+            self.ollama_host = "http://localhost:11434"
+        self.ollama_host = self.ollama_host.rstrip("/")

--- a/src/markdown_vault_mcp/config_sections/git.py
+++ b/src/markdown_vault_mcp/config_sections/git.py
@@ -1,0 +1,21 @@
+"""Git write-strategy configuration for a markdown vault collection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GitConfig:
+    """Git auth, identity, and sync cadence (``MARKDOWN_VAULT_MCP_GIT_*``)."""
+
+    token: str | None = None
+    repo_url: str | None = None
+    username: str = "x-access-token"
+    push_delay_s: float = 30.0
+    commit_name: str = "markdown-vault-mcp"
+    commit_email: str = "noreply@markdown-vault-mcp"
+    commit_name_claim: str | None = None
+    commit_email_claim: str | None = None
+    lfs: bool = True
+    pull_interval_s: int = 600

--- a/src/markdown_vault_mcp/config_sections/indexing.py
+++ b/src/markdown_vault_mcp/config_sections/indexing.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
 
 
 @dataclass

--- a/src/markdown_vault_mcp/config_sections/indexing.py
+++ b/src/markdown_vault_mcp/config_sections/indexing.py
@@ -1,0 +1,21 @@
+"""Index + scanner configuration (paths, frontmatter, exclusions)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass
+class IndexingConfig:
+    """SQLite/vector index paths and what gets scanned + indexed."""
+
+    index_path: Path | None = None
+    state_path: Path | None = None
+    embeddings_path: Path | None = None
+    indexed_frontmatter_fields: list[str] | None = None
+    required_frontmatter: list[str] | None = None
+    exclude_patterns: list[str] | None = None

--- a/src/markdown_vault_mcp/config_sections/search.py
+++ b/src/markdown_vault_mcp/config_sections/search.py
@@ -1,0 +1,15 @@
+"""Search ranking + snippet-truncation knobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SearchConfig:
+    """Ranking/snippet tuning for keyword/semantic/hybrid search."""
+
+    chunks_per_file: int = 2
+    snippet_words: int = 200
+    length_downweight_alpha: float = 0.25
+    max_chunk_words: int = 400

--- a/src/markdown_vault_mcp/config_sections/sync.py
+++ b/src/markdown_vault_mcp/config_sections/sync.py
@@ -1,0 +1,14 @@
+"""External-change-detection configuration (file watcher + webhook)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SyncConfig:
+    """File-watcher + GitHub-webhook settings for external changes."""
+
+    file_watcher_enabled: bool = True
+    file_watcher_debounce_s: float = 2.0
+    github_webhook_secret: str | None = None

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -452,8 +452,9 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
             model=config.embeddings.openai_embedding_model,
         )
 
-    # Auto-detect: Ollama reachable?
-    host = config.embeddings.ollama_host.rstrip("/")
+    # Auto-detect: Ollama reachable? (EmbeddingsConfig.__post_init__ already
+    # guarantees ollama_host is non-empty with no trailing slash.)
+    host = config.embeddings.ollama_host
     try:
         import httpx
 
@@ -462,7 +463,7 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
         if response.status_code == 200:
             logger.info("Auto-detected OllamaProvider (Ollama reachable at %s)", host)
             return OllamaProvider(
-                host=config.embeddings.ollama_host,
+                host=host,
                 model=config.embeddings.ollama_model,
                 cpu_only=config.embeddings.ollama_cpu_only,
             )

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -386,11 +386,11 @@ class FastEmbedProvider(EmbeddingProvider):
 def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
     """Auto-detect and return an embedding provider from config.
 
-    Checks ``config.embedding_provider`` for an explicit selection. When
+    Checks ``config.embeddings.provider`` for an explicit selection. When
     that field is ``None``, probes for available providers in this order:
 
-    1. If ``config.openai_api_key`` is set → :class:`OpenAIProvider`.
-    2. If Ollama is reachable at ``config.ollama_host`` →
+    1. If ``config.embeddings.openai_api_key`` is set → :class:`OpenAIProvider`.
+    2. If Ollama is reachable at ``config.embeddings.ollama_host`` →
        :class:`OllamaProvider`.
     3. If ``fastembed`` can be imported →
        :class:`FastEmbedProvider`.
@@ -404,27 +404,27 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
 
     Raises:
         RuntimeError: If no provider is available and
-            ``config.embedding_provider`` is not set, or if the explicitly
+            ``config.embeddings.provider`` is not set, or if the explicitly
             requested provider cannot be initialised.
-        ValueError: If ``config.embedding_provider`` is set to an
+        ValueError: If ``config.embeddings.provider`` is set to an
             unrecognised value.
     """
-    explicit = (config.embedding_provider or "").strip().lower()
+    explicit = (config.embeddings.provider or "").strip().lower()
 
     if explicit == "openai":
         logger.info("Using OpenAIProvider (embedding_provider=openai)")
         return OpenAIProvider(
-            api_key=config.openai_api_key or "",
-            base_url=config.openai_base_url,
-            model=config.openai_embedding_model,
+            api_key=config.embeddings.openai_api_key or "",
+            base_url=config.embeddings.openai_base_url,
+            model=config.embeddings.openai_embedding_model,
         )
 
     if explicit == "ollama":
         logger.info("Using OllamaProvider (embedding_provider=ollama)")
         return OllamaProvider(
-            host=config.ollama_host,
-            model=config.ollama_model,
-            cpu_only=config.ollama_cpu_only,
+            host=config.embeddings.ollama_host,
+            model=config.embeddings.ollama_model,
+            cpu_only=config.embeddings.ollama_cpu_only,
         )
 
     if explicit == "fastembed":
@@ -433,8 +433,8 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
             explicit,
         )
         return FastEmbedProvider(
-            model_name=config.fastembed_model,
-            cache_dir=config.fastembed_cache_dir,
+            model_name=config.embeddings.fastembed_model,
+            cache_dir=config.embeddings.fastembed_cache_dir,
         )
 
     if explicit:
@@ -444,16 +444,16 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
         )
 
     # Auto-detect: OpenAI API key present?
-    if config.openai_api_key:
+    if config.embeddings.openai_api_key:
         logger.info("Auto-detected OpenAIProvider (openai_api_key is set)")
         return OpenAIProvider(
-            api_key=config.openai_api_key,
-            base_url=config.openai_base_url,
-            model=config.openai_embedding_model,
+            api_key=config.embeddings.openai_api_key,
+            base_url=config.embeddings.openai_base_url,
+            model=config.embeddings.openai_embedding_model,
         )
 
     # Auto-detect: Ollama reachable?
-    host = config.ollama_host.rstrip("/")
+    host = config.embeddings.ollama_host.rstrip("/")
     try:
         import httpx
 
@@ -462,9 +462,9 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
         if response.status_code == 200:
             logger.info("Auto-detected OllamaProvider (Ollama reachable at %s)", host)
             return OllamaProvider(
-                host=config.ollama_host,
-                model=config.ollama_model,
-                cpu_only=config.ollama_cpu_only,
+                host=config.embeddings.ollama_host,
+                model=config.embeddings.ollama_model,
+                cpu_only=config.embeddings.ollama_cpu_only,
             )
     except Exception:
         logger.debug("Ollama not reachable at %s, skipping", host)
@@ -475,8 +475,8 @@ def get_embedding_provider(config: CollectionConfig) -> EmbeddingProvider:
 
         logger.info("Auto-detected FastEmbedProvider")
         return FastEmbedProvider(
-            model_name=config.fastembed_model,
-            cache_dir=config.fastembed_cache_dir,
+            model_name=config.embeddings.fastembed_model,
+            cache_dir=config.embeddings.fastembed_cache_dir,
         )
     except ImportError:
         logger.debug("fastembed not available, skipping")

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -179,7 +179,7 @@ def make_server(transport: str = "stdio") -> FastMCP:
         auth_mode,
         "read-only" if is_read_only else "read-write",
         config.source_dir,
-        "enabled" if config.embeddings_path else "disabled",
+        "enabled" if config.indexing.embeddings_path else "disabled",
     )
 
     mcp = FastMCP(
@@ -214,8 +214,8 @@ def make_server(transport: str = "stdio") -> FastMCP:
     register_apps(mcp)
     register_prompts(
         mcp,
-        templates_folder=config.templates_folder,
-        prompts_folder=config.prompts_folder,
+        templates_folder=config.content.templates_folder,
+        prompts_folder=config.content.prompts_folder,
     )
 
     # ``register_server_info_tool`` is intentionally read-only and stays
@@ -258,11 +258,11 @@ def make_server(transport: str = "stdio") -> FastMCP:
 
     # GitHub webhook endpoint — only when secret is configured and transport
     # is HTTP/SSE (stdio has no HTTP server to receive POST requests).
-    if config.github_webhook_secret and transport != "stdio":
+    if config.sync.github_webhook_secret and transport != "stdio":
         from markdown_vault_mcp._github_webhook import make_webhook_handler
 
         mcp.custom_route("/github-webhook", methods=["POST"])(
-            make_webhook_handler(config.github_webhook_secret)
+            make_webhook_handler(config.sync.github_webhook_secret)
         )
     # DOMAIN-WIRING-END
 
@@ -324,10 +324,10 @@ def make_server(transport: str = "stdio") -> FastMCP:
     # provider (slow, GBs of memory) and may run ``git clone`` as a side
     # effect.  The runtime check inside the ``git_sync`` tool body
     # (``isinstance(strategy, GitWriteStrategy) and strategy._managed``)
-    # stays aligned with this gate via the same ``git_repo_url`` config
+    # stays aligned with this gate via the same ``config.git.repo_url``
     # value: managed mode requires an explicit remote URL.  See #220 for
     # the broader cleanup of duplicate ``to_collection_kwargs`` calls.
-    if config.git_repo_url is None:
+    if config.git.repo_url is None:
         mcp.disable(tags={"git-managed"})
 
     return mcp

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,11 @@ from markdown_vault_mcp.config import (
     CollectionConfig,
     load_config,
 )
+from markdown_vault_mcp.config_sections import (
+    EmbeddingsConfig,
+    GitConfig,
+    IndexingConfig,
+)
 
 
 def test_search_ranking_config_defaults(
@@ -28,10 +33,10 @@ def test_search_ranking_config_defaults(
         monkeypatch.delenv(var, raising=False)
 
     cfg = load_config()
-    assert cfg.chunks_per_file == 2
-    assert cfg.snippet_words == 200
-    assert cfg.length_downweight_alpha == 0.25
-    assert cfg.max_chunk_words == 400
+    assert cfg.search.chunks_per_file == 2
+    assert cfg.search.snippet_words == 200
+    assert cfg.search.length_downweight_alpha == 0.25
+    assert cfg.search.max_chunk_words == 400
 
 
 def test_search_ranking_config_env_overrides(
@@ -45,10 +50,10 @@ def test_search_ranking_config_env_overrides(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS", "100000")
 
     cfg = load_config()
-    assert cfg.chunks_per_file == 1
-    assert cfg.snippet_words == 0
-    assert cfg.length_downweight_alpha == 0.0
-    assert cfg.max_chunk_words == 100000
+    assert cfg.search.chunks_per_file == 1
+    assert cfg.search.snippet_words == 0
+    assert cfg.search.length_downweight_alpha == 0.0
+    assert cfg.search.max_chunk_words == 100000
 
 
 def test_search_ranking_config_rejects_zero_chunks_per_file(
@@ -108,17 +113,17 @@ class TestLoadConfig:
 
         assert config.source_dir == Path("/tmp/vault")
         assert config.read_only is True  # default
-        assert config.index_path is None
-        assert config.embeddings_path is None
-        assert config.state_path is None
-        assert config.indexed_frontmatter_fields is None
-        assert config.required_frontmatter is None
-        assert config.exclude_patterns is None
-        assert config.git_repo_url is None
-        assert config.git_username == "x-access-token"
-        assert config.git_token is None
-        assert config.git_pull_interval_s == 600
-        assert config.templates_folder == "_templates"
+        assert config.indexing.index_path is None
+        assert config.indexing.embeddings_path is None
+        assert config.indexing.state_path is None
+        assert config.indexing.indexed_frontmatter_fields is None
+        assert config.indexing.required_frontmatter is None
+        assert config.indexing.exclude_patterns is None
+        assert config.git.repo_url is None
+        assert config.git.username == "x-access-token"
+        assert config.git.token is None
+        assert config.git.pull_interval_s == 600
+        assert config.content.templates_folder == "_templates"
 
     def test_full_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/data/vault")
@@ -141,23 +146,23 @@ class TestLoadConfig:
 
         assert config.source_dir == Path("/data/vault")
         assert config.read_only is False
-        assert config.index_path == Path("/data/index.db")
-        assert config.embeddings_path == Path("/data/embeddings")
-        assert config.state_path == Path("/data/state.json")
-        assert config.indexed_frontmatter_fields == ["cluster", "topics"]
-        assert config.required_frontmatter == ["title", "cluster"]
-        assert config.exclude_patterns == [".obsidian/**", ".trash/**"]
-        assert config.git_repo_url == "https://github.com/acme/vault.git"
-        assert config.git_username == "oauth2"
-        assert config.git_token == "ghp_test123"
-        assert config.git_pull_interval_s == 300
-        assert config.templates_folder == "Templates"
+        assert config.indexing.index_path == Path("/data/index.db")
+        assert config.indexing.embeddings_path == Path("/data/embeddings")
+        assert config.indexing.state_path == Path("/data/state.json")
+        assert config.indexing.indexed_frontmatter_fields == ["cluster", "topics"]
+        assert config.indexing.required_frontmatter == ["title", "cluster"]
+        assert config.indexing.exclude_patterns == [".obsidian/**", ".trash/**"]
+        assert config.git.repo_url == "https://github.com/acme/vault.git"
+        assert config.git.username == "oauth2"
+        assert config.git.token == "ghp_test123"
+        assert config.git.pull_interval_s == 300
+        assert config.content.templates_folder == "Templates"
 
     def test_git_username_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_USERNAME", raising=False)
         config = load_config()
-        assert config.git_username == "x-access-token"
+        assert config.git.username == "x-access-token"
 
     def test_templates_folder_trailing_slash_normalized(
         self, monkeypatch: pytest.MonkeyPatch
@@ -165,7 +170,7 @@ class TestLoadConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER", "Templates/")
         config = load_config()
-        assert config.templates_folder == "Templates"
+        assert config.content.templates_folder == "Templates"
 
     def test_templates_folder_backslashes_normalized(
         self, monkeypatch: pytest.MonkeyPatch
@@ -173,7 +178,7 @@ class TestLoadConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER", "Templates\\Notes\\")
         config = load_config()
-        assert config.templates_folder == "Templates/Notes"
+        assert config.content.templates_folder == "Templates/Notes"
 
     def test_templates_folder_slash_only_falls_back_to_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -181,7 +186,7 @@ class TestLoadConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER", "/")
         config = load_config()
-        assert config.templates_folder == "_templates"
+        assert config.content.templates_folder == "_templates"
 
     def test_token_without_repo_url_logs_deprecation(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -198,7 +203,7 @@ class TestLoadConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S", "nope")
         config = load_config()
-        assert config.git_pull_interval_s == 600
+        assert config.git.pull_interval_s == 600
 
     def test_negative_pull_interval_disables(
         self, monkeypatch: pytest.MonkeyPatch
@@ -206,7 +211,7 @@ class TestLoadConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S", "-5")
         config = load_config()
-        assert config.git_pull_interval_s == 0
+        assert config.git.pull_interval_s == 0
 
     def test_comma_separated_strips_whitespace(
         self, monkeypatch: pytest.MonkeyPatch
@@ -214,7 +219,7 @@ class TestLoadConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEXED_FIELDS", " a , b , c ")
         config = load_config()
-        assert config.indexed_frontmatter_fields == ["a", "b", "c"]
+        assert config.indexing.indexed_frontmatter_fields == ["a", "b", "c"]
 
     def test_empty_comma_list_yields_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -222,14 +227,14 @@ class TestLoadConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEXED_FIELDS", "")
         config = load_config()
-        assert config.indexed_frontmatter_fields is None
+        assert config.indexing.indexed_frontmatter_fields is None
 
 
 class TestToCollectionKwargs:
     def test_includes_exclude_patterns(self) -> None:
         config = CollectionConfig(
             source_dir=Path("/tmp/vault"),
-            exclude_patterns=[".obsidian/**"],
+            indexing=IndexingConfig(exclude_patterns=[".obsidian/**"]),
         )
         kwargs = config.to_collection_kwargs()
         assert kwargs["exclude_patterns"] == [".obsidian/**"]
@@ -238,7 +243,7 @@ class TestToCollectionKwargs:
     def test_excludes_git_token(self) -> None:
         config = CollectionConfig(
             source_dir=Path("/tmp/vault"),
-            git_token="ghp_secret",
+            git=GitConfig(token="ghp_secret"),
         )
         kwargs = config.to_collection_kwargs()
         assert "git_token" not in kwargs
@@ -254,12 +259,14 @@ class TestToCollectionKwargs:
         config = CollectionConfig(
             source_dir=Path("/tmp/vault"),
             read_only=False,
-            index_path=Path("/tmp/index.db"),
-            embeddings_path=Path("/tmp/emb"),
-            state_path=Path("/tmp/state.json"),
-            indexed_frontmatter_fields=["cluster"],
-            required_frontmatter=["title"],
-            exclude_patterns=[".obsidian/**"],
+            indexing=IndexingConfig(
+                index_path=Path("/tmp/index.db"),
+                embeddings_path=Path("/tmp/emb"),
+                state_path=Path("/tmp/state.json"),
+                indexed_frontmatter_fields=["cluster"],
+                required_frontmatter=["title"],
+                exclude_patterns=[".obsidian/**"],
+            ),
         )
         kwargs = config.to_collection_kwargs()
         assert kwargs["source_dir"] == Path("/tmp/vault")
@@ -290,9 +297,7 @@ class TestToCollectionKwargs:
 
         config = CollectionConfig(
             source_dir=source_dir,
-            git_repo_url=str(bare),
-            git_token="ghp_secret",
-            git_pull_interval_s=123,
+            git=GitConfig(repo_url=str(bare), token="ghp_secret", pull_interval_s=123),
         )
         kwargs = config.to_collection_kwargs()
         assert kwargs["git_pull_interval_s"] == 123
@@ -308,28 +313,28 @@ class TestGitCommitterConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME", raising=False)
         config = load_config()
-        assert config.git_commit_name == "markdown-vault-mcp"
+        assert config.git.commit_name == "markdown-vault-mcp"
 
     def test_default_git_commit_email(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() uses default git_commit_email when env var is not set."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL", raising=False)
         config = load_config()
-        assert config.git_commit_email == "noreply@markdown-vault-mcp"
+        assert config.git.commit_email == "noreply@markdown-vault-mcp"
 
     def test_override_git_commit_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() reads MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME from environment."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME", "MyBot")
         config = load_config()
-        assert config.git_commit_name == "MyBot"
+        assert config.git.commit_name == "MyBot"
 
     def test_override_git_commit_email(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() reads MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL from environment."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL", "bot@example.com")
         config = load_config()
-        assert config.git_commit_email == "bot@example.com"
+        assert config.git.commit_email == "bot@example.com"
 
     def test_both_git_committer_vars_override(
         self, monkeypatch: pytest.MonkeyPatch
@@ -339,8 +344,8 @@ class TestGitCommitterConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME", "DeployBot")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL", "deploy@corp.local")
         config = load_config()
-        assert config.git_commit_name == "DeployBot"
-        assert config.git_commit_email == "deploy@corp.local"
+        assert config.git.commit_name == "DeployBot"
+        assert config.git.commit_email == "deploy@corp.local"
 
     def test_empty_git_commit_name_uses_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -349,7 +354,7 @@ class TestGitCommitterConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME", "")
         config = load_config()
-        assert config.git_commit_name == "markdown-vault-mcp"
+        assert config.git.commit_name == "markdown-vault-mcp"
 
     def test_empty_git_commit_email_uses_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -358,23 +363,22 @@ class TestGitCommitterConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL", "")
         config = load_config()
-        assert config.git_commit_email == "noreply@markdown-vault-mcp"
+        assert config.git.commit_email == "noreply@markdown-vault-mcp"
 
     def test_config_dataclass_defaults(self) -> None:
         """CollectionConfig has correct default committer values."""
         config = CollectionConfig(source_dir=Path("/tmp/vault"))
-        assert config.git_commit_name == "markdown-vault-mcp"
-        assert config.git_commit_email == "noreply@markdown-vault-mcp"
+        assert config.git.commit_name == "markdown-vault-mcp"
+        assert config.git.commit_email == "noreply@markdown-vault-mcp"
 
     def test_config_dataclass_custom_values(self) -> None:
         """CollectionConfig accepts custom committer name and email."""
         config = CollectionConfig(
             source_dir=Path("/tmp/vault"),
-            git_commit_name="CI",
-            git_commit_email="ci@example.com",
+            git=GitConfig(commit_name="CI", commit_email="ci@example.com"),
         )
-        assert config.git_commit_name == "CI"
-        assert config.git_commit_email == "ci@example.com"
+        assert config.git.commit_name == "CI"
+        assert config.git.commit_email == "ci@example.com"
 
     def test_to_collection_kwargs_includes_commit_identity(self) -> None:
         """to_collection_kwargs() passes commit identity to GitWriteStrategy."""
@@ -382,9 +386,9 @@ class TestGitCommitterConfig:
 
         config = CollectionConfig(
             source_dir=Path("/tmp/vault"),
-            git_token="ghp_test",
-            git_commit_name="TestBot",
-            git_commit_email="test@example.com",
+            git=GitConfig(
+                token="ghp_test", commit_name="TestBot", commit_email="test@example.com"
+            ),
         )
         kwargs = config.to_collection_kwargs()
 
@@ -401,7 +405,7 @@ class TestGitCommitterConfig:
 
         config = CollectionConfig(
             source_dir=Path("/tmp/vault"),
-            git_token="ghp_test",
+            git=GitConfig(token="ghp_test"),
         )
         kwargs = config.to_collection_kwargs()
 
@@ -421,7 +425,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", raising=False)
         config = load_config()
-        assert config.attachment_extensions is None
+        assert config.content.attachment_extensions is None
 
     def test_attachment_extensions_comma_separated(
         self, monkeypatch: pytest.MonkeyPatch
@@ -430,7 +434,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", "pdf,png,docx")
         config = load_config()
-        assert config.attachment_extensions == ["pdf", "png", "docx"]
+        assert config.content.attachment_extensions == ["pdf", "png", "docx"]
 
     def test_attachment_extensions_wildcard(
         self, monkeypatch: pytest.MonkeyPatch
@@ -439,7 +443,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", "*")
         config = load_config()
-        assert config.attachment_extensions == ["*"]
+        assert config.content.attachment_extensions == ["*"]
 
     def test_attachment_extensions_empty_returns_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -448,7 +452,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", "")
         config = load_config()
-        assert config.attachment_extensions is None
+        assert config.content.attachment_extensions is None
 
     def test_default_max_attachment_size_mb(
         self, monkeypatch: pytest.MonkeyPatch
@@ -457,7 +461,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", raising=False)
         config = load_config()
-        assert config.max_attachment_size_mb == 1.0
+        assert config.content.max_attachment_size_mb == 1.0
 
     def test_max_attachment_size_mb_parsed(
         self, monkeypatch: pytest.MonkeyPatch
@@ -466,7 +470,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "25.5")
         config = load_config()
-        assert config.max_attachment_size_mb == 25.5
+        assert config.content.max_attachment_size_mb == 25.5
 
     def test_max_attachment_size_mb_zero_disables_limit(
         self, monkeypatch: pytest.MonkeyPatch
@@ -475,7 +479,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "0")
         config = load_config()
-        assert config.max_attachment_size_mb == 0.0
+        assert config.content.max_attachment_size_mb == 0.0
 
     def test_max_attachment_size_mb_invalid_uses_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -484,7 +488,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "not-a-number")
         config = load_config()
-        assert config.max_attachment_size_mb == 1.0
+        assert config.content.max_attachment_size_mb == 1.0
 
     def test_max_attachment_size_mb_negative_uses_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -493,7 +497,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "-5")
         config = load_config()
-        assert config.max_attachment_size_mb == 1.0
+        assert config.content.max_attachment_size_mb == 1.0
 
     def test_attachment_config_passed_through_to_collection_kwargs(
         self, monkeypatch: pytest.MonkeyPatch
@@ -516,21 +520,21 @@ class TestGitLfsConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_LFS", raising=False)
         config = load_config()
-        assert config.git_lfs is True
+        assert config.git.lfs is True
 
     def test_git_lfs_disabled_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() parses GIT_LFS=false as False."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_LFS", "false")
         config = load_config()
-        assert config.git_lfs is False
+        assert config.git.lfs is False
 
     def test_git_lfs_enabled_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() parses GIT_LFS=true as True."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_LFS", "true")
         config = load_config()
-        assert config.git_lfs is True
+        assert config.git.lfs is True
 
     def test_git_lfs_passed_to_strategy(self, tmp_path: Path) -> None:
         """to_collection_kwargs() passes git_lfs to GitWriteStrategy."""
@@ -538,8 +542,7 @@ class TestGitLfsConfig:
 
         config = CollectionConfig(
             source_dir=tmp_path,
-            git_token="ghp_test",
-            git_lfs=False,
+            git=GitConfig(token="ghp_test", lfs=False),
         )
         kwargs = config.to_collection_kwargs()
         strategy = kwargs["on_write"]
@@ -552,7 +555,7 @@ class TestGitLfsConfig:
 
         config = CollectionConfig(
             source_dir=tmp_path,
-            git_token="ghp_test",
+            git=GitConfig(token="ghp_test"),
         )
         kwargs = config.to_collection_kwargs()
         strategy = kwargs["on_write"]
@@ -572,15 +575,15 @@ class TestCollectionConfigDefaults:
     def test_embedding_provider_defaults(self) -> None:
         """Embedding fields have correct defaults."""
         config = CollectionConfig(source_dir=Path("/tmp/vault"))
-        assert config.embedding_provider is None
-        assert config.ollama_host == "http://localhost:11434"
-        assert config.ollama_model == "nomic-embed-text"
-        assert config.ollama_cpu_only is False
-        assert config.openai_api_key is None
-        assert config.openai_base_url == "https://api.openai.com/v1"
-        assert config.openai_embedding_model == "text-embedding-3-small"
-        assert config.fastembed_model == "BAAI/bge-small-en-v1.5"
-        assert config.fastembed_cache_dir is None
+        assert config.embeddings.provider is None
+        assert config.embeddings.ollama_host == "http://localhost:11434"
+        assert config.embeddings.ollama_model == "nomic-embed-text"
+        assert config.embeddings.ollama_cpu_only is False
+        assert config.embeddings.openai_api_key is None
+        assert config.embeddings.openai_base_url == "https://api.openai.com/v1"
+        assert config.embeddings.openai_embedding_model == "text-embedding-3-small"
+        assert config.embeddings.fastembed_model == "BAAI/bge-small-en-v1.5"
+        assert config.embeddings.fastembed_cache_dir is None
 
     def test_custom_values_accepted(self) -> None:
         """CollectionConfig accepts custom values for all new fields."""
@@ -588,27 +591,29 @@ class TestCollectionConfigDefaults:
             source_dir=Path("/tmp/vault"),
             server_name="my-server",
             instructions="Be helpful",
-            embedding_provider="ollama",
-            ollama_host="http://gpu-server:11434",
-            ollama_model="mxbai-embed-large",
-            ollama_cpu_only=True,
-            openai_api_key="sk-test",
-            openai_base_url="https://api.siliconflow.cn/v1",
-            openai_embedding_model="BAAI/bge-m3",
-            fastembed_model="BAAI/bge-base-en-v1.5",
-            fastembed_cache_dir="/tmp/cache",
+            embeddings=EmbeddingsConfig(
+                provider="ollama",
+                ollama_host="http://gpu-server:11434",
+                ollama_model="mxbai-embed-large",
+                ollama_cpu_only=True,
+                openai_api_key="sk-test",
+                openai_base_url="https://api.siliconflow.cn/v1",
+                openai_embedding_model="BAAI/bge-m3",
+                fastembed_model="BAAI/bge-base-en-v1.5",
+                fastembed_cache_dir="/tmp/cache",
+            ),
         )
         assert config.server_name == "my-server"
         assert config.instructions == "Be helpful"
-        assert config.embedding_provider == "ollama"
-        assert config.ollama_host == "http://gpu-server:11434"
-        assert config.ollama_model == "mxbai-embed-large"
-        assert config.ollama_cpu_only is True
-        assert config.openai_api_key == "sk-test"
-        assert config.openai_base_url == "https://api.siliconflow.cn/v1"
-        assert config.openai_embedding_model == "BAAI/bge-m3"
-        assert config.fastembed_model == "BAAI/bge-base-en-v1.5"
-        assert config.fastembed_cache_dir == "/tmp/cache"
+        assert config.embeddings.provider == "ollama"
+        assert config.embeddings.ollama_host == "http://gpu-server:11434"
+        assert config.embeddings.ollama_model == "mxbai-embed-large"
+        assert config.embeddings.ollama_cpu_only is True
+        assert config.embeddings.openai_api_key == "sk-test"
+        assert config.embeddings.openai_base_url == "https://api.siliconflow.cn/v1"
+        assert config.embeddings.openai_embedding_model == "BAAI/bge-m3"
+        assert config.embeddings.fastembed_model == "BAAI/bge-base-en-v1.5"
+        assert config.embeddings.fastembed_cache_dir == "/tmp/cache"
 
 
 class TestLoadConfigServerIdentityFields:
@@ -651,6 +656,23 @@ class TestLoadConfigServerIdentityFields:
         assert config.instructions == "Be concise"
 
 
+class TestEmbeddingsConfigNormalization:
+    """EmbeddingsConfig.__post_init__ normalizes ollama_host on direct construction.
+
+    load_config() pre-normalizes ollama_host before building EmbeddingsConfig, so
+    these assert the dataclass's own contract independently of the loader.
+    """
+
+    def test_empty_ollama_host_falls_back_to_default(self) -> None:
+        assert EmbeddingsConfig(ollama_host="").ollama_host == "http://localhost:11434"
+
+    def test_ollama_host_trailing_slash_stripped(self) -> None:
+        assert (
+            EmbeddingsConfig(ollama_host="http://gpu:11434/").ollama_host
+            == "http://gpu:11434"
+        )
+
+
 class TestLoadConfigEmbeddingFields:
     """Verify embedding env vars are read correctly by load_config()."""
 
@@ -662,7 +684,7 @@ class TestLoadConfigEmbeddingFields:
         """load_config() reads MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER", "ollama")
         config = load_config()
-        assert config.embedding_provider == "ollama"
+        assert config.embeddings.provider == "ollama"
 
     def test_embedding_provider_default_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -670,19 +692,19 @@ class TestLoadConfigEmbeddingFields:
         """load_config() defaults embedding_provider to None."""
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER", raising=False)
         config = load_config()
-        assert config.embedding_provider is None
+        assert config.embeddings.provider is None
 
     def test_ollama_host_bare_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() reads OLLAMA_HOST (bare, not prefixed)."""
         monkeypatch.setenv("OLLAMA_HOST", "http://gpu:11434")
         config = load_config()
-        assert config.ollama_host == "http://gpu:11434"
+        assert config.embeddings.ollama_host == "http://gpu:11434"
 
     def test_ollama_host_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() defaults ollama_host to http://localhost:11434."""
         monkeypatch.delenv("OLLAMA_HOST", raising=False)
         config = load_config()
-        assert config.ollama_host == "http://localhost:11434"
+        assert config.embeddings.ollama_host == "http://localhost:11434"
 
     def test_ollama_host_empty_uses_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -690,7 +712,7 @@ class TestLoadConfigEmbeddingFields:
         """load_config() treats empty OLLAMA_HOST as default."""
         monkeypatch.setenv("OLLAMA_HOST", "")
         config = load_config()
-        assert config.ollama_host == "http://localhost:11434"
+        assert config.embeddings.ollama_host == "http://localhost:11434"
 
     def test_ollama_host_trailing_slash_stripped(
         self, monkeypatch: pytest.MonkeyPatch
@@ -698,19 +720,19 @@ class TestLoadConfigEmbeddingFields:
         """load_config() strips trailing slash from OLLAMA_HOST."""
         monkeypatch.setenv("OLLAMA_HOST", "http://gpu:11434/")
         config = load_config()
-        assert config.ollama_host == "http://gpu:11434"
+        assert config.embeddings.ollama_host == "http://gpu:11434"
 
     def test_ollama_model_prefixed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() reads MARKDOWN_VAULT_MCP_OLLAMA_MODEL."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OLLAMA_MODEL", "mxbai-embed-large")
         config = load_config()
-        assert config.ollama_model == "mxbai-embed-large"
+        assert config.embeddings.ollama_model == "mxbai-embed-large"
 
     def test_ollama_model_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() defaults ollama_model to nomic-embed-text."""
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_OLLAMA_MODEL", raising=False)
         config = load_config()
-        assert config.ollama_model == "nomic-embed-text"
+        assert config.embeddings.ollama_model == "nomic-embed-text"
 
     def test_ollama_cpu_only_default_false(
         self, monkeypatch: pytest.MonkeyPatch
@@ -718,25 +740,25 @@ class TestLoadConfigEmbeddingFields:
         """load_config() defaults ollama_cpu_only to False."""
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY", raising=False)
         config = load_config()
-        assert config.ollama_cpu_only is False
+        assert config.embeddings.ollama_cpu_only is False
 
     def test_ollama_cpu_only_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() parses OLLAMA_CPU_ONLY=true."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY", "true")
         config = load_config()
-        assert config.ollama_cpu_only is True
+        assert config.embeddings.ollama_cpu_only is True
 
     def test_openai_api_key_bare_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() reads OPENAI_API_KEY (bare, not prefixed)."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test123")
         config = load_config()
-        assert config.openai_api_key == "sk-test123"
+        assert config.embeddings.openai_api_key == "sk-test123"
 
     def test_openai_api_key_default_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() defaults openai_api_key to None."""
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         config = load_config()
-        assert config.openai_api_key is None
+        assert config.embeddings.openai_api_key is None
 
     def test_openai_base_url_prefixed_env_var(
         self, monkeypatch: pytest.MonkeyPatch
@@ -747,7 +769,7 @@ class TestLoadConfigEmbeddingFields:
             "https://api.siliconflow.cn/v1/",
         )
         config = load_config()
-        assert config.openai_base_url == "https://api.siliconflow.cn/v1"
+        assert config.embeddings.openai_base_url == "https://api.siliconflow.cn/v1"
 
     def test_openai_base_url_bare_env_var(
         self, monkeypatch: pytest.MonkeyPatch
@@ -756,7 +778,7 @@ class TestLoadConfigEmbeddingFields:
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_BASE_URL", raising=False)
         monkeypatch.setenv("OPENAI_BASE_URL", "https://api.compat.example/v1")
         config = load_config()
-        assert config.openai_base_url == "https://api.compat.example/v1"
+        assert config.embeddings.openai_base_url == "https://api.compat.example/v1"
 
     def test_openai_base_url_prefixed_env_var_wins(
         self, monkeypatch: pytest.MonkeyPatch
@@ -768,14 +790,14 @@ class TestLoadConfigEmbeddingFields:
         )
         monkeypatch.setenv("OPENAI_BASE_URL", "https://api.bare.example/v1")
         config = load_config()
-        assert config.openai_base_url == "https://api.prefixed.example/v1"
+        assert config.embeddings.openai_base_url == "https://api.prefixed.example/v1"
 
     def test_openai_base_url_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() defaults openai_base_url to the OpenAI API base URL."""
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_BASE_URL", raising=False)
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
         config = load_config()
-        assert config.openai_base_url == "https://api.openai.com/v1"
+        assert config.embeddings.openai_base_url == "https://api.openai.com/v1"
 
     def test_openai_embedding_model_prefixed_env_var(
         self, monkeypatch: pytest.MonkeyPatch
@@ -783,7 +805,7 @@ class TestLoadConfigEmbeddingFields:
         """load_config() reads MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", "BAAI/bge-m3")
         config = load_config()
-        assert config.openai_embedding_model == "BAAI/bge-m3"
+        assert config.embeddings.openai_embedding_model == "BAAI/bge-m3"
 
     def test_openai_embedding_model_bare_env_var(
         self, monkeypatch: pytest.MonkeyPatch
@@ -792,7 +814,7 @@ class TestLoadConfigEmbeddingFields:
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", raising=False)
         monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
         config = load_config()
-        assert config.openai_embedding_model == "text-embedding-3-large"
+        assert config.embeddings.openai_embedding_model == "text-embedding-3-large"
 
     def test_openai_embedding_model_prefixed_env_var_wins(
         self, monkeypatch: pytest.MonkeyPatch
@@ -804,7 +826,7 @@ class TestLoadConfigEmbeddingFields:
         )
         monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "bare-embedding-model")
         config = load_config()
-        assert config.openai_embedding_model == "prefixed-embedding-model"
+        assert config.embeddings.openai_embedding_model == "prefixed-embedding-model"
 
     def test_openai_embedding_model_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -813,7 +835,7 @@ class TestLoadConfigEmbeddingFields:
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL", raising=False)
         monkeypatch.delenv("OPENAI_EMBEDDING_MODEL", raising=False)
         config = load_config()
-        assert config.openai_embedding_model == "text-embedding-3-small"
+        assert config.embeddings.openai_embedding_model == "text-embedding-3-small"
 
     def test_fastembed_model_prefixed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() reads MARKDOWN_VAULT_MCP_FASTEMBED_MODEL."""
@@ -821,13 +843,13 @@ class TestLoadConfigEmbeddingFields:
             "MARKDOWN_VAULT_MCP_FASTEMBED_MODEL", "BAAI/bge-base-en-v1.5"
         )
         config = load_config()
-        assert config.fastembed_model == "BAAI/bge-base-en-v1.5"
+        assert config.embeddings.fastembed_model == "BAAI/bge-base-en-v1.5"
 
     def test_fastembed_model_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """load_config() defaults fastembed_model to BAAI/bge-small-en-v1.5."""
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_FASTEMBED_MODEL", raising=False)
         config = load_config()
-        assert config.fastembed_model == "BAAI/bge-small-en-v1.5"
+        assert config.embeddings.fastembed_model == "BAAI/bge-small-en-v1.5"
 
     def test_fastembed_cache_dir_prefixed(
         self, monkeypatch: pytest.MonkeyPatch
@@ -835,7 +857,7 @@ class TestLoadConfigEmbeddingFields:
         """load_config() reads MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR", "/tmp/fe-cache")
         config = load_config()
-        assert config.fastembed_cache_dir == "/tmp/fe-cache"
+        assert config.embeddings.fastembed_cache_dir == "/tmp/fe-cache"
 
     def test_fastembed_cache_dir_default_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -843,7 +865,7 @@ class TestLoadConfigEmbeddingFields:
         """load_config() defaults fastembed_cache_dir to None."""
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR", raising=False)
         config = load_config()
-        assert config.fastembed_cache_dir is None
+        assert config.embeddings.fastembed_cache_dir is None
 
 
 class TestEmptyBoolEnvVarsFallToDefault:
@@ -871,7 +893,7 @@ class TestEmptyBoolEnvVarsFallToDefault:
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_LFS", "")
         config = load_config()
-        assert config.git_lfs is True  # default
+        assert config.git.lfs is True  # default
 
     def test_oidc_verify_access_token_empty_falls_through_to_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -885,7 +907,7 @@ class TestEmptyBoolEnvVarsFallToDefault:
     ) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY", "")
         config = load_config()
-        assert config.ollama_cpu_only is False  # default
+        assert config.embeddings.ollama_cpu_only is False  # default
 
 
 class TestServerConfigComposition:
@@ -992,7 +1014,7 @@ class TestMaxNoteReadBytesEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", raising=False)
         config = load_config()
-        assert config.max_note_read_bytes == 262144
+        assert config.content.max_note_read_bytes == 262144
 
     def test_override_via_env(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -1000,7 +1022,7 @@ class TestMaxNoteReadBytesEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "1048576")
         config = load_config()
-        assert config.max_note_read_bytes == 1048576
+        assert config.content.max_note_read_bytes == 1048576
 
     def test_zero_disables_limit(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -1008,7 +1030,7 @@ class TestMaxNoteReadBytesEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "0")
         config = load_config()
-        assert config.max_note_read_bytes == 0
+        assert config.content.max_note_read_bytes == 0
 
     def test_invalid_value_falls_back_to_default(
         self,
@@ -1020,7 +1042,7 @@ class TestMaxNoteReadBytesEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "not-a-number")
         with caplog.at_level(logging.WARNING):
             config = load_config()
-        assert config.max_note_read_bytes == 262144
+        assert config.content.max_note_read_bytes == 262144
         assert "MAX_NOTE_READ_BYTES" in caplog.text
 
     def test_negative_value_falls_back_to_default(
@@ -1033,7 +1055,7 @@ class TestMaxNoteReadBytesEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "-1")
         with caplog.at_level(logging.WARNING):
             config = load_config()
-        assert config.max_note_read_bytes == 262144
+        assert config.content.max_note_read_bytes == 262144
         assert "MAX_NOTE_READ_BYTES" in caplog.text
         assert "negative" in caplog.text.lower()
 
@@ -1047,4 +1069,4 @@ class TestMaxAttachmentSizeMbDefault:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", raising=False)
         config = load_config()
-        assert config.max_attachment_size_mb == 1.0
+        assert config.content.max_attachment_size_mb == 1.0

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -303,7 +303,7 @@ def test_load_config_file_watcher_disabled_via_env(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER", "false")
     config = load_config()
-    assert config.file_watcher_enabled is False
+    assert config.sync.file_watcher_enabled is False
 
 
 def test_load_config_file_watcher_debounce_custom(
@@ -315,7 +315,7 @@ def test_load_config_file_watcher_debounce_custom(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S", "5.0")
     config = load_config()
-    assert config.file_watcher_debounce_s == 5.0
+    assert config.sync.file_watcher_debounce_s == 5.0
 
 
 def test_load_config_file_watcher_debounce_invalid_falls_back(
@@ -327,7 +327,7 @@ def test_load_config_file_watcher_debounce_invalid_falls_back(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S", "not-a-number")
     config = load_config()
-    assert config.file_watcher_debounce_s == 2.0
+    assert config.sync.file_watcher_debounce_s == 2.0
 
 
 def test_load_config_file_watcher_debounce_nonpositive_falls_back(
@@ -339,7 +339,7 @@ def test_load_config_file_watcher_debounce_nonpositive_falls_back(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S", "0")
     config = load_config()
-    assert config.file_watcher_debounce_s == 2.0
+    assert config.sync.file_watcher_debounce_s == 2.0
 
 
 def test_fire_exception_in_on_change_is_logged(tmp_path: Path) -> None:
@@ -399,11 +399,12 @@ def test_lifespan_skips_watcher_when_git_pull_active(tmp_path: Path) -> None:
     from markdown_vault_mcp.config import CollectionConfig
 
     (tmp_path / "note.md").write_text("# note\n\nbody", encoding="utf-8")
+    from markdown_vault_mcp.config_sections import GitConfig
+
     config = CollectionConfig(
         source_dir=tmp_path,
         read_only=False,
-        git_token="fake-token",
-        git_pull_interval_s=600,
+        git=GitConfig(token="fake-token", pull_interval_s=600),
     )
     lifespan_fn = make_collection_lifespan(config)
 
@@ -423,8 +424,12 @@ def test_lifespan_skips_watcher_when_webhook_active(tmp_path: Path) -> None:
     from markdown_vault_mcp.config import CollectionConfig
 
     (tmp_path / "note.md").write_text("# note\n\nbody", encoding="utf-8")
+    from markdown_vault_mcp.config_sections import SyncConfig
+
     config = CollectionConfig(
-        source_dir=tmp_path, read_only=False, github_webhook_secret="shhh"
+        source_dir=tmp_path,
+        read_only=False,
+        sync=SyncConfig(github_webhook_secret="shhh"),
     )
     lifespan_fn = make_collection_lifespan(config)
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -606,11 +606,12 @@ class TestConfigIntegration:
     def test_git_token_wires_up_strategy(self, tmp_path: Path) -> None:
         """Legacy mode: token-only config still wires pull+push strategy."""
         from markdown_vault_mcp.config import CollectionConfig
+        from markdown_vault_mcp.config_sections import GitConfig
 
         config = CollectionConfig(
             source_dir=tmp_path,
             read_only=False,
-            git_token="ghp_test",
+            git=GitConfig(token="ghp_test"),
         )
         kwargs = config.to_collection_kwargs()
         assert "on_write" in kwargs
@@ -633,6 +634,7 @@ class TestConfigIntegration:
         """Managed mode uses configured pull interval and write callback."""
 
         from markdown_vault_mcp.config import CollectionConfig
+        from markdown_vault_mcp.config_sections import GitConfig
 
         bare = tmp_path / "remote.git"
         subprocess.run(
@@ -644,9 +646,7 @@ class TestConfigIntegration:
         config = CollectionConfig(
             source_dir=tmp_path / "vault",
             read_only=False,
-            git_repo_url=str(bare),
-            git_token="ghp_test",
-            git_pull_interval_s=321,
+            git=GitConfig(repo_url=str(bare), token="ghp_test", pull_interval_s=321),
         )
         kwargs = config.to_collection_kwargs()
         assert "on_write" in kwargs
@@ -655,12 +655,12 @@ class TestConfigIntegration:
     def test_push_delay_passed_to_strategy(self, tmp_path: Path) -> None:
         """to_collection_kwargs() passes git_push_delay_s to strategy."""
         from markdown_vault_mcp.config import CollectionConfig
+        from markdown_vault_mcp.config_sections import GitConfig
 
         config = CollectionConfig(
             source_dir=tmp_path,
             read_only=False,
-            git_token="ghp_test",
-            git_push_delay_s=60.0,
+            git=GitConfig(token="ghp_test", push_delay_s=60.0),
         )
         kwargs = config.to_collection_kwargs()
         strategy = kwargs["on_write"]
@@ -676,7 +676,7 @@ class TestConfigIntegration:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S", "45")
         config = load_config()
-        assert config.git_push_delay_s == 45.0
+        assert config.git.push_delay_s == 45.0
 
     def test_load_config_invalid_push_delay_uses_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -687,7 +687,7 @@ class TestConfigIntegration:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S", "not_a_number")
         config = load_config()
-        assert config.git_push_delay_s == 30.0
+        assert config.git.push_delay_s == 30.0
 
 
 class TestCollectionCloseWiresStrategy:
@@ -3458,7 +3458,7 @@ class TestGitClaimConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM", "name")
         config = load_config()
-        assert config.git_commit_name_claim == "name"
+        assert config.git.commit_name_claim == "name"
 
     def test_load_config_reads_email_claim(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3469,7 +3469,7 @@ class TestGitClaimConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM", "email")
         config = load_config()
-        assert config.git_commit_email_claim == "email"
+        assert config.git.commit_email_claim == "email"
 
     def test_load_config_claim_defaults_to_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3481,18 +3481,18 @@ class TestGitClaimConfig:
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM", raising=False)
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM", raising=False)
         config = load_config()
-        assert config.git_commit_name_claim is None
-        assert config.git_commit_email_claim is None
+        assert config.git.commit_name_claim is None
+        assert config.git.commit_email_claim is None
 
     def test_claim_config_passed_to_strategy(self, tmp_path: Path) -> None:
         """CollectionConfig.to_collection_kwargs() passes claim keys to GitWriteStrategy."""
         from markdown_vault_mcp.config import CollectionConfig
+        from markdown_vault_mcp.config_sections import GitConfig
 
         config = CollectionConfig(
             source_dir=tmp_path,
             read_only=False,
-            git_commit_name_claim="name",
-            git_commit_email_claim="email",
+            git=GitConfig(commit_name_claim="name", commit_email_claim="email"),
         )
         kwargs = config.to_collection_kwargs()
         strategy = kwargs["on_write"]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from markdown_vault_mcp.config import CollectionConfig
+from markdown_vault_mcp.config_sections import EmbeddingsConfig
 from markdown_vault_mcp.providers import (
     FastEmbedProvider,
     OllamaProvider,
@@ -36,11 +37,12 @@ def _make_httpx_mock(
     return mock_client, mock_response
 
 
-def _config(**overrides: object) -> CollectionConfig:
-    """Build a minimal CollectionConfig with optional overrides."""
-    defaults: dict[str, object] = {"source_dir": Path("/tmp/vault")}
-    defaults.update(overrides)
-    return CollectionConfig(**defaults)  # type: ignore[arg-type]
+def _config(**embedding_overrides: object) -> CollectionConfig:
+    """Build a minimal CollectionConfig with optional embedding overrides."""
+    return CollectionConfig(
+        source_dir=Path("/tmp/vault"),
+        embeddings=EmbeddingsConfig(**embedding_overrides),  # type: ignore[arg-type]
+    )
 
 
 class TestOllamaProvider:
@@ -344,7 +346,7 @@ class TestGetEmbeddingProvider:
 
     def test_explicit_openai_returns_openai_provider(self) -> None:
         cfg = _config(
-            embedding_provider="openai",
+            provider="openai",
             openai_api_key="sk-test",
             openai_base_url="https://api.siliconflow.cn/v1",
             openai_embedding_model="BAAI/bge-m3",
@@ -355,13 +357,13 @@ class TestGetEmbeddingProvider:
         assert provider.model_name == "BAAI/bge-m3"
 
     def test_explicit_ollama_returns_ollama_provider(self) -> None:
-        cfg = _config(embedding_provider="ollama")
+        cfg = _config(provider="ollama")
         with patch("httpx.Client"):
             provider = get_embedding_provider(cfg)
         assert isinstance(provider, OllamaProvider)
 
     def test_explicit_fastembed_returns_fastembed_provider(self) -> None:
-        cfg = _config(embedding_provider="fastembed")
+        cfg = _config(provider="fastembed")
         module = MagicMock()
         module.TextEmbedding.return_value = MagicMock(embed=lambda *_: [])
         with patch.dict("sys.modules", {"fastembed": module}):
@@ -369,7 +371,7 @@ class TestGetEmbeddingProvider:
         assert isinstance(provider, FastEmbedProvider)
 
     def test_explicit_unknown_raises_value_error(self) -> None:
-        cfg = _config(embedding_provider="unknown_value")
+        cfg = _config(provider="unknown_value")
         with pytest.raises(
             ValueError, match="Valid values: 'openai', 'ollama', 'fastembed'"
         ):


### PR DESCRIPTION
Refs #579 (PR B of 3). PR A (#611) removed the dead auth duplicates; this groups the remaining domain fields into composed sub-configs. PR C (from_env + frozen, now unblocked by pvl-core v3.2.0) follows.

## What
`CollectionConfig`'s ~37 flat domain fields move into six composed sub-config dataclasses in a new `config_sections/` package: `GitConfig`, `IndexingConfig`, `EmbeddingsConfig`, `SearchConfig`, `SyncConfig`, `ContentConfig`. `source_dir`, `read_only`, `server_name`, `instructions`, and `server: ServerConfig` stay top-level.

`load_config()` stays the entrypoint and builds the sub-configs from the same env reads; `to_collection_kwargs()` + the src consumers (`providers.py`, `_server_deps.py`, `_server_resources.py`, `server.py`) + tests read `config.<group>.<field>`.

## Naming / shape decisions
- **`source_dir`/`read_only` stay top-level** (vault identity/mode) so the common `CollectionConfig(source_dir=...)` construction stays clean. Refines spec §6, which had grouped them into a `VaultConfig`.
- **Dropped redundant whole-group prefixes** (`git_token`→`config.git.token`, `embedding_provider`→`config.embeddings.provider`); **kept meaningful sub-prefixes** (`config.embeddings.ollama_host`, `config.sync.file_watcher_enabled`).
- The `ollama_host` non-empty/no-trailing-slash normalization moved from `CollectionConfig.__post_init__` to `EmbeddingsConfig.__post_init__`.

## No behaviour change
No env-var renames; every `MARKDOWN_VAULT_MCP_*` var is read exactly as before, just landing on a sub-config. Defaults preserved verbatim.

## Scope decision (pre-declared)
Field **validation** (e.g. `SearchConfig`'s `chunks_per_file >= 1`) stays in `load_config()` for now — that's the production path and behaviour is unchanged. Moving validation into the sub-configs' `__post_init__`/`from_env` is deferred to **PR C** (the `from_env`+frozen convergence), where env-reading itself moves into the sub-configs. Doing it here would be a behaviour change (direct construction would start raising); PR B is a pure no-behaviour-change relocation.

## Verification
1829 passed / 1 skipped / 1 xpassed; mypy + ruff clean (106 files). Full five-lens preflight + type-design/pr-test/code/comment analyzers run before this first push — clean at the ≥80 bar; sub-80 items (a stale `server.py` comment, `EmbeddingsConfig.__post_init__` direct-construction tests, `docs/design.md` structure entry) closed pre-push. config.py 808→712 LOC (the <400 target lands with PR C retiring the imperative `load_config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)