### PR TITLE
refactor(collection): extract reader/writer/graph/index facets (#604)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,11 @@ src/markdown_vault_mcp/
     index_writer.py    -- IndexWriter: single-owner FIFO writer thread + job dataclasses/runners
     readiness.py       -- ReadinessState: build-readiness state machine (#576)
     coordinator.py     -- IndexWriteCoordinator: owns the writer + build/async orchestration (#576)
+  facets/
+    reader.py          -- ReaderFacet: search/read/list/toc/similar/context/stats/history (#604)
+    writer.py          -- WriterFacet: write/edit/delete/rename/attachments (#604)
+    graph.py           -- GraphFacet: backlinks/outlinks/broken/orphans/most-linked/paths (#604)
+    index.py           -- IndexFacet: build/reindex/embeddings, readiness, writer + embeddings status (#604)
   scanner.py           -- file discovery, frontmatter parsing, chunking
   fts_index.py         -- SQLite FTS5 schema, BM25 search
   vector_index.py      -- numpy embeddings, cosine similarity

--- a/docs/design.md
+++ b/docs/design.md
@@ -82,6 +82,11 @@ markdown-vault-mcp (new package)
 |   +-- index_writer.py -- IndexWriter: single-owner FIFO writer thread + jobs/runners
 |   +-- readiness.py  -- ReadinessState: build-readiness state machine (#576)
 |   +-- coordinator.py -- IndexWriteCoordinator: writer + build/async orchestration (#576)
++-- facets/
+|   +-- reader.py     -- ReaderFacet: search/read/list/toc/similar/context/stats/history (#604)
+|   +-- writer.py     -- WriterFacet: write/edit/delete/rename/attachments (#604)
+|   +-- graph.py      -- GraphFacet: backlinks/outlinks/broken/orphans/most-linked/paths (#604)
+|   +-- index.py      -- IndexFacet: thin wrapper over the coordinator (#604)
 
 ifcraftcorpus (existing, refactored later)
 +-- depends on markdown-vault-mcp
@@ -1162,8 +1167,37 @@ isolated unit testing and clear dependency boundaries. Pure utility functions
 live in ``utils/text.py`` (normalization, position mapping, fuzzy matching) and
 ``utils/links.py`` (link target computation and replacement).
 
+#### Facets (`facets/`, #604)
+
+The ``facets/`` package groups the formerly-flat ``Collection`` surface into
+four cohesive views, each a thin delegator over the managers/coordinator the
+root already owns:
+
+| Facet | Surface | Collaborators |
+|-------|---------|--------------|
+| ``ReaderFacet`` | search, read, list, folders, tags, toc, recent, similar, context, stats, history, diff, read_attachment | ``SearchManager``, ``DocumentManager``, ``GitQueryManager``, ``require_built`` |
+| ``WriterFacet`` | write, edit, delete, rename, write_attachment | ``DocumentManager`` |
+| ``GraphFacet`` | backlinks, outlinks, broken_links, orphans, most_linked, connection_path | ``LinkManager``, ``require_built`` |
+| ``IndexFacet`` | build/reindex/embeddings (sync + async), readiness, writer status, embeddings_status | ``IndexWriteCoordinator`` (public subset only), ``IndexManager`` (embeddings_status) |
+
+``Collection`` constructs the facets once in ``__init__`` and exposes them via
+the ``reader`` / ``writer`` / ``graph`` / ``index`` properties. The bucket-3
+readiness gate (``require_built``) lives inside the facets — ``ReaderFacet``
+(``get_toc`` / ``get_similar`` / ``get_context``) and ``GraphFacet``
+(``get_backlinks`` / ``get_outlinks`` / ``get_connection_path``) call it before
+delegating, so the gate is expressed in exactly one place. ``IndexFacet`` is a
+deliberate wrapper: it surfaces the coordinator's public operations (plus
+``IndexManager.embeddings_status``) and hides the root-owned coordinator
+internals (``close``, ``writer``, ``require_built``, ``mark_paths_dirty``,
+``rebuild_embeddings``).
+
+The migration follows **addition before removal**: the flat ``Collection``
+methods now delegate to the facets (PR3a, #604); callers migrate to the facet
+accessors in follow-up PRs (#605, #606); the flat methods are removed and
+``Collection`` is renamed to ``Vault`` in the final PR.
+
 Collection's public API signatures remain unchanged — clients interact with
-Collection, never with managers directly.
+Collection (or, increasingly, its facets), never with managers directly.
 
 ```python
 class Collection:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -11,6 +11,12 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Any, Literal
 
+from markdown_vault_mcp.facets import (
+    GraphFacet,
+    IndexFacet,
+    ReaderFacet,
+    WriterFacet,
+)
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.indexing import IndexWriteCoordinator
 from markdown_vault_mcp.scanner import (
@@ -261,7 +267,7 @@ class Collection:
 
         # 1. LinkManager (no deps)
         self._link_mgr = LinkManager(fts=self._fts, source_dir=self._source_dir)
-        # 1b. GitQueryManager (git history/diff reads; needs only git_strategy)
+        # 1b. GitQueryManager (git history/diff reads; needs git_strategy + source_dir)
         self._git_query_mgr = GitQueryManager(self._git_strategy, self._source_dir)
         # 2. IndexManager (needs fts, tracker — NOT search_mgr)
         #    get_vectors/set_vectors use late-binding lambdas that capture
@@ -332,6 +338,47 @@ class Collection:
             on_write_callback=self._write_callback.fire,
             mark_paths_dirty=self._coordinator.mark_paths_dirty,
         )
+
+        # Facets (#604): thin views grouping the formerly-flat surface,
+        # constructed once over the shared managers/coordinator. The flat
+        # methods below delegate to them (addition before removal).
+        self._reader_facet = ReaderFacet(
+            search_mgr=self._search_mgr,
+            doc_mgr=self._doc_mgr,
+            git_query_mgr=self._git_query_mgr,
+            require_built=self._require_built,
+        )
+        self._writer_facet = WriterFacet(self._doc_mgr)
+        self._graph_facet = GraphFacet(
+            link_mgr=self._link_mgr, require_built=self._require_built
+        )
+        self._index_facet = IndexFacet(
+            coordinator=self._coordinator, index_mgr=self._index_mgr
+        )
+
+    # ------------------------------------------------------------------
+    # Facets (#604)
+    # ------------------------------------------------------------------
+
+    @property
+    def reader(self) -> ReaderFacet:
+        """Read-only facet: search, read, list, toc, similar, stats, history."""
+        return self._reader_facet
+
+    @property
+    def writer(self) -> WriterFacet:
+        """Document-mutation facet: write, edit, delete, rename, attachments."""
+        return self._writer_facet
+
+    @property
+    def graph(self) -> GraphFacet:
+        """Link-graph facet: backlinks, outlinks, broken, orphans, paths."""
+        return self._graph_facet
+
+    @property
+    def index(self) -> IndexFacet:
+        """Index facet: build/reindex/embeddings, readiness, writer status."""
+        return self._index_facet
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -462,7 +509,7 @@ class Collection:
         A captured build error does NOT demote queryability: it is
         diagnostic state surfaced via :meth:`get_index_status`, not a gate.
         """
-        return self._coordinator.is_queryable()
+        return self._index_facet.is_queryable()
 
     def start_background_build_index(self) -> None:
         """Spawn a daemon thread that runs :meth:`build_index` to completion.
@@ -470,7 +517,7 @@ class Collection:
         .. deprecated:: 1.28
            Superseded by :meth:`build_index_async`. Retained for legacy tests.
         """
-        self._coordinator.start_background_build_index()
+        self._index_facet.start_background_build_index()
 
     def should_use_background_build(self) -> bool:
         """Return True iff the lifespan should route to the background build.
@@ -478,7 +525,7 @@ class Collection:
         .. deprecated:: 1.28
            Retained for legacy tests; the lifespan no longer branches on it.
         """
-        return self._coordinator.should_use_background_build()
+        return self._index_facet.should_use_background_build()
 
     def is_drained(self) -> bool:
         """Return True iff the IndexWriter has no pending or in-flight work.
@@ -486,7 +533,7 @@ class Collection:
         Reflects the moment of call only; pair with :meth:`write_generation`
         to detect a complete write cycle inside a read window.
         """
-        return self._coordinator.is_drained()
+        return self._index_facet.is_drained()
 
     def write_generation(self) -> int:
         """Return the writer's monotonic completion counter.
@@ -494,11 +541,11 @@ class Collection:
         Increments once per completed job. Pair with :meth:`is_drained` to
         detect a write cycle inside a read window.
         """
-        return self._coordinator.write_generation()
+        return self._index_facet.write_generation()
 
     def wait_for_drain(self, timeout: float | None = None) -> bool:
         """Block until :meth:`is_drained`, or until *timeout* (best-effort)."""
-        return self._coordinator.wait_for_drain(timeout)
+        return self._index_facet.wait_for_drain(timeout)
 
     def get_index_status(self) -> dict[str, Any]:
         """Return a non-blocking eleven-key snapshot of build + writer state.
@@ -512,7 +559,7 @@ class Collection:
         ``queryable`` status; ``documents_indexed_error`` carries a SQLite
         read failure (``documents_indexed`` stays ``0``) (#583).
         """
-        return self._coordinator.get_index_status()
+        return self._index_facet.get_index_status()
 
     def wait_until_queryable(self, timeout: float | None = None) -> None:
         """Block until the FTS index is queryable, or raise.
@@ -527,7 +574,7 @@ class Collection:
                 build ran and failed (``reason="build_failed"``), or no build
                 was ever scheduled (``reason="never_built"``).
         """
-        self._coordinator.wait_until_queryable(timeout)
+        self._index_facet.wait_until_queryable(timeout)
 
     @property
     def _vectors(self) -> VectorIndex | None:
@@ -578,7 +625,7 @@ class Collection:
             ValueError: If *mode* is ``"semantic"`` or ``"hybrid"`` but no
                 embedding provider or embeddings path is configured.
         """
-        return self._search_mgr.search(
+        return self._reader_facet.search(
             query,
             limit=limit,
             mode=mode,
@@ -607,7 +654,7 @@ class Collection:
             A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``
             if the file does not exist.
         """
-        return self._doc_mgr.read(path, section=section)
+        return self._reader_facet.read(path, section=section)
 
     def list_documents(
         self,
@@ -633,7 +680,7 @@ class Collection:
             optionally :class:`~markdown_vault_mcp.types.AttachmentInfo`)
             objects.
         """
-        return self._search_mgr.list(
+        return self._reader_facet.list_documents(
             folder=folder, pattern=pattern, include_attachments=include_attachments
         )
 
@@ -651,7 +698,7 @@ class Collection:
         Returns:
             :class:`~markdown_vault_mcp.types.IndexStats` describing what was indexed.
         """
-        return self._coordinator.build_index(force=force)
+        return self._index_facet.build_index(force=force)
 
     def reindex(self) -> ReindexResult:
         """Incrementally update the index based on file changes.
@@ -662,7 +709,7 @@ class Collection:
         Raises:
             IndexUnavailableError: If :meth:`build_index` has not been called.
         """
-        return self._coordinator.reindex()
+        return self._index_facet.reindex()
 
     def build_embeddings(self, *, force: bool = False) -> int:
         """Build the vector index from all chunks currently in the FTS index.
@@ -678,7 +725,7 @@ class Collection:
             IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is unset.
         """
-        return self._coordinator.build_embeddings(force=force)
+        return self._index_facet.build_embeddings(force=force)
 
     def build_index_async(self, *, force: bool = False) -> Future[IndexStats]:
         """Submit a full FTS index build and return the Future.
@@ -693,7 +740,7 @@ class Collection:
         Returns:
             ``concurrent.futures.Future`` carrying the :class:`IndexStats`.
         """
-        return self._coordinator.build_index_async(force=force)
+        return self._index_facet.build_index_async(force=force)
 
     def reindex_async(self) -> Future[ReindexResult]:
         """Submit an incremental FTS reindex and return the Future.
@@ -702,7 +749,7 @@ class Collection:
         orders any earlier :class:`BuildIndex` before this job. Writer-thread
         failures are surfaced via :meth:`get_index_status` (#561).
         """
-        return self._coordinator.reindex_async()
+        return self._index_facet.reindex_async()
 
     def build_embeddings_async(self, *, force: bool = False) -> Future[int]:
         """Submit a vector index build and return the Future.
@@ -711,7 +758,7 @@ class Collection:
         earlier :class:`BuildIndex` first. Writer-thread failures are surfaced
         via :meth:`get_index_status` (#561).
         """
-        return self._coordinator.build_embeddings_async(force=force)
+        return self._index_facet.build_embeddings_async(force=force)
 
     def embeddings_status(self) -> dict[str, Any]:
         """Return status information about the vector index.
@@ -720,7 +767,7 @@ class Collection:
             Dict with keys ``provider``, ``chunk_count``, ``path``,
             ``available``.
         """
-        return self._index_mgr.embeddings_status()
+        return self._index_facet.embeddings_status()
 
     # ------------------------------------------------------------------
     # Metadata
@@ -732,7 +779,7 @@ class Collection:
         Returns:
             Sorted list of folder strings (``""`` for the collection root).
         """
-        return self._search_mgr.list_folders()
+        return self._reader_facet.list_folders()
 
     def list_tags(self, field: str = "tags") -> list[str]:
         """Return all distinct values indexed for a given frontmatter field.
@@ -745,7 +792,7 @@ class Collection:
         Returns:
             Sorted list of distinct value strings.
         """
-        return self._search_mgr.list_tags(field)
+        return self._reader_facet.list_tags(field)
 
     def get_toc(self, path: str) -> list[dict[str, Any]]:
         """Return table of contents for a document.
@@ -765,8 +812,7 @@ class Collection:
             IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
-        self._require_built()
-        return self._doc_mgr.get_toc(path)
+        return self._reader_facet.get_toc(path)
 
     def get_backlinks(self, path: str) -> list[BacklinkInfo]:
         """Return all documents that link to the given document.
@@ -783,8 +829,7 @@ class Collection:
             IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
-        self._require_built()
-        return self._link_mgr.get_backlinks(path)
+        return self._graph_facet.get_backlinks(path)
 
     def get_outlinks(self, path: str) -> list[OutlinkInfo]:
         """Return all links from the given document to other documents.
@@ -804,8 +849,7 @@ class Collection:
             IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
-        self._require_built()
-        return self._link_mgr.get_outlinks(path)
+        return self._graph_facet.get_outlinks(path)
 
     def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
         """Return all links whose target does not exist in the collection.
@@ -817,7 +861,7 @@ class Collection:
         Returns:
             List of :class:`~markdown_vault_mcp.types.BrokenLinkInfo` objects.
         """
-        return self._link_mgr.get_broken_links(folder=folder)
+        return self._graph_facet.get_broken_links(folder=folder)
 
     def get_similar(
         self,
@@ -844,8 +888,7 @@ class Collection:
         Raises:
             IndexUnavailableError: If :meth:`build_index` has not been called.
         """
-        self._require_built()
-        return self._search_mgr.get_similar(
+        return self._reader_facet.get_similar(
             path, limit=limit, chunks_per_file=chunks_per_file
         )
 
@@ -863,7 +906,7 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.NoteInfo` objects
             ordered by modification time (most recent first).
         """
-        return self._search_mgr.get_recent(limit=limit, folder=folder)
+        return self._reader_facet.get_recent(limit=limit, folder=folder)
 
     def get_context(
         self,
@@ -894,8 +937,7 @@ class Collection:
             IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
-        self._require_built()
-        return self._search_mgr.get_context(
+        return self._reader_facet.get_context(
             path, similar_limit=similar_limit, link_limit=link_limit
         )
 
@@ -909,7 +951,7 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.NoteInfo` objects,
             ordered by path.
         """
-        return self._link_mgr.get_orphan_notes()
+        return self._graph_facet.get_orphan_notes()
 
     def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]:
         """Return the documents with the most inbound links.
@@ -921,7 +963,7 @@ class Collection:
             List of :class:`~markdown_vault_mcp.types.MostLinkedNote` ordered
             by backlink_count descending.
         """
-        return self._link_mgr.get_most_linked(limit=limit)
+        return self._graph_facet.get_most_linked(limit=limit)
 
     def get_connection_path(
         self, source: str, target: str, max_depth: int = 10
@@ -945,8 +987,9 @@ class Collection:
             IndexUnavailableError: If :meth:`build_index` has not been called.
             ValueError: If *source* or *target* is not found in the index.
         """
-        self._require_built()
-        return self._link_mgr.get_connection_path(source, target, max_depth=max_depth)
+        return self._graph_facet.get_connection_path(
+            source, target, max_depth=max_depth
+        )
 
     # ------------------------------------------------------------------
     # Git history query methods
@@ -993,7 +1036,9 @@ class Collection:
         Raises:
             ValueError: If *path* is provided but fails path validation.
         """
-        return self._git_query_mgr.get_history(path, since, until, limit)
+        return self._reader_facet.get_history(
+            path, since=since, until=until, limit=limit
+        )
 
     def get_diff(
         self,
@@ -1040,7 +1085,7 @@ class Collection:
                 not supplied, *since_sha* contains invalid characters, or the
                 resolved ref is not found in history.
         """
-        return self._git_query_mgr.get_diff(
+        return self._reader_facet.get_diff(
             path,
             since_sha=since_sha,
             since_timestamp=since_timestamp,
@@ -1051,9 +1096,9 @@ class Collection:
     def stats(self) -> CollectionStats:
         """Return collection-wide statistics.
 
-        Delegates to :meth:`SearchManager.stats`.
+        Delegates to :meth:`SearchManager.stats` via the reader facet.
         """
-        return self._search_mgr.stats()
+        return self._reader_facet.stats()
 
     # ------------------------------------------------------------------
     # Write operations (delegated to DocumentManager)
@@ -1085,7 +1130,7 @@ class Collection:
 
         Delegates to :meth:`DocumentManager.read_attachment`.
         """
-        return self._doc_mgr.read_attachment(path)
+        return self._reader_facet.read_attachment(path)
 
     def write_attachment(
         self,
@@ -1103,7 +1148,7 @@ class Collection:
         already validated against ``MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES``);
         leave ``False`` for base64 callers of the MCP ``write`` tool.
         """
-        return self._doc_mgr.write_attachment(
+        return self._writer_facet.write_attachment(
             path, content, if_match=if_match, skip_size_cap=skip_size_cap
         )
 
@@ -1137,7 +1182,7 @@ class Collection:
                 not match the current file hash.
             ValueError: If *path* escapes the source directory.
         """
-        return self._doc_mgr.write(
+        return self._writer_facet.write(
             path, content, frontmatter=frontmatter, if_match=if_match
         )
 
@@ -1177,7 +1222,7 @@ class Collection:
                 not match.
             ValueError: If *path* escapes the source directory.
         """
-        return self._doc_mgr.edit(
+        return self._writer_facet.edit(
             path,
             old_text=old_text,
             new_text=new_text,
@@ -1206,7 +1251,7 @@ class Collection:
                 not match.
             DocumentNotFoundError: If *path* does not exist.
         """
-        return self._doc_mgr.delete(path, if_match=if_match)
+        return self._writer_facet.delete(path, if_match=if_match)
 
     def rename(
         self,
@@ -1241,6 +1286,6 @@ class Collection:
             ValueError: If *old_path* or *new_path* escapes the source
                 directory.
         """
-        return self._doc_mgr.rename(
+        return self._writer_facet.rename(
             old_path, new_path, if_match=if_match, update_links=update_links
         )

--- a/src/markdown_vault_mcp/facets/__init__.py
+++ b/src/markdown_vault_mcp/facets/__init__.py
@@ -1,0 +1,16 @@
+"""Cohesive facets over the Collection composition root (#576 / #604).
+
+Each facet is a thin view holding references to the collaborators it needs
+(managers + coordinator), grouping the formerly-flat ``Collection`` surface
+into ``reader`` / ``writer`` / ``graph`` / ``index``. The single ``Collection``
+root owns one shared core and constructs the facets once; the flat methods
+delegate to them (addition before removal — see the facet architecture in
+``docs/design.md``).
+"""
+
+from markdown_vault_mcp.facets.graph import GraphFacet
+from markdown_vault_mcp.facets.index import IndexFacet
+from markdown_vault_mcp.facets.reader import ReaderFacet
+from markdown_vault_mcp.facets.writer import WriterFacet
+
+__all__ = ["GraphFacet", "IndexFacet", "ReaderFacet", "WriterFacet"]

--- a/src/markdown_vault_mcp/facets/graph.py
+++ b/src/markdown_vault_mcp/facets/graph.py
@@ -1,0 +1,142 @@
+"""Graph facet: the link-graph query surface (#604).
+
+A thin view over :class:`~markdown_vault_mcp.managers.link.LinkManager`
+exposing backlinks / outlinks / broken-links / orphans / most-linked /
+connection-path queries. Part of the ``collection.py`` facade decomposition
+(#576). The bucket-3 methods (:meth:`get_backlinks`, :meth:`get_outlinks`,
+:meth:`get_connection_path`) gate on the index-readiness callback before
+delegating; the bucket-2 methods operate on a cold index.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from markdown_vault_mcp.managers.link import LinkManager
+    from markdown_vault_mcp.types import (
+        BacklinkInfo,
+        BrokenLinkInfo,
+        MostLinkedNote,
+        NoteInfo,
+        OutlinkInfo,
+    )
+
+
+class GraphFacet:
+    """Link-graph queries, backed by :class:`LinkManager`."""
+
+    def __init__(
+        self, *, link_mgr: LinkManager, require_built: Callable[[], None]
+    ) -> None:
+        """Hold the link manager and the index-readiness gate.
+
+        Args:
+            link_mgr: The shared :class:`LinkManager` owned by the root.
+            require_built: Raises :exc:`IndexUnavailableError` if the index has
+                not been built; called by the bucket-3 query methods.
+        """
+        self._link_mgr = link_mgr
+        self._require_built = require_built
+
+    def get_backlinks(self, path: str) -> list[BacklinkInfo]:
+        """Return all documents that link to the given document.
+
+        Args:
+            path: Relative path of the target document
+                (e.g. ``"notes/topic.md"``).
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.BacklinkInfo` objects
+            for each document that contains a link pointing to ``path``.
+
+        Raises:
+            IndexUnavailableError: If :meth:`build_index` has not been called.
+            ValueError: If no document exists at the given path.
+        """
+        self._require_built()
+        return self._link_mgr.get_backlinks(path)
+
+    def get_outlinks(self, path: str) -> list[OutlinkInfo]:
+        """Return all links from the given document to other documents.
+
+        The ``exists`` field on each :class:`~markdown_vault_mcp.types.OutlinkInfo`
+        indicates whether the target document is currently indexed.
+
+        Args:
+            path: Relative path of the source document
+                (e.g. ``"notes/topic.md"``).
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.OutlinkInfo` objects for
+            each link originating from ``path``.
+
+        Raises:
+            IndexUnavailableError: If :meth:`build_index` has not been called.
+            ValueError: If no document exists at the given path.
+        """
+        self._require_built()
+        return self._link_mgr.get_outlinks(path)
+
+    def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
+        """Return all links whose target does not exist in the collection.
+
+        Args:
+            folder: If provided, restrict to source documents in this folder
+                (exact match or sub-folder prefix).
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.BrokenLinkInfo` objects.
+        """
+        return self._link_mgr.get_broken_links(folder=folder)
+
+    def get_orphan_notes(self) -> list[NoteInfo]:
+        """Return all documents with no inbound or outbound links.
+
+        A document is an orphan if it has zero outlinks and is not referenced
+        by any other document's links.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.NoteInfo` objects,
+            ordered by path.
+        """
+        return self._link_mgr.get_orphan_notes()
+
+    def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]:
+        """Return the documents with the most inbound links.
+
+        Args:
+            limit: Maximum number of results to return. Default 10.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.MostLinkedNote` ordered
+            by backlink_count descending.
+        """
+        return self._link_mgr.get_most_linked(limit=limit)
+
+    def get_connection_path(
+        self, source: str, target: str, max_depth: int = 10
+    ) -> list[str] | None:
+        """Return the shortest undirected path between two notes.
+
+        Treats the link graph as undirected — a link in either direction
+        counts as a connection.  Uses BFS with a configurable depth cap.
+
+        Args:
+            source: Vault-relative path of the starting note.
+            target: Vault-relative path of the destination note.
+            max_depth: Maximum path length in edges.  Clamped to ``[1, 10]``.
+                Defaults to ``10``.
+
+        Returns:
+            Ordered list of vault-relative paths from *source* to *target*
+            (inclusive), or ``None`` if unreachable within *max_depth* hops.
+
+        Raises:
+            IndexUnavailableError: If :meth:`build_index` has not been called.
+            ValueError: If *source* or *target* is not found in the index.
+        """
+        self._require_built()
+        return self._link_mgr.get_connection_path(source, target, max_depth=max_depth)

--- a/src/markdown_vault_mcp/facets/index.py
+++ b/src/markdown_vault_mcp/facets/index.py
@@ -1,0 +1,202 @@
+"""Index facet: the build / readiness / writer-status surface (#604).
+
+A thin view over the
+:class:`~markdown_vault_mcp.indexing.IndexWriteCoordinator` (build / reindex /
+embeddings sync + async, plus the readiness and writer-status queries) and
+:class:`~markdown_vault_mcp.managers.index.IndexManager`
+(:meth:`embeddings_status`). It deliberately does NOT expose the coordinator's
+internal surface (``close``, ``writer``, ``require_built``,
+``mark_paths_dirty``, ``rebuild_embeddings``), which the root owns. Part of the
+``collection.py`` facade decomposition (#576).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from concurrent.futures import Future
+    from typing import Any
+
+    from markdown_vault_mcp.indexing import IndexWriteCoordinator
+    from markdown_vault_mcp.managers.index import IndexManager
+    from markdown_vault_mcp.types import IndexStats, ReindexResult
+
+
+class IndexFacet:
+    """Index build, readiness, writer-status, and embeddings-status operations.
+
+    Delegates 1:1 to the :class:`IndexWriteCoordinator` (build / readiness /
+    writer status) and to :class:`IndexManager` (:meth:`embeddings_status`).
+    """
+
+    def __init__(
+        self,
+        *,
+        coordinator: IndexWriteCoordinator,
+        index_mgr: IndexManager,
+    ) -> None:
+        """Hold the collaborators the index operations delegate to.
+
+        Args:
+            coordinator: The shared :class:`IndexWriteCoordinator` owned by the
+                root. Only its public operations are surfaced here.
+            index_mgr: The shared :class:`IndexManager`, queried by
+                :meth:`embeddings_status`.
+        """
+        self._coordinator = coordinator
+        self._index_mgr = index_mgr
+
+    def is_queryable(self) -> bool:
+        """Return True when the FTS index is queryable (precondition snapshot).
+
+        A captured build error does NOT demote queryability: it is
+        diagnostic state surfaced via :meth:`get_index_status`, not a gate.
+        """
+        return self._coordinator.is_queryable()
+
+    def start_background_build_index(self) -> None:
+        """Spawn a daemon thread that runs :meth:`build_index` to completion.
+
+        .. deprecated:: 1.28
+           Superseded by :meth:`build_index_async`. Retained for legacy tests.
+        """
+        self._coordinator.start_background_build_index()
+
+    def should_use_background_build(self) -> bool:
+        """Return True iff the lifespan should route to the background build.
+
+        .. deprecated:: 1.28
+           Retained for legacy tests; the lifespan no longer branches on it.
+        """
+        return self._coordinator.should_use_background_build()
+
+    def is_drained(self) -> bool:
+        """Return True iff the IndexWriter has no pending or in-flight work.
+
+        Reflects the moment of call only; pair with :meth:`write_generation`
+        to detect a complete write cycle inside a read window.
+        """
+        return self._coordinator.is_drained()
+
+    def write_generation(self) -> int:
+        """Return the writer's monotonic completion counter.
+
+        Increments once per completed job. Pair with :meth:`is_drained` to
+        detect a write cycle inside a read window.
+        """
+        return self._coordinator.write_generation()
+
+    def wait_for_drain(self, timeout: float | None = None) -> bool:
+        """Block until :meth:`is_drained`, or until *timeout* (best-effort)."""
+        return self._coordinator.wait_for_drain(timeout)
+
+    def get_index_status(self) -> dict[str, Any]:
+        """Return a non-blocking eleven-key snapshot of build + writer state.
+
+        Keys: ``status`` (``"queryable"`` | ``"building"`` | ``"failed"``),
+        ``documents_indexed``, ``documents_indexed_error``, ``error``,
+        ``last_reindex_error``, ``last_build_embeddings_error``, plus
+        ``queue_depth``, ``in_flight``, ``dirty_paths``, ``dirty_embeddings``,
+        ``write_generation`` merged from the writer. A captured build error
+        appears in ``error`` as diagnostic context without demoting a
+        ``queryable`` status; ``documents_indexed_error`` carries a SQLite
+        read failure (``documents_indexed`` stays ``0``) (#583).
+        """
+        return self._coordinator.get_index_status()
+
+    def wait_until_queryable(self, timeout: float | None = None) -> None:
+        """Block until the FTS index is queryable, or raise.
+
+        A captured build error does NOT block here; it surfaces as
+        ``IndexUnavailableError(reason="build_failed")`` and is also readable
+        via :meth:`get_index_status`. Library bucket-3/4 methods use the
+        root's ``_require_built`` instead, which raises immediately.
+
+        Raises:
+            IndexUnavailableError: timeout expired (``reason="timeout"``), a
+                build ran and failed (``reason="build_failed"``), or no build
+                was ever scheduled (``reason="never_built"``).
+        """
+        self._coordinator.wait_until_queryable(timeout)
+
+    def build_index(self, *, force: bool = False) -> IndexStats:
+        """Scan source_dir and build the FTS index.
+
+        Warm restarts (existing populated index, ``force=False``) are an O(1)
+        no-op keyed on FTS state. ``force=True`` drops and rebuilds; config
+        changes require ``force=True`` to apply (see issue #525).
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.IndexStats` describing what was indexed.
+        """
+        return self._coordinator.build_index(force=force)
+
+    def reindex(self) -> ReindexResult:
+        """Incrementally update the index based on file changes.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.ReindexResult` with counts applied.
+
+        Raises:
+            IndexUnavailableError: If :meth:`build_index` has not been called.
+        """
+        return self._coordinator.reindex()
+
+    def build_embeddings(self, *, force: bool = False) -> int:
+        """Build the vector index from all chunks currently in the FTS index.
+
+        Args:
+            force: If ``True``, rebuild from scratch even if a vector index
+                already exists on disk.
+
+        Returns:
+            Total number of chunks embedded.
+
+        Raises:
+            IndexUnavailableError: If :meth:`build_index` has not been called.
+            ValueError: If ``embedding_provider`` or ``embeddings_path`` is unset.
+        """
+        return self._coordinator.build_embeddings(force=force)
+
+    def build_index_async(self, *, force: bool = False) -> Future[IndexStats]:
+        """Submit a full FTS index build and return the Future.
+
+        Caller may ``.result()`` to wait or fire-and-forget. Warm-restart
+        short-circuit returns an already-resolved Future without queuing a
+        job, mirroring :meth:`build_index`.
+
+        Args:
+            force: When ``True``, drop and rebuild the index unconditionally.
+
+        Returns:
+            ``concurrent.futures.Future`` carrying the :class:`IndexStats`.
+        """
+        return self._coordinator.build_index_async(force=force)
+
+    def reindex_async(self) -> Future[ReindexResult]:
+        """Submit an incremental FTS reindex and return the Future.
+
+        Does not require :meth:`build_index` first — the writer's FIFO queue
+        orders any earlier :class:`BuildIndex` before this job. Writer-thread
+        failures are surfaced via :meth:`get_index_status` (#561).
+        """
+        return self._coordinator.reindex_async()
+
+    def build_embeddings_async(self, *, force: bool = False) -> Future[int]:
+        """Submit a vector index build and return the Future.
+
+        Does not require :meth:`build_index` first — FIFO ordering runs any
+        earlier :class:`BuildIndex` first. Writer-thread failures are surfaced
+        via :meth:`get_index_status` (#561).
+        """
+        return self._coordinator.build_embeddings_async(force=force)
+
+    def embeddings_status(self) -> dict[str, Any]:
+        """Return status information about the vector index.
+
+        Returns:
+            Dict with keys ``provider``, ``chunk_count``, ``path``,
+            ``available``.
+        """
+        return self._index_mgr.embeddings_status()

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -1,0 +1,388 @@
+"""Reader facet: the read-only query surface (#604).
+
+A thin view exposing search, document reads, listing, table-of-contents,
+similarity, recent, context, stats, attachment reads, and git history/diff.
+Each method delegates 1:1 to one collaborator (:class:`SearchManager`,
+:class:`DocumentManager`, or :class:`GitQueryManager`); the bucket-3 methods
+(:meth:`get_toc`,
+:meth:`get_similar`, :meth:`get_context`) gate on the index-readiness callback
+first. Part of the ``collection.py`` facade decomposition (#576); the flat
+``Collection`` read methods delegate here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any, Literal
+
+    from markdown_vault_mcp.managers.document import DocumentManager
+    from markdown_vault_mcp.managers.git_query import GitQueryManager
+    from markdown_vault_mcp.managers.search import SearchManager
+    from markdown_vault_mcp.types import (
+        AttachmentContent,
+        AttachmentInfo,
+        CollectionStats,
+        CommitDiff,
+        GroupedResult,
+        HistoryEntry,
+        NoteContent,
+        NoteContext,
+        NoteInfo,
+    )
+
+
+class ReaderFacet:
+    """Read-only queries over the shared managers."""
+
+    def __init__(
+        self,
+        *,
+        search_mgr: SearchManager,
+        doc_mgr: DocumentManager,
+        git_query_mgr: GitQueryManager,
+        require_built: Callable[[], None],
+    ) -> None:
+        """Hold the managers the read methods delegate to.
+
+        Args:
+            search_mgr: Search / list / similarity / context / recent / stats
+                queries.
+            doc_mgr: Document and attachment reads, table-of-contents.
+            git_query_mgr: Git history / diff reads.
+            require_built: Index-readiness gate for the bucket-3 methods.
+        """
+        self._search_mgr = search_mgr
+        self._doc_mgr = doc_mgr
+        self._git_query_mgr = git_query_mgr
+        self._require_built = require_built
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+        filters: dict[str, str] | None = None,
+        folder: str | None = None,
+        chunks_per_file: int | None = None,
+        snippet_words: int | None = None,
+    ) -> list[GroupedResult]:
+        """Search the collection.
+
+        Args:
+            query: Search string.
+            limit: Maximum number of files (not chunks) to return.
+            mode: ``"keyword"`` for BM25 FTS5, ``"semantic"`` for cosine
+                similarity, or ``"hybrid"`` for Reciprocal Rank Fusion of both.
+            filters: Dict of ``{frontmatter_key: value}`` pairs (AND semantics).
+                Only works for fields in ``indexed_frontmatter_fields``.
+            folder: If provided, restrict results to documents in this folder
+                (and its sub-folders).
+            chunks_per_file: Maximum number of sections returned per file.
+                ``None`` uses the server default configured at startup.
+            snippet_words: Width of the snippet window in words.  ``0`` returns
+                the full chunk.  ``None`` uses the server default.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.GroupedResult` ordered
+            by descending file score (max of section scores).  Each result
+            wraps one document with up to ``chunks_per_file`` sections.
+
+        Raises:
+            ValueError: If *mode* is ``"semantic"`` or ``"hybrid"`` but no
+                embedding provider or embeddings path is configured.
+        """
+        return self._search_mgr.search(
+            query,
+            limit=limit,
+            mode=mode,
+            filters=filters,
+            folder=folder,
+            chunks_per_file=chunks_per_file,
+            snippet_words=snippet_words,
+        )
+
+    def read(self, path: str, *, section: str | None = None) -> NoteContent | None:
+        """Read the full content of a document from disk.
+
+        Args:
+            path: Relative document path (e.g. ``"Journal/note.md"``).
+            section: When provided, return only the section whose heading
+                matches *section* exactly (case-sensitive). Pass the
+                ``heading`` value from a ``search`` result unchanged for
+                guaranteed match. ``None`` (the default) returns the whole
+                document. Raises :exc:`ValueError` if the section is not found.
+
+        Returns:
+            A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``
+            if the file does not exist.
+        """
+        return self._doc_mgr.read(path, section=section)
+
+    def list_documents(
+        self,
+        *,
+        folder: str | None = None,
+        pattern: str | None = None,
+        include_attachments: bool = False,
+    ) -> list[NoteInfo | AttachmentInfo]:
+        """List documents (and optionally attachments) in the collection.
+
+        Args:
+            folder: If provided, only return documents in this folder (and
+                sub-folders).
+            pattern: Unix glob matched against the relative path using
+                :func:`fnmatch.fnmatch`.  Example: ``"Journal/*.md"``.
+            include_attachments: When ``True``, also return non-.md files
+                that match the attachment allowlist.  Each
+                :class:`~markdown_vault_mcp.types.AttachmentInfo` entry
+                includes ``kind="attachment"`` and ``mime_type``.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.NoteInfo` (and
+            optionally :class:`~markdown_vault_mcp.types.AttachmentInfo`)
+            objects.
+        """
+        return self._search_mgr.list(
+            folder=folder, pattern=pattern, include_attachments=include_attachments
+        )
+
+    def list_folders(self) -> list[str]:
+        """Return all distinct folder values across the indexed collection.
+
+        Returns:
+            Sorted list of folder strings (``""`` for the collection root).
+        """
+        return self._search_mgr.list_folders()
+
+    def list_tags(self, field: str = "tags") -> list[str]:
+        """Return all distinct values indexed for a given frontmatter field.
+
+        If *field* was not in ``indexed_frontmatter_fields``, returns ``[]``.
+
+        Args:
+            field: Frontmatter key to query (default: ``"tags"``).
+
+        Returns:
+            Sorted list of distinct value strings.
+        """
+        return self._search_mgr.list_tags(field)
+
+    def get_toc(self, path: str) -> list[dict[str, Any]]:
+        """Return table of contents for a document.
+
+        Queries the FTS sections table for headings and prepends the document
+        title as a synthetic H1 entry. The result depends on the FTS index, so
+        cold-start callers must build the index first (bucket 3).
+
+        Args:
+            path: Relative path to the document (e.g. ``"notes/intro.md"``).
+
+        Returns:
+            List of ``{"heading": str, "level": int}`` dicts ordered by
+            position, with the document title prepended as level 1.
+
+        Raises:
+            IndexUnavailableError: If :meth:`build_index` has not been called.
+            ValueError: If no document exists at the given path.
+        """
+        self._require_built()
+        return self._doc_mgr.get_toc(path)
+
+    def get_recent(
+        self, *, limit: int = 20, folder: str | None = None
+    ) -> list[NoteInfo]:
+        """Return the most recently modified documents.
+
+        Args:
+            limit: Maximum number of documents to return.
+            folder: If provided, restrict to documents in this folder
+                (exact match or sub-folder prefix).
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.NoteInfo` objects
+            ordered by modification time (most recent first).
+        """
+        return self._search_mgr.get_recent(limit=limit, folder=folder)
+
+    def get_similar(
+        self,
+        path: str,
+        *,
+        limit: int = 10,
+        chunks_per_file: int | None = None,
+    ) -> list[GroupedResult]:
+        """Return semantically similar documents grouped by file.
+
+        See :meth:`SearchManager.get_similar` for details.  Returns
+        :class:`~markdown_vault_mcp.types.GroupedResult` objects ordered by
+        descending file score; each result wraps one document with up to
+        ``chunks_per_file`` sections.
+
+        Args:
+            path: Relative path of the reference document.
+            limit: Maximum number of files to return.
+            chunks_per_file: Maximum sections per result file.
+
+        Returns:
+            List of grouped results.
+
+        Raises:
+            IndexUnavailableError: If :meth:`build_index` has not been called.
+        """
+        self._require_built()
+        return self._search_mgr.get_similar(
+            path, limit=limit, chunks_per_file=chunks_per_file
+        )
+
+    def get_context(
+        self,
+        path: str,
+        *,
+        similar_limit: int = 5,
+        link_limit: int = 10,
+    ) -> NoteContext:
+        """Return a consolidated context dossier for a document.
+
+        Combines backlinks, outlinks, similar notes, folder peers, and
+        indexed frontmatter tags into a single response, saving the caller
+        multiple round trips.
+
+        Args:
+            path: Relative path of the document (e.g. ``"notes/topic.md"``).
+            similar_limit: Maximum number of similar notes to include.
+            link_limit: Maximum number of backlinks and outlinks to include.
+
+        Returns:
+            A :class:`~markdown_vault_mcp.types.NoteContext` object.  Its
+            ``similar`` field is a list of
+            :class:`~markdown_vault_mcp.types.GroupedResult` entries, each
+            with exactly one section (chunks_per_file=1) so the dossier
+            stays compact.
+
+        Raises:
+            IndexUnavailableError: If :meth:`build_index` has not been called.
+            ValueError: If no document exists at the given path.
+        """
+        self._require_built()
+        return self._search_mgr.get_context(
+            path, similar_limit=similar_limit, link_limit=link_limit
+        )
+
+    def get_history(
+        self,
+        path: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 20,
+    ) -> list[HistoryEntry]:
+        """Return commits that touched a note or the whole vault.
+
+        When *path* is ``None``, queries the full vault history.  Returns an
+        empty list for vaults whose source directory is not inside a git
+        repository.
+
+        Args:
+            path: Vault-relative path of the note to filter on (e.g.
+                ``"notes/alpha.md"``).  Must end with ``.md``.  ``None``
+                returns vault-wide history.
+            since: ISO 8601 datetime string or git date expression (e.g.
+                ``"1 week ago"``).  Passed as ``--since`` to ``git log``.
+                ``None`` disables the filter.
+            until: ISO 8601 datetime string or git date expression, passed as
+                ``--until`` to ``git log``.  ``None`` disables the filter.
+                Both ``since`` and ``until`` boundaries are **inclusive**: a
+                commit whose committer date equals either endpoint is included
+                in the result.
+            limit: Maximum number of commits to return.  Clamped to
+                ``[1, 100]``.  Defaults to ``20``.
+
+        Returns:
+            List of :class:`~markdown_vault_mcp.types.HistoryEntry` ordered
+            newest-first.  Empty list when the vault has no git history or
+            the note has no commits in the given range.  The
+            ``paths_changed`` field on each entry is populated for vault-wide
+            queries (``path=None``); it is always empty for single-note
+            queries, since the path is already determined by the query
+            arguments — callers know which file the commit touched without
+            needing it echoed back.
+
+        Raises:
+            ValueError: If *path* is provided but fails path validation.
+        """
+        return self._git_query_mgr.get_history(
+            path, since=since, until=until, limit=limit
+        )
+
+    def get_diff(
+        self,
+        path: str,
+        since_sha: str | None = None,
+        since_timestamp: str | None = None,
+        per_commit: bool = False,
+        limit: int | None = None,
+    ) -> str | list[CommitDiff]:
+        """Return the diff of a note between a reference point and HEAD.
+
+        Exactly one of *since_sha* or *since_timestamp* must be supplied.
+
+        Args:
+            path: Vault-relative path of the note to diff.  Must end with
+                ``.md``.
+            since_sha: A commit SHA (full or abbreviated, at least 4 hex
+                digits) to diff from.  Mutually exclusive with
+                *since_timestamp*.
+            since_timestamp: ISO 8601 datetime string, resolved via
+                ``git rev-list --before=<ts> -1 HEAD`` to the most recent
+                commit at or before that instant.  Boundary is
+                **inclusive**: a commit whose committer date equals
+                *since_timestamp* IS the resolved ref.  Mutually exclusive
+                with *since_sha*.
+            per_commit: When ``False`` (default), return a single unified diff
+                string from the reference point to HEAD.  When ``True``,
+                return one :class:`~markdown_vault_mcp.types.CommitDiff` per
+                intervening commit.
+            limit: When *per_commit* is ``True``, cap the number of
+                intervening commits returned to the *limit* most recent ones.
+                Clamped to ``[1, 100]``.  ``None`` (the default) means
+                unbounded (still bounded by the underlying ``since..HEAD``
+                range).  Silently ignored when *per_commit* is ``False``.
+
+        Returns:
+            A unified diff string when *per_commit* is ``False``, or a list of
+            :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
+            ``True``.  Returns an empty string / empty list when the note has
+            no changes in the given range.
+
+        Raises:
+            ValueError: If exactly one of *since_sha* / *since_timestamp* is
+                not supplied, *since_sha* contains invalid characters, or the
+                resolved ref is not found in history.
+        """
+        return self._git_query_mgr.get_diff(
+            path,
+            since_sha=since_sha,
+            since_timestamp=since_timestamp,
+            per_commit=per_commit,
+            limit=limit,
+        )
+
+    def stats(self) -> CollectionStats:
+        """Return collection-wide statistics.
+
+        Delegates to :meth:`SearchManager.stats`.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.CollectionStats` snapshot.
+        """
+        return self._search_mgr.stats()
+
+    def read_attachment(self, path: str) -> AttachmentContent:
+        """Read the binary content of a non-.md attachment.
+
+        Delegates to :meth:`DocumentManager.read_attachment`.
+        """
+        return self._doc_mgr.read_attachment(path)

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -1,0 +1,207 @@
+"""Writer facet: the document-mutation surface (#604).
+
+A thin view over :class:`~markdown_vault_mcp.managers.document.DocumentManager`
+exposing the vault's write / edit / delete / rename / attachment operations.
+Part of the ``collection.py`` facade decomposition (#576); the flat
+``Collection.write`` / ``edit`` / ``delete`` / ``rename`` / ``write_attachment``
+methods delegate here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from markdown_vault_mcp.managers.document import DocumentManager
+    from markdown_vault_mcp.types import (
+        DeleteResult,
+        EditResult,
+        RenameResult,
+        WriteResult,
+    )
+
+
+class WriterFacet:
+    """Document-mutation operations, backed by :class:`DocumentManager`."""
+
+    def __init__(self, doc_mgr: DocumentManager) -> None:
+        """Hold the document manager the write operations delegate to.
+
+        Args:
+            doc_mgr: The shared :class:`DocumentManager` owned by the root.
+        """
+        self._doc_mgr = doc_mgr
+
+    def write(
+        self,
+        path: str,
+        content: str,
+        frontmatter: dict[str, Any] | None = None,
+        if_match: str | None = None,
+    ) -> WriteResult:
+        """Create or overwrite a document.
+
+        Creates intermediate directories as needed.  If *frontmatter* is
+        provided, it is serialised as a YAML header at the top of the file.
+
+        Args:
+            path: Relative document path (e.g. ``"notes/topic.md"``).
+            content: Markdown body (excluding frontmatter).
+            frontmatter: Optional frontmatter dict serialised as a YAML header.
+            if_match: Optional etag from a previous :meth:`read` call.  When
+                provided, the write is only performed if the current file hash
+                matches this value, preventing overwrites of concurrent
+                modifications.  Pass ``None`` (default) to skip the check.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.WriteResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current file hash.
+            ValueError: If *path* escapes the source directory.
+        """
+        return self._doc_mgr.write(
+            path, content, frontmatter=frontmatter, if_match=if_match
+        )
+
+    def edit(
+        self,
+        path: str,
+        old_text: str | None = None,
+        new_text: str = "",
+        if_match: str | None = None,
+        line_start: int | None = None,
+        line_end: int | None = None,
+    ) -> EditResult:
+        """Patch a section of a document.
+
+        Replaces the first occurrence of *old_text* with *new_text*, or
+        replaces the line range [*line_start*, *line_end*] when line numbers
+        are given instead.
+
+        Args:
+            path: Relative document path.
+            old_text: Exact text to replace (must occur exactly once).
+                Mutually exclusive with *line_start* / *line_end*.
+            new_text: Replacement text (may be empty to delete *old_text*).
+            if_match: Optional etag for optimistic concurrency; see
+                :meth:`write`.
+            line_start: 1-based start line for line-range mode.
+            line_end: 1-based end line (inclusive) for line-range mode.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.EditResult`.
+
+        Raises:
+            EditConflictError: If *old_text* is not found or appears more than
+                once.
+            ReadOnlyError: If the collection is read-only.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match.
+            ValueError: If *path* escapes the source directory.
+        """
+        return self._doc_mgr.edit(
+            path,
+            old_text=old_text,
+            new_text=new_text,
+            if_match=if_match,
+            line_start=line_start,
+            line_end=line_end,
+        )
+
+    def delete(self, path: str, if_match: str | None = None) -> DeleteResult:
+        """Delete a document or attachment.
+
+        Removes the file from disk and purges its entries from the FTS and
+        vector indices.
+
+        Args:
+            path: Relative path of the document or attachment to remove.
+            if_match: Optional etag for optimistic concurrency; see
+                :meth:`write`.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.DeleteResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match.
+            DocumentNotFoundError: If *path* does not exist.
+        """
+        return self._doc_mgr.delete(path, if_match=if_match)
+
+    def rename(
+        self,
+        old_path: str,
+        new_path: str,
+        if_match: str | None = None,
+        *,
+        update_links: bool = False,
+    ) -> RenameResult:
+        """Rename or move a document or attachment.
+
+        Moves the file on disk and updates the FTS / vector indices.  When
+        *update_links* is ``True``, all wikilinks and markdown links in other
+        documents that pointed to *old_path* are rewritten to *new_path*.
+
+        Args:
+            old_path: Current relative path of the document or attachment.
+            new_path: Desired relative path after the move.
+            if_match: Optional etag for optimistic concurrency; see
+                :meth:`write`.
+            update_links: When ``True``, rewrite internal links across the
+                vault to reflect the new path.  Defaults to ``False``.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.RenameResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match.
+            DocumentNotFoundError: If *old_path* does not exist.
+            ValueError: If *old_path* or *new_path* escapes the source
+                directory.
+        """
+        return self._doc_mgr.rename(
+            old_path,
+            new_path,
+            if_match=if_match,
+            update_links=update_links,
+        )
+
+    def write_attachment(
+        self,
+        path: str,
+        content: bytes,
+        if_match: str | None = None,
+        *,
+        skip_size_cap: bool = False,
+    ) -> WriteResult:
+        """Create or overwrite a non-.md attachment.
+
+        Delegates to :meth:`DocumentManager.write_attachment`.  Pass
+        ``skip_size_cap=True`` from callers that have their own size
+        gate (e.g. the ``create_upload_link`` receiver path, which has
+        already validated against ``MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES``);
+        leave ``False`` for base64 callers of the MCP ``write`` tool.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.WriteResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current file hash.
+            ValueError: If the path escapes the source directory, has an
+                extension not in the allowlist, or the content exceeds the
+                size limit (when *skip_size_cap* is ``False``).
+        """
+        return self._doc_mgr.write_attachment(
+            path, content, if_match=if_match, skip_size_cap=skip_size_cap
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,19 @@ def populated_collection(tmp_path: Path):
     return col
 
 
+@pytest.fixture
+def built(vault_path: Path):
+    """A built Collection over the clean vault fixture (shared by facet tests)."""
+    from markdown_vault_mcp.collection import Collection
+
+    col = Collection(source_dir=vault_path)
+    col.build_index()
+    try:
+        yield col
+    finally:
+        col.close()
+
+
 async def get_app_html() -> str:
     """Spin up a fresh server and fetch the SPA HTML resource."""
     from fastmcp import Client

--- a/tests/test_facet_graph.py
+++ b/tests/test_facet_graph.py
@@ -1,0 +1,57 @@
+"""Unit tests for GraphFacet (facade-decomposition PR3a, issue #604)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.exceptions import IndexUnavailableError
+from markdown_vault_mcp.facets.graph import GraphFacet
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestGraphFacetAccessor:
+    def test_accessor_returns_graph_facet(self, built: Collection) -> None:
+        assert isinstance(built.graph, GraphFacet)
+
+    def test_accessor_is_stable(self, built: Collection) -> None:
+        assert built.graph is built.graph
+
+
+class TestGraphFacetBehaviour:
+    def test_backlinks_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.graph.get_backlinks("full_frontmatter.md"), list)
+
+    def test_outlinks_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.graph.get_outlinks("full_frontmatter.md"), list)
+
+    def test_broken_links_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.graph.get_broken_links(), list)
+
+    def test_orphan_notes_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.graph.get_orphan_notes(), list)
+
+    def test_most_linked_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.graph.get_most_linked(), list)
+
+    def test_connection_path_returns_none_or_list(self, built: Collection) -> None:
+        result = built.graph.get_connection_path("full_frontmatter.md", "simple.md")
+        assert result is None or isinstance(result, list)
+
+
+class TestGraphFacetReadinessGate:
+    def test_bucket3_methods_raise_on_cold_index(self, vault_path: Path) -> None:
+        col = Collection(source_dir=vault_path)  # never built
+        try:
+            with pytest.raises(IndexUnavailableError):
+                col.graph.get_backlinks("full_frontmatter.md")
+            with pytest.raises(IndexUnavailableError):
+                col.graph.get_outlinks("full_frontmatter.md")
+            with pytest.raises(IndexUnavailableError):
+                col.graph.get_connection_path("full_frontmatter.md", "simple.md")
+        finally:
+            col.close()

--- a/tests/test_facet_index.py
+++ b/tests/test_facet_index.py
@@ -1,0 +1,53 @@
+"""Unit tests for IndexFacet (facade-decomposition PR3a, issue #604)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.facets.index import IndexFacet
+
+if TYPE_CHECKING:
+    from markdown_vault_mcp.collection import Collection
+
+
+class TestIndexFacetAccessor:
+    def test_accessor_returns_index_facet(self, built: Collection) -> None:
+        assert isinstance(built.index, IndexFacet)
+
+    def test_accessor_is_stable(self, built: Collection) -> None:
+        assert built.index is built.index
+
+
+class TestIndexFacetBehaviour:
+    def test_is_queryable_after_build(self, built: Collection) -> None:
+        assert built.index.is_queryable() is True
+
+    def test_get_index_status_reports_queryable(self, built: Collection) -> None:
+        assert built.index.get_index_status()["status"] == "queryable"
+
+    def test_is_drained_after_build(self, built: Collection) -> None:
+        assert built.index.is_drained() is True
+
+    def test_write_generation_is_int(self, built: Collection) -> None:
+        assert isinstance(built.index.write_generation(), int)
+
+    def test_reindex_runs(self, built: Collection) -> None:
+        # ReindexResult; just exercise the delegation end to end.
+        result = built.index.reindex()
+        assert result is not None
+
+    def test_embeddings_status_returns_dict(self, built: Collection) -> None:
+        assert isinstance(built.index.embeddings_status(), dict)
+
+
+class TestIndexFacetEncapsulation:
+    def test_hides_coordinator_internals(self, built: Collection) -> None:
+        """The wrapper must NOT surface the coordinator's internal methods."""
+        for internal in (
+            "close",
+            "writer",
+            "require_built",
+            "mark_paths_dirty",
+            "rebuild_embeddings",
+        ):
+            assert not hasattr(built.index, internal), internal

--- a/tests/test_facet_reader.py
+++ b/tests/test_facet_reader.py
@@ -1,0 +1,104 @@
+"""Unit tests for ReaderFacet (facade-decomposition PR3a, issue #604)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.exceptions import IndexUnavailableError
+from markdown_vault_mcp.facets.reader import ReaderFacet
+from markdown_vault_mcp.types import CollectionStats, NoteContext
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestReaderFacetAccessor:
+    def test_accessor_returns_reader_facet(self, built: Collection) -> None:
+        assert isinstance(built.reader, ReaderFacet)
+
+    def test_accessor_is_stable(self, built: Collection) -> None:
+        assert built.reader is built.reader
+
+
+class TestReaderFacetBehaviour:
+    def test_search_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.reader.search("frontmatter"), list)
+
+    def test_read_existing_document(self, built: Collection) -> None:
+        note = built.reader.read("full_frontmatter.md")
+        assert note is not None
+        assert note.path == "full_frontmatter.md"
+
+    def test_read_missing_returns_none(self, built: Collection) -> None:
+        assert built.reader.read("does/not/exist.md") is None
+
+    def test_list_documents_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.reader.list_documents(), list)
+
+    def test_list_folders_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.reader.list_folders(), list)
+
+    def test_list_tags_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.reader.list_tags(), list)
+
+    def test_get_recent_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.reader.get_recent(), list)
+
+    def test_get_toc_returns_list(self, built: Collection) -> None:
+        assert isinstance(built.reader.get_toc("full_frontmatter.md"), list)
+
+    def test_get_similar_empty_without_embeddings(self, built: Collection) -> None:
+        # No embedding provider configured -> semantic similarity degrades to [].
+        assert built.reader.get_similar("full_frontmatter.md") == []
+
+    def test_get_context_returns_note_context(self, built: Collection) -> None:
+        ctx = built.reader.get_context("full_frontmatter.md")
+        assert isinstance(ctx, NoteContext)
+        assert ctx.path == "full_frontmatter.md"
+
+    def test_stats_returns_collection_stats(self, built: Collection) -> None:
+        stats = built.reader.stats()
+        assert isinstance(stats, CollectionStats)
+        assert stats.document_count >= 1
+
+    def test_get_history_empty_without_git(self, built: Collection) -> None:
+        # vault fixture is not a git repo -> git strategy is None -> [].
+        assert built.reader.get_history() == []
+
+    def test_get_diff_empty_without_git(self, built: Collection) -> None:
+        # No git strategy -> empty string before any argument validation.
+        assert built.reader.get_diff("full_frontmatter.md") == ""
+
+
+class TestReaderFacetAttachments:
+    """Writable-collection attachment round-trip; owns its own lifecycle."""
+
+    def test_read_attachment_round_trips(self, vault_path: Path) -> None:
+        col = Collection(
+            source_dir=vault_path, read_only=False, attachment_extensions=["*"]
+        )
+        col.build_index()
+        try:
+            col.writer.write_attachment("facet_read.bin", b"\x01\x02\x03")
+            att = col.reader.read_attachment("facet_read.bin")
+            assert att.path == "facet_read.bin"
+            assert att.size_bytes == 3
+        finally:
+            col.close()
+
+
+class TestReaderFacetReadinessGate:
+    def test_bucket3_methods_raise_on_cold_index(self, vault_path: Path) -> None:
+        col = Collection(source_dir=vault_path)  # never built
+        try:
+            with pytest.raises(IndexUnavailableError):
+                col.reader.get_toc("full_frontmatter.md")
+            with pytest.raises(IndexUnavailableError):
+                col.reader.get_similar("full_frontmatter.md")
+            with pytest.raises(IndexUnavailableError):
+                col.reader.get_context("full_frontmatter.md")
+        finally:
+            col.close()

--- a/tests/test_facet_writer.py
+++ b/tests/test_facet_writer.py
@@ -1,0 +1,73 @@
+"""Unit tests for WriterFacet (facade-decomposition PR3a, issue #604).
+
+Exercises the writer facet through a real Collection (real on-disk effects),
+mirroring the flat-method assertions in test_collection.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.collection import Collection
+from markdown_vault_mcp.facets.writer import WriterFacet
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def writable(vault_path: Path) -> Iterator[Collection]:
+    """Writable, indexed collection accepting any attachment extension."""
+    col = Collection(
+        source_dir=vault_path, read_only=False, attachment_extensions=["*"]
+    )
+    col.build_index()
+    try:
+        yield col
+    finally:
+        col.close()
+
+
+class TestWriterFacetAccessor:
+    def test_accessor_returns_writer_facet(self, writable: Collection) -> None:
+        assert isinstance(writable.writer, WriterFacet)
+
+    def test_accessor_is_stable(self, writable: Collection) -> None:
+        assert writable.writer is writable.writer
+
+
+class TestWriterFacetBehaviour:
+    def test_write_creates_document(
+        self, writable: Collection, vault_path: Path
+    ) -> None:
+        result = writable.writer.write("facet_new.md", "# New\n\nbody text.\n")
+        assert result.path == "facet_new.md"
+        assert "body text" in (vault_path / "facet_new.md").read_text()
+
+    def test_edit_patches_document(
+        self, writable: Collection, vault_path: Path
+    ) -> None:
+        writable.writer.write("facet_edit.md", "alpha beta\n")
+        writable.writer.edit("facet_edit.md", old_text="alpha", new_text="gamma")
+        assert "gamma" in (vault_path / "facet_edit.md").read_text()
+
+    def test_delete_removes_document(self, writable: Collection) -> None:
+        writable.writer.write("facet_del.md", "x\n")
+        writable.writer.delete("facet_del.md")
+        assert writable.read("facet_del.md") is None
+
+    def test_rename_moves_document(self, writable: Collection) -> None:
+        writable.writer.write("facet_a.md", "x\n")
+        writable.writer.rename("facet_a.md", "facet_b.md")
+        assert writable.read("facet_a.md") is None
+        assert writable.read("facet_b.md") is not None
+
+    def test_write_attachment_creates_file(
+        self, writable: Collection, vault_path: Path
+    ) -> None:
+        result = writable.writer.write_attachment("facet.bin", b"\x00\x01\x02")
+        assert result.path == "facet.bin"
+        assert (vault_path / "facet.bin").read_bytes() == b"\x00\x01\x02"


### PR DESCRIPTION
## Summary

PR3a of the `collection.py` facade-decomposition epic (#576). Introduces a `facets/` package that groups the formerly-flat `Collection` surface into four cohesive, thin delegating views over the existing managers + coordinator:

| Facet | Surface | Collaborators |
|-------|---------|--------------|
| `ReaderFacet` | search, read, list, folders, tags, toc, recent, similar, context, stats, embeddings_status, history, diff, read_attachment | `SearchManager`, `DocumentManager`, `IndexManager`, `GitQueryManager`, `require_built` |
| `WriterFacet` | write, edit, delete, rename, write_attachment | `DocumentManager` |
| `GraphFacet` | backlinks, outlinks, broken_links, orphans, most_linked, connection_path | `LinkManager`, `require_built` |
| `IndexFacet` | build/reindex/embeddings (sync + async), readiness, writer status | `IndexWriteCoordinator` (public subset only) |

`Collection` constructs the facets once in `__init__` and exposes them via `reader` / `writer` / `graph` / `index` properties; the flat methods now delegate to them (**addition before removal**). The bucket-3 readiness gate (`require_built`) moved inside the facets, so it is expressed in exactly one place per method.

This is a deliberately **behaviour-preserving** extraction — every flat method routes 1:1 to the matching facet, which delegates 1:1 to the same manager/coordinator as before. Signatures, kwarg forwarding, and the readiness-gate placement are unchanged.

## Why ReaderFacet is thin

The discarded first attempt (#608) produced a 12-parameter `ReaderFacet` because `stats()` computed FTS aggregates inline and `get_history`/`get_diff` held git logic directly. PR-A (#612) first moved `stats()` into `SearchManager` and extracted `GitQueryManager`, so `ReaderFacet` now lands at **5 collaborators** with no duplicated config state. (Manager-boundary refactor before facet extraction — the sequencing lesson from #608.)

## Note on docstrings (deviation from #604's text)

Issue #604 suggested *moving* the rich docstrings to the facets and stubbing the flat methods to "delegates to". I kept the rich docstrings on **both** layers instead: `SearchManager.search` (and the other managers) already carry the full Args/Returns/Raises docstrings that `Collection.search` does — Collection↔manager docstring duplication is the established codebase convention. Stubbing the flat methods would make the facade layer internally inconsistent (every other `Collection` method is richly documented). The facets carry the same rich docstrings as their permanent home for PR4.

The facet docstrings are verbatim copies of `Collection`'s. A few pre-existing `Raises:`-completeness gaps in those docstrings (e.g. `edit` omits `DocumentNotFoundError`) are tracked in **#614** for a separate accuracy pass across both layers, rather than divergently half-fixing them here.

## Tests / docs

- New `tests/test_facet_{reader,writer,graph,index}.py` (42 tests) exercise each facet through a real `Collection`, plus a shared `built` fixture in `tests/conftest.py`.
- `CLAUDE.md` + `docs/design.md` updated with the `facets/` package (tree + a new "Facets" architecture section).
- No new MCP tools / env vars / resources — `Collection`'s public API is unchanged, so the user-facing docs need no change.

## Verification

- `uv run pytest` — **1875 passed**, 1 skipped, 1 xpassed.
- `uv run mypy src/ tests/` — clean.
- `uv run ruff check` + `ruff format --check` — clean.
- diff-cover vs main — **100%** on changed lines; `facets/` package at 100% under the full suite.
- Pre-flight review circus (5 core + code-reviewer/type-design/pr-test/comment lenses) run over two rounds; converged clean (round 1 fixed a duplicated `built` fixture and a `(PR1)` meta-reference; round-2 findings were pre-existing/sub-threshold).

## Non-goals (follow-ups)

- Internal-caller migration to the facet accessors — #605.
- Test-suite migration to the facet surface — #606.
- `Collection`→`Vault` rename + flat-method removal — final PR.
- Docstring `Raises`-accuracy pass — #614.

Closes #604. Refs #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)