### PR TITLE
perf(tests): module-scope the shared read-only vault fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,23 @@ class MockEmbeddingProvider(EmbeddingProvider):
         return f"mock-dim-{self._dim}"
 
 
+_VAULT_FIXTURE_EXCLUDED = {"invalid_utf8.md"}
+
+
+def _copy_md_fixtures(fixtures_dir: Path, dest: Path) -> Path:
+    """Copy ``*.md`` fixtures into ``dest``, excluding non-UTF-8 fixtures."""
+    import shutil
+
+    dest.mkdir(parents=True, exist_ok=True)
+    for src in fixtures_dir.rglob("*.md"):
+        if src.name in _VAULT_FIXTURE_EXCLUDED:
+            continue
+        target = dest / src.relative_to(fixtures_dir)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, target)
+    return dest
+
+
 @pytest.fixture
 def fixtures_path() -> Path:
     """Path to test fixtures directory."""
@@ -103,14 +120,21 @@ def populated_vault(tmp_path: Path):
     return col
 
 
-@pytest.fixture
-def built(vault_path: Path):
-    """A built Vault over the clean vault fixture (shared by facet tests)."""
+@pytest.fixture(scope="module")
+def _shared_vault_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Module-scoped copy of the markdown fixtures for read-only sharing (#618)."""
+    fixtures_dir = Path(__file__).parent / "fixtures"
+    return _copy_md_fixtures(fixtures_dir, tmp_path_factory.mktemp("shared_vault"))
+
+
+@pytest.fixture(scope="module")
+def built(_shared_vault_path: Path):
+    """A built Vault over the shared read-only vault fixture (module-scoped, #618)."""
     from markdown_vault_mcp.vault import Vault
 
-    col = Vault(source_dir=vault_path)
-    col.index.build_index()
+    col = Vault(source_dir=_shared_vault_path)
     try:
+        col.index.build_index()
         yield col
     finally:
         col.close()
@@ -241,19 +265,4 @@ def vault_path(tmp_path: Path, fixtures_path: Path) -> Path:
     Returns:
         Path to the vault root inside ``tmp_path``.
     """
-    import shutil
-
-    vault = tmp_path / "vault"
-    vault.mkdir()
-
-    _EXCLUDED = {"invalid_utf8.md"}
-
-    for src in fixtures_path.rglob("*.md"):
-        if src.name in _EXCLUDED:
-            continue
-        rel = src.relative_to(fixtures_path)
-        dest = vault / rel
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dest)
-
-    return vault
+    return _copy_md_fixtures(fixtures_path, tmp_path / "vault")

--- a/tests/test_facet_index.py
+++ b/tests/test_facet_index.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.facets.index import IndexFacet
+from markdown_vault_mcp.vault import Vault
 
 if TYPE_CHECKING:
-    from markdown_vault_mcp.vault import Vault
+    from pathlib import Path
 
 
 class TestIndexFacetAccessor:
@@ -31,10 +32,15 @@ class TestIndexFacetBehaviour:
     def test_write_generation_is_int(self, built: Vault) -> None:
         assert isinstance(built.index.write_generation(), int)
 
-    def test_reindex_runs(self, built: Vault) -> None:
-        # ReindexResult; just exercise the delegation end to end.
-        result = built.index.reindex()
-        assert result is not None
+    def test_reindex_runs(self, vault_path: Path) -> None:
+        # Own vault: reindex() mutates index state -> must not share `built` (#618).
+        col = Vault(source_dir=vault_path)
+        try:
+            col.index.build_index()
+            result = col.index.reindex()
+            assert result is not None
+        finally:
+            col.close()
 
     def test_embeddings_status_returns_dict(self, built: Vault) -> None:
         assert isinstance(built.index.embeddings_status(), dict)


### PR DESCRIPTION
Closes #618. Refs #576.

## Problem

The `built` pytest fixture (consumed read-only by the reader/graph/index facet test modules) was function-scoped, so every test that used it ran `Vault.__init__` + `build_index()` from scratch. Across those three modules that was **34 `build_index()` invocations** for what is identical read-only setup.

## Fix

- New **module-scoped** `_shared_vault_path` fixture copies the markdown fixtures once per module via `tmp_path_factory` (it computes the fixtures dir inline because it can't depend on the function-scoped `fixtures_path`).
- `built` becomes **module-scoped** over `_shared_vault_path` → `build_index()` runs once per module. Measured **34 → 6** across reader/graph/index (the remaining 3 are the genuinely-independent tests that build their own vault: attachment round-trip, graph-limit, reindex).
- The one `built` consumer that mutates index state — `test_reindex_runs` — moves to its own per-function Vault, keeping the shared `built` strictly read-only.
- A `_copy_md_fixtures` helper de-duplicates the copy logic, now used by both `_shared_vault_path` and the (unchanged, function-scoped) `vault_path`.
- Fixture setup (`build_index()`) now runs inside the `try`, so a build failure still closes the Vault.

## Divergence from the issue title

The issue is titled "module-scope the `vault_path` fixture," but doing that literally is the path the issue's own `[unverified]` caution warns against: `vault_path` backs the writable `writable` fixture and the attachment/readiness tests, which write *into* that directory — sharing one dir per module would contaminate siblings. Instead this PR module-scopes a **separate** read-only vault (`_shared_vault_path` + `built`) and leaves `vault_path` function-scoped, achieving the same build reduction with zero contamination.

## Verification

- `uv run ruff check .` / `ruff format --check` — clean
- `uv run mypy src/ tests/` — clean
- `uv run pytest` — 1852 passed, 1 skipped, 1 xpassed
- `build_index()` invocation count across reader/graph/index: **34 → 6** (instrumented)
- Every `built` consumer audited read-only; the sole mutator isolated to its own Vault