### PR TITLE
refactor(git): extract query.py; harden askpass (#659); get_history author docs (#484) (#577 PR2)

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -669,7 +669,7 @@ List commits that touched a note (or the whole vault) within an optional time wi
 | `sha` | string | Full 40-character commit SHA |
 | `short_sha` | string | 7-character abbreviated SHA |
 | `timestamp` | string | ISO 8601 author timestamp |
-| `author` | string | Committer name and email |
+| `author` | string | Author name and email |
 | `message` | string | First line of the commit message |
 | `paths_changed` | list[string] | Files touched by the commit. Populated for vault-wide queries (`path=null`); always empty for single-note queries, since the path is already determined by the query arguments — callers know which file the commit touched without needing it echoed back. |
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1597,7 +1597,7 @@ def register_tools(mcp: FastMCP) -> None:
                 - sha (str): Full 40-character commit SHA.
                 - short_sha (str): 7-character abbreviated SHA.
                 - timestamp (str): ISO 8601 author timestamp.
-                - author (str): Committer name and email, e.g. "Name <email>".
+                - author (str): Author name and email, e.g. "Name <email>".
                 - message (str): First line of the commit message.
                 - paths_changed (list[str]): Files touched by the commit.
                   Populated for vault-wide queries (path=None). Always empty

--- a/src/markdown_vault_mcp/git/_run.py
+++ b/src/markdown_vault_mcp/git/_run.py
@@ -32,16 +32,31 @@ def _normalize_remote(url: str) -> str:
 
 def _build_askpass_env(token: str, username: str) -> dict[str, str]:
     fd, script_path_str = tempfile.mkstemp(suffix=".sh", prefix="git_askpass_")
-    script_path = Path(script_path_str)
-    os.close(fd)
-    script_path.write_text(
-        "#!/bin/sh\n"
-        'case "$1" in\n'
-        "  *sername*) printf '%s\\n' \"${MVMCP_GIT_USERNAME:-}\" ;;\n"
-        "  *) printf '%s\\n' \"${MVMCP_GIT_TOKEN:-}\" ;;\n"
-        "esac\n"
-    )
-    script_path.chmod(stat.S_IRWXU)
+    # GIT_ASKPASS must be executable; mkstemp creates the file 0600. Prefer
+    # fchmod on the still-owned fd (no reopen-by-path) where available; fall back
+    # to chmod-by-path on platforms without fchmod (e.g. Windows), where the exec
+    # bit is a no-op anyway since the script only runs under a POSIX shell.
+    _has_fchmod = hasattr(os, "fchmod")
+    try:
+        if _has_fchmod:
+            os.fchmod(fd, stat.S_IRWXU)
+        with os.fdopen(fd, "w") as f:  # fdopen takes ownership of fd
+            f.write(
+                "#!/bin/sh\n"
+                'case "$1" in\n'
+                "  *sername*) printf '%s\\n' \"${MVMCP_GIT_USERNAME:-}\" ;;\n"
+                "  *) printf '%s\\n' \"${MVMCP_GIT_TOKEN:-}\" ;;\n"
+                "esac\n"
+            )
+        if not _has_fchmod:
+            Path(script_path_str).chmod(stat.S_IRWXU)
+    except BaseException:
+        # fdopen took ownership only if it succeeded; suppress double-close.
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        with contextlib.suppress(OSError):
+            Path(script_path_str).unlink()
+        raise
     return {
         **os.environ,
         "GIT_ASKPASS": script_path_str,
@@ -104,7 +119,7 @@ def cleanup_git_env(env: dict[str, str] | None) -> None:
         return
     env.pop("MVMCP_GIT_USERNAME", None)
     env.pop("MVMCP_GIT_TOKEN", None)
-    script_path_str = env.get("GIT_ASKPASS")
+    script_path_str = env.pop("GIT_ASKPASS", None)
     if not script_path_str:
         return
     with contextlib.suppress(OSError):

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -6,8 +6,11 @@ intercepts them.
 
 The ``git_root`` parameter is pre-resolved by the caller (typically via
 :meth:`GitWriteStrategy._ensure_git_root`, which memoises the result).  Passing
-``None`` is a no-op: both functions return an empty result immediately.  This keeps
-git-root discovery out of these functions so that tests can prime the cache on the
+``None`` to the two query entry points (:func:`get_file_history` /
+:func:`get_file_diff`) is a no-op: they return an empty result immediately.
+(:func:`resolve_path_at_ref` is an internal helper and requires a resolved
+``git_root``.)  This keeps git-root discovery out of these functions so that tests
+can prime the cache on the
 strategy instance and then patch ``subprocess.run`` without the patch also
 interfering with the discovery call.
 """

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -1,0 +1,440 @@
+"""Read-only git history and diff queries.
+
+Pure functions -- lock-free, no mutation of repository state. Subprocess calls are
+module-qualified (``subprocess.run``) so the test suite's global monkeypatch still
+intercepts them.
+
+The ``git_root`` parameter is pre-resolved by the caller (typically via
+:meth:`GitWriteStrategy._ensure_git_root`, which memoises the result).  Passing
+``None`` is a no-op: both functions return an empty result immediately.  This keeps
+git-root discovery out of these functions so that tests can prime the cache on the
+strategy instance and then patch ``subprocess.run`` without the patch also
+interfering with the discovery call.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from markdown_vault_mcp.git._run import cleanup_git_env, git_env
+from markdown_vault_mcp.types import CommitDiff, HistoryEntry
+
+logger = logging.getLogger(__name__)
+
+
+def get_file_history(
+    git_root: Path | None,
+    repo_path: Path,
+    path: Path | None,
+    since: str | None,
+    limit: int,
+    until: str | None = None,
+    *,
+    token: str | None,
+    username: str,
+) -> list[HistoryEntry]:
+    """Return commits that touched *path* (or the whole vault).
+
+    Args:
+        git_root: Pre-resolved git repository root, or ``None`` if the vault
+            is not inside a git repository (returns ``[]`` immediately).
+        repo_path: Absolute path of the vault root.  Used to compute the
+            vault-relative prefix when the git root is a parent of the vault.
+        path: Absolute path of the file to filter on, or ``None`` for the
+            entire vault.
+        since: Passed as ``--since`` to ``git log`` (ISO 8601 or git date
+            expression such as ``"1 week ago"``).  ``None`` disables the
+            filter.
+        limit: Maximum number of commits to return (capped at 100).
+        until: Passed as ``--until`` to ``git log`` (same format as
+            *since*).  ``None`` disables the filter.  When both *since*
+            and *until* are given the window is bounded on both sides,
+            inclusive at both endpoints (git's ``--since`` / ``--until``
+            semantics: a commit whose committer date equals either
+            boundary is included).
+        token: Personal access token for authenticated git operations, or
+            ``None`` for unauthenticated access.
+        username: Git username for authenticated operations.
+
+    Returns:
+        List of :class:`HistoryEntry` ordered from newest to oldest.
+
+    Raises:
+        ValueError: If ``git log`` exits non-zero (e.g. an invalid
+            ``since`` / ``until`` expression).
+    """
+    if git_root is None:
+        return []
+
+    limit = min(max(1, limit), 100)
+
+    # Compute vault-relative prefix for normalising --name-only output.
+    # When the git root is a parent of repo_path, git reports paths
+    # relative to the git root (e.g. "vault/note.md").  We strip the
+    # leading prefix so callers always receive vault-relative paths.
+    # Resolve repo_path to handle symlinks: git rev-parse --show-toplevel
+    # always returns the real (resolved) path, so we must match it.
+    try:
+        vault_rel = repo_path.resolve().relative_to(git_root)
+    except ValueError:
+        vault_rel = Path()
+    vault_prefix = "" if vault_rel == Path() else vault_rel.as_posix() + "/"
+
+    # \x1e (ASCII Record Separator) is the sentinel used to split commit
+    # blocks in the output — it cannot appear in filenames or commit messages.
+    _SENTINEL = "\x1e"
+    cmd = [
+        "git",
+        "-C",
+        str(git_root),
+        "log",
+        f"--format={_SENTINEL}%H%x00%h%x00%aI%x00%aN <%aE>%x00%s",
+        f"-n{limit}",
+    ]
+    if since:
+        cmd.append(f"--since={since}")
+    if until:
+        cmd.append(f"--until={until}")
+    if path is None:
+        # vault-wide: scope to the resolved real path so symlinked SOURCE_DIR
+        # values work correctly (git compares against the real toplevel).
+        cmd += ["--name-only", "--", str(repo_path.resolve())]
+    else:
+        cmd += ["--follow", "--", str(path)]
+
+    env = git_env(token, username)
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"git log failed: {(exc.stderr or '').strip()}") from exc
+    finally:
+        cleanup_git_env(env)
+
+    entries: list[HistoryEntry] = []
+    raw = result.stdout
+    if not raw.strip():
+        return []
+    # Split on the sentinel we embedded at the start of each format line.
+    # The first element will be empty (output starts with sentinel), so we
+    # skip it.  Each remaining block is: header_line\nfile1\nfile2\n
+    blocks = raw.split(_SENTINEL)
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+        lines = block.splitlines()
+        if not lines:
+            continue
+        header = lines[0]
+        parts = header.split("\x00")
+        if len(parts) < 5:
+            continue
+        sha, short_sha, timestamp, author, message = parts[:5]
+        paths_changed: list[str] = []
+        if path is None and len(lines) > 1:
+            # vault-wide query: strip vault prefix to get vault-relative paths
+            for ln in lines[1:]:
+                ln = ln.strip()
+                if not ln:
+                    continue
+                if vault_prefix and ln.startswith(vault_prefix):
+                    ln = ln[len(vault_prefix) :]
+                paths_changed.append(ln)
+        entries.append(
+            HistoryEntry(
+                sha=sha,
+                short_sha=short_sha,
+                timestamp=timestamp,
+                author=author,
+                message=message,
+                paths_changed=paths_changed,
+            )
+        )
+    return entries
+
+
+def resolve_path_at_ref(
+    git_root: Path,
+    ref: str,
+    cur_rel: str,
+    env: dict[str, str] | None,
+) -> str | None:
+    """Return the path *cur_rel* had at *ref* via rename detection, else None."""
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(git_root),
+                "diff",
+                "--name-status",
+                # 30% threshold: catch rename-with-edits per #338, avoid template false-positives.
+                "--find-renames=30",
+                # -z: NUL-terminated fields, tolerates tabs/newlines in paths.
+                "-z",
+                ref,
+                "HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    # Stream: <status>\0<path>\0  (R*/C* add a second path before the closing NUL).
+    items = result.stdout.split("\0")[:-1]
+    i = 0
+    while i < len(items):
+        status = items[i]
+        if status.startswith("R"):
+            if i + 2 >= len(items):
+                break
+            if items[i + 2] == cur_rel:
+                return items[i + 1]
+            i += 3
+        elif status.startswith("C"):
+            if i + 2 >= len(items):
+                break
+            i += 3
+        else:
+            if i + 1 >= len(items):
+                break
+            i += 2
+    return None
+
+
+def get_file_diff(
+    git_root: Path | None,
+    path: Path,
+    ref: str | None,
+    per_commit: bool,
+    since_timestamp: str | None = None,
+    limit: int | None = None,
+    *,
+    token: str | None,
+    username: str,
+) -> str | list[CommitDiff]:
+    """Return a unified diff of *path* from *ref* to HEAD.
+
+    Exactly one of *ref* or *since_timestamp* must be supplied.  When
+    *since_timestamp* is given, it is resolved via
+    ``git rev-list --before=<ts> -1 HEAD`` to the most recent commit at
+    or before that instant.  Boundary is **inclusive**: a commit whose
+    committer date equals *since_timestamp* IS the resolved ref.
+
+    Args:
+        git_root: Pre-resolved git repository root, or ``None`` if the vault
+            is not inside a git repository (returns ``""`` / ``[]``
+            immediately).
+        path: Absolute path of the file to diff.
+        ref: The git ref (SHA or expression) to diff from.  Mutually
+            exclusive with *since_timestamp*.
+        per_commit: When ``False``, return a single unified diff string.
+            When ``True``, return one :class:`CommitDiff` per intervening
+            commit.
+        since_timestamp: ISO 8601 datetime string resolved to a commit SHA
+            via ``git rev-list --before``.  Mutually exclusive with *ref*.
+        limit: When *per_commit* is ``True``, cap the number of commits
+            walked to the *limit* most recent ones (clamped to
+            ``[1, 100]``).  Ignored when *per_commit* is ``False``.
+            ``None`` means unbounded (still capped by the underlying
+            ``ref..HEAD`` range).
+        token: Personal access token for authenticated git operations, or
+            ``None`` for unauthenticated access.
+        username: Git username for authenticated operations.
+
+    Returns:
+        A unified diff string when *per_commit* is ``False``, or a list of
+        :class:`CommitDiff` when *per_commit* is ``True``.
+
+    Raises:
+        ValueError: If *ref* is not found in history, *since_timestamp*
+            cannot be resolved, or a git subprocess exits non-zero.
+    """
+    _DIFF_MAX_BYTES = 50 * 1024  # 50 KB
+
+    if git_root is None:
+        if per_commit:
+            return []
+        return ""
+
+    path_str = str(path)
+    env = git_env(token, username)
+    try:
+        if since_timestamp is not None:
+            # Resolve the ISO timestamp to the most recent commit before it.
+            try:
+                rev_result = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(git_root),
+                        "rev-list",
+                        f"--before={since_timestamp}",
+                        "-1",
+                        "HEAD",
+                        # No path filter: git rev-list has no --follow, so
+                        # filtering by current path silently misses pre-rename
+                        # commits.  Resolve the timestamp globally and let the
+                        # subsequent diff (which uses -- path_str) handle scope.
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=env,
+                )
+            except subprocess.CalledProcessError as exc:
+                raise ValueError(
+                    f"Could not resolve timestamp {since_timestamp!r}: "
+                    f"{(exc.stderr or '').strip()}"
+                ) from exc
+            ref = rev_result.stdout.strip()
+            if not ref:
+                return [] if per_commit else ""
+
+        if ref is None:
+            raise ValueError("Either 'ref' or 'since_timestamp' must be provided")
+
+        if not per_commit:
+            # Recover path-at-ref so diffs across renames show real deltas.
+            try:
+                cur_rel = path.resolve().relative_to(git_root).as_posix()
+            except ValueError:
+                cur_rel = None
+            old_path = (
+                resolve_path_at_ref(git_root, ref, cur_rel, env)
+                if cur_rel is not None
+                else None
+            )
+            if old_path is None or cur_rel is None or old_path == cur_rel:
+                diff_cmd = [
+                    "git",
+                    "-C",
+                    str(git_root),
+                    "diff",
+                    f"{ref}..HEAD",
+                    "--",
+                    path_str,
+                ]
+            else:
+                diff_cmd = [
+                    "git",
+                    "-C",
+                    str(git_root),
+                    "diff",
+                    f"{ref}:{old_path}",
+                    f"HEAD:{cur_rel}",
+                ]
+            try:
+                result = subprocess.run(
+                    diff_cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=env,
+                )
+            except subprocess.CalledProcessError as exc:
+                raise ValueError(
+                    f"Could not compute diff against {ref!r}: invalid ref or "
+                    f"path not present at that revision"
+                ) from exc
+            diff = result.stdout
+            if len(diff.encode()) > _DIFF_MAX_BYTES:
+                omitted = len(diff.encode()) - _DIFF_MAX_BYTES
+                diff = diff.encode()[:_DIFF_MAX_BYTES].decode(errors="replace")
+                diff += f"\n[diff truncated: {omitted} bytes omitted]"
+            return diff
+
+        # per_commit=True: enumerate commits in range then show each.
+        # Use --name-only with a sentinel so we can recover the path the
+        # file had at each commit — critical for correct diffs across
+        # renames (git show sha -- new.md returns nothing for pre-rename
+        # commits; we must pass the old filename instead).
+        _PC_SENTINEL = "\x1e"
+        log_cmd = [
+            "git",
+            "-C",
+            str(git_root),
+            "log",
+            "--follow",
+            f"--format={_PC_SENTINEL}%H%x00%h%x00%aI%x00%s",
+            "--name-only",
+        ]
+        if limit is not None:
+            clamped_limit = min(max(1, limit), 100)
+            log_cmd.append(f"-n{clamped_limit}")
+        log_cmd += [f"{ref}..HEAD", "--", path_str]
+        try:
+            log_result = subprocess.run(
+                log_cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                env=env,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(f"Commit {ref!r} not found in history") from exc
+
+        diffs: list[CommitDiff] = []
+        for block in log_result.stdout.split(_PC_SENTINEL):
+            block = block.strip()
+            if not block:
+                continue
+            lines = block.splitlines()
+            if not lines:
+                continue
+            parts = lines[0].split("\x00")
+            if len(parts) < 4:
+                continue
+            sha, short_sha, timestamp, message = parts[:4]
+            # Recover the path the file had at this specific commit.
+            # With --follow, this will be the old name for pre-rename commits.
+            commit_path = next((ln.strip() for ln in lines[1:] if ln.strip()), path_str)
+            try:
+                show_result = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(git_root),
+                        "show",
+                        "--format=",
+                        "-p",
+                        sha,
+                        "--",
+                        commit_path,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=env,
+                )
+            except subprocess.CalledProcessError as exc:
+                raise ValueError(f"Could not retrieve diff for commit {sha!r}") from exc
+            commit_diff = show_result.stdout.lstrip("\n")
+            if len(commit_diff.encode()) > _DIFF_MAX_BYTES:
+                omitted = len(commit_diff.encode()) - _DIFF_MAX_BYTES
+                commit_diff = commit_diff.encode()[:_DIFF_MAX_BYTES].decode(
+                    errors="replace"
+                )
+                commit_diff += f"\n[diff truncated: {omitted} bytes omitted]"
+            diffs.append(
+                CommitDiff(
+                    sha=sha,
+                    short_sha=short_sha,
+                    timestamp=timestamp,
+                    message=message,
+                    diff=commit_diff,
+                )
+            )
+        return diffs
+    finally:
+        cleanup_git_env(env)

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -21,9 +21,12 @@ import frontmatter
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from markdown_vault_mcp.types import CommitDiff, HistoryEntry
+
 from fastmcp.server.dependencies import get_access_token as _get_access_token
 
 from markdown_vault_mcp.exceptions import ConfigurationError
