### PR TITLE
test: sync on wait_for_drain in foreground-write race test (fixes #647)

### DIFF
--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -817,6 +817,13 @@ def test_foreground_write_during_background_scan_on_disk(tmp_path: Path) -> None
       2. racy.md row exists in FTS.
       3. NO assertion on which content wins. Last-writer-wins per path
          is the accepted contract; staleness is corrected by next reindex.
+
+    ``write()`` indexes asynchronously: it marks the path dirty and enqueues a
+    ProcessDirtyPaths job on the single-owner writer. ``wait_until_queryable``
+    only fires on the *build's* done-event — when that job is queued behind the
+    BuildIndex, it can still be pending when the build becomes queryable, so the
+    write is not yet in FTS. Sync on ``wait_for_drain`` (writer queue empty) to
+    observe the foreground write, not just the build (#647).
     """
     vault = tmp_path / "vault"
     vault.mkdir()
@@ -828,6 +835,9 @@ def test_foreground_write_during_background_scan_on_disk(tmp_path: Path) -> None
     col.index.start_background_build_index()
     col.writer.write("racy.md", "# Racy\n\nFOREGROUND CONTENT\n")
     col.index.wait_until_queryable(timeout=10.0)
+    # The build is queryable, but the foreground write's index job may still be
+    # in flight — wait for the writer to drain before asserting FTS membership.
+    assert col.index.wait_for_drain(timeout=10.0)
 
     rows = {r["path"]: r for r in col._fts.list_notes()}
     assert "racy.md" in rows, "foreground write must end up in FTS"


### PR DESCRIPTION
## Summary

`test_foreground_write_during_background_scan_on_disk` was flaky — it failed on **Python 3.12** in CI (PR #646 run) while passing on 3.11/3.13/3.14.

## Root cause

The test asserted the foreground write landed in FTS after only `wait_until_queryable`, which fires on the background **BUILD's** done-event. But `write()` indexes **asynchronously**: it marks the path dirty and enqueues a separate `ProcessDirtyPaths` job on the single-owner writer (#559). When that job is queued behind the `BuildIndex`, it can still be pending when the build becomes queryable — so `col._fts.list_notes()` reads before `racy.md` is indexed.

**Not a production bug.** The write *is* indexed once the writer drains, and the `_meta.index_stale` / `wait_for_pending_writes` signal from #645 covers the read-before-drain case for clients. The test simply synchronized on the wrong primitive.

## Fix

Wait on `wait_for_drain` (writer queue empty) before asserting FTS membership, in addition to `wait_until_queryable`.

## Verification

- **Reproduced deterministically**: forcing `BuildIndex`-first submission order + a slowed `process_dirty_paths` makes the assertion fail without the fix (`is_drained=False, racy.md present=False` after `wait_until_queryable`).
- The **fixed** test passes **8/8** under that same forced window (proving the fix addresses the race, not timing luck), **15/15** normally, and the full `test_background_fts.py` (54 tests) passes.

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)