### PR TITLE
refactor: remove the 39 flat Collection delegators; re-home API docs to facets (#627)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ src/markdown_vault_mcp/
   vector_index.py      -- numpy embeddings, cosine similarity
   providers.py         -- embedding provider ABC + implementations
   tracker.py           -- hash-based change detection
-  collection.py        -- thin facade: lifecycle, wiring, delegation (index-write → indexing/coordinator.py)
+  collection.py        -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
   write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
   config.py            -- configuration loading
   server.py            -- generic FastMCP server factory (make_server) with tool annotations

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ from pathlib import Path
 from markdown_vault_mcp import Collection
 
 collection = Collection(source_dir=Path("/path/to/vault"))
-results = collection.search("query text", limit=10)
+collection.index.build_index()
+results = collection.reader.search("query text", limit=10)
 ```
 
 ### As an MCP server

--- a/docs/api/collection.md
+++ b/docs/api/collection.md
@@ -1,6 +1,6 @@
 # Collection
 
-The `Collection` class is the primary public API for the library. MCP tools, CLI commands, and direct integrations all go through this class.
+The `Collection` class is the primary public API for the library. MCP tools, CLI commands, and direct integrations all go through this class. It is a thin composition root: the read / write / graph / index operations live on the four facets, reached through the `reader` / `writer` / `graph` / `index` accessors (see [Facets](facets.md)).
 
 ## Quick Start
 
@@ -10,16 +10,16 @@ from markdown_vault_mcp import Collection
 
 # Basic read-only collection
 collection = Collection(source_dir=Path("/path/to/vault"))
-stats = collection.build_index()
+stats = collection.index.build_index()
 print(f"Indexed {stats.documents_indexed} documents")
 
-# Search
-results = collection.search("query text", limit=10)
+# Search (reader facet)
+results = collection.reader.search("query text", limit=10)
 for r in results:
     print(f"{r.path}: {r.title} (score: {r.score:.2f})")
 
-# Read a document
-note = collection.read("Journal/note.md")
+# Read a document (reader facet)
+note = collection.reader.read("Journal/note.md")
 print(note.content)
 ```
 

--- a/docs/api/facets.md
+++ b/docs/api/facets.md
@@ -1,0 +1,53 @@
+# Facets
+
+The read / write / graph / index operations live on four cohesive facets,
+reached through the `reader` / `writer` / `graph` / `index` accessors on the
+[`Collection`](collection.md) composition root.
+
+```python
+from pathlib import Path
+from markdown_vault_mcp import Collection
+
+collection = Collection(source_dir=Path("/path/to/vault"))
+collection.index.build_index()
+
+# Reader facet — search / read / list / metadata
+results = collection.reader.search("query text", limit=10)
+note = collection.reader.read("Journal/note.md")
+
+# Writer facet — write / edit / delete / rename / attachments
+collection.writer.write("Journal/new.md", "# New note")
+
+# Graph facet — backlinks / outlinks / orphans / paths
+backlinks = collection.graph.get_backlinks("Journal/note.md")
+
+# Index facet — build / reindex / embeddings / readiness
+collection.index.reindex()
+```
+
+## ReaderFacet
+
+Search, read, listing, table-of-contents, similarity, context, history/diff,
+and attachment reads.
+
+::: markdown_vault_mcp.facets.reader.ReaderFacet
+
+## WriterFacet
+
+Create, edit, delete, rename, and attachment writes.
+
+::: markdown_vault_mcp.facets.writer.WriterFacet
+
+## GraphFacet
+
+Backlinks, outlinks, broken links, orphans, most-linked notes, and connection
+paths.
+
+::: markdown_vault_mcp.facets.graph.GraphFacet
+
+## IndexFacet
+
+Index build / reindex / embeddings (sync + async), readiness, and writer
+status.
+
+::: markdown_vault_mcp.facets.index.IndexFacet

--- a/docs/api/git.md
+++ b/docs/api/git.md
@@ -23,7 +23,7 @@ collection = Collection(
 )
 
 # Writes are now auto-committed and pushed
-collection.write("notes/new.md", "Hello world")
+collection.writer.write("notes/new.md", "Hello world")
 
 # Clean up on shutdown
 collection.close()

--- a/docs/design.md
+++ b/docs/design.md
@@ -64,7 +64,7 @@ markdown-vault-mcp (new package)
 +-- vector_index.py   -- numpy embeddings, cosine similarity
 +-- providers.py      -- Ollama / OpenAI / SentenceTransformers
 +-- tracker.py        -- hash-based change detection
-+-- collection.py     -- thin facade: lifecycle, wiring, delegation (index-write → indexing/coordinator.py)
++-- collection.py     -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
 +-- write_callback.py -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
 +-- config.py         -- configuration loading
 +-- config_sections/  -- domain-grouped sub-configs (git/indexing/embeddings/search/sync/content)
@@ -376,7 +376,7 @@ Two methods manage the index:
   crashed mid-build, since `IndexManager.build_index` commits per-document
   in its own transaction — is treated as cold and triggers a full
   rebuild. The sentinel is the `build_completed_at` row in the FTS
-  `meta` table, cleared by `Collection.build_index` before any
+  `meta` table, cleared by `IndexFacet.build_index` before any
   destructive rebuild and written only after `_index_mgr.build_index`
   returns cleanly. `force=True` drops and rebuilds from scratch. When a
   persistent `index_path` contains documents that now match
@@ -417,12 +417,12 @@ with a captured error — `wait_until_queryable` reports that as
 **Cold-start background FTS (issue #513 PR1, tool-layer wait
 boundary)**: when the persisted FTS DB is cold (sentinel absent),
 the MCP server lifespan calls
-`Collection.start_background_build_index()` to spawn a daemon
+`IndexFacet.start_background_build_index()` to spawn a daemon
 thread that runs `build_index()` to completion. Bucket-3/4 calls
 arriving at the MCP layer go through the
 `needs_queryable` decorator (in
 `src/markdown_vault_mcp/_server_queryable.py`), which blocks via
-`Collection.wait_until_queryable(timeout)` with a configurable
+`IndexFacet.wait_until_queryable(timeout)` with a configurable
 default (env `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`, default 60s).
 A failed background build surfaces to operators as
 `get_index_status` reporting
@@ -461,7 +461,7 @@ without deadlocking on internal blocking.
 
 The `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` env var bounds the
 `@needs_queryable` decorator's wait, which calls
-`Collection.wait_until_queryable`. The env var and the method name
+`IndexFacet.wait_until_queryable`. The env var and the method name
 describe the same wait from different angles — operators tune the
 timeout in seconds; the method describes what predicate the wait
 resolves to.
@@ -554,7 +554,7 @@ takes a snapshot set as an argument (no lock contention with the writer's
 dirty-set ownership) and performs the slow embed step outside any
 file-mutation lock.
 
-**Status surface.** `Collection.get_index_status()` merges the writer's
+**Status surface.** `IndexFacet.get_index_status()` merges the writer's
 non-blocking snapshot (`queue_depth`, `in_flight`, `dirty_paths`,
 `dirty_embeddings`) into its response shape, so operators can observe
 exactly what the writer is doing without taking any lock. The document
@@ -597,12 +597,12 @@ pair could not detect: a write that started and finished entirely
 between two snapshots.
 
 Each B3 tool accepts an optional `wait_for_drain: bool = false`
-parameter. When `true`, the tool layer polls `Collection.is_drained()`
+parameter. When `true`, the tool layer polls `IndexFacet.is_drained()`
 with `asyncio.sleep` until the writer drains or
 `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s) elapses, then
 runs the query. On timeout the tool returns the result with
 `stale=true` rather than raising — best-effort fresh-read
-semantics. (`Collection.wait_for_drain()` is the synchronous
+semantics. (`IndexFacet.wait_for_drain()` is the synchronous
 counterpart for in-process callers.)
 
 The drift signal reflects writer-internal state only: paths in
@@ -685,8 +685,8 @@ The etag used for comparison is the same value returned in the `etag` field of
 `read()` and `read_attachment()` responses, so the round-trip pattern is:
 
 ```python
-note = collection.read("doc.md")
-collection.write("doc.md", new_content, if_match=note.etag)
+note = collection.reader.read("doc.md")
+collection.writer.write("doc.md", new_content, if_match=note.etag)
 ```
 
 ### Security: Path Traversal Protection
@@ -759,8 +759,8 @@ The library is **synchronous** internally. This is appropriate for the
 single-user vault use case and for Python library consumers (LangChain tools
 are typically sync).
 
-In the MCP server layer, use `asyncio.to_thread(collection.search, ...)` for
-tool handlers to avoid blocking the FastMCP event loop.
+In the MCP server layer, use `asyncio.to_thread(collection.reader.search, ...)`
+for tool handlers to avoid blocking the FastMCP event loop.
 
 **Future work**: async embedding provider path for non-blocking batch
 operations.
@@ -1104,7 +1104,7 @@ vault-wide resolution rules rather than relative path resolution:
   shortest path wins. Path matches always take priority over alias matches.
 
 `resolve_vault_wikilinks()` is called automatically at the end of
-`Collection.build_index()`, `Collection.reindex()`, and every
+`IndexFacet.build_index()`, `IndexFacet.reindex()`, and every
 `DocumentManager` write that mutates the `links` table — `write()` and
 `edit()` of a `.md` document, `delete()` of a `.md` document, and
 `rename()` of a `.md` document.  Attachment writes do not invoke the
@@ -1139,7 +1139,7 @@ The adjacency dict is built per-query from the `links` table; it is not cached
 between calls. For typical vault sizes (hundreds to low thousands of notes),
 this is fast enough that caching adds complexity without measurable benefit.
 
-`Collection.get_connection_path()` wraps the FTS call and applies path
+`GraphFacet.get_connection_path()` wraps the FTS call and applies path
 traversal protection via `_validate_path()` before delegating.
 
 The MCP tool `get_connection_path` returns
@@ -1192,13 +1192,17 @@ deliberate wrapper: it surfaces the coordinator's public operations (plus
 internals (``close``, ``writer``, ``require_built``, ``mark_paths_dirty``,
 ``rebuild_embeddings``).
 
-The migration follows **addition before removal**: the flat ``Collection``
-methods now delegate to the facets (PR3a, #604); callers migrate to the facet
-accessors in follow-up PRs (#605, #606); the flat methods are removed and
-``Collection`` is renamed to ``Vault`` in the final PR.
+The migration followed **addition before removal**: the flat ``Collection``
+methods first delegated to the facets (PR3a, #604); production callers (PR3b,
+#605) and the test suite (PR3c, #606) then migrated to the facet accessors; the
+flat delegators were removed (PR4a, #627), leaving ``Collection`` a thin
+composition root. ``Collection`` is renamed to ``Vault`` in PR4b.
 
-Collection's public API signatures remain unchanged — clients interact with
-Collection (or, increasingly, its facets), never with managers directly.
+Clients reach the read / write / graph / index operations through the facet
+accessors (e.g. ``collection.reader.search(...)``), never through managers
+directly. ``Collection`` itself now exposes only construction, the four facet
+accessors, and lifecycle — the per-facet method surface is the Facets table
+above.
 
 ```python
 class Collection:
@@ -1218,52 +1222,27 @@ class Collection:
         exclude_patterns: list[str] | None = None,
     ): ...
 
-    # --- Search ---
-    def search(
-        self, query: str, *, limit: int = 10,
-        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
-        filters: dict[str, str] | None = None,
-        folder: str | None = None,
-        chunks_per_file: int | None = None,
-        snippet_words: int | None = None,
-    ) -> list[GroupedResult]: ...
+    # --- Facet accessors (the public operation surface) ---
+    # search / read / write / edit / delete / rename / list / graph / index /
+    # stats operations live on these facets; see the Facets table above for the
+    # per-facet method surface (e.g. collection.reader.search(...),
+    # collection.writer.write(...), collection.index.build_index(...)).
+    @property
+    def reader(self) -> ReaderFacet: ...
+    @property
+    def writer(self) -> WriterFacet: ...
+    @property
+    def graph(self) -> GraphFacet: ...
+    @property
+    def index(self) -> IndexFacet: ...
 
