### PR TITLE
feat: adopt fastmcp-pvl-core 3.x — conforming logging + KV_STORE_URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,11 @@ All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` pr
 | `MARKDOWN_VAULT_MCP_SERVER_NAME` | `markdown-vault-mcp` | MCP server name shown to clients; useful for multi-instance setups |
 | `MARKDOWN_VAULT_MCP_INSTRUCTIONS` | (auto) | System-level instructions injected into LLM context; defaults to a description that reflects read-only vs read-write state |
 | `MARKDOWN_VAULT_MCP_HTTP_PATH` | `/mcp` | HTTP endpoint path for streamable HTTP transport (used by `serve --transport http`) |
-| `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | `file:///data/state/events` | Event store backend for HTTP session persistence. `file:///path` (default) survives restarts; `memory://` for dev (lost on restart). |
+| `MARKDOWN_VAULT_MCP_KV_STORE_URL` | `file:///data/state` | Unified key-value backend for HTTP session persistence (the `events` keyspace is namespaced inside the directory). `file:///path` (default) survives restarts; `memory://` for dev (lost on restart). Preferred over `EVENT_STORE_URL`. |
+| `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | (unset) | Legacy alias for `KV_STORE_URL`; honoured only when `KV_STORE_URL` is unset, and logs a one-shot deprecation warning. Prefer `KV_STORE_URL`. |
 | `MARKDOWN_VAULT_MCP_APP_DOMAIN` | (auto) | Override the Claude app domain used for MCP Apps iframe sandboxing. Auto-computed from `BASE_URL` when not set. |
 | `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). App loggers default to `INFO`. `-v` overrides both to `DEBUG`. |
-| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output. |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Rich `key=value` text by default. Set to `false` for one-JSON-object-per-record output — recommended for production / log-aggregator deployments. |
 
 ### Search and embeddings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,10 +51,11 @@ faster client feedback when the index has chronic backlog.
 | `MARKDOWN_VAULT_MCP_INSTRUCTIONS` | string | (auto) | System-level instructions injected into LLM context; defaults to a description that reflects read-only vs read-write state |
 | `MARKDOWN_VAULT_MCP_HTTP_PATH` | path | `/mcp` | HTTP endpoint path for streamable HTTP transport (`serve --transport http`) |
 | `MARKDOWN_VAULT_MCP_BASE_URL` | url | — | Public base URL of the server (e.g. `https://mcp.example.com`). Required for OIDC auth, MCP Apps domain computation, and the one-time transfer link tools |
-| `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | url | `file:///data/state/events` | Event store backend for HTTP session persistence. `file:///path` survives restarts; `memory://` for dev (lost on restart) |
+| `MARKDOWN_VAULT_MCP_KV_STORE_URL` | url | `file:///data/state` | Unified key-value backend for HTTP session persistence (the `events` keyspace is namespaced inside the directory). `file:///path` survives restarts; `memory://` for dev (lost on restart). Preferred over `EVENT_STORE_URL`. |
+| `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | url | (unset) | Legacy alias for `KV_STORE_URL`; honoured only when `KV_STORE_URL` is unset, and logs a one-shot deprecation warning. Prefer `KV_STORE_URL`. |
 | `MARKDOWN_VAULT_MCP_APP_DOMAIN` | string | (auto) | Override the Claude app domain used for MCP Apps iframe sandboxing. Auto-computed from `BASE_URL` when not set |
 | `FASTMCP_LOG_LEVEL` | string | `INFO` | Log level for FastMCP internals (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `-v` CLI flag overrides both app and FastMCP loggers to `DEBUG` |
-| `FASTMCP_ENABLE_RICH_LOGGING` | bool | `true` | Set to `false` for plain/structured JSON log output instead of Rich-formatted output |
+| `FASTMCP_ENABLE_RICH_LOGGING` | bool | `true` | Rich `key=value` text by default. Set to `false` for one-JSON-object-per-record output — recommended for production / log-aggregator deployments |
 
 ## Search Ranking and Snippet Truncation
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -838,11 +838,14 @@ receive the transfer request).
 ### HTTP Session Persistence
 
 For HTTP/streamable-HTTP transport, the server uses an `EventStore` so MCP
-sessions survive container restarts. The backend is configured via
-`MARKDOWN_VAULT_MCP_EVENT_STORE_URL`:
+sessions survive container restarts. The backend is configured via the unified
+key-value store URL `MARKDOWN_VAULT_MCP_KV_STORE_URL` (the legacy
+`MARKDOWN_VAULT_MCP_EVENT_STORE_URL` is still honoured when `KV_STORE_URL` is
+unset, with a one-shot deprecation warning):
 
-- **Default** (unset or `file:///path`): `FileTreeStore` at
-  `/data/state/events`. Sessions persist on disk inside the Docker state volume.
+- **Default** (unset): a file-backed store at `/data/state` (the `events`
+  keyspace is namespaced inside the directory). Sessions persist on disk inside
+  the Docker state volume.
 - **`memory://`**: In-memory store; sessions are lost on restart. Suitable for
   development or single-shot CI environments.
 
