### PR TITLE
refactor(config): strict fail-fast validation + canonical ConfigurationError (#638 PR1)

### DIFF
--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -28,4 +28,10 @@ All exceptions inherit from `MarkdownMCPError`, so callers can catch the base cl
 
 ## Configuration Errors
 
-::: markdown_vault_mcp.exceptions.ConfigurationError
+`markdown_vault_mcp.exceptions.ConfigurationError` is re-exported from
+[`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the shared
+base library across the `*-mcp` server series — so the whole ecosystem raises one
+canonical config error. It is raised for invalid or out-of-range configuration at
+startup (e.g. a non-numeric env var, a value outside its documented range, or a
+missing required variable). Unlike the other exceptions on this page it is **not**
+a subclass of `MarkdownMCPError`.

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -6,7 +6,7 @@ All exceptions are importable from the top-level `markdown_vault_mcp` package.
 from markdown_vault_mcp import DocumentNotFoundError, ReadOnlyError
 ```
 
-All exceptions inherit from `MarkdownMCPError`, so callers can catch the base class to handle any library error.
+Most exceptions inherit from `MarkdownMCPError`, so callers can catch the base class to handle any library error. The one exception is `ConfigurationError`, which is re-exported from `fastmcp-pvl-core` and is **not** a `MarkdownMCPError` subclass (see [Configuration Errors](#configuration-errors)) — startup config failures are meant to fail hard rather than be caught by a library-error handler.
 
 ## Base Exception
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,9 @@
 
 All configuration is via environment variables. Most use the `MARKDOWN_VAULT_MCP_` prefix. `OLLAMA_HOST` and `OPENAI_API_KEY` are bare ecosystem-standard names; all other variables use the `MARKDOWN_VAULT_MCP_` prefix.
 
+!!! note "Configuration is validated at startup"
+    Numeric variables are validated against the **Type** column below (e.g. `int ≥ 1`). A non-numeric or out-of-range value makes the server **fail fast** at startup with a `ConfigurationError` naming the offending setting, rather than silently falling back to a default — so a typo in an env var surfaces immediately instead of producing surprising behavior later.
+
 ## Core
 
 | Variable | Type | Default | Required | Description |

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -25,6 +25,7 @@ from markdown_vault_mcp.config_sections import (
     TransferConfig,
 )
 from markdown_vault_mcp.config_sections._helpers import env as _env
+from markdown_vault_mcp.exceptions import ConfigurationError
 from markdown_vault_mcp.git import GitWriteStrategy
 
 logger = logging.getLogger(__name__)
@@ -354,8 +355,8 @@ class VaultConfig:
             A fully populated :class:`VaultConfig` instance.
 
         Raises:
-            ValueError: If ``MARKDOWN_VAULT_MCP_SOURCE_DIR`` is not set, or if a
-                search ranking env var is invalid or out of range.
+            ConfigurationError: If ``MARKDOWN_VAULT_MCP_SOURCE_DIR`` is not set,
+                or if a search-ranking env var is non-numeric or out of range.
 
         Example::
 
@@ -366,8 +367,8 @@ class VaultConfig:
         """
         raw_source_dir = (_env(prefix, "SOURCE_DIR") or "").strip()
         if not raw_source_dir:
-            raise ValueError(
-                "MARKDOWN_VAULT_MCP_SOURCE_DIR is required but not set. "
+            raise ConfigurationError(
+                f"{prefix}_SOURCE_DIR is required but not set. "
                 "Set it to the path of your markdown vault."
             )
         source_dir = Path(raw_source_dir)

--- a/src/markdown_vault_mcp/config_sections/_helpers.py
+++ b/src/markdown_vault_mcp/config_sections/_helpers.py
@@ -6,8 +6,6 @@ import these without a cycle.
 
 from __future__ import annotations
 
-import logging
-
 from fastmcp_pvl_core import (
     env as _core_env,
 )
@@ -17,8 +15,6 @@ from fastmcp_pvl_core import (
 from fastmcp_pvl_core import (
     env_int as _core_env_int,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def env(prefix: str, name: str, default: str | None = None) -> str | None:
@@ -51,27 +47,3 @@ def env_float(prefix: str, name: str, default: float) -> float:
 def opt_int(prefix: str, name: str) -> int | None:
     """Read a strict optional int env var (``None`` when unset); raise on invalid."""
     return _core_env_int(prefix, name, None, strict=True)
-
-
-def parse_int_env(prefix: str, name: str, default: int) -> int:
-    """Read an int env var; warn-and-default on absence/parse error."""
-    raw = (env(prefix, name) or "").strip()
-    if not raw:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        logger.warning("invalid %s_%s=%r, using default %s", prefix, name, raw, default)
-        return default
-
-
-def parse_float_env(prefix: str, name: str, default: float) -> float:
-    """Read a float env var; warn-and-default on absence/parse error."""
-    raw = (env(prefix, name) or "").strip()
-    if not raw:
-        return default
-    try:
-        return float(raw)
-    except ValueError:
-        logger.warning("invalid %s_%s=%r, using default %s", prefix, name, raw, default)
-        return default

--- a/src/markdown_vault_mcp/config_sections/_helpers.py
+++ b/src/markdown_vault_mcp/config_sections/_helpers.py
@@ -8,7 +8,15 @@ from __future__ import annotations
 
 import logging
 
-from fastmcp_pvl_core import env as _core_env
+from fastmcp_pvl_core import (
+    env as _core_env,
+)
+from fastmcp_pvl_core import (
+    env_float as _core_env_float,
+)
+from fastmcp_pvl_core import (
+    env_int as _core_env_int,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +24,33 @@ logger = logging.getLogger(__name__)
 def env(prefix: str, name: str, default: str | None = None) -> str | None:
     """Read ``{prefix}_{name}`` (whitespace-stripped, empty-as-unset)."""
     return _core_env(prefix, name, default=default)
+
+
+def env_int(prefix: str, name: str, default: int) -> int:
+    """Read a strict int env var; raise ``ConfigurationError`` on invalid input.
+
+    Returns *default* when unset. Range validation lives in each sub-config's
+    ``__post_init__`` so direct construction is validated too (#638).
+    """
+    value = _core_env_int(prefix, name, default, strict=True)
+    # A non-None default under strict=True never resolves to None (unset →
+    # default; set → parsed int or raise); the guard only narrows the type.
+    return value if value is not None else default
+
+
+def env_float(prefix: str, name: str, default: float) -> float:
+    """Read a strict float env var; raise ``ConfigurationError`` on invalid input.
+
+    Returns *default* when unset. Range validation lives in each sub-config's
+    ``__post_init__`` (#638).
+    """
+    value = _core_env_float(prefix, name, default, strict=True)
+    return value if value is not None else default
+
+
+def opt_int(prefix: str, name: str) -> int | None:
+    """Read a strict optional int env var (``None`` when unset); raise on invalid."""
+    return _core_env_int(prefix, name, None, strict=True)
 
 
 def parse_int_env(prefix: str, name: str, default: int) -> int:

--- a/src/markdown_vault_mcp/config_sections/content.py
+++ b/src/markdown_vault_mcp/config_sections/content.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from markdown_vault_mcp.exceptions import ConfigurationError
 
 
 @dataclass(frozen=True)
@@ -19,14 +18,32 @@ class ContentConfig:
     templates_folder: str = "_templates"
     prompts_folder: str | None = None
 
+    def __post_init__(self) -> None:
+        """Validate non-negative size limits on every construction path (#638).
+
+        ``0`` is a valid sentinel for "unlimited"; only negative values are
+        rejected.
+
+        Raises:
+            ConfigurationError: If ``max_attachment_size_mb`` or
+                ``max_note_read_bytes`` is negative.
+        """
+        if self.max_attachment_size_mb < 0:
+            raise ConfigurationError(
+                "max_attachment_size_mb must be >= 0, got "
+                f"{self.max_attachment_size_mb}"
+            )
+        if self.max_note_read_bytes < 0:
+            raise ConfigurationError(
+                f"max_note_read_bytes must be >= 0, got {self.max_note_read_bytes}"
+            )
+
     @classmethod
     def from_env(cls, prefix: str, source_dir: Path) -> ContentConfig:
         """Construct ContentConfig by reading ``{prefix}_*`` env vars.
 
-        Invalid ``MAX_ATTACHMENT_SIZE_MB``/``MAX_NOTE_READ_BYTES`` values
-        warn and reset to the default.  ``TEMPLATES_FOLDER`` has backslash and
-        trailing-slash normalization applied.  ``PROMPTS_FOLDER`` is joined to
-        ``source_dir`` when relative.
+        ``TEMPLATES_FOLDER`` has backslash and trailing-slash normalization
+        applied. ``PROMPTS_FOLDER`` is joined to ``source_dir`` when relative.
 
         Args:
             prefix: Env var prefix, e.g. ``"MARKDOWN_VAULT_MCP"``.
@@ -34,12 +51,14 @@ class ContentConfig:
 
         Returns:
             Populated ContentConfig with defaults for unset vars.
+
+        Raises:
+            ConfigurationError: If ``MAX_ATTACHMENT_SIZE_MB`` /
+                ``MAX_NOTE_READ_BYTES`` is non-numeric or negative.
         """
         from fastmcp_pvl_core import parse_list
 
-        from markdown_vault_mcp.config_sections._helpers import (
-            env,
-        )
+        from markdown_vault_mcp.config_sections._helpers import env, env_float, env_int
 
         # --- attachment_extensions ---
         raw_exts = (env(prefix, "ATTACHMENT_EXTENSIONS") or "").strip()
@@ -49,48 +68,6 @@ class ContentConfig:
             attachment_extensions = ["*"]
         else:
             attachment_extensions = parse_list(raw_exts) or None
-
-        # --- max_attachment_size_mb ---
-        raw_max_att = (env(prefix, "MAX_ATTACHMENT_SIZE_MB") or "").strip()
-        if raw_max_att:
-            try:
-                max_attachment_size_mb = float(raw_max_att)
-            except ValueError:
-                logger.warning(
-                    "from_env: invalid MAX_ATTACHMENT_SIZE_MB=%r, using default 1.0",
-                    raw_max_att,
-                )
-                max_attachment_size_mb = 1.0
-            else:
-                if max_attachment_size_mb < 0:
-                    logger.warning(
-                        "from_env: MAX_ATTACHMENT_SIZE_MB=%r is negative, using default 1.0",
-                        max_attachment_size_mb,
-                    )
-                    max_attachment_size_mb = 1.0
-        else:
-            max_attachment_size_mb = 1.0
-
-        # --- max_note_read_bytes ---
-        raw_max_note = (env(prefix, "MAX_NOTE_READ_BYTES") or "").strip()
-        if raw_max_note:
-            try:
-                max_note_read_bytes = int(raw_max_note)
-            except ValueError:
-                logger.warning(
-                    "from_env: invalid MAX_NOTE_READ_BYTES=%r, using default 262144",
-                    raw_max_note,
-                )
-                max_note_read_bytes = 262144
-            else:
-                if max_note_read_bytes < 0:
-                    logger.warning(
-                        "from_env: MAX_NOTE_READ_BYTES=%r is negative, using default 262144",
-                        max_note_read_bytes,
-                    )
-                    max_note_read_bytes = 262144
-        else:
-            max_note_read_bytes = 262144
 
         # --- templates_folder ---
         raw_templates = (env(prefix, "TEMPLATES_FOLDER") or "").strip()
@@ -108,8 +85,8 @@ class ContentConfig:
 
         return cls(
             attachment_extensions=attachment_extensions,
-            max_attachment_size_mb=max_attachment_size_mb,
-            max_note_read_bytes=max_note_read_bytes,
+            max_attachment_size_mb=env_float(prefix, "MAX_ATTACHMENT_SIZE_MB", 1.0),
+            max_note_read_bytes=env_int(prefix, "MAX_NOTE_READ_BYTES", 262144),
             templates_folder=templates_folder,
             prompts_folder=prompts_folder,
         )

--- a/src/markdown_vault_mcp/config_sections/embeddings.py
+++ b/src/markdown_vault_mcp/config_sections/embeddings.py
@@ -20,9 +20,11 @@ class EmbeddingsConfig:
     fastembed_cache_dir: str | None = None
 
     def __post_init__(self) -> None:
-        """Normalize ollama_host: non-empty, no trailing slash."""
+        """Normalize ollama_host and openai_base_url: non-empty, no trailing slash."""
         host = (self.ollama_host or "http://localhost:11434").rstrip("/")
         object.__setattr__(self, "ollama_host", host)
+        base = (self.openai_base_url or "https://api.openai.com/v1").rstrip("/")
+        object.__setattr__(self, "openai_base_url", base)
 
     @classmethod
     def from_env(cls, prefix: str) -> EmbeddingsConfig:
@@ -61,7 +63,7 @@ class EmbeddingsConfig:
             ollama_model=env(prefix, "OLLAMA_MODEL") or "nomic-embed-text",
             ollama_cpu_only=parse_bool(raw_cpu) if raw_cpu is not None else False,
             openai_api_key=(os.environ.get("OPENAI_API_KEY") or "").strip() or None,
-            openai_base_url=openai_base_url.rstrip("/"),
+            openai_base_url=openai_base_url,
             openai_embedding_model=openai_model,
             fastembed_model=env(prefix, "FASTEMBED_MODEL") or "BAAI/bge-small-en-v1.5",
             fastembed_cache_dir=env(prefix, "FASTEMBED_CACHE_DIR") or None,

--- a/src/markdown_vault_mcp/config_sections/git.py
+++ b/src/markdown_vault_mcp/config_sections/git.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 
 from fastmcp_pvl_core import parse_bool
 
-logger = logging.getLogger(__name__)
+from markdown_vault_mcp.exceptions import ConfigurationError
 
 
 @dataclass(frozen=True)
@@ -25,6 +24,22 @@ class GitConfig:
     lfs: bool = True
     pull_interval_s: int = 600
 
+    def __post_init__(self) -> None:
+        """Validate non-negative sync cadences on every construction path (#638).
+
+        Raises:
+            ConfigurationError: If ``push_delay_s`` or ``pull_interval_s`` is
+                negative.
+        """
+        if self.push_delay_s < 0:
+            raise ConfigurationError(
+                f"push_delay_s must be >= 0, got {self.push_delay_s}"
+            )
+        if self.pull_interval_s < 0:
+            raise ConfigurationError(
+                f"pull_interval_s must be >= 0, got {self.pull_interval_s}"
+            )
+
     @classmethod
     def from_env(cls, prefix: str) -> GitConfig:
         """Construct GitConfig by reading ``{prefix}_GIT_*`` env vars.
@@ -34,36 +49,24 @@ class GitConfig:
 
         Returns:
             Populated GitConfig with defaults for unset vars.
+
+        Raises:
+            ConfigurationError: If ``GIT_PUSH_DELAY_S``/``GIT_PULL_INTERVAL_S``
+                is non-numeric or negative.
         """
-        from markdown_vault_mcp.config_sections._helpers import env, parse_float_env
-
-        push_delay_s = parse_float_env(prefix, "GIT_PUSH_DELAY_S", 30.0)
-
-        raw_pull = (env(prefix, "GIT_PULL_INTERVAL_S") or "").strip()
-        pull_interval_s = 600
-        if raw_pull:
-            try:
-                pull_interval_s = int(raw_pull)
-            except ValueError:
-                logger.warning("invalid GIT_PULL_INTERVAL_S=%r, using 600", raw_pull)
-            else:
-                if pull_interval_s < 0:
-                    logger.warning(
-                        "negative GIT_PULL_INTERVAL_S=%r, clamping to 0", raw_pull
-                    )
-                    pull_interval_s = 0
+        from markdown_vault_mcp.config_sections._helpers import env, env_float, env_int
 
         raw_lfs = env(prefix, "GIT_LFS")
         return cls(
             token=env(prefix, "GIT_TOKEN") or None,
             repo_url=env(prefix, "GIT_REPO_URL") or None,
             username=env(prefix, "GIT_USERNAME") or "x-access-token",
-            push_delay_s=push_delay_s,
+            push_delay_s=env_float(prefix, "GIT_PUSH_DELAY_S", 30.0),
             commit_name=env(prefix, "GIT_COMMIT_NAME") or "markdown-vault-mcp",
             commit_email=env(prefix, "GIT_COMMIT_EMAIL")
             or "noreply@markdown-vault-mcp",
             commit_name_claim=env(prefix, "GIT_COMMIT_NAME_CLAIM") or None,
             commit_email_claim=env(prefix, "GIT_COMMIT_EMAIL_CLAIM") or None,
             lfs=parse_bool(raw_lfs) if raw_lfs is not None else True,
-            pull_interval_s=pull_interval_s,
+            pull_interval_s=env_int(prefix, "GIT_PULL_INTERVAL_S", 600),
         )

--- a/src/markdown_vault_mcp/config_sections/search.py
+++ b/src/markdown_vault_mcp/config_sections/search.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from markdown_vault_mcp.exceptions import ConfigurationError
+
 
 @dataclass(frozen=True)
 class SearchConfig:
@@ -15,103 +17,61 @@ class SearchConfig:
     max_chunk_words: int = 400
     max_chunk_chars_override: int | None = None
 
+    def __post_init__(self) -> None:
+        """Validate ranges on every construction path (#638).
+
+        Raises:
+            ConfigurationError: If any field is out of range.
+        """
+        if self.chunks_per_file < 1:
+            raise ConfigurationError(
+                f"chunks_per_file must be >= 1, got {self.chunks_per_file}"
+            )
+        if self.snippet_words < 0:
+            raise ConfigurationError(
+                f"snippet_words must be >= 0, got {self.snippet_words}"
+            )
+        if self.length_downweight_alpha < 0:
+            raise ConfigurationError(
+                "length_downweight_alpha must be >= 0, got "
+                f"{self.length_downweight_alpha}"
+            )
+        if self.max_chunk_words < 1:
+            raise ConfigurationError(
+                f"max_chunk_words must be >= 1, got {self.max_chunk_words}"
+            )
+        if (
+            self.max_chunk_chars_override is not None
+            and self.max_chunk_chars_override < 1
+        ):
+            raise ConfigurationError(
+                f"max_chunk_chars must be >= 1, got {self.max_chunk_chars_override}"
+            )
+
     @classmethod
     def from_env(cls, prefix: str) -> SearchConfig:
         """Construct SearchConfig by reading ``{prefix}_*`` env vars.
-
-        Raises:
-            ValueError: If any search integer/float env var is invalid or
-                out of range.
 
         Args:
             prefix: Env var prefix, e.g. ``"MARKDOWN_VAULT_MCP"``.
 
         Returns:
             Populated SearchConfig with defaults for unset vars.
+
+        Raises:
+            ConfigurationError: If any search integer/float env var is invalid
+                (non-numeric) or out of range.
         """
-        # Only env (not parse_int/float_env): SearchConfig raises on invalid input, not warn-and-default.
-        from markdown_vault_mcp.config_sections._helpers import env
-
-        raw_chunks = (env(prefix, "CHUNKS_PER_FILE") or "").strip()
-        if raw_chunks:
-            try:
-                chunks_per_file = int(raw_chunks)
-            except ValueError as exc:
-                raise ValueError(
-                    f"{prefix}_CHUNKS_PER_FILE must be a positive integer, "
-                    f"got {raw_chunks!r}"
-                ) from exc
-        else:
-            chunks_per_file = 2
-        if chunks_per_file < 1:
-            raise ValueError(
-                f"chunks_per_file must be >= 1, got {chunks_per_file}; set "
-                f"{prefix}_CHUNKS_PER_FILE to a positive integer."
-            )
-
-        raw_snippet = (env(prefix, "SNIPPET_WORDS") or "").strip()
-        if raw_snippet:
-            try:
-                snippet_words = int(raw_snippet)
-            except ValueError as exc:
-                raise ValueError(
-                    f"{prefix}_SNIPPET_WORDS must be a non-negative integer, "
-                    f"got {raw_snippet!r}"
-                ) from exc
-        else:
-            snippet_words = 200
-        if snippet_words < 0:
-            raise ValueError(f"snippet_words must be >= 0, got {snippet_words}")
-
-        raw_alpha = (env(prefix, "LENGTH_DOWNWEIGHT_ALPHA") or "").strip()
-        if raw_alpha:
-            try:
-                alpha = float(raw_alpha)
-            except ValueError as e:
-                raise ValueError(
-                    f"{prefix}_LENGTH_DOWNWEIGHT_ALPHA must be a non-negative "
-                    f"float, got {raw_alpha!r}"
-                ) from e
-            if alpha < 0:
-                raise ValueError(f"length_downweight_alpha must be >= 0, got {alpha}")
-        else:
-            alpha = 0.25
-
-        raw_max_chunk = (env(prefix, "MAX_CHUNK_WORDS") or "").strip()
-        if raw_max_chunk:
-            try:
-                max_chunk_words = int(raw_max_chunk)
-            except ValueError as exc:
-                raise ValueError(
-                    f"{prefix}_MAX_CHUNK_WORDS must be a positive integer, "
-                    f"got {raw_max_chunk!r}"
-                ) from exc
-        else:
-            max_chunk_words = 400
-        if max_chunk_words < 1:
-            raise ValueError(f"max_chunk_words must be >= 1, got {max_chunk_words}")
-
-        raw_max_chars = (env(prefix, "MAX_CHUNK_CHARS") or "").strip()
-        max_chunk_chars_override: int | None
-        if raw_max_chars:
-            try:
-                max_chunk_chars_override = int(raw_max_chars)
-            except ValueError as exc:
-                raise ValueError(
-                    f"{prefix}_MAX_CHUNK_CHARS must be a positive integer, "
-                    f"got {raw_max_chars!r}"
-                ) from exc
-            if max_chunk_chars_override < 1:
-                raise ValueError(
-                    f"max_chunk_chars must be >= 1, got {max_chunk_chars_override}"
-                )
-        else:
-            max_chunk_chars_override = None
+        from markdown_vault_mcp.config_sections._helpers import (
+            env_float,
+            env_int,
+            opt_int,
+        )
 
         return cls(
-            chunks_per_file=chunks_per_file,
-            snippet_words=snippet_words,
-            length_downweight_alpha=alpha,
-            max_chunk_words=max_chunk_words,
-            max_chunk_chars_override=max_chunk_chars_override,
+            chunks_per_file=env_int(prefix, "CHUNKS_PER_FILE", 2),
+            snippet_words=env_int(prefix, "SNIPPET_WORDS", 200),
+            length_downweight_alpha=env_float(prefix, "LENGTH_DOWNWEIGHT_ALPHA", 0.25),
+            max_chunk_words=env_int(prefix, "MAX_CHUNK_WORDS", 400),
+            max_chunk_chars_override=opt_int(prefix, "MAX_CHUNK_CHARS"),
         )

--- a/src/markdown_vault_mcp/config_sections/sync.py
+++ b/src/markdown_vault_mcp/config_sections/sync.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 
-logger = logging.getLogger(__name__)
+from markdown_vault_mcp.exceptions import ConfigurationError
 
 
 @dataclass(frozen=True)
@@ -16,39 +15,39 @@ class SyncConfig:
     file_watcher_debounce_s: float = 2.0
     github_webhook_secret: str | None = None
 
+    def __post_init__(self) -> None:
+        """Validate a positive debounce on every construction path (#638).
+
+        Raises:
+            ConfigurationError: If ``file_watcher_debounce_s`` is not > 0.
+        """
+        if self.file_watcher_debounce_s <= 0:
+            raise ConfigurationError(
+                "file_watcher_debounce_s must be > 0, got "
+                f"{self.file_watcher_debounce_s}"
+            )
+
     @classmethod
     def from_env(cls, prefix: str) -> SyncConfig:
         """Construct SyncConfig by reading ``{prefix}_*`` env vars.
-
-        Invalid ``FILE_WATCHER_DEBOUNCE_S`` values (non-numeric or ``<= 0``)
-        warn and reset to the default ``2.0``.
 
         Args:
             prefix: Env var prefix, e.g. ``"MARKDOWN_VAULT_MCP"``.
 
         Returns:
             Populated SyncConfig with defaults for unset vars.
+
+        Raises:
+            ConfigurationError: If ``FILE_WATCHER_DEBOUNCE_S`` is non-numeric or
+                ``<= 0``.
         """
         from fastmcp_pvl_core import parse_bool
 
-        from markdown_vault_mcp.config_sections._helpers import env
+        from markdown_vault_mcp.config_sections._helpers import env, env_float
 
         raw_fw = env(prefix, "FILE_WATCHER")
-        raw_deb = (env(prefix, "FILE_WATCHER_DEBOUNCE_S") or "").strip()
-        debounce = 2.0
-        if raw_deb:
-            try:
-                debounce = float(raw_deb)
-            except ValueError:
-                logger.warning("invalid FILE_WATCHER_DEBOUNCE_S=%r, using 2.0", raw_deb)
-            else:
-                if debounce <= 0:
-                    logger.warning(
-                        "FILE_WATCHER_DEBOUNCE_S=%r <= 0, using 2.0", raw_deb
-                    )
-                    debounce = 2.0
         return cls(
             file_watcher_enabled=parse_bool(raw_fw) if raw_fw is not None else True,
-            file_watcher_debounce_s=debounce,
+            file_watcher_debounce_s=env_float(prefix, "FILE_WATCHER_DEBOUNCE_S", 2.0),
             github_webhook_secret=env(prefix, "GITHUB_WEBHOOK_SECRET") or None,
         )

--- a/src/markdown_vault_mcp/config_sections/transfer.py
+++ b/src/markdown_vault_mcp/config_sections/transfer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from markdown_vault_mcp.exceptions import ConfigurationError
+
 
 @dataclass(frozen=True)
 class TransferConfig:
@@ -20,33 +22,37 @@ class TransferConfig:
     max_upload_bytes: int = 104857600  # 100 MiB
 
     def __post_init__(self) -> None:
-        """Validate the TTL ordering and positivity invariants at construction."""
+        """Validate the TTL ordering and positivity invariants at construction.
+
+        Raises:
+            ConfigurationError: If any value is out of range or the TTL ordering
+                is violated.
+        """
         if self.ttl_default_s < 1:
-            raise ValueError("ttl_default_s must be >= 1")
+            raise ConfigurationError("ttl_default_s must be >= 1")
         if self.ttl_max_s < self.ttl_default_s:
-            raise ValueError("ttl_max_s must be >= ttl_default_s")
+            raise ConfigurationError("ttl_max_s must be >= ttl_default_s")
         if self.max_upload_bytes < 1:
-            raise ValueError("max_upload_bytes must be >= 1")
+            raise ConfigurationError("max_upload_bytes must be >= 1")
 
     @classmethod
     def from_env(cls, prefix: str) -> TransferConfig:
         """Construct TransferConfig by reading ``{prefix}_TRANSFER_*`` env vars.
-
-        Invalid values warn and fall back to the default; out-of-range values
-        are validated by ``__post_init__`` (raises ``ValueError``).
 
         Args:
             prefix: Env var prefix, e.g. ``"MARKDOWN_VAULT_MCP"``.
 
         Returns:
             Populated TransferConfig with defaults for unset vars.
+
+        Raises:
+            ConfigurationError: If any ``TRANSFER_*`` value is non-numeric or
+                out of range.
         """
-        from markdown_vault_mcp.config_sections._helpers import parse_int_env
+        from markdown_vault_mcp.config_sections._helpers import env_int
 
         return cls(
-            ttl_default_s=parse_int_env(prefix, "TRANSFER_TTL_DEFAULT_S", 3600),
-            ttl_max_s=parse_int_env(prefix, "TRANSFER_TTL_MAX_S", 86400),
-            max_upload_bytes=parse_int_env(
-                prefix, "TRANSFER_MAX_UPLOAD_BYTES", 104857600
-            ),
+            ttl_default_s=env_int(prefix, "TRANSFER_TTL_DEFAULT_S", 3600),
+            ttl_max_s=env_int(prefix, "TRANSFER_TTL_MAX_S", 86400),
+            max_upload_bytes=env_int(prefix, "TRANSFER_MAX_UPLOAD_BYTES", 104857600),
         )

--- a/src/markdown_vault_mcp/config_sections/transfer.py
+++ b/src/markdown_vault_mcp/config_sections/transfer.py
@@ -29,11 +29,18 @@ class TransferConfig:
                 is violated.
         """
         if self.ttl_default_s < 1:
-            raise ConfigurationError("ttl_default_s must be >= 1")
+            raise ConfigurationError(
+                f"ttl_default_s must be >= 1, got {self.ttl_default_s}"
+            )
         if self.ttl_max_s < self.ttl_default_s:
-            raise ConfigurationError("ttl_max_s must be >= ttl_default_s")
+            raise ConfigurationError(
+                f"ttl_max_s must be >= ttl_default_s, got ttl_max_s={self.ttl_max_s} "
+                f"ttl_default_s={self.ttl_default_s}"
+            )
         if self.max_upload_bytes < 1:
-            raise ConfigurationError("max_upload_bytes must be >= 1")
+            raise ConfigurationError(
+                f"max_upload_bytes must be >= 1, got {self.max_upload_bytes}"
+            )
 
     @classmethod
     def from_env(cls, prefix: str) -> TransferConfig:

--- a/src/markdown_vault_mcp/exceptions.py
+++ b/src/markdown_vault_mcp/exceptions.py
@@ -2,6 +2,13 @@
 
 from typing import Literal
 
+# ConfigurationError is owned by fastmcp-pvl-core — the shared base guaranteed
+# across the whole *-mcp server series — and re-exported here as the project's
+# one canonical config error (#638). env_int/env_float(strict=...) raise it,
+# and config validation + git-remote checks raise the same catchable type, so
+# `markdown_vault_mcp.ConfigurationError` and the pvl-core class are identical.
+from fastmcp_pvl_core import ConfigurationError as ConfigurationError
+
 
 class MarkdownMCPError(Exception):
     """Base exception for all markdown-vault-mcp errors."""
@@ -62,10 +69,6 @@ class ConcurrentModificationError(MarkdownMCPError):
             f"Concurrent modification on {path}: "
             f"expected etag {expected!r}, actual {actual!r}"
         )
-
-
-class ConfigurationError(MarkdownMCPError):
-    """Raised for invalid or unsupported configuration at startup."""
 
 
 IndexUnavailableReason = Literal[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,10 @@ from markdown_vault_mcp.config_sections import (
     EmbeddingsConfig,
     GitConfig,
     IndexingConfig,
+    SearchConfig,
     TransferConfig,
 )
+from markdown_vault_mcp.exceptions import ConfigurationError
 
 
 def test_search_ranking_config_defaults(
@@ -64,7 +66,7 @@ def test_search_ranking_config_rejects_zero_chunks_per_file(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE", "0")
 
-    with pytest.raises(ValueError, match="chunks_per_file"):
+    with pytest.raises(ConfigurationError, match="chunks_per_file"):
         VaultConfig.from_env()
 
 
@@ -112,7 +114,7 @@ def test_max_chunk_chars_override_rejects_zero(
     """MAX_CHUNK_CHARS < 1 is rejected like MAX_CHUNK_WORDS."""
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_CHUNK_CHARS", "0")
-    with pytest.raises(ValueError, match="max_chunk_chars"):
+    with pytest.raises(ConfigurationError, match="max_chunk_chars"):
         VaultConfig.from_env()
 
 
@@ -122,7 +124,7 @@ def test_max_chunk_chars_override_rejects_malformed(
     """A non-integer MAX_CHUNK_CHARS raises."""
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_CHUNK_CHARS", "lots")
-    with pytest.raises(ValueError, match="MAX_CHUNK_CHARS"):
+    with pytest.raises(ConfigurationError, match="MAX_CHUNK_CHARS"):
         VaultConfig.from_env()
 
 
@@ -1078,7 +1080,7 @@ def test_search_ranking_config_rejects_malformed_int(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE", "foo")
 
-    with pytest.raises(ValueError, match="MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE"):
+    with pytest.raises(ConfigurationError, match="MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE"):
         VaultConfig.from_env()
 
 
@@ -1089,7 +1091,9 @@ def test_search_ranking_config_rejects_malformed_float(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA", "abc")
 
-    with pytest.raises(ValueError, match="MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA"):
+    with pytest.raises(
+        ConfigurationError, match="MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA"
+    ):
         VaultConfig.from_env()
 
 
@@ -1365,14 +1369,16 @@ class TestSearchConfigFromEnv:
         from markdown_vault_mcp.config_sections import SearchConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE", "0")
-        with pytest.raises(ValueError, match="chunks_per_file"):
+        with pytest.raises(ConfigurationError, match="chunks_per_file"):
             SearchConfig.from_env("MARKDOWN_VAULT_MCP")
 
     def test_chunks_per_file_invalid_raises(self, monkeypatch):
         from markdown_vault_mcp.config_sections import SearchConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE", "nope")
-        with pytest.raises(ValueError, match="MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE"):
+        with pytest.raises(
+            ConfigurationError, match="MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE"
+        ):
             SearchConfig.from_env("MARKDOWN_VAULT_MCP")
 
     @pytest.mark.parametrize(
@@ -1389,7 +1395,7 @@ class TestSearchConfigFromEnv:
         from markdown_vault_mcp.config_sections import SearchConfig
 
         monkeypatch.setenv(f"MARKDOWN_VAULT_MCP_{var}", value)
-        with pytest.raises(ValueError):
+        with pytest.raises(ConfigurationError):
             SearchConfig.from_env("MARKDOWN_VAULT_MCP")
 
     def test_alpha_invalid_raises(self, monkeypatch):
@@ -1397,7 +1403,7 @@ class TestSearchConfigFromEnv:
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA", "abc")
         with pytest.raises(
-            ValueError, match="MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA"
+            ConfigurationError, match="MARKDOWN_VAULT_MCP_LENGTH_DOWNWEIGHT_ALPHA"
         ):
             SearchConfig.from_env("MARKDOWN_VAULT_MCP")
 
@@ -1408,6 +1414,32 @@ class TestSearchConfigFromEnv:
 
         with pytest.raises(dataclasses.FrozenInstanceError):
             SearchConfig().chunks_per_file = 5  # type: ignore[misc]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"chunks_per_file": 0},
+            {"snippet_words": -1},
+            {"length_downweight_alpha": -0.5},
+            {"max_chunk_words": 0},
+            {"max_chunk_chars_override": 0},
+        ],
+    )
+    def test_direct_construction_validates(self, kwargs):
+        """__post_init__ rejects out-of-range values on every construction path (#638)."""
+        with pytest.raises(ConfigurationError):
+            SearchConfig(**kwargs)
+
+    def test_direct_construction_valid_passes(self):
+        """In-range values (and a None char-cap override) construct fine."""
+        cfg = SearchConfig(
+            chunks_per_file=1,
+            snippet_words=0,
+            length_downweight_alpha=0.0,
+            max_chunk_words=1,
+            max_chunk_chars_override=None,
+        )
+        assert cfg.max_chunk_chars_override is None
 
 
 class TestSyncConfigFromEnv:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -258,21 +258,23 @@ class TestLoadConfig:
         _ = VaultConfig.from_env()
         assert "legacy mode is deprecated" in caplog.text
 
-    def test_invalid_pull_interval_uses_default(
+    def test_invalid_pull_interval_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A non-numeric GIT_PULL_INTERVAL_S raises (no warn-and-default; #638)."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S", "nope")
-        config = VaultConfig.from_env()
-        assert config.git.pull_interval_s == 600
+        with pytest.raises(ConfigurationError):
+            VaultConfig.from_env()
 
-    def test_negative_pull_interval_disables(
+    def test_negative_pull_interval_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A negative GIT_PULL_INTERVAL_S raises (no longer clamps to 0; #638)."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S", "-5")
-        config = VaultConfig.from_env()
-        assert config.git.pull_interval_s == 0
+        with pytest.raises(ConfigurationError, match="pull_interval_s"):
+            VaultConfig.from_env()
 
     def test_comma_separated_strips_whitespace(
         self, monkeypatch: pytest.MonkeyPatch
@@ -638,11 +640,31 @@ class TestGitConfigFromEnv:
         g = GitConfig.from_env("MARKDOWN_VAULT_MCP")
         assert g == GitConfig()
 
-    def test_pull_interval_negative_clamps_to_zero(self, monkeypatch):
+    def test_pull_interval_negative_raises(self, monkeypatch):
+        """A negative GIT_PULL_INTERVAL_S raises (no longer clamps to 0; #638)."""
         from markdown_vault_mcp.config_sections import GitConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S", "-5")
-        assert GitConfig.from_env("MARKDOWN_VAULT_MCP").pull_interval_s == 0
+        with pytest.raises(ConfigurationError, match="pull_interval_s"):
+            GitConfig.from_env("MARKDOWN_VAULT_MCP")
+
+    def test_push_delay_invalid_raises(self, monkeypatch):
+        """A non-numeric GIT_PUSH_DELAY_S raises (no warn-and-default; #638)."""
+        from markdown_vault_mcp.config_sections import GitConfig
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S", "nope")
+        with pytest.raises(ConfigurationError):
+            GitConfig.from_env("MARKDOWN_VAULT_MCP")
+
+    @pytest.mark.parametrize(
+        "kwargs", [{"push_delay_s": -1.0}, {"pull_interval_s": -5}]
+    )
+    def test_direct_construction_validates(self, kwargs):
+        """__post_init__ rejects negative cadences on direct construction (#638)."""
+        from markdown_vault_mcp.config_sections import GitConfig
+
+        with pytest.raises(ConfigurationError):
+            GitConfig(**kwargs)
 
     def test_frozen(self):
         import dataclasses

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import pytest
@@ -149,7 +148,7 @@ class TestParseHelpers:
 class TestLoadConfig:
     def test_missing_source_dir_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", raising=False)
-        with pytest.raises(ValueError, match="MARKDOWN_VAULT_MCP_SOURCE_DIR"):
+        with pytest.raises(ConfigurationError, match="MARKDOWN_VAULT_MCP_SOURCE_DIR"):
             VaultConfig.from_env()
 
     def test_minimal_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -544,23 +543,23 @@ class TestAttachmentConfig:
         config = VaultConfig.from_env()
         assert config.content.max_attachment_size_mb == 0.0
 
-    def test_max_attachment_size_mb_invalid_uses_default(
+    def test_max_attachment_size_mb_invalid_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """VaultConfig.from_env() falls back to 1.0 for invalid MAX_ATTACHMENT_SIZE_MB."""
+        """VaultConfig.from_env() raises on a non-numeric MAX_ATTACHMENT_SIZE_MB (#638)."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "not-a-number")
-        config = VaultConfig.from_env()
-        assert config.content.max_attachment_size_mb == 1.0
+        with pytest.raises(ConfigurationError):
+            VaultConfig.from_env()
 
-    def test_max_attachment_size_mb_negative_uses_default(
+    def test_max_attachment_size_mb_negative_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """VaultConfig.from_env() resets negative MAX_ATTACHMENT_SIZE_MB to 1.0."""
+        """VaultConfig.from_env() raises on a negative MAX_ATTACHMENT_SIZE_MB (#638)."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "-5")
-        config = VaultConfig.from_env()
-        assert config.content.max_attachment_size_mb == 1.0
+        with pytest.raises(ConfigurationError, match="max_attachment_size_mb"):
+            VaultConfig.from_env()
 
     def test_attachment_config_passed_through_to_vault_kwargs(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1146,32 +1145,27 @@ class TestMaxNoteReadBytesEnv:
         config = VaultConfig.from_env()
         assert config.content.max_note_read_bytes == 0
 
-    def test_invalid_value_falls_back_to_default(
+    def test_invalid_value_raises(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        """A non-numeric MAX_NOTE_READ_BYTES raises (no warn-and-default; #638)."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "not-a-number")
-        with caplog.at_level(logging.WARNING):
-            config = VaultConfig.from_env()
-        assert config.content.max_note_read_bytes == 262144
-        assert "MAX_NOTE_READ_BYTES" in caplog.text
+        with pytest.raises(ConfigurationError, match="MAX_NOTE_READ_BYTES"):
+            VaultConfig.from_env()
 
-    def test_negative_value_falls_back_to_default(
+    def test_negative_value_raises(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        """A negative MAX_NOTE_READ_BYTES raises (#638)."""
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "-1")
-        with caplog.at_level(logging.WARNING):
-            config = VaultConfig.from_env()
-        assert config.content.max_note_read_bytes == 262144
-        assert "MAX_NOTE_READ_BYTES" in caplog.text
-        assert "negative" in caplog.text.lower()
+        with pytest.raises(ConfigurationError, match="max_note_read_bytes"):
+            VaultConfig.from_env()
 
 
 class TestMaxAttachmentSizeMbDefault:
@@ -1209,34 +1203,76 @@ def test_transfer_config_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_transfer_config_rejects_default_above_max():
     """TransferConfig refuses a default TTL above the ceiling."""
-    with pytest.raises(ValueError, match="ttl_max_s"):
+    with pytest.raises(ConfigurationError, match="ttl_max_s"):
         TransferConfig(ttl_default_s=7200, ttl_max_s=3600)
 
 
 def test_transfer_config_rejects_nonpositive_upload_cap():
     """TransferConfig refuses a non-positive upload size cap."""
-    with pytest.raises(ValueError, match="max_upload_bytes"):
+    with pytest.raises(ConfigurationError, match="max_upload_bytes"):
         TransferConfig(max_upload_bytes=0)
 
 
 class TestConfigHelpers:
-    def test_parse_int_env_valid(self, monkeypatch):
-        from markdown_vault_mcp.config_sections._helpers import parse_int_env
+    def test_env_int_valid(self, monkeypatch):
+        from markdown_vault_mcp.config_sections._helpers import env_int
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_X", "7")
-        assert parse_int_env("MARKDOWN_VAULT_MCP", "X", 3) == 7
+        assert env_int("MARKDOWN_VAULT_MCP", "X", 3) == 7
 
-    def test_parse_int_env_invalid_falls_back(self, monkeypatch):
-        from markdown_vault_mcp.config_sections._helpers import parse_int_env
+    def test_env_int_unset_returns_default(self, monkeypatch):
+        from markdown_vault_mcp.config_sections._helpers import env_int
+
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_X", raising=False)
+        assert env_int("MARKDOWN_VAULT_MCP", "X", 3) == 3
+
+    def test_env_int_invalid_raises(self, monkeypatch):
+        from markdown_vault_mcp.config_sections._helpers import env_int
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_X", "nope")
-        assert parse_int_env("MARKDOWN_VAULT_MCP", "X", 3) == 3
+        with pytest.raises(ConfigurationError):
+            env_int("MARKDOWN_VAULT_MCP", "X", 3)
 
-    def test_parse_float_env_invalid_falls_back(self, monkeypatch):
-        from markdown_vault_mcp.config_sections._helpers import parse_float_env
+    def test_env_float_invalid_raises(self, monkeypatch):
+        from markdown_vault_mcp.config_sections._helpers import env_float
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_X", "nope")
-        assert parse_float_env("MARKDOWN_VAULT_MCP", "X", 1.5) == 1.5
+        with pytest.raises(ConfigurationError):
+            env_float("MARKDOWN_VAULT_MCP", "X", 1.5)
+
+    def test_opt_int_unset_is_none(self, monkeypatch):
+        from markdown_vault_mcp.config_sections._helpers import opt_int
+
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_X", raising=False)
+        assert opt_int("MARKDOWN_VAULT_MCP", "X") is None
+
+    def test_opt_int_invalid_raises(self, monkeypatch):
+        from markdown_vault_mcp.config_sections._helpers import opt_int
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_X", "nope")
+        with pytest.raises(ConfigurationError):
+            opt_int("MARKDOWN_VAULT_MCP", "X")
+
+
+class TestConfigurationErrorCanonical:
+    """Pin the canonical-config-error contract (#638)."""
+
+    def test_is_pvl_core_class(self):
+        """The project's ConfigurationError IS pvl-core's, so env_int's raises are catchable."""
+        import fastmcp_pvl_core
+
+        import markdown_vault_mcp
+
+        assert ConfigurationError is fastmcp_pvl_core.ConfigurationError
+        assert (
+            markdown_vault_mcp.ConfigurationError is fastmcp_pvl_core.ConfigurationError
+        )
+
+    def test_not_a_markdown_mcp_error_subclass(self):
+        """Deliberately outside the MarkdownMCPError tree (env_int raises the bare CE)."""
+        from markdown_vault_mcp.exceptions import MarkdownMCPError
+
+        assert not issubclass(ConfigurationError, MarkdownMCPError)
 
 
 class TestIndexingConfigFromEnv:
@@ -1349,6 +1385,21 @@ class TestEmbeddingsConfigFromEnv:
         assert (
             EmbeddingsConfig(ollama_host="http://gpu:11434/").ollama_host
             == "http://gpu:11434"
+        )
+
+    def test_post_init_normalizes_openai_base_url_on_direct_construction(self):
+        """openai_base_url is normalized on direct construction too, not just from_env (#638)."""
+        from markdown_vault_mcp.config_sections import EmbeddingsConfig
+
+        assert (
+            EmbeddingsConfig(
+                openai_base_url="https://proxy.example/v1/"
+            ).openai_base_url
+            == "https://proxy.example/v1"
+        )
+        assert (
+            EmbeddingsConfig(openai_base_url="").openai_base_url
+            == "https://api.openai.com/v1"
         )
 
     def test_frozen(self):
@@ -1479,23 +1530,37 @@ class TestSyncConfigFromEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER", "false")
         assert SyncConfig.from_env("MARKDOWN_VAULT_MCP").file_watcher_enabled is False
 
-    def test_debounce_invalid_resets_to_default(self, monkeypatch):
+    def test_debounce_invalid_raises(self, monkeypatch):
+        """A non-numeric FILE_WATCHER_DEBOUNCE_S raises (no warn-and-default; #638)."""
         from markdown_vault_mcp.config_sections import SyncConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S", "notanumber")
-        assert SyncConfig.from_env("MARKDOWN_VAULT_MCP").file_watcher_debounce_s == 2.0
+        with pytest.raises(ConfigurationError):
+            SyncConfig.from_env("MARKDOWN_VAULT_MCP")
 
-    def test_debounce_zero_resets_to_default(self, monkeypatch):
+    def test_debounce_zero_raises(self, monkeypatch):
+        """A zero FILE_WATCHER_DEBOUNCE_S raises (must be > 0; #638)."""
         from markdown_vault_mcp.config_sections import SyncConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S", "0")
-        assert SyncConfig.from_env("MARKDOWN_VAULT_MCP").file_watcher_debounce_s == 2.0
+        with pytest.raises(ConfigurationError, match="file_watcher_debounce_s"):
+            SyncConfig.from_env("MARKDOWN_VAULT_MCP")
 
-    def test_debounce_negative_resets_to_default(self, monkeypatch):
+    def test_debounce_negative_raises(self, monkeypatch):
+        """A negative FILE_WATCHER_DEBOUNCE_S raises (#638)."""
         from markdown_vault_mcp.config_sections import SyncConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S", "-1.0")
-        assert SyncConfig.from_env("MARKDOWN_VAULT_MCP").file_watcher_debounce_s == 2.0
+        with pytest.raises(ConfigurationError, match="file_watcher_debounce_s"):
+            SyncConfig.from_env("MARKDOWN_VAULT_MCP")
+
+    @pytest.mark.parametrize("debounce", [0, -1.0])
+    def test_direct_construction_validates(self, debounce):
+        """__post_init__ rejects a non-positive debounce on direct construction (#638)."""
+        from markdown_vault_mcp.config_sections import SyncConfig
+
+        with pytest.raises(ConfigurationError, match="file_watcher_debounce_s"):
+            SyncConfig(file_watcher_debounce_s=debounce)
 
     def test_github_webhook_secret(self, monkeypatch):
         from markdown_vault_mcp.config_sections import SyncConfig
@@ -1551,19 +1616,21 @@ class TestContentConfigFromEnv:
         cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
         assert cfg.attachment_extensions is None
 
-    def test_max_attachment_invalid_resets(self, monkeypatch, tmp_path):
+    def test_max_attachment_invalid_raises(self, monkeypatch, tmp_path):
+        """A non-numeric MAX_ATTACHMENT_SIZE_MB raises (#638)."""
         from markdown_vault_mcp.config_sections import ContentConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "not-a-number")
-        cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
-        assert cfg.max_attachment_size_mb == 1.0
+        with pytest.raises(ConfigurationError):
+            ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
 
-    def test_max_attachment_negative_resets(self, monkeypatch, tmp_path):
+    def test_max_attachment_negative_raises(self, monkeypatch, tmp_path):
+        """A negative MAX_ATTACHMENT_SIZE_MB raises (#638)."""
         from markdown_vault_mcp.config_sections import ContentConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "-5")
-        cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
-        assert cfg.max_attachment_size_mb == 1.0
+        with pytest.raises(ConfigurationError, match="max_attachment_size_mb"):
+            ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
 
     def test_max_attachment_zero_allowed(self, monkeypatch, tmp_path):
         from markdown_vault_mcp.config_sections import ContentConfig
@@ -1572,19 +1639,21 @@ class TestContentConfigFromEnv:
         cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
         assert cfg.max_attachment_size_mb == 0.0
 
-    def test_max_note_read_bytes_invalid_resets(self, monkeypatch, tmp_path):
+    def test_max_note_read_bytes_invalid_raises(self, monkeypatch, tmp_path):
+        """A non-numeric MAX_NOTE_READ_BYTES raises (#638)."""
         from markdown_vault_mcp.config_sections import ContentConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "nope")
-        cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
-        assert cfg.max_note_read_bytes == 262144
+        with pytest.raises(ConfigurationError):
+            ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
 
-    def test_max_note_read_bytes_negative_resets(self, monkeypatch, tmp_path):
+    def test_max_note_read_bytes_negative_raises(self, monkeypatch, tmp_path):
+        """A negative MAX_NOTE_READ_BYTES raises (#638)."""
         from markdown_vault_mcp.config_sections import ContentConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "-1")
-        cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
-        assert cfg.max_note_read_bytes == 262144
+        with pytest.raises(ConfigurationError, match="max_note_read_bytes"):
+            ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
 
     def test_max_note_read_bytes_zero_allowed(self, monkeypatch, tmp_path):
         from markdown_vault_mcp.config_sections import ContentConfig
@@ -1592,6 +1661,26 @@ class TestContentConfigFromEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES", "0")
         cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
         assert cfg.max_note_read_bytes == 0
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"max_attachment_size_mb": -1.0}, {"max_note_read_bytes": -1}],
+    )
+    def test_direct_construction_validates(self, kwargs):
+        """__post_init__ rejects negative size limits on direct construction (#638)."""
+        from markdown_vault_mcp.config_sections import ContentConfig
+
+        with pytest.raises(ConfigurationError):
+            ContentConfig(**kwargs)
+
+    @pytest.mark.parametrize(
+        "kwargs", [{"max_attachment_size_mb": 0}, {"max_note_read_bytes": 0}]
+    )
+    def test_direct_construction_zero_allowed(self, kwargs):
+        """0 (the unlimited sentinel) is accepted on direct construction (#638)."""
+        from markdown_vault_mcp.config_sections import ContentConfig
+
+        assert ContentConfig(**kwargs) is not None
 
     def test_templates_folder_backslash_trailing_slash(self, monkeypatch, tmp_path):
         from markdown_vault_mcp.config_sections import ContentConfig
@@ -1654,19 +1743,20 @@ class TestTransferConfigFromEnv:
         assert cfg.ttl_max_s == 600
         assert cfg.max_upload_bytes == 2048
 
-    def test_invalid_falls_back_to_default(self, monkeypatch):
+    def test_invalid_raises(self, monkeypatch):
+        """A non-numeric TRANSFER_TTL_DEFAULT_S raises (no warn-and-default; #638)."""
         from markdown_vault_mcp.config_sections import TransferConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TRANSFER_TTL_DEFAULT_S", "nope")
-        cfg = TransferConfig.from_env("MARKDOWN_VAULT_MCP")
-        assert cfg.ttl_default_s == 3600
+        with pytest.raises(ConfigurationError):
+            TransferConfig.from_env("MARKDOWN_VAULT_MCP")
 
     def test_post_init_raises_on_default_above_max(self, monkeypatch):
         from markdown_vault_mcp.config_sections import TransferConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TRANSFER_TTL_DEFAULT_S", "7200")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TRANSFER_TTL_MAX_S", "3600")
-        with pytest.raises(ValueError, match="ttl_max_s"):
+        with pytest.raises(ConfigurationError, match="ttl_max_s"):
             TransferConfig.from_env("MARKDOWN_VAULT_MCP")
 
     def test_frozen(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1246,33 +1246,19 @@ class TestConfigHelpers:
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_X", raising=False)
         assert opt_int("MARKDOWN_VAULT_MCP", "X") is None
 
+    def test_opt_int_empty_string_is_none(self, monkeypatch):
+        """An empty/whitespace value is treated as unset (returns None), not invalid."""
+        from markdown_vault_mcp.config_sections._helpers import opt_int
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_X", "   ")
+        assert opt_int("MARKDOWN_VAULT_MCP", "X") is None
+
     def test_opt_int_invalid_raises(self, monkeypatch):
         from markdown_vault_mcp.config_sections._helpers import opt_int
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_X", "nope")
         with pytest.raises(ConfigurationError):
             opt_int("MARKDOWN_VAULT_MCP", "X")
-
-
-class TestConfigurationErrorCanonical:
-    """Pin the canonical-config-error contract (#638)."""
-
-    def test_is_pvl_core_class(self):
-        """The project's ConfigurationError IS pvl-core's, so env_int's raises are catchable."""
-        import fastmcp_pvl_core
-
-        import markdown_vault_mcp
-
-        assert ConfigurationError is fastmcp_pvl_core.ConfigurationError
-        assert (
-            markdown_vault_mcp.ConfigurationError is fastmcp_pvl_core.ConfigurationError
-        )
-
-    def test_not_a_markdown_mcp_error_subclass(self):
-        """Deliberately outside the MarkdownMCPError tree (env_int raises the bare CE)."""
-        from markdown_vault_mcp.exceptions import MarkdownMCPError
-
-        assert not issubclass(ConfigurationError, MarkdownMCPError)
 
 
 class TestIndexingConfigFromEnv:
@@ -1758,6 +1744,21 @@ class TestTransferConfigFromEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_TRANSFER_TTL_MAX_S", "3600")
         with pytest.raises(ConfigurationError, match="ttl_max_s"):
             TransferConfig.from_env("MARKDOWN_VAULT_MCP")
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"ttl_default_s": 0}, "ttl_default_s"),
+            ({"ttl_default_s": 7200, "ttl_max_s": 3600}, "ttl_max_s"),
+            ({"max_upload_bytes": 0}, "max_upload_bytes"),
+        ],
+    )
+    def test_direct_construction_validates(self, kwargs, match):
+        """__post_init__ rejects out-of-range/ordering violations on direct construction (#638)."""
+        from markdown_vault_mcp.config_sections import TransferConfig
+
+        with pytest.raises(ConfigurationError, match=match):
+            TransferConfig(**kwargs)
 
     def test_frozen(self):
         import dataclasses

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -55,3 +55,26 @@ def test_index_unavailable_reason_literal_values() -> None:
     for value in ("never_built", "build_failed", "timeout", "broken", "busy"):
         err = IndexUnavailableError("x", reason=value)  # type: ignore[arg-type]
         assert err.reason == value
+
+
+class TestConfigurationErrorCanonical:
+    """ConfigurationError is pvl-core's canonical type, re-exported (#638)."""
+
+    def test_is_pvl_core_class(self) -> None:
+        """The project's ConfigurationError IS pvl-core's, so env_int's raises are catchable."""
+        import fastmcp_pvl_core
+
+        import markdown_vault_mcp
+        from markdown_vault_mcp.exceptions import ConfigurationError
+
+        assert ConfigurationError is fastmcp_pvl_core.ConfigurationError
+        assert (
+            markdown_vault_mcp.ConfigurationError is fastmcp_pvl_core.ConfigurationError
+        )
+
+    def test_not_a_markdown_mcp_error_subclass(self) -> None:
+        """Deliberately outside the MarkdownMCPError tree (env_int raises the bare CE)."""
+        from markdown_vault_mcp.exceptions import ConfigurationError
+
+        assert not issubclass(ConfigurationError, MarkdownMCPError)
+        assert issubclass(ConfigurationError, Exception)

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -21,6 +21,8 @@ import time
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import pytest
+
 from markdown_vault_mcp._file_watcher import (
     VaultFileWatcher,
     _has_hidden_component,
@@ -30,8 +32,6 @@ from markdown_vault_mcp._server_deps import make_vault_lifespan
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -318,28 +318,30 @@ def test_from_env_file_watcher_debounce_custom(
     assert config.sync.file_watcher_debounce_s == 5.0
 
 
-def test_from_env_file_watcher_debounce_invalid_falls_back(
+def test_from_env_file_watcher_debounce_invalid_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Non-numeric FILE_WATCHER_DEBOUNCE_S falls back to 2.0."""
+    """Non-numeric FILE_WATCHER_DEBOUNCE_S raises (no warn-and-default; #638)."""
     from markdown_vault_mcp.config import VaultConfig
+    from markdown_vault_mcp.exceptions import ConfigurationError
 
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S", "not-a-number")
-    config = VaultConfig.from_env()
-    assert config.sync.file_watcher_debounce_s == 2.0
+    with pytest.raises(ConfigurationError):
+        VaultConfig.from_env()
 
 
-def test_from_env_file_watcher_debounce_nonpositive_falls_back(
+def test_from_env_file_watcher_debounce_nonpositive_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """FILE_WATCHER_DEBOUNCE_S <= 0 falls back to 2.0."""
+    """FILE_WATCHER_DEBOUNCE_S <= 0 raises (must be > 0; #638)."""
     from markdown_vault_mcp.config import VaultConfig
+    from markdown_vault_mcp.exceptions import ConfigurationError
 
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S", "0")
-    config = VaultConfig.from_env()
-    assert config.sync.file_watcher_debounce_s == 2.0
+    with pytest.raises(ConfigurationError, match="file_watcher_debounce_s"):
+        VaultConfig.from_env()
 
 
 def test_fire_exception_in_on_change_is_logged(tmp_path: Path) -> None:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -678,16 +678,17 @@ class TestConfigIntegration:
         config = VaultConfig.from_env()
         assert config.git.push_delay_s == 45.0
 
-    def test_from_env_invalid_push_delay_uses_default(
+    def test_from_env_invalid_push_delay_raises(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """VaultConfig.from_env() falls back to default on invalid GIT_PUSH_DELAY_S."""
+        """VaultConfig.from_env() raises on a non-numeric GIT_PUSH_DELAY_S (#638)."""
         from markdown_vault_mcp.config import VaultConfig
+        from markdown_vault_mcp.exceptions import ConfigurationError
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S", "not_a_number")
-        config = VaultConfig.from_env()
-        assert config.git.push_delay_s == 30.0
+        with pytest.raises(ConfigurationError):
+            VaultConfig.from_env()
 
 
 class TestVaultCloseWiresStrategy:

--- a/uv.lock
+++ b/uv.lock
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "1.28.0"
+version = "2.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },

--- a/uv.lock
+++ b/uv.lock
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "2.0.0rc1"
+version = "1.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

PR1 of the #638 config-hardening follow-up (the behaviour-changing sequel to the behaviour-neutral #637/#619 refactor). Makes invalid configuration **fail fast** uniformly and standardizes on one canonical config-error type.

**Refs #638** — the issue stays open for PR2 (explicit-provider fail-fast) and PR3 (`list`→`tuple` deep immutability, with #639).

### What changed
- **Canonical `ConfigurationError`.** The local `ConfigurationError(MarkdownMCPError)` is retired and `fastmcp_pvl_core.ConfigurationError` — the shared base across the `*-mcp` series — is re-exported as the project's one config error. `env_int`/`env_float(strict=…)`, `__post_init__` validators, and the existing git-remote checks now all raise the same catchable type.
- **Strict env helpers.** New `_helpers.env_int`/`env_float`/`opt_int` wrap pvl-core's strict readers (type-narrowed); the warn-and-default `parse_int_env`/`parse_float_env` are removed.
- **Validation on every construction path.** Range checks moved into each sub-config's `__post_init__` (Search/Git/Content/Sync; Transfer/Embeddings already had one), so illegal **direct** construction is rejected too — not just `from_env`.
- **Behaviour change (fail-fast).** A non-numeric or out-of-range numeric env var now raises `ConfigurationError` at startup instead of warn-and-default (search/content) or clamp (git `pull_interval_s`, sync `debounce`). The `0 = unlimited` sentinel (content) stays valid; debounce must be `> 0`.
- **Tidies (obs 7).** `SOURCE_DIR`-missing error uses the `prefix` arg + raises CE; git/sync warn-prefix strings are gone (the warnings became raises); `EmbeddingsConfig` normalizes `openai_base_url` symmetrically with `ollama_host`.
- **Docs.** `docs/configuration.md` fail-fast note; `docs/api/exceptions.md` documents the re-export.

### ⚠️ API-contract note
`markdown_vault_mcp.ConfigurationError` is **no longer a `MarkdownMCPError` subclass** (it's pvl-core's, whose base is `Exception`). No `except MarkdownMCPError` site relies on catching config errors today (verified), but a future request-handler catch-all would not catch them — which is correct (config errors are startup/operator failures that should fail hard). Pinned by a regression test.

### Testing
- 2055 tests pass; ruff + mypy + mkdocs `--strict` clean.
- Every warn-default/clamp/`ValueError` config test flips to expect `ConfigurationError`; `parse_*_env` helper tests replaced with `env_int`/`env_float`/`opt_int` tests; direct-construction validation tests added for Search/Git/Content/Sync, openai_base_url normalization, and the CE-canonical/`not-a-MarkdownMCPError` contract.

### Review
9-lens preflight circus run; the one ≥80 finding (a stale `Raises: ValueError` docstring on `VaultConfig.from_env`) and several cheap coverage/doc-accuracy items were addressed before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)