### PR TITLE
docs: correct inherited Raises/Returns docstring gaps (closes #614)

### DIFF
--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -424,8 +424,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 (e.g. "Journal/note.md" or "assets/diagram.pdf").
                 Case-sensitive.
             section: When provided, return only the section whose heading
-                matches *section* exactly (case-sensitive). Pass the ``heading``
-                value from a ``search`` result unchanged for guaranteed match.
+                matches *section* (case-sensitive; internal whitespace is
+                collapsed before comparison). Pass the ``heading`` value
+                from a ``search`` result unchanged for guaranteed match.
                 ``None`` (the default) returns the whole document.
                 Ignored for non-.md paths.
 
@@ -1545,7 +1546,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             ValueError: If content_base64 is missing/invalid for
                 attachments, or the content exceeds the size limit.
             McpError: If if_match is provided and the file has been
-                modified (ConcurrentModificationError).
+                modified, or if_match is supplied for a file that does not
+                yet exist (ConcurrentModificationError).
         """
         if not path.endswith(".md"):
             if not content_base64:
@@ -1627,6 +1629,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 numbers are out of range.
             EditConflictError: If old_text is not found or appears more
                 than once.
+            DocumentNotFoundError: If no file exists at the given path.
+            McpError: If if_match is provided and the file has been modified
+                (ConcurrentModificationError).
         """
         try:
             result = await asyncio.to_thread(

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -544,7 +544,7 @@ class Collection:
         return self._index_facet.write_generation()
 
     def wait_for_drain(self, timeout: float | None = None) -> bool:
-        """Block until :meth:`is_drained`, or until *timeout* (best-effort)."""
+        """Block until :meth:`is_drained`; ``True`` if drained, ``False`` on timeout."""
         return self._index_facet.wait_for_drain(timeout)
 
     def get_index_status(self) -> dict[str, Any]:
@@ -645,10 +645,11 @@ class Collection:
         Args:
             path: Relative document path (e.g. ``"Journal/note.md"``).
             section: When provided, return only the section whose heading
-                matches *section* exactly (case-sensitive). Pass the
-                ``heading`` value from a ``search`` result unchanged for
-                guaranteed match. ``None`` (the default) returns the whole
-                document. Raises :exc:`ValueError` if the section is not found.
+                matches *section* (case-sensitive; internal whitespace is
+                collapsed before comparison). Pass the ``heading`` value from
+                a ``search`` result unchanged for guaranteed match. ``None``
+                (the default) returns the whole document. Raises
+                :exc:`ValueError` if the section is not found.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``
@@ -1084,7 +1085,8 @@ class Collection:
             A unified diff string when *per_commit* is ``False``, or a list of
             :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
             ``True``.  Returns an empty string / empty list when the note has
-            no changes in the given range.
+            no changes in the given range, or when the vault's source
+            directory is not inside a git repository.
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is
@@ -1153,6 +1155,18 @@ class Collection:
         gate (e.g. the ``create_upload_link`` receiver path, which has
         already validated against ``MARKDOWN_VAULT_MCP_UPLOAD_MAX_BYTES``);
         leave ``False`` for base64 callers of the MCP ``write`` tool.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.WriteResult`.
+
+        Raises:
+            ReadOnlyError: If the collection is read-only.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current file hash, or *if_match* is supplied
+                for a file that does not yet exist.
+            ValueError: If the path escapes the source directory, has an
+                extension not in the allowlist, or the content exceeds the
+                size limit (when *skip_size_cap* is ``False``).
         """
         return self._writer_facet.write_attachment(
             path, content, if_match=if_match, skip_size_cap=skip_size_cap
@@ -1185,7 +1199,8 @@ class Collection:
         Raises:
             ReadOnlyError: If the collection is read-only.
             ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash.
+                not match the current file hash, or *if_match* is supplied
+                for a file that does not yet exist.
             ValueError: If *path* escapes the source directory.
         """
         return self._writer_facet.write(
@@ -1226,6 +1241,7 @@ class Collection:
             ReadOnlyError: If the collection is read-only.
             ConcurrentModificationError: If *if_match* is provided and does
                 not match.
+            DocumentNotFoundError: If the file does not exist.
             ValueError: If *path* escapes the source directory.
         """
         return self._writer_facet.edit(
@@ -1289,6 +1305,7 @@ class Collection:
             ConcurrentModificationError: If *if_match* is provided and does
                 not match.
             DocumentNotFoundError: If *old_path* does not exist.
+            DocumentExistsError: If *new_path* already exists.
             ValueError: If *old_path* or *new_path* escapes the source
                 directory.
         """

--- a/src/markdown_vault_mcp/facets/index.py
+++ b/src/markdown_vault_mcp/facets/index.py
@@ -88,7 +88,7 @@ class IndexFacet:
         return self._coordinator.write_generation()
 
     def wait_for_drain(self, timeout: float | None = None) -> bool:
-        """Block until :meth:`is_drained`, or until *timeout* (best-effort)."""
+        """Block until :meth:`is_drained`; ``True`` if drained, ``False`` on timeout."""
         return self._coordinator.wait_for_drain(timeout)
 
     def get_index_status(self) -> dict[str, Any]:

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -111,10 +111,11 @@ class ReaderFacet:
         Args:
             path: Relative document path (e.g. ``"Journal/note.md"``).
             section: When provided, return only the section whose heading
-                matches *section* exactly (case-sensitive). Pass the
-                ``heading`` value from a ``search`` result unchanged for
-                guaranteed match. ``None`` (the default) returns the whole
-                document. Raises :exc:`ValueError` if the section is not found.
+                matches *section* (case-sensitive; internal whitespace is
+                collapsed before comparison). Pass the ``heading`` value from
+                a ``search`` result unchanged for guaranteed match. ``None``
+                (the default) returns the whole document. Raises
+                :exc:`ValueError` if the section is not found.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``
@@ -355,7 +356,8 @@ class ReaderFacet:
             A unified diff string when *per_commit* is ``False``, or a list of
             :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
             ``True``.  Returns an empty string / empty list when the note has
-            no changes in the given range.
+            no changes in the given range, or when the vault's source
+            directory is not inside a git repository.
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -61,7 +61,8 @@ class WriterFacet:
         Raises:
             ReadOnlyError: If the collection is read-only.
             ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash.
+                not match the current file hash, or *if_match* is supplied
+                for a file that does not yet exist.
             ValueError: If *path* escapes the source directory.
         """
         return self._doc_mgr.write(
@@ -102,6 +103,7 @@ class WriterFacet:
             ReadOnlyError: If the collection is read-only.
             ConcurrentModificationError: If *if_match* is provided and does
                 not match.
+            DocumentNotFoundError: If the file does not exist.
             ValueError: If *path* escapes the source directory.
         """
         return self._doc_mgr.edit(
@@ -165,6 +167,7 @@ class WriterFacet:
             ConcurrentModificationError: If *if_match* is provided and does
                 not match.
             DocumentNotFoundError: If *old_path* does not exist.
+            DocumentExistsError: If *new_path* already exists.
             ValueError: If *old_path* or *new_path* escapes the source
                 directory.
         """
@@ -197,7 +200,8 @@ class WriterFacet:
         Raises:
             ReadOnlyError: If the collection is read-only.
             ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash.
+                not match the current file hash, or *if_match* is supplied
+                for a file that does not yet exist.
             ValueError: If the path escapes the source directory, has an
                 extension not in the allowlist, or the content exceeds the
                 size limit (when *skip_size_cap* is ``False``).

--- a/src/markdown_vault_mcp/indexing/coordinator.py
+++ b/src/markdown_vault_mcp/indexing/coordinator.py
@@ -172,7 +172,7 @@ class IndexWriteCoordinator:
         return int(self._writer.get_status()["write_generation"])
 
     def wait_for_drain(self, timeout: float | None = None) -> bool:
-        """Block until :meth:`is_drained`, or until *timeout*. Polls every 50ms."""
+        """Block until :meth:`is_drained`; ``True`` if drained, ``False`` on timeout."""
         deadline = None if timeout is None else time.monotonic() + timeout
         poll_interval = 0.05
         while True:

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -233,7 +233,8 @@ class DocumentManager:
         Args:
             path: Relative document path (e.g. ``"Journal/note.md"``).
             section: When provided, return only the chunk whose heading
-                matches *section* exactly. ``None`` returns the whole
+                matches *section* (case-sensitive; internal whitespace is
+                collapsed before comparison). ``None`` returns the whole
                 document (today's behaviour).
 
         Returns:
@@ -568,7 +569,8 @@ class DocumentManager:
         Raises:
             ReadOnlyError: If the collection is read-only.
             ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash.
+                not match the current file hash, or *if_match* is supplied
+                for a file that does not yet exist.
             ValueError: If the path escapes the source directory, has an
                 extension not in the allowlist, or the content exceeds the
                 size limit (when *skip_size_cap* is ``False``).

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -124,7 +124,8 @@ class GitQueryManager:
             A unified diff string when *per_commit* is ``False``, or a list of
             :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
             ``True``.  Returns an empty string / empty list when the note has
-            no changes in the given range.
+            no changes in the given range, or when the vault's source
+            directory is not inside a git repository.
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3734,6 +3734,18 @@ class TestOptimisticConcurrency:
         assert exc_info.value.path == "assets/report.pdf"
         assert exc_info.value.expected == "stale-etag-value"
 
+    def test_write_attachment_with_if_match_on_nonexistent_raises(
+        self, vault_with_attachment: Path
+    ) -> None:
+        """write_attachment() with if_match for a missing file raises CME."""
+        col = Collection(source_dir=vault_with_attachment, read_only=False)
+
+        with pytest.raises(ConcurrentModificationError) as exc_info:
+            col.write_attachment("assets/missing.pdf", b"data", if_match="any-etag")
+
+        assert exc_info.value.path == "assets/missing.pdf"
+        assert exc_info.value.actual == "(file does not exist)"
+
     # --- Round-trip test ---
 
     def test_read_etag_roundtrip_with_write(self, writable: Collection) -> None:


### PR DESCRIPTION
## Summary

The facet docstrings introduced in #604 were verbatim copies of the flat `Collection` docstrings, which carried several small pre-existing completeness gaps. These surfaced one-at-a-time across the #604 / #615 / #619 review rounds, so #614 was filed to own the **whole class** and fix it in a single cross-layer pass. This is that pass.

Each gap is corrected at the **source** (manager / coordinator) *and* every verbatim copy (`Collection`, the relevant facet, and — where applicable — the MCP `read` tool) so the layers stay in sync:

| Method | Correction |
|--------|-----------|
| `edit` | document `DocumentNotFoundError` (target file missing) |
| `rename` | document `DocumentExistsError` (`new_path` already exists) |
| `write` / `write_attachment` | `ConcurrentModificationError` also fires when `if_match` is supplied for a not-yet-existing file (and `Collection.write_attachment` gains the `Returns`/`Raises` it was missing entirely) |
| `read` | section match is "case-sensitive; internal whitespace is collapsed before comparison" — not "exactly" (fixed at manager, `Collection`, `ReaderFacet`, **and the MCP `read` tool**) |
| `get_diff` | `Returns` empty when the vault is not a git repo (mirrors `get_history`) |
| `wait_for_drain` | one-liner now documents the `bool` return (`True` = drained, `False` = timeout) |

## Behaviour

**None changed.** Every documented exception/return was traced to its implementation and verified accurate; the `"exactly"` wording was stale ever since #497 (May 15) added whitespace-tolerant section matching without updating the upstream docstrings.

## Tests

Documentation-only, with one exception: the `write_attachment` `if_match`-on-missing-file branch was the one documented behaviour with **no test** (the `write` `.md` equivalent was covered, but `write_attachment` routes through its own branch). Added `test_write_attachment_with_if_match_on_nonexistent_raises` to pin it (asserts `ConcurrentModificationError` with `actual == "(file does not exist)"`).

## Verification

Full suite **1887 passing**, mypy + ruff clean. Pre-flight review (CLAUDE.md / diff / history / prior-PR / comments / code-review / comment-accuracy / test-coverage lenses) clean over two rounds — round 1 caught a missed lockstep copy (the MCP `read` tool still said "exactly") and the untested `write_attachment` branch, both fixed here.

Closes #614. Refs #576, #604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)