@@ -871,6 +874,17 @@ Follow FastMCP conventions and standard Python logging:
 unless overridden by `-v` (sets both app and FastMCP to `DEBUG`). When
 `DEBUG` is active, `httpx` and
 `httpcore` loggers are pinned to `WARNING` to reduce noise.
+
+**Request logging:** `make_server()` wires pvl-core's single
+`RequestLoggingMiddleware` (via `wire_middleware_stack`), which emits
+family-conforming, tool-aware lines — a bare event name first, then
+`key=value` pairs, with request timing carried inline on the terminal line.
+Tool calls (`tools/call`) use the `tool_call_started` / `tool_call_completed`
+/ `tool_call_failed` vocabulary and carry `tool=<name>`; other messages use
+`<type>_started` / `<type>_completed` / `<type>_failed`. Output is `key=value`
+text by default, or one JSON object per record when
+`FASTMCP_ENABLE_RICH_LOGGING=false`. Tracebacks attach to `*_failed` records
+when the root logger is at `DEBUG`.
 
 **Auth logging:** At `DEBUG`, the OIDC and bearer auth builders log full
 configuration details (secrets redacted). At `INFO`, only the auth mode

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -229,10 +229,10 @@ If `BASE_URL` is already set (e.g., for OIDC), no additional configuration is ne
 For long-running HTTP sessions (especially with MCP Apps), configure the event store so sessions survive container restarts:
 
 ```bash
-MARKDOWN_VAULT_MCP_EVENT_STORE_URL=file:///data/state/events
+MARKDOWN_VAULT_MCP_KV_STORE_URL=file:///data/state
 ```
 
-This is the default when using the Docker image with the `state-data` volume. For development, use `memory://` (sessions lost on restart).
+This is the default when using the Docker image with the `state-data` volume (the `events` keyspace is namespaced inside the directory). The legacy `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` still works but logs a one-shot deprecation warning. For development, use `memory://` (sessions lost on restart).
 
 ### Verify
 

--- a/examples/bearer-auth.env
+++ b/examples/bearer-auth.env
@@ -10,8 +10,8 @@ MARKDOWN_VAULT_MCP_BEARER_TOKEN=change-me-to-a-random-secret
 # Optional: override Claude app domain for MCP Apps iframe sandboxing (auto-computed from BASE_URL)
 # MARKDOWN_VAULT_MCP_APP_DOMAIN=
 
-# Optional: event store for HTTP session persistence (default: file:///data/state/events)
-# MARKDOWN_VAULT_MCP_EVENT_STORE_URL=file:///data/state/events
+# Optional: unified KV backend for HTTP session persistence (default: file:///data/state)
+# MARKDOWN_VAULT_MCP_KV_STORE_URL=file:///data/state
 
 # Maximum attachment size in MB returned by read() / accepted by write().
 # Default 1 MB (lowered from 10 MB to keep LLM context bounded).
@@ -22,3 +22,7 @@ MARKDOWN_VAULT_MCP_BEARER_TOKEN=change-me-to-a-random-secret
 # Default 262144 (256 KB).  Use read(path, section=...) for partial reads.
 # Set to 0 to disable the limit.
 # MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES=262144
