### PR TITLE
refactor: migrate production callers to the facet surface (#605)

### DIFF
--- a/src/markdown_vault_mcp/_cli_impl.py
+++ b/src/markdown_vault_mcp/_cli_impl.py
@@ -119,7 +119,7 @@ def _cmd_serve(args: argparse.Namespace) -> None:
 def _cmd_index(args: argparse.Namespace) -> None:
     """Build the full-text search index."""
     collection = _build_collection(args)
-    stats = collection.build_index(force=args.force)
+    stats = collection.index.build_index(force=args.force)
     logger.info(
         "Indexed %d documents, %d chunks",
         stats.documents_indexed,
@@ -127,7 +127,7 @@ def _cmd_index(args: argparse.Namespace) -> None:
     )
     print(f"Indexed {stats.documents_indexed} documents, {stats.chunks_indexed} chunks")
     try:
-        n = collection.build_embeddings(force=args.force)
+        n = collection.index.build_embeddings(force=args.force)
         logger.info("Embedded %d chunks", n)
         print(f"Embedded {n} chunks")
     except ValueError:
@@ -138,7 +138,7 @@ def _cmd_search(args: argparse.Namespace) -> None:
     """Search the collection."""
     collection = _build_collection(args)
 
-    results = collection.search(
+    results = collection.reader.search(
         args.query,
         limit=args.limit,
         mode=args.mode,
@@ -167,8 +167,8 @@ def _cmd_reindex(args: argparse.Namespace) -> None:
     # reindex() requires a built index (bucket 4 readiness contract,
     # issue #525). build_index() short-circuits in O(1) on a coherent
     # persisted DB, so this is free on the warm path and correct on cold.
-    collection.build_index()
-    result = collection.reindex()
+    collection.index.build_index()
+    result = collection.index.reindex()
     logger.info(
         "Reindex complete: %d added, %d modified, %d deleted, %d unchanged",
         result.added,
@@ -182,7 +182,7 @@ def _cmd_reindex(args: argparse.Namespace) -> None:
     )
     try:
         should_force = result.added > 0 or result.modified > 0 or result.deleted > 0
-        n = collection.build_embeddings(force=should_force)
+        n = collection.index.build_embeddings(force=should_force)
         logger.info("Embedded %d chunks", n)
         print(f"Embedded {n} chunks")
     except ValueError:

--- a/src/markdown_vault_mcp/_github_webhook.py
+++ b/src/markdown_vault_mcp/_github_webhook.py
@@ -82,7 +82,7 @@ def _reindex_after_pull(collection: Any) -> None:
     """
     try:
         with collection.pause_writes():
-            collection.reindex()
+            collection.index.reindex()
     except Exception:
         logger.error(
             "github_webhook: reindex after pull failed — FTS index is "
@@ -185,7 +185,7 @@ def make_webhook_handler(secret: str) -> Callable[[Request], Any]:
             )
 
         if pull_result.from_sha != pull_result.to_sha:
-            if collection.is_queryable():
+            if collection.index.is_queryable():
                 await asyncio.to_thread(_reindex_after_pull, collection)
             else:
                 logger.info(

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -278,7 +278,7 @@ def register_apps(mcp: FastMCP) -> None:
         summary_parts: list[str] = []
 
         if path:
-            note = await asyncio.to_thread(collection.read, path)
+            note = await asyncio.to_thread(collection.reader.read, path)
             if note:
                 summary_parts.append(f"Note: {note.title} ({path})")
                 summary_parts.append(f"Folder: {note.folder}")
@@ -288,7 +288,7 @@ def register_apps(mcp: FastMCP) -> None:
             else:
                 summary_parts.append(f"Note not found: {path}")
         else:
-            stats = await asyncio.to_thread(collection.stats)
+            stats = await asyncio.to_thread(collection.reader.stats)
             summary_parts.append(
                 f"Vault: {stats.document_count} notes, {stats.folder_count} folders"
             )
@@ -332,7 +332,7 @@ def register_apps(mcp: FastMCP) -> None:
             field details. Returns {"error": "..."} if the note is not found.
         """
         try:
-            ctx = await asyncio.to_thread(collection.get_context, path)
+            ctx = await asyncio.to_thread(collection.reader.get_context, path)
         except ValueError:
             return {"error": f"Note not found: {path}"}
         return asdict(ctx)
@@ -369,7 +369,7 @@ def register_apps(mcp: FastMCP) -> None:
             - summary (str): Text summary with backlink, outlink, and similarity counts.
         """
         try:
-            ctx = await asyncio.to_thread(collection.get_context, path)
+            ctx = await asyncio.to_thread(collection.reader.get_context, path)
         except ValueError:
             return {
                 "path": path,
@@ -463,7 +463,7 @@ def register_apps(mcp: FastMCP) -> None:
             visited.add(current)
 
             # Add node
-            note = await asyncio.to_thread(collection.read, current)
+            note = await asyncio.to_thread(collection.reader.read, current)
             label = (
                 note.title if note else current.rsplit("/", 1)[-1].replace(".md", "")
             )
@@ -482,11 +482,15 @@ def register_apps(mcp: FastMCP) -> None:
 
             # Fetch backlinks/outlinks for interior nodes (orphan detection + edges)
             try:
-                backlinks = await asyncio.to_thread(collection.get_backlinks, current)
+                backlinks = await asyncio.to_thread(
+                    collection.graph.get_backlinks, current
+                )
             except ValueError:
                 backlinks = []
             try:
-                outlinks = await asyncio.to_thread(collection.get_outlinks, current)
+                outlinks = await asyncio.to_thread(
+                    collection.graph.get_outlinks, current
+                )
             except ValueError:
                 outlinks = []
             is_orphan = len(backlinks) == 0 and len(outlinks) == 0
@@ -541,7 +545,7 @@ def register_apps(mcp: FastMCP) -> None:
                     break
                 try:
                     similar = await asyncio.to_thread(
-                        collection.get_similar, node_path, limit=5
+                        collection.reader.get_similar, node_path, limit=5
                     )
                 except ValueError:
                     # Expected when embeddings are not configured for this collection
@@ -564,7 +568,9 @@ def register_apps(mcp: FastMCP) -> None:
                         if len(nodes) >= max_nodes:
                             truncated = True
                             break
-                        sim_note = await asyncio.to_thread(collection.read, sr.path)
+                        sim_note = await asyncio.to_thread(
+                            collection.reader.read, sr.path
+                        )
                         sim_label = (
                             sim_note.title
                             if sim_note
@@ -628,7 +634,7 @@ def register_apps(mcp: FastMCP) -> None:
               - to (str): Target node ID.
               - type (str): "markdown", "wikilink", or "reference".
         """
-        hubs = await asyncio.to_thread(collection.get_most_linked, limit=limit)
+        hubs = await asyncio.to_thread(collection.graph.get_most_linked, limit=limit)
         nodes: dict[str, dict[str, Any]] = {}
         edges: list[dict[str, Any]] = []
         seen_edges: set[tuple[str, str]] = set()
@@ -644,12 +650,16 @@ def register_apps(mcp: FastMCP) -> None:
 
             # Get immediate connections for each hub
             try:
-                backlinks = await asyncio.to_thread(collection.get_backlinks, hub.path)
+                backlinks = await asyncio.to_thread(
+                    collection.graph.get_backlinks, hub.path
+                )
             except ValueError:
                 backlinks = []
             for bl in backlinks:
                 if bl.source_path not in nodes:
-                    note = await asyncio.to_thread(collection.read, bl.source_path)
+                    note = await asyncio.to_thread(
+                        collection.reader.read, bl.source_path
+                    )
                     label = (
                         note.title
                         if note
@@ -711,9 +721,9 @@ def register_apps(mcp: FastMCP) -> None:
               - kind (str): "note" or "attachment".
         """
         docs = await asyncio.to_thread(
-            collection.list_documents, folder=folder, include_attachments=True
+            collection.reader.list_documents, folder=folder, include_attachments=True
         )
-        folders = await asyncio.to_thread(collection.list_folders)
+        folders = await asyncio.to_thread(collection.reader.list_folders)
 
         # Build direct children: extract the first path component after the
         # prefix from every folder that lives under it.  This handles vaults
@@ -769,7 +779,7 @@ def register_apps(mcp: FastMCP) -> None:
             Dict with path, title, frontmatter, content (markdown body), and
             modified_at (Unix timestamp), or null if the note is not found.
         """
-        note = await asyncio.to_thread(collection.read, path)
+        note = await asyncio.to_thread(collection.reader.read, path)
         if note is None:
             return None
         return {
@@ -814,7 +824,7 @@ def register_apps(mcp: FastMCP) -> None:
         """
         try:
             results = await asyncio.to_thread(
-                collection.search, query, limit=limit, mode=mode
+                collection.reader.search, query, limit=limit, mode=mode
             )
         except ValueError as exc:
             return [{"error": str(exc)}]

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -108,11 +108,11 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # Bucket-3 tools block on @needs_queryable until the build
         # completes; bucket-2 tools return whatever is currently in
         # the index per #526.
-        collection.build_index_async()
+        collection.index.build_index_async()
         logger.info("Submitted BuildIndex job to writer")
 
         if kwargs.get("embedding_provider") is not None:
-            collection.build_embeddings_async()
+            collection.index.build_embeddings_async()
             logger.info("Submitted BuildEmbeddings job to writer")
 
         # Start any other background tasks (e.g. git pull loop).
@@ -141,7 +141,7 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
             def _on_file_change() -> None:
                 try:
                     with collection.pause_writes():
-                        collection.reindex()
+                        collection.index.reindex()
                 except IndexUnavailableError:
                     logger.info(
                         "file_watcher: index not yet queryable, skipping reindex"

--- a/src/markdown_vault_mcp/_server_queryable.py
+++ b/src/markdown_vault_mcp/_server_queryable.py
@@ -117,9 +117,11 @@ def needs_queryable(
                     "handler must declare "
                     "`collection: Collection = Depends(get_collection)`."
                 )
-            if not collection.is_queryable():
+            if not collection.index.is_queryable():
                 effective = timeout if timeout is not None else _resolve_build_timeout()
-                await asyncio.to_thread(collection.wait_until_queryable, effective)
+                await asyncio.to_thread(
+                    collection.index.wait_until_queryable, effective
+                )
             try:
                 return await handler(*args, **kwargs)
             except sqlite3.OperationalError as exc:

--- a/src/markdown_vault_mcp/_server_resources.py
+++ b/src/markdown_vault_mcp/_server_resources.py
@@ -57,7 +57,7 @@ def register_resources(mcp: FastMCP) -> None:
     ) -> str:
         """Vault configuration: source path, read-only mode, indexed frontmatter fields, exclude patterns, allowed attachment extensions. For counts and search capabilities, use stats://vault."""
         config = _get_config(ctx)
-        stats = await asyncio.to_thread(collection.stats)
+        stats = await asyncio.to_thread(collection.reader.stats)
         return json.dumps(
             {
                 "source_dir": str(config.source_dir),
@@ -78,7 +78,7 @@ def register_resources(mcp: FastMCP) -> None:
         collection: Collection = Depends(get_collection),
     ) -> str:
         """Collection statistics — document count, chunk count, capabilities."""
-        result = await asyncio.to_thread(collection.stats)
+        result = await asyncio.to_thread(collection.reader.stats)
         return json.dumps(asdict(result))
 
     @mcp.resource(
@@ -88,11 +88,11 @@ def register_resources(mcp: FastMCP) -> None:
         collection: Collection = Depends(get_collection),
     ) -> str:
         """All tags grouped by indexed field."""
-        stats = await asyncio.to_thread(collection.stats)
+        stats = await asyncio.to_thread(collection.reader.stats)
         tag_lists: list[list[str]] = list(
             await asyncio.gather(
                 *[
-                    asyncio.to_thread(collection.list_tags, field)
+                    asyncio.to_thread(collection.reader.list_tags, field)
                     for field in stats.indexed_frontmatter_fields
                 ]
             )
@@ -112,7 +112,7 @@ def register_resources(mcp: FastMCP) -> None:
         collection: Collection = Depends(get_collection),
     ) -> str:
         """Tags for a specific indexed field."""
-        values = await asyncio.to_thread(collection.list_tags, field)
+        values = await asyncio.to_thread(collection.reader.list_tags, field)
         return json.dumps(values)
 
     @mcp.resource(
@@ -124,7 +124,7 @@ def register_resources(mcp: FastMCP) -> None:
         collection: Collection = Depends(get_collection),
     ) -> str:
         """All folder paths in the vault."""
-        folders = await asyncio.to_thread(collection.list_folders)
+        folders = await asyncio.to_thread(collection.reader.list_folders)
         return json.dumps(folders)
 
     @mcp.resource(
@@ -136,7 +136,7 @@ def register_resources(mcp: FastMCP) -> None:
         collection: Collection = Depends(get_collection),
     ) -> str:
         """Table of contents — ordered list of {level, text, anchor} headings. Useful for navigating long notes without reading full content."""
-        toc = await asyncio.to_thread(collection.get_toc, path)
+        toc = await asyncio.to_thread(collection.reader.get_toc, path)
         return json.dumps(toc)
 
     @mcp.resource(
@@ -150,7 +150,7 @@ def register_resources(mcp: FastMCP) -> None:
         collection: Collection = Depends(get_collection),
     ) -> str:
         """Top 10 semantically similar notes for a document."""
-        results = await asyncio.to_thread(collection.get_similar, path, limit=10)
+        results = await asyncio.to_thread(collection.reader.get_similar, path, limit=10)
         return json.dumps([asdict(r) for r in results])
 
     @mcp.resource(
@@ -162,7 +162,7 @@ def register_resources(mcp: FastMCP) -> None:
         collection: Collection = Depends(get_collection),
     ) -> str:
         """20 most recently modified notes."""
-        results = await asyncio.to_thread(collection.get_recent, limit=20)
+        results = await asyncio.to_thread(collection.reader.get_recent, limit=20)
         items: list[dict[str, Any]] = [
             {
                 **asdict(r),

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -61,7 +61,7 @@ async def _maybe_wait_for_drain(
     deadline = loop.time() + timeout
     poll_interval = 0.05
     while True:
-        if collection.is_drained():
+        if collection.index.is_drained():
             return True
         if loop.time() >= deadline:
             logger.warning(
@@ -223,7 +223,7 @@ async def _reindex_after_pull(
 
     def _pause_and_reindex() -> None:
         with collection.pause_writes():
-            collection.reindex()
+            collection.index.reindex()
 
     try:
         await asyncio.to_thread(_pause_and_reindex)
@@ -373,7 +373,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 provider is configured.
         """
         results = await asyncio.to_thread(
-            collection.search,
+            collection.reader.search,
             query,
             limit=limit,
             mode=mode,
@@ -448,9 +448,11 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 limit, or the requested section heading is not found.
         """
         if not path.endswith(".md"):
-            attachment = await asyncio.to_thread(collection.read_attachment, path)
+            attachment = await asyncio.to_thread(
+                collection.reader.read_attachment, path
+            )
             return asdict(attachment)
-        note = await asyncio.to_thread(collection.read, path, section=section)
+        note = await asyncio.to_thread(collection.reader.read, path, section=section)
         if note is None:
             raise ValueError(f"Document not found: {path}")
         return asdict(note)
@@ -493,7 +495,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             Body content is not included in either case.
         """
         results = await asyncio.to_thread(
-            collection.list_documents,
+            collection.reader.list_documents,
             folder=folder,
             pattern=pattern,
             include_attachments=include_attachments,
@@ -522,7 +524,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             Pass any of these as the 'folder' argument to 'search' or
             'list_documents'.
         """
-        return await asyncio.to_thread(collection.list_folders)
+        return await asyncio.to_thread(collection.reader.list_folders)
 
     @mcp.tool(
         icons=_TOOL_ICONS["list_tags"],
@@ -553,7 +555,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             ["craft", "pacing", "worldbuilding"]. Use these as values in the
             'filters' dict when calling 'search'.
         """
-        return await asyncio.to_thread(collection.list_tags, field)
+        return await asyncio.to_thread(collection.reader.list_tags, field)
 
     @mcp.tool(
         icons=_TOOL_ICONS["stats"],
@@ -591,7 +593,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - orphan_count (int): Notes with no inbound or outbound links.
               Call 'get_orphan_notes' if non-zero.
         """
-        result = await asyncio.to_thread(collection.stats)
+        result = await asyncio.to_thread(collection.reader.stats)
         return asdict(result)
 
     @mcp.tool(
@@ -623,7 +625,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - chunk_count (int): Number of chunks currently in the vector index.
             - path (str | None): Vector index file path when persisted, or null.
         """
-        return await asyncio.to_thread(collection.embeddings_status)
+        return await asyncio.to_thread(collection.index.embeddings_status)
 
     @mcp.tool(
         annotations={
@@ -664,7 +666,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - error (str | None): ``None`` unless the background build
               raised.
         """
-        return await asyncio.to_thread(collection.get_index_status)
+        return await asyncio.to_thread(collection.index.get_index_status)
 
     # --- Link tools (read-only) ---
 
@@ -735,13 +737,15 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_backlinks"
         )
-        gen_before = collection.write_generation()
-        results = await asyncio.to_thread(collection.get_backlinks, path, limit=limit)
+        gen_before = collection.index.write_generation()
+        results = await asyncio.to_thread(
+            collection.graph.get_backlinks, path, limit=limit
+        )
         return {
             "stale": (
                 (not drained_on_request)
-                or (collection.write_generation() != gen_before)
-                or (not collection.is_drained())
+                or (collection.index.write_generation() != gen_before)
+                or (not collection.index.is_drained())
             ),
             "data": [asdict(r) for r in results],
         }
@@ -811,13 +815,15 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_outlinks"
         )
-        gen_before = collection.write_generation()
-        results = await asyncio.to_thread(collection.get_outlinks, path, limit=limit)
+        gen_before = collection.index.write_generation()
+        results = await asyncio.to_thread(
+            collection.graph.get_outlinks, path, limit=limit
+        )
         return {
             "stale": (
                 (not drained_on_request)
-                or (collection.write_generation() != gen_before)
-                or (not collection.is_drained())
+                or (collection.index.write_generation() != gen_before)
+                or (not collection.index.is_drained())
             ),
             "data": [asdict(r) for r in results],
         }
@@ -859,7 +865,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - fragment (str | None): Heading anchor (e.g. "#section"), or null.
             - raw_target (str): Literal link target as written in the source.
         """
-        results = await asyncio.to_thread(collection.get_broken_links, folder=folder)
+        results = await asyncio.to_thread(
+            collection.graph.get_broken_links, folder=folder
+        )
         return [asdict(r) for r in results]
 
     # --- Similarity tools (read-only) ---
@@ -938,9 +946,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_similar"
         )
-        gen_before = collection.write_generation()
+        gen_before = collection.index.write_generation()
         results = await asyncio.to_thread(
-            collection.get_similar,
+            collection.reader.get_similar,
             path,
             limit=limit,
             chunks_per_file=chunks_per_file,
@@ -948,8 +956,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         return {
             "stale": (
                 (not drained_on_request)
-                or (collection.write_generation() != gen_before)
-                or (not collection.is_drained())
+                or (collection.index.write_generation() != gen_before)
+                or (not collection.index.is_drained())
             ),
             "data": [asdict(r) for r in results],
         }
@@ -986,7 +994,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             frontmatter, modified_at (Unix timestamp), kind ("note").
         """
         results = await asyncio.to_thread(
-            collection.get_recent, limit=limit, folder=folder
+            collection.reader.get_recent, limit=limit, folder=folder
         )
         return [asdict(r) for r in results]
 
@@ -1100,9 +1108,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_context"
         )
-        gen_before = collection.write_generation()
+        gen_before = collection.index.write_generation()
         result = await asyncio.to_thread(
-            collection.get_context,
+            collection.reader.get_context,
             path,
             similar_limit=similar_limit,
             link_limit=link_limit,
@@ -1110,8 +1118,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         return {
             "stale": (
                 (not drained_on_request)
-                or (collection.write_generation() != gen_before)
-                or (not collection.is_drained())
+                or (collection.index.write_generation() != gen_before)
+                or (not collection.index.is_drained())
             ),
             "data": asdict(result),
         }
@@ -1147,7 +1155,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             - modified_at (float): Unix timestamp of last modification.
             - kind (str): Always "note".
         """
-        results = await asyncio.to_thread(collection.get_orphan_notes)
+        results = await asyncio.to_thread(collection.graph.get_orphan_notes)
         return [asdict(r) for r in results]
 
     @mcp.tool(
@@ -1176,7 +1184,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             — number of distinct source documents linking to this note), ordered
             by backlink_count descending.
         """
-        results = await asyncio.to_thread(collection.get_most_linked, limit=limit)
+        results = await asyncio.to_thread(collection.graph.get_most_linked, limit=limit)
         return [asdict(r) for r in results]
 
     @mcp.tool(
@@ -1234,9 +1242,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         drained_on_request = await _maybe_wait_for_drain(
             collection, wait_for_drain, "get_connection_path"
         )
-        gen_before = collection.write_generation()
+        gen_before = collection.index.write_generation()
         result: list[str] | None = await asyncio.to_thread(
-            collection.get_connection_path, source, target, max_depth
+            collection.graph.get_connection_path, source, target, max_depth
         )
 
         if result is None:
@@ -1246,8 +1254,8 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         return {
             "stale": (
                 (not drained_on_request)
-                or (collection.write_generation() != gen_before)
-                or (not collection.is_drained())
+                or (collection.index.write_generation() != gen_before)
+                or (not collection.index.is_drained())
             ),
             "data": inner,
         }
@@ -1312,7 +1320,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """
         try:
             results = await asyncio.to_thread(
-                collection.get_history,
+                collection.reader.get_history,
                 path,
                 since=since,
                 until=until,
@@ -1391,7 +1399,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """
         try:
             result = await asyncio.to_thread(
-                collection.get_diff,
+                collection.reader.get_diff,
                 path,
                 since_sha=since_sha,
                 since_timestamp=since_timestamp,
@@ -1441,7 +1449,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
               stringified exception.  Operators can re-run ``reindex`` to
               retry; a subsequent successful run clears the field.
         """
-        collection.reindex_async()
+        collection.index.reindex_async()
         return {"status": "queued"}
 
     @mcp.tool(
@@ -1481,7 +1489,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
               ``build_embeddings`` to retry; a subsequent successful run
               clears the field.
         """
-        collection.build_embeddings_async(force=force)
+        collection.index.build_embeddings_async(force=force)
         return {"status": "queued"}
 
     # --- Write tools (tag-based visibility) ---
@@ -1559,11 +1567,15 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             except Exception as exc:
                 raise ValueError(f"Invalid base64 in content_base64: {exc}") from exc
             result = await asyncio.to_thread(
-                collection.write_attachment, path, raw_bytes, if_match=if_match
+                collection.writer.write_attachment, path, raw_bytes, if_match=if_match
             )
             return asdict(result)
         result = await asyncio.to_thread(
-            collection.write, path, content, frontmatter=frontmatter, if_match=if_match
+            collection.writer.write,
+            path,
+            content,
+            frontmatter=frontmatter,
+            if_match=if_match,
         )
         return asdict(result)
 
@@ -1635,7 +1647,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         """
         try:
             result = await asyncio.to_thread(
-                collection.edit,
+                collection.writer.edit,
                 path,
                 old_text=old_text,
                 new_text=new_text,
@@ -1696,7 +1708,9 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             McpError: If if_match is provided and the file has been modified
                 (ConcurrentModificationError).
         """
-        result = await asyncio.to_thread(collection.delete, path, if_match=if_match)
+        result = await asyncio.to_thread(
+            collection.writer.delete, path, if_match=if_match
+        )
         return asdict(result)
 
     @mcp.tool(
@@ -1751,7 +1765,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                 (ConcurrentModificationError).
         """
         result = await asyncio.to_thread(
-            collection.rename,
+            collection.writer.rename,
             old_path,
             new_path,
             if_match=if_match,
@@ -2028,7 +2042,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
                     "Only UTF-8 encoded responses can be saved as .md notes."
                 ) from exc
             result = await asyncio.to_thread(
-                collection.write,
+                collection.writer.write,
                 path,
                 text,
                 frontmatter=frontmatter,
@@ -2036,7 +2050,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
             )
         else:
             result = await asyncio.to_thread(
-                collection.write_attachment,
+                collection.writer.write_attachment,
                 path,
                 raw_bytes,
                 if_match=if_match,

--- a/src/markdown_vault_mcp/uploads.py
+++ b/src/markdown_vault_mcp/uploads.py
@@ -49,9 +49,9 @@ def _vault_upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
     """
     collection = get_collection_singleton()
     if record.target_id.endswith(".md"):
-        collection.write(record.target_id, content=body.decode("utf-8"))
+        collection.writer.write(record.target_id, content=body.decode("utf-8"))
     else:
-        collection.write_attachment(record.target_id, body, skip_size_cap=True)
+        collection.writer.write_attachment(record.target_id, body, skip_size_cap=True)
     return {"path": record.target_id, "size_bytes": len(body)}
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -447,17 +447,17 @@ class TestCmdIndex:
         mock_stats = MagicMock()
         mock_stats.documents_indexed = 42
         mock_stats.chunks_indexed = 128
-        mock_collection.build_index.return_value = mock_stats
+        mock_collection.index.build_index.return_value = mock_stats
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "index"]):
             main()
 
-        mock_collection.build_index.assert_called_once_with(force=False)
+        mock_collection.index.build_index.assert_called_once_with(force=False)
         captured = capsys.readouterr()
         assert "42 documents" in captured.out
         assert "128 chunks" in captured.out
-        mock_collection.build_index.assert_called_once_with(force=False)
+        mock_collection.index.build_index.assert_called_once_with(force=False)
 
     @patch("markdown_vault_mcp._cli_impl._build_collection")
     def test_valueerror_exits_with_message(
@@ -481,13 +481,13 @@ class TestCmdIndex:
         mock_stats = MagicMock()
         mock_stats.documents_indexed = 10
         mock_stats.chunks_indexed = 30
-        mock_collection.build_index.return_value = mock_stats
+        mock_collection.index.build_index.return_value = mock_stats
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "index", "--force"]):
             main()
 
-        mock_collection.build_index.assert_called_once_with(force=True)
+        mock_collection.index.build_index.assert_called_once_with(force=True)
 
     @patch("markdown_vault_mcp._cli_impl._build_collection")
     def test_index_builds_embeddings_when_configured(
@@ -499,14 +499,14 @@ class TestCmdIndex:
         mock_stats = MagicMock()
         mock_stats.documents_indexed = 5
         mock_stats.chunks_indexed = 20
-        mock_collection.build_index.return_value = mock_stats
-        mock_collection.build_embeddings.return_value = 20
+        mock_collection.index.build_index.return_value = mock_stats
+        mock_collection.index.build_embeddings.return_value = 20
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "index"]):
             main()
 
-        mock_collection.build_embeddings.assert_called_once_with(force=False)
+        mock_collection.index.build_embeddings.assert_called_once_with(force=False)
 
     @patch("markdown_vault_mcp._cli_impl._build_collection")
     def test_index_skips_embeddings_when_not_configured(
@@ -518,14 +518,16 @@ class TestCmdIndex:
         mock_stats = MagicMock()
         mock_stats.documents_indexed = 5
         mock_stats.chunks_indexed = 20
-        mock_collection.build_index.return_value = mock_stats
-        mock_collection.build_embeddings.side_effect = ValueError("not configured")
+        mock_collection.index.build_index.return_value = mock_stats
+        mock_collection.index.build_embeddings.side_effect = ValueError(
+            "not configured"
+        )
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "index"]):
             main()  # must not raise
 
-        mock_collection.build_embeddings.assert_called_once()
+        mock_collection.index.build_embeddings.assert_called_once()
 
     @patch("markdown_vault_mcp._cli_impl._build_collection")
     def test_index_force_propagates_to_embeddings(
@@ -537,14 +539,14 @@ class TestCmdIndex:
         mock_stats = MagicMock()
         mock_stats.documents_indexed = 5
         mock_stats.chunks_indexed = 20
-        mock_collection.build_index.return_value = mock_stats
-        mock_collection.build_embeddings.return_value = 20
+        mock_collection.index.build_index.return_value = mock_stats
+        mock_collection.index.build_embeddings.return_value = 20
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "index", "--force"]):
             main()
 
-        mock_collection.build_embeddings.assert_called_once_with(force=True)
+        mock_collection.index.build_embeddings.assert_called_once_with(force=True)
 
 
 class TestCmdSearch:
@@ -562,7 +564,7 @@ class TestCmdSearch:
         mock_result.score = 0.9876
 
         mock_collection = MagicMock()
-        mock_collection.search.return_value = [mock_result]
+        mock_collection.reader.search.return_value = [mock_result]
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "search", "test"]):
@@ -592,7 +594,7 @@ class TestCmdSearch:
             frontmatter={},
         )
         mock_collection = MagicMock()
-        mock_collection.search.return_value = [result]
+        mock_collection.reader.search.return_value = [result]
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "search", "test", "--json"]):
@@ -607,7 +609,7 @@ class TestCmdSearch:
     @patch("markdown_vault_mcp._cli_impl._build_collection")
     def test_search_passes_options(self, mock_build: MagicMock) -> None:
         mock_collection = MagicMock()
-        mock_collection.search.return_value = []
+        mock_collection.reader.search.return_value = []
         mock_build.return_value = mock_collection
 
         with patch(
@@ -626,7 +628,7 @@ class TestCmdSearch:
         ):
             main()
 
-        mock_collection.search.assert_called_once_with(
+        mock_collection.reader.search.assert_called_once_with(
             "query", limit=5, mode="semantic", folder="Journal"
         )
 
@@ -865,7 +867,7 @@ class TestCmdSearchJsonOutput:
             ),
         ]
         mock_collection = MagicMock()
-        mock_collection.search.return_value = results
+        mock_collection.reader.search.return_value = results
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "search", "alpha", "--json"]):
@@ -887,7 +889,7 @@ class TestCmdSearchJsonOutput:
     ) -> None:
         """_cmd_search with --json and no results outputs an empty JSON array."""
         mock_collection = MagicMock()
