### PR TITLE
refactor(config): freeze sub-config sequence fields into tuples (#638 PR3, closes #639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,11 @@ ignore = ["E501"]
 "src/markdown_vault_mcp/_server_prompts.py" = ["B008", "TC002"]
 "src/markdown_vault_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
 "src/markdown_vault_mcp/_server_transfer.py" = ["B008", "TC001", "TC002"]
-# IndexingConfig needs pathlib.Path at runtime so typing.get_type_hints() works
-# on the public dataclass; keep the import top-level, not behind TYPE_CHECKING.
+# IndexingConfig/ContentConfig need pathlib.Path and collections.abc.Sequence at
+# runtime so typing.get_type_hints() works on the public frozen dataclasses; keep
+# those imports top-level, not behind TYPE_CHECKING.
 "src/markdown_vault_mcp/config_sections/indexing.py" = ["TC003"]
+"src/markdown_vault_mcp/config_sections/content.py" = ["TC003"]
 # Test fixtures import vault/protocol types only used in annotations.
 "tests/conftest.py" = ["TC002", "TC003"]
 "tests/test_smoke.py" = ["TC002", "TC003"]

--- a/src/markdown_vault_mcp/_server_transfer.py
+++ b/src/markdown_vault_mcp/_server_transfer.py
@@ -25,6 +25,7 @@ from markdown_vault_mcp.utils import (
 from markdown_vault_mcp.vault import Vault
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from fastmcp import FastMCP
@@ -70,7 +71,7 @@ def _iso(epoch: float) -> str:
 def _validate_destination(
     path: str,
     source_dir: Path,
-    attachment_extensions: list[str] | None,
+    attachment_extensions: Sequence[str] | None,
 ) -> bool:
     """Validate an upload destination and return whether it is an attachment.
 
@@ -101,7 +102,7 @@ def _validate_destination(
 def _validate_source(
     path: str,
     source_dir: Path,
-    attachment_extensions: list[str] | None,
+    attachment_extensions: Sequence[str] | None,
 ) -> bool:
     """Validate a download source (stat-only) and return whether it is an attachment.
 

--- a/src/markdown_vault_mcp/config_sections/content.py
+++ b/src/markdown_vault_mcp/config_sections/content.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+# Imported at runtime (not under TYPE_CHECKING) so the frozen dataclass's field
+# annotation stays resolvable if anything introspects it via get_type_hints.
+# (TC003 is suppressed for this file in pyproject.toml, matching indexing.py.)
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -12,22 +16,29 @@ from markdown_vault_mcp.exceptions import ConfigurationError
 class ContentConfig:
     """Attachment/note-read limits and template/prompt folder paths."""
 
-    attachment_extensions: list[str] | None = None
+    attachment_extensions: Sequence[str] | None = None
     max_attachment_size_mb: float = 1.0  # MB; 0 = unlimited
     max_note_read_bytes: int = 262144  # 256 KB; 0 = unlimited
     templates_folder: str = "_templates"
     prompts_folder: str | None = None
 
     def __post_init__(self) -> None:
-        """Validate non-negative size limits on every construction path (#638).
+        """Validate size limits (#638) and freeze attachment_extensions (#639).
 
-        ``0`` is a valid sentinel for "unlimited"; only negative values are
-        rejected.
+        ``0`` is a valid sentinel for "unlimited"; only negative size values are
+        rejected. ``attachment_extensions`` accepts any ``Sequence[str]`` but is
+        stored as a tuple so the frozen config's contents cannot be mutated.
 
         Raises:
             ConfigurationError: If ``max_attachment_size_mb`` or
                 ``max_note_read_bytes`` is negative.
         """
+        if self.attachment_extensions is not None and not isinstance(
+            self.attachment_extensions, tuple
+        ):
+            object.__setattr__(
+                self, "attachment_extensions", tuple(self.attachment_extensions)
+            )
         if self.max_attachment_size_mb < 0:
             raise ConfigurationError(
                 "max_attachment_size_mb must be >= 0, got "

--- a/src/markdown_vault_mcp/config_sections/content.py
+++ b/src/markdown_vault_mcp/config_sections/content.py
@@ -27,18 +27,25 @@ class ContentConfig:
 
         ``0`` is a valid sentinel for "unlimited"; only negative size values are
         rejected. ``attachment_extensions`` accepts any ``Sequence[str]`` but is
-        stored as a tuple so the frozen config's contents cannot be mutated.
+        stored as a tuple so the frozen config's contents cannot be mutated; a
+        bare ``str``/``bytes`` is rejected (it would otherwise be silently split
+        into characters).
 
         Raises:
             ConfigurationError: If ``max_attachment_size_mb`` or
-                ``max_note_read_bytes`` is negative.
+                ``max_note_read_bytes`` is negative, or ``attachment_extensions``
+                is a ``str``/``bytes`` instead of a sequence of strings.
         """
-        if self.attachment_extensions is not None and not isinstance(
-            self.attachment_extensions, tuple
-        ):
-            object.__setattr__(
-                self, "attachment_extensions", tuple(self.attachment_extensions)
-            )
+        if self.attachment_extensions is not None:
+            if isinstance(self.attachment_extensions, (str, bytes)):
+                raise ConfigurationError(
+                    "attachment_extensions must be a sequence of strings, not a "
+                    f"single {type(self.attachment_extensions).__name__}"
+                )
+            if not isinstance(self.attachment_extensions, tuple):
+                object.__setattr__(
+                    self, "attachment_extensions", tuple(self.attachment_extensions)
+                )
         if self.max_attachment_size_mb < 0:
             raise ConfigurationError(
                 "max_attachment_size_mb must be >= 0, got "

--- a/src/markdown_vault_mcp/config_sections/indexing.py
+++ b/src/markdown_vault_mcp/config_sections/indexing.py
@@ -8,6 +8,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from markdown_vault_mcp.exceptions import ConfigurationError
+
 _SEQUENCE_FIELDS = (
     "indexed_frontmatter_fields",
     "required_frontmatter",
@@ -31,11 +33,24 @@ class IndexingConfig:
 
         The fields accept any ``Sequence[str]`` (e.g. a list from ``from_env``)
         but are stored as tuples so a caller cannot mutate the frozen config's
-        contents after construction.
+        contents after construction. A bare ``str``/``bytes`` is rejected: it is
+        itself a ``Sequence[str]`` and would otherwise be silently split into
+        individual characters.
+
+        Raises:
+            ConfigurationError: If a sequence field is set to a ``str`` or
+                ``bytes`` instead of a sequence of strings.
         """
         for name in _SEQUENCE_FIELDS:
             value = getattr(self, name)
-            if value is not None and not isinstance(value, tuple):
+            if value is None:
+                continue
+            if isinstance(value, (str, bytes)):
+                raise ConfigurationError(
+                    f"{name} must be a sequence of strings, not a single "
+                    f"{type(value).__name__}"
+                )
+            if not isinstance(value, tuple):
                 object.__setattr__(self, name, tuple(value))
 
     @classmethod

--- a/src/markdown_vault_mcp/config_sections/indexing.py
+++ b/src/markdown_vault_mcp/config_sections/indexing.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
+# Imported at runtime (not under TYPE_CHECKING) so the frozen dataclass's field
+# annotations stay resolvable if anything introspects them via get_type_hints.
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+
+_SEQUENCE_FIELDS = (
+    "indexed_frontmatter_fields",
+    "required_frontmatter",
+    "exclude_patterns",
+)
 
 
 @dataclass(frozen=True)
@@ -13,9 +22,21 @@ class IndexingConfig:
     index_path: Path | None = None
     state_path: Path | None = None
     embeddings_path: Path | None = None
-    indexed_frontmatter_fields: list[str] | None = None
-    required_frontmatter: list[str] | None = None
-    exclude_patterns: list[str] | None = None
+    indexed_frontmatter_fields: Sequence[str] | None = None
+    required_frontmatter: Sequence[str] | None = None
+    exclude_patterns: Sequence[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Freeze the sequence fields into tuples for deep immutability (#639).
+
+        The fields accept any ``Sequence[str]`` (e.g. a list from ``from_env``)
+        but are stored as tuples so a caller cannot mutate the frozen config's
+        contents after construction.
+        """
+        for name in _SEQUENCE_FIELDS:
+            value = getattr(self, name)
+            if value is not None and not isinstance(value, tuple):
+                object.__setattr__(self, name, tuple(value))
 
     @classmethod
     def from_env(cls, prefix: str) -> IndexingConfig:

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from markdown_vault_mcp.types import DEFAULT_ATTACHMENT_EXTENSIONS
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 from markdown_vault_mcp.utils.fts import fts_row_to_note_info
 from markdown_vault_mcp.utils.links import (
@@ -22,7 +23,7 @@ from markdown_vault_mcp.utils.text import (
 )
 
 
-def is_path_excluded(path: str, exclude_patterns: list[str] | None) -> bool:
+def is_path_excluded(path: str, exclude_patterns: Sequence[str] | None) -> bool:
     """Check whether *path* matches any configured exclude pattern.
 
     Args:
@@ -39,7 +40,7 @@ def is_path_excluded(path: str, exclude_patterns: list[str] | None) -> bool:
 
 
 def effective_attachment_extensions(
-    attachment_extensions: list[str] | None,
+    attachment_extensions: Sequence[str] | None,
 ) -> frozenset[str]:
     """Return the effective set of allowed attachment extensions.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -746,7 +746,7 @@ class TestBuildVaultConfigFields:
         args = _build_parser().parse_args(["index"])
         vault = _build_vault(args)
 
-        assert vault._exclude_patterns == ["**/*.log.md", ".obsidian/**"]
+        assert vault._exclude_patterns == ("**/*.log.md", ".obsidian/**")
 
     def test_attachment_fields_propagated_from_env(
         self,
@@ -766,7 +766,7 @@ class TestBuildVaultConfigFields:
         args = _build_parser().parse_args(["index"])
         vault = _build_vault(args)
 
-        assert vault._attachment_extensions == ["pdf", "png", "jpg"]
+        assert vault._attachment_extensions == ("pdf", "png", "jpg")
         assert vault._max_attachment_size_mb == 25.0
 
     def test_exclude_patterns_are_functional_via_cli_path(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -209,9 +209,9 @@ class TestLoadConfig:
         assert config.indexing.index_path == Path("/data/index.db")
         assert config.indexing.embeddings_path == Path("/data/embeddings")
         assert config.indexing.state_path == Path("/data/state.json")
-        assert config.indexing.indexed_frontmatter_fields == ["cluster", "topics"]
-        assert config.indexing.required_frontmatter == ["title", "cluster"]
-        assert config.indexing.exclude_patterns == [".obsidian/**", ".trash/**"]
+        assert config.indexing.indexed_frontmatter_fields == ("cluster", "topics")
+        assert config.indexing.required_frontmatter == ("title", "cluster")
+        assert config.indexing.exclude_patterns == (".obsidian/**", ".trash/**")
         assert config.git.repo_url == "https://github.com/acme/vault.git"
         assert config.git.username == "oauth2"
         assert config.git.token == "ghp_test123"
@@ -281,7 +281,7 @@ class TestLoadConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEXED_FIELDS", " a , b , c ")
         config = VaultConfig.from_env()
-        assert config.indexing.indexed_frontmatter_fields == ["a", "b", "c"]
+        assert config.indexing.indexed_frontmatter_fields == ("a", "b", "c")
 
     def test_empty_comma_list_yields_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -299,7 +299,7 @@ class TestToVaultKwargs:
             indexing=IndexingConfig(exclude_patterns=[".obsidian/**"]),
         )
         kwargs = config.to_vault_kwargs()
-        assert kwargs["exclude_patterns"] == [".obsidian/**"]
+        assert kwargs["exclude_patterns"] == (".obsidian/**",)
         assert kwargs["source_dir"] == Path("/tmp/vault")
 
     def test_excludes_git_token(self) -> None:
@@ -340,9 +340,9 @@ class TestToVaultKwargs:
         assert kwargs["index_path"] == Path("/tmp/index.db")
         assert kwargs["embeddings_path"] == Path("/tmp/emb")
         assert kwargs["state_path"] == Path("/tmp/state.json")
-        assert kwargs["indexed_frontmatter_fields"] == ["cluster"]
-        assert kwargs["required_frontmatter"] == ["title"]
-        assert kwargs["exclude_patterns"] == [".obsidian/**"]
+        assert kwargs["indexed_frontmatter_fields"] == ("cluster",)
+        assert kwargs["required_frontmatter"] == ("title",)
+        assert kwargs["exclude_patterns"] == (".obsidian/**",)
         assert kwargs["attachment_extensions"] is None
         assert kwargs["max_attachment_size_mb"] == 1.0
         assert kwargs["git_pull_interval_s"] == 0
@@ -587,7 +587,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", "pdf,png,docx")
         config = VaultConfig.from_env()
-        assert config.content.attachment_extensions == ["pdf", "png", "docx"]
+        assert config.content.attachment_extensions == ("pdf", "png", "docx")
 
     def test_attachment_extensions_wildcard(
         self, monkeypatch: pytest.MonkeyPatch
@@ -596,7 +596,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", "*")
         config = VaultConfig.from_env()
-        assert config.content.attachment_extensions == ["*"]
+        assert config.content.attachment_extensions == ("*",)
 
     def test_attachment_extensions_empty_returns_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -661,7 +661,7 @@ class TestAttachmentConfig:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "5.0")
         config = VaultConfig.from_env()
         kwargs = config.to_vault_kwargs()
-        assert kwargs["attachment_extensions"] == ["pdf", "png"]
+        assert kwargs["attachment_extensions"] == ("pdf", "png")
         assert kwargs["max_attachment_size_mb"] == 5.0
 
 
@@ -1353,6 +1353,25 @@ class TestConfigHelpers:
 
 
 class TestIndexingConfigFromEnv:
+    def test_sequence_fields_frozen_as_tuples(self):
+        """List inputs are stored as tuples so the frozen config is deeply immutable (#639)."""
+        from markdown_vault_mcp.config_sections import IndexingConfig
+
+        cfg = IndexingConfig(
+            indexed_frontmatter_fields=["a", "b"],
+            required_frontmatter=["title"],
+            exclude_patterns=[".obsidian/**"],
+        )
+        assert cfg.indexed_frontmatter_fields == ("a", "b")
+        assert isinstance(cfg.indexed_frontmatter_fields, tuple)
+        assert isinstance(cfg.required_frontmatter, tuple)
+        assert isinstance(cfg.exclude_patterns, tuple)
+        # The stored contents cannot be mutated (the actual #639 contract).
+        with pytest.raises(AttributeError):
+            cfg.exclude_patterns.append("x")  # type: ignore[union-attr]
+        # None stays None (not coerced to an empty tuple).
+        assert IndexingConfig().exclude_patterns is None
+
     def test_defaults(self, monkeypatch):
         from markdown_vault_mcp.config_sections import IndexingConfig
 
@@ -1384,8 +1403,8 @@ class TestIndexingConfigFromEnv:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEXED_FIELDS", "a, b, c")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_EXCLUDE", ".obsidian/**")
         cfg = IndexingConfig.from_env("MARKDOWN_VAULT_MCP")
-        assert cfg.indexed_frontmatter_fields == ["a", "b", "c"]
-        assert cfg.exclude_patterns == [".obsidian/**"]
+        assert cfg.indexed_frontmatter_fields == ("a", "b", "c")
+        assert cfg.exclude_patterns == (".obsidian/**",)
 
     def test_empty_list_yields_none(self, monkeypatch):
         from markdown_vault_mcp.config_sections import IndexingConfig
@@ -1658,6 +1677,18 @@ class TestSyncConfigFromEnv:
 
 
 class TestContentConfigFromEnv:
+    def test_attachment_extensions_frozen_as_tuple(self):
+        """A list of extensions is stored as a tuple for deep immutability (#639)."""
+        from markdown_vault_mcp.config_sections import ContentConfig
+
+        cfg = ContentConfig(attachment_extensions=["png", "pdf"])
+        assert cfg.attachment_extensions == ("png", "pdf")
+        assert isinstance(cfg.attachment_extensions, tuple)
+        # The stored contents cannot be mutated (the actual #639 contract).
+        with pytest.raises(AttributeError):
+            cfg.attachment_extensions.append("x")  # type: ignore[union-attr]
+        assert ContentConfig().attachment_extensions is None
+
     def test_defaults(self, monkeypatch, tmp_path):
         from markdown_vault_mcp.config_sections import ContentConfig
 
@@ -1677,14 +1708,14 @@ class TestContentConfigFromEnv:
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", "*")
         cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
-        assert cfg.attachment_extensions == ["*"]
+        assert cfg.attachment_extensions == ("*",)
 
     def test_attachment_extensions_list(self, monkeypatch, tmp_path):
         from markdown_vault_mcp.config_sections import ContentConfig
 
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS", "pdf,png,docx")
         cfg = ContentConfig.from_env("MARKDOWN_VAULT_MCP", tmp_path)
-        assert cfg.attachment_extensions == ["pdf", "png", "docx"]
+        assert cfg.attachment_extensions == ("pdf", "png", "docx")
 
     def test_attachment_extensions_empty_is_none(self, monkeypatch, tmp_path):
         from markdown_vault_mcp.config_sections import ContentConfig

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1369,6 +1369,9 @@ class TestIndexingConfigFromEnv:
         # The stored contents cannot be mutated (the actual #639 contract).
         with pytest.raises(AttributeError):
             cfg.exclude_patterns.append("x")  # type: ignore[union-attr]
+        # A bare str (itself a Sequence[str]) is rejected, not split into chars.
+        with pytest.raises(ConfigurationError, match="must be a sequence of strings"):
+            IndexingConfig(exclude_patterns="x.md")
         # None stays None (not coerced to an empty tuple).
         assert IndexingConfig().exclude_patterns is None
 
@@ -1687,6 +1690,9 @@ class TestContentConfigFromEnv:
         # The stored contents cannot be mutated (the actual #639 contract).
         with pytest.raises(AttributeError):
             cfg.attachment_extensions.append("x")  # type: ignore[union-attr]
+        # A bare str (itself a Sequence[str]) is rejected, not split into chars.
+        with pytest.raises(ConfigurationError, match="must be a sequence of strings"):
+            ContentConfig(attachment_extensions="pdf")
         assert ContentConfig().attachment_extensions is None
 
     def test_defaults(self, monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "1.28.0"
+version = "2.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

**PR3 of #638 — closes the epic, and #639** (deep-immutability gap in the frozen config dataclasses).

`@dataclass(frozen=True)` blocks attribute *reassignment* but not mutation of a `list` field's *contents* — a caller holding a reference can `.append()` to a shared config's list. The four sequence fields are now annotated `Sequence[str]` and coerced to **tuples** in `__post_init__`, so the frozen config's contents are genuinely immutable:

- `IndexingConfig.indexed_frontmatter_fields` / `required_frontmatter` / `exclude_patterns`
- `ContentConfig.attachment_extensions`

The fields still accept any `Sequence[str]` (e.g. the list `from_env`/`parse_list` produces) for ergonomics; the stored value is always a tuple (or `None`). Coercion runs in `__post_init__` (not just `from_env`), so direct construction and `dataclasses.replace` are covered too.

### Scope / boundary (deliberate)
The immutability boundary is the **frozen config**. Downstream (`Vault`/managers/scanner) receives these via `to_vault_kwargs`'s `dict[str, Any]`, so its `list[str]` signatures keep working unchanged — and the Explore audit confirmed **no downstream mutation** (`.append`/`isinstance(list)`/index-assignment) of these values exists. Only the two read-path helpers that receive the *precise* type (`utils.is_path_excluded`, `utils.effective_attachment_extensions`) and the transfer validators are widened to `Sequence[str]`. Widening the rest is a no-op churn that the `Any` boundary makes unnecessary.

### Notes
- `Sequence` stays a runtime import on the dataclass files (a `TYPE_CHECKING`-gated annotation import breaks `get_type_hints` on dataclasses — prior lesson). TC003 is suppressed for both config files via `pyproject.toml` (matching the pre-existing `indexing.py` entry).
- `uv.lock` syncs the editable project version `1.28.0` → `2.0.0rc1`, which main's lock had left stale after the rc manifest bump (`uv lock --check` now passes).

### Tests
- Immutability tests assert the stored value is a tuple, that `None` stays `None`, **and that the contents cannot be mutated** (`pytest.raises(AttributeError)` on `.append`).
- ~17 equality assertions that compared config values against list literals now compare against tuples.
- 2069 tests pass; ruff + mypy + mkdocs `--strict` clean.

### Review
9-lens preflight circus run. Type-design noted `Sequence` vs `tuple[str, ...]` for the field type — I kept `Sequence` (sound; enables list inputs as first-class, with the coercion guaranteeing immutability) and added the negative-mutation test to assert the contract directly. Unified the TC003 suppression mechanism across both config files; the downstream `list[str]` boundary is documented above.

Closes #638, closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)