### PR TITLE
fix(embeddings): throttle build_embeddings progress logging to deciles (#311)

### DIFF
--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -513,15 +514,34 @@ class IndexManager:
         if vectors is None:
             raise ValueError("Vector index unexpectedly None after initialisation")
         total = len(texts)
+        # Per-batch detail at DEBUG (loud, opt-in via -v); INFO carries only a
+        # bounded decile heartbeat with an ETA so operators can track progress
+        # without thousands of lines per build (#311).
+        started = time.monotonic()
+        last_decile = 0
         for start in range(0, total, _EMBEDDING_BATCH_SIZE):
             end = min(start + _EMBEDDING_BATCH_SIZE, total)
             vectors.add(texts[start:end], meta[start:end])
-            logger.info(
+            logger.debug(
                 "build_embeddings: embedded chunks %d-%d of %d",
                 start + 1,
                 end,
                 total,
             )
+            decile = end * 10 // total
+            if decile > last_decile:
+                last_decile = decile
+                elapsed = time.monotonic() - started
+                rate = end / elapsed if elapsed > 0 else 0.0
+                remaining = (total - end) / rate if rate > 0 else 0.0
+                logger.info(
+                    "build_embeddings: %d%% (%d/%d chunks, %.0fs elapsed, ~%.0fs remaining)",
+                    decile * 10,
+                    end,
+                    total,
+                    elapsed,
+                    remaining,
+                )
 
         if total > 0:
             vectors.save(self._embeddings_path)

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -266,6 +267,52 @@ class TestBuildEmbeddings:
         count = mgr.build_embeddings()
         assert count >= 4
         assert vectors_holder["vectors"] is not None
+
+    def test_progress_logging_throttled_and_per_batch_at_debug(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Per-batch embed detail logs at DEBUG; INFO carries only bounded
+        decile progress lines (≤11) plus the final summary (#311)."""
+        from tests.conftest import MockEmbeddingProvider
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        # One doc with 60 H2 sections -> ~60 chunks -> ~15 batches of 4.
+        body = "\n".join(
+            f"## Section {i}\n\nContent for section {i}.\n" for i in range(60)
+        )
+        (vault / "big.md").write_text(f"# Big\n\n{body}\n", encoding="utf-8")
+
+        holder: dict = {"vectors": None}
+        mgr, _fts, _ = _make_index_mgr(
+            vault,
+            tmp_path,
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=MockEmbeddingProvider(),
+            get_vectors=lambda: holder["vectors"],
+            set_vectors=lambda v: holder.__setitem__("vectors", v),
+        )
+        mgr.build_index()
+        with caplog.at_level(logging.DEBUG, logger="markdown_vault_mcp.managers.index"):
+            total = mgr.build_embeddings()
+        assert total >= 40  # many chunks => many batches
+
+        per_batch = [r for r in caplog.records if "embedded chunks" in r.getMessage()]
+        info_progress = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO
+            and "build_embeddings:" in r.getMessage()
+            and "%" in r.getMessage()
+        ]
+        # Per-batch detail is still emitted, but only at DEBUG.
+        assert per_batch, "per-batch detail should still be logged (at DEBUG)"
+        assert all(r.levelno == logging.DEBUG for r in per_batch)
+        # INFO progress is throttled well below the per-batch count and bounded
+        # by deciles.
+        assert info_progress, "an INFO decile-progress line should be emitted"
+        assert len(info_progress) <= 11
+        assert len(info_progress) < len(per_batch)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`build_embeddings` emitted one INFO line per batch of 4 chunks — **~4,100 lines** for the deployed 16,457-chunk vault, flooding `docker logs` during a cold-start build (observed live while validating #513).

## Change — three-tier logging

- **Per-batch detail → `DEBUG`.** The loud firehose is still available on demand via `-v` / `FASTMCP_LOG_LEVEL=DEBUG` when debugging a stuck/slow build (preserves "loud over silent").
- **INFO progress heartbeat at each 10% decile**, with count + elapsed + ETA — `≤11` lines for any vault size, conveying both *how far* and *still alive*:
  ```
  build_embeddings: 30% (4937/16457 chunks, 360s elapsed, ~840s remaining)
  ```
- **Final summary INFO** unchanged.

Net at default INFO: **~12 lines instead of ~4,100**, with progress still visible.

## Test plan

- [x] New `test_progress_logging_throttled_and_per_batch_at_debug` (60-section doc → 15 batches): asserts per-batch lines are DEBUG-only, INFO progress lines are present, bounded (`≤11`), and fewer than the per-batch count. Confirmed RED before the change (15 INFO per-batch lines), GREEN after.
- [x] Full suite: **1996 passed**.
- [x] ruff + mypy clean.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)