-        mock_collection.search.return_value = []
+        mock_collection.reader.search.return_value = []
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "search", "nothing", "--json"]):
@@ -914,7 +916,7 @@ class TestCmdReindex:
         mock_result.unchanged = 10
 
         mock_collection = MagicMock()
-        mock_collection.reindex.return_value = mock_result
+        mock_collection.index.reindex.return_value = mock_result
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
@@ -938,14 +940,14 @@ class TestCmdReindex:
         mock_result.modified = 0
         mock_result.deleted = 0
         mock_result.unchanged = 5
-        mock_collection.reindex.return_value = mock_result
-        mock_collection.build_embeddings.return_value = 10
+        mock_collection.index.reindex.return_value = mock_result
+        mock_collection.index.build_embeddings.return_value = 10
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
             main()
 
-        mock_collection.build_embeddings.assert_called_once_with(force=True)
+        mock_collection.index.build_embeddings.assert_called_once_with(force=True)
 
     @patch("markdown_vault_mcp._cli_impl._build_collection")
     def test_reindex_skips_embeddings_when_not_configured(
@@ -959,14 +961,16 @@ class TestCmdReindex:
         mock_result.modified = 0
         mock_result.deleted = 0
         mock_result.unchanged = 5
-        mock_collection.reindex.return_value = mock_result
-        mock_collection.build_embeddings.side_effect = ValueError("not configured")
+        mock_collection.index.reindex.return_value = mock_result
+        mock_collection.index.build_embeddings.side_effect = ValueError(
+            "not configured"
+        )
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
             main()  # must not raise
 
-        mock_collection.build_embeddings.assert_called_once()
+        mock_collection.index.build_embeddings.assert_called_once()
 
     @patch("markdown_vault_mcp._cli_impl._build_collection")
     def test_reindex_uses_force_false_when_no_changes(
@@ -980,14 +984,14 @@ class TestCmdReindex:
         mock_result.modified = 0
         mock_result.deleted = 0
         mock_result.unchanged = 10
-        mock_collection.reindex.return_value = mock_result
-        mock_collection.build_embeddings.return_value = 0
+        mock_collection.index.reindex.return_value = mock_result
+        mock_collection.index.build_embeddings.return_value = 0
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
             main()
 
-        mock_collection.build_embeddings.assert_called_once_with(force=False)
+        mock_collection.index.build_embeddings.assert_called_once_with(force=False)
 
     @patch("markdown_vault_mcp._cli_impl._build_collection")
     def test_reindex_uses_force_true_when_changes_exist(
@@ -1001,14 +1005,14 @@ class TestCmdReindex:
         mock_result.modified = 1
         mock_result.deleted = 0
         mock_result.unchanged = 10
-        mock_collection.reindex.return_value = mock_result
-        mock_collection.build_embeddings.return_value = 30
+        mock_collection.index.reindex.return_value = mock_result
+        mock_collection.index.build_embeddings.return_value = 30
         mock_build.return_value = mock_collection
 
         with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
             main()
 
-        mock_collection.build_embeddings.assert_called_once_with(force=True)
+        mock_collection.index.build_embeddings.assert_called_once_with(force=True)
 
     def test_reindex_against_real_collection(
         self,

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -354,7 +354,7 @@ class TestGitSync:
             def _failing_reindex() -> None:
                 raise RuntimeError("simulated reindex failure")
 
-            monkeypatch.setattr(collection, "reindex", _failing_reindex)
+            monkeypatch.setattr(collection.index, "reindex", _failing_reindex)
 
             result = await client.call_tool("git_sync", {"direction": "pull"})
 

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -71,7 +71,7 @@ def _mock_collection(
     *, queryable: bool = True, pull_result: PullResult | None = None
 ) -> MagicMock:
     col = MagicMock()
-    col.is_queryable.return_value = queryable
+    col.index.is_queryable.return_value = queryable
     col.force_pull.return_value = pull_result or _pull_result(
         from_sha="aaa", to_sha="bbb"
     )
@@ -238,7 +238,7 @@ def test_webhook_push_triggers_pull_and_reindex():
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
     col.force_pull.assert_called_once()
-    col.reindex.assert_called_once()
+    col.index.reindex.assert_called_once()
 
 
 def test_webhook_push_skips_reindex_when_already_up_to_date():
@@ -260,7 +260,7 @@ def test_webhook_push_skips_reindex_when_already_up_to_date():
         )
     assert resp.status_code == 200
     col.force_pull.assert_called_once()
-    col.reindex.assert_not_called()
+    col.index.reindex.assert_not_called()
 
 
 def test_webhook_push_returns_503_when_pull_fails():
@@ -284,7 +284,7 @@ def test_webhook_push_returns_503_when_pull_fails():
         )
     assert resp.status_code == 503
     assert "error" in resp.json()
-    col.reindex.assert_not_called()
+    col.index.reindex.assert_not_called()
 
 
 def test_webhook_push_runs_pull_but_skips_reindex_when_not_queryable():
@@ -310,7 +310,7 @@ def test_webhook_push_runs_pull_but_skips_reindex_when_not_queryable():
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
     col.force_pull.assert_called_once()
-    col.reindex.assert_not_called()
+    col.index.reindex.assert_not_called()
 
 
 def test_webhook_push_returns_503_when_singleton_not_initialized():
@@ -353,13 +353,13 @@ def test_webhook_push_no_git_strategy_returns_200():
             },
         )
     assert resp.status_code == 200
