### PR TITLE
fix: signal index staleness out-of-band via _meta on read tools + resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` pr
 | `MARKDOWN_VAULT_MCP_EXCLUDE` | — | No | Comma-separated glob patterns to exclude from scanning (e.g. `.obsidian/**,.trash/**`) |
 | `MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER` | `_templates` | No | Relative folder path where note templates live (used by the `create_from_template` prompt) |
 | `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | — | No | Path to a directory of `.md` prompt files that extend or override built-in prompts (see [User-defined prompts](#user-defined-prompts)) |
-| `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` | `60` | No | Maximum seconds the B3 reader tools wait for the IndexWriter to drain when called with `wait_for_drain=True`. On timeout the tool returns the result with `stale=True` rather than raising. |
+| `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` | `60` | No | Maximum seconds an index-querying read tool waits for the IndexWriter to drain when called with `wait_for_pending_writes=True`. On timeout the tool answers from the current index rather than raising and reports `index_stale=True` in the response's `_meta`. |
 
 ### Server identity
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,13 +34,16 @@ on stuck builds.
 
 Default: `60` (seconds).
 
-Maximum time the B3 MCP tools (`get_backlinks`, `get_outlinks`,
-`get_similar`, `get_context`, `get_connection_path`) wait for the
-IndexWriter to drain when called with `wait_for_drain=true`. On
-timeout the tool returns the result with `stale=true` rather than
-raising — best-effort fresh read. Increase for very large vaults
-where reindex / build_embeddings jobs take longer; decrease for
-faster client feedback when the index has chronic backlog.
+Maximum time an index-querying read tool (`search`, `list_documents`,
+`list_folders`, `list_tags`, `stats`, `get_recent`, `get_backlinks`,
+`get_outlinks`, `get_broken_links`, `get_similar`, `get_context`,
+`get_orphan_notes`, `get_most_linked`, `get_connection_path`) waits for
+the IndexWriter to drain when called with `wait_for_pending_writes=true`. On
+timeout the tool answers from the current index rather than raising —
+best-effort fresh read — and reports `index_stale=true` in the response's
+`_meta`. Increase for very large vaults where reindex / build_embeddings
+jobs take longer; decrease for faster client feedback when the index has
+chronic backlog.
 
 <!-- DOMAIN-CONFIG-VARS-START -->
 ## Server Identity

--- a/docs/design.md
+++ b/docs/design.md
@@ -581,29 +581,62 @@ See `docs/superpowers/specs/2026-05-31-issue-559-single-writer-for-indexes-desig
 for the full design rationale, including the cascade of #513 / #519
 prerequisites that motivated centralising mutations on a single writer.
 
-#### Drift signals on B3 readers (#534)
+#### Drift signals on index-querying read tools (#534, #641, #645)
 
-B3 MCP tools (`get_backlinks`, `get_outlinks`, `get_similar`,
-`get_context`, `get_connection_path`) wrap their response in a
-`{"stale": bool, "data": ...}` envelope. `stale` is the OR of three
-signals: the optional `wait_for_drain` timed out (writer never went
-idle within the budget), the writer's monotonic `write_generation`
-counter advanced during the read (a write cycle completed inside the
-read window), or `is_drained()` reports a non-idle writer at
-response-construction time (a write is in flight). The
-`write_generation` counter — incremented under `_in_flight_lock`
-once per completed job — closes the case the pre/post `is_drained()`
-pair could not detect: a write that started and finished entirely
-between two snapshots.
+Every MCP read tool that queries the index — `search`, the B2 listing /
+aggregate tools (`list_documents`, `list_folders`, `list_tags`, `stats`,
+`get_recent`, `get_broken_links`, `get_orphan_notes`, `get_most_linked`),
+and the B3 graph tools (`get_backlinks`, `get_outlinks`, `get_similar`,
+`get_context`, `get_connection_path`) — returns its **bare** payload (a
+list or dict) and reports index freshness **out-of-band in the MCP
+response's `_meta.index_stale` field** via FastMCP `ToolResult(meta=...)`.
+The data payload is identical whether the index is fresh or stale, so
+clients that do not care about drift read it exactly as before; the ~1%
+that need a fresh-read guarantee inspect `result._meta.index_stale`. This
+replaces the earlier `{"stale": bool, "data": ...}` envelope (#534): the
+envelope conflated response metadata with domain data, could not extend to
+resources without breaking their bare-JSON contract, and added wrapper
+noise on every fresh read. `_meta` is MCP's dedicated out-of-band channel
+for exactly this kind of response metadata.
 
-Each B3 tool accepts an optional `wait_for_drain: bool = false`
-parameter. When `true`, the tool layer polls `IndexFacet.is_drained()`
+`index_stale` is the OR of three signals: the optional `wait_for_pending_writes`
+timed out (writer never went idle within the budget), the writer's
+monotonic `write_generation` counter advanced during the read (a write
+cycle completed inside the read window), or `is_drained()` reports a
+non-idle writer at response-construction time (a write is in flight). The
+`write_generation` counter — incremented under `_in_flight_lock` once per
+completed job — closes the case the pre/post `is_drained()` pair could not
+detect: a write that started and finished entirely between two snapshots.
+
+Each such tool accepts an optional `wait_for_pending_writes: bool = false`
+parameter (client-facing name; the internal primitive is still "drain").
+When `true`, the tool layer polls `IndexFacet.is_drained()`
 with `asyncio.sleep` until the writer drains or
 `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s) elapses, then
-runs the query. On timeout the tool returns the result with
-`stale=true` rather than raising — best-effort fresh-read
-semantics. (`IndexFacet.wait_for_drain()` is the synchronous
-counterpart for in-process callers.)
+runs the query. On timeout the tool answers from the current index
+rather than raising — best-effort fresh-read semantics, with
+`index_stale=true` in `_meta`. (`IndexFacet.wait_for_drain()` is the
+synchronous counterpart for in-process callers.)
+
+The index-querying **resources** (`config://vault`, `stats://vault`,
+`tags://vault`, `tags://vault/{field}`, `folders://vault`,
+`toc://vault/{path}`, `similar://vault/{path}`, `recent://vault`) carry
+the same `_meta.index_stale` signal via FastMCP `ResourceResult(meta=...)`,
+readable through the resource read's `_meta`. Resources take no
+`wait_for_pending_writes` parameter (a resource URI template binds only address
+path segments, not ad-hoc control parameters), so they signal staleness
+only. Each body is wrapped in an explicit `application/json`
+`ResourceContent` so the declared MIME type survives — a bare `str` in a
+`ResourceResult` would default to `text/plain`.
+
+Implementation: the shared `_staleness_result()` helper (in
+`_server_tools.py`) wraps a tool's data in a `ToolResult` whose
+`structured_content` mirrors FastMCP's wrap-result convention (a
+list/primitive payload is nested under `{"result": ...}`) so the client
+still deserializes `result.data` to the bare shape advertised by the
+tool's data-typed return annotation. The annotation drives the output
+schema; the `ToolResult` is the runtime payload. The resource counterpart
+is `_stale_resource()` in `_server_resources.py`.
 
 The drift signal reflects writer-internal state only: paths in
 `dirty_paths`, paths in `dirty_embeddings`, the in-flight job

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -2,6 +2,9 @@
 
 MCP resources expose vault metadata that clients can read directly without invoking tools. Most resources return `application/json`; `ui://vault/app.html` is an exception — it returns a self-contained HTML SPA for MCP Apps clients.
 
+!!! note "Index freshness (`_meta.index_stale`)"
+    The index-querying resources — `config://vault`, `stats://vault`, `tags://vault`, `tags://vault/{field}`, `folders://vault`, `toc://vault/{path}`, `similar://vault/{path}`, and `recent://vault` — keep their bare JSON contents unchanged and report index freshness out-of-band in the resource read's **`_meta.index_stale`** field (read it via `read_resource_mcp(uri).meta`). It is `true` when a write landed during the read or the IndexWriter was non-idle at response time. Resources carry no `wait_for_pending_writes` parameter — they signal only; use the equivalent MCP tool with `wait_for_pending_writes=true` when you need to block for a fresh read.
+
 ## Quick Reference
 
 | URI | Description |
@@ -122,8 +125,8 @@ Top 10 semantically similar notes for a document. Requires embeddings to be buil
 
 Results are **grouped per file** — each file appears at most once, with up to `chunks_per_file` (server default `2`) best-matching sections in a `sections` array. Each entry is a `GroupedResult` dict with `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
 
-!!! note "Resource shape differs from `get_similar` tool"
-    This resource returns a flat JSON array. The `get_similar` MCP tool wraps the same data in a `{"stale": bool, "data": [...]}` envelope so callers see a drift signal (#534). Resource handlers do not accept a `wait_for_drain` parameter, so this resource intentionally omits the envelope; clients that need the drift signal should use the tool. Lifting the envelope to resources is tracked as a follow-up — see [`IndexFacet.is_drained()`](https://github.com/pvliesdonk/markdown-vault-mcp/issues/534) for the underlying primitive.
+!!! note "Index freshness via `_meta.index_stale`"
+    This resource returns a flat JSON array as its contents, and reports index freshness out-of-band in the read's `_meta.index_stale` field — the same mechanism the `get_similar` MCP tool uses (#534, #645). Resources carry no `wait_for_pending_writes` parameter (a resource URI template binds only address path segments, not ad-hoc control parameters), so they signal only: read `_meta.index_stale` and re-read or fall back to the `get_similar` tool with `wait_for_pending_writes=true` if you need a fresh-read guarantee.
 
 **Example:** `similar://vault/Journal/note.md`
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -2,6 +2,9 @@
 
 markdown-vault-mcp exposes MCP tools across several categories. Write tools are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`.
 
+!!! note "Index freshness on read tools (`wait_for_pending_writes` + `_meta.index_stale`)"
+    Every read tool that queries the FTS index — `search`, `list_documents`, `list_folders`, `list_tags`, `stats`, `get_recent`, `get_backlinks`, `get_outlinks`, `get_broken_links`, `get_similar`, `get_context`, `get_orphan_notes`, `get_most_linked`, and `get_connection_path` — accepts an optional **`wait_for_pending_writes`** (`bool`, default `false`) parameter and reports index freshness **out-of-band in the MCP response's `_meta.index_stale` field** rather than wrapping the payload in a `{stale, data}` envelope. The data payload is a **bare list/dict, identical whether the index is fresh or stale** — clients that do not care about drift ignore `_meta` entirely. Clients that need a fresh-read guarantee either inspect `result._meta.index_stale`, or pass `wait_for_pending_writes=true` to block until the writer drains (bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S`, default 60s; on timeout it answers from the current index rather than raising). `index_stale` is `true` when the IndexWriter had pending or in-flight work at any of three observation points: the optional `wait_for_pending_writes` timed out, a write completed inside the read window, or the writer was non-idle at response time. The same `_meta.index_stale` field rides on the index-querying MCP **resources** (`config://`, `stats://`, `folders://`, `tags://`, `recent://`, `toc://`, `similar://`), readable via the resource read's `_meta` (resources carry no `wait_for_pending_writes` parameter — they signal only).
+
 <!-- DOMAIN-TOOLS-LIST-START -->
 
 ## Quick Reference
@@ -534,12 +537,9 @@ Find all documents that link to a given document.
 |-----------|------|---------|-------------|
 | `path` | string | required | Relative path to the target document |
 | `limit` | int | `null` | Maximum number of backlinks to return. Omitted (the default) returns all. |
-| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
+| `wait_for_pending_writes` | bool | `false` | Block until the IndexWriter drains before answering, then report freshness via `_meta.index_stale` (see the *Index freshness on read tools* note at the top of this page). |
 
-**Returns:** Dict envelope with two keys:
-
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
-- `data` (list[dict]): List of documents containing links to the given path. Each entry has `source_path`, `source_title`, `link_text`, `link_type`, `fragment`, and `raw_target` fields.
+**Returns:** List of documents containing links to the given path. Each entry has `source_path`, `source_title`, `link_text`, `link_type`, `fragment`, and `raw_target` fields. Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).
 
 ### `get_outlinks`
 
@@ -551,12 +551,9 @@ Find all links from a document, with existence check.
 |-----------|------|---------|-------------|
 | `path` | string | required | Relative path to the source document |
 | `limit` | int | `null` | Maximum number of outlinks to return. Omitted (the default) returns all. |
-| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
+| `wait_for_pending_writes` | bool | `false` | Block until the IndexWriter drains before answering, then report freshness via `_meta.index_stale` (see the *Index freshness on read tools* note at the top of this page). |
 
-**Returns:** Dict envelope with two keys:
-
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
-- `data` (list[dict]): List of link targets with an `exists` field indicating whether the target document is in the vault. Each entry has `target_path`, `link_text`, `link_type`, `fragment`, `raw_target`, and `exists` fields.
+**Returns:** List of link targets with an `exists` field indicating whether the target document is in the vault. Each entry has `target_path`, `link_text`, `link_type`, `fragment`, `raw_target`, and `exists` fields. Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).
 
 ### `get_broken_links`
 
@@ -581,12 +578,9 @@ Find semantically similar notes by document path. Requires embeddings to be buil
 | `path` | string | required | Relative path to the document |
 | `limit` | int | `10` | Maximum files to return |
 | `chunks_per_file` | int | server default (`2`) | Maximum number of matching sections returned per file. Overrides `MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE` for this call. `0` is rejected. |
-| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
+| `wait_for_pending_writes` | bool | `false` | Block until the IndexWriter drains before answering, then report freshness via `_meta.index_stale` (see the *Index freshness on read tools* note at the top of this page). |
 
-**Returns:** Dict envelope with two keys:
-
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
-- `data` (list[dict]): List of grouped similar-document dicts ranked by cosine similarity, one entry per file with up to `chunks_per_file` best-matching sections. Each entry contains: `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order.
+**Returns:** List of grouped similar-document dicts ranked by cosine similarity, one entry per file with up to `chunks_per_file` best-matching sections. Each entry contains: `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts sorted by score then document order. Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).
 
 !!! note "Grouped result shape"
     Returns one entry per file with up to `chunks_per_file` best-matching sections. Default is 2 sections per file; pass `chunks_per_file=1` for compact dossiers.
@@ -615,12 +609,9 @@ Get a consolidated context dossier for a note. Combines backlinks, outlinks, sim
 | `path` | string | required | Relative path to the document |
 | `similar_limit` | int | `5` | Max similar files to include. Pass `0` to skip the similarity lookup (e.g. when `stats` shows `semantic_search_available=false`) |
 | `link_limit` | int | `10` | Max backlinks and outlinks to include each |
-| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
+| `wait_for_pending_writes` | bool | `false` | Block until the IndexWriter drains before answering, then report freshness via `_meta.index_stale` (see the *Index freshness on read tools* note at the top of this page). |
 
-**Returns:** Dict envelope with two keys:
-
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
-- `data` (dict): Object with `path`, `title`, `folder`, `frontmatter`, `modified_at`, `backlinks`, `outlinks`, `similar`, `folder_notes`, and `tags` fields. The `similar` list contains grouped result dicts — one entry per file with up to `chunks_per_file` best-matching sections (default 1 for `get_context` to keep dossiers compact).
+**Returns:** Object with `path`, `title`, `folder`, `frontmatter`, `modified_at`, `backlinks`, `outlinks`, `similar`, `folder_notes`, and `tags` fields. The `similar` list contains grouped result dicts — one entry per file with up to `chunks_per_file` best-matching sections (default 1 for `get_context` to keep dossiers compact). Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).
 
 !!! note "Grouped similar shape"
     Each `similar` entry contains `path`, `title`, `folder`, `score`, `search_type`, `frontmatter`, and `sections` — a list of `{heading, content, score}` dicts. `get_context` defaults to one section per file for compact dossiers; `search` and `get_similar` default to 2.
@@ -654,12 +645,9 @@ Find the shortest path between two notes via BFS on the undirected link graph (m
 | `source` | string | required | Relative path to the starting document |
 | `target` | string | required | Relative path to the target document |
 | `max_depth` | int | `10` | Maximum hops to search (clamped to [1, 10]) |
-| `wait_for_drain` | bool | `false` | When `true`, blocks until the IndexWriter has no pending or in-flight work before answering. Bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60s). On timeout, the tool returns the result with `stale=true` rather than raising. Default `false` returns immediately and reports staleness via the envelope's `stale` field. |
+| `wait_for_pending_writes` | bool | `false` | Block until the IndexWriter drains before answering, then report freshness via `_meta.index_stale` (see the *Index freshness on read tools* note at the top of this page). |
 
-**Returns:** Dict envelope with two keys:
-
-- `stale` (bool): True when the IndexWriter had pending or in-flight work at any of three observation points (wait timed out, a write cycle completed inside the read window, or non-idle at response time). False otherwise; the `data` payload reflects the index as of response time.
-- `data` (dict): Object with `found` (bool), `path` (ordered list of note paths from source to target), and `hops` (number of edges, or `-1` if not found).
+**Returns:** Object with `found` (bool), `path` (ordered list of note paths from source to target), and `hops` (number of edges, or `-1` if not found). Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).
 
 ### `get_history`
 

--- a/src/markdown_vault_mcp/_server_resources.py
+++ b/src/markdown_vault_mcp/_server_resources.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import CurrentContext, Depends
+from fastmcp.resources import ResourceContent, ResourceResult
 from fastmcp.server.context import Context
 
 from markdown_vault_mcp.config import VaultConfig
@@ -23,6 +24,31 @@ from markdown_vault_mcp.vault import Vault
 from ._icons import _TOOL_ICONS
 from ._server_deps import get_vault
 from ._server_queryable import needs_queryable
+
+
+def _stale_resource(vault: Vault, contents: str, gen_before: int) -> ResourceResult:
+    """Wrap a resource's JSON body with index-freshness metadata.
+
+    Resources keep their bare JSON contents unchanged; freshness rides
+    out-of-band in the MCP ``_meta`` field as ``index_stale``, retrievable
+    via ``read_resource_mcp(uri).meta``. Resources do not expose a
+    ``wait_for_pending_writes`` knob — a resource URI template binds only address path
+    segments, with no mechanism for an ad-hoc control parameter — so they
+    only signal: ``index_stale`` is True when a write landed during the read
+    (``write_generation`` advanced past ``gen_before``) or the writer was
+    non-idle at response time.
+
+    The body is wrapped in an explicit ``application/json`` ``ResourceContent``
+    so the declared MIME type survives — a bare ``str`` in ``ResourceResult``
+    defaults to ``text/plain``, dropping the ``@mcp.resource`` MIME type.
+    """
+    index_stale = (vault.index.write_generation() != gen_before) or (
+        not vault.index.is_drained()
+    )
+    return ResourceResult(
+        contents=[ResourceContent(contents, mime_type="application/json")],
+        meta={"index_stale": index_stale},
+    )
 
 
 def _get_config(ctx: Context) -> VaultConfig:
@@ -54,21 +80,29 @@ def register_resources(mcp: FastMCP) -> None:
     async def vault_config(
         ctx: Context = CurrentContext(),
         vault: Vault = Depends(get_vault),
-    ) -> str:
-        """Vault configuration: source path, read-only mode, indexed frontmatter fields, exclude patterns, allowed attachment extensions. For counts and search capabilities, use stats://vault."""
+    ) -> ResourceResult:
+        """Vault configuration: source path, read-only mode, indexed frontmatter fields, exclude patterns, allowed attachment extensions. For counts and search capabilities, use stats://vault.
+
+        Index freshness is reported in _meta.index_stale.
+        """
         config = _get_config(ctx)
+        gen_before = vault.index.write_generation()
         stats = await asyncio.to_thread(vault.reader.stats)
-        return json.dumps(
-            {
-                "source_dir": str(config.source_dir),
-                "read_only": config.read_only,
-                "indexed_fields": config.indexing.indexed_frontmatter_fields or [],
-                "required_fields": config.indexing.required_frontmatter or [],
-                "exclude_patterns": config.indexing.exclude_patterns or [],
-                "templates_folder": config.content.templates_folder,
-                "semantic_search_available": stats.semantic_search_available,
-                "attachment_extensions": stats.attachment_extensions,
-            }
+        return _stale_resource(
+            vault,
+            json.dumps(
+                {
+                    "source_dir": str(config.source_dir),
+                    "read_only": config.read_only,
+                    "indexed_fields": config.indexing.indexed_frontmatter_fields or [],
+                    "required_fields": config.indexing.required_frontmatter or [],
+                    "exclude_patterns": config.indexing.exclude_patterns or [],
+                    "templates_folder": config.content.templates_folder,
+                    "semantic_search_available": stats.semantic_search_available,
+                    "attachment_extensions": stats.attachment_extensions,
+                }
+            ),
+            gen_before,
         )
 
     @mcp.resource(
@@ -76,18 +110,26 @@ def register_resources(mcp: FastMCP) -> None:
     )
     async def vault_stats(
         vault: Vault = Depends(get_vault),
-    ) -> str:
-        """Vault statistics — document count, chunk count, capabilities."""
+    ) -> ResourceResult:
+        """Vault statistics — document count, chunk count, capabilities.
+
+        Index freshness is reported in _meta.index_stale.
+        """
+        gen_before = vault.index.write_generation()
         result = await asyncio.to_thread(vault.reader.stats)
-        return json.dumps(asdict(result))
+        return _stale_resource(vault, json.dumps(asdict(result)), gen_before)
 
     @mcp.resource(
         "tags://vault", mime_type="application/json", icons=_TOOL_ICONS["list_tags"]
     )
     async def vault_tags(
         vault: Vault = Depends(get_vault),
-    ) -> str:
-        """All tags grouped by indexed field."""
+    ) -> ResourceResult:
+        """All tags grouped by indexed field.
+
+        Index freshness is reported in _meta.index_stale.
+        """
+        gen_before = vault.index.write_generation()
         stats = await asyncio.to_thread(vault.reader.stats)
         tag_lists: list[list[str]] = list(
             await asyncio.gather(
@@ -100,7 +142,7 @@ def register_resources(mcp: FastMCP) -> None:
         grouped: dict[str, list[str]] = dict(
             zip(stats.indexed_frontmatter_fields, tag_lists, strict=False)
         )
-        return json.dumps(grouped)
+        return _stale_resource(vault, json.dumps(grouped), gen_before)
 
     @mcp.resource(
         "tags://vault/{field}",
@@ -110,10 +152,14 @@ def register_resources(mcp: FastMCP) -> None:
     async def vault_tags_by_field(
         field: str,
         vault: Vault = Depends(get_vault),
-    ) -> str:
-        """Tags for a specific indexed field."""
+    ) -> ResourceResult:
+        """Tags for a specific indexed field.
+
+        Index freshness is reported in _meta.index_stale.
+        """
+        gen_before = vault.index.write_generation()
         values = await asyncio.to_thread(vault.reader.list_tags, field)
-        return json.dumps(values)
+        return _stale_resource(vault, json.dumps(values), gen_before)
 
     @mcp.resource(
         "folders://vault",
@@ -122,10 +168,14 @@ def register_resources(mcp: FastMCP) -> None:
     )
     async def vault_folders(
         vault: Vault = Depends(get_vault),
-    ) -> str:
-        """All folder paths in the vault."""
+    ) -> ResourceResult:
+        """All folder paths in the vault.
+
+        Index freshness is reported in _meta.index_stale.
+        """
+        gen_before = vault.index.write_generation()
         folders = await asyncio.to_thread(vault.reader.list_folders)
-        return json.dumps(folders)
+        return _stale_resource(vault, json.dumps(folders), gen_before)
 
     @mcp.resource(
         "toc://vault/{path}", mime_type="application/json", icons=_TOOL_ICONS["read"]
@@ -134,10 +184,14 @@ def register_resources(mcp: FastMCP) -> None:
     async def vault_toc(
         path: str,
         vault: Vault = Depends(get_vault),
-    ) -> str:
-        """Table of contents — ordered list of {level, text, anchor} headings. Useful for navigating long notes without reading full content."""
+    ) -> ResourceResult:
+        """Table of contents — ordered list of {level, text, anchor} headings. Useful for navigating long notes without reading full content.
+
+        Index freshness is reported in _meta.index_stale.
+        """
+        gen_before = vault.index.write_generation()
         toc = await asyncio.to_thread(vault.reader.get_toc, path)
-        return json.dumps(toc)
+        return _stale_resource(vault, json.dumps(toc), gen_before)
 
     @mcp.resource(
         "similar://vault/{path}",
@@ -148,10 +202,16 @@ def register_resources(mcp: FastMCP) -> None:
     async def vault_similar(
         path: str,
         vault: Vault = Depends(get_vault),
-    ) -> str:
-        """Top 10 semantically similar notes for a document."""
+    ) -> ResourceResult:
+        """Top 10 semantically similar notes for a document.
+
+        Index freshness is reported in _meta.index_stale.
+        """
+        gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(vault.reader.get_similar, path, limit=10)
-        return json.dumps([asdict(r) for r in results])
+        return _stale_resource(
+            vault, json.dumps([asdict(r) for r in results]), gen_before
+        )
 
     @mcp.resource(
         "recent://vault",
@@ -160,8 +220,12 @@ def register_resources(mcp: FastMCP) -> None:
     )
     async def vault_recent(
         vault: Vault = Depends(get_vault),
-    ) -> str:
-        """20 most recently modified notes."""
+    ) -> ResourceResult:
+        """20 most recently modified notes.
+
+        Index freshness is reported in _meta.index_stale.
+        """
+        gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(vault.reader.get_recent, limit=20)
         items: list[dict[str, Any]] = [
             {
@@ -172,4 +236,4 @@ def register_resources(mcp: FastMCP) -> None:
             }
             for r in results
         ]
-        return json.dumps(items)
+        return _stale_resource(vault, json.dumps(items), gen_before)

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -13,12 +13,13 @@ import logging
 import os
 import subprocess
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 from urllib.parse import urlparse, urlunparse
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 from fastmcp.exceptions import ToolError
+from fastmcp.tools import ToolResult
 
 from markdown_vault_mcp.exceptions import EditConflictError
 from markdown_vault_mcp.git import GitWriteStrategy, PullResult, PushResult
@@ -32,6 +33,13 @@ from ._server_deps import get_vault
 from ._server_queryable import needs_queryable
 
 logger = logging.getLogger(__name__)
+
+# Bridges a read tool's data-shaped return annotation (which drives the
+# advertised output schema) to the ToolResult it returns at runtime.
+# Return-only: _staleness_result() is declared `-> _T` but returns a
+# ToolResult, so its result must be `return`ed directly from a tool, never
+# stored or processed as `_T` (mypy would not catch the mismatch).
+_T = TypeVar("_T")
 
 
 def _resolve_drain_timeout() -> float:
@@ -51,8 +59,7 @@ async def _maybe_wait_for_drain(
 
     Returns True when the writer was drained at the point of asking
     (or when no wait was requested), False when the bounded wait
-    timed out. Callers OR the negation into the response envelope's
-    ``stale`` field so a timed-out wait reliably reports ``stale=True``.
+    timed out.
     """
     if not wait_for_drain:
         return True
@@ -71,6 +78,53 @@ async def _maybe_wait_for_drain(
             )
             return False
         await asyncio.sleep(poll_interval)
+
+
+def _staleness_result(
+    vault: Vault,
+    data: _T,
+    *,
+    drained_on_request: bool,
+    gen_before: int,
+) -> _T:
+    """Wrap a read tool's payload with index-freshness metadata.
+
+    The payload is returned unchanged (a bare list/dict) as the tool's
+    content and structured output; freshness rides out-of-band in the MCP
+    ``_meta`` channel as ``index_stale``. Clients that do not care ignore
+    ``_meta`` and read the data exactly as before; the 1% that need a
+    fresh-read guarantee inspect ``result.meta["index_stale"]``.
+
+    ``index_stale`` is True when the IndexWriter had pending or in-flight
+    work at any of three observation points: the optional ``wait_for_pending_writes``
+    timed out (``drained_on_request`` False), a write completed inside the
+    read window (``write_generation`` advanced past ``gen_before``), or the
+    writer was non-idle at response time.
+
+    ``structured_content`` mirrors FastMCP's wrap-result convention (a
+    primitive/collection payload is nested under ``{"result": ...}``) so the
+    client still deserializes ``result.data`` to the bare shape, matching the
+    tool's data-shaped return annotation. The annotation drives the advertised
+    output schema; the ``ToolResult`` is the runtime payload — hence the typed
+    bridge below (the function is declared to return the data type ``_T`` while
+    actually returning a ``ToolResult`` FastMCP unwraps to that same shape).
+
+    ``content`` is the bare ``data`` value: FastMCP's ``ToolResult.content``
+    accepts ``Any`` serializable value and converts it to a JSON ``TextContent``
+    block, which is the documented path for non-content-block payloads (it is
+    not the ``# type: ignore`` target — that is solely the ``-> _T`` bridge).
+    """
+    index_stale = (
+        (not drained_on_request)
+        or (vault.index.write_generation() != gen_before)
+        or (not vault.index.is_drained())
+    )
+    structured = data if isinstance(data, dict) else {"result": data}
+    return ToolResult(  # type: ignore[return-value]
+        content=data,
+        structured_content=structured,
+        meta={"index_stale": index_stale},
+    )
 
 
 _ALLOWED_FETCH_SCHEMES = frozenset({"http", "https"})
@@ -304,6 +358,7 @@ def register_tools(mcp: FastMCP) -> None:
         filters: dict[str, str] | None = None,
         chunks_per_file: int | None = None,
         snippet_words: int | None = None,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Find documents matching a query using full-text or semantic search.
@@ -338,6 +393,18 @@ def register_tools(mcp: FastMCP) -> None:
             snippet_words: Width of the snippet window in words. Omit to use
                 the server default. Set to 0 to return full chunk content.
                 Use read(path, section=heading) for full section recovery.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
             List of result dicts ranked by file relevance. Each contains:
@@ -359,6 +426,11 @@ def register_tools(mcp: FastMCP) -> None:
                 the full section text.
               - score (float): Chunk-level score for this section.
 
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
+
         Also useful for finding merge candidates during triage — if a
         close match exists for a new capture, prefer merging over
         creating a near-duplicate.
@@ -367,6 +439,8 @@ def register_tools(mcp: FastMCP) -> None:
             ValueError: If mode is "semantic" or "hybrid" and no embedding
                 provider is configured.
         """
+        drained = await _maybe_wait_for_drain(vault, wait_for_pending_writes, "search")
+        gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(
             vault.reader.search,
             query,
@@ -377,7 +451,12 @@ def register_tools(mcp: FastMCP) -> None:
             chunks_per_file=chunks_per_file,
             snippet_words=snippet_words,
         )
-        return [asdict(r) for r in results]
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["read"],
@@ -473,6 +552,7 @@ def register_tools(mcp: FastMCP) -> None:
         folder: str | None = None,
         pattern: str | None = None,
         include_attachments: bool = False,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """List documents (and optionally attachments) in the vault.
@@ -490,6 +570,18 @@ def register_tools(mcp: FastMCP) -> None:
                 images, etc.) that match the configured allowlist. Each
                 attachment entry includes kind="attachment" and mime_type.
                 Default False (notes only).
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
             List of info dicts. Every entry has a 'kind' field.
@@ -497,14 +589,28 @@ def register_tools(mcp: FastMCP) -> None:
             Attachments (when include_attachments=True): path, folder,
             mime_type, size_bytes, modified_at, kind="attachment".
             Body content is not included in either case.
+
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
         """
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "list_documents"
+        )
+        gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(
             vault.reader.list_documents,
             folder=folder,
             pattern=pattern,
             include_attachments=include_attachments,
         )
-        return [asdict(r) for r in results]
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["list_folders"],
@@ -515,6 +621,7 @@ def register_tools(mcp: FastMCP) -> None:
         },
     )
     async def list_folders(
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[str]:
         """List all folder paths that contain documents.
@@ -523,12 +630,38 @@ def register_tools(mcp: FastMCP) -> None:
         'list_documents' by folder. The root folder (top-level documents) is
         represented as an empty string "".
 
+        Args:
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
+
         Returns:
             Sorted list of folder paths, e.g. ["", "Journal", "Projects"].
             Pass any of these as the 'folder' argument to 'search' or
             'list_documents'.
+
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
         """
-        return await asyncio.to_thread(vault.reader.list_folders)
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "list_folders"
+        )
+        gen_before = vault.index.write_generation()
+        folders = await asyncio.to_thread(vault.reader.list_folders)
+        return _staleness_result(
+            vault, folders, drained_on_request=drained, gen_before=gen_before
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["list_tags"],
@@ -540,6 +673,7 @@ def register_tools(mcp: FastMCP) -> None:
     )
     async def list_tags(
         field: str = "tags",
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[str]:
         """List all distinct values for a frontmatter field across the vault.
@@ -553,13 +687,37 @@ def register_tools(mcp: FastMCP) -> None:
                 be one of the values in indexed_frontmatter_fields (from 'stats')
                 — passing any other field silently returns an empty list, not an
                 error.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
             Sorted list of distinct string values, e.g.
             ["craft", "pacing", "worldbuilding"]. Use these as values in the
             'filters' dict when calling 'search'.
+
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
         """
-        return await asyncio.to_thread(vault.reader.list_tags, field)
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "list_tags"
+        )
+        gen_before = vault.index.write_generation()
+        values = await asyncio.to_thread(vault.reader.list_tags, field)
+        return _staleness_result(
+            vault, values, drained_on_request=drained, gen_before=gen_before
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["stats"],
@@ -570,6 +728,7 @@ def register_tools(mcp: FastMCP) -> None:
         },
     )
     async def stats(
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> dict[str, Any]:
         """Get an overview of the vault's size, capabilities, and configuration.
@@ -578,6 +737,20 @@ def register_tools(mcp: FastMCP) -> None:
         contains and what search modes are available. The
         'semantic_search_available' field tells you whether mode="semantic" or
         mode="hybrid" can be used in 'search'.
+
+        Args:
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
             Dict with the following fields:
@@ -596,9 +769,18 @@ def register_tools(mcp: FastMCP) -> None:
               Call 'get_broken_links' if non-zero.
             - orphan_count (int): Notes with no inbound or outbound links.
               Call 'get_orphan_notes' if non-zero.
+
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
         """
+        drained = await _maybe_wait_for_drain(vault, wait_for_pending_writes, "stats")
+        gen_before = vault.index.write_generation()
         result = await asyncio.to_thread(vault.reader.stats)
-        return asdict(result)
+        return _staleness_result(
+            vault, asdict(result), drained_on_request=drained, gen_before=gen_before
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["embeddings_status"],
@@ -686,9 +868,9 @@ def register_tools(mcp: FastMCP) -> None:
     async def get_backlinks(
         path: str,
         limit: int | None = None,
-        wait_for_drain: bool = False,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
-    ) -> dict[str, Any]:
+    ) -> list[dict[str, Any]]:
         """Find all documents that link TO the given document (backlinks).
 
         Use this to discover which notes reference a particular document.
@@ -705,32 +887,35 @@ def register_tools(mcp: FastMCP) -> None:
                 "notes/topic.md"). Case-sensitive.
             limit: Maximum number of backlinks to return. Omitted (the
                 default) returns all.
-            wait_for_drain: When True, block until the IndexWriter has
-                no pending or in-flight work before answering. Bounded
-                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
-                On timeout, returns the result with `stale=True` rather
-                than raising — best-effort fresh read. Default False
-                returns immediately and reports staleness via the
-                envelope's `stale` field.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
-            Dict envelope with two keys:
+            List of backlink dicts, each with:
 
-            - stale (bool): True when the IndexWriter had pending or
-              in-flight work at any of three observation points (the
-              optional ``wait_for_drain`` timing out, a completed
-              write cycle inside the read window, or non-idle at
-              response construction). False when none of those
-              conditions held — the data is current as of response
-              time.
-            - data (list[dict]): The backlinks list. Each entry has:
+            - source_path (str): Path of the document containing the link.
+            - source_title (str): Title of the source document.
+            - link_text (str): The clickable text of the link.
+            - link_type (str): One of "markdown", "wikilink", or "reference".
+            - fragment (str | None): Heading anchor (e.g. "#section"), or null.
+            - raw_target (str): Literal link target as written in the source.
 
-              - source_path (str): Path of the document containing the link.
-              - source_title (str): Title of the source document.
-              - link_text (str): The clickable text of the link.
-              - link_type (str): One of "markdown", "wikilink", or "reference".
-              - fragment (str | None): Heading anchor (e.g. "#section"), or null.
-              - raw_target (str): Literal link target as written in the source.
+            Index freshness is reported out-of-band in the response's
+            ``_meta.index_stale`` field — True when the IndexWriter had
+            pending or in-flight work at any of three observation points
+            (``wait_for_pending_writes`` timing out, a write completing inside the
+            read window, or non-idle at response time), False when the data
+            is current as of response time.
 
         Combine with ``get_similar`` to find connection gaps — notes that are
         semantically close to the target but not yet linked.
@@ -738,19 +923,17 @@ def register_tools(mcp: FastMCP) -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        drained_on_request = await _maybe_wait_for_drain(
-            vault, wait_for_drain, "get_backlinks"
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_backlinks"
         )
         gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(vault.graph.get_backlinks, path, limit=limit)
-        return {
-            "stale": (
-                (not drained_on_request)
-                or (vault.index.write_generation() != gen_before)
-                or (not vault.index.is_drained())
-            ),
-            "data": [asdict(r) for r in results],
-        }
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_outlinks"],
@@ -764,9 +947,9 @@ def register_tools(mcp: FastMCP) -> None:
     async def get_outlinks(
         path: str,
         limit: int | None = None,
-        wait_for_drain: bool = False,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
-    ) -> dict[str, Any]:
+    ) -> list[dict[str, Any]]:
         """Find all links FROM the given document to other documents (outlinks).
 
         Use this to see what a document references. For a full picture of
@@ -781,32 +964,35 @@ def register_tools(mcp: FastMCP) -> None:
                 "notes/topic.md"). Case-sensitive.
             limit: Maximum number of outlinks to return. Omitted (the
                 default) returns all.
-            wait_for_drain: When True, block until the IndexWriter has
-                no pending or in-flight work before answering. Bounded
-                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
-                On timeout, returns the result with `stale=True` rather
-                than raising — best-effort fresh read. Default False
-                returns immediately and reports staleness via the
-                envelope's `stale` field.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
-            Dict envelope with two keys:
+            List of outlink dicts, each with:
 
-            - stale (bool): True when the IndexWriter had pending or
-              in-flight work at any of three observation points (the
-              optional ``wait_for_drain`` timing out, a completed
-              write cycle inside the read window, or non-idle at
-              response construction). False when none of those
-              conditions held — the data is current as of response
-              time.
-            - data (list[dict]): The outlinks list. Each entry has:
+            - target_path (str): Path of the linked document.
+            - link_text (str): The clickable text of the link.
+            - link_type (str): One of "markdown", "wikilink", or "reference".
+            - fragment (str | None): Heading anchor (e.g. "#section"), or null.
+            - raw_target (str): Literal link target as written in the source.
+            - exists (bool): True if the target document is indexed.
 
-              - target_path (str): Path of the linked document.
-              - link_text (str): The clickable text of the link.
-              - link_type (str): One of "markdown", "wikilink", or "reference".
-              - fragment (str | None): Heading anchor (e.g. "#section"), or null.
-              - raw_target (str): Literal link target as written in the source.
-              - exists (bool): True if the target document is indexed.
+            Index freshness is reported out-of-band in the response's
+            ``_meta.index_stale`` field — True when the IndexWriter had
+            pending or in-flight work at any of three observation points
+            (``wait_for_pending_writes`` timing out, a write completing inside the
+            read window, or non-idle at response time), False when the data
+            is current as of response time.
 
         Combine with ``get_similar`` to find connection gaps — notes the
         source is semantically close to but hasn't linked yet.
@@ -814,19 +1000,17 @@ def register_tools(mcp: FastMCP) -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        drained_on_request = await _maybe_wait_for_drain(
-            vault, wait_for_drain, "get_outlinks"
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_outlinks"
         )
         gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(vault.graph.get_outlinks, path, limit=limit)
-        return {
-            "stale": (
-                (not drained_on_request)
-                or (vault.index.write_generation() != gen_before)
-                or (not vault.index.is_drained())
-            ),
-            "data": [asdict(r) for r in results],
-        }
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_broken_links"],
@@ -838,6 +1022,7 @@ def register_tools(mcp: FastMCP) -> None:
     )
     async def get_broken_links(
         folder: str | None = None,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Find all links that point to non-existent documents (broken links).
@@ -853,6 +1038,18 @@ def register_tools(mcp: FastMCP) -> None:
             folder: Optional folder filter. When provided, only checks
                 links from documents in this folder (e.g. "Journal").
                 Without this, checks all documents.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
             List of dicts, each with:
@@ -864,9 +1061,23 @@ def register_tools(mcp: FastMCP) -> None:
             - link_type (str): One of "markdown", "wikilink", or "reference".
             - fragment (str | None): Heading anchor (e.g. "#section"), or null.
             - raw_target (str): Literal link target as written in the source.
+
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
         """
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_broken_links"
+        )
+        gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(vault.graph.get_broken_links, folder=folder)
-        return [asdict(r) for r in results]
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     # --- Similarity tools (read-only) ---
 
@@ -883,18 +1094,17 @@ def register_tools(mcp: FastMCP) -> None:
         path: str,
         limit: int = 10,
         chunks_per_file: int | None = None,
-        wait_for_drain: bool = False,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
-    ) -> dict[str, Any]:
+    ) -> list[dict[str, Any]]:
         """Find notes most semantically similar to the given document.
 
         Uses stored embedding vectors — no re-embedding needed. The
         reference document is excluded from results. Requires semantic
         search to be configured (check 'stats' for
-        semantic_search_available). The envelope's ``data`` field is an
-        empty list if embeddings are not configured (check
-        'embeddings_status') or the document has no stored vectors (call
-        'build_embeddings' to embed missing chunks).
+        semantic_search_available). Returns an empty list if embeddings are
+        not configured (check 'embeddings_status') or the document has no
+        stored vectors (call 'build_embeddings' to embed missing chunks).
 
         Args:
             path: Relative path of the reference document (e.g.
@@ -902,37 +1112,41 @@ def register_tools(mcp: FastMCP) -> None:
             limit: Maximum number of similar notes to return (default 10).
             chunks_per_file: Maximum sections returned per file (default 2).
                 Set to 1 for one best section per file.  Must be >= 1.
-            wait_for_drain: When True, block until the IndexWriter has
-                no pending or in-flight work before answering. Bounded
-                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
-                On timeout, returns the result with `stale=True` rather
-                than raising — best-effort fresh read. Default False
-                returns immediately and reports staleness via the
-                envelope's `stale` field.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
-            Dict envelope with two keys:
+            List of result dicts ranked by file similarity. Each contains:
 
-            - stale (bool): True when the IndexWriter had pending or
-              in-flight work at any of three observation points (wait
-              timed out, write completed inside the read window, or
-              non-idle at response time). False otherwise.
-            - data (list[dict]): Result dicts ranked by file similarity.
-              Each entry contains:
+            - path (str): Relative path of the similar document.
+            - title (str): Document title.
+            - folder (str): Parent folder path.
+            - score (float): File-level cosine similarity (max of section
+              scores), 0.0-1.0; higher = more similar.
+            - search_type (str): Always "semantic".
+            - frontmatter (dict): Parsed YAML frontmatter.
+            - sections (list[dict]): Up to chunks_per_file best-matching
+              sections, each with:
 
-              - path (str): Relative path of the similar document.
-              - title (str): Document title.
-              - folder (str): Parent folder path.
-              - score (float): File-level cosine similarity (max of section
-                scores), 0.0-1.0; higher = more similar.
-              - search_type (str): Always "semantic".
-              - frontmatter (dict): Parsed YAML frontmatter.
-              - sections (list[dict]): Up to chunks_per_file best-matching
-                sections, each with:
+              - heading (str | None): Section heading or null for intro.
+              - content (str): Matched chunk text.
+              - score (float): Chunk-level score for this section.
 
-                - heading (str | None): Section heading or null for intro.
-                - content (str): Matched chunk text.
-                - score (float): Chunk-level score for this section.
+            Index freshness is reported out-of-band in the response's
+            ``_meta.index_stale`` field — True when the IndexWriter had
+            pending or in-flight work at any of three observation points
+            (``wait_for_pending_writes`` timing out, a write completing inside the
+            read window, or non-idle at response time), False otherwise.
 
         Useful for finding link candidates that aren't yet wikilinked — the
         vault's organic graph is almost always denser than its explicit one.
@@ -941,8 +1155,8 @@ def register_tools(mcp: FastMCP) -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        drained_on_request = await _maybe_wait_for_drain(
-            vault, wait_for_drain, "get_similar"
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_similar"
         )
         gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(
@@ -951,14 +1165,12 @@ def register_tools(mcp: FastMCP) -> None:
             limit=limit,
             chunks_per_file=chunks_per_file,
         )
-        return {
-            "stale": (
-                (not drained_on_request)
-                or (vault.index.write_generation() != gen_before)
-                or (not vault.index.is_drained())
-            ),
-            "data": [asdict(r) for r in results],
-        }
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     # --- Recently modified ---
 
@@ -973,6 +1185,7 @@ def register_tools(mcp: FastMCP) -> None:
     async def get_recent(
         limit: int = 20,
         folder: str | None = None,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Get the most recently modified notes in the vault.
@@ -986,15 +1199,41 @@ def register_tools(mcp: FastMCP) -> None:
             limit: Maximum number of notes to return (default 20).
             folder: Optional folder filter. When provided, only returns
                 notes from this folder (e.g. "Journal").
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
             List of note info dicts, each with: path, title, folder,
             frontmatter, modified_at (Unix timestamp), kind ("note").
+
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
         """
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_recent"
+        )
+        gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(
             vault.reader.get_recent, limit=limit, folder=folder
         )
-        return [asdict(r) for r in results]
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     # --- Context dossier ---
 
@@ -1011,7 +1250,7 @@ def register_tools(mcp: FastMCP) -> None:
         path: str,
         similar_limit: int = 5,
         link_limit: int = 10,
-        wait_for_drain: bool = False,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> dict[str, Any]:
         """Get a consolidated context dossier for a document.
@@ -1035,66 +1274,71 @@ def register_tools(mcp: FastMCP) -> None:
                 are not configured).
             link_limit: Maximum number of backlinks and outlinks to include
                 each (default 10).
-            wait_for_drain: When True, block until the IndexWriter has
-                no pending or in-flight work before answering. Bounded
-                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
-                On timeout, returns the result with `stale=True` rather
-                than raising — best-effort fresh read. Default False
-                returns immediately and reports staleness via the
-                envelope's `stale` field.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
-            Dict envelope with two keys:
+            Dict with the note context. Fields:
 
-            - stale (bool): True when the IndexWriter had pending or
-              in-flight work at any of three observation points (wait
-              timed out, write completed inside the read window, or
-              non-idle at response time). False otherwise.
-            - data (dict): The note context. Inner fields:
+            - path (str): Relative path of the document.
+            - title (str): Document title.
+            - folder (str): Parent folder path.
+            - frontmatter (dict): Parsed YAML frontmatter.
+            - modified_at (float): Unix timestamp of last modification.
+            - backlinks (list): Documents linking to this note. List of dicts,
+              each with:
 
-              - path (str): Relative path of the document.
+              - source_path (str): Path of the document containing the link.
+              - source_title (str): Title of the source document.
+              - link_text (str): The clickable text of the link.
+              - link_type (str): One of "markdown", "wikilink", or "reference".
+              - fragment (str | None): Heading anchor (e.g. "#section"), or null.
+              - raw_target (str): Literal link target as written in the source.
+
+            - outlinks (list): Links from this note. List of dicts, each with:
+
+              - target_path (str): Path of the linked document.
+              - link_text (str): The clickable text of the link.
+              - link_type (str): One of "markdown", "wikilink", or "reference".
+              - fragment (str | None): Heading anchor (e.g. "#section"), or null.
+              - raw_target (str): Literal link target as written in the source.
+              - exists (bool): True if the target document is indexed.
+
+            - similar (list): Semantically similar notes, field-collapsed by
+              file (chunks_per_file=1 for compact dossiers).  List of dicts,
+              each with:
+
+              - path (str): Relative path of the similar document.
               - title (str): Document title.
               - folder (str): Parent folder path.
+              - score (float): File-level cosine similarity 0.0-1.0 = score
+                of the best matching section.
+              - search_type (str): Always "semantic".
               - frontmatter (dict): Parsed YAML frontmatter.
-              - modified_at (float): Unix timestamp of last modification.
-              - backlinks (list): Documents linking to this note. List of dicts,
-                each with:
+              - sections (list): Single best-matching section, each with
+                heading (str|null), content (str), score (float).
+                Call get_similar(path, chunks_per_file=N) for more sections.
 
-                - source_path (str): Path of the document containing the link.
-                - source_title (str): Title of the source document.
-                - link_text (str): The clickable text of the link.
-                - link_type (str): One of "markdown", "wikilink", or "reference".
-                - fragment (str | None): Heading anchor (e.g. "#section"), or null.
-                - raw_target (str): Literal link target as written in the source.
+            - folder_notes (list[str]): Paths of other notes in the same
+              folder (up to 20). Plain strings, not dicts.
+            - tags (dict[str, list[str]]): Indexed frontmatter field →
+              distinct values for this note.
 
-              - outlinks (list): Links from this note. List of dicts, each with:
-
-                - target_path (str): Path of the linked document.
-                - link_text (str): The clickable text of the link.
-                - link_type (str): One of "markdown", "wikilink", or "reference".
-                - fragment (str | None): Heading anchor (e.g. "#section"), or null.
-                - raw_target (str): Literal link target as written in the source.
-                - exists (bool): True if the target document is indexed.
-
-              - similar (list): Semantically similar notes, field-collapsed by
-                file (chunks_per_file=1 for compact dossiers).  List of dicts,
-                each with:
-
-                - path (str): Relative path of the similar document.
-                - title (str): Document title.
-                - folder (str): Parent folder path.
-                - score (float): File-level cosine similarity 0.0-1.0 = score
-                  of the best matching section.
-                - search_type (str): Always "semantic".
-                - frontmatter (dict): Parsed YAML frontmatter.
-                - sections (list): Single best-matching section, each with
-                  heading (str|null), content (str), score (float).
-                  Call get_similar(path, chunks_per_file=N) for more sections.
-
-              - folder_notes (list[str]): Paths of other notes in the same
-                folder (up to 20). Plain strings, not dicts.
-              - tags (dict[str, list[str]]): Indexed frontmatter field →
-                distinct values for this note.
+            Index freshness is reported out-of-band in the response's
+            ``_meta.index_stale`` field — True when the IndexWriter had
+            pending or in-flight work at any of three observation points
+            (``wait_for_pending_writes`` timing out, a write completing inside the
+            read window, or non-idle at response time), False otherwise.
 
         The ``similar`` field in the response surfaces notes that may warrant
         explicit links to the context note but don't yet — a common input to
@@ -1103,8 +1347,8 @@ def register_tools(mcp: FastMCP) -> None:
         Raises:
             ValueError: If no document exists at the given path.
         """
-        drained_on_request = await _maybe_wait_for_drain(
-            vault, wait_for_drain, "get_context"
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_context"
         )
         gen_before = vault.index.write_generation()
         result = await asyncio.to_thread(
@@ -1113,14 +1357,9 @@ def register_tools(mcp: FastMCP) -> None:
             similar_limit=similar_limit,
             link_limit=link_limit,
         )
-        return {
-            "stale": (
-                (not drained_on_request)
-                or (vault.index.write_generation() != gen_before)
-                or (not vault.index.is_drained())
-            ),
-            "data": asdict(result),
-        }
+        return _staleness_result(
+            vault, asdict(result), drained_on_request=drained, gen_before=gen_before
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_orphan_notes"],
@@ -1131,6 +1370,7 @@ def register_tools(mcp: FastMCP) -> None:
         },
     )
     async def get_orphan_notes(
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Return all notes with no inbound or outbound links.
@@ -1143,6 +1383,20 @@ def register_tools(mcp: FastMCP) -> None:
         orphan_count > 0. Useful for finding isolated notes that may need to
         be connected to the rest of the vault or removed.
 
+        Args:
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
+
         Returns:
             List of dicts ordered by path, each with:
 
@@ -1152,9 +1406,23 @@ def register_tools(mcp: FastMCP) -> None:
             - frontmatter (dict): Parsed YAML frontmatter.
             - modified_at (float): Unix timestamp of last modification.
             - kind (str): Always "note".
+
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
         """
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_orphan_notes"
+        )
+        gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(vault.graph.get_orphan_notes)
-        return [asdict(r) for r in results]
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_most_linked"],
@@ -1166,6 +1434,7 @@ def register_tools(mcp: FastMCP) -> None:
     )
     async def get_most_linked(
         limit: int = 10,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Return the documents with the most inbound links, ranked by backlink count.
@@ -1176,14 +1445,40 @@ def register_tools(mcp: FastMCP) -> None:
 
         Args:
             limit: Maximum number of results to return. Default 10.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
             List of dicts with path (str), title (str), and backlink_count (int
             — number of distinct source documents linking to this note), ordered
             by backlink_count descending.
+
+            Index freshness rides in the response's ``_meta.index_stale``
+            field — True when the IndexWriter was non-idle, a write completed
+            inside the read window, or ``wait_for_pending_writes`` timed out; False
+            otherwise.
         """
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_most_linked"
+        )
+        gen_before = vault.index.write_generation()
         results = await asyncio.to_thread(vault.graph.get_most_linked, limit=limit)
-        return [asdict(r) for r in results]
+        return _staleness_result(
+            vault,
+            [asdict(r) for r in results],
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
 
     @mcp.tool(
         icons=_TOOL_ICONS["get_connection_path"],
@@ -1198,7 +1493,7 @@ def register_tools(mcp: FastMCP) -> None:
         source: str,
         target: str,
         max_depth: int = 10,
-        wait_for_drain: bool = False,
+        wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> dict[str, Any]:
         """Find the shortest connection path between two notes in the link graph.
@@ -1214,31 +1509,36 @@ def register_tools(mcp: FastMCP) -> None:
             source: Vault-relative path of the starting note (e.g. 'Ideas/spark.md').
             target: Vault-relative path of the destination note.
             max_depth: Maximum number of hops to search. Default 10, max 10.
-            wait_for_drain: When True, block until the IndexWriter has
-                no pending or in-flight work before answering. Bounded
-                by MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S (default 60s).
-                On timeout, returns the result with `stale=True` rather
-                than raising — best-effort fresh read. Default False
-                returns immediately and reports staleness via the
-                envelope's `stale` field.
+            wait_for_pending_writes: When True, wait until your recent
+                write/edit/delete/rename operations have been applied to the
+                index before answering, so the results reflect those changes.
+                Use it right after modifying notes when this read must see
+                them (e.g. right after a write/edit/delete/rename whose
+                effect this read should reflect). Default
+                False answers immediately from the current index — almost
+                always already up to date; inspect the response's
+                ``_meta.index_stale`` field to tell whether a write was still
+                in flight. Bounded by a server timeout (default 60s); on
+                timeout it answers from the current index rather than waiting
+                longer.
 
         Returns:
-            Dict envelope with two keys:
+            Dict with the connection-path result. Fields:
 
-            - stale (bool): True when the IndexWriter had pending or
-              in-flight work at any of three observation points (wait
-              timed out, write completed inside the read window, or
-              non-idle at response time). False otherwise.
-            - data (dict): The connection-path result. Inner fields:
+            - `found` (bool): Whether a path was found within `max_depth` hops.
+            - `path` (list[str]): Ordered list of note paths from source to target,
+              or an empty list if not found.
+            - `hops` (int): Number of edges in the path (`len(path) - 1`), or -1 if
+              not found.
 
-              - `found` (bool): Whether a path was found within `max_depth` hops.
-              - `path` (list[str]): Ordered list of note paths from source to target,
-                or an empty list if not found.
-              - `hops` (int): Number of edges in the path (`len(path) - 1`), or -1 if
-                not found.
+            Index freshness is reported out-of-band in the response's
+            ``_meta.index_stale`` field — True when the IndexWriter had
+            pending or in-flight work at any of three observation points
+            (``wait_for_pending_writes`` timing out, a write completing inside the
+            read window, or non-idle at response time), False otherwise.
         """
-        drained_on_request = await _maybe_wait_for_drain(
-            vault, wait_for_drain, "get_connection_path"
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_connection_path"
         )
         gen_before = vault.index.write_generation()
         result: list[str] | None = await asyncio.to_thread(
@@ -1249,14 +1549,9 @@ def register_tools(mcp: FastMCP) -> None:
             inner: dict[str, Any] = {"found": False, "path": [], "hops": -1}
         else:
             inner = {"found": True, "path": result, "hops": len(result) - 1}
-        return {
-            "stale": (
-                (not drained_on_request)
-                or (vault.index.write_generation() != gen_before)
-                or (not vault.index.is_drained())
-            ),
-            "data": inner,
-        }
+        return _staleness_result(
+            vault, inner, drained_on_request=drained, gen_before=gen_before
+        )
 
     # --- Git history tools ---
 

--- a/src/markdown_vault_mcp/static/prompts/propose-links.md
+++ b/src/markdown_vault_mcp/static/prompts/propose-links.md
@@ -28,12 +28,12 @@ If the resolved set contains more than 100 notes, pause and ask the user whether
 
 For each note in scope:
 
-1. Call `get_similar(path=<note path>, limit=$per_note_limit)` (default limit: 5). The tool returns a `{"stale": bool, "data": [...]}` envelope — use the `data` list for the candidates.
-2. If `get_similar`'s `data` list is empty (no embeddings configured), fall back to `search(query=<note title>, mode='keyword', limit=$per_note_limit)` and drop the note itself from the result.
+1. Call `get_similar(path=<note path>, limit=$per_note_limit)` (default limit: 5). The tool returns a list of candidate dicts directly (index freshness is reported out-of-band in `_meta.index_stale`).
+2. If `get_similar` returns an empty list (no embeddings configured), fall back to `search(query=<note title>, mode='keyword', limit=$per_note_limit)` and drop the note itself from the result.
 
 ## Step 3: Filter out already-linked pairs
 
-For each scanned note, call `get_outlinks(path=<note>)` once. The tool returns a `{"stale": bool, "data": [...]}` envelope; iterate `data` for the outlink dicts. For each candidate pair (A, B), drop the candidate if A already links to B — compare the candidate path `B` against each outlink's `target_path` (the resolved vault-relative path of the link target, which is what you want for equality checks). `raw_target` is the literal link text as written (and may be a wikilink without `.md`) — only fall back to comparing against `raw_target` when `target_path` is empty (e.g., the link hasn't been resolved).
+For each scanned note, call `get_outlinks(path=<note>)` once. The tool returns a list of outlink dicts directly; iterate them. For each candidate pair (A, B), drop the candidate if A already links to B — compare the candidate path `B` against each outlink's `target_path` (the resolved vault-relative path of the link target, which is what you want for equality checks). `raw_target` is the literal link text as written (and may be a wikilink without `.md`) — only fall back to comparing against `raw_target` when `target_path` is empty (e.g., the link hasn't been resolved).
 
 ## Step 4: Apply LLM judgment
 

--- a/src/markdown_vault_mcp/static/prompts/related.md
+++ b/src/markdown_vault_mcp/static/prompts/related.md
@@ -7,7 +7,7 @@ arguments:
 icons: search
 ---
 Step 1: Call `read` with path='$path'. Extract the main topics and key terms.
-Step 2: Call `get_context` with path='$path' — this returns a `{"stale": bool, "data": {...}}` envelope; the `data` dict contains backlinks, outlinks, and similar notes in one call. Also call `search` using the main topic terms to surface additional documents not captured by direct links or overall document similarity.
+Step 2: Call `get_context` with path='$path' — this returns a dict containing backlinks, outlinks, and similar notes in one call (index freshness is reported out-of-band in `_meta.index_stale`). Also call `search` using the main topic terms to surface additional documents not captured by direct links or overall document similarity.
 Step 3: Present a list of the most relevant related documents. For each, include: the document title, its path, and one sentence explaining the connection.
 Format suggested cross-references as: [title](relative/path.md)
 Do not edit any documents — this prompt is read-only.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -14,6 +16,32 @@ from markdown_vault_mcp.providers import EmbeddingProvider
 # test module without requiring a per-file import (which would trip ruff's
 # F811 redefinition check on the parameter shadowing).
 from tests.fixtures.git import git_repo_pair  # noqa: F401
+
+
+def _parse_tool_data(result: Any) -> Any:
+    """Extract the data payload from a CallToolResult, handling FastMCP serialization.
+
+    FastMCP serializes ``list[dict]`` as a single JSON TextContent blob.
+    ``result.data`` works for simple types (dict, str, list[str]) but returns
+    opaque ``Root()`` objects for ``list[dict]``; this falls back to parsing
+    the raw text content when needed.
+    """
+    data = result.data
+    if isinstance(data, list) and data and not isinstance(data[0], (dict, str)):
+        raw = result.content[0].text if result.content else "[]"
+        return json.loads(raw)
+    return data
+
+
+def _meta_stale(result: Any) -> bool | None:
+    """Read ``index_stale`` from a tool result's out-of-band ``_meta`` channel.
+
+    Index-querying read tools surface freshness in ``result.meta`` rather than
+    wrapping the payload in a ``{stale, data}`` envelope. Returns the flag, or
+    None for tools that do not set it.
+    """
+    meta = getattr(result, "meta", None) or {}
+    return meta.get("index_stale")
 
 
 class MockEmbeddingProvider(EmbeddingProvider):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -16,19 +15,10 @@ from markdown_vault_mcp.types import (
     ParsedNote,
 )
 from markdown_vault_mcp.vault import Vault
-from tests.conftest import wait_for_mcp_writer_drain
+from tests.conftest import _meta_stale, _parse_tool_data, wait_for_mcp_writer_drain
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def _parse_tool_data(result: Any) -> Any:
-    """Extract list/dict from a CallToolResult, handling FastMCP serialization."""
-    data = result.data
-    if isinstance(data, list) and data and not isinstance(data[0], (dict, str)):
-        raw = result.content[0].text if result.content else "[]"
-        return json.loads(raw)
-    return data
 
 
 # ---------------------------------------------------------------------------
@@ -670,9 +660,8 @@ class TestMCPGetConnectionPath:
             result = await client.call_tool(
                 "get_connection_path", {"source": "a.md", "target": "c.md"}
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert data["found"] is True
         assert data["path"] == ["a.md", "b.md", "c.md"]
         assert data["hops"] == 2
@@ -690,9 +679,8 @@ class TestMCPGetConnectionPath:
                 "get_connection_path",
                 {"source": "a.md", "target": "isolated.md"},
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert data["found"] is False
         assert data["path"] == []
         assert data["hops"] == -1
@@ -709,9 +697,8 @@ class TestMCPGetConnectionPath:
             result = await client.call_tool(
                 "get_connection_path", {"source": "a.md", "target": "a.md"}
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert data["found"] is True
         assert data["path"] == ["a.md"]
         assert data["hops"] == 0
@@ -731,10 +718,10 @@ class TestMCPGetConnectionPath:
                     {"source": "nonexistent.md", "target": "a.md"},
                 )
 
-    async def test_get_connection_path_with_wait_for_drain(
+    async def test_get_connection_path_with_wait_for_pending_writes(
         self, _mcp_env_path: None
     ) -> None:
-        """wait_for_drain=True blocks until writer drained, then returns envelope."""
+        """wait_for_pending_writes=True blocks until writer drained; index_stale is False."""
         from fastmcp import Client
 
         from markdown_vault_mcp.server import make_server
@@ -747,9 +734,8 @@ class TestMCPGetConnectionPath:
                 {
                     "source": "a.md",
                     "target": "c.md",
-                    "wait_for_drain": True,
+                    "wait_for_pending_writes": True,
                 },
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        assert envelope["data"]["found"] is True
+        assert _meta_stale(result) is False
+        assert _parse_tool_data(result)["found"] is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,26 +17,10 @@ from fastmcp.exceptions import ToolError
 from mcp.shared.exceptions import McpError
 
 from markdown_vault_mcp.server import make_server
-from tests.conftest import wait_for_mcp_writer_drain
+from tests.conftest import _meta_stale, _parse_tool_data, wait_for_mcp_writer_drain
 
 if TYPE_CHECKING:
     import mcp.types as mcp_types
-
-
-def _parse_tool_data(result: Any) -> Any:
-    """Extract data from a CallToolResult, handling FastMCP v2 serialization.
-
-    FastMCP v2 serializes list[dict] as a single JSON TextContent blob.
-    ``result.data`` works for simple types (dict, str, list[str]) but
-    returns opaque ``Root()`` objects for list[dict].  This helper falls
-    back to parsing the raw text content when needed.
-    """
-    data = result.data
-    if isinstance(data, list) and data and not isinstance(data[0], (dict, str)):
-        # Opaque Root objects — parse from raw text content.
-        raw = result.content[0].text if result.content else "[]"
-        return json.loads(raw)
-    return data
 
 
 _CLEAR_VARS = (
@@ -1424,25 +1408,23 @@ class TestLinkTools:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_backlinks", {"path": "notes/topic.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert len(data) == 1
         assert data[0]["source_path"] == "index.md"
         assert data[0]["link_text"] == "Topic"
 
     @pytest.mark.usefixtures("_mcp_env_linked")
-    async def test_get_backlinks_with_wait_for_drain(self) -> None:
+    async def test_get_backlinks_with_wait_for_pending_writes(self) -> None:
         server = make_server()
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 "get_backlinks",
-                {"path": "notes/topic.md", "wait_for_drain": True},
+                {"path": "notes/topic.md", "wait_for_pending_writes": True},
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        assert len(envelope["data"]) == 1
+        assert _meta_stale(result) is False
+        assert len(_parse_tool_data(result)) == 1
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_backlinks_nonexistent_raises(self) -> None:
@@ -1457,9 +1439,8 @@ class TestLinkTools:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_outlinks", {"path": "index.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert len(data) == 2
         targets = {d["target_path"] for d in data}
         assert "notes/topic.md" in targets
@@ -1470,17 +1451,16 @@ class TestLinkTools:
         assert by_target["ghost.md"]["exists"] is False
 
     @pytest.mark.usefixtures("_mcp_env_linked")
-    async def test_get_outlinks_with_wait_for_drain(self) -> None:
+    async def test_get_outlinks_with_wait_for_pending_writes(self) -> None:
         server = make_server()
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 "get_outlinks",
-                {"path": "index.md", "wait_for_drain": True},
+                {"path": "index.md", "wait_for_pending_writes": True},
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        assert len(envelope["data"]) == 2
+        assert _meta_stale(result) is False
+        assert len(_parse_tool_data(result)) == 2
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_outlinks_nonexistent_path(self) -> None:
@@ -1498,12 +1478,12 @@ class TestLinkTools:
             capped = await client.call_tool(
                 "get_outlinks", {"path": "index.md", "limit": 1}
             )
-            assert len(_parse_tool_data(capped)["data"]) == 1
+            assert len(_parse_tool_data(capped)) == 1
             # get_backlinks also accepts limit and forwards it.
             backlinks = await client.call_tool(
                 "get_backlinks", {"path": "notes/topic.md", "limit": 5}
             )
-            assert len(_parse_tool_data(backlinks)["data"]) == 1
+            assert len(_parse_tool_data(backlinks)) == 1
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     async def test_get_broken_links(self) -> None:
@@ -1548,9 +1528,8 @@ class TestSimilarTool:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_similar", {"path": "simple.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert data == []
 
     @pytest.mark.usefixtures("_mcp_env")
@@ -1572,23 +1551,21 @@ class TestSimilarTool:
                 "get_similar",
                 {"path": "simple.md", "limit": 5, "chunks_per_file": 1},
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert isinstance(data, list)
 
     @pytest.mark.usefixtures("_mcp_env")
-    async def test_get_similar_with_wait_for_drain(self) -> None:
+    async def test_get_similar_with_wait_for_pending_writes(self) -> None:
         server = make_server()
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 "get_similar",
-                {"path": "simple.md", "wait_for_drain": True},
+                {"path": "simple.md", "wait_for_pending_writes": True},
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        assert isinstance(envelope["data"], list)
+        assert _meta_stale(result) is False
+        assert isinstance(_parse_tool_data(result), list)
 
 
 class TestRecentTool:
@@ -1670,9 +1647,8 @@ class TestContextTool:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert data["path"] == "index.md"
         assert data["title"] == "Index"
         assert "modified_at" in data
@@ -1689,12 +1665,10 @@ class TestContextTool:
         server = make_server()
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
-            envelope = _parse_tool_data(
-                await client.call_tool("get_context", {"path": "index.md"})
-            )
+            ctx_result = await client.call_tool("get_context", {"path": "index.md"})
             read = (await client.call_tool("read", {"path": "index.md"})).data
-        assert envelope["stale"] is False
-        ctx = envelope["data"]
+        assert _meta_stale(ctx_result) is False
+        ctx = _parse_tool_data(ctx_result)
         assert ctx["modified_at"] == read["modified_at"]
 
     @pytest.mark.usefixtures("_mcp_env_context")
@@ -1704,9 +1678,8 @@ class TestContextTool:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "notes/topic.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         sources = [b["source_path"] for b in data["backlinks"]]
         assert "index.md" in sources
 
@@ -1717,9 +1690,8 @@ class TestContextTool:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         targets = [o["target_path"] for o in data["outlinks"]]
         assert "notes/topic.md" in targets
 
@@ -1730,9 +1702,8 @@ class TestContextTool:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "notes/topic.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert "notes/topic.md" not in data["folder_notes"]
         assert "notes/peer.md" in data["folder_notes"]
 
@@ -1743,9 +1714,8 @@ class TestContextTool:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert "tags" in data["tags"]
         assert "ai" in data["tags"]["tags"]
         assert "research" in data["tags"]["tags"]
@@ -1757,9 +1727,8 @@ class TestContextTool:
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool("get_context", {"path": "index.md"})
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        data = envelope["data"]
+        assert _meta_stale(result) is False
+        data = _parse_tool_data(result)
         assert data["similar"] == []
 
     @pytest.mark.usefixtures("_mcp_env_context")
@@ -1780,17 +1749,16 @@ class TestContextTool:
         assert "get_context" in names
 
     @pytest.mark.usefixtures("_mcp_env_context")
-    async def test_get_context_with_wait_for_drain(self) -> None:
+    async def test_get_context_with_wait_for_pending_writes(self) -> None:
         server = make_server()
         async with Client(server) as client:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 "get_context",
-                {"path": "index.md", "wait_for_drain": True},
+                {"path": "index.md", "wait_for_pending_writes": True},
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
-        assert envelope["data"]["path"] == "index.md"
+        assert _meta_stale(result) is False
+        assert _parse_tool_data(result)["path"] == "index.md"
 
 
 # ---------------------------------------------------------------------------
@@ -3137,8 +3105,13 @@ class TestGitToolsUntilParam:
         assert past_data["total"] == 0
 
 
-class TestB3StaleSignal:
-    """Tests for the writer-state staleness signal on B3 tools (#534)."""
+class TestIndexStaleSignal:
+    """Tests for the writer-state staleness signal carried in ``_meta``.
+
+    Index-querying read tools surface freshness out-of-band as
+    ``result.meta["index_stale"]`` rather than wrapping the payload in a
+    ``{stale, data}`` envelope (#534, #641, #645).
+    """
 
     @pytest.fixture
     def _mcp_env_linked(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3181,13 +3154,12 @@ class TestB3StaleSignal:
                 # Clear the sentinel so subsequent tests are not affected
                 # by leaked dirty-set state.
                 col._coordinator.writer.drain_dirty_paths()
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is True
-        # The data is still returned despite stale=True.
-        assert isinstance(envelope["data"], list)
+        assert _meta_stale(result) is True
+        # The data is still returned despite index_stale=True.
+        assert isinstance(_parse_tool_data(result), list)
 
     @pytest.mark.usefixtures("_mcp_env_linked")
-    async def test_wait_for_drain_clears_stale_when_writer_idle(
+    async def test_wait_for_pending_writes_clears_stale_when_writer_idle(
         self,
     ) -> None:
         server = make_server()
@@ -3195,13 +3167,12 @@ class TestB3StaleSignal:
             await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 "get_backlinks",
-                {"path": "notes/topic.md", "wait_for_drain": True},
+                {"path": "notes/topic.md", "wait_for_pending_writes": True},
             )
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is False
+        assert _meta_stale(result) is False
 
     @pytest.mark.usefixtures("_mcp_env_linked")
-    async def test_wait_for_drain_timeout_reports_stale_true(
+    async def test_wait_for_pending_writes_timeout_reports_stale_true(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from markdown_vault_mcp._server_deps import get_vault_singleton
@@ -3215,32 +3186,67 @@ class TestB3StaleSignal:
             try:
                 result = await client.call_tool(
                     "get_backlinks",
-                    {"path": "notes/topic.md", "wait_for_drain": True},
+                    {"path": "notes/topic.md", "wait_for_pending_writes": True},
                 )
             finally:
                 col._coordinator.writer.drain_dirty_paths()
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is True
-        assert isinstance(envelope["data"], list)
+        assert _meta_stale(result) is True
+        assert isinstance(_parse_tool_data(result), list)
+
+    @pytest.mark.usefixtures("_mcp_env_linked")
+    async def test_stale_true_when_generation_advances(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A write that completes inside the read window (write_generation
+        advances while the writer is idle at entry and exit, and no
+        wait_for_pending_writes is requested) flips index_stale True via the middle
+        observation point — the only one the dirty-path tests cannot exercise
+        because a non-empty dirty set short-circuits the OR on is_drained."""
+        import itertools
+
+        from markdown_vault_mcp._server_deps import get_vault_singleton
+
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            col = get_vault_singleton()
+            # Drained writer + no wait ⇒ observations 1 and 3 are both False;
+            # advancing the generation counter on every read makes gen_before
+            # differ from the post-read snapshot, so only observation 2 decides.
+            counter = itertools.count()
+            monkeypatch.setattr(col.index, "write_generation", lambda: next(counter))
+            result = await client.call_tool("get_backlinks", {"path": "notes/topic.md"})
+        assert _meta_stale(result) is True
 
     @pytest.mark.usefixtures("_mcp_env_linked")
     @pytest.mark.parametrize(
-        ("tool_name", "tool_args"),
+        ("tool_name", "tool_args", "expected_type"),
         [
-            ("get_backlinks", {"path": "notes/topic.md"}),
-            ("get_outlinks", {"path": "notes/topic.md"}),
-            ("get_similar", {"path": "notes/topic.md"}),
-            ("get_context", {"path": "notes/topic.md"}),
+            ("search", {"query": "topic"}, list),
+            ("list_documents", {}, list),
+            ("list_folders", {}, list),
+            ("list_tags", {}, list),
+            ("stats", {}, dict),
+            ("get_recent", {}, list),
+            ("get_broken_links", {}, list),
+            ("get_orphan_notes", {}, list),
+            ("get_most_linked", {}, list),
+            ("get_backlinks", {"path": "notes/topic.md"}, list),
+            ("get_outlinks", {"path": "notes/topic.md"}, list),
+            ("get_similar", {"path": "notes/topic.md"}, list),
+            ("get_context", {"path": "notes/topic.md"}, dict),
             (
                 "get_connection_path",
                 {"source": "notes/topic.md", "target": "index.md"},
+                dict,
             ),
         ],
     )
-    async def test_stale_true_uniform_across_b3_tools(
-        self, tool_name: str, tool_args: dict[str, str]
+    async def test_index_stale_true_uniform_across_index_tools(
+        self, tool_name: str, tool_args: dict[str, str], expected_type: type
     ) -> None:
-        """Each B3 tool independently ORs stale; catch copy-paste regressions."""
+        """Every index-querying tool independently surfaces index_stale in
+        ``_meta``; catch copy-paste regressions across the whole set."""
         from markdown_vault_mcp._server_deps import get_vault_singleton
 
         server = make_server()
@@ -3252,9 +3258,147 @@ class TestB3StaleSignal:
                 result = await client.call_tool(tool_name, tool_args)
             finally:
                 col._coordinator.writer.drain_dirty_paths()
-        envelope = _parse_tool_data(result)
-        assert envelope["stale"] is True
-        assert "data" in envelope
+        assert _meta_stale(result) is True
+        # The bare payload is still delivered (correct top-level type, never a
+        # {stale, data} envelope) alongside the staleness signal.
+        data = _parse_tool_data(result)
+        assert isinstance(data, expected_type)
+        assert not (isinstance(data, dict) and "stale" in data and "data" in data)
+
+
+# ---------------------------------------------------------------------------
+# wait_for_pending_writes + _meta staleness on search and B2 tools (#641, #645)
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForDrainDirect:
+    """search and B2 tools accept wait_for_pending_writes and return BARE data, with
+    freshness surfaced out-of-band via ``result.meta["index_stale"]`` rather
+    than a ``{stale, data}`` envelope (#641, #645)."""
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_search_wait_for_pending_writes_returns_bare_list_fresh(self) -> None:
+        """search returns a bare list; drained writer ⇒ index_stale False."""
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "search", {"query": "simple", "wait_for_pending_writes": True}
+            )
+        data = _parse_tool_data(result)
+        assert isinstance(data, list)
+        # Payload is NOT wrapped in a stale/data envelope.
+        assert not (isinstance(data, dict) and "stale" in data and "data" in data)
+        assert _meta_stale(result) is False
+
+    @pytest.mark.usefixtures("_mcp_env")
+    @pytest.mark.parametrize(
+        ("tool_name", "tool_args", "expected_type"),
+        [
+            ("list_documents", {}, list),
+            ("list_folders", {}, list),
+            ("list_tags", {}, list),
+            ("stats", {}, dict),
+            ("get_recent", {}, list),
+            ("get_broken_links", {}, list),
+            ("get_orphan_notes", {}, list),
+            ("get_most_linked", {}, list),
+        ],
+    )
+    async def test_b2_tools_bare_data_and_meta_fresh(
+        self, tool_name: str, tool_args: dict[str, Any], expected_type: type
+    ) -> None:
+        """B2 tools return bare data + index_stale=False on the drained path.
+
+        The positive ``isinstance(data, expected_type)`` check pins the bare
+        shape: it would fail if a list payload regressed to the FastMCP
+        ``{"result": [...]}`` wrapper not being unwrapped (a dict, not a list).
+        """
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                tool_name, {**tool_args, "wait_for_pending_writes": True}
+            )
+        data = _parse_tool_data(result)
+        assert isinstance(data, expected_type)
+        # Bare payload, never a {stale, data} envelope.
+        assert not (isinstance(data, dict) and "stale" in data and "data" in data)
+        assert _meta_stale(result) is False
+
+
+class TestResourceStaleSignal:
+    """MCP resources surface index freshness in the response ``_meta`` field
+    while keeping their contents a bare JSON document (#645)."""
+
+    @pytest.mark.usefixtures("_mcp_env")
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "config://vault",
+            "stats://vault",
+            "tags://vault",
+            "tags://vault/tags",
+            "folders://vault",
+            "recent://vault",
+            "toc://vault/simple.md",
+            "similar://vault/simple.md",
+        ],
+    )
+    async def test_resource_meta_index_stale_false_when_drained(self, uri: str) -> None:
+        """On a drained index every resource reports index_stale=False in _meta
+        and still returns parseable JSON contents."""
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.read_resource_mcp(uri)
+        assert result.meta is not None
+        assert result.meta.get("index_stale") is False
+        # Contents stay a bare JSON document — no envelope — and the declared
+        # application/json MIME type survives the ResourceResult wrapping.
+        assert result.contents[0].mimeType == "application/json"
+        json.loads(result.contents[0].text)
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_resource_meta_index_stale_true_when_writer_dirty(self) -> None:
+        """A non-idle writer flips index_stale True in the resource _meta."""
+        from markdown_vault_mcp._server_deps import get_vault_singleton
+
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            col = get_vault_singleton()
+            col._coordinator.writer.mark_dirty(["sentinel.md"])
+            try:
+                result = await client.read_resource_mcp("stats://vault")
+            finally:
+                col._coordinator.writer.drain_dirty_paths()
+        assert result.meta is not None
+        assert result.meta.get("index_stale") is True
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_resource_index_stale_true_when_generation_advances(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A write that completes inside the read window (write_generation
+        advances while the writer is idle at entry and exit) flips index_stale
+        True via the generation-counter observation point — the resource case."""
+        import itertools
+
+        from markdown_vault_mcp._server_deps import get_vault_singleton
+
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            col = get_vault_singleton()
+            # Writer stays drained (is_drained True); advancing the generation
+            # counter on every read makes gen_before != the post-read snapshot,
+            # isolating the middle observation point.
+            counter = itertools.count()
+            monkeypatch.setattr(col.index, "write_generation", lambda: next(counter))
+            result = await client.read_resource_mcp("stats://vault")
+        assert result.meta is not None
+        assert result.meta.get("index_stale") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Index staleness was either **absent** (`search`, B2 tools, resources) or wrapped in a `{stale, data}` **envelope** (B3 tools). The envelope conflated response metadata with domain data, added wrapper noise on every fresh read (~99% of calls), and couldn't extend to resources without breaking their bare-JSON contract.

This moves staleness to MCP's dedicated **out-of-band `_meta` channel**. Every index-querying read tool now returns its **bare payload** and reports freshness in `result._meta.index_stale` via FastMCP `ToolResult(meta=)`. The data payload is identical whether fresh or stale, so the 99% of clients that don't care read it unchanged; the ~1% that need a fresh-read guarantee inspect `result._meta.index_stale` (or pass `wait_for_pending_writes=true` to block until pending writes are indexed).

### Design decision

The reframe: index staleness is **metadata about the response**, not part of the answer. The envelope conflated the two; MCP's `_meta` is the right home, and crucially it works for resources too (which can't carry a `{stale, data}` envelope). Picked over "block by default" and "split by staleness source" after weighing the trade-offs.

### Changes

- **Tools** (`search`; B2: `list_documents`, `list_folders`, `list_tags`, `stats`, `get_recent`, `get_broken_links`, `get_orphan_notes`, `get_most_linked`; B3: `get_backlinks`, `get_outlinks`, `get_similar`, `get_context`, `get_connection_path`) — bare payload + `_meta.index_stale`; all accept `wait_for_pending_writes`. The `{stale, data}` envelope on B3 tools is **retired** — one uniform staleness model.
- **LLM-facing parameter renamed** `wait_for_drain` → **`wait_for_pending_writes`** with a client-facing description (the opaque "drain" name leaked internal state). The internal `IndexFacet.wait_for_drain()` / coordinator method and `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` env var keep the "drain" vocabulary.
- **Resources** (`config://`, `stats://`, `tags://`, `tags://{field}`, `folders://`, `toc://`, `similar://`, `recent://`) — bare JSON contents + `_meta.index_stale` via `ResourceResult(meta=)`, readable through `read_resource_mcp(uri).meta`. Bodies wrapped in explicit `application/json` `ResourceContent` so the declared MIME type survives (a bare `str` would default to `text/plain`).
- Shared helpers `_staleness_result()` / `_stale_resource()`. `index_stale` ORs three signals: the wait timed out, `write_generation` advanced during the read, or non-idle writer at response time.
- Built-in prompts (`propose-links.md`, `related.md`) updated to read bare payloads instead of the removed envelope.
- Docs (`design.md`, `README`, `docs/tools`, `docs/resources`, `docs/configuration`) updated in lockstep.

## Test plan

- [x] New `TestIndexStaleSignal` (parametrized `index_stale=True` across all 14 index tools + `write_generation`-advance isolation test), `TestWaitForDrainDirect` (search + 8 B2 tools, positive bare-shape `isinstance` checks), `TestResourceStaleSignal` (8 resources fresh + MIME assertion + dirty-writer + generation-advance). All B3 envelope tests migrated to `_meta_stale()`.
- [x] Full suite: **1995 passed**, 0 failures.
- [x] `ruff check` + `ruff format --check` + `mypy` clean. Patch coverage 100%.
- [x] Four-round local five-lens review (preflight-circus) — clean.

Note: CI flake on Python 3.12 (`test_foreground_write_during_background_scan_on_disk`, passes on 3.11/3.13/3.14) is unrelated to this change — tracked in #647.

Closes #641, closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)