### PR TITLE
refactor: move attachment context-cap from the vault library to the MCP tools

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1596,7 +1596,7 @@ For MCP server deployment:
 | `MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES` | Comma-separated OAuth scopes to request | `openid` |
 | `MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN` | Verify the upstream access token as JWT instead of the id token. Set `true` only when your provider issues JWT access tokens and you need audience-claim validation on that token | `false` (verify id token) |
 | `MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS` | Comma-separated allowlist of non-.md extensions (without dot), e.g. `pdf,png,docx`; use `*` to allow all non-.md files | common list (pdf, png, jpg, docx, …) |
-| `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` | Maximum attachment size in MB enforced on both read and write; `0` disables the limit | `1.0` |
+| `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` | Maximum attachment size in MB, enforced by the `read` / `write` / `fetch` MCP tools (not the vault library); `0` disables the limit | `1.0` |
 | `MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES` | Maximum bytes returned by full-document `read()` for `.md` files; raises `ValueError` if exceeded. `read(path, section=...)` for partial reads bypasses the cap. `0` disables the limit | `262144` (256 KB) |
 | `MARKDOWN_VAULT_MCP_APP_DOMAIN` | Claude app domain for MCP Apps iframe sandboxing; auto-computed from `BASE_URL` via `_compute_claude_app_domain()` | derived from `BASE_URL` |
 | `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | `openai`, `ollama`, `fastembed` | auto-detect |
@@ -1732,7 +1732,7 @@ The server supports reading and writing non-markdown binary files (PDFs, images,
 
 Attachments are **not indexed or searched** — only direct path-based read/write/delete/rename. MIME type is detected via Python's `mimetypes.guess_type()` (no extra dependencies).
 
-Size limit applies to both `read_attachment()` and `write_attachment()`. Set `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB=0` to disable the limit. The default was tightened from 10 MB to 1 MB in #442 to keep LLM context bounded — most contexts can't survive a 10 MB base64-encoded attachment, so the old default was a silent context-blow-up. The error message names `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` as the knob to raise if the bytes are genuinely needed in context.
+The cap is enforced by the `read`, `write`, and `fetch` MCP tools — the layer where attachment bytes flow through the LLM context as base64. The vault library's `read_attachment()` / `write_attachment()` accept any size, so out-of-band byte movement (e.g. an HTTP transfer route) is not gated by it. Set `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB=0` to disable the limit. The default was tightened from 10 MB to 1 MB in #442 to keep LLM context bounded — most contexts can't survive a 10 MB base64-encoded attachment, so the old default was a silent context-blow-up. The error message names `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` as the knob to raise if the bytes are genuinely needed in context.
 
 A parallel cap on whole-document `read()` for `.md` files (`MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES`, default 256 KB) raises `ValueError` with a message pointing at `read(path, section=heading)` for partial reads. Section reads bypass the cap because they only load one chunk.
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -437,10 +437,23 @@ def register_tools(mcp: FastMCP) -> None:
 
         Raises:
             ValueError: If no file exists at the given path, the extension is
-                not in the attachment allowlist, the file exceeds the size
-                limit, or the requested section heading is not found.
+                not in the attachment allowlist, the file exceeds
+                ``MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB``, or the requested
+                section heading is not found.
         """
         if not path.endswith(".md"):
+            cap_mb = vault.max_attachment_size_mb
+            if cap_mb > 0:
+                size = await asyncio.to_thread(vault.reader.attachment_size, path)
+                limit = int(cap_mb * 1024 * 1024)
+                if size > limit:
+                    raise ValueError(
+                        f"Attachment {path!r} is {size} bytes "
+                        f"({size / 1024 / 1024:.1f} MB), exceeds "
+                        f"MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB ({cap_mb} MB). "
+                        f"Increase MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB if "
+                        f"you need the bytes in context."
+                    )
             attachment = await asyncio.to_thread(vault.reader.read_attachment, path)
             return asdict(attachment)
         note = await asyncio.to_thread(vault.reader.read, path, section=section)
@@ -1535,7 +1548,8 @@ def register_tools(mcp: FastMCP) -> None:
 
         Raises:
             ValueError: If content_base64 is missing/invalid for
-                attachments, or the content exceeds the size limit.
+                attachments, or the content exceeds
+                ``MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB``.
             McpError: If if_match is provided and the file has been
                 modified, or if_match is supplied for a file that does not
                 yet exist (ConcurrentModificationError).
@@ -1549,6 +1563,15 @@ def register_tools(mcp: FastMCP) -> None:
                 raw_bytes = base64.b64decode(content_base64)
             except Exception as exc:
                 raise ValueError(f"Invalid base64 in content_base64: {exc}") from exc
+            cap_mb = vault.max_attachment_size_mb
+            if cap_mb > 0 and len(raw_bytes) > int(cap_mb * 1024 * 1024):
+                raise ValueError(
+                    f"Attachment {path!r} is {len(raw_bytes)} bytes "
+                    f"({len(raw_bytes) / 1024 / 1024:.1f} MB), exceeds "
+                    f"MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB ({cap_mb} MB). "
+                    f"Increase MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB if "
+                    f"you need the bytes in context."
+                )
             result = await asyncio.to_thread(
                 vault.writer.write_attachment, path, raw_bytes, if_match=if_match
             )
@@ -1956,15 +1979,12 @@ def register_tools(mcp: FastMCP) -> None:
 
         # Determine size limit (attachments only). This pre-check enforces
         # the limit during streaming so we abort early without buffering the
-        # entire payload. write_attachment() has a redundant check that
-        # covers the non-fetch code path.
+        # entire payload.
         is_markdown = path.endswith(".md")
-        # pylint: disable=protected-access  # No public API for size limit;
-        # MCP layer is a trusted consumer of Vault internals.
         max_bytes = (
             0
-            if is_markdown or vault._max_attachment_size_mb <= 0
-            else int(vault._max_attachment_size_mb * 1024 * 1024)
+            if is_markdown or vault.max_attachment_size_mb <= 0
+            else int(vault.max_attachment_size_mb * 1024 * 1024)
         )
 
         # Stream download — enforce size limit as chunks arrive.
@@ -1981,7 +2001,7 @@ def register_tools(mcp: FastMCP) -> None:
                 if max_bytes > 0 and downloaded > max_bytes:
                     raise ValueError(
                         f"Download exceeded the attachment size limit "
-                        f"of {vault._max_attachment_size_mb} MB "
+                        f"of {vault.max_attachment_size_mb} MB "
                         f"({max_bytes} bytes). Raise "
                         "MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB or "
                         "set it to 0 to disable the limit."

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -382,6 +382,13 @@ class ReaderFacet:
         """
         return self._search_mgr.stats()
 
+    def attachment_size(self, path: str) -> int:
+        """Return an attachment's on-disk byte size without reading it.
+
+        Delegates to :meth:`DocumentManager.attachment_size`.
+        """
+        return self._doc_mgr.attachment_size(path)
+
     def read_attachment(self, path: str) -> AttachmentContent:
         """Read the binary content of a non-.md attachment.
 

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -195,8 +195,7 @@ class WriterFacet:
             ConcurrentModificationError: If *if_match* is provided and does
                 not match the current file hash, or *if_match* is supplied
                 for a file that does not yet exist.
-            ValueError: If the path escapes the source directory, has an
-                extension not in the allowlist, or the content exceeds the
-                size limit.
+            ValueError: If the path escapes the source directory or has an
+                extension not in the allowlist.
         """
         return self._doc_mgr.write_attachment(path, content, if_match=if_match)

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -83,7 +83,6 @@ class DocumentManager:
             :exc:`~markdown_vault_mcp.exceptions.ReadOnlyError`.
         exclude_patterns: Glob patterns for paths to exclude.
         attachment_extensions: Allowlist of attachment file extensions.
-        max_attachment_size_mb: Maximum attachment size in megabytes.
         max_note_read_bytes: Maximum bytes returned by full-document reads.
             ``0`` disables the limit (default ``262144``, i.e. 256 KB).
         on_write_callback: Fires after a successful write to enqueue a
@@ -107,7 +106,6 @@ class DocumentManager:
         read_only: bool = True,
         exclude_patterns: list[str] | None = None,
         attachment_extensions: list[str] | None = None,
-        max_attachment_size_mb: float = 1.0,
         max_note_read_bytes: int = 262144,
         on_write_callback: Callable[[Path, str, WriteOperation], None] | None = None,
         mark_paths_dirty: Callable[[Iterable[str]], None] | None = None,
@@ -119,7 +117,6 @@ class DocumentManager:
         self._read_only = read_only
         self._exclude_patterns = exclude_patterns
         self._attachment_extensions = attachment_extensions
-        self._max_attachment_size_mb = max_attachment_size_mb
         self._max_note_read_bytes = max_note_read_bytes
         self._on_write_callback = on_write_callback or (lambda *_a: None)
         self._mark_paths_dirty = mark_paths_dirty
@@ -370,6 +367,27 @@ class DocumentManager:
             etag="",  # ETag is whole-file; not meaningful for a section
         )
 
+    def attachment_size(self, path: str) -> int:
+        """Return the on-disk byte size of an attachment without reading it.
+
+        Args:
+            path: Relative attachment path.
+
+        Returns:
+            The file size in bytes (from ``stat``).
+
+        Raises:
+            ValueError: If the path escapes the source directory, has an
+                extension not in the allowlist, or the file does not exist.
+        """
+        abs_path = self._validate_attachment_path(path)
+        try:
+            if not abs_path.is_file():
+                raise ValueError(f"Attachment not found: {path}")
+            return abs_path.stat().st_size
+        except OSError as exc:
+            raise ValueError(f"Attachment not found: {path}") from exc
+
     def read_attachment(self, path: str) -> AttachmentContent:
         """Read the binary content of a non-.md attachment.
 
@@ -383,7 +401,6 @@ class DocumentManager:
         Raises:
             ValueError: If the path escapes the source directory, has an
                 extension not in the allowlist, or the file does not exist.
-            ValueError: If the file exceeds the configured size limit.
         """
         abs_path = self._validate_attachment_path(path)
         if not abs_path.is_file():
@@ -391,17 +408,6 @@ class DocumentManager:
 
         stat = abs_path.stat()
         size_bytes = stat.st_size
-        if self._max_attachment_size_mb > 0:
-            limit_bytes = int(self._max_attachment_size_mb * 1024 * 1024)
-            if size_bytes > limit_bytes:
-                raise ValueError(
-                    f"Attachment {path!r} is {size_bytes} bytes "
-                    f"({size_bytes / 1024 / 1024:.1f} MB), exceeds "
-                    f"MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
-                    f"({self._max_attachment_size_mb} MB). "
-                    f"Increase MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB if "
-                    f"you need the bytes in context."
-                )
 
         mime_type, _ = mimetypes.guess_type(path)
         raw = abs_path.read_bytes()
@@ -559,9 +565,8 @@ class DocumentManager:
             ConcurrentModificationError: If *if_match* is provided and does
                 not match the current file hash, or *if_match* is supplied
                 for a file that does not yet exist.
-            ValueError: If the path escapes the source directory, has an
-                extension not in the allowlist, or the content exceeds the
-                size limit.
+            ValueError: If the path escapes the source directory or has an
+                extension not in the allowlist.
         """
         self._check_writable()
         with self._file_write_lock:
@@ -577,18 +582,6 @@ class DocumentManager:
                 if current_hash != if_match:
                     raise ConcurrentModificationError(
                         path, expected=if_match, actual=current_hash
-                    )
-            if self._max_attachment_size_mb > 0:
-                limit_bytes = int(self._max_attachment_size_mb * 1024 * 1024)
-                if len(content) > limit_bytes:
-                    size_bytes = len(content)
-                    raise ValueError(
-                        f"Attachment {path!r} is {size_bytes} bytes "
-                        f"({size_bytes / 1024 / 1024:.1f} MB), exceeds "
-                        f"MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
-                        f"({self._max_attachment_size_mb} MB). "
-                        f"Increase MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB "
-                        f"if you need the bytes in context."
                     )
             created = not abs_path.is_file()
             abs_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -162,8 +162,9 @@ class Vault:
             and directories to exclude from indexing.
         attachment_extensions: Allowlist of extensions (without leading dot)
             for binary attachments.  ``["*"]`` accepts all extensions.
-        max_attachment_size_mb: Maximum binary attachment size in megabytes.
-            ``0`` disables the limit (default ``1.0``).
+        max_attachment_size_mb: Attachment context-size cap in megabytes,
+            enforced by the ``read`` / ``write`` / ``fetch`` MCP tools (not by
+            the vault library). ``0`` disables the limit (default ``1.0``).
         max_note_read_bytes: Maximum bytes returned by full-document reads.
             ``0`` disables the limit (default ``262144``, i.e. 256 KB).
     """
@@ -321,7 +322,6 @@ class Vault:
             read_only=self._read_only,
             exclude_patterns=self._exclude_patterns,
             attachment_extensions=self._attachment_extensions,
-            max_attachment_size_mb=self._max_attachment_size_mb,
             max_note_read_bytes=self._max_note_read_bytes,
             on_write_callback=self._write_callback.fire,
             mark_paths_dirty=self._coordinator.mark_paths_dirty,
@@ -365,6 +365,15 @@ class Vault:
     def index(self) -> IndexFacet:
         """Index facet: build/reindex/embeddings, readiness, writer status."""
         return self._index_facet
+
+    @property
+    def max_attachment_size_mb(self) -> float:
+        """The attachment context-size cap in MB (``0`` = unlimited).
+
+        Enforced by the ``read`` / ``write`` / ``fetch`` MCP tools, not by the
+        vault library itself.
+        """
+        return self._max_attachment_size_mb
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -482,16 +482,66 @@ class TestCallbacks:
 
 
 # ---------------------------------------------------------------------------
-# Attachment size-cap error message tests
+# attachment_size tests
 # ---------------------------------------------------------------------------
 
 
-class TestReadAttachmentErrorMessage:
-    """The size-cap ValueError must name the env var the caller can raise."""
+class TestAttachmentSize:
+    """DocumentManager.attachment_size returns the on-disk byte size."""
 
-    def test_error_mentions_size_cap_env_var(self, doc_vault: Path) -> None:
+    def _mgr(self, source_dir: Path) -> DocumentManager:
+        return DocumentManager(
+            fts=FTSIndex(db_path=":memory:"),
+            source_dir=source_dir,
+            write_lock=threading.RLock(),
+            chunk_strategy=HeadingChunker(),
+            attachment_extensions=["bin", "png"],
+        )
+
+    def test_returns_correct_size(self, doc_vault: Path) -> None:
+        """attachment_size() returns the byte count matching the written file."""
+        content = b"x" * 12345
+        (doc_vault / "sized.bin").write_bytes(content)
+        mgr = self._mgr(doc_vault)
+        assert mgr.attachment_size("sized.bin") == 12345
+
+    def test_missing_raises(self, doc_vault: Path) -> None:
+        """attachment_size() raises ValueError for a missing file."""
+        mgr = self._mgr(doc_vault)
+        with pytest.raises(ValueError, match="not found"):
+            mgr.attachment_size("missing.bin")
+
+    def test_stat_oserror_becomes_valueerror(
+        self, doc_vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An OSError during stat (a race) surfaces as the documented ValueError."""
+        mgr = self._mgr(doc_vault)
+
+        class _Racy:
+            def is_file(self) -> bool:
+                return True
+
+            def stat(self) -> object:
+                raise OSError("vanished mid-stat")
+
+        monkeypatch.setattr(mgr, "_validate_attachment_path", lambda _p: _Racy())
+        with pytest.raises(ValueError, match="Attachment not found"):
+            mgr.attachment_size("gone.bin")
+
+
+# ---------------------------------------------------------------------------
+# Attachment no-cap-at-manager-layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadAttachmentNoCap:
+    """read_attachment() no longer enforces a size cap — that lives in the MCP tools."""
+
+    def test_large_attachment_succeeds(self, doc_vault: Path) -> None:
+        """read_attachment() returns >1 MB content without raising."""
         big_file = doc_vault / "big.bin"
-        big_file.write_bytes(b"x" * (2 * 1024 * 1024))  # 2 MB
+        big_content = b"x" * (2 * 1024 * 1024)  # 2 MB
+        big_file.write_bytes(big_content)
 
         mgr = DocumentManager(
             fts=FTSIndex(db_path=":memory:"),
@@ -499,19 +549,17 @@ class TestReadAttachmentErrorMessage:
             write_lock=threading.RLock(),
             chunk_strategy=HeadingChunker(),
             attachment_extensions=["bin"],
-            max_attachment_size_mb=1.0,
         )
 
-        with pytest.raises(
-            ValueError, match="MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB"
-        ):
-            mgr.read_attachment("big.bin")
+        result = mgr.read_attachment("big.bin")
+        assert result.size_bytes == len(big_content)
 
 
-class TestWriteAttachmentErrorMessage:
-    """The size-cap ValueError must name the env var the caller can raise."""
+class TestWriteAttachmentNoCap:
+    """write_attachment() no longer enforces a size cap — that lives in the MCP tools."""
 
-    def test_error_mentions_size_cap_env_var(self, doc_vault: Path) -> None:
+    def test_large_attachment_succeeds(self, doc_vault: Path) -> None:
+        """write_attachment() writes >1 MB content without raising."""
         big_content = b"x" * (2 * 1024 * 1024)  # 2 MB
 
         mgr = DocumentManager(
@@ -520,34 +568,11 @@ class TestWriteAttachmentErrorMessage:
             write_lock=threading.RLock(),
             chunk_strategy=HeadingChunker(),
             attachment_extensions=["bin"],
-            max_attachment_size_mb=1.0,
             read_only=False,
         )
 
-        with pytest.raises(
-            ValueError, match="MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB"
-        ):
-            mgr.write_attachment("big.bin", big_content)
-
-
-class TestWriteAttachmentSizeCap:
-    """write_attachment enforces MAX_ATTACHMENT_SIZE_MB on the content."""
-
-    def _mgr(self, doc_vault: Path) -> DocumentManager:
-        return DocumentManager(
-            fts=FTSIndex(db_path=":memory:"),
-            source_dir=doc_vault,
-            write_lock=threading.RLock(),
-            chunk_strategy=HeadingChunker(),
-            attachment_extensions=["bin"],
-            max_attachment_size_mb=1.0,
-            read_only=False,
-        )
-
-    def test_enforces_cap(self, doc_vault: Path) -> None:
-        big = b"x" * (2 * 1024 * 1024)
-        with pytest.raises(ValueError, match="exceeds"):
-            self._mgr(doc_vault).write_attachment("big.bin", big)
+        result = mgr.write_attachment("big.bin", big_content)
+        assert result.path == "big.bin"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -857,6 +857,130 @@ class TestMCPWriteAttachment:
                 )
 
 
+class TestAttachmentSizeCap:
+    """Cap enforcement lives in the read/write MCP tools, not the vault library."""
+
+    async def test_read_rejects_oversized_attachment(
+        self, _mcp_env_writable_with_attachments: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """read tool raises when attachment exceeds MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB."""
+        # Write a 2 KB attachment then set cap to 0.001 MB (~1 KB)
+        (_mcp_env_writable_with_attachments / "assets" / "large.pdf").write_bytes(
+            b"x" * 2048
+        )
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "0.001")
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(
+                ToolError, match="MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB"
+            ):
+                await client.call_tool("read", {"path": "assets/large.pdf"})
+
+    async def test_read_allows_attachment_when_cap_zero(
+        self, _mcp_env_writable_with_attachments: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """read tool succeeds when cap is 0 (unlimited)."""
+        (_mcp_env_writable_with_attachments / "assets" / "large.pdf").write_bytes(
+            b"x" * 2048
+        )
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "0")
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool("read", {"path": "assets/large.pdf"})
+        assert result.data["size_bytes"] == 2048
+
+    async def test_write_rejects_oversized_attachment(
+        self, _mcp_env_writable_with_attachments: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """write tool raises when content_base64 decodes to more than cap allows."""
+        import base64
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "0.001")
+        big_b64 = base64.b64encode(b"x" * 2048).decode("ascii")
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(
+                ToolError, match="MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB"
+            ):
+                await client.call_tool(
+                    "write",
+                    {"path": "assets/big.pdf", "content_base64": big_b64},
+                )
+
+    async def test_write_allows_attachment_when_cap_zero(
+        self, _mcp_env_writable_with_attachments: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """write tool succeeds when cap is 0 (unlimited)."""
+        import base64
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "0")
+        big_b64 = base64.b64encode(b"x" * 2048).decode("ascii")
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "write",
+                {"path": "assets/big.pdf", "content_base64": big_b64},
+            )
+        assert result.data["path"] == "assets/big.pdf"
+
+    async def test_read_rejects_oversized_without_loading_bytes(
+        self, _mcp_env_writable_with_attachments: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The read tool rejects via stat(); it never loads the oversized bytes."""
+        from markdown_vault_mcp.managers.document import DocumentManager
+
+        (_mcp_env_writable_with_attachments / "assets" / "large.pdf").write_bytes(
+            b"x" * 2048
+        )
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "0.001")
+        seen: list[str] = []
+        real = DocumentManager.read_attachment
+
+        def spy(self: DocumentManager, path: str) -> object:
+            seen.append(path)
+            return real(self, path)
+
+        monkeypatch.setattr(DocumentManager, "read_attachment", spy)
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(
+                ToolError, match="MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB"
+            ):
+                await client.call_tool("read", {"path": "assets/large.pdf"})
+        assert seen == []
+
+    async def test_write_cap_boundary_exact_size_allowed(
+        self, _mcp_env_writable_with_attachments: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A payload exactly at the cap is allowed; one byte over is rejected."""
+        import base64
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "0.001")
+        limit = int(0.001 * 1024 * 1024)
+        server = make_server()
+        async with Client(server) as client:
+            ok = await client.call_tool(
+                "write",
+                {
+                    "path": "assets/exact.pdf",
+                    "content_base64": base64.b64encode(b"x" * limit).decode("ascii"),
+                },
+            )
+            assert ok.data["path"] == "assets/exact.pdf"
+            with pytest.raises(
+                ToolError, match="MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB"
+            ):
+                await client.call_tool(
+                    "write",
+                    {
+                        "path": "assets/over.pdf",
+                        "content_base64": base64.b64encode(b"x" * (limit + 1)).decode(
+                            "ascii"
+                        ),
+                    },
+                )
+
+
 class TestFetchTool:
     """Test the fetch MCP tool — downloads from URL and writes to vault."""
 

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -2066,22 +2066,29 @@ class TestReadAttachment:
         with pytest.raises(ValueError, match="allowlist"):
             col.reader.read_attachment("assets/report.xyz")
 
-    def test_read_attachment_size_limit_enforced(
+    def test_read_attachment_no_cap_at_vault_layer(
         self, vault_with_attachment: Path
     ) -> None:
-        """read_attachment() raises ValueError when file exceeds the size limit."""
-        # 1-byte limit
+        """read_attachment() succeeds regardless of max_attachment_size_mb (cap is in MCP tools)."""
         col = Vault(source_dir=vault_with_attachment, max_attachment_size_mb=0.000001)
-        with pytest.raises(ValueError, match="exceeds"):
-            col.reader.read_attachment("assets/report.pdf")
+        result = col.reader.read_attachment("assets/report.pdf")
+        assert result.size_bytes > 0
 
-    def test_read_attachment_zero_size_limit_disables(
+    def test_read_attachment_zero_size_limit_succeeds(
         self, vault_with_attachment: Path
     ) -> None:
-        """read_attachment() with max_attachment_size_mb=0 has no size limit."""
+        """read_attachment() with max_attachment_size_mb=0 succeeds (unlimited)."""
         col = Vault(source_dir=vault_with_attachment, max_attachment_size_mb=0)
         result = col.reader.read_attachment("assets/report.pdf")
         assert result.size_bytes > 0
+
+    def test_attachment_size_returns_byte_count(
+        self, vault_with_attachment: Path
+    ) -> None:
+        """attachment_size() returns the on-disk byte size without reading the file."""
+        col = Vault(source_dir=vault_with_attachment)
+        size = col.reader.attachment_size("assets/report.pdf")
+        assert size == len(b"%PDF-1.4 fake content")
 
     def test_read_attachment_png_mime_type(self, vault_with_attachment: Path) -> None:
         """read_attachment() detects image/png MIME type."""
@@ -2165,17 +2172,17 @@ class TestWriteAttachment:
         with pytest.raises(ReadOnlyError):
             col.writer.write_attachment("assets/new.pdf", b"content")
 
-    def test_write_attachment_size_limit_enforced(
+    def test_write_attachment_no_cap_at_vault_layer(
         self, vault_with_attachment: Path
     ) -> None:
-        """write_attachment() raises ValueError when content exceeds size limit."""
+        """write_attachment() succeeds regardless of max_attachment_size_mb (cap is in MCP tools)."""
         col = Vault(
             source_dir=vault_with_attachment,
             read_only=False,
             max_attachment_size_mb=0.000001,
         )
-        with pytest.raises(ValueError, match="exceeds"):
-            col.writer.write_attachment("assets/big.pdf", b"a" * 100)
+        result = col.writer.write_attachment("assets/big.pdf", b"a" * 100)
+        assert result.path == "assets/big.pdf"
 
     def test_write_attachment_disallowed_extension_raises(
         self, vault_with_attachment: Path
@@ -3321,26 +3328,22 @@ class TestListAttachmentEdgeCases:
 
 
 # ---------------------------------------------------------------------------
-# Gap coverage: write_attachment() size limit
+# Vault-layer write_attachment() has no size cap (cap lives in MCP tools)
 # ---------------------------------------------------------------------------
 
 
 class TestWriteAttachmentSizeLimit:
-    def test_write_attachment_raises_when_content_exceeds_limit(
-        self, vault_path: Path
-    ) -> None:
-        """write_attachment() raises ValueError when content size exceeds the limit."""
+    def test_write_attachment_no_cap_at_vault_layer(self, vault_path: Path) -> None:
+        """write_attachment() succeeds regardless of max_attachment_size_mb (cap is in MCP tools)."""
         col = Vault(
             source_dir=vault_path,
             read_only=False,
-            max_attachment_size_mb=0.000001,  # ~1 byte limit
+            max_attachment_size_mb=0.000001,  # ~1 byte limit — no longer enforced here
         )
-        with pytest.raises(ValueError, match="exceeds"):
-            col.writer.write_attachment("assets/big.pdf", b"a" * 100)
+        result = col.writer.write_attachment("assets/big.pdf", b"a" * 100)
+        assert result.path == "assets/big.pdf"
 
-    def test_write_attachment_unlimited_when_max_is_zero(
-        self, vault_path: Path
-    ) -> None:
+    def test_write_attachment_succeeds_when_max_is_zero(self, vault_path: Path) -> None:
         """write_attachment() with max_attachment_size_mb=0 accepts any size."""
         col = Vault(
             source_dir=vault_path,


### PR DESCRIPTION
## What

Relocates the `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` cap (default 1.0 MB)
out of the vault library (`DocumentManager.read_attachment` / `write_attachment`)
and into the MCP `read` / `write` tools. The vault becomes a pure byte mover.

## Why

The cap exists solely to protect the **LLM context window** from base64
inflation — its own error message says *"Increase … if you need the bytes in
context"*. Enforcing it inside the vault library is the wrong layer: any
out-of-band byte movement that doesn't pass through context (notably the
one-time HTTP transfer route in #622) inherits a 1 MB ceiling it shouldn't.
`fetch` already worked around this with its own streaming check. This moves the
guard structurally to the tools that actually feed the LLM context.

## Design

- **`DocumentManager`**: removed the size-cap block from `read_attachment` /
  `write_attachment` and the `max_attachment_size_mb` constructor param; added
  **`attachment_size(path) -> int`** (validate + `stat`, no read) so the read
  tool can reject an oversized attachment *before loading it* (avoids an
  OOM/DoS where a huge file is read into memory only to be rejected).
- **`ReaderFacet`**: `attachment_size` delegator.
- **`Vault`**: keeps the value, exposed as a public **`max_attachment_size_mb`**
  property (replaces three tools' `vault._max_attachment_size_mb` protected
  access); no longer passes it to `DocumentManager`.
- **`read` tool**: `attachment_size()` → cap check → `read_attachment` (only if
  within limit). **`write` tool**: `len(decoded)` check before `write_attachment`.
  **`fetch` tool**: unchanged behavior; now uses the public property.

Invariants preserved: `0` = unlimited; errors still name the env var; `fetch`
streaming abort-early.

## Verification

```
grep -rn "max_attachment_size_mb" src/markdown_vault_mcp/managers/document.py   # → empty
grep -n  "MAX_ATTACHMENT_SIZE_MB"  src/markdown_vault_mcp/_server_tools.py       # → read + write + fetch
grep -n  "def max_attachment_size_mb" src/markdown_vault_mcp/vault.py            # → property
```

## Tests

- Manager/vault cap tests **rewritten** (not deleted) to assert the vault no
  longer caps; cap behavior re-tested at the **tool layer** via `Client`
  (read/write reject oversized, honor `=0`); `attachment_size` tested; a
  **stat-only proof** test asserts `read_attachment` is never called when the
  read tool rejects (locks the OOM-prevention design against a load-then-check
  regression); a boundary test pins the exact-at-limit edge; `fetch` cap test
  kept. Full suite: **1861 passed**.

Reviewed locally with the five-lens preflight circus + spec/quality passes
(docstrings + `docs/design.md` updated to reflect the new enforcement layer).

Closes #633.

**Prerequisite for #622** (one-time HTTP transfer links), which will rebase on
this so its route inherits cap-free vault access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)