+
+# Structured (one-JSON-object-per-record) logs for log aggregators —
+# recommended in production. Default is rich key=value text.
+# FASTMCP_ENABLE_RICH_LOGGING=false

--- a/examples/obsidian-oidc.env
+++ b/examples/obsidian-oidc.env
@@ -66,8 +66,8 @@ MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY=your-random-hex-secret-here
 # MARKDOWN_VAULT_MCP_APP_DOMAIN=
 
 # --- HTTP session persistence (optional) ---
-# Event store backend; default file:///data/state/events survives restarts
-# MARKDOWN_VAULT_MCP_EVENT_STORE_URL=file:///data/state/events
+# Unified KV backend; default file:///data/state survives restarts
+# MARKDOWN_VAULT_MCP_KV_STORE_URL=file:///data/state
 
 # --- Attachments (optional) ---
 # Maximum attachment size in MB returned by read() / accepted by write().
@@ -83,3 +83,7 @@ MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY=your-random-hex-secret-here
 MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=ollama
 OLLAMA_HOST=http://localhost:11434
 MARKDOWN_VAULT_MCP_OLLAMA_MODEL=nomic-embed-text
+
+# Structured (one-JSON-object-per-record) logs for log aggregators —
+# recommended in production. Default is rich key=value text.
+# FASTMCP_ENABLE_RICH_LOGGING=false

--- a/examples/oidc.env
+++ b/examples/oidc.env
@@ -18,3 +18,7 @@ MARKDOWN_VAULT_MCP_READ_ONLY=false
 # Default 262144 (256 KB).  Use read(path, section=...) for partial reads.
 # Set to 0 to disable the limit.
 # MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES=262144
+
+# Structured (one-JSON-object-per-record) logs for log aggregators —
+# recommended in production. Default is rich key=value text.
+# FASTMCP_ENABLE_RICH_LOGGING=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "fastmcp-pvl-core>=2.1.0,<4",
+    "fastmcp-pvl-core>=3.2.0,<4",
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update
     "python-frontmatter>=1.0",
     "requests>=2.33.0",

