### PR TITLE
test: close Vault-owning fixtures via yield/finally

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,9 +98,12 @@ def populated_vault(tmp_path: Path):
         embedding_provider=MockEmbeddingProvider(),
         embeddings_path=tmp_path / "vectors",
     )
-    col.index.build_index()
-    col.index.build_embeddings()
-    return col
+    try:
+        col.index.build_index()
+        col.index.build_embeddings()
+        yield col
+    finally:
+        col.close()
 
 
 @pytest.fixture

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -13,6 +13,7 @@ import pytest
 from markdown_vault_mcp.vault import Vault
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from markdown_vault_mcp.types import IndexStats
@@ -118,10 +119,10 @@ def corpus_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def corpus_vault(corpus_path: Path) -> tuple[Vault, IndexStats]:
-    """Return a built Vault configured with ifcraftcorpus settings.
+def corpus_vault(corpus_path: Path) -> Iterator[tuple[Vault, IndexStats]]:
+    """A built Vault configured with ifcraftcorpus settings.
 
-    Returns:
+    Yields:
         Tuple of (vault, index_stats) so tests can inspect both.
     """
     vault = Vault(
@@ -130,8 +131,11 @@ def corpus_vault(corpus_path: Path) -> tuple[Vault, IndexStats]:
         indexed_frontmatter_fields=["cluster", "topics"],
         read_only=True,
     )
-    stats = vault.index.build_index()
-    return vault, stats
+    try:
+        stats = vault.index.build_index()
+        yield vault, stats
+    finally:
+        vault.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -43,6 +43,8 @@ from markdown_vault_mcp.vault import Vault
 from tests.conftest import wait_for_writer_drain
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from .conftest import MockEmbeddingProvider
 
 
@@ -100,11 +102,14 @@ def _make_vault(
 
 
 @pytest.fixture
-def vault(vault_path: Path) -> Vault:
+def vault(vault_path: Path) -> Iterator[Vault]:
     """Built Vault backed by the clean vault fixture."""
     col = _make_vault(vault_path)
-    col.index.build_index()
-    return col
+    try:
+        col.index.build_index()
+        yield col
+    finally:
+        col.close()
 
 
 # ---------------------------------------------------------------------------
@@ -756,11 +761,14 @@ class TestWriteReadOnly:
 
 
 @pytest.fixture
-def writable(vault_path: Path) -> Vault:
+def writable(vault_path: Path) -> Iterator[Vault]:
     """Writable Vault backed by the clean vault fixture."""
     col = _make_vault(vault_path, read_only=False)
-    col.index.build_index()
-    return col
+    try:
+        col.index.build_index()
+        yield col
+    finally:
+        col.close()
 
 
 @pytest.fixture
@@ -768,7 +776,7 @@ def writable_with_embeddings(
     vault_path: Path,
     tmp_path: Path,
     mock_provider: MockEmbeddingProvider,
-) -> Vault:
+) -> Iterator[Vault]:
     """Writable Vault with mock embeddings enabled."""
     col = Vault(
         source_dir=vault_path,
@@ -776,9 +784,12 @@ def writable_with_embeddings(
         embedding_provider=mock_provider,
         read_only=False,
     )
-    col.index.build_index()
-    col.index.build_embeddings()
-    return col
+    try:
+        col.index.build_index()
+        col.index.build_embeddings()
+        yield col
+    finally:
+        col.close()
 
 
 class TestWrite:
@@ -2419,16 +2430,19 @@ def semantic_vault(
     vault_path: Path,
     tmp_path: Path,
     mock_provider: MockEmbeddingProvider,
-) -> Vault:
+) -> Iterator[Vault]:
     """Vault with FTS index and vector embeddings fully built."""
     col = Vault(
         source_dir=vault_path,
         embeddings_path=tmp_path / "embeddings",
         embedding_provider=mock_provider,
     )
-    col.index.build_index()
-    col.index.build_embeddings()
-    return col
+    try:
+        col.index.build_index()
+        col.index.build_embeddings()
+        yield col
+    finally:
+        col.close()
 
 
 class TestSemanticSearch:
@@ -3025,7 +3039,7 @@ class TestReindexWithVectors:
         vault_path: Path,
         tmp_path: Path,
         mock_provider: MockEmbeddingProvider,
-    ) -> Vault:
+    ) -> Iterator[Vault]:
         """Writable vault with vectors loaded in memory."""
         col = Vault(
             source_dir=vault_path,
@@ -3034,11 +3048,14 @@ class TestReindexWithVectors:
             state_path=tmp_path / "state.json",
             read_only=False,
         )
-        col.index.build_index()
-        col.index.build_embeddings()
-        # Trigger vector load so _vectors is not None.
-        col._search_mgr._load_vectors()
-        return col
+        try:
+            col.index.build_index()
+            col.index.build_embeddings()
+            # Trigger vector load so _vectors is not None.
+            col._search_mgr._load_vectors()
+            yield col
+        finally:
+            col.close()
 
     def test_reindex_adds_vector_entries_for_new_files(
         self,
@@ -3463,12 +3480,15 @@ Line 31.
 
 
 @pytest.fixture
-def vault_with_long_doc(vault_path: Path) -> Vault:
+def vault_with_long_doc(vault_path: Path) -> Iterator[Vault]:
     """Vault with a long multi-section document added for ToC testing."""
     (vault_path / "long_doc.md").write_text(_LONG_DOC, encoding="utf-8")
     col = _make_vault(vault_path)
-    col.index.build_index()
-    return col
+    try:
+        col.index.build_index()
+        yield col
+    finally:
+        col.close()
 
 
 class TestVaultGetToc:


### PR DESCRIPTION
Closes #625. Refs #576.

## Problem

Eight `Vault`-owning pytest fixtures built a `Vault` (opening a SQLite handle + spawning the writer thread) and `return`ed it without ever closing it. Each leaked its handle and background thread for the lifetime of the test session — inconsistent with the sibling `built` fixture, which already used the `yield`/`finally: close()` teardown pattern.

## Fix

Convert the eight leaking fixtures from `return X` to `try: yield X / finally: X.close()`, so the SQLite handle and writer thread are released at fixture teardown even when a test raises:

- `populated_vault` (`tests/conftest.py`)
- `corpus_vault` (`tests/test_api_validation.py`) — yields the `(vault, stats)` tuple, closes `vault` in `finally`
- `vault`, `writable`, `writable_with_embeddings`, `semantic_vault`, `writable_semantic`, `vault_with_long_doc` (`tests/test_vault.py`)

Each `-> Vault` annotation widens to `-> Iterator[Vault]` (generator fixtures); `Iterator` is imported under `TYPE_CHECKING`. `corpus_vault`'s docstring switches `Returns:` → `Yields:` to match.

## Scope

Per the issue, the helper functions (`_make_vault*`, `_ready_vault`) are intentionally left as-is — their callers own the returned `Vault`'s lifetime. Tightening those callers is a lower-severity follow-up.

## Verification

- `uv run ruff check .` / `ruff format --check` — clean
- `uv run mypy src/ tests/` — clean
- `uv run pytest` — 1852 passed
- `populated_vault` consumers pass under `-W error::ResourceWarning`, confirming the close releases the handle rather than masking it