-    col.reindex.assert_not_called()
+    col.index.reindex.assert_not_called()
 
 
 def test_webhook_push_reindex_failure_does_not_propagate_to_github():
     """Reindex error is logged but webhook returns 200 so GitHub doesn't retry."""
     col = _mock_collection(pull_result=_pull_result(from_sha="aaa", to_sha="bbb"))
-    col.reindex.side_effect = Exception("disk full")
+    col.index.reindex.side_effect = Exception("disk full")
     client = _make_client()
     body = _push_body()
     with patch(

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -171,16 +171,16 @@ class TestGraphDataTools:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """vault_graph_hubs uses MostLinkedNote.folder, not per-hub collection.read."""
-        from markdown_vault_mcp.collection import Collection
+        from markdown_vault_mcp.facets.reader import ReaderFacet
 
-        original_read = Collection.read
+        original_read = ReaderFacet.read
         read_paths: list[str] = []
 
-        def _spy(self: Collection, path: str) -> Any:
+        def _spy(self: ReaderFacet, path: str) -> Any:
             read_paths.append(path)
             return original_read(self, path)
 
-        monkeypatch.setattr(Collection, "read", _spy)
+        monkeypatch.setattr(ReaderFacet, "read", _spy)
         server = make_server()
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
@@ -432,7 +432,7 @@ class TestIncludeSemanticEdges:
                 return_value=mock_prov,
             ),
             patch(
-                "markdown_vault_mcp.collection.Collection.get_similar",
+                "markdown_vault_mcp.facets.reader.ReaderFacet.get_similar",
                 side_effect=ValueError("not found"),
             ),
         ):
