### PR TITLE
feat(config): explicit embedding provider fails fast instead of silent degrade (#638 PR2)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ The first three knobs adjust *ranking and rendering* — they take effect immedi
     2. **Ollama** — if `OLLAMA_HOST` is reachable
     3. **FastEmbed** — if the `fastembed` package is installed
 
-    **Explicit vs. auto-detect failure handling:** when you set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` to a specific backend and it cannot be constructed at startup — a missing dependency, missing/empty credentials, or an unrecognised value — the server **fails fast** with a `ConfigurationError` rather than silently falling back to keyword-only search. (An unreachable Ollama/OpenAI *service* is not probed at startup; that surfaces later as an embedding error during index build.) When the variable is *unset* (auto-detect) and no backend is available, the server logs a warning and continues with semantic search disabled. Set the variable explicitly if you want a missing provider to be a hard startup error.
+    **Explicit vs. auto-detect failure handling:** when you set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` to a specific backend and it cannot be constructed at startup — a missing dependency, missing/empty credentials, or an unrecognised value — the server **fails fast** with a `ConfigurationError` rather than silently falling back to keyword-only search. (An unreachable Ollama/OpenAI *service* does not prevent startup — the provider still loads; the failure surfaces later as an embedding error during index build.) When the variable is *unset* (auto-detect) and no backend is available, the server logs a warning and continues with semantic search disabled. Set the variable explicitly if you want a missing provider to be a hard startup error.
 
 ## Git Integration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,8 @@ The first three knobs adjust *ranking and rendering* — they take effect immedi
     2. **Ollama** — if `OLLAMA_HOST` is reachable
     3. **FastEmbed** — if the `fastembed` package is installed
 
+    **Explicit vs. auto-detect failure handling:** when you set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` to a specific backend and it cannot be constructed at startup — a missing dependency, missing/empty credentials, or an unrecognised value — the server **fails fast** with a `ConfigurationError` rather than silently falling back to keyword-only search. (An unreachable Ollama/OpenAI *service* is not probed at startup; that surfaces later as an embedding error during index build.) When the variable is *unset* (auto-detect) and no backend is available, the server logs a warning and continues with semantic search disabled. Set the variable explicitly if you want a missing provider to be a hard startup error.
+
 ## Git Integration
 
 Git integration has three modes:

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -150,18 +150,31 @@ class VaultConfig:
 
         # Semantic search is gated by the storage path in config.indexing,
         # while the provider lives in config.embeddings (cross-section coupling).
-        # ValueError propagates — it means the user set an invalid provider
-        # name, which is a config mistake that should not be silenced.
+        # An unrecognised provider name raises ConfigurationError from the
+        # resolver and propagates here unchanged.
         provider = None
         if self.indexing.embeddings_path is not None:
+            explicit_provider = (self.embeddings.provider or "").strip()
             try:
                 from markdown_vault_mcp import providers as _providers
 
                 provider = _providers.get_embedding_provider(self)
                 kwargs["embedding_provider"] = provider
-            except (ImportError, RuntimeError):
+            except (ImportError, RuntimeError) as exc:
+                if explicit_provider:
+                    # The operator explicitly chose a backend; a load failure is
+                    # a configuration error that must surface, not silently fall
+                    # back to keyword-only search.
+                    raise ConfigurationError(
+                        f"Embedding provider {explicit_provider!r} was explicitly "
+                        "configured (MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER) but "
+                        f"could not be loaded: {exc}. Fix the configuration, or "
+                        "unset the variable to fall back to auto-detection."
+                    ) from exc
                 logger.warning(
-                    "Could not load embedding provider; semantic search disabled",
+                    "Could not auto-detect an embedding provider; semantic "
+                    "search disabled. Set MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER "
+                    "to require a specific backend.",
                     exc_info=True,
                 )
 

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -16,6 +16,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+from markdown_vault_mcp.exceptions import ConfigurationError
+
 if TYPE_CHECKING:
     from markdown_vault_mcp.config import VaultConfig
 
@@ -511,7 +513,7 @@ def get_embedding_provider(config: VaultConfig) -> EmbeddingProvider:
         RuntimeError: If no provider is available and
             ``config.embeddings.provider`` is not set, or if the explicitly
             requested provider cannot be initialised.
-        ValueError: If ``config.embeddings.provider`` is set to an
+        ConfigurationError: If ``config.embeddings.provider`` is set to an
             unrecognised value.
     """
     explicit = (config.embeddings.provider or "").strip().lower()
@@ -543,7 +545,7 @@ def get_embedding_provider(config: VaultConfig) -> EmbeddingProvider:
         )
 
     if explicit:
-        raise ValueError(
+        raise ConfigurationError(
             f"Unrecognised embedding_provider value: {explicit!r}. "
             "Valid values: 'openai', 'ollama', 'fastembed'."
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -310,14 +310,18 @@ class TestToVaultKwargs:
         kwargs = config.to_vault_kwargs()
         assert "git_token" not in kwargs
 
-    @pytest.mark.xfail(
-        raises=ValueError,
-        reason="embeddings_path set without a provider resolves FastEmbedProvider, "
-        "which downloads BAAI/bge-small-en-v1.5 from HuggingFace — flaky/unavailable "
-        "in CI (#595)",
-        strict=False,
-    )
-    def test_includes_all_vault_params(self) -> None:
+    def test_includes_all_vault_params(self, monkeypatch) -> None:
+        # Monkeypatch the resolver so the test is deterministic (the old form
+        # relied on a live FastEmbed model download and was flaky-xfail).
+        import markdown_vault_mcp.providers as providers_mod
+
+        class _FakeProvider:
+            context_length = 512
+
+        fake = _FakeProvider()
+        monkeypatch.setattr(
+            providers_mod, "get_embedding_provider", lambda _config: fake
+        )
         config = VaultConfig(
             source_dir=Path("/tmp/vault"),
             read_only=False,
@@ -342,6 +346,9 @@ class TestToVaultKwargs:
         assert kwargs["attachment_extensions"] is None
         assert kwargs["max_attachment_size_mb"] == 1.0
         assert kwargs["git_pull_interval_s"] == 0
+        assert kwargs["embedding_provider"] is fake
+        # The resolved provider's context length drives the chunk char cap (#649).
+        assert kwargs["max_chunk_chars"] == round(512 * 2.8)
         assert "git_strategy" in kwargs
         assert "on_write" in kwargs
 
@@ -365,6 +372,90 @@ class TestToVaultKwargs:
         assert kwargs["git_pull_interval_s"] == 123
         assert "git_strategy" in kwargs
         assert "on_write" in kwargs
+
+
+class TestToVaultKwargsProvider:
+    """Embedding-provider resolution in to_vault_kwargs (#638 PR2).
+
+    An *explicitly* configured provider that fails to load is a hard
+    ConfigurationError; auto-detection failures degrade to keyword-only.
+    """
+
+    def _config(self, *, provider: str | None, tmp_path: Path) -> VaultConfig:
+        return VaultConfig(
+            source_dir=tmp_path,
+            embeddings=EmbeddingsConfig(provider=provider),
+            indexing=IndexingConfig(embeddings_path=tmp_path / "emb"),
+        )
+
+    @pytest.mark.parametrize("exc", [ImportError("missing dep"), RuntimeError("boom")])
+    def test_explicit_provider_load_failure_raises(
+        self, monkeypatch, tmp_path, exc
+    ) -> None:
+        """An explicit provider that can't load fails hard (no silent degrade)."""
+        import markdown_vault_mcp.providers as providers_mod
+
+        def _boom(_config):
+            raise exc
+
+        monkeypatch.setattr(providers_mod, "get_embedding_provider", _boom)
+        config = self._config(provider="openai", tmp_path=tmp_path)
+        with pytest.raises(ConfigurationError, match="openai"):
+            config.to_vault_kwargs()
+
+    def test_unrecognized_provider_name_raises(self, tmp_path) -> None:
+        """A bogus EMBEDDING_PROVIDER value surfaces as ConfigurationError."""
+        config = self._config(provider="bogus", tmp_path=tmp_path)
+        with pytest.raises(ConfigurationError, match="Unrecognised"):
+            config.to_vault_kwargs()
+
+    @pytest.mark.parametrize("exc", [ImportError("missing dep"), RuntimeError("none")])
+    def test_autodetect_failure_degrades(self, monkeypatch, tmp_path, exc) -> None:
+        """Auto-detection (no explicit provider) degrades to keyword-only, no raise."""
+        import markdown_vault_mcp.providers as providers_mod
+
+        def _boom(_config):
+            raise exc
+
+        monkeypatch.setattr(providers_mod, "get_embedding_provider", _boom)
+        config = self._config(provider=None, tmp_path=tmp_path)
+        kwargs = config.to_vault_kwargs()
+        assert "embedding_provider" not in kwargs
+        # No provider → the chunk char cap falls back to the fixed default (#649).
+        assert kwargs["max_chunk_chars"] == 6000
+
+    def test_no_embeddings_path_skips_provider(self, monkeypatch, tmp_path) -> None:
+        """With no embeddings_path the provider is never resolved, even if broken."""
+        import markdown_vault_mcp.providers as providers_mod
+
+        def _boom(_config):
+            raise RuntimeError("should not be called")
+
+        monkeypatch.setattr(providers_mod, "get_embedding_provider", _boom)
+        config = VaultConfig(
+            source_dir=tmp_path,
+            embeddings=EmbeddingsConfig(provider="openai"),
+            indexing=IndexingConfig(embeddings_path=None),
+        )
+        kwargs = config.to_vault_kwargs()
+        assert "embedding_provider" not in kwargs
+
+    def test_provider_loads_sets_kwarg(self, monkeypatch, tmp_path) -> None:
+        """A successfully resolved provider is threaded into the kwargs."""
+        import markdown_vault_mcp.providers as providers_mod
+
+        class _FakeProvider:
+            context_length = 512
+
+        fake = _FakeProvider()
+        monkeypatch.setattr(
+            providers_mod, "get_embedding_provider", lambda _config: fake
+        )
+        config = self._config(provider="openai", tmp_path=tmp_path)
+        kwargs = config.to_vault_kwargs()
+        assert kwargs["embedding_provider"] is fake
+        # The resolved provider's context length drives the chunk char cap (#649).
+        assert kwargs["max_chunk_chars"] == round(512 * 2.8)
 
 
 class TestGitCommitterConfig:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -370,10 +370,12 @@ class TestGetEmbeddingProvider:
             provider = get_embedding_provider(cfg)
         assert isinstance(provider, FastEmbedProvider)
 
-    def test_explicit_unknown_raises_value_error(self) -> None:
+    def test_explicit_unknown_raises_configuration_error(self) -> None:
+        from markdown_vault_mcp.exceptions import ConfigurationError
+
         cfg = _config(provider="unknown_value")
         with pytest.raises(
-            ValueError, match="Valid values: 'openai', 'ollama', 'fastembed'"
+            ConfigurationError, match="Valid values: 'openai', 'ollama', 'fastembed'"
         ):
             get_embedding_provider(cfg)
 


### PR DESCRIPTION
## Summary

PR2 of #638. Removes a **silent failure**: previously, when an embedding provider couldn't be loaded, `to_vault_kwargs` always logged a warning and disabled semantic search — even when the operator had *explicitly* chosen a backend via `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER`. A misconfigured deployment silently became keyword-only search with no signal.

**Refs #638** — the issue closes with PR3 (`list`→`tuple`, + #639).

### Behaviour
- **Explicit provider** (`EMBEDDING_PROVIDER` set) that can't be constructed at startup — missing dependency, missing/empty credentials, or an unrecognised value → **fail fast** with `ConfigurationError`.
- **Auto-detect** (variable unset) with no backend available → unchanged: warn + continue with semantic search disabled (the zero-config FTS-only path stays supported).
- `get_embedding_provider` now raises `ConfigurationError` (was `ValueError`) for an unrecognised provider name, so it propagates as the canonical config error (and isn't caught by the `except (ImportError, RuntimeError)` gate).
- An unreachable Ollama/OpenAI *service* is **not** probed at startup (constructors don't connect) — it surfaces later as an embedding error during index build. Documented as such.

### Tests
- New `TestToVaultKwargsProvider` covers the full matrix: explicit ImportError/RuntimeError → raise; unrecognised name → raise; auto-detect ImportError/RuntimeError → degrade (no `embedding_provider` kwarg); no `embeddings_path` → resolver never called; happy path → provider threaded through.
- Asserts the provider→`max_chunk_chars` derivation integration (#649 coupling): `512` context → `round(512*2.8)`; no provider → `6000` fallback.
- Rewrote the previously-flaky `test_includes_all_vault_params` to monkeypatch the resolver (deterministic) instead of relying on a live FastEmbed download + `xfail`.
- 2067 tests pass; ruff + mypy + mkdocs `--strict` clean.

### Review
9-lens preflight circus run; addressed a doc inaccuracy (an unreachable service does not fail fast at startup) and two test improvements (the `max_chunk_chars` integration assertion + the xfail rewrite) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)