-    # --- Read/Write (mirrors LLM file tool semantics) ---
-    def read(self, path: str) -> NoteContent | None: ...
-    def write(self, path: str, content: str,
-              frontmatter: dict | None = None,
-              if_match: str | None = None) -> WriteResult: ...
-    def edit(self, path: str, old_text: str | None = None,
-             new_text: str = "", if_match: str | None = None,
-             line_start: int | None = None,
-             line_end: int | None = None) -> EditResult: ...
-    def delete(self, path: str,
-               if_match: str | None = None) -> DeleteResult: ...
-    def rename(self, old_path: str, new_path: str,
-               if_match: str | None = None, *,
-               update_links: bool = False) -> RenameResult: ...
-    def list_documents(self, *, folder: str | None = None,
-                       pattern: str | None = None) -> list[NoteInfo]: ...
-
-    # --- Index management ---
-    def build_index(self, *, force: bool = False) -> IndexStats: ...
-    def reindex(self) -> ReindexResult: ...
-    def build_embeddings(self, *, force: bool = False) -> int: ...
-    def embeddings_status(self) -> dict: ...
-
-    # --- Metadata ---
-    def list_folders(self) -> list[str]: ...
-    def list_tags(self, field: str = "tags") -> list[str]: ...
-    def get_backlinks(self, path: str, *, limit: int | None = None) -> list[BacklinkInfo]: ...
-    def get_outlinks(self, path: str, *, limit: int | None = None) -> list[OutlinkInfo]: ...
-    def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]: ...
-    def get_similar(self, path: str, *, limit: int = 10,
-                    chunks_per_file: int | None = None) -> list[GroupedResult]: ...
-    def get_recent(self, *, limit: int = 20, folder: str | None = None) -> list[NoteInfo]: ...
-    def get_context(self, path: str, *, similar_limit: int = 5, link_limit: int = 10) -> NoteContext: ...
-    def get_orphan_notes(self) -> list[NoteInfo]: ...
-    def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]: ...
-    def stats(self) -> CollectionStats: ...
+    # --- Lifecycle ---
+    def start(self) -> None: ...
+    def stop(self) -> None: ...
+    def close(self) -> None: ...
+    def pause_writes(self) -> Iterator[None]: ...        # context manager
+    def force_pull(self) -> PullResult | None: ...
+    def sync_from_remote_before_index(self) -> None: ...
 ```
 
 **Constructor defaults**:
@@ -1272,9 +1251,9 @@ class Collection:
 - `embeddings_path=None`: semantic search is disabled.
 - `state_path=None`: defaults to `{source_dir}/.markdown_vault_mcp/state.json`.
 
-**Lazy initialization**: on first call to `search()`, `list_documents()`, or
-`read()`, `Collection` lazily builds the FTS index from `source_dir` if no
-pre-built `index_path` was provided.
+**Index build**: callers build the FTS index explicitly via
+`IndexFacet.build_index` — the server builds at startup, and a cold on-disk
+start builds in the background (#513). There is no lazy build on first query.
 
 **Write operations** (`write`, `edit`, `delete`, `rename`) raise
 `ReadOnlyError` when `read_only=True`.
@@ -1404,7 +1383,7 @@ class FTSIndex:
 
 Uses the schema defined in [Database Schema](#database-schema). Note that
 `FTSIndex.search()` returns `list[FTSResult]` (raw BM25 results), while
-`Collection.search()` returns `list[GroupedResult]` (file-grouped results
+`ReaderFacet.search()` returns `list[GroupedResult]` (file-grouped results
 with RRF scoring in hybrid mode; each file appears once with up to
 `chunks_per_file` matching sections).
 
@@ -1484,7 +1463,7 @@ pattern). Each tool is annotated with MCP `ToolAnnotations`:
 
 **Tool name note**: the MCP tool is registered as `list_documents` (not `list`)
 to avoid shadowing Python's built-in `list`. The underlying
-`Collection.list_documents()` method matches the MCP name; both deliberately
+`ReaderFacet.list_documents()` method matches the MCP name; both deliberately
 avoid the bare name `list` so type annotations like `list[NoteInfo]` are not
 mis-resolved against the method in class scope.
 
@@ -1525,11 +1504,11 @@ template functions with no collection dependency.
 | URI | Source | Description |
 |-----|--------|-------------|
 | ``config://vault`` | ``CollectionConfig`` | Source dir, read-only flag, indexed fields, extensions |
-| ``stats://vault`` | ``Collection.stats()`` | Document/chunk/folder counts, capabilities |
-| ``tags://vault`` | ``Collection.list_tags()`` | All tags grouped by indexed field |
-| ``tags://vault/{field}`` | ``Collection.list_tags(field)`` | Flat list for one field (template) |
-| ``folders://vault`` | ``Collection.list_folders()`` | Sorted folder path list |
-| ``toc://vault/{path}`` | ``Collection.get_toc(path)`` | Document headings with synthetic H1 title |
+| ``stats://vault`` | ``ReaderFacet.stats()`` | Document/chunk/folder counts, capabilities |
+| ``tags://vault`` | ``ReaderFacet.list_tags()`` | All tags grouped by indexed field |
+| ``tags://vault/{field}`` | ``ReaderFacet.list_tags(field)`` | Flat list for one field (template) |
+| ``folders://vault`` | ``ReaderFacet.list_folders()`` | Sorted folder path list |
+| ``toc://vault/{path}`` | ``ReaderFacet.get_toc(path)`` | Document headings with synthetic H1 title |
 
 Resources return JSON (``mime_type="application/json"``). The ToC resource
 queries the existing ``sections`` table — no file I/O.
@@ -1933,7 +1912,7 @@ Set `MARKDOWN_VAULT_MCP_GIT_LFS=false` for repos that do not use LFS, or when
   so the index scans the freshest working tree.
 - Starts a daemon thread that repeats `fetch + ff-only update` every interval.
 - After a successful fast-forward that advanced `HEAD`, triggers
-  `Collection.reindex()` to incrementally update the index.
+  `IndexFacet.reindex()` to incrementally update the index.
 - Blocks write operations during the **reindex phase** of each pull tick
   (not during fetch/ff-only merge) by acquiring the Collection write lock.
   Read/search operations are not blocked at the Python level (SQLite WAL
@@ -1950,7 +1929,7 @@ Safety branch mode for push failures is tracked separately (see #119).
 
 Both methods use the existing `_git_env()` / `_cleanup_git_env()` pattern for credential forwarding and cleanup. Path arguments are always validated via `Collection._validate_path()` before being passed to the git layer. No shell injection is possible because all subprocess calls use list arguments with `shell=False`.
 
-**MCP response envelope**: the MCP wrappers for `get_history` and `get_diff(per_commit=True)` return a `{"commits": [...], "total": N}` envelope rather than a bare list, so the structured payload is self-describing on the wire. FastMCP otherwise auto-wraps list-typed tool returns under a synthetic `"result"` key (`x-fastmcp-wrap-result: true` in the output schema), which forces clients re-reading persisted MCP content to know FastMCP's wrapping convention to find the data. The Python facade (`Collection.get_history`, `Collection.get_diff`) stays list-returning — only the MCP-tool wrapper transforms to the envelope. `get_diff(per_commit=False)` keeps its existing `{"diff": str}` shape since it is already self-describing.
+**MCP response envelope**: the MCP wrappers for `get_history` and `get_diff(per_commit=True)` return a `{"commits": [...], "total": N}` envelope rather than a bare list, so the structured payload is self-describing on the wire. FastMCP otherwise auto-wraps list-typed tool returns under a synthetic `"result"` key (`x-fastmcp-wrap-result: true` in the output schema), which forces clients re-reading persisted MCP content to know FastMCP's wrapping convention to find the data. The Python facade (`ReaderFacet.get_history`, `ReaderFacet.get_diff`) stays list-returning — only the MCP-tool wrapper transforms to the envelope. `get_diff(per_commit=False)` keeps its existing `{"diff": str}` shape since it is already self-describing.
 
 ### Release channels
 

--- a/docs/guides/para.md
+++ b/docs/guides/para.md
@@ -110,14 +110,14 @@ Then you can run targeted queries via the Python API:
 
 ```python
 # All active projects