--- a/server.json
+++ b/server.json
@@ -43,9 +43,9 @@
           ]
         },
         {
-          "name": "MARKDOWN_VAULT_MCP_EVENT_STORE_URL",
-          "description": "Event store backend for HTTP session persistence (file:///path or memory://)",
-          "default": "file:///data/state/events"
+          "name": "MARKDOWN_VAULT_MCP_KV_STORE_URL",
+          "description": "Unified key-value backend for HTTP session persistence (file:///path or memory://). Legacy alias: MARKDOWN_VAULT_MCP_EVENT_STORE_URL",
+          "default": "file:///data/state"
         },
         {
           "name": "MARKDOWN_VAULT_MCP_SERVER_NAME",
@@ -274,9 +274,9 @@
           ]
         },
         {
-          "name": "MARKDOWN_VAULT_MCP_EVENT_STORE_URL",
-          "description": "Event store backend for HTTP session persistence (file:///path or memory://)",
-          "default": "file:///data/state/events"
+          "name": "MARKDOWN_VAULT_MCP_KV_STORE_URL",
+          "description": "Unified key-value backend for HTTP session persistence (file:///path or memory://). Legacy alias: MARKDOWN_VAULT_MCP_EVENT_STORE_URL",
+          "default": "file:///data/state"
         },
         {
           "name": "MARKDOWN_VAULT_MCP_SERVER_NAME",

--- a/src/markdown_vault_mcp/_cli_impl.py
+++ b/src/markdown_vault_mcp/_cli_impl.py
@@ -97,7 +97,7 @@ def _cmd_serve(args: argparse.Namespace) -> None:
         import uvicorn
 
         config = load_config()
-        event_store = build_event_store(config.server.event_store_url)
+        event_store = build_event_store(config.server)
         # FastMCP's run() doesn't pass event_store through to http_app(),
         # so we build the ASGI app and run uvicorn directly.
         app = server.http_app(

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -216,7 +216,7 @@ def register_apps(mcp: FastMCP) -> None:
 
     app_config = AppConfig(
         domain=app_domain,
-        csp=ResourceCSP(resourceDomains=_CDN_RESOURCE_DOMAINS),
+        csp=ResourceCSP(resource_domains=_CDN_RESOURCE_DOMAINS),
     )
 
     # -- SPA shell resource -------------------------------------------------
@@ -244,7 +244,7 @@ def register_apps(mcp: FastMCP) -> None:
             "destructiveHint": False,
             "idempotentHint": True,
         },
-        app=AppConfig(resourceUri=_VAULT_APP_URI),
+        app=AppConfig(resource_uri=_VAULT_APP_URI),
     )
     async def browse_vault(
         path: str | None = None,
@@ -312,7 +312,7 @@ def register_apps(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
         meta=_app_tool_meta("vault_context"),
-        app=AppConfig(resourceUri=_VAULT_APP_URI, visibility=["app"]),
+        app=AppConfig(resource_uri=_VAULT_APP_URI, visibility=["app"]),
     )
     async def vault_context(
         path: str,
@@ -344,7 +344,7 @@ def register_apps(mcp: FastMCP) -> None:
             "destructiveHint": False,
             "idempotentHint": True,
         },
-        app=AppConfig(resourceUri=_VAULT_APP_URI),
+        app=AppConfig(resource_uri=_VAULT_APP_URI),
     )
     async def show_context(
         path: str,
@@ -403,7 +403,7 @@ def register_apps(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
         meta=_app_tool_meta("vault_graph_neighborhood"),
-        app=AppConfig(resourceUri=_VAULT_APP_URI, visibility=["app"]),
+        app=AppConfig(resource_uri=_VAULT_APP_URI, visibility=["app"]),
     )
     async def vault_graph_neighborhood(
         path: str,
@@ -597,7 +597,7 @@ def register_apps(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
         meta=_app_tool_meta("vault_graph_hubs"),
-        app=AppConfig(resourceUri=_VAULT_APP_URI, visibility=["app"]),
+        app=AppConfig(resource_uri=_VAULT_APP_URI, visibility=["app"]),
     )
     async def vault_graph_hubs(
         limit: int = 20,
@@ -685,7 +685,7 @@ def register_apps(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
         meta=_app_tool_meta("vault_list"),
-        app=AppConfig(resourceUri=_VAULT_APP_URI, visibility=["app"]),
+        app=AppConfig(resource_uri=_VAULT_APP_URI, visibility=["app"]),
     )
     async def vault_list(
         folder: str | None = None,
@@ -751,7 +751,7 @@ def register_apps(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
         meta=_app_tool_meta("vault_read"),
-        app=AppConfig(resourceUri=_VAULT_APP_URI, visibility=["app"]),
+        app=AppConfig(resource_uri=_VAULT_APP_URI, visibility=["app"]),
     )
     async def vault_read(
         path: str,
@@ -789,7 +789,7 @@ def register_apps(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
         meta=_app_tool_meta("vault_search"),
-        app=AppConfig(resourceUri=_VAULT_APP_URI, visibility=["app"]),
+        app=AppConfig(resource_uri=_VAULT_APP_URI, visibility=["app"]),
     )
     async def vault_search(
         query: str,

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -326,7 +326,8 @@ def load_config() -> VaultConfig:
 
     Transport and auth variables (``TRANSPORT``, ``HOST``, ``PORT``,
     ``BASE_URL``, ``AUTH_MODE``, ``OIDC_*``, ``BEARER_TOKEN``,
-    ``EVENT_STORE_URL``, ``APP_DOMAIN``) are read into ``config.server`` by
+    ``KV_STORE_URL`` (legacy ``EVENT_STORE_URL``), ``APP_DOMAIN``) are read
+    into ``config.server`` by
     :meth:`fastmcp_pvl_core.ServerConfig.from_env`; see
     ``docs/configuration.md`` for the full list.
 

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -54,20 +54,25 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def build_event_store(url: str | None = None) -> EventStore:
+def build_event_store(config: ServerConfig) -> EventStore:
     """Build an ``EventStore`` for SSE polling/resumability.
 
-    Thin shim over :func:`fastmcp_pvl_core.build_event_store`: wraps the
-    legacy URL-only call shape used by ``cli.py`` and delegates the actual
-    backend selection (file-tree vs in-memory) to the shared core helper.
+    Thin shim over :func:`fastmcp_pvl_core.build_event_store`: forwards the
+    whole server config so the unified KV factory honours ``kv_store_url``
+    (preferred) or the legacy ``event_store_url`` per its own resolution
+    priority, then selects the backend from the URL scheme (``file://``,
+    ``memory://``, or any extra-installed backend — see the fastmcp-pvl-core
+    docs).
 
     Args:
-        url: Event store URL from ``MARKDOWN_VAULT_MCP_EVENT_STORE_URL``.
+        config: The server config; its ``kv_store_url`` / ``event_store_url``
+            fields (from ``MARKDOWN_VAULT_MCP_KV_STORE_URL`` /
+            ``MARKDOWN_VAULT_MCP_EVENT_STORE_URL``) select the backend.
 
     Returns:
         A configured :class:`~fastmcp.server.event_store.EventStore`.
     """
-    return _core_build_event_store(_ENV_PREFIX, ServerConfig(event_store_url=url))
+    return _core_build_event_store(_ENV_PREFIX, config)
 
 
 # ---------------------------------------------------------------------------
@@ -184,8 +189,8 @@ def make_server(transport: str = "stdio") -> FastMCP:
         auth=auth,
     )
 
-    # include_traceback=None infers from root log level (-v→DEBUG→tracebacks); transform_errors=False lets exceptions propagate to FastMCP's own handlers.
-    wire_middleware_stack(mcp, include_traceback=None, transform_errors=False)
+    # 3.x: kwargs removed; installs one tool-aware logging middleware.
+    wire_middleware_stack(mcp)
 
     # Optional: enable opt-in per-subject authorization on tools / resources /
     # prompts.  See fastmcp-pvl-core's README "Authorization" section for the

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -3,70 +3,74 @@
 from __future__ import annotations
 
 import pytest
+from fastmcp_pvl_core import ServerConfig
 
 from markdown_vault_mcp.config import load_config
 from markdown_vault_mcp.server import build_event_store
 
 
 class TestBuildEventStore:
-    """Unit tests for build_event_store() URL parsing and backend selection."""
+    """Unit tests for build_event_store() backend selection from ServerConfig."""
 
     def test_default_uses_file_backend(self, tmp_path):
-        """Unset URL defaults to FileTreeStore."""
+        """An empty config defaults to a file-backed store at the package default dir."""
         from unittest.mock import patch
 
         with patch(
-            "fastmcp_pvl_core._factory._DEFAULT_EVENT_STORE_DIR",
+            "fastmcp_pvl_core._kv_store._DEFAULT_KV_STORE_DIR",
             str(tmp_path / "events"),
         ):
-            store = build_event_store(None)
+            store = build_event_store(ServerConfig())
 
         assert store is not None
         assert (tmp_path / "events").is_dir()
 
     def test_empty_string_uses_file_backend(self, tmp_path):
-        """Empty string URL defaults to FileTreeStore."""
+        """Empty event_store_url defaults to a file-backed store at the package default dir."""
         from unittest.mock import patch
 
         with patch(
-            "fastmcp_pvl_core._factory._DEFAULT_EVENT_STORE_DIR",
+            "fastmcp_pvl_core._kv_store._DEFAULT_KV_STORE_DIR",
             str(tmp_path / "events"),
         ):
-            store = build_event_store("")
+            store = build_event_store(ServerConfig(event_store_url=""))
 
         assert store is not None
         assert (tmp_path / "events").is_dir()
 
     def test_file_url_creates_directory(self, tmp_path):
-        """file:// URL creates specified directory and uses FileTreeStore."""
+        """file:// URL creates the specified directory and uses a file backend."""
         target = tmp_path / "custom" / "events"
-        store = build_event_store(f"file://{target}")
+        store = build_event_store(ServerConfig(event_store_url=f"file://{target}"))
 
         assert store is not None
         assert target.is_dir()
 
     def test_memory_url_returns_in_memory_store(self):
         """memory:// URL returns an in-memory EventStore."""
-        store = build_event_store("memory://")
+        store = build_event_store(ServerConfig(event_store_url="memory://"))
         assert store is not None
+
+    def test_kv_store_url_takes_priority(self, tmp_path):
+        """kv_store_url is honoured over the legacy event_store_url."""
+        ignored = tmp_path / "should-not-exist"
+        store = build_event_store(
+            ServerConfig(kv_store_url="memory://", event_store_url=f"file://{ignored}")
+        )
+
+        assert store is not None
+        # If event_store_url had been used, file:// would have created this dir.
+        assert not ignored.exists()
 
     def test_unsupported_scheme_raises(self):
-        """Unsupported URL scheme raises ValueError."""
-        with pytest.raises(ValueError, match="Unsupported event store URL scheme"):
-            build_event_store("redis://localhost:6379")
+        """An unrecognised URL scheme propagates a ValueError from the core factory."""
+        with pytest.raises(ValueError):
+            build_event_store(ServerConfig(event_store_url="bogus://host"))
 
-    def test_file_url_without_path_uses_default(self, tmp_path):
-        """file:// with no path falls back to default directory."""
-        from unittest.mock import patch
-
-        with patch(
-            "fastmcp_pvl_core._factory._DEFAULT_EVENT_STORE_DIR",
-            str(tmp_path / "events"),
-        ):
-            store = build_event_store("file://")
-
-        assert store is not None
-        assert (tmp_path / "events").is_dir()
+    def test_file_url_without_path_raises(self):
+        """pvl-core 3.x rejects a path-less file:// URL (use the file:///path form)."""
+        with pytest.raises(ValueError):
+            build_event_store(ServerConfig(event_store_url="file://"))
 
 
 class TestEventStoreConfig:
@@ -85,6 +89,13 @@ class TestEventStoreConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_EVENT_STORE_URL", "memory://")
         config = load_config()
         assert config.server.event_store_url == "memory://"
+
+    def test_kv_store_url_from_env(self, monkeypatch):
+        """KV_STORE_URL is read into config.server.kv_store_url (preferred over EVENT_STORE_URL)."""
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_KV_STORE_URL", "memory://")
+        config = load_config()
+        assert config.server.kv_store_url == "memory://"
 
     def test_event_store_url_empty_is_none(self, monkeypatch):
         """Empty EVENT_STORE_URL yields None (file default)."""
@@ -112,13 +123,13 @@ class TestFileEventStorePersistence:
         url = f"file://{store_dir}"
 
         # First store instance — write an event (None message = priming event)
-        store1 = build_event_store(url)
+        store1 = build_event_store(ServerConfig(event_store_url=url))
         stream_id = "test-session-1"
         event_id = await store1.store_event(stream_id, None)
         assert event_id  # UUID string returned
 
         # Second store instance — same path, simulating restart
-        store2 = build_event_store(url)
+        store2 = build_event_store(ServerConfig(event_store_url=url))
         # Verify the event is retrievable by replaying after it
         replayed_events: list = []
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2675,49 +2675,32 @@ class TestStartupSummaryLogging:
 
 
 class TestMiddlewareStack:
-    """Verify that make_server() wires the expected middleware."""
+    """Verify that make_server() wires pvl-core 3.x's logging middleware."""
 
     @pytest.mark.usefixtures("_mcp_env")
-    def test_default_middleware_stack(self) -> None:
-        """Server has ErrorHandling, Timing, and Logging middleware by default."""
-        from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
-        from fastmcp.server.middleware.logging import LoggingMiddleware
-        from fastmcp.server.middleware.timing import TimingMiddleware
+    def test_default_middleware_wired(self) -> None:
+        """make_server() installs one RequestLoggingMiddleware in rich mode by default."""
+        # Not re-exported at pvl-core's public root; private import is unavoidable.
+        from fastmcp_pvl_core._middleware import RequestLoggingMiddleware
 
         server = make_server()
-        types = [type(m) for m in server.middleware]
-        assert ErrorHandlingMiddleware in types
-        assert TimingMiddleware in types
-        assert LoggingMiddleware in types
+        mws = [m for m in server.middleware if isinstance(m, RequestLoggingMiddleware)]
+        assert len(mws) == 1
+        assert mws[0].structured is False
 
     @pytest.mark.usefixtures("_mcp_env")
     def test_structured_logging_when_rich_disabled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """FASTMCP_ENABLE_RICH_LOGGING=false selects StructuredLoggingMiddleware."""
-        from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
+        """FASTMCP_ENABLE_RICH_LOGGING=false selects structured (JSON) output."""
+        # Not re-exported at pvl-core's public root; private import is unavoidable.
+        from fastmcp_pvl_core._middleware import RequestLoggingMiddleware
 
         monkeypatch.setenv("FASTMCP_ENABLE_RICH_LOGGING", "false")
         server = make_server()
-        types = [type(m) for m in server.middleware]
-        assert StructuredLoggingMiddleware in types
-
-    @pytest.mark.usefixtures("_mcp_env")
-    def test_middleware_order(self) -> None:
-        """ErrorHandling is first, then Timing, then Logging."""
-        from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
-        from fastmcp.server.middleware.logging import LoggingMiddleware
-        from fastmcp.server.middleware.timing import TimingMiddleware
-
-        server = make_server()
-        types = [type(m) for m in server.middleware]
-        assert ErrorHandlingMiddleware in types, "ErrorHandlingMiddleware missing"
-        assert TimingMiddleware in types, "TimingMiddleware missing"
-        assert LoggingMiddleware in types, "LoggingMiddleware missing"
-        eh_idx = types.index(ErrorHandlingMiddleware)
-        tm_idx = types.index(TimingMiddleware)
-        lg_idx = types.index(LoggingMiddleware)
-        assert eh_idx < tm_idx < lg_idx
+        mws = [m for m in server.middleware if isinstance(m, RequestLoggingMiddleware)]
+        assert len(mws) == 1
+        assert mws[0].structured is True
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -728,53 +728,83 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.4"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
+]
+
+[[package]]
+name = "fastmcp-pvl-core"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/05/2d414878c6575ab9b82418fd61b9b9d47c93104041764ec0a6e1c34e0135/fastmcp_pvl_core-3.2.0.tar.gz", hash = "sha256:0bcd3dced86305a69c727e4e7779c33a3f57b275c8b302ea330c0817fa1066fc", size = 331755, upload-time = "2026-06-03T17:01:34.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/12/b15f31ef4fa85d39b5c0c0bc9cbcb5202b0ad595cd03f72467307d23e393/fastmcp_pvl_core-3.2.0-py3-none-any.whl", hash = "sha256:71b2760ec491bdfd9ad131f489795b1dd5bdc31a62552ef4f5df8beba3308dff", size = 52644, upload-time = "2026-06-03T17:01:33.133Z" },
+]
+
+[package.optional-dependencies]
+debug = [
+    { name = "debugpy" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
-]
-
-[[package]]
-name = "fastmcp-pvl-core"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastmcp" },
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/4a/161f08dd9ce9feec3ef72687bb4112f377cd7afaa45b81add3e6281b2ff1/fastmcp_pvl_core-2.1.0.tar.gz", hash = "sha256:46bf41e032c15d4533fbd032cb4d9dbadf852f0509973b9e0b23c1cbbe7b49ca", size = 333983, upload-time = "2026-05-10T09:06:02.342Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/de/2918c68e3423dc7562f0d6df48cd99f23cd322f8a7db9be1292b5e8d4368/fastmcp_pvl_core-2.1.0-py3-none-any.whl", hash = "sha256:d5baf34f6f1cf425d6e4e104fbe8a584d9d97dd2035561bb5a4e9bc85d6ac53f", size = 89834, upload-time = "2026-05-10T09:06:00.755Z" },
-]
-
-[package.optional-dependencies]
-debug = [
-    { name = "debugpy" },
 ]
 
 [[package]]
@@ -1016,6 +1046,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/2f590052b55cbdd0ace470ee7ee1f685f6882051be93a9374891005623e2/joserfc-1.7.0.tar.gz", hash = "sha256:4aced6ab0c47846f0a531402aec2419a874b91e918df9c4c9da8a82fb559d6c4", size = 232967, upload-time = "2026-06-02T09:59:34.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/83/b6b62a66a06ce872d9429a5eb5ee20b2002fd9c331b953c94381c1f7c9f9/joserfc-1.7.0-py3-none-any.whl", hash = "sha256:17e5d7a5a35e65442b05efc435a3d5d46696ffa2c8a2ed0eea6f63fc268e3224", size = 70387, upload-time = "2026-06-02T09:59:33.264Z" },
 ]
 
 [[package]]
@@ -1266,7 +1308,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.3" },
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "fastmcp-pvl-core", specifier = ">=2.1.0,<4" },
+    { name = "fastmcp-pvl-core", specifier = ">=3.2.0,<4" },
     { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25" },
     { name = "httpx", marker = "extra == 'embeddings-api'", specifier = ">=0.25" },


### PR DESCRIPTION
## Summary

Adopts **fastmcp-pvl-core 3.x** (2.1.0 → 3.2.0; transitive fastmcp 3.2.4 → 3.4.2) — the gating prerequisite for the #579 config-`from_env` work. #492 assumed a pin-only bump, but the 3.x major release reworked the middleware stack, replaced the event-store factory with a unified KV factory, and (via fastmcp 3.4) renamed app-config kwargs — so this adapts MV to all of it.

Closes #492. Closes #500.

## Code
- **`server.py`** `wire_middleware_stack(mcp)` — 3.x dropped `include_traceback`/`transform_errors`; it installs a single tool-aware `RequestLoggingMiddleware` that infers tracebacks from the root log level and lets exceptions propagate to FastMCP (behaviour-equivalent to the old `transform_errors=False`).
- **`server.py` / `_cli_impl.py`** `build_event_store` now forwards the whole `ServerConfig` instead of reconstructing `ServerConfig(event_store_url=url)`. 3.x's unified KV factory prefers `kv_store_url`; the old shim silently dropped `MARKDOWN_VAULT_MCP_KV_STORE_URL` (surfaced by the local pre-flight review, folded in here).
- **`_server_apps.py`** fastmcp 3.4 `AppConfig.resourceUri`→`resource_uri` (8 sites), `ResourceCSP.resourceDomains`→`resource_domains` (1 site).

## Logging conformance (#500)
The new middleware emits family-conforming, tool-aware lines — `tool_call_started`/`_completed`/`_failed` with `tool=<name>`, `<type>_*` otherwise. Documented in `docs/design.md`; `FASTMCP_ENABLE_RICH_LOGGING=false` recommended for production / log-aggregator deployments in configuration.md/README/examples.

## KV_STORE_URL migration
`KV_STORE_URL` documented as the preferred unified backend; `EVENT_STORE_URL` kept as a legacy alias (one-shot deprecation warning); event-store default dir corrected `file:///data/state/events` → `file:///data/state` — consistently across README, configuration.md, design.md, docker.md, server.json, the `load_config` docstring, and example env files.

## Tests
- `TestMiddlewareStack` rewritten for the single 3.x middleware (ordering test dropped — obsolete with one middleware).
- `test_event_store.py` rewritten for `build_event_store(ServerConfig)`; default-dir mock re-pointed to 3.x's `_kv_store._DEFAULT_KV_STORE_DIR`; unsupported-scheme switched off `redis://` (a recognised 3.x backend); path-less `file://` now asserts 3.x's stricter `ValueError`; **added `test_kv_store_url_takes_priority`** (proves `kv_store_url` wins, catching the silent-discard regression) **+ `test_kv_store_url_from_env`**.

## Verification
- 1909 tests pass on 3.x; mypy + ruff clean.
- Full local pre-flight review (9 lenses) run; the `kv_store_url` silent-discard it surfaced is fixed and re-verified.

## Out of scope (follow-ups)
- `get_claims()` (#178) and `env_int`/`env_float` (#180) adoption → the #579 PR-C work.
- CLAUDE.md's stale "ErrorHandlingMiddleware is a safety net" line is template-owned → fastmcp-server-template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)