@@ -468,7 +468,7 @@ class TestIncludeSemanticEdges:
                 return_value=mock_prov,
             ),
             patch(
-                "markdown_vault_mcp.collection.Collection.get_similar",
+                "markdown_vault_mcp.facets.reader.ReaderFacet.get_similar",
                 side_effect=RuntimeError("embedding backend unavailable"),
             ),
         ):


### PR DESCRIPTION
## Summary

PR3b of the `collection.py` facade-decomposition epic (#576). This migrates every **production** internal caller from the flat `collection.<method>(...)` surface to `collection.<facet>.<method>(...)` (reader / writer / graph / index facets, extracted in PR3a #615), so that PR4 can later delete the flat delegators. **Non-breaking** — the flat delegators still exist throughout PR3; this is a pure call-site rename with no behaviour change.

## What changed

- **86 production callsites** across 8 modules — `_server_tools`, `_server_apps`, `_server_resources`, `_cli_impl`, `_server_deps`, `uploads`, `_server_queryable`, `_github_webhook` — including the `asyncio.to_thread(collection.<method>, ...)` callable forms.
- `embeddings_status` routes to the **index** facet (it moved reader→index in #615), not reader. mypy caught the one wrong-facet mapping during development.
- **Intentionally left flat:** lifecycle / git-sync calls (`start`/`stop`/`close`/`pause_writes`/`force_pull`/`sync_from_remote_before_index`) and the deliberate `collection._git_strategy` reach stay on `collection` — they are not facet-owned.

## Why the test files are in this PR

This PR also migrates the 4 test files that **mock or patch** the flat methods — they are inseparable from the production migration: once production calls the facet surface, those mocks no longer match reality (and `assert_not_called` variants would pass *vacuously*).

- `test_cli`, `test_github_webhook` — MagicMock receivers re-pointed (`col.reindex` → `col.index.reindex`, etc.); lifecycle `col.force_pull` left flat.
- `test_git_sync` — `monkeypatch.setattr(collection.index, "reindex", ...)`.
- `test_mcp_apps_graph` — the read-spy and two `get_similar` patch targets re-pointed from `Collection` to `ReaderFacet`.

Tests that merely **call** the flat methods (still valid via the delegators) remain for **PR3c (#606)** — the cosmetic call-site sweep. The precise PR3b/PR3c boundary is documented as a scope note on #605.

## Verification

- `uv run mypy src/ tests/` — clean
- Full suite green; diff-cover **98%** (≥80 gate); the one uncovered migrated line (`_server_deps.py:144`, the filesystem-watcher reindex callback) was equally uncovered on `main` — pre-existing, not a regression.
- Pre-flight review circus (5 core lenses + code-reviewer + pr-test-analyzer): **clean**, no findings ≥80. The git-history lens confirmed the drift-aware stale-signal envelope ordering (#534) is preserved, since both flat + facet paths delegate to the same coordinator instance.

Closes #605. Refs #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)