-results = collection.search(
+results = collection.reader.search(
     "project",
     filters={"type": "project", "status": "active"},
     limit=50,
 )
 
 # All active projects in the Health area
-results = collection.search(
+results = collection.reader.search(
     "project",
     filters={"type": "project", "status": "active", "area": "Health"},
     limit=50,
@@ -158,7 +158,7 @@ Use the create_from_template prompt with template_name="inbox"
 from markdown_vault_mcp import Collection
 
 collection = Collection(source_dir="/path/to/vault")
-collection.write(
+collection.writer.write(
     "0-Inbox/migrate-postgres.md",
     content="We should look into migrating to Postgres 16.",
     frontmatter={"tags": [], "created": "2026-04-19"},
@@ -268,14 +268,14 @@ collection = Collection(source_dir="/path/to/vault")
 today = date.today().isoformat()
 
 # Flip status and add archived_at. One targeted replacement each.
-collection.edit(
+collection.writer.edit(
     "1-Projects/ship-v2.md",
     old_text="status: active",
     new_text=f"status: archived\narchived_at: {today}",
 )
 
 # Move to the archive folder, preserving backlinks.
-collection.rename(
+collection.writer.rename(
     "1-Projects/ship-v2.md",
     "4-Archive/ship-v2.md",
     update_links=True,

--- a/docs/guides/zettelkasten.md
+++ b/docs/guides/zettelkasten.md
@@ -75,8 +75,8 @@ export MARKDOWN_VAULT_MCP_INDEXED_FIELDS=type,tags
 Then you can search by note type or tag using the Python API:
 
 ```python
-results = collection.search("query", filters={"type": "permanent"})
-results = collection.search("query", filters={"tags": "system-design"})
+results = collection.reader.search("query", filters={"type": "permanent"})
+results = collection.reader.search("query", filters={"tags": "system-design"})
 ```
 
 Or restrict to a folder via the CLI:
@@ -115,7 +115,7 @@ Or programmatically:
 from markdown_vault_mcp import Collection
 
 collection = Collection(source_dir="/path/to/vault")
-collection.write(
+collection.writer.write(
     "Inbox/quick-idea.md",
     content="Distributed systems are hard.",
     frontmatter={"type": "fleeting", "tags": ["systems"]}
@@ -154,15 +154,15 @@ Expand fleeting notes into permanent knowledge. Two paths:
 
 ```python
 # See the note's current neighborhood
-context = collection.get_context("Inbox/consensus-algorithms.md")
+context = collection.reader.get_context("Inbox/consensus-algorithms.md")
 print(f"Backlinks: {context.backlinks}")
 print(f"Similar notes: {context.similar}")
 
 # Search for related notes
-results = collection.search("consensus", mode="hybrid", limit=20)
+results = collection.reader.search("consensus", mode="hybrid", limit=20)
 
 # Once expanded, update the note
-collection.edit(
+collection.writer.edit(
     "Inbox/consensus-algorithms.md",
     old_text="type: fleeting",
     new_text="type: permanent"
@@ -177,7 +177,7 @@ Linking transforms isolated notes into a knowledge network. Four tools support t
 
 ```python
 # See everything connected to this note
-context = collection.get_context("Notes/consensus.md")
+context = collection.reader.get_context("Notes/consensus.md")
 ```
 
 Returns:
@@ -191,7 +191,7 @@ Returns:
 **Find related notes you haven't linked yet:**
 
 ```python
-similar = collection.get_similar("Notes/consensus.md", limit=10)
+similar = collection.reader.get_similar("Notes/consensus.md", limit=10)
 for note in similar:
     print(f"Similar: {note.title} ({note.score:.2f})")
 ```
@@ -200,7 +200,7 @@ for note in similar:
 
 ```python
 # Find the shortest path between two ideas
-path = collection.get_connection_path(
+path = collection.graph.get_connection_path(
     source="Notes/distributed-systems.md",
     target="Notes/fault-tolerance.md",
     max_depth=5
@@ -216,7 +216,7 @@ else:
 Edit the note and add `[[wikilink]]` or `[text](path.md)` references:
 
 ```python
-collection.edit(
+collection.writer.edit(
     "Notes/consensus.md",
     old_text="## Evidence",
     new_text="## Evidence\n\nSee [[Byzantine Fault Tolerance]] for formal proofs."
@@ -233,7 +233,7 @@ All three link formats work:
 When a note title changes, rename it and update all backlinks automatically:
 
 ```python
-collection.rename(
+collection.writer.rename(
     "Notes/old-title.md",
     "Notes/new-title.md",
     update_links=True  # Rewrites [[old-title]] to [[new-title]] in all notes
@@ -247,7 +247,7 @@ Weekly reviews keep your vault healthy and connected:
 **Check vault statistics:**
 
 ```python
-stats = collection.stats()
+stats = collection.reader.stats()
 print(f"Documents: {stats.document_count}")
 print(f"Broken links: {stats.broken_link_count}")
 print(f"Orphan notes: {stats.orphan_count}")
@@ -256,7 +256,7 @@ print(f"Orphan notes: {stats.orphan_count}")
 **Find isolated notes:**
 
 ```python
-orphans = collection.get_orphan_notes()
+orphans = collection.graph.get_orphan_notes()
 for note in orphans:
     print(f"Isolated: {note.path}")
     # Either link it to the rest of the vault, or delete it
@@ -265,7 +265,7 @@ for note in orphans:
 **Find and fix broken links:**
 
 ```python
-broken = collection.get_broken_links()
+broken = collection.graph.get_broken_links()
 for link in broken:
     print(f"Broken: {link.source_path} -> {link.target_path}")
     # Fix the link or delete the file it points to
@@ -274,7 +274,7 @@ for link in broken:
 **Identify hub notes (candidates for MOCs):**
 
 ```python
-hubs = collection.get_most_linked(limit=10)
+hubs = collection.graph.get_most_linked(limit=10)
 for hub in hubs:
     print(f"{hub.title}: {hub.backlink_count} inbound links")
 ```
@@ -294,15 +294,15 @@ A **MOC** (Map of Content) is a curated hub note that aggregates links to relate
 1. Identify the theme — e.g., "Distributed Systems"
 2. Search for related notes:
    ```python
-   results = collection.search("distributed systems", mode="hybrid", limit=30)
+   results = collection.reader.search("distributed systems", mode="hybrid", limit=30)
    ```
 3. Use `get_most_linked()` to find existing hubs:
    ```python
-   hubs = collection.get_most_linked(limit=10)
+   hubs = collection.graph.get_most_linked(limit=10)
    ```
 4. Create a new `moc` template note:
    ```python
-   collection.write(
+   collection.writer.write(
        "Notes/Distributed-Systems-MOC.md",
        content="# Distributed Systems\n\n## Core concepts\n...",
        frontmatter={
@@ -315,7 +315,7 @@ A **MOC** (Map of Content) is a curated hub note that aggregates links to relate
 5. Add `[[wikilinks]]` to permanent notes grouped by depth or topic
 6. Link the MOC back from related permanent notes:
    ```python
-   collection.edit(
+   collection.writer.edit(
        "Notes/consensus.md",
        old_text="## Related",
        new_text="## Related\n\nSee [[Distributed-Systems-MOC]] for the full map."
@@ -432,7 +432,7 @@ The prompt will walk you through connecting the note, discovering related ideas,
 Before writing your first note, run `stats()` to understand your vault's shape:
 
 ```python
-stats = collection.stats()
+stats = collection.reader.stats()
 print(f"Documents: {stats.document_count}")
 print(f"Broken links: {stats.broken_link_count}")
 print(f"Orphaned notes: {stats.orphan_count}")
@@ -455,10 +455,10 @@ Always prefer `mode='hybrid'` when searching:
 
 ```python
 # Good
-collection.search("consensus", mode="hybrid", limit=20)
+collection.reader.search("consensus", mode="hybrid", limit=20)
 
 # Weaker (keyword only)
-collection.search("consensus", mode="keyword", limit=20)
+collection.reader.search("consensus", mode="keyword", limit=20)
 ```
 
 Hybrid search combines full-text ranking (exact matches, stemming) with semantic similarity (meaning), so you get both precision and discovery.
@@ -468,7 +468,7 @@ Hybrid search combines full-text ranking (exact matches, stemming) with semantic
 Orphaned notes (no inbound or outbound links) are knowledge dead zones. Schedule a weekly check:
 
 ```python
-orphans = collection.get_orphan_notes()
+orphans = collection.graph.get_orphan_notes()
 for note in orphans:
     # Either integrate it: add outlinks to existing notes
     # Or delete it: it wasn't worth connecting
@@ -481,7 +481,7 @@ This prevents accumulating notes you're not thinking about.
 When you want to see how two seemingly distant topics relate, use `get_connection_path()`:
 
 ```python
-path = collection.get_connection_path(
+path = collection.graph.get_connection_path(
     source="Notes/machine-learning.md",
     target="Notes/philosophy.md",
     max_depth=6

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,8 @@ from pathlib import Path
 from markdown_vault_mcp import Collection
 
 collection = Collection(source_dir=Path("/path/to/vault"))
-results = collection.search("query text", limit=10)
+collection.index.build_index()
+results = collection.reader.search("query text", limit=10)
 ```
 
 ### As an MCP server

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -123,7 +123,7 @@ Top 10 semantically similar notes for a document. Requires embeddings to be buil
 Results are **grouped per file** — each file appears at most once, with up to `chunks_per_file` (server default `2`) best-matching sections in a `sections` array. Each entry is a `GroupedResult` dict with `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 
 !!! note "Resource shape differs from `get_similar` tool"
-    This resource returns a flat JSON array. The `get_similar` MCP tool wraps the same data in a `{"stale": bool, "data": [...]}` envelope so callers see a drift signal (#534). Resource handlers do not accept a `wait_for_drain` parameter, so this resource intentionally omits the envelope; clients that need the drift signal should use the tool. Lifting the envelope to resources is tracked as a follow-up — see [`Collection.is_drained()`](https://github.com/pvliesdonk/markdown-vault-mcp/issues/534) for the underlying primitive.
+    This resource returns a flat JSON array. The `get_similar` MCP tool wraps the same data in a `{"stale": bool, "data": [...]}` envelope so callers see a drift signal (#534). Resource handlers do not accept a `wait_for_drain` parameter, so this resource intentionally omits the envelope; clients that need the drift signal should use the tool. Lifting the envelope to resources is tracked as a follow-up — see [`IndexFacet.is_drained()`](https://github.com/pvliesdonk/markdown-vault-mcp/issues/534) for the underlying primitive.
 
 **Example:** `similar://vault/Journal/note.md`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ plugins:
           - deployment/oidc.md: OIDC authentication setup with Authelia
         Python API:
           - api/collection.md: Collection class API reference
+          - api/facets.md: Reader/Writer/Graph/Index facet API reference
           - api/git.md: GitWriteStrategy API reference
           - api/config.md: Configuration loading API reference
           - api/providers.md: Embedding provider API reference
@@ -159,6 +160,7 @@ nav:
       - OIDC Authentication: deployment/oidc.md
   - Python API:
       - Collection: api/collection.md
+      - Facets: api/facets.md
       - Git Integration: api/git.md
       - Configuration: api/config.md
       - Embedding Providers: api/providers.md

--- a/src/markdown_vault_mcp/_server_queryable.py
+++ b/src/markdown_vault_mcp/_server_queryable.py
@@ -69,7 +69,7 @@ def needs_queryable(
     """Decorator for bucket-3/4 MCP tool and resource handlers.
 
     Before invoking the wrapped handler, blocks on
-    ``Collection.wait_until_queryable(timeout)``. On the warm path
+    ``IndexFacet.wait_until_queryable(timeout)``. On the warm path
     (``is_queryable`` already True) the wait is skipped — no
     thread-pool overhead.
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -44,7 +44,7 @@ async def _maybe_wait_for_drain(
 ) -> bool:
     """Wait for the writer to drain when requested. Log on timeout.
 
-    Polls :meth:`Collection.is_drained` directly with ``asyncio.sleep``
+    Polls :meth:`IndexFacet.is_drained` directly with ``asyncio.sleep``
     so concurrent waiters yield to the event loop instead of occupying
     ``asyncio.to_thread`` slots for the full timeout (would starve the
     default thread pool at moderate concurrency).

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.facets import (
     GraphFacet,
@@ -29,32 +29,12 @@ from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from concurrent.futures import Future
     from pathlib import Path
 
     from markdown_vault_mcp.git import GitWriteStrategy, PullResult
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.types import (
-        AttachmentContent,
-        AttachmentInfo,
-        BacklinkInfo,
-        BrokenLinkInfo,
-        CollectionStats,
-        CommitDiff,
-        DeleteResult,
-        EditResult,
-        GroupedResult,
-        HistoryEntry,
-        IndexStats,
-        MostLinkedNote,
-        NoteContent,
-        NoteContext,
-        NoteInfo,
-        OutlinkInfo,
-        ReindexResult,
-        RenameResult,
         WriteCallback,
-        WriteResult,
     )
     from markdown_vault_mcp.vector_index import VectorIndex
 
@@ -92,34 +72,42 @@ def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
 class Collection:
     """Facade over FTS5 index, vector index, and change tracker.
 
-    Instantiate once per collection root.  Callers must invoke
-    :meth:`build_index` before bucket-3 relational/FTS-backed queries
-    (:meth:`get_backlinks`, :meth:`get_outlinks`, :meth:`get_similar`,
-    :meth:`get_context`, :meth:`get_connection_path`, :meth:`get_toc`)
-    or the bucket-4 coordinators :meth:`reindex` and
-    :meth:`build_embeddings`; otherwise
-    :exc:`~markdown_vault_mcp.exceptions.IndexUnavailableError` is raised.
-    :meth:`build_index` must also precede :meth:`start` — see
-    :meth:`start` for the rationale.
-    Bucket-1 file operations (:meth:`read`, :meth:`write`, :meth:`edit`,
-    :meth:`delete`, :meth:`rename`, :meth:`write_attachment`) and bucket-2
-    aggregate queries (:meth:`search`, :meth:`list`, :meth:`stats`, …)
-    work on an unbuilt index — bucket-1 hits disk directly; bucket-2
-    returns whatever is currently in the index (empty on cold start).
-    See issue #525.
+    Instantiate once per collection root.  The read / write / graph / index
+    operations live on the four facets, reached through the :attr:`reader` /
+    :attr:`writer` / :attr:`graph` / :attr:`index` accessors (e.g.
+    ``collection.reader.search(...)``); this class itself exposes only
+    construction, those accessors, and lifecycle.
+
+    Callers must invoke :meth:`IndexFacet.build_index` before bucket-3
+    relational/FTS-backed queries (:meth:`GraphFacet.get_backlinks`,
+    :meth:`GraphFacet.get_outlinks`, :meth:`ReaderFacet.get_similar`,
+    :meth:`ReaderFacet.get_context`, :meth:`GraphFacet.get_connection_path`,
+    :meth:`ReaderFacet.get_toc`) or the bucket-4 coordinators
+    :meth:`IndexFacet.reindex` and :meth:`IndexFacet.build_embeddings`;
+    otherwise :exc:`~markdown_vault_mcp.exceptions.IndexUnavailableError` is
+    raised. :meth:`IndexFacet.build_index` must also precede :meth:`start` —
+    see :meth:`start` for the rationale.
+    Bucket-1 file operations (:meth:`ReaderFacet.read`,
+    :meth:`WriterFacet.write`, :meth:`WriterFacet.edit`,
+    :meth:`WriterFacet.delete`, :meth:`WriterFacet.rename`,
+    :meth:`WriterFacet.write_attachment`) and bucket-2 aggregate queries
+    (:meth:`ReaderFacet.search`, :meth:`ReaderFacet.list_documents`,
+    :meth:`ReaderFacet.stats`, …) work on an unbuilt index — bucket-1 hits
+    disk directly; bucket-2 returns whatever is currently in the index (empty
+    on cold start). See issue #525.
 
     **Index lifecycle (issues #513, #526, #559).** The MCP server
     lifespan submits a :class:`~markdown_vault_mcp.indexing.BuildIndex`
     job to the single-owner
     :class:`~markdown_vault_mcp.indexing.IndexWriter` via
-    :meth:`build_index_async` and yields immediately. On a warm
+    :meth:`IndexFacet.build_index_async` and yields immediately. On a warm
     restart the persisted FTS completeness sentinel (PR #526) causes
-    :meth:`build_index_async` to return an already-resolved
+    :meth:`IndexFacet.build_index_async` to return an already-resolved
     ``Future`` in O(1) without touching the writer queue. On a cold
     restart the writer thread runs the job asynchronously while the
     lifespan yields; bucket-3/4 MCP tool *clients* block on the
     :class:`markdown_vault_mcp._server_queryable.needs_queryable`
-    decorator, which calls :meth:`wait_until_queryable` with a
+    decorator, which calls :meth:`IndexFacet.wait_until_queryable` with a
     bounded default timeout
     (``MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S``, default 60s). The
     library stays honest: bucket-3/4 *methods* keep the PR #525
@@ -128,9 +116,9 @@ class Collection:
     users) get the raise contract and handle "not ready" with
     caller-appropriate logic — never block.
 
-    **Thread safety (issue #519):** every public method on this class is safe
-    to call from any thread, concurrently with other reads and writes from
-    any other thread. Index mutations (FTS + vector index) are serialised
+    **Thread safety (issue #519):** every facet operation and lifecycle method
+    is safe to call from any thread, concurrently with other reads and writes
+    from any other thread. Index mutations (FTS + vector index) are serialised
     by the single-owner :class:`~markdown_vault_mcp.indexing.IndexWriter`
     thread (#559); file-mutation operations on disk are serialised via
     ``_file_write_lock`` (RLock) so two MCP write tools racing on the
@@ -339,9 +327,7 @@ class Collection:
             mark_paths_dirty=self._coordinator.mark_paths_dirty,
         )
 
-        # Facets (#604): thin views grouping the formerly-flat surface,
-        # constructed once over the shared managers/coordinator. The flat
-        # methods below delegate to them (addition before removal).
+        # Facets (#604): thin views over the shared managers/coordinator, exposed via the reader/writer/graph/index accessors.
         self._reader_facet = ReaderFacet(
             search_mgr=self._search_mgr,
             doc_mgr=self._doc_mgr,
@@ -412,11 +398,11 @@ class Collection:
     def start(self) -> None:
         """Start background tasks for this Collection (e.g. git pull loop).
 
-        Call :meth:`build_index` **before** :meth:`start`. The git pull
-        loop wires :meth:`reindex` (bucket 4) as its ``on_pull`` callback,
-        and ``reindex`` raises :exc:`IndexUnavailableError` on an unbuilt
-        index — so a pull event firing before the initial build would
-        crash the loop thread.
+        Call :meth:`IndexFacet.build_index` **before** :meth:`start`. The git
+        pull loop wires :meth:`IndexFacet.reindex` (bucket 4) as its
+        ``on_pull`` callback, and ``reindex`` raises
+        :exc:`IndexUnavailableError` on an unbuilt index — so a pull event
+        firing before the initial build would crash the loop thread.
         """
         if self._git_strategy is None or self._git_pull_interval_s <= 0:
             return
@@ -424,7 +410,7 @@ class Collection:
             repo_path=self._source_dir,
             pull_interval_s=self._git_pull_interval_s,
             pause_writes=self.pause_writes,
-            on_pull=self.reindex,
+            on_pull=self._index_facet.reindex,
         )
 
     def force_pull(self) -> PullResult | None:
@@ -500,81 +486,8 @@ class Collection:
     # ------------------------------------------------------------------
 
     def _require_built(self) -> None:
-        """Raise :exc:`IndexUnavailableError` if :meth:`build_index` has not run."""
+        """Raise :exc:`IndexUnavailableError` if :meth:`IndexFacet.build_index` has not run."""
         self._coordinator.require_built()
-
-    def is_queryable(self) -> bool:
-        """Return True when the FTS index is queryable (precondition snapshot).
-
-        A captured build error does NOT demote queryability: it is
-        diagnostic state surfaced via :meth:`get_index_status`, not a gate.
-        """
-        return self._index_facet.is_queryable()
-
-    def start_background_build_index(self) -> None:
-        """Spawn a daemon thread that runs :meth:`build_index` to completion.
-
-        .. deprecated:: 1.28
-           Superseded by :meth:`build_index_async`. Retained for legacy tests.
-        """
-        self._index_facet.start_background_build_index()
-
-    def should_use_background_build(self) -> bool:
-        """Return True iff the lifespan should route to the background build.
-
-        .. deprecated:: 1.28
-           Retained for legacy tests; the lifespan no longer branches on it.
-        """
-        return self._index_facet.should_use_background_build()
-
-    def is_drained(self) -> bool:
-        """Return True iff the IndexWriter has no pending or in-flight work.
-
-        Reflects the moment of call only; pair with :meth:`write_generation`
-        to detect a complete write cycle inside a read window.
-        """
-        return self._index_facet.is_drained()
-
-    def write_generation(self) -> int:
-        """Return the writer's monotonic completion counter.
-
-        Increments once per completed job. Pair with :meth:`is_drained` to
-        detect a write cycle inside a read window.
-        """
-        return self._index_facet.write_generation()
-
-    def wait_for_drain(self, timeout: float | None = None) -> bool:
-        """Block until :meth:`is_drained`; ``True`` if drained, ``False`` on timeout."""
-        return self._index_facet.wait_for_drain(timeout)
-
-    def get_index_status(self) -> dict[str, Any]:
-        """Return a non-blocking eleven-key snapshot of build + writer state.
-
-        Keys: ``status`` (``"queryable"`` | ``"building"`` | ``"failed"``),
-        ``documents_indexed``, ``documents_indexed_error``, ``error``,
-        ``last_reindex_error``, ``last_build_embeddings_error``, plus
-        ``queue_depth``, ``in_flight``, ``dirty_paths``, ``dirty_embeddings``,
-        ``write_generation`` merged from the writer. A captured build error
-        appears in ``error`` as diagnostic context without demoting a
-        ``queryable`` status; ``documents_indexed_error`` carries a SQLite
-        read failure (``documents_indexed`` stays ``0``) (#583).
-        """
-        return self._index_facet.get_index_status()
-
-    def wait_until_queryable(self, timeout: float | None = None) -> None:
-        """Block until the FTS index is queryable, or raise.
-
-        A captured build error does NOT block here; it surfaces as
-        ``IndexUnavailableError(reason="build_failed")`` and is also readable
-        via :meth:`get_index_status`. Library bucket-3/4 methods use
-        :meth:`_require_built` instead, which raises immediately.
-
-        Raises:
-            IndexUnavailableError: timeout expired (``reason="timeout"``), a
-                build ran and failed (``reason="build_failed"``), or no build
-                was ever scheduled (``reason="never_built"``).
-        """
-        self._index_facet.wait_until_queryable(timeout)
 
     @property
     def _vectors(self) -> VectorIndex | None:
@@ -586,530 +499,7 @@ class Collection:
         self._search_mgr.vectors = value
 
     # ------------------------------------------------------------------
-    # Search
-    # ------------------------------------------------------------------
-
-    def search(
-        self,
-        query: str,
-        *,
-        limit: int = 10,
-        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
-        filters: dict[str, str] | None = None,
-        folder: str | None = None,
-        chunks_per_file: int | None = None,
-        snippet_words: int | None = None,
-    ) -> list[GroupedResult]:
-        """Search the collection.
-
-        Args:
-            query: Search string.
-            limit: Maximum number of files (not chunks) to return.
-            mode: ``"keyword"`` for BM25 FTS5, ``"semantic"`` for cosine
-                similarity, or ``"hybrid"`` for Reciprocal Rank Fusion of both.
-            filters: Dict of ``{frontmatter_key: value}`` pairs (AND semantics).
-                Only works for fields in ``indexed_frontmatter_fields``.
-            folder: If provided, restrict results to documents in this folder
-                (and its sub-folders).
-            chunks_per_file: Maximum number of sections returned per file.
-                ``None`` uses the server default configured at startup.
-            snippet_words: Width of the snippet window in words.  ``0`` returns
-                the full chunk.  ``None`` uses the server default.
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.GroupedResult` ordered
-            by descending file score (max of section scores).  Each result
-            wraps one document with up to ``chunks_per_file`` sections.
-
-        Raises:
-            ValueError: If *mode* is ``"semantic"`` or ``"hybrid"`` but no
-                embedding provider or embeddings path is configured.
-        """
-        return self._reader_facet.search(
-            query,
-            limit=limit,
-            mode=mode,
-            filters=filters,
-            folder=folder,
-            chunks_per_file=chunks_per_file,
-            snippet_words=snippet_words,
-        )
-
-    # ------------------------------------------------------------------
-    # Read / list
-    # ------------------------------------------------------------------
-
-    def read(self, path: str, *, section: str | None = None) -> NoteContent | None:
-        """Read the full content of a document from disk.
-
-        Args:
-            path: Relative document path (e.g. ``"Journal/note.md"``).
-            section: When provided, return only the section whose heading
-                matches *section* (case-sensitive; internal whitespace is
-                collapsed before comparison). Pass the ``heading`` value from
-                a ``search`` result unchanged for guaranteed match. ``None``
-                (the default) returns the whole document. Raises
-                :exc:`ValueError` if the section is not found.
-
-        Returns:
-            A :class:`~markdown_vault_mcp.types.NoteContent` instance, or ``None``
-            if the file does not exist.
-        """
-        return self._reader_facet.read(path, section=section)
-
-    def list_documents(
-        self,
-        *,
-        folder: str | None = None,
-        pattern: str | None = None,
-        include_attachments: bool = False,
-    ) -> list[NoteInfo | AttachmentInfo]:
-        """List documents (and optionally attachments) in the collection.
-
-        Args:
-            folder: If provided, only return documents in this folder (and
-                sub-folders).
-            pattern: Unix glob matched against the relative path using
-                :func:`fnmatch.fnmatch`.  Example: ``"Journal/*.md"``.
-            include_attachments: When ``True``, also return non-.md files
-                that match the attachment allowlist.  Each
-                :class:`~markdown_vault_mcp.types.AttachmentInfo` entry
-                includes ``kind="attachment"`` and ``mime_type``.
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.NoteInfo` (and
-            optionally :class:`~markdown_vault_mcp.types.AttachmentInfo`)
-            objects.
-        """
-        return self._reader_facet.list_documents(
-            folder=folder, pattern=pattern, include_attachments=include_attachments
-        )
-
-    # ------------------------------------------------------------------
-    # Index management
-    # ------------------------------------------------------------------
-
-    def build_index(self, *, force: bool = False) -> IndexStats:
-        """Scan source_dir and build the FTS index.
-
-        Warm restarts (existing populated index, ``force=False``) are an O(1)
-        no-op keyed on FTS state. ``force=True`` drops and rebuilds; config
-        changes require ``force=True`` to apply (see issue #525).
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.IndexStats` describing what was indexed.
-        """
-        return self._index_facet.build_index(force=force)
-
-    def reindex(self) -> ReindexResult:
-        """Incrementally update the index based on file changes.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.ReindexResult` with counts applied.
-
-        Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
-        """
-        return self._index_facet.reindex()
-
-    def build_embeddings(self, *, force: bool = False) -> int:
-        """Build the vector index from all chunks currently in the FTS index.
-
-        Args:
-            force: If ``True``, rebuild from scratch even if a vector index
-                already exists on disk.
-
-        Returns:
-            Total number of chunks embedded.
-
-        Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
-            ValueError: If ``embedding_provider`` or ``embeddings_path`` is unset.
-        """
-        return self._index_facet.build_embeddings(force=force)
-
-    def build_index_async(self, *, force: bool = False) -> Future[IndexStats]:
-        """Submit a full FTS index build and return the Future.
-
-        Caller may ``.result()`` to wait or fire-and-forget. Warm-restart
-        short-circuit returns an already-resolved Future without queuing a
-        job, mirroring :meth:`build_index`.
-
-        Args:
-            force: When ``True``, drop and rebuild the index unconditionally.
-
-        Returns:
-            ``concurrent.futures.Future`` carrying the :class:`IndexStats`.
-        """
-        return self._index_facet.build_index_async(force=force)
-
-    def reindex_async(self) -> Future[ReindexResult]:
-        """Submit an incremental FTS reindex and return the Future.
-
-        Does not require :meth:`build_index` first — the writer's FIFO queue
-        orders any earlier :class:`BuildIndex` before this job. Writer-thread
-        failures are surfaced via :meth:`get_index_status` (#561).
-        """
-        return self._index_facet.reindex_async()
-
-    def build_embeddings_async(self, *, force: bool = False) -> Future[int]:
-        """Submit a vector index build and return the Future.
-
-        Does not require :meth:`build_index` first — FIFO ordering runs any
-        earlier :class:`BuildIndex` first. Writer-thread failures are surfaced
-        via :meth:`get_index_status` (#561).
-        """
-        return self._index_facet.build_embeddings_async(force=force)
-
-    def embeddings_status(self) -> dict[str, Any]:
-        """Return status information about the vector index.
-
-        Returns:
-            Dict with keys ``provider``, ``chunk_count``, ``path``,
-            ``available``.
-        """
-        return self._index_facet.embeddings_status()
-
-    # ------------------------------------------------------------------
-    # Metadata
-    # ------------------------------------------------------------------
-
-    def list_folders(self) -> list[str]:
-        """Return all distinct folder values across the indexed collection.
-
-        Returns:
-            Sorted list of folder strings (``""`` for the collection root).
-        """
-        return self._reader_facet.list_folders()
-
-    def list_tags(self, field: str = "tags") -> list[str]:
-        """Return all distinct values indexed for a given frontmatter field.
-
-        If *field* was not in ``indexed_frontmatter_fields``, returns ``[]``.
-
-        Args:
-            field: Frontmatter key to query (default: ``"tags"``).
-
-        Returns:
-            Sorted list of distinct value strings.
-        """
-        return self._reader_facet.list_tags(field)
-
-    def get_toc(self, path: str) -> list[dict[str, Any]]:
-        """Return table of contents for a document.
-
-        Queries the FTS sections table for headings and prepends the document
-        title as a synthetic H1 entry. The result depends on the FTS index, so
-        cold-start callers must build the index first (bucket 3).
-
-        Args:
-            path: Relative path to the document (e.g. ``"notes/intro.md"``).
-
-        Returns:
-            List of ``{"heading": str, "level": int}`` dicts ordered by
-            position, with the document title prepended as level 1.
-
-        Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
-            ValueError: If no document exists at the given path.
-        """
-        return self._reader_facet.get_toc(path)
-
-    def get_backlinks(
-        self, path: str, *, limit: int | None = None
-    ) -> list[BacklinkInfo]:
-        """Return all documents that link to the given document.
-
-        Args:
-            path: Relative path of the target document
-                (e.g. ``"notes/topic.md"``).
-            limit: Maximum number of results to return.  ``None`` (default)
-                means unlimited.
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.BacklinkInfo` objects
-            for each document that contains a link pointing to ``path``.
-
-        Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
-            ValueError: If no document exists at the given path.
-        """
-        return self._graph_facet.get_backlinks(path, limit=limit)
-
-    def get_outlinks(self, path: str, *, limit: int | None = None) -> list[OutlinkInfo]:
-        """Return all links from the given document to other documents.
-
-        The ``exists`` field on each :class:`~markdown_vault_mcp.types.OutlinkInfo`
-        indicates whether the target document is currently indexed.
-
-        Args:
-            path: Relative path of the source document
-                (e.g. ``"notes/topic.md"``).
-            limit: Maximum number of results to return.  ``None`` (default)
-                means unlimited.
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.OutlinkInfo` objects for
-            each link originating from ``path``.
-
-        Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
-            ValueError: If no document exists at the given path.
-        """
-        return self._graph_facet.get_outlinks(path, limit=limit)
-
-    def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
-        """Return all links whose target does not exist in the collection.
-
-        Args:
-            folder: If provided, restrict to source documents in this folder
-                (exact match or sub-folder prefix).
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.BrokenLinkInfo` objects.
-        """
-        return self._graph_facet.get_broken_links(folder=folder)
-
-    def get_similar(
-        self,
-        path: str,
-        *,
-        limit: int = 10,
-        chunks_per_file: int | None = None,
-    ) -> list[GroupedResult]:
-        """Return semantically similar documents grouped by file.
-
-        See :meth:`SearchManager.get_similar` for details.  Returns
-        :class:`~markdown_vault_mcp.types.GroupedResult` objects ordered by
-        descending file score; each result wraps one document with up to
-        ``chunks_per_file`` sections.
-
-        Args:
-            path: Relative path of the reference document.
-            limit: Maximum number of files to return.
-            chunks_per_file: Maximum sections per result file.
-
-        Returns:
-            List of grouped results.
-
-        Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
-        """
-        return self._reader_facet.get_similar(
-            path, limit=limit, chunks_per_file=chunks_per_file
-        )
-
-    def get_recent(
-        self, *, limit: int = 20, folder: str | None = None
-    ) -> list[NoteInfo]:
-        """Return the most recently modified documents.
-
-        Args:
-            limit: Maximum number of documents to return.
-            folder: If provided, restrict to documents in this folder
-                (exact match or sub-folder prefix).
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.NoteInfo` objects
-            ordered by modification time (most recent first).
-        """
-        return self._reader_facet.get_recent(limit=limit, folder=folder)
-
-    def get_context(
-        self,
-        path: str,
-        *,
-        similar_limit: int = 5,
-        link_limit: int = 10,
-    ) -> NoteContext:
-        """Return a consolidated context dossier for a document.
-
-        Combines backlinks, outlinks, similar notes, folder peers, and
-        indexed frontmatter tags into a single response, saving the caller
-        multiple round trips.
-
-        Args:
-            path: Relative path of the document (e.g. ``"notes/topic.md"``).
-            similar_limit: Maximum number of similar notes to include.
-            link_limit: Maximum number of backlinks and outlinks to include.
-
-        Returns:
-            A :class:`~markdown_vault_mcp.types.NoteContext` object.  Its
-            ``similar`` field is a list of
-            :class:`~markdown_vault_mcp.types.GroupedResult` entries, each
-            with exactly one section (chunks_per_file=1) so the dossier
-            stays compact.
-
-        Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
-            ValueError: If no document exists at the given path.
-        """
-        return self._reader_facet.get_context(
-            path, similar_limit=similar_limit, link_limit=link_limit
-        )
-
-    def get_orphan_notes(self) -> list[NoteInfo]:
-        """Return all documents with no inbound or outbound links.
-
-        A document is an orphan if it has zero outlinks and is not referenced
-        by any other document's links.
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.NoteInfo` objects,
-            ordered by path.
-        """
-        return self._graph_facet.get_orphan_notes()
-
-    def get_most_linked(self, *, limit: int = 10) -> list[MostLinkedNote]:
-        """Return the documents with the most inbound links.
-
-        Args:
-            limit: Maximum number of results to return. Default 10.
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.MostLinkedNote` ordered
-            by backlink_count descending.
-        """
-        return self._graph_facet.get_most_linked(limit=limit)
-
-    def get_connection_path(
-        self, source: str, target: str, max_depth: int = 10
-    ) -> list[str] | None:
-        """Return the shortest undirected path between two notes.
-
-        Treats the link graph as undirected — a link in either direction
-        counts as a connection.  Uses BFS with a configurable depth cap.
-
-        Args:
-            source: Vault-relative path of the starting note.
-            target: Vault-relative path of the destination note.
-            max_depth: Maximum path length in edges.  Clamped to ``[1, 10]``.
-                Defaults to ``10``.
-
-        Returns:
-            Ordered list of vault-relative paths from *source* to *target*
-            (inclusive), or ``None`` if unreachable within *max_depth* hops.
-
-        Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
-            ValueError: If *source* or *target* is not found in the index.
-        """
-        return self._graph_facet.get_connection_path(
-            source, target, max_depth=max_depth
-        )
-
-    # ------------------------------------------------------------------
-    # Git history query methods
-    # ------------------------------------------------------------------
-
-    def get_history(
-        self,
-        path: str | None = None,
-        since: str | None = None,
-        until: str | None = None,
-        limit: int = 20,
-    ) -> list[HistoryEntry]:
-        """Return commits that touched a note or the whole vault.
-
-        When *path* is ``None``, queries the full vault history.  Returns an
-        empty list for vaults whose source directory is not inside a git
-        repository.
-
-        Args:
-            path: Vault-relative path of the note to filter on (e.g.
-                ``"notes/alpha.md"``).  Must end with ``.md``.  ``None``
-                returns vault-wide history.
-            since: ISO 8601 datetime string or git date expression (e.g.
-                ``"1 week ago"``).  Passed as ``--since`` to ``git log``.
-                ``None`` disables the filter.
-            until: ISO 8601 datetime string or git date expression, passed as
-                ``--until`` to ``git log``.  ``None`` disables the filter.
-                Both ``since`` and ``until`` boundaries are **inclusive**: a
-                commit whose committer date equals either endpoint is included
-                in the result.
-            limit: Maximum number of commits to return.  Clamped to
-                ``[1, 100]``.  Defaults to ``20``.
-
-        Returns:
-            List of :class:`~markdown_vault_mcp.types.HistoryEntry` ordered
-            newest-first.  Empty list when the vault has no git history or
-            the note has no commits in the given range.  The
-            ``paths_changed`` field on each entry is populated for vault-wide
-            queries (``path=None``); it is always empty for single-note
-            queries, since the path is already determined by the query
-            arguments — callers know which file the commit touched without
-            needing it echoed back.
-
-        Raises:
-            ValueError: If *path* is provided but fails path validation.
-        """
-        return self._reader_facet.get_history(
-            path, since=since, until=until, limit=limit
-        )
-
-    def get_diff(
-        self,
-        path: str,
-        since_sha: str | None = None,
-        since_timestamp: str | None = None,
-        per_commit: bool = False,
-        limit: int | None = None,
-    ) -> str | list[CommitDiff]:
-        """Return the diff of a note between a reference point and HEAD.
-
-        Exactly one of *since_sha* or *since_timestamp* must be supplied.
-
-        Args:
-            path: Vault-relative path of the note to diff.  Must end with
-                ``.md``.
-            since_sha: A commit SHA (full or abbreviated, at least 4 hex
-                digits) to diff from.  Mutually exclusive with
-                *since_timestamp*.
-            since_timestamp: ISO 8601 datetime string, resolved via
-                ``git rev-list --before=<ts> -1 HEAD`` to the most recent
-                commit at or before that instant.  Boundary is
-                **inclusive**: a commit whose committer date equals
-                *since_timestamp* IS the resolved ref.  Mutually exclusive
-                with *since_sha*.
-            per_commit: When ``False`` (default), return a single unified diff
-                string from the reference point to HEAD.  When ``True``,
-                return one :class:`~markdown_vault_mcp.types.CommitDiff` per
-                intervening commit.
-            limit: When *per_commit* is ``True``, cap the number of
-                intervening commits returned to the *limit* most recent ones.
-                Clamped to ``[1, 100]``.  ``None`` (the default) means
-                unbounded (still bounded by the underlying ``since..HEAD``
-                range).  Silently ignored when *per_commit* is ``False``.
-
-        Returns:
-            A unified diff string when *per_commit* is ``False``, or a list of
-            :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
-            ``True``.  Returns an empty string / empty list when the note has
-            no changes in the given range, or when the vault's source
-            directory is not inside a git repository.
-
-        Raises:
-            ValueError: If exactly one of *since_sha* / *since_timestamp* is
-                not supplied, *since_sha* contains invalid characters, or the
-                resolved ref is not found in history.
-        """
-        return self._reader_facet.get_diff(
-            path,
-            since_sha=since_sha,
-            since_timestamp=since_timestamp,
-            per_commit=per_commit,
-            limit=limit,
-        )
-
-    def stats(self) -> CollectionStats:
-        """Return collection-wide statistics.
-
-        Delegates to :meth:`SearchManager.stats` via the reader facet.
-        """
-        return self._reader_facet.stats()
-
-    # ------------------------------------------------------------------
-    # Write operations (delegated to DocumentManager)
+    # Path validation helpers
     # ------------------------------------------------------------------
 
     def _validate_path(self, path: str) -> Path:
@@ -1132,175 +522,3 @@ class Collection:
     def _validate_attachment_path(self, path: str) -> Path:
         """Resolve and validate a non-.md attachment path."""
         return self._doc_mgr._validate_attachment_path(path)
-
-    def read_attachment(self, path: str) -> AttachmentContent:
-        """Read the binary content of a non-.md attachment.
-
-        Delegates to :meth:`DocumentManager.read_attachment`.
-        """
-        return self._reader_facet.read_attachment(path)
-
-    def write_attachment(
-        self,
-        path: str,
-        content: bytes,
-        if_match: str | None = None,
-    ) -> WriteResult:
-        """Create or overwrite a non-.md attachment.
-
-        Delegates to :meth:`DocumentManager.write_attachment`.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.WriteResult`.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash, or *if_match* is supplied
-                for a file that does not yet exist.
-            ValueError: If the path escapes the source directory, has an
-                extension not in the allowlist, or the content exceeds the
-                size limit.
-        """
-        return self._writer_facet.write_attachment(path, content, if_match=if_match)
-
-    def write(
-        self,
-        path: str,
-        content: str,
-        frontmatter: dict[str, Any] | None = None,
-        if_match: str | None = None,
-    ) -> WriteResult:
-        """Create or overwrite a document.
-
-        Creates intermediate directories as needed.  If *frontmatter* is
-        provided, it is serialised as a YAML header at the top of the file.
-
-        Args:
-            path: Relative document path (e.g. ``"notes/topic.md"``).
-            content: Markdown body (excluding frontmatter).
-            frontmatter: Optional frontmatter dict serialised as a YAML header.
-            if_match: Optional etag from a previous :meth:`read` call.  When
-                provided, the write is only performed if the current file hash
-                matches this value, preventing overwrites of concurrent
-                modifications.  Pass ``None`` (default) to skip the check.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.WriteResult`.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash, or *if_match* is supplied
-                for a file that does not yet exist.
-            ValueError: If *path* escapes the source directory.
-        """
-        return self._writer_facet.write(
-            path, content, frontmatter=frontmatter, if_match=if_match
-        )
-
-    def edit(
-        self,
-        path: str,
-        old_text: str | None = None,
-        new_text: str = "",
-        if_match: str | None = None,
-        line_start: int | None = None,
-        line_end: int | None = None,
-    ) -> EditResult:
-        """Patch a section of a document.
-
-        Replaces the first occurrence of *old_text* with *new_text*, or
-        replaces the line range [*line_start*, *line_end*] when line numbers
-        are given instead.
-
-        Args:
-            path: Relative document path.
-            old_text: Exact text to replace (must occur exactly once).
-                Mutually exclusive with *line_start* / *line_end*.
-            new_text: Replacement text (may be empty to delete *old_text*).
-            if_match: Optional etag for optimistic concurrency; see
-                :meth:`write`.
-            line_start: 1-based start line for line-range mode.
-            line_end: 1-based end line (inclusive) for line-range mode.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.EditResult`.
-
-        Raises:
-            EditConflictError: If *old_text* is not found or appears more than
-                once.
-            ReadOnlyError: If the collection is read-only.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match.
-            DocumentNotFoundError: If the file does not exist.
-            ValueError: If *path* escapes the source directory.
-        """
-        return self._writer_facet.edit(
-            path,
-            old_text=old_text,
-            new_text=new_text,
-            if_match=if_match,
-            line_start=line_start,
-            line_end=line_end,
-        )
-
-    def delete(self, path: str, if_match: str | None = None) -> DeleteResult:
-        """Delete a document or attachment.
-
-        Removes the file from disk and purges its entries from the FTS and
-        vector indices.
-
-        Args:
-            path: Relative path of the document or attachment to remove.
-            if_match: Optional etag for optimistic concurrency; see
-                :meth:`write`.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.DeleteResult`.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match.
-            DocumentNotFoundError: If *path* does not exist.
-        """
-        return self._writer_facet.delete(path, if_match=if_match)
-
-    def rename(
-        self,
-        old_path: str,
-        new_path: str,
-        if_match: str | None = None,
-        *,
-        update_links: bool = False,
-    ) -> RenameResult:
-        """Rename or move a document or attachment.
-
-        Moves the file on disk and updates the FTS / vector indices.  When
-        *update_links* is ``True``, all wikilinks and markdown links in other
-        documents that pointed to *old_path* are rewritten to *new_path*.
-
-        Args:
-            old_path: Current relative path of the document or attachment.
-            new_path: Desired relative path after the move.
-            if_match: Optional etag for optimistic concurrency; see
-                :meth:`write`.
-            update_links: When ``True``, rewrite internal links across the
-                vault to reflect the new path.  Defaults to ``False``.
-
-        Returns:
-            :class:`~markdown_vault_mcp.types.RenameResult`.
-
-        Raises:
-            ReadOnlyError: If the collection is read-only.
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match.
-            DocumentNotFoundError: If *old_path* does not exist.
-            DocumentExistsError: If *new_path* already exists.
-            ValueError: If *old_path* or *new_path* escapes the source
-                directory.
-        """
-        return self._writer_facet.rename(
-            old_path, new_path, if_match=if_match, update_links=update_links
-        )

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -111,9 +111,9 @@ class IndexUnavailableError(MarkdownMCPError):
     - **Build did not complete successfully** (``reason="build_failed"``).
       A previous build was scheduled, ran, raised, and was not retried
       (``_index_built`` remained False; the captured error is available
-      via :meth:`Collection.get_index_status`'s ``error`` field) (#586).
+      via :meth:`IndexFacet.get_index_status`'s ``error`` field) (#586).
     - **Timeout** (``reason="timeout"``). A caller waited via
-      :meth:`Collection.wait_until_queryable` and the bounded timeout
+      :meth:`IndexFacet.wait_until_queryable` and the bounded timeout
       elapsed before the background build signaled completion.
     - **SQLite operational error — broken** (``reason="broken"``). A
       bucket-3/4 MCP handler call raised ``sqlite3.OperationalError``
@@ -129,7 +129,7 @@ class IndexUnavailableError(MarkdownMCPError):
 
     A captured background-build error is NOT a separate exception
     class: it is diagnostic state surfaced via
-    :meth:`Collection.get_index_status`'s ``error`` field.
+    :meth:`IndexFacet.get_index_status`'s ``error`` field.
     """
 
     def __init__(self, message: str, *, reason: IndexUnavailableReason) -> None:

--- a/src/markdown_vault_mcp/facets/__init__.py
+++ b/src/markdown_vault_mcp/facets/__init__.py
@@ -3,9 +3,8 @@
 Each facet is a thin view holding references to the collaborators it needs
 (managers + coordinator), grouping the formerly-flat ``Collection`` surface
 into ``reader`` / ``writer`` / ``graph`` / ``index``. The single ``Collection``
-root owns one shared core and constructs the facets once; the flat methods
-delegate to them (addition before removal — see the facet architecture in
-``docs/design.md``).
+root owns one shared core and constructs the facets once, exposing them via
+accessors of the same names (see the facet architecture in ``docs/design.md``).
 """
 
 from markdown_vault_mcp.facets.graph import GraphFacet

--- a/src/markdown_vault_mcp/facets/graph.py
+++ b/src/markdown_vault_mcp/facets/graph.py
@@ -3,8 +3,8 @@
 A thin view over :class:`~markdown_vault_mcp.managers.link.LinkManager`
 exposing backlinks / outlinks / broken-links / orphans / most-linked /
 connection-path queries. Part of the ``collection.py`` facade decomposition
-(#576). The bucket-3 methods (:meth:`get_backlinks`, :meth:`get_outlinks`,
-:meth:`get_connection_path`) gate on the index-readiness callback before
+(#576). The bucket-3 methods (:meth:`GraphFacet.get_backlinks`, :meth:`GraphFacet.get_outlinks`,
+:meth:`GraphFacet.get_connection_path`) gate on the index-readiness callback before
 delegating; the bucket-2 methods operate on a cold index.
 """
 
@@ -57,7 +57,7 @@ class GraphFacet:
             for each document that contains a link pointing to ``path``.
 
         Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_built()
@@ -80,7 +80,7 @@ class GraphFacet:
             each link originating from ``path``.
 
         Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_built()
@@ -141,7 +141,7 @@ class GraphFacet:
             (inclusive), or ``None`` if unreachable within *max_depth* hops.
 
         Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
             ValueError: If *source* or *target* is not found in the index.
         """
         self._require_built()

--- a/src/markdown_vault_mcp/facets/index.py
+++ b/src/markdown_vault_mcp/facets/index.py
@@ -4,7 +4,7 @@ A thin view over the
 :class:`~markdown_vault_mcp.indexing.IndexWriteCoordinator` (build / reindex /
 embeddings sync + async, plus the readiness and writer-status queries) and
 :class:`~markdown_vault_mcp.managers.index.IndexManager`
-(:meth:`embeddings_status`). It deliberately does NOT expose the coordinator's
+(:meth:`IndexFacet.embeddings_status`). It deliberately does NOT expose the coordinator's
 internal surface (``close``, ``writer``, ``require_built``,
 ``mark_paths_dirty``, ``rebuild_embeddings``), which the root owns. Part of the
 ``collection.py`` facade decomposition (#576).
@@ -27,7 +27,7 @@ class IndexFacet:
     """Index build, readiness, writer-status, and embeddings-status operations.
 
     Delegates 1:1 to the :class:`IndexWriteCoordinator` (build / readiness /
-    writer status) and to :class:`IndexManager` (:meth:`embeddings_status`).
+    writer status) and to :class:`IndexManager` (:meth:`IndexFacet.embeddings_status`).
     """
 
     def __init__(
@@ -42,7 +42,7 @@ class IndexFacet:
             coordinator: The shared :class:`IndexWriteCoordinator` owned by the
                 root. Only its public operations are surfaced here.
             index_mgr: The shared :class:`IndexManager`, queried by
-                :meth:`embeddings_status`.
+                :meth:`IndexFacet.embeddings_status`.
         """
         self._coordinator = coordinator
         self._index_mgr = index_mgr
@@ -51,15 +51,15 @@ class IndexFacet:
         """Return True when the FTS index is queryable (precondition snapshot).
 
         A captured build error does NOT demote queryability: it is
-        diagnostic state surfaced via :meth:`get_index_status`, not a gate.
+        diagnostic state surfaced via :meth:`IndexFacet.get_index_status`, not a gate.
         """
         return self._coordinator.is_queryable()
 
     def start_background_build_index(self) -> None:
-        """Spawn a daemon thread that runs :meth:`build_index` to completion.
+        """Spawn a daemon thread that runs :meth:`IndexFacet.build_index` to completion.
 
         .. deprecated:: 1.28
-           Superseded by :meth:`build_index_async`. Retained for legacy tests.
+           Superseded by :meth:`IndexFacet.build_index_async`. Retained for legacy tests.
         """
         self._coordinator.start_background_build_index()
 
@@ -74,7 +74,7 @@ class IndexFacet:
     def is_drained(self) -> bool:
         """Return True iff the IndexWriter has no pending or in-flight work.
 
-        Reflects the moment of call only; pair with :meth:`write_generation`
+        Reflects the moment of call only; pair with :meth:`IndexFacet.write_generation`
         to detect a complete write cycle inside a read window.
         """
         return self._coordinator.is_drained()
@@ -82,13 +82,13 @@ class IndexFacet:
     def write_generation(self) -> int:
         """Return the writer's monotonic completion counter.
 
-        Increments once per completed job. Pair with :meth:`is_drained` to
+        Increments once per completed job. Pair with :meth:`IndexFacet.is_drained` to
         detect a write cycle inside a read window.
         """
         return self._coordinator.write_generation()
 
     def wait_for_drain(self, timeout: float | None = None) -> bool:
-        """Block until :meth:`is_drained`; ``True`` if drained, ``False`` on timeout."""
+        """Block until :meth:`IndexFacet.is_drained`; ``True`` if drained, ``False`` on timeout."""
         return self._coordinator.wait_for_drain(timeout)
 
     def get_index_status(self) -> dict[str, Any]:
@@ -110,7 +110,7 @@ class IndexFacet:
 
         A captured build error does NOT block here; it surfaces as
         ``IndexUnavailableError(reason="build_failed")`` and is also readable
-        via :meth:`get_index_status`. Library bucket-3/4 methods use the
+        via :meth:`IndexFacet.get_index_status`. Library bucket-3/4 methods use the
         root's ``_require_built`` instead, which raises immediately.
 
         Raises:
@@ -139,7 +139,7 @@ class IndexFacet:
             :class:`~markdown_vault_mcp.types.ReindexResult` with counts applied.
 
         Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
         """
         return self._coordinator.reindex()
 
@@ -154,7 +154,7 @@ class IndexFacet:
             Total number of chunks embedded.
 
         Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is unset.
         """
         return self._coordinator.build_embeddings(force=force)
@@ -164,7 +164,7 @@ class IndexFacet:
 
         Caller may ``.result()`` to wait or fire-and-forget. Warm-restart
         short-circuit returns an already-resolved Future without queuing a
-        job, mirroring :meth:`build_index`.
+        job, mirroring :meth:`IndexFacet.build_index`.
 
         Args:
             force: When ``True``, drop and rebuild the index unconditionally.
@@ -177,18 +177,18 @@ class IndexFacet:
     def reindex_async(self) -> Future[ReindexResult]:
         """Submit an incremental FTS reindex and return the Future.
 
-        Does not require :meth:`build_index` first — the writer's FIFO queue
+        Does not require :meth:`IndexFacet.build_index` first — the writer's FIFO queue
         orders any earlier :class:`BuildIndex` before this job. Writer-thread
-        failures are surfaced via :meth:`get_index_status` (#561).
+        failures are surfaced via :meth:`IndexFacet.get_index_status` (#561).
         """
         return self._coordinator.reindex_async()
 
     def build_embeddings_async(self, *, force: bool = False) -> Future[int]:
         """Submit a vector index build and return the Future.
 
-        Does not require :meth:`build_index` first — FIFO ordering runs any
+        Does not require :meth:`IndexFacet.build_index` first — FIFO ordering runs any
         earlier :class:`BuildIndex` first. Writer-thread failures are surfaced
-        via :meth:`get_index_status` (#561).
+        via :meth:`IndexFacet.get_index_status` (#561).
         """
         return self._coordinator.build_embeddings_async(force=force)
 

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -4,10 +4,10 @@ A thin view exposing search, document reads, listing, table-of-contents,
 similarity, recent, context, stats, attachment reads, and git history/diff.
 Each method delegates 1:1 to one collaborator (:class:`SearchManager`,
 :class:`DocumentManager`, or :class:`GitQueryManager`); the bucket-3 methods
-(:meth:`get_toc`,
-:meth:`get_similar`, :meth:`get_context`) gate on the index-readiness callback
-first. Part of the ``collection.py`` facade decomposition (#576); the flat
-``Collection`` read methods delegate here.
+(:meth:`ReaderFacet.get_toc`,
+:meth:`ReaderFacet.get_similar`, :meth:`ReaderFacet.get_context`) gate on the index-readiness callback
+first. Part of the ``collection.py`` facade decomposition (#576); reached via
+the ``Collection.reader`` accessor.
 """
 
 from __future__ import annotations
@@ -187,7 +187,7 @@ class ReaderFacet:
             position, with the document title prepended as level 1.
 
         Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_built()
@@ -232,7 +232,7 @@ class ReaderFacet:
             List of grouped results.
 
         Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
         """
         self._require_built()
         return self._search_mgr.get_similar(
@@ -265,7 +265,7 @@ class ReaderFacet:
             stays compact.
 
         Raises:
-            IndexUnavailableError: If :meth:`build_index` has not been called.
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
             ValueError: If no document exists at the given path.
         """
         self._require_built()

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -2,9 +2,8 @@
 
 A thin view over :class:`~markdown_vault_mcp.managers.document.DocumentManager`
 exposing the vault's write / edit / delete / rename / attachment operations.
-Part of the ``collection.py`` facade decomposition (#576); the flat
-``Collection.write`` / ``edit`` / ``delete`` / ``rename`` / ``write_attachment``
-methods delegate here.
+Part of the ``collection.py`` facade decomposition (#576); reached via the
+``Collection.writer`` accessor.
 """
 
 from __future__ import annotations
@@ -50,7 +49,7 @@ class WriterFacet:
             path: Relative document path (e.g. ``"notes/topic.md"``).
             content: Markdown body (excluding frontmatter).
             frontmatter: Optional frontmatter dict serialised as a YAML header.
-            if_match: Optional etag from a previous :meth:`read` call.  When
+            if_match: Optional etag from a previous :meth:`ReaderFacet.read` call.  When
                 provided, the write is only performed if the current file hash
                 matches this value, preventing overwrites of concurrent
                 modifications.  Pass ``None`` (default) to skip the check.
@@ -90,7 +89,7 @@ class WriterFacet:
                 Mutually exclusive with *line_start* / *line_end*.
             new_text: Replacement text (may be empty to delete *old_text*).
             if_match: Optional etag for optimistic concurrency; see
-                :meth:`write`.
+                :meth:`WriterFacet.write`.
             line_start: 1-based start line for line-range mode.
             line_end: 1-based end line (inclusive) for line-range mode.
 
@@ -124,7 +123,7 @@ class WriterFacet:
         Args:
             path: Relative path of the document or attachment to remove.
             if_match: Optional etag for optimistic concurrency; see
-                :meth:`write`.
+                :meth:`WriterFacet.write`.
 
         Returns:
             :class:`~markdown_vault_mcp.types.DeleteResult`.
@@ -155,7 +154,7 @@ class WriterFacet:
             old_path: Current relative path of the document or attachment.
             new_path: Desired relative path after the move.
             if_match: Optional etag for optimistic concurrency; see
-                :meth:`write`.
+                :meth:`WriterFacet.write`.
             update_links: When ``True``, rewrite internal links across the
                 vault to reflect the new path.  Defaults to ``False``.
 

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -194,7 +194,7 @@ CREATE TABLE IF NOT EXISTS meta (
 );
 """
 
-# Key written into ``meta`` after :meth:`Collection.build_index` completes
+# Key written into ``meta`` after :meth:`IndexFacet.build_index` completes
 # a full scan successfully. Warm-restart short-circuits keyed solely on
 # ``documents`` row presence would otherwise treat a partial index (left
 # by a crash mid-build, since per-document upserts each commit in their
@@ -887,7 +887,7 @@ class FTSIndex:
 
         Absence of the sentinel — paired with non-empty ``documents`` —
         signals a partial index left by a crashed prior build, and the
-        caller (``Collection.build_index``) treats it as cold.
+        caller (``IndexFacet.build_index``) treats it as cold.
         """
         conn = self._conn()
         with conn:
@@ -1315,7 +1315,7 @@ class FTSIndex:
         and do not participate in vault-wide resolution.
 
         Call this method after all documents have been indexed
-        (``Collection.build_index()`` and ``Collection.reindex()`` do this
+        (``IndexFacet.build_index()`` and ``IndexFacet.reindex()`` do this
         automatically).  Callers that add documents via :meth:`upsert_note`
         directly are responsible for calling this method once all upserts are
         complete.

--- a/src/markdown_vault_mcp/hashing.py
+++ b/src/markdown_vault_mcp/hashing.py
@@ -11,8 +11,8 @@ from pathlib import (
 def compute_etag(data: bytes) -> str:
     """Compute the SHA256 hex digest of in-memory bytes.
 
-    Used to compute the ``etag`` field returned by :meth:`Collection.read`
-    and :meth:`Collection.read_attachment` from already-loaded byte content.
+    Used to compute the ``etag`` field returned by :meth:`ReaderFacet.read`
+    and :meth:`ReaderFacet.read_attachment` from already-loaded byte content.
 
     Args:
         data: Raw bytes to hash.

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -69,7 +69,7 @@ class ParsedNote:
 
 @dataclass
 class SearchResult:
-    """A search result from :meth:`~markdown_vault_mcp.collection.Collection.search`.
+    """A search result from :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.search`.
 
     Attributes:
         path: Relative path of the document containing this chunk.
@@ -182,7 +182,7 @@ class FTSResult:
 
 @dataclass
 class NoteContent:
-    """Full content of a document, returned by :meth:`~markdown_vault_mcp.collection.Collection.read`.
+    """Full content of a document, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.read`.
 
     Attributes:
         path: Relative path from the vault root (e.g. ``Journal/note.md``).
@@ -205,7 +205,7 @@ class NoteContent:
 
 @dataclass
 class NoteInfo:
-    """Summary info for a document, returned by :meth:`~markdown_vault_mcp.collection.Collection.list_documents`.
+    """Summary info for a document, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.list_documents`.
 
     Attributes:
         path: Relative path from the vault root.
@@ -280,7 +280,7 @@ class RenameResult:
 
 @dataclass
 class IndexStats:
-    """Statistics from :meth:`~markdown_vault_mcp.collection.Collection.build_index`.
+    """Statistics from :meth:`~markdown_vault_mcp.facets.index.IndexFacet.build_index`.
 
     Attributes:
         documents_indexed: Number of documents successfully indexed.
@@ -295,7 +295,7 @@ class IndexStats:
 
 @dataclass
 class ReindexResult:
-    """Result of :meth:`~markdown_vault_mcp.collection.Collection.reindex`.
+    """Result of :meth:`~markdown_vault_mcp.facets.index.IndexFacet.reindex`.
 
     Attributes:
         added: Documents added since the last index.
@@ -312,7 +312,7 @@ class ReindexResult:
 
 @dataclass
 class AttachmentContent:
-    """Full content of an attachment, returned by :meth:`~markdown_vault_mcp.collection.Collection.read` for non-.md files.
+    """Full content of an attachment, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.read_attachment` for non-.md files.
 
     Attributes:
         path: Relative path from the vault root.
@@ -333,7 +333,7 @@ class AttachmentContent:
 
 @dataclass
 class AttachmentInfo:
-    """Summary info for an attachment, returned by :meth:`~markdown_vault_mcp.collection.Collection.list_documents` when ``include_attachments=True``.
+    """Summary info for an attachment, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.list_documents` when ``include_attachments=True``.
 
     Attributes:
         path: Relative path from the vault root.
@@ -354,7 +354,7 @@ class AttachmentInfo:
 
 @dataclass
 class CollectionStats:
-    """Collection-wide statistics, returned by :meth:`~markdown_vault_mcp.collection.Collection.stats`.
+    """Collection-wide statistics, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.stats`.
 
     Attributes:
         document_count: Number of indexed markdown documents.
@@ -398,7 +398,7 @@ class ChangeSet:
 
 @dataclass
 class BacklinkInfo:
-    """A document that links to a given path, returned by :meth:`~markdown_vault_mcp.collection.Collection.get_backlinks`.
+    """A document that links to a given path, returned by :meth:`~markdown_vault_mcp.facets.graph.GraphFacet.get_backlinks`.
 
     Attributes:
         source_path: Relative path of the document containing the link.
@@ -419,7 +419,7 @@ class BacklinkInfo:
 
 @dataclass
 class OutlinkInfo:
-    """A link from a document to another path, returned by :meth:`~markdown_vault_mcp.collection.Collection.get_outlinks`.
+    """A link from a document to another path, returned by :meth:`~markdown_vault_mcp.facets.graph.GraphFacet.get_outlinks`.
 
     Attributes:
         target_path: Resolved relative path of the link target.
@@ -440,7 +440,7 @@ class OutlinkInfo:
 
 @dataclass
 class BrokenLinkInfo:
-    """A link whose target does not exist, returned by :meth:`~markdown_vault_mcp.collection.Collection.get_broken_links`.
+    """A link whose target does not exist, returned by :meth:`~markdown_vault_mcp.facets.graph.GraphFacet.get_broken_links`.
 
     Attributes:
         source_path: Relative path of the document containing the broken link.
@@ -463,7 +463,7 @@ class BrokenLinkInfo:
 
 @dataclass
 class MostLinkedNote:
-    """A document with its inbound backlink count, returned by :meth:`~markdown_vault_mcp.collection.Collection.get_most_linked`.
+    """A document with its inbound backlink count, returned by :meth:`~markdown_vault_mcp.facets.graph.GraphFacet.get_most_linked`.
 
     Attributes:
         path: Relative path from the vault root.
@@ -480,7 +480,7 @@ class MostLinkedNote:
 
 @dataclass
 class NoteContext:
-    """Consolidated context for a document, returned by :meth:`~markdown_vault_mcp.collection.Collection.get_context`.
+    """Consolidated context for a document, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.get_context`.
 
     Attributes:
         path: Relative path from the vault root.
@@ -511,7 +511,7 @@ class NoteContext:
 
 @dataclass
 class HistoryEntry:
-    """A commit that touched a note or the vault, returned by :meth:`~markdown_vault_mcp.collection.Collection.get_history`.
+    """A commit that touched a note or the vault, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.get_history`.
 
     Attributes:
         sha: Full 40-character commit SHA.
@@ -536,7 +536,7 @@ class HistoryEntry:
 
 @dataclass
 class CommitDiff:
-    """A per-commit diff entry, returned by :meth:`~markdown_vault_mcp.collection.Collection.get_diff` when ``per_commit=True``.
+    """A per-commit diff entry, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.get_diff` when ``per_commit=True``.
 
     Attributes:
         sha: Full 40-character commit SHA.

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4039,7 +4039,7 @@ def test_collection_search_honours_default_chunks_per_file(tmp_path):
 
 
 def test_collection_build_index_uses_writer(tmp_path):
-    """Collection.build_index() routes through the IndexWriter."""
+    """IndexFacet.build_index() routes through the IndexWriter."""
     from markdown_vault_mcp.collection import Collection
 
     col = Collection(source_dir=tmp_path, read_only=False)
@@ -4222,7 +4222,7 @@ def test_build_embeddings_async_failure_recorded_in_status(tmp_path, monkeypatch
 
 
 class TestIsDrained:
-    """Tests for Collection.is_drained() (#534)."""
+    """Tests for IndexFacet.is_drained() (#534)."""
 
     def test_returns_true_on_idle_writer(self, tmp_path: Path) -> None:
         from markdown_vault_mcp.collection import Collection
@@ -4287,7 +4287,7 @@ class TestIsDrained:
 
 
 class TestWriteGeneration:
-    """Tests for Collection.write_generation() (#534)."""
+    """Tests for IndexFacet.write_generation() (#534)."""
 
     def test_increments_on_job_completion(self, tmp_path: Path) -> None:
         from markdown_vault_mcp.collection import Collection
@@ -4327,7 +4327,7 @@ class TestWriteGeneration:
 
 
 class TestWaitForDrain:
-    """Tests for Collection.wait_for_drain() (#534)."""
+    """Tests for IndexFacet.wait_for_drain() (#534)."""
 
     def test_returns_true_immediately_when_already_drained(
         self, tmp_path: Path
@@ -4400,3 +4400,35 @@ class TestWaitForDrain:
             fut.result(timeout=5)
         finally:
             col.close()
+
+
+# The 39 flat delegators removed in PR4a (#627) — reachable only via the facets.
+_REMOVED_FLAT_METHODS = [
+    "search", "read", "read_attachment", "list_documents", "list_folders",
+    "list_tags", "get_toc", "get_recent", "get_similar", "get_context",
+    "get_history", "get_diff", "stats", "write", "edit", "delete", "rename",
+    "write_attachment", "get_backlinks", "get_outlinks", "get_broken_links",
+    "get_orphan_notes", "get_most_linked", "get_connection_path", "build_index",
+    "build_index_async", "reindex", "reindex_async", "build_embeddings",
+    "build_embeddings_async", "is_queryable", "is_drained", "wait_for_drain",
+    "wait_until_queryable", "write_generation", "get_index_status",
+    "embeddings_status", "start_background_build_index", "should_use_background_build",
+]  # fmt: skip
+# Facet accessors + lifecycle the thin facade still exposes.
+_RETAINED_SURFACE = [
+    "reader", "writer", "graph", "index",
+    "start", "stop", "close", "pause_writes", "force_pull",
+    "sync_from_remote_before_index",
+]  # fmt: skip
+
+
+class TestCollectionThinSurface:
+    """The facade is a thin composition root after the flat delegators (PR4a)."""
+
+    def test_flat_delegators_are_gone(self) -> None:
+        present = [m for m in _REMOVED_FLAT_METHODS if hasattr(Collection, m)]
+        assert present == [], f"flat delegators still on Collection: {present}"
+
+    def test_facet_accessors_and_lifecycle_retained(self) -> None:
+        missing = [m for m in _RETAINED_SURFACE if not hasattr(Collection, m)]
+        assert missing == [], f"retained surface missing from Collection: {missing}"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2925,7 +2925,7 @@ class TestGetFileHistoryVaultScope:
 
 
 class TestCollectionGitHistoryMethods:
-    """Tests for Collection.get_history / Collection.get_diff edge cases."""
+    """Tests for ReaderFacet.get_history / ReaderFacet.get_diff edge cases."""
 
     def _make_collection_no_git(self, tmp_path: Path):  # type: ignore[no-untyped-def]
         """Return a Collection with no git strategy (plain directory vault)."""

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -322,7 +322,7 @@ class TestGitSync:
     ) -> None:
         """Failed reindex after a successful pull surfaces ``reindex_failed=True``.
 
-        Regression for ``fb524e8``: when ``Collection.reindex()`` raises
+        Regression for ``fb524e8``: when ``IndexFacet.reindex()`` raises
         after the pull leg has already moved HEAD, the tool must not fail —
         the side-effect on disk is real and the agent needs to see it.
         Instead, the bookkeeping failure is surfaced on the pull payload as

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -226,7 +226,7 @@ class TestFTSGetMostLinked:
 
 
 # ---------------------------------------------------------------------------
-# Collection.get_orphan_notes / Collection.get_most_linked
+# GraphFacet.get_orphan_notes / GraphFacet.get_most_linked
 # ---------------------------------------------------------------------------
 
 
@@ -250,7 +250,7 @@ def graph_vault(tmp_path: Path) -> Path:
 
 class TestCollectionOrphanAndHub:
     def test_get_orphan_notes_returns_note_info(self, graph_vault: Path) -> None:
-        """Collection.get_orphan_notes() returns NoteInfo objects."""
+        """GraphFacet.get_orphan_notes() returns NoteInfo objects."""
         col = Collection(source_dir=graph_vault)
         col.index.build_index()
         orphans = col.graph.get_orphan_notes()
@@ -273,7 +273,7 @@ class TestCollectionOrphanAndHub:
         assert "source2.md" not in paths
 
     def test_get_most_linked_returns_dataclasses(self, graph_vault: Path) -> None:
-        """Collection.get_most_linked() returns list of MostLinkedNote dataclasses."""
+        """GraphFacet.get_most_linked() returns list of MostLinkedNote dataclasses."""
         col = Collection(source_dir=graph_vault)
         col.index.build_index()
         results = col.graph.get_most_linked()
@@ -567,12 +567,12 @@ class TestFTSGetConnectionPath:
 
 
 # ---------------------------------------------------------------------------
-# Collection.get_connection_path
+# GraphFacet.get_connection_path
 # ---------------------------------------------------------------------------
 
 
 class TestCollectionGetConnectionPath:
-    """Integration tests for Collection.get_connection_path."""
+    """Integration tests for GraphFacet.get_connection_path."""
 
     @pytest.fixture
     def path_vault(self, tmp_path: Path) -> Path:

--- a/tests/test_indexing_readiness.py
+++ b/tests/test_indexing_readiness.py
@@ -324,7 +324,7 @@ class TestWarmRestartCompletenessSentinel:
 
         # Simulate a crash-mid-build: upsert one note directly into the
         # FTS DB (so list_notes() is non-empty) without going through
-        # Collection.build_index() (so no sentinel is set).
+        # IndexFacet.build_index() (so no sentinel is set).
         fts = FTSIndex(db_path=index_path)
         for note in scan_directory(vault):
             fts.upsert_note(note)

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1011,12 +1011,12 @@ class TestParsedNoteDefault:
 
 
 # ---------------------------------------------------------------------------
-# Collection.get_context
+# ReaderFacet.get_context
 # ---------------------------------------------------------------------------
 
 
 class TestCollectionGetContext:
-    """Tests for Collection.get_context(), including graceful degradation."""
+    """Tests for ReaderFacet.get_context(), including graceful degradation."""
 
     @pytest.fixture
     def context_vault(self, tmp_path: Path) -> Path:
@@ -1137,7 +1137,7 @@ class TestCollectionGetContext:
 
 
 # ---------------------------------------------------------------------------
-# Collection.rename update_links
+# WriterFacet.rename update_links
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

PR4a of the `collection.py` facade-decomposition epic (#576). With production callers (PR3b #605) and the test suite (PR3c #606) migrated to the facet surface, the 39 flat `Collection.<method>` delegators are now **caller-free** and are removed, leaving `Collection` a thin composition root. `collection.py` shrinks **1314 → 546 lines**.

## What changed

**Removal**
- Deleted the 39 one-line delegators (reader 13 / writer 5 / graph 6 / index 15). Their rich docstrings already live verbatim on the facet methods, so no documentation content is lost.
- **Kept:** `__init__`, the four facet `@property` accessors (`reader`/`writer`/`graph`/`index`), lifecycle (`start`/`stop`/`close`/`pause_writes`/`force_pull`/`sync_from_remote_before_index`), and the private helpers (`_require_built`/`_vectors`/`_validate_path`/`_validate_attachment_path`).
- Fixed the one internal self-call: `start()`'s periodic git-pull `on_pull` callback now references `self._index_facet.reindex` (was `self.reindex`).
- New `TestCollectionThinSurface` mechanically pins the new surface — the 39 names are gone (`hasattr` = False), the 4 accessors + 6 lifecycle methods remain.

**API-docs re-homing** (necessary because `api/collection.md` renders `Collection` under `mkdocs build --strict`, so removing its methods would delete the rendered method docs and break ~75 `:meth:` xrefs)
- New `docs/api/facets.md` renders `ReaderFacet`/`WriterFacet`/`GraphFacet`/`IndexFacet` (+ wired into `mkdocs.yml` nav), so the method API documentation now lives with the facets.
- Repointed every `:meth:`/`:class:` xref to a removed method — in the `Collection` class docstring, the four facet module docstrings, `types.py`, `exceptions.py`, `hashing.py`, and the facets' own cross-facet refs — to the facet form.
- Updated runnable examples (`README.md`, `docs/index.md`, `docs/api/collection.md`, `docs/api/git.md`, `docs/guides/{para,zettelkasten}.md`) to the facet form, including the callable-reference form (`asyncio.to_thread(collection.reader.search, ...)`); Quick Starts now build before querying (no lazy build since #526).
- `docs/design.md`: illustrative `class Collection` block now shows the thin facade; migration-status, index-build, and structure prose updated. `types.py` `AttachmentContent` xref corrected to `ReaderFacet.read_attachment` (a pre-existing wrong-method ref).

## Verification

- `mypy src/ tests/` clean; ruff clean; **`mkdocs build --strict` passes** (all facet xrefs resolve against the new facet pages).
- Full suite **1852 passed**, 1 skipped, 1 xpassed (#595 HF flake). The new thin-surface test guards the removal in both directions.
- Preflight circus (5 core lenses + code-reviewer + pr-test-analyzer + comment-analyzer): clean. The delegator removal is caller-free; every repoint lands on the owning facet.

## Scope

This is **not** the `Collection`→`Vault` rename (PR4b, `feat!:`). The class stays named `Collection` here; PR4a is a non-version-bumping `refactor:` so the epic cuts a single major (2.0.0) when PR4b lands.

Closes #627. Refs #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)