+from markdown_vault_mcp.git import query
 from markdown_vault_mcp.git._run import (
     _build_askpass_env,
     _find_git_root,
@@ -49,7 +52,6 @@ from markdown_vault_mcp.git.types import (
     PullResult,
     PushResult,
 )
-from markdown_vault_mcp.types import CommitDiff, HistoryEntry
 
 logger = logging.getLogger(__name__)
 
@@ -1876,101 +1878,16 @@ class GitWriteStrategy:
             ValueError: If ``git log`` exits non-zero (e.g. an invalid
                 ``since`` / ``until`` expression).
         """
-        git_root = self._ensure_git_root(repo_path)
-        if git_root is None:
-            return []
-
-        limit = min(max(1, limit), 100)
-
-        # Compute vault-relative prefix for normalising --name-only output.
-        # When the git root is a parent of repo_path, git reports paths
-        # relative to the git root (e.g. "vault/note.md").  We strip the
-        # leading prefix so callers always receive vault-relative paths.
-        # Resolve repo_path to handle symlinks: git rev-parse --show-toplevel
-        # always returns the real (resolved) path, so we must match it.
-        try:
-            vault_rel = repo_path.resolve().relative_to(git_root)
-        except ValueError:
-            vault_rel = Path()
-        vault_prefix = "" if vault_rel == Path() else vault_rel.as_posix() + "/"
-
-        # \x1e (ASCII Record Separator) is the sentinel used to split commit
-        # blocks in the output — it cannot appear in filenames or commit messages.
-        _SENTINEL = "\x1e"
-        cmd = [
-            "git",
-            "-C",
-            str(git_root),
-            "log",
-            f"--format={_SENTINEL}%H%x00%h%x00%aI%x00%aN <%aE>%x00%s",
-            f"-n{limit}",
-        ]
-        if since:
-            cmd.append(f"--since={since}")
-        if until:
-            cmd.append(f"--until={until}")
-        if path is None:
-            # vault-wide: scope to the resolved real path so symlinked SOURCE_DIR
-            # values work correctly (git compares against the real toplevel).
-            cmd += ["--name-only", "--", str(repo_path.resolve())]
-        else:
-            cmd += ["--follow", "--", str(path)]
-
-        env = self._git_env()
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                check=True,
-                env=env,
-            )
-        except subprocess.CalledProcessError as exc:
-            raise ValueError(f"git log failed: {(exc.stderr or '').strip()}") from exc
-        finally:
-            self._cleanup_git_env(env)
-
-        entries: list[HistoryEntry] = []
-        raw = result.stdout
-        if not raw.strip():
-            return []
-        # Split on the sentinel we embedded at the start of each format line.
-        # The first element will be empty (output starts with sentinel), so we
-        # skip it.  Each remaining block is: header_line\nfile1\nfile2\n
-        blocks = raw.split(_SENTINEL)
-        for block in blocks:
-            block = block.strip()
-            if not block:
-                continue
-            lines = block.splitlines()
-            if not lines:
-                continue
-            header = lines[0]
-            parts = header.split("\x00")
-            if len(parts) < 5:
-                continue
-            sha, short_sha, timestamp, author, message = parts[:5]
-            paths_changed: list[str] = []
-            if path is None and len(lines) > 1:
-                # vault-wide query: strip vault prefix to get vault-relative paths
-                for ln in lines[1:]:
-                    ln = ln.strip()
-                    if not ln:
-                        continue
-                    if vault_prefix and ln.startswith(vault_prefix):
-                        ln = ln[len(vault_prefix) :]
-                    paths_changed.append(ln)
-            entries.append(
-                HistoryEntry(
-                    sha=sha,
-                    short_sha=short_sha,
-                    timestamp=timestamp,
-                    author=author,
-                    message=message,
-                    paths_changed=paths_changed,
-                )
-            )
-        return entries
+        return query.get_file_history(
+            self._ensure_git_root(repo_path),
+            repo_path,
+            path,
+            since,
+            limit,
+            until,
+            token=self._token,
+            username=self._username,
+        )
 
     @staticmethod
     def _resolve_path_at_ref(
@@ -1980,48 +1897,7 @@ class GitWriteStrategy:
         env: dict[str, str] | None,
     ) -> str | None:
         """Return the path *cur_rel* had at *ref* via rename detection, else None."""
-        try:
-            result = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(git_root),
-                    "diff",
-                    "--name-status",
-                    # 30% threshold: catch rename-with-edits per #338, avoid template false-positives.
-                    "--find-renames=30",
-                    # -z: NUL-terminated fields, tolerates tabs/newlines in paths.
-                    "-z",
-                    ref,
-                    "HEAD",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-                env=env,
-            )
-        except subprocess.CalledProcessError:
-            return None
-        # Stream: <status>\0<path>\0  (R*/C* add a second path before the closing NUL).
-        items = result.stdout.split("\0")[:-1]
-        i = 0
-        while i < len(items):
-            status = items[i]
-            if status.startswith("R"):
-                if i + 2 >= len(items):
-                    break
-                if items[i + 2] == cur_rel:
-                    return items[i + 1]
-                i += 3
-            elif status.startswith("C"):
-                if i + 2 >= len(items):
-                    break
-                i += 3
-            else:
-                if i + 1 >= len(items):
-                    break
-                i += 2
-        return None
+        return query.resolve_path_at_ref(git_root, ref, cur_rel, env)
 
     def get_file_diff(
         self,
@@ -2064,189 +1940,16 @@ class GitWriteStrategy:
             ValueError: If *ref* is not found in history, *since_timestamp*
                 cannot be resolved, or a git subprocess exits non-zero.
         """
-        _DIFF_MAX_BYTES = 50 * 1024  # 50 KB
-
-        git_root = self._ensure_git_root(repo_path)
-        if git_root is None:
-            if per_commit:
-                return []
-            return ""
-
-        path_str = str(path)
-        env = self._git_env()
-        try:
-            if since_timestamp is not None:
-                # Resolve the ISO timestamp to the most recent commit before it.
-                try:
-                    rev_result = subprocess.run(
-                        [
-                            "git",
-                            "-C",
-                            str(git_root),
-                            "rev-list",
-                            f"--before={since_timestamp}",
-                            "-1",
-                            "HEAD",
-                            # No path filter: git rev-list has no --follow, so
-                            # filtering by current path silently misses pre-rename
-                            # commits.  Resolve the timestamp globally and let the
-                            # subsequent diff (which uses -- path_str) handle scope.
-                        ],
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                        env=env,
-                    )
-                except subprocess.CalledProcessError as exc:
-                    raise ValueError(
-                        f"Could not resolve timestamp {since_timestamp!r}: "
-                        f"{(exc.stderr or '').strip()}"
-                    ) from exc
-                ref = rev_result.stdout.strip()
-                if not ref:
-                    return [] if per_commit else ""
-
-            if ref is None:
-                raise ValueError("Either 'ref' or 'since_timestamp' must be provided")
-
-            if not per_commit:
-                # Recover path-at-ref so diffs across renames show real deltas.
-                try:
-                    cur_rel = path.resolve().relative_to(git_root).as_posix()
-                except ValueError:
-                    cur_rel = None
-                old_path = (
-                    self._resolve_path_at_ref(git_root, ref, cur_rel, env)
-                    if cur_rel is not None
-                    else None
-                )
-                if old_path is None or cur_rel is None or old_path == cur_rel:
-                    diff_cmd = [
-                        "git",
-                        "-C",
-                        str(git_root),
-                        "diff",
-                        f"{ref}..HEAD",
-                        "--",
-                        path_str,
-                    ]
-                else:
-                    diff_cmd = [
-                        "git",
-                        "-C",
-                        str(git_root),
-                        "diff",
-                        f"{ref}:{old_path}",
-                        f"HEAD:{cur_rel}",
-                    ]
-                try:
-                    result = subprocess.run(
-                        diff_cmd,
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                        env=env,
-                    )
-                except subprocess.CalledProcessError as exc:
-                    raise ValueError(
-                        f"Could not compute diff against {ref!r}: invalid ref or "
-                        f"path not present at that revision"
-                    ) from exc
-                diff = result.stdout
-                if len(diff.encode()) > _DIFF_MAX_BYTES:
-                    omitted = len(diff.encode()) - _DIFF_MAX_BYTES
-                    diff = diff.encode()[:_DIFF_MAX_BYTES].decode(errors="replace")
-                    diff += f"\n[diff truncated: {omitted} bytes omitted]"
-                return diff
-
-            # per_commit=True: enumerate commits in range then show each.
-            # Use --name-only with a sentinel so we can recover the path the
-            # file had at each commit — critical for correct diffs across
-            # renames (git show sha -- new.md returns nothing for pre-rename
-            # commits; we must pass the old filename instead).
-            _PC_SENTINEL = "\x1e"
-            log_cmd = [
-                "git",
-                "-C",
-                str(git_root),
-                "log",
-                "--follow",
-                f"--format={_PC_SENTINEL}%H%x00%h%x00%aI%x00%s",
-                "--name-only",
-            ]
-            if limit is not None:
-                clamped_limit = min(max(1, limit), 100)
-                log_cmd.append(f"-n{clamped_limit}")
-            log_cmd += [f"{ref}..HEAD", "--", path_str]
-            try:
-                log_result = subprocess.run(
-                    log_cmd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=env,
-                )
-            except subprocess.CalledProcessError as exc:
-                raise ValueError(f"Commit {ref!r} not found in history") from exc
-
-            diffs: list[CommitDiff] = []
-            for block in log_result.stdout.split(_PC_SENTINEL):
-                block = block.strip()
-                if not block:
-                    continue
-                lines = block.splitlines()
-                if not lines:
-                    continue
-                parts = lines[0].split("\x00")
-                if len(parts) < 4:
-                    continue
-                sha, short_sha, timestamp, message = parts[:4]
-                # Recover the path the file had at this specific commit.
-                # With --follow, this will be the old name for pre-rename commits.
-                commit_path = next(
-                    (ln.strip() for ln in lines[1:] if ln.strip()), path_str
-                )
-                try:
-                    show_result = subprocess.run(
-                        [
-                            "git",
-                            "-C",
-                            str(git_root),
-                            "show",
-                            "--format=",
-                            "-p",
-                            sha,
-                            "--",
-                            commit_path,
-                        ],
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                        env=env,
-                    )
-                except subprocess.CalledProcessError as exc:
-                    raise ValueError(
-                        f"Could not retrieve diff for commit {sha!r}"
-                    ) from exc
-                commit_diff = show_result.stdout.lstrip("\n")
-                if len(commit_diff.encode()) > _DIFF_MAX_BYTES:
-                    omitted = len(commit_diff.encode()) - _DIFF_MAX_BYTES
-                    commit_diff = commit_diff.encode()[:_DIFF_MAX_BYTES].decode(
-                        errors="replace"
-                    )
-                    commit_diff += f"\n[diff truncated: {omitted} bytes omitted]"
-                diffs.append(
-                    CommitDiff(
-                        sha=sha,
-                        short_sha=short_sha,
-                        timestamp=timestamp,
-                        message=message,
-                        diff=commit_diff,
-                    )
-                )
-            return diffs
-        finally:
-            self._cleanup_git_env(env)
+        return query.get_file_diff(
+            self._ensure_git_root(repo_path),
+            path,
+            ref,
+            per_commit,
+            since_timestamp,
+            limit,
+            token=self._token,
+            username=self._username,
+        )
 
 
 def git_write_strategy(

--- a/src/markdown_vault_mcp/git/types.py
+++ b/src/markdown_vault_mcp/git/types.py
@@ -72,9 +72,12 @@ class PullResult:
               MCP versions as ``.conflict-mcp-*`` siblings (see #232).
               HEAD advanced; ``applied`` is ``True`` and
               ``conflict_files`` is populated.
-            * ``"conflict_resolution_failed"`` — rebase produced no
-              recoverable saved files and the working tree was
-              restored; HEAD did not move.
+            * ``"conflict_resolution_failed"`` — the conflict-resolution
+              path could not produce a usable result.  Two variants:
+              (a) the rebase was aborted before completing — HEAD did not
+              move (``from_sha == to_sha``); (b) the rebase completed and
+              HEAD advanced, but the sibling-files commit failed — HEAD
+              has moved (``from_sha != to_sha``, ``applied=False``).
 
             See module-level ``PULL_REASON_*`` constants for the
             string values.
@@ -92,19 +95,19 @@ class PullResult:
     from_sha: str
     to_sha: str
     reason: str | None = None
-    conflict_files: tuple[str, ...] = field(default_factory=tuple)
+    conflict_files: tuple[str, ...] = field(default=())
 
     @classmethod
     def head_unchanged_failure(cls, from_sha: str, reason: str) -> PullResult:
         """Construct a ``PullResult`` for a failure path where HEAD did not move.
 
-        The 5 failure paths in :meth:`GitWriteStrategy.force_pull` and its
-        helpers (``no_remote``, ``non_fast_forward``,
-        ``conflict_resolution_failed``, ``non_fast_forward_with_conflicts``,
-        ``fetch_failed``) all share the same shape: ``applied=False``,
-        ``fast_forward=False``, ``commits_pulled=0``, and
-        ``to_sha == from_sha`` (HEAD unchanged).  This factory reduces the
-        repetition.
+        The failure paths in :meth:`GitWriteStrategy.force_pull` and its
+        helpers that use this factory (``no_remote``, ``fetch_failed``,
+        ``conflict_resolution_failed`` when the rebase was aborted before
+        completing, and ``non_fast_forward_with_conflicts``) all share the
+        same shape: ``applied=False``, ``fast_forward=False``,
+        ``commits_pulled=0``, and ``to_sha == from_sha`` (HEAD unchanged).
+        This factory reduces the repetition.
 
         Args:
             from_sha: HEAD SHA before the failed operation.  Used for both

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -556,6 +556,165 @@ class TestGitWriteStrategyClass:
         finally:
             strategy._cleanup_git_env(env)
 
+    def test_askpass_script_is_executable_and_cleanup_pops_key(self) -> None:
+        """GIT_ASKPASS script has exec bit set; cleanup_git_env removes key from dict.
+
+        Regression test for two issues:
+        1. The script must be executable (S_IXUSR) — git cannot run it otherwise.
+           This guards against accidentally dropping the fchmod/chmod call.
+        2. cleanup_git_env must pop (not just read) GIT_ASKPASS so the stale
+           key is gone from the env dict after cleanup.
+        """
+        import stat
+        from pathlib import Path
+
+        from markdown_vault_mcp.git._run import _build_askpass_env, cleanup_git_env
+
+        env = _build_askpass_env("tok", "user")
+        script_path = env["GIT_ASKPASS"]
+        try:
+            # (1) exec bit must be set
+            assert Path(script_path).stat().st_mode & stat.S_IXUSR, (
+                f"GIT_ASKPASS script {script_path!r} is not executable"
+            )
+            # (2) cleanup removes the key from the dict AND unlinks the file
+            cleanup_git_env(env)
+            assert "GIT_ASKPASS" not in env, (
+                "cleanup_git_env must pop GIT_ASKPASS from the env dict"
+            )
+            assert not Path(script_path).exists(), (
+                "cleanup_git_env must unlink the temporary script file"
+            )
+        except AssertionError:
+            # Ensure we don't leak the script on assertion failure before cleanup ran.
+            import contextlib
+
+            with contextlib.suppress(OSError):
+                Path(script_path).unlink()
+            raise
+
+    def test_build_askpass_env_chmod_fallback_without_fchmod(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On platforms without ``os.fchmod`` (e.g. Windows), the exec bit is set
+        via ``os.chmod`` on the path and the script is still produced.
+
+        Guards the portability fallback in ``_build_askpass_env``: removing
+        ``os.fchmod`` must not raise ``AttributeError`` and must still yield an
+        executable askpass script.
+        """
+        import os
+        import stat
+        from pathlib import Path
+
+        from markdown_vault_mcp.git._run import _build_askpass_env, cleanup_git_env
+
+        monkeypatch.delattr(os, "fchmod", raising=False)
+
+        env = _build_askpass_env("tok", "user")
+        script_path = env["GIT_ASKPASS"]
+        try:
+            assert Path(script_path).stat().st_mode & stat.S_IXUSR, (
+                "chmod fallback did not make the askpass script executable"
+            )
+        finally:
+            cleanup_git_env(env)
+
+    def test_build_askpass_env_unlinks_script_on_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If a step after mkstemp fails, the temp script is unlinked (no leak).
+
+        Guards the ``except BaseException`` cleanup path in ``_build_askpass_env``
+        (#659): when ``os.fchmod`` raises, the still-owned fd is closed, the
+        just-created temp file is removed, and the original error propagates.
+        """
+        import os
+        import tempfile
+        from pathlib import Path
+
+        from markdown_vault_mcp.git import _run
+
+        created: dict[str, str] = {}
+        real_mkstemp = tempfile.mkstemp
+
+        def recording_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+            fd, path = real_mkstemp(*args, **kwargs)  # type: ignore[arg-type]
+            created["path"] = path
+            return fd, path
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("simulated fchmod failure")
+
+        monkeypatch.setattr(tempfile, "mkstemp", recording_mkstemp)
+        monkeypatch.setattr(os, "fchmod", boom)
+
+        with pytest.raises(OSError, match="simulated fchmod failure"):
+            _run._build_askpass_env("tok", "user")
+
+        assert "path" in created, "mkstemp was not reached"
+        assert not Path(created["path"]).exists(), (
+            "temp askpass script leaked when _build_askpass_env failed mid-build"
+        )
+
+    def test_build_askpass_env_write_failure_propagates_not_ebadf(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A write failure inside the fdopen block propagates the original error.
+
+        Exercises the second branch of the ``except BaseException`` cleanup in
+        ``_build_askpass_env`` (#659): when ``f.write`` raises inside the
+        ``with os.fdopen(fd)`` block, the context manager has already closed the
+        fd, so the explicit ``os.close(fd)`` in the handler is a double-close that
+        raises ``OSError(EBADF)``.  The ``contextlib.suppress(OSError)`` must
+        absorb it so the ORIGINAL error propagates (not a misleading "Bad file
+        descriptor"), and the temp script must still be unlinked.
+        """
+        import os
+        import tempfile
+        from pathlib import Path
+
+        from markdown_vault_mcp.git import _run
+
+        created: dict[str, str] = {}
+        real_mkstemp = tempfile.mkstemp
+        real_fdopen = os.fdopen
+
+        def recording_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+            fd, path = real_mkstemp(*args, **kwargs)  # type: ignore[arg-type]
+            created["path"] = path
+            return fd, path
+
+        class _BoomWriter:
+            """Delegates ``__exit__`` to the real file (closing the fd) but
+            raises on ``write`` to force a failure inside the ``with`` block."""
+
+            def __init__(self, real: object) -> None:
+                self._real = real
+
+            def __enter__(self) -> _BoomWriter:
+                return self
+
+            def __exit__(self, *exc: object) -> object:
+                return self._real.__exit__(*exc)  # type: ignore[attr-defined]
+
+            def write(self, *_args: object, **_kwargs: object) -> None:
+                raise RuntimeError("simulated write failure")
+
+        def fake_fdopen(fd: int, *args: object, **kwargs: object) -> _BoomWriter:
+            return _BoomWriter(real_fdopen(fd, *args, **kwargs))  # type: ignore[arg-type]
+
+        monkeypatch.setattr(tempfile, "mkstemp", recording_mkstemp)
+        monkeypatch.setattr(os, "fdopen", fake_fdopen)
+
+        with pytest.raises(RuntimeError, match="simulated write failure"):
+            _run._build_askpass_env("tok", "user")
+
+        assert "path" in created, "mkstemp was not reached"
+        assert not Path(created["path"]).exists(), (
+            "temp askpass script leaked when write failed inside the fdopen block"
+        )
+
     def test_startup_recovery_pushes_unpushed(
         self, git_repo_with_remote: tuple[Path, Path]
     ) -> None:
@@ -1364,7 +1523,10 @@ class TestGitSyncOnce:
         captured: list[dict[str, str] | None] = []
 
         def fake_lfs_pull(env: dict[str, str] | None = None) -> None:
-            captured.append(env)
+            # Snapshot the env at call time: sync_once's finally-block runs
+            # cleanup_git_env(env), which pops GIT_ASKPASS from the same dict,
+            # so a by-reference capture would not see it post-cleanup (#659).
+            captured.append(dict(env) if env is not None else None)
 
         strategy._lfs_pull = fake_lfs_pull  # type: ignore[assignment]
         did_advance = strategy.sync_once(work)


### PR DESCRIPTION
Second PR of the #577 GitWriteStrategy decomposition (PR1 #658 merged). 3 commits: (1) extract git/query.py with thin delegators (no behavior change); (2) harden askpass temp-file — write-to-fd + os.fchmod exec-bit + env.pop, with happy-path + both except-cleanup-regime tests (closes #659); (3) fix get_history author-vs-committer docs + PullResult reason-code docstrings (closes #484). 2072 passed, mypy + ruff clean, preflight-circus clean at >=80. PR3 (conflict.py, closes #577) follows.

Closes #484, closes #659. Refs #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)