### PR TITLE
fix: 🐛 Eliminate boot-time full reindex, skip-churn, and embedding drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `list_tags` | List all unique frontmatter tag values |
 | `reindex` | Force a full reindex of the vault |
 | `stats` | Get collection statistics (document count, chunk count, link health metrics, etc.) |
-| `build_embeddings` | Build or rebuild vector embeddings for semantic search |
+| `build_embeddings` | Embed missing/changed chunks for semantic search (`force=true` rebuilds from scratch) |
 | `embeddings_status` | Check embedding provider and index status |
 | `get_backlinks` | Find all documents that link to a given document |
 | `get_outlinks` | Find all links from a document, with existence check |

--- a/docs/design.md
+++ b/docs/design.md
@@ -255,6 +255,17 @@ Two methods manage the index:
 - **`reindex()`**: incremental update. Uses `ChangeTracker` to detect
   adds/modifies/deletes since the last scan and applies only the delta.
   Applies `exclude_patterns` filtering and purges stale excluded documents.
+- **`build_embeddings(force=False)`**: vector-index convergence. Without
+  `force`, diffs the persisted vector index against the chunks currently in
+  the FTS index (chunk identity: the `(title, heading, content)` multiset
+  per document path) and reconciles: missing chunks are embedded and added,
+  vectors for documents no longer in the FTS index are removed, and
+  documents whose indexed content changed are re-embedded. After every call
+  the vector index mirrors the FTS chunk set exactly, logged as a single
+  summary line (`build_embeddings: +N added, -M removed, K up-to-date`).
+  Embedding work scales with the diff size, not the vault size. An empty
+  vector index (cold boot) builds everything; `force=True` discards and
+  rebuilds from scratch (e.g. after an embedding-model change).
 
 **Server startup**: the MCP server lifespan checks
 `Collection.has_indexed_documents()`. When the persistent index is already
@@ -262,7 +273,10 @@ populated it runs `reindex()` (adopt + incremental delta for files changed
 while the server was down); only an empty index triggers a full
 `build_index()`. This keeps boot time independent of vault size and avoids
 SQLite write contention between concurrent server processes sharing one
-`index_path`.
+`index_path`. `build_embeddings()` then converges the vector index, so
+documents that entered the FTS index via the boot-time `reindex()` (written
+while no server was running) are embedded instead of silently accumulating
+as semantic-search drift.
 
 **Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
 `Collection` lazily builds the FTS index from `source_dir` if no pre-built
@@ -296,8 +310,8 @@ pathological memory allocation from embedding providers (see issue #159).
 FastEmbed's ONNX inference uses a further inner batch size of 4 to keep
 per-call memory bounded — without this, the ONNX attention matrix for 64 long
 chunks can require >192 GB of allocation. The save happens once at the end so a
-mid-run crash does not leave a partial index that the skip-if-exists check
-treats as complete on the next startup.
+mid-run crash does not leave a partial index on disk; whatever was persisted
+last is simply converged against the FTS index on the next startup.
 
 ### Thread Safety
 
@@ -382,7 +396,7 @@ Collection(...)
   → sync_from_remote_before_index()   # git fetch + ff-only before first index
   → build_index() or reindex()        # full build (empty index) or
                                       # adopt + incremental delta (populated)
-  → build_embeddings()                # build vector index (when configured)
+  → build_embeddings()                # converge vector index to FTS (when configured)
   → start()                           # launch background pull loop
   → zero or more read/write operations
   → close()                           # stop pull loop, flush git, release SQLite

--- a/docs/design.md
+++ b/docs/design.md
@@ -240,12 +240,23 @@ Two methods manage the index:
 
 - **`build_index(force=False)`**: initial population. Scans `source_dir` and
   builds the FTS index. If the index already has data and `force=False`, this
-  is a no-op. `force=True` drops and rebuilds from scratch. When a persistent
-  `index_path` contains documents that now match `exclude_patterns`, they are
-  purged from the FTS and vector indexes after the scan.
+  is a no-op: the populated index is *adopted* as-is, even by a freshly
+  spawned process opening a persistent `index_path` — no rescan, no
+  re-upserts. Adoption purges documents that now match `exclude_patterns`
+  from the FTS and vector indexes, but does not pick up external file
+  changes (use `reindex()` for that). `force=True` drops and rebuilds from
+  scratch.
 - **`reindex()`**: incremental update. Uses `ChangeTracker` to detect
   adds/modifies/deletes since the last scan and applies only the delta.
   Applies `exclude_patterns` filtering and purges stale excluded documents.
+
+**Server startup**: the MCP server lifespan checks
+`Collection.has_indexed_documents()`. When the persistent index is already
+populated it runs `reindex()` (adopt + incremental delta for files changed
+while the server was down); only an empty index triggers a full
+`build_index()`. This keeps boot time independent of vault size and avoids
+SQLite write contention between concurrent server processes sharing one
+`index_path`.
 
 **Lazy initialization**: on first call to `search()`, `list()`, or `read()`,
 `Collection` lazily builds the FTS index from `source_dir` if no pre-built
@@ -363,7 +374,8 @@ This ensures no work is lost on shutdown. The full lifecycle contract is:
 ```
 Collection(...)
   → sync_from_remote_before_index()   # git fetch + ff-only before first index
-  → build_index()                     # build FTS index
+  → build_index() or reindex()        # full build (empty index) or
+                                      # adopt + incremental delta (populated)
   → build_embeddings()                # build vector index (when configured)
   → start()                           # launch background pull loop
   → zero or more read/write operations
@@ -800,6 +812,7 @@ class Collection:
              pattern: str | None = None) -> list[NoteInfo]: ...
 
     # --- Index management ---
+    def has_indexed_documents(self) -> bool: ...
     def build_index(self, *, force: bool = False) -> IndexStats: ...
     def reindex(self) -> ReindexResult: ...
     def build_embeddings(self, *, force: bool = False) -> int: ...

--- a/docs/design.md
+++ b/docs/design.md
@@ -212,7 +212,13 @@ for built-in names, or pass a custom instance.
 **Hash-based**, not git-based. Works with any directory, no git dependency.
 
 - **State file** (the JSON persistence layer for hash-based change detection):
-  `{relative_path: sha256_hash}` as JSON.
+  `{"version": 2, "indexed": {relative_path: sha256_hash}, "skipped": {relative_path: sha256_hash}}`
+  as JSON. The `skipped` map records files seen on disk but deliberately not
+  indexed (missing required frontmatter, excluded, unparseable), so they are
+  not re-reported as added — and their skips not re-logged — on every scan; a
+  skipped file is re-evaluated only when its content hash changes. The legacy
+  flat format (`{relative_path: sha256_hash}`) still loads, with all entries
+  treated as indexed.
 - **Default path**: `{source_dir}/.markdown_vault_mcp/state.json` (when
   `state_path=None`).
 - On `reindex()`: scan all files, compare hashes to stored state, re-parse and
@@ -547,6 +553,7 @@ class ReindexResult:
     modified: int
     deleted: int
     unchanged: int
+    skipped: int = 0                  # files on disk deliberately not indexed
 
 @dataclass
 class CollectionStats:
@@ -570,6 +577,7 @@ class ChangeSet:
     modified: list[str]
     deleted: list[str]
     unchanged: int
+    skipped_unchanged: int = 0        # known-skipped files, content unchanged
 
 # --- Graph types ---
 
@@ -1001,12 +1009,16 @@ class ChangeTracker:
     def __init__(self, state_path: Path): ...
     def detect_changes(self, source_dir: Path,
                        glob_pattern: str = "**/*.md") -> ChangeSet: ...
-    def update_state(self, notes: list[ParsedNote]) -> None: ...
+    def update_state(self, notes: list[ParsedNote],
+                     skipped: dict[str, str] | None = None) -> None: ...
     def reset(self) -> None: ...
 ```
 
 `tracker.py` is entirely new code (no ifcraftcorpus equivalent). State file
-format: `{"Journal/note.md": "sha256hex", ...}` as JSON.
+format (version 2):
+`{"version": 2, "indexed": {"Journal/note.md": "sha256hex", ...}, "skipped": {"CLAUDE.md": "sha256hex", ...}}`
+as JSON. The legacy flat format (`{"Journal/note.md": "sha256hex", ...}`)
+still loads; all entries are treated as indexed.
 
 ### `mcp_server.py` -- Generic MCP Server
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -181,7 +181,9 @@ Incrementally update the full-text search index to reflect file changes made out
 
 If semantic search is already active (vector index loaded), this also re-embeds changed documents automatically.
 
-**Returns:** `{"added": 3, "modified": 1, "deleted": 0, "unchanged": 38}`
+**Returns:** `{"added": 3, "modified": 1, "deleted": 0, "unchanged": 38, "skipped": 2}`
+
+`skipped` counts files present on disk that were deliberately not indexed (missing required frontmatter, matching an exclude pattern, or unparseable). Unchanged skipped files are remembered and not re-evaluated until their content changes.
 
 ### `build_embeddings`
 

--- a/src/markdown_vault_mcp/__init__.py
+++ b/src/markdown_vault_mcp/__init__.py
@@ -1,39 +1,96 @@
-"""Generic markdown collection with FTS5 + semantic search."""
+"""Generic markdown collection with FTS5 + semantic search.
 
-from markdown_vault_mcp.collection import Collection
-from markdown_vault_mcp.config import CollectionConfig, load_config
-from markdown_vault_mcp.exceptions import (
-    ConcurrentModificationError,
-    ConfigurationError,
-    DocumentExistsError,
-    DocumentNotFoundError,
-    EditConflictError,
-    MarkdownMCPError,
-    ReadOnlyError,
-)
-from markdown_vault_mcp.git import GitWriteStrategy, git_write_strategy
-from markdown_vault_mcp.types import (
-    AttachmentContent,
-    AttachmentInfo,
-    ChangeSet,
-    Chunk,
-    CollectionStats,
-    DeleteResult,
-    EditResult,
-    FTSResult,
-    IndexStats,
-    MostLinkedNote,
-    NoteContent,
-    NoteContext,
-    NoteInfo,
-    ParsedNote,
-    ReindexResult,
-    RenameResult,
-    SearchResult,
-    SimilarItem,
-    WriteCallback,
-    WriteResult,
-)
+Public attributes are loaded lazily (PEP 562) instead of eagerly importing
+every submodule here. Eager imports pulled the full dependency tree
+(``python-frontmatter`` → PyYAML, including the ``yaml._yaml`` C extension)
+into any import of this package — which broke
+``pytest --cov=markdown_vault_mcp.<submodule>``: coverage.py resolves dotted
+source packages with :func:`importlib.util.find_spec` inside a
+sys.modules-restoring context, unloading PyYAML's pure-Python modules while
+the single-phase-init C extension stayed cached with references to the
+original classes. Every subsequent ``CSafeLoader`` parse then failed with
+``ConstructorError: could not determine a constructor for the tag None``.
+Keeping this module import-light avoids that interaction entirely (and
+speeds up CLI startup).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from markdown_vault_mcp.collection import Collection
+    from markdown_vault_mcp.config import CollectionConfig, load_config
+    from markdown_vault_mcp.exceptions import (
+        ConcurrentModificationError,
+        ConfigurationError,
+        DocumentExistsError,
+        DocumentNotFoundError,
+        EditConflictError,
+        MarkdownMCPError,
+        ReadOnlyError,
+    )
+    from markdown_vault_mcp.git import GitWriteStrategy, git_write_strategy
+    from markdown_vault_mcp.types import (
+        AttachmentContent,
+        AttachmentInfo,
+        ChangeSet,
+        Chunk,
+        CollectionStats,
+        DeleteResult,
+        EditResult,
+        FTSResult,
+        IndexStats,
+        MostLinkedNote,
+        NoteContent,
+        NoteContext,
+        NoteInfo,
+        ParsedNote,
+        ReindexResult,
+        RenameResult,
+        SearchResult,
+        SimilarItem,
+        WriteCallback,
+        WriteResult,
+    )
+
+# Public attribute name → defining submodule. Resolved on first access by
+# __getattr__ below.
+_EXPORTS: dict[str, str] = {
+    "Collection": "markdown_vault_mcp.collection",
+    "CollectionConfig": "markdown_vault_mcp.config",
+    "load_config": "markdown_vault_mcp.config",
+    "ConcurrentModificationError": "markdown_vault_mcp.exceptions",
+    "ConfigurationError": "markdown_vault_mcp.exceptions",
+    "DocumentExistsError": "markdown_vault_mcp.exceptions",
+    "DocumentNotFoundError": "markdown_vault_mcp.exceptions",
+    "EditConflictError": "markdown_vault_mcp.exceptions",
+    "MarkdownMCPError": "markdown_vault_mcp.exceptions",
+    "ReadOnlyError": "markdown_vault_mcp.exceptions",
+    "GitWriteStrategy": "markdown_vault_mcp.git",
+    "git_write_strategy": "markdown_vault_mcp.git",
+    "AttachmentContent": "markdown_vault_mcp.types",
+    "AttachmentInfo": "markdown_vault_mcp.types",
+    "ChangeSet": "markdown_vault_mcp.types",
+    "Chunk": "markdown_vault_mcp.types",
+    "CollectionStats": "markdown_vault_mcp.types",
+    "DeleteResult": "markdown_vault_mcp.types",
+    "EditResult": "markdown_vault_mcp.types",
+    "FTSResult": "markdown_vault_mcp.types",
+    "IndexStats": "markdown_vault_mcp.types",
+    "MostLinkedNote": "markdown_vault_mcp.types",
+    "NoteContent": "markdown_vault_mcp.types",
+    "NoteContext": "markdown_vault_mcp.types",
+    "NoteInfo": "markdown_vault_mcp.types",
+    "ParsedNote": "markdown_vault_mcp.types",
+    "ReindexResult": "markdown_vault_mcp.types",
+    "RenameResult": "markdown_vault_mcp.types",
+    "SearchResult": "markdown_vault_mcp.types",
+    "SimilarItem": "markdown_vault_mcp.types",
+    "WriteCallback": "markdown_vault_mcp.types",
+    "WriteResult": "markdown_vault_mcp.types",
+}
 
 __all__ = [
     "AttachmentContent",
@@ -69,3 +126,32 @@ __all__ = [
     "git_write_strategy",
     "load_config",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve a public attribute from its defining submodule.
+
+    Args:
+        name: Attribute name being looked up on the package.
+
+    Returns:
+        The resolved attribute.
+
+    Raises:
+        AttributeError: If *name* is not a public attribute of this package.
+    """
+    try:
+        module_name = _EXPORTS[name]
+    except KeyError:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg) from None
+    return getattr(importlib.import_module(module_name), name)
+
+
+def __dir__() -> list[str]:
+    """Expose lazily resolved public attributes to :func:`dir`.
+
+    Returns:
+        Sorted list of public attribute names.
+    """
+    return sorted(set(__all__) | set(globals()))

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -69,13 +69,28 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
         # build_index() scans the freshest working tree.
         await asyncio.to_thread(collection.sync_from_remote_before_index)
 
-        # Build index eagerly so first tool call is fast.
-        stats = await asyncio.to_thread(collection.build_index)
-        logger.info(
-            "Index built: %d documents, %d chunks",
-            stats.documents_indexed,
-            stats.chunks_indexed,
-        )
+        # Build index eagerly so first tool call is fast.  When a persistent
+        # index is already populated from a previous process, adopt it and
+        # apply only the incremental delta (files changed while the server
+        # was down) instead of re-upserting every document — full rebuilds
+        # made boot time grow with vault size and caused SQLite lock
+        # contention between concurrent server instances.
+        if await asyncio.to_thread(collection.has_indexed_documents):
+            result = await asyncio.to_thread(collection.reindex)
+            logger.info(
+                "index_adopted added=%d modified=%d deleted=%d unchanged=%d",
+                result.added,
+                result.modified,
+                result.deleted,
+                result.unchanged,
+            )
+        else:
+            stats = await asyncio.to_thread(collection.build_index)
+            logger.info(
+                "index_built documents=%d chunks=%d",
+                stats.documents_indexed,
+                stats.chunks_indexed,
+            )
 
         # Build embeddings eagerly when an embedding provider is configured.
         # build_embeddings() skips work if the vector index already exists on disk,

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -93,8 +93,10 @@ def make_collection_lifespan(config: CollectionConfig) -> Any:
             )
 
         # Build embeddings eagerly when an embedding provider is configured.
-        # build_embeddings() skips work if the vector index already exists on disk,
-        # so this is safe to call on every startup.
+        # build_embeddings() converges the persisted vector index to the FTS
+        # index: chunks added/changed while the server was down are embedded
+        # and vectors for deleted documents are dropped, so semantic search
+        # never drifts from keyword search.  Work scales with the diff size.
         if embedding_provider is not None:
             chunks_embedded = await asyncio.to_thread(collection.build_embeddings)
             logger.info("Embeddings ready: %d chunks", chunks_embedded)

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -742,7 +742,7 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
         model), use 'build_embeddings' with force=True instead.
 
         Returns:
-            Dict with counts: added, modified, deleted, unchanged.
+            Dict with counts: added, modified, deleted, unchanged, skipped.
         """
         result = await asyncio.to_thread(collection.reindex)
         return asdict(result)

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -761,17 +761,20 @@ def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     ) -> dict[str, Any]:
         """Rebuild vector embeddings for semantic and hybrid search.
 
-        Embeddings are built automatically on startup, so this is normally
-        not needed. Use force=True to rebuild from scratch after changing
-        the embedding model. Without force, skips if embeddings already exist.
+        Embeddings are converged automatically on startup, so this is
+        normally not needed. Without force, the vector index is diffed
+        against the search index: missing or changed chunks are embedded
+        and stale vectors are removed. Use force=True to rebuild from
+        scratch after changing the embedding model.
 
         Args:
             force: When True, discards existing embeddings and rebuilds from
                 scratch. Use only if the embedding model has changed.
-                False (default) only embeds chunks not yet embedded.
+                False (default) embeds only missing or changed chunks.
 
         Returns:
-            Dict with chunks_embedded: number of chunks newly embedded.
+            Dict with chunks_embedded: total chunks in the vector index
+            after the call.
         """
         count = await asyncio.to_thread(collection.build_embeddings, force=force)
         return {"chunks_embedded": count}

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -197,10 +197,11 @@ def _cmd_reindex(args: argparse.Namespace) -> None:
         f"{result.skipped} skipped"
     )
     try:
-        should_force = result.added > 0 or result.modified > 0 or result.deleted > 0
-        n = collection.build_embeddings(force=should_force)
-        logger.info("Embedded %d chunks", n)
-        print(f"Embedded {n} chunks")
+        # build_embeddings() converges the vector index to the FTS index,
+        # embedding only the changed chunks — no force rebuild needed.
+        n = collection.build_embeddings()
+        logger.info("Embeddings ready: %d chunks", n)
+        print(f"Embeddings ready: {n} chunks")
     except ValueError:
         pass  # embeddings not configured
 

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -184,15 +184,17 @@ def _cmd_reindex(args: argparse.Namespace) -> None:
     collection = _build_collection(args)
     result = collection.reindex()
     logger.info(
-        "Reindex complete: %d added, %d modified, %d deleted, %d unchanged",
+        "Reindex complete: %d added, %d modified, %d deleted, %d unchanged, %d skipped",
         result.added,
         result.modified,
         result.deleted,
         result.unchanged,
+        result.skipped,
     )
     print(
         f"Reindex: {result.added} added, {result.modified} modified, "
-        f"{result.deleted} deleted, {result.unchanged} unchanged"
+        f"{result.deleted} deleted, {result.unchanged} unchanged, "
+        f"{result.skipped} skipped"
     )
     try:
         should_force = result.added > 0 or result.modified > 0 or result.deleted > 0

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -20,7 +20,7 @@ import sqlite3
 import tempfile
 import threading
 import unicodedata
-from collections import defaultdict
+from collections import Counter, defaultdict
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -1174,7 +1174,8 @@ class Collection:
             return 0
 
         # Load persisted vectors so stale entries are purged from the
-        # .npy sidecar too (build_embeddings skips if count > 0).
+        # .npy sidecar too, keeping it consistent immediately (the next
+        # build_embeddings() convergence would also remove them).
         if (
             self._vectors is None
             and self._embedding_provider is not None
@@ -1495,14 +1496,25 @@ class Collection:
         )
 
     def build_embeddings(self, *, force: bool = False) -> int:
-        """Build the vector index from all chunks currently in the FTS index.
+        """Build or converge the vector index against the FTS index.
+
+        Without ``force``, the persisted vector index is diffed against the
+        chunks currently in the FTS index and reconciled: chunks present in
+        the FTS index but missing from the vector index are embedded and
+        added, vectors for documents no longer in the FTS index are removed,
+        and documents whose indexed content changed are re-embedded.  After
+        every call the vector index mirrors the FTS chunk set exactly, so
+        external changes picked up by a boot-time :meth:`reindex` (while no
+        vector index was loaded) cannot accumulate as permanent
+        semantic-search drift.  Work scales with the size of the diff, not
+        the size of the vault.
 
         Args:
-            force: If ``True``, rebuild from scratch even if a vector index
-                already exists on disk.
+            force: If ``True``, discard any existing vectors and rebuild the
+                index from scratch (e.g. after changing the embedding model).
 
         Returns:
-            Total number of chunks embedded.
+            Total number of chunks in the vector index after the call.
 
         Raises:
             ValueError: If ``embedding_provider`` or ``embeddings_path`` is
@@ -1521,12 +1533,9 @@ class Collection:
         else:
             # Load persisted vectors (or create empty) so we can check count.
             self._load_vectors()
+            assert self._vectors is not None
             if self._vectors.count > 0:
-                logger.info(
-                    "build_embeddings: index already exists (%d chunks), skipping",
-                    self._vectors.count,
-                )
-                return self._vectors.count
+                return self._converge_embeddings()
             # Empty index — fall through to build from scratch.
 
         rows = self._fts.list_notes()
@@ -1586,6 +1595,88 @@ class Collection:
         else:
             logger.info("build_embeddings: nothing to embed")
         return total
+
+    def _converge_embeddings(self) -> int:
+        """Reconcile the loaded vector index with the FTS chunk set.
+
+        Chunk identity is the ``(title, heading, content)`` multiset per
+        document path — exactly the metadata stored alongside each vector
+        row.  Documents present only in the vector index are removed;
+        documents missing from it are embedded; documents whose chunk
+        multiset differs in any way (modified content, changed title) are
+        re-embedded in full.
+
+        Follows the two-phase locking discipline of
+        :meth:`_flush_dirty_embeddings`: the snapshot/diff and the fast
+        numpy mutations run under ``_write_lock``, while the (potentially
+        slow) embedding provider runs outside it.  The window between
+        phases is the same accepted TOCTOU as deferred flushes — any
+        concurrent change is reconciled by the next flush or boot.
+
+        Returns:
+            Total number of chunks in the vector index after convergence.
+        """
+        assert self._vectors is not None
+        assert self._embeddings_path is not None
+        assert self._embedding_provider is not None
+        vectors = self._vectors
+
+        def _signature(rows: list[dict]) -> Counter:
+            return Counter(
+                (r.get("title"), r.get("heading"), r.get("content")) for r in rows
+            )
+
+        # Phase 1: snapshot both sides and compute the diff under the lock.
+        with self._write_lock:
+            fts_by_path: dict[str, list[dict]] = defaultdict(list)
+            for row in self._fts.list_chunks():
+                fts_by_path[row["path"]].append(row)
+            vec_by_path = vectors.chunks_by_path()
+
+            stale_paths = [p for p in vec_by_path if p not in fts_by_path]
+            refresh_paths: list[str] = []
+            to_embed: list[dict] = []
+            up_to_date = 0
+            for path, rows in fts_by_path.items():
+                existing = vec_by_path.get(path)
+                if existing is None:
+                    to_embed.extend(rows)
+                elif _signature(rows) != _signature(existing):
+                    refresh_paths.append(path)
+                    to_embed.extend(rows)
+                else:
+                    up_to_date += len(rows)
+
+        # Phase 2: embed outside the lock — the provider can take seconds
+        # per batch and must not block foreground writes.  Bounded batches
+        # avoid pathological provider memory allocation (issue #159).
+        texts = [row["content"] for row in to_embed]
+        raw_vectors: list[list[float]] = []
+        for start in range(0, len(texts), _EMBEDDING_BATCH_SIZE):
+            raw_vectors.extend(
+                self._embedding_provider.embed(
+                    texts[start : start + _EMBEDDING_BATCH_SIZE]
+                )
+            )
+
+        # Phase 3: apply fast numpy mutations and save under the lock.
+        with self._write_lock:
+            removed = 0
+            for path in stale_paths + refresh_paths:
+                removed += vectors.delete_by_path(path)
+            added = 0
+            if raw_vectors:
+                added = vectors.add_vectors(raw_vectors, to_embed)
+            if removed or added:
+                vectors.save(self._embeddings_path)
+
+        logger.info(
+            "build_embeddings: +%d added, -%d removed, %d up-to-date",
+            added,
+            removed,
+            up_to_date,
+        )
+        return vectors.count
 
     def embeddings_status(self) -> dict:
         """Return status information about the vector index.

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -1276,8 +1276,26 @@ class Collection:
         # Resolve vault-wide wikilinks now that all documents are indexed.
         self._fts.resolve_vault_wikilinks()
 
+        # Record skipped files (excluded, missing frontmatter, unparseable)
+        # in tracker state too, so the first reindex() does not re-report
+        # them as added and re-log every skip.
+        indexed_paths = {note.path for note in notes}
+        skipped_state: dict[str, str] = {}
+        for abs_path in all_files:
+            if not abs_path.is_file():
+                continue
+            rel_str = abs_path.relative_to(self._source_dir).as_posix()
+            if rel_str in indexed_paths:
+                continue
+            try:
+                skipped_state[rel_str] = compute_file_hash(abs_path)
+            except OSError as exc:
+                logger.debug(
+                    "build_index: cannot hash skipped file %s (%s)", rel_str, exc
+                )
+
         # Update tracker state so reindex() knows the baseline.
-        self._tracker.update_state(notes)
+        self._tracker.update_state(notes, skipped=skipped_state)
 
         self._initialized = True
         if errored:
@@ -1323,11 +1341,12 @@ class Collection:
         # Phase 1: scan (outside lock — read-only filesystem walk + hashing).
         changes = self._tracker.detect_changes(self._source_dir)
         logger.info(
-            "reindex: %d added, %d modified, %d deleted, %d unchanged",
+            "reindex: %d added, %d modified, %d deleted, %d unchanged, %d skipped",
             len(changes.added),
             len(changes.modified),
             len(changes.deleted),
             changes.unchanged,
+            changes.skipped_unchanged,
         )
 
         # Pre-parse notes outside the lock to minimise lock hold time.
@@ -1337,18 +1356,39 @@ class Collection:
         # written content is indexed rather than the version that triggered
         # the change.  This is acceptable — the next reindex() call will
         # reconcile the difference.
+        # Files seen this scan but deliberately not indexed.  Recording their
+        # content hash in tracker state means an unchanged skipped file is
+        # neither re-parsed nor re-reported (or re-logged) on the next scan;
+        # it is only re-evaluated when its content changes.  Transient I/O
+        # errors are NOT recorded, so those files are retried on every scan.
+        newly_skipped: dict[str, str] = {}
+
+        def _record_skip(rel_path: str, abs_file: Path) -> None:
+            """Record a deterministically skipped file's current hash."""
+            try:
+                newly_skipped[rel_path] = compute_file_hash(abs_file)
+            except OSError as exc:
+                logger.debug("reindex: cannot hash skipped file %s (%s)", rel_path, exc)
+
         parsed: list[tuple[str, ParsedNote]] = []
         for path in changes.added + changes.modified:
+            abs_path = self._source_dir / path
+
             # Apply exclude_patterns — mirrors scan_directory behaviour.
             if self._is_path_excluded(path):
                 logger.debug("reindex: excluding %s (matched exclude pattern)", path)
+                _record_skip(path, abs_path)
                 continue
 
-            abs_path = self._source_dir / path
             try:
                 note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-            except (UnicodeDecodeError, OSError) as exc:
+            except OSError as exc:
+                # Possibly transient — do not record; retry on the next scan.
                 logger.warning("reindex: skipping %s — %s", path, exc)
+                continue
+            except UnicodeDecodeError as exc:
+                logger.warning("reindex: skipping %s — %s", path, exc)
+                _record_skip(path, abs_path)
                 continue
             except Exception as exc:
                 logger.warning(
@@ -1357,6 +1397,7 @@ class Collection:
                     exc,
                     exc_info=True,
                 )
+                _record_skip(path, abs_path)
                 continue
 
             # Apply required_frontmatter filter.
@@ -1368,6 +1409,7 @@ class Collection:
                     logger.info(
                         "reindex: skipping %s — missing frontmatter: %s", path, missing
                     )
+                    newly_skipped[path] = note.content_hash
                     continue
 
             parsed.append((path, note))
@@ -1442,13 +1484,14 @@ class Collection:
                 )
                 for r in self._fts.list_notes()
             ]
-            self._tracker.update_state(state_notes)
+            self._tracker.update_state(state_notes, skipped=newly_skipped)
 
         return ReindexResult(
             added=indexed_added,
             modified=indexed_modified,
             deleted=len(changes.deleted),
             unchanged=changes.unchanged,
+            skipped=changes.skipped_unchanged + len(newly_skipped),
         )
 
     def build_embeddings(self, *, force: bool = False) -> int:

--- a/src/markdown_vault_mcp/collection.py
+++ b/src/markdown_vault_mcp/collection.py
@@ -1147,12 +1147,65 @@ class Collection:
     # Index management
     # ------------------------------------------------------------------
 
+    def has_indexed_documents(self) -> bool:
+        """Return ``True`` if the FTS index already contains documents.
+
+        For a persistent ``index_path`` this reflects what previous processes
+        have indexed, so callers can choose an incremental :meth:`reindex`
+        over a full :meth:`build_index` at startup.
+
+        Returns:
+            ``True`` when at least one document is present in the index.
+        """
+        return self._fts.count_documents() > 0
+
+    def _purge_stale_excluded(self) -> int:
+        """Purge indexed documents that match ``exclude_patterns``.
+
+        Handles persistent indexes built before ``exclude_patterns`` were
+        configured (issue #255): matching rows are removed from the FTS
+        index and, when embeddings are configured, from the vector sidecar
+        (which is saved back to disk if anything was purged).
+
+        Returns:
+            Number of documents purged.
+        """
+        if not self._exclude_patterns:
+            return 0
+
+        # Load persisted vectors so stale entries are purged from the
+        # .npy sidecar too (build_embeddings skips if count > 0).
+        if (
+            self._vectors is None
+            and self._embedding_provider is not None
+            and self._embeddings_path is not None
+        ):
+            self._load_vectors()
+
+        purged = 0
+        for row in self._fts.list_notes():
+            if self._is_path_excluded(row["path"]):
+                self._fts.delete_by_path(row["path"])
+                if self._vectors is not None:
+                    self._vectors.delete_by_path(row["path"])
+                purged += 1
+
+        if purged and self._vectors is not None and self._embeddings_path is not None:
+            self._vectors.save(self._embeddings_path)
+
+        return purged
+
     def build_index(self, *, force: bool = False) -> IndexStats:
         """Scan source_dir and build the FTS index.
 
         If the index already contains documents and *force* is ``False``,
-        this is a no-op.  ``force=True`` drops all existing data and rebuilds
-        from scratch.
+        this is a no-op: the existing (persistent) index is adopted as-is
+        instead of re-upserting every document.  This holds across process
+        restarts — a fresh ``Collection`` opening a populated ``index_path``
+        does not rescan the vault.  Adopting an existing index purges any
+        documents that now match ``exclude_patterns`` but does not pick up
+        external file changes; call :meth:`reindex` for that.  ``force=True``
+        drops all existing data and rebuilds from scratch.
 
         Args:
             force: When ``True``, drop and rebuild the index unconditionally.
@@ -1160,16 +1213,27 @@ class Collection:
         Returns:
             :class:`~markdown_vault_mcp.types.IndexStats` describing what was indexed.
         """
-        # Check if index already has data and we are not forcing.
-        if not force and self._initialized:
-            existing = self._fts.list_notes()
-            if existing:
-                logger.debug(
-                    "build_index: index already populated (%d docs), skipping",
-                    len(existing),
-                )
+        # Check if index already has data and we are not forcing.  The check
+        # consults the persistent index itself (not just the in-memory
+        # _initialized flag) so a freshly spawned process adopts an
+        # already-populated on-disk index instead of re-upserting everything.
+        if not force:
+            existing_count = self._fts.count_documents()
+            if existing_count:
+                if not self._initialized:
+                    existing_count -= self._purge_stale_excluded()
+                    self._initialized = True
+                    logger.info(
+                        "build_index: adopted populated index docs=%d",
+                        existing_count,
+                    )
+                else:
+                    logger.debug(
+                        "build_index: index already populated (%d docs), skipping",
+                        existing_count,
+                    )
                 return IndexStats(
-                    documents_indexed=len(existing),
+                    documents_indexed=existing_count,
                     chunks_indexed=0,
                     skipped=0,
                 )
@@ -1202,36 +1266,6 @@ class Collection:
                 logger.warning(
                     "build_index: failed to index %s", note.path, exc_info=True
                 )
-
-        # Purge stale excluded docs from a persistent index that was built
-        # before exclude_patterns were configured (upgrade scenario, #255).
-        indexed_paths = {note.path for note in notes}
-        if self._exclude_patterns:
-            # Load persisted vectors so stale entries are purged from the
-            # .npy sidecar too (build_embeddings skips if count > 0).
-            if (
-                self._vectors is None
-                and self._embedding_provider is not None
-                and self._embeddings_path is not None
-            ):
-                self._load_vectors()
-
-            purged = 0
-            for row in self._fts.list_notes():
-                if row["path"] not in indexed_paths and self._is_path_excluded(
-                    row["path"]
-                ):
-                    self._fts.delete_by_path(row["path"])
-                    if self._vectors is not None:
-                        self._vectors.delete_by_path(row["path"])
-                    purged += 1
-
-            if (
-                purged
-                and self._vectors is not None
-                and self._embeddings_path is not None
-            ):
-                self._vectors.save(self._embeddings_path)
 
         # Count how many files were skipped due to required_frontmatter.
         # scan_directory logs skipped counts itself; we compute it by comparing
@@ -1348,28 +1382,12 @@ class Collection:
 
             # Purge stale excluded docs that were indexed before
             # exclude_patterns were enforced in reindex() (issue #255).
-            stale_excluded = 0
-            if self._exclude_patterns:
-                # Load persisted vectors so stale entries are purged from
-                # the .npy sidecar too (not just FTS).
-                if (
-                    self._vectors is None
-                    and self._embedding_provider is not None
-                    and self._embeddings_path is not None
-                ):
-                    self._load_vectors()
-
-                for row in self._fts.list_notes():
-                    if self._is_path_excluded(row["path"]):
-                        self._fts.delete_by_path(row["path"])
-                        if self._vectors is not None:
-                            self._vectors.delete_by_path(row["path"])
-                        stale_excluded += 1
-                if stale_excluded:
-                    logger.info(
-                        "reindex: purged %d stale excluded document(s)",
-                        stale_excluded,
-                    )
+            stale_excluded = self._purge_stale_excluded()
+            if stale_excluded:
+                logger.info(
+                    "reindex: purged %d stale excluded document(s)",
+                    stale_excluded,
+                )
 
             # Upsert parsed notes.
             indexed_added = 0

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -760,6 +760,15 @@ class FTSIndex:
         )
         return [row[0] for row in cur.fetchall()]
 
+    def count_documents(self) -> int:
+        """Return the total number of rows in the ``documents`` table.
+
+        Returns:
+            Integer count of all indexed documents.
+        """
+        row = self._conn.execute("SELECT COUNT(*) FROM documents").fetchone()
+        return row[0] if row else 0
+
     def count_chunks(self) -> int:
         """Return the total number of chunk rows in the ``sections`` table.
 

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -760,6 +760,29 @@ class FTSIndex:
         )
         return [row[0] for row in cur.fetchall()]
 
+    def list_chunks(self) -> list[dict]:
+        """Return every indexed chunk joined with its document metadata.
+
+        Used to converge the vector index against the FTS index: the
+        returned rows have exactly the shape stored as vector-row
+        metadata, so callers can diff and embed without re-parsing
+        source files.
+
+        Returns:
+            List of dicts with keys ``path``, ``title``, ``folder``,
+            ``heading`` (may be ``None``), and ``content``, ordered by
+            document path then chunk position.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT d.path, d.title, d.folder, s.heading, s.content
+            FROM sections AS s
+            JOIN documents AS d ON d.id = s.document_id
+            ORDER BY d.path, s.id
+            """
+        )
+        return [dict(row) for row in cur.fetchall()]
+
     def count_documents(self) -> int:
         """Return the total number of rows in the ``documents`` table.
 

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -13,20 +13,29 @@ from markdown_vault_mcp.types import ChangeSet, ParsedNote
 
 logger = logging.getLogger(__name__)
 
+# Current on-disk state file format version. Version 2 splits the flat
+# path → digest map into separate "indexed" and "skipped" maps.
+_STATE_VERSION = 2
+
 
 class ChangeTracker:
     """Detects file additions, modifications, and deletions using SHA256 hashes.
 
-    State is persisted as a JSON file mapping relative document paths to their
-    last-seen SHA256 hex digest. On the first run (no state file), every file
-    on disk is treated as newly added.
+    State is persisted as a JSON file with two maps of relative document path
+    to last-seen SHA256 hex digest: ``indexed`` (files that made it into the
+    index) and ``skipped`` (files seen on disk but deliberately not indexed,
+    e.g. missing required frontmatter). A skipped file is only re-reported as
+    added when its content changes, so it can be re-evaluated. Legacy state
+    files (a flat path-to-hash object) load fine; all entries are treated as
+    indexed. On the first run (no state file), every file on disk is treated
+    as newly added.
 
     Example::
 
         tracker = ChangeTracker(Path("/data/vault/.markdown_vault_mcp/state.json"))
         changes = tracker.detect_changes(Path("/data/vault"))
         # process changes ...
-        tracker.update_state(notes)
+        tracker.update_state(notes, skipped=newly_skipped)
     """
 
     def __init__(self, state_path: Path) -> None:
@@ -37,6 +46,9 @@ class ChangeTracker:
                 yet; the parent directory is created on first write.
         """
         self._state_path = state_path
+        # Skipped entries from the last detect_changes() that are still on
+        # disk with unchanged content; carried forward by update_state().
+        self._skipped_carry: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -51,15 +63,21 @@ class ChangeTracker:
 
         Algorithm:
 
-        1. Load existing state (empty dict if state file does not exist).
+        1. Load existing state (empty maps if state file does not exist).
         2. Scan *source_dir* for all files matching *glob_pattern*.
         3. Compute SHA256 of each file's raw bytes.
         4. Categorise each path:
 
            - present on disk but absent from state → **added**
-           - present in both and hash differs → **modified**
-           - present in state but absent from disk → **deleted**
-           - present in both and hash matches → **unchanged** (counted only)
+           - in indexed state and hash differs → **modified**
+           - in indexed state and hash matches → **unchanged** (counted only)
+           - in skipped state and hash matches → **skipped_unchanged**
+             (counted only; not re-reported)
+           - in skipped state and hash differs → **added** (re-evaluated;
+             it may now qualify for indexing)
+           - in indexed state but absent from disk → **deleted**
+           - in skipped state but absent from disk → dropped silently (it
+             was never indexed, so nothing needs deleting)
 
         5. Return a :class:`~markdown_vault_mcp.types.ChangeSet`.
 
@@ -71,7 +89,7 @@ class ChangeTracker:
         Returns:
             A :class:`~markdown_vault_mcp.types.ChangeSet` describing the delta.
         """
-        stored_state = self._load_state()
+        indexed_state, skipped_state = self._load_state()
 
         # Build a mapping of relative path → sha256 for current disk contents.
         disk_state: dict[str, str] = {}
@@ -93,25 +111,37 @@ class ChangeTracker:
         added: list[str] = []
         modified: list[str] = []
         unchanged: int = 0
+        skipped_unchanged: int = 0
+        self._skipped_carry = {}
 
         for rel_path, current_hash in disk_state.items():
-            if rel_path not in stored_state:
-                added.append(rel_path)
-            elif stored_state[rel_path] != current_hash:
-                modified.append(rel_path)
+            if rel_path in indexed_state:
+                if indexed_state[rel_path] != current_hash:
+                    modified.append(rel_path)
+                else:
+                    unchanged += 1
+            elif rel_path in skipped_state:
+                if skipped_state[rel_path] != current_hash:
+                    # Content changed since the skip — re-evaluate it.
+                    added.append(rel_path)
+                else:
+                    skipped_unchanged += 1
+                    self._skipped_carry[rel_path] = current_hash
             else:
-                unchanged += 1
+                added.append(rel_path)
 
         deleted: list[str] = [
-            rel_path for rel_path in stored_state if rel_path not in disk_state
+            rel_path for rel_path in indexed_state if rel_path not in disk_state
         ]
 
         logger.debug(
-            "detect_changes: %d added, %d modified, %d deleted, %d unchanged",
+            "detect_changes: %d added, %d modified, %d deleted, %d unchanged, "
+            "%d skipped-unchanged",
             len(added),
             len(modified),
             len(deleted),
             unchanged,
+            skipped_unchanged,
         )
 
         return ChangeSet(
@@ -119,29 +149,51 @@ class ChangeTracker:
             modified=modified,
             deleted=deleted,
             unchanged=unchanged,
+            skipped_unchanged=skipped_unchanged,
         )
 
-    def update_state(self, notes: list[ParsedNote]) -> None:
+    def update_state(
+        self,
+        notes: list[ParsedNote],
+        skipped: dict[str, str] | None = None,
+    ) -> None:
         """Persist the current hash state derived from *notes*.
 
-        Overwrites the entire state file with the hashes from *notes*. Call
-        this after successfully (re)indexing a set of documents to record their
-        current content hashes.
+        Overwrites the entire state file. The indexed map comes from *notes*;
+        the skipped map merges the unchanged skipped entries observed by the
+        preceding :meth:`detect_changes` call with *skipped*. Call this after
+        successfully (re)indexing a set of documents to record their current
+        content hashes.
 
         Args:
             notes: Parsed notes whose ``path`` and ``content_hash`` attributes
-                form the new state. Any paths not in this list are dropped from
-                state (treated as deleted on the next scan).
+                form the new indexed state. Any indexed paths not in this list
+                are dropped from state (treated as deleted on the next scan).
+            skipped: Mapping of relative path to SHA256 hex digest for files
+                seen during this scan but deliberately not indexed (missing
+                required frontmatter, excluded, unparseable). Indexed paths
+                always win: any path also present in *notes* is dropped from
+                the skipped map.
         """
-        new_state = {note.path: note.content_hash for note in notes}
-        self._save_state(new_state)
-        logger.debug("update_state: wrote state for %d document(s)", len(notes))
+        new_indexed = {note.path: note.content_hash for note in notes}
+        new_skipped = {
+            path: content_hash
+            for path, content_hash in {**self._skipped_carry, **(skipped or {})}.items()
+            if path not in new_indexed
+        }
+        self._save_state(new_indexed, new_skipped)
+        logger.debug(
+            "update_state: wrote state for %d indexed, %d skipped document(s)",
+            len(new_indexed),
+            len(new_skipped),
+        )
 
     def reset(self) -> None:
         """Delete the state file so the next scan treats all files as added.
 
         If the state file does not exist, this is a no-op.
         """
+        self._skipped_carry = {}
         if self._state_path.exists():
             self._state_path.unlink()
             logger.debug("reset: deleted state file %s", self._state_path)
@@ -152,18 +204,24 @@ class ChangeTracker:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _load_state(self) -> dict[str, str]:
+    def _load_state(self) -> tuple[dict[str, str], dict[str, str]]:
         """Load the persisted state from disk.
 
+        Supports two formats: the current versioned object
+        (``{"version": 2, "indexed": {...}, "skipped": {...}}``) and the
+        legacy flat mapping of path to digest, which is loaded with every
+        entry treated as indexed.
+
         Returns:
-            Mapping of relative document path to SHA256 hex digest.
-            Returns an empty dict when the state file does not exist.
+            Tuple of ``(indexed, skipped)`` maps of relative document path to
+            SHA256 hex digest. Both are empty when the state file does not
+            exist or is malformed.
         """
         if not self._state_path.exists():
             logger.debug(
                 "No state file at %s; treating all files as added", self._state_path
             )
-            return {}
+            return {}, {}
         try:
             with self._state_path.open(encoding="utf-8") as fh:
                 state = json.load(fh)
@@ -172,24 +230,39 @@ class ChangeTracker:
                     "State file %s is malformed (expected object); resetting",
                     self._state_path,
                 )
-                return {}
-            return state
+                return {}, {}
+            if state.get("version") == _STATE_VERSION:
+                indexed = state.get("indexed", {})
+                skipped = state.get("skipped", {})
+                if not isinstance(indexed, dict) or not isinstance(skipped, dict):
+                    logger.warning(
+                        "State file %s is malformed (expected object maps); resetting",
+                        self._state_path,
+                    )
+                    return {}, {}
+                return indexed, skipped
+            # Legacy flat format: every entry is an indexed path → digest.
+            return state, {}
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning(
                 "Cannot read state file %s (%s); treating all files as added",
                 self._state_path,
                 exc,
             )
-            return {}
+            return {}, {}
 
-    def _save_state(self, state: dict[str, str]) -> None:
-        """Write *state* to the state file as JSON.
+    def _save_state(self, indexed: dict[str, str], skipped: dict[str, str]) -> None:
+        """Write the indexed and skipped maps to the state file as JSON.
 
         Creates parent directories if they do not exist.
 
         Args:
-            state: Mapping of relative document path to SHA256 hex digest.
+            indexed: Mapping of relative document path to SHA256 hex digest
+                for documents present in the index.
+            skipped: Mapping of relative document path to SHA256 hex digest
+                for files seen on disk but deliberately not indexed.
         """
+        state = {"version": _STATE_VERSION, "indexed": indexed, "skipped": skipped}
         self._state_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_path = tempfile.mkstemp(dir=self._state_path.parent, suffix=".tmp")
         try:
@@ -199,7 +272,12 @@ class ChangeTracker:
         except:
             Path(tmp_path).unlink(missing_ok=True)
             raise
-        logger.debug("Saved state for %d path(s) to %s", len(state), self._state_path)
+        logger.debug(
+            "Saved state for %d indexed, %d skipped path(s) to %s",
+            len(indexed),
+            len(skipped),
+            self._state_path,
+        )
 
     def _compute_hash(self, path: Path) -> str:
         """Compute the SHA256 hex digest of *path* using chunked reads.

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -137,12 +137,19 @@ class IndexStats:
 
 @dataclass
 class ReindexResult:
-    """Result of an incremental reindex."""
+    """Result of an incremental reindex.
+
+    ``skipped`` counts files present on disk that were deliberately not
+    indexed (missing required frontmatter, matching an exclude pattern, or
+    unparseable), whether newly skipped this scan or unchanged since they
+    were last skipped.
+    """
 
     added: int
     modified: int
     deleted: int
     unchanged: int
+    skipped: int = 0
 
 
 @dataclass
@@ -186,12 +193,18 @@ class CollectionStats:
 
 @dataclass
 class ChangeSet:
-    """Documents that changed since last index."""
+    """Documents that changed since last index.
+
+    ``skipped_unchanged`` counts files that were previously recorded as
+    skipped (never indexed) and whose content has not changed since; they
+    appear in no other bucket and need no re-evaluation.
+    """
 
     added: list[str]
     modified: list[str]
     deleted: list[str]
     unchanged: int
+    skipped_unchanged: int = 0
 
 
 @dataclass

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -148,6 +148,20 @@ class VectorIndex:
         """
         return len(self._metadata)
 
+    def chunks_by_path(self) -> dict[str, list[dict]]:
+        """Group stored metadata rows by document path.
+
+        Used to diff the vector index against the FTS index at startup.
+
+        Returns:
+            Mapping of document path to copies of the stored metadata
+            dicts for that document, in storage order.
+        """
+        grouped: dict[str, list[dict]] = {}
+        for row in self._metadata:
+            grouped.setdefault(row.get("path", ""), []).append(dict(row))
+        return grouped
+
     def add(self, texts: list[str], metadata: list[dict]) -> int:
         """Embed ``texts`` and append rows to the index.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -798,7 +798,7 @@ class TestCmdReindex:
         self,
         mock_build: MagicMock,
     ) -> None:
-        """reindex command calls build_embeddings(force=True) when configured."""
+        """reindex command calls build_embeddings() when configured."""
         mock_collection = MagicMock()
         mock_result = MagicMock()
         mock_result.added = 1
@@ -812,7 +812,7 @@ class TestCmdReindex:
         with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
             main()
 
-        mock_collection.build_embeddings.assert_called_once_with(force=True)
+        mock_collection.build_embeddings.assert_called_once_with()
 
     @patch("markdown_vault_mcp.cli._build_collection")
     def test_reindex_skips_embeddings_when_not_configured(
@@ -836,37 +836,21 @@ class TestCmdReindex:
         mock_collection.build_embeddings.assert_called_once()
 
     @patch("markdown_vault_mcp.cli._build_collection")
-    def test_reindex_uses_force_false_when_no_changes(
+    def test_reindex_never_forces_embedding_rebuild(
         self,
         mock_build: MagicMock,
     ) -> None:
-        """reindex skips force rebuild when FTS found no changes."""
-        mock_collection = MagicMock()
-        mock_result = MagicMock()
-        mock_result.added = 0
-        mock_result.modified = 0
-        mock_result.deleted = 0
-        mock_result.unchanged = 10
-        mock_collection.reindex.return_value = mock_result
-        mock_collection.build_embeddings.return_value = 0
-        mock_build.return_value = mock_collection
+        """reindex relies on convergence, never on a force rebuild.
 
-        with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
-            main()
-
-        mock_collection.build_embeddings.assert_called_once_with(force=False)
-
-    @patch("markdown_vault_mcp.cli._build_collection")
-    def test_reindex_uses_force_true_when_changes_exist(
-        self,
-        mock_build: MagicMock,
-    ) -> None:
-        """reindex forces rebuild when FTS found added/modified/deleted files."""
+        build_embeddings() diffs the vector index against the FTS index
+        and embeds only the delta, so the CLI must not pass force=True
+        even when the reindex found changes.
+        """
         mock_collection = MagicMock()
         mock_result = MagicMock()
         mock_result.added = 2
         mock_result.modified = 1
-        mock_result.deleted = 0
+        mock_result.deleted = 1
         mock_result.unchanged = 10
         mock_collection.reindex.return_value = mock_result
         mock_collection.build_embeddings.return_value = 30
@@ -875,4 +859,4 @@ class TestCmdReindex:
         with patch("sys.argv", ["markdown-vault-mcp", "reindex"]):
             main()
 
-        mock_collection.build_embeddings.assert_called_once_with(force=True)
+        mock_collection.build_embeddings.assert_called_once_with()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -417,6 +417,207 @@ class TestLazyInitialisation:
 
 
 # ---------------------------------------------------------------------------
+# Persistent index adoption across process restarts
+# ---------------------------------------------------------------------------
+
+
+class TestPersistentIndexAdoption:
+    """A fresh Collection on a populated index must not re-upsert everything.
+
+    Simulates a server process restart: build the index with one Collection
+    instance, then open a second instance against the same ``index_path`` and
+    ``state_path`` — as the MCP server lifespan does on every boot.
+    """
+
+    @pytest.fixture
+    def mini_vault(self, tmp_path: Path) -> Path:
+        """Small clean vault with three parseable documents."""
+        vault = tmp_path / "mini_vault"
+        vault.mkdir()
+        (vault / "alpha.md").write_text("# Alpha\n\nFirst note.\n")
+        (vault / "beta.md").write_text("# Beta\n\nSecond note.\n")
+        (vault / "gamma.md").write_text("# Gamma\n\nThird note.\n")
+        return vault
+
+    @staticmethod
+    def _count_upserts(col: Collection) -> list[object]:
+        """Wrap ``col._fts.upsert_note`` to record every upserted note."""
+        calls: list[object] = []
+        original = col._fts.upsert_note
+
+        def counting_upsert(note):
+            calls.append(note)
+            return original(note)
+
+        col._fts.upsert_note = counting_upsert  # type: ignore[method-assign]
+        return calls
+
+    def test_build_index_adopts_populated_index(
+        self, tmp_path: Path, mini_vault: Path
+    ) -> None:
+        """build_index() on a populated persistent index skips re-upserting."""
+        index_path = tmp_path / "index.db"
+        state_path = tmp_path / "state.json"
+
+        col1 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        stats1 = col1.build_index()
+        col1.close()
+        assert stats1.documents_indexed == 3
+
+        col2 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        upserts = self._count_upserts(col2)
+        stats2 = col2.build_index()
+        col2.close()
+
+        assert stats2.documents_indexed == 3
+        assert stats2.chunks_indexed == 0
+        assert upserts == []
+        assert col2._initialized is True
+
+    def test_second_boot_unchanged_vault_does_not_reupsert(
+        self, tmp_path: Path, mini_vault: Path
+    ) -> None:
+        """Boot reindex on an unchanged vault applies no upserts at all."""
+        index_path = tmp_path / "index.db"
+        state_path = tmp_path / "state.json"
+
+        col1 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        col1.build_index()
+        col1.close()
+
+        col2 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        upserts = self._count_upserts(col2)
+        assert col2.has_indexed_documents()
+
+        result = col2.reindex()
+        col2.close()
+
+        assert result.added == 0
+        assert result.modified == 0
+        assert result.deleted == 0
+        assert result.unchanged == 3
+        assert upserts == []
+
+    def test_second_boot_picks_up_offline_changes(
+        self, tmp_path: Path, mini_vault: Path
+    ) -> None:
+        """Files changed while the server was down are reindexed incrementally."""
+        index_path = tmp_path / "index.db"
+        state_path = tmp_path / "state.json"
+
+        col1 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        col1.build_index()
+        col1.close()
+
+        # Mutate the vault "while the server is down".
+        (mini_vault / "alpha.md").write_text("# Alpha\n\nEdited offline.\n")
+        (mini_vault / "delta.md").write_text("# Delta\n\nAdded offline.\n")
+
+        col2 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        upserts = self._count_upserts(col2)
+        result = col2.reindex()
+
+        assert result.added == 1
+        assert result.modified == 1
+        assert result.deleted == 0
+        assert result.unchanged == 2
+        # Exactly the two changed documents were upserted.
+        assert len(upserts) == 2
+
+        # The offline edits are searchable.
+        paths = [r.path for r in col2.search("offline")]
+        col2.close()
+        assert "alpha.md" in paths
+        assert "delta.md" in paths
+
+    def test_second_boot_detects_offline_deletion(
+        self, tmp_path: Path, mini_vault: Path
+    ) -> None:
+        """A file deleted while the server was down is purged on boot reindex."""
+        index_path = tmp_path / "index.db"
+        state_path = tmp_path / "state.json"
+
+        col1 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        col1.build_index()
+        col1.close()
+
+        (mini_vault / "gamma.md").unlink()
+
+        col2 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        result = col2.reindex()
+        paths = [row["path"] for row in col2._fts.list_notes()]
+        col2.close()
+
+        assert result.deleted == 1
+        assert result.unchanged == 2
+        assert "gamma.md" not in paths
+
+    def test_missing_state_file_with_populated_index_degrades(
+        self, tmp_path: Path, mini_vault: Path
+    ) -> None:
+        """state.json gone but SQLite populated: no crash, full re-upsert."""
+        index_path = tmp_path / "index.db"
+        state_path = tmp_path / "state.json"
+
+        col1 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        col1.build_index()
+        col1.close()
+        state_path.unlink()
+
+        col2 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        result = col2.reindex()
+        col2.close()
+
+        # ChangeTracker treats everything as added — acceptable degradation.
+        assert result.added == 3
+        assert result.deleted == 0
+
+    def test_force_rebuild_ignores_adoption(
+        self, tmp_path: Path, mini_vault: Path
+    ) -> None:
+        """build_index(force=True) still rebuilds from scratch on a new instance."""
+        index_path = tmp_path / "index.db"
+        state_path = tmp_path / "state.json"
+
+        col1 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        col1.build_index()
+        col1.close()
+
+        col2 = _make_collection(
+            mini_vault, index_path=index_path, state_path=state_path
+        )
+        upserts = self._count_upserts(col2)
+        stats = col2.build_index(force=True)
+        col2.close()
+
+        assert stats.documents_indexed == 3
+        assert stats.chunks_indexed == 3
+        assert len(upserts) == 3
+
+
+# ---------------------------------------------------------------------------
 # Search tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -6,7 +6,7 @@ import concurrent.futures
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -615,6 +615,154 @@ class TestPersistentIndexAdoption:
         assert stats.documents_indexed == 3
         assert stats.chunks_indexed == 3
         assert len(upserts) == 3
+
+
+# ---------------------------------------------------------------------------
+# Skipped-file tracking (required_frontmatter) across reindex scans
+# ---------------------------------------------------------------------------
+
+
+class TestSkippedFileTracking:
+    """Files skipped for missing frontmatter must not be re-reported per scan.
+
+    Regression tests for the warm-boot loop where every ``reindex()`` saw
+    frontmatter-skipped files as "added", re-parsed them, and re-logged the
+    skip (O(skipped files) wasted parsing per boot).
+    """
+
+    REQUIRED: ClassVar[list[str]] = ["name", "type"]
+
+    @pytest.fixture
+    def fm_vault(self, tmp_path: Path) -> Path:
+        """Vault with one valid document and one missing required frontmatter."""
+        vault = tmp_path / "fm_vault"
+        vault.mkdir()
+        (vault / "valid.md").write_text(
+            "---\nname: Valid\ntype: note\n---\n# Valid\n\nIndexed note.\n"
+        )
+        (vault / "CLAUDE.md").write_text("# Claude\n\nNo frontmatter here.\n")
+        return vault
+
+    def _make(self, vault: Path, tmp_path: Path) -> Collection:
+        """Build a Collection enforcing required frontmatter with shared state."""
+        return Collection(
+            source_dir=vault,
+            index_path=tmp_path / "index.db",
+            state_path=tmp_path / "state.json",
+            required_frontmatter=self.REQUIRED,
+        )
+
+    def test_skipped_file_not_rereported_on_second_reindex(
+        self, tmp_path: Path, fm_vault: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unchanged skipped file is neither re-parsed nor re-logged."""
+        col1 = self._make(fm_vault, tmp_path)
+        col1.build_index()
+        col1.close()
+
+        # Warm boot: adopt the index, run the boot reindex.
+        col2 = self._make(fm_vault, tmp_path)
+        with caplog.at_level(logging.INFO, logger="markdown_vault_mcp.collection"):
+            result = col2.reindex()
+
+        assert result.added == 0
+        assert result.modified == 0
+        assert result.deleted == 0
+        assert result.unchanged == 1
+        assert result.skipped == 1
+        assert not any("missing frontmatter" in r.message for r in caplog.records)
+
+        # And again — still quiet, still not reported as added.
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="markdown_vault_mcp.collection"):
+            result2 = col2.reindex()
+        col2.close()
+
+        assert result2.added == 0
+        assert result2.skipped == 1
+        assert not any("missing frontmatter" in r.message for r in caplog.records)
+
+    def test_skipped_file_gaining_frontmatter_gets_indexed(
+        self, tmp_path: Path, fm_vault: Path
+    ) -> None:
+        """A skipped file that gains the required frontmatter is indexed."""
+        col = self._make(fm_vault, tmp_path)
+        col.build_index()
+
+        (fm_vault / "CLAUDE.md").write_text(
+            "---\nname: Claude\ntype: agent\n---\n# Claude\n\nNow valid.\n"
+        )
+
+        result = col.reindex()
+        paths = [row["path"] for row in col._fts.list_notes()]
+        col.close()
+
+        assert result.added == 1
+        assert result.skipped == 0
+        assert "CLAUDE.md" in paths
+
+    def test_changed_but_still_skipped_file_logged_once(
+        self, tmp_path: Path, fm_vault: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A changed-and-still-skipped file is re-logged once, then quiet."""
+        col = self._make(fm_vault, tmp_path)
+        col.build_index()
+
+        (fm_vault / "CLAUDE.md").write_text("# Claude\n\nStill no frontmatter.\n")
+
+        with caplog.at_level(logging.INFO, logger="markdown_vault_mcp.collection"):
+            result1 = col.reindex()
+        assert result1.skipped == 1
+        assert any("missing frontmatter" in r.message for r in caplog.records)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="markdown_vault_mcp.collection"):
+            result2 = col.reindex()
+        col.close()
+
+        assert result2.skipped == 1
+        assert not any("missing frontmatter" in r.message for r in caplog.records)
+
+    def test_legacy_flat_state_file_migrates_cleanly(
+        self, tmp_path: Path, fm_vault: Path
+    ) -> None:
+        """An old flat-format state.json loads fine; skips settle after one scan."""
+        col1 = self._make(fm_vault, tmp_path)
+        col1.build_index()
+        col1.close()
+
+        # Rewrite state.json in the legacy flat format (indexed entries only).
+        state_path = tmp_path / "state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state_path.write_text(json.dumps(state["indexed"]), encoding="utf-8")
+
+        col2 = self._make(fm_vault, tmp_path)
+        # First scan re-evaluates the skipped file once (it is absent from
+        # legacy state), records it, and does not index it.
+        result1 = col2.reindex()
+        assert result1.added == 0
+        assert result1.unchanged == 1
+        assert result1.skipped == 1
+
+        # Second scan: the skip is remembered; nothing is re-evaluated.
+        result2 = col2.reindex()
+        col2.close()
+        assert result2.added == 0
+        assert result2.skipped == 1
+
+    def test_build_index_records_skipped_files_in_state(
+        self, tmp_path: Path, fm_vault: Path
+    ) -> None:
+        """build_index() persists skipped files so reindex() stays quiet."""
+        col = self._make(fm_vault, tmp_path)
+        col.build_index()
+        col.close()
+
+        state = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert state["version"] == 2
+        assert "valid.md" in state["indexed"]
+        assert "CLAUDE.md" in state["skipped"]
+        assert "CLAUDE.md" not in state["indexed"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3162,13 +3162,13 @@ class TestEmbeddingsStatus:
 
 
 class TestBuildEmbeddings:
-    def test_build_embeddings_skip_when_already_built(
+    def test_build_embeddings_noop_when_converged(
         self,
         vault_path: Path,
         tmp_path: Path,
         mock_provider: MockEmbeddingProvider,
     ) -> None:
-        """build_embeddings(force=False) skips rebuild when index already has chunks.
+        """build_embeddings(force=False) does no work when vectors match FTS.
 
         The first call embeds 9 chunks and saves to disk.  The second call (no
         force) must return the same count without re-embedding.
@@ -3308,6 +3308,220 @@ class TestBuildEmbeddings:
         # The .npy file must exist (saved at the end).
         npy_path = tmp_path / "embeddings.npy"
         assert npy_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# build_embeddings() convergence (boot-time embedding drift, issue: vector
+# index frozen while FTS index grows via boot reindex)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEmbeddingsConvergence:
+    """build_embeddings() must converge the vector index to the FTS index.
+
+    Simulates the MCP server boot sequence: a fresh ``Collection`` over a
+    persistent ``index_path``/``embeddings_path`` runs ``reindex()`` (while
+    no vector index is loaded — exactly the lifespan code path) followed by
+    ``build_embeddings()``.  Files changed externally while "down" must be
+    reflected in the vector index after boot.
+    """
+
+    @staticmethod
+    def _boot(
+        vault_path: Path,
+        tmp_path: Path,
+        provider: MockEmbeddingProvider,
+    ) -> Collection:
+        """Replicate the server lifespan boot sequence."""
+        col = Collection(
+            source_dir=vault_path,
+            index_path=tmp_path / "index.db",
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=provider,
+        )
+        if col.has_indexed_documents():
+            col.reindex()
+        else:
+            col.build_index()
+        col.build_embeddings()
+        return col
+
+    @staticmethod
+    def _track_embeds(
+        provider: MockEmbeddingProvider,
+    ) -> list[list[str]]:
+        """Record every batch of texts passed to provider.embed()."""
+        original_embed = provider.embed
+        calls: list[list[str]] = []
+
+        def tracking_embed(texts: list[str]) -> list[list[float]]:
+            calls.append(list(texts))
+            return original_embed(texts)
+
+        provider.embed = tracking_embed  # type: ignore[method-assign]
+        return calls
+
+    def test_boot_with_no_drift_does_no_embedding_work(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """Second boot with vectors == FTS embeds nothing and drops nothing."""
+        col1 = self._boot(vault_path, tmp_path, mock_provider)
+        count1 = col1._load_vectors().count
+        col1.close()
+
+        calls = self._track_embeds(mock_provider)
+        col2 = self._boot(vault_path, tmp_path, mock_provider)
+
+        assert calls == []
+        vectors = col2._load_vectors()
+        assert vectors.count == count1
+        assert vectors.count == col2._fts.count_chunks()
+        col2.close()
+
+    def test_boot_embeds_documents_added_while_down(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """Files written externally while no server runs get embedded at boot."""
+        col1 = self._boot(vault_path, tmp_path, mock_provider)
+        count1 = col1._load_vectors().count
+        col1.close()
+
+        # External process (e.g. a hook) writes new notes while "down".
+        (vault_path / "hook_summary.md").write_text(
+            "# Hook Summary\n\nSession summary written by a hook.\n"
+        )
+        (vault_path / "hook_followup.md").write_text(
+            "# Hook Followup\n\nFollow-up note written by a hook.\n"
+        )
+
+        calls = self._track_embeds(mock_provider)
+        col2 = self._boot(vault_path, tmp_path, mock_provider)
+
+        # Exactly the new chunks were embedded — nothing re-embedded.
+        embedded_texts = [t for batch in calls for t in batch]
+        assert len(embedded_texts) == 2
+        assert any("Session summary" in t for t in embedded_texts)
+        assert any("Follow-up note" in t for t in embedded_texts)
+
+        vectors = col2._load_vectors()
+        assert vectors.count == count1 + 2
+        assert vectors.count == col2._fts.count_chunks()
+        by_path = vectors.chunks_by_path()
+        assert "hook_summary.md" in by_path
+        assert "hook_followup.md" in by_path
+
+        # The new document is reachable via semantic search.  The mock
+        # provider's vectors are hash-based (no real semantics), so use a
+        # limit that returns every chunk and assert reachability only.
+        results = col2.search(
+            "Session summary written by a hook", mode="semantic", limit=50
+        )
+        assert any(r.path == "hook_summary.md" for r in results)
+        col2.close()
+
+    def test_boot_removes_vectors_for_documents_deleted_while_down(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """Vectors for files deleted externally are dropped at boot."""
+        col1 = self._boot(vault_path, tmp_path, mock_provider)
+        vectors1 = col1._load_vectors()
+        doomed_chunks = len(vectors1.chunks_by_path()["simple.md"])
+        assert doomed_chunks > 0
+        count1 = vectors1.count
+        col1.close()
+
+        (vault_path / "simple.md").unlink()
+
+        calls = self._track_embeds(mock_provider)
+        col2 = self._boot(vault_path, tmp_path, mock_provider)
+
+        assert calls == []
+        vectors = col2._load_vectors()
+        assert "simple.md" not in vectors.chunks_by_path()
+        assert vectors.count == count1 - doomed_chunks
+        assert vectors.count == col2._fts.count_chunks()
+        col2.close()
+
+    def test_boot_refreshes_vectors_for_documents_modified_while_down(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """Modified documents get fresh vectors; stale chunk vectors are gone."""
+        col1 = self._boot(vault_path, tmp_path, mock_provider)
+        col1.close()
+
+        (vault_path / "simple.md").write_text(
+            "# Simple Document\n\nCompletely rewritten body about gardening.\n"
+        )
+
+        calls = self._track_embeds(mock_provider)
+        col2 = self._boot(vault_path, tmp_path, mock_provider)
+
+        # Only the modified document's chunks were embedded.
+        embedded_texts = [t for batch in calls for t in batch]
+        assert len(embedded_texts) > 0
+        assert all("gardening" in t for t in embedded_texts)
+
+        vectors = col2._load_vectors()
+        rows = vectors.chunks_by_path()["simple.md"]
+        assert all("gardening" in r["content"] for r in rows)
+        # No stale vectors for the old content remain anywhere.
+        all_rows = [r for rs in vectors.chunks_by_path().values() for r in rs]
+        assert not any("Section Two" in r["content"] for r in all_rows)
+        assert vectors.count == col2._fts.count_chunks()
+        col2.close()
+
+    def test_boot_converges_legacy_drifted_vector_index(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        mock_provider: MockEmbeddingProvider,
+    ) -> None:
+        """A historic vectors-subset-of-FTS state heals in a single boot.
+
+        Reproduces the observed 307/1379 drift in miniature: the persisted
+        vector index is missing several documents that the FTS index knows
+        about.  One boot must embed exactly the missing chunks.
+        """
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        col1 = self._boot(vault_path, tmp_path, mock_provider)
+        fts_chunks = col1._fts.count_chunks()
+        col1.close()
+
+        # Corrupt the sidecar the way older code did: drop some documents'
+        # vectors while FTS keeps them.
+        embeddings_path = tmp_path / "embeddings"
+        vectors = VectorIndex.load(embeddings_path, mock_provider)
+        dropped = vectors.delete_by_path("simple.md")
+        dropped += vectors.delete_by_path("unicode.md")
+        assert dropped > 0
+        vectors.save(embeddings_path)
+
+        calls = self._track_embeds(mock_provider)
+        col2 = self._boot(vault_path, tmp_path, mock_provider)
+
+        # Exactly the missing chunks were re-embedded.
+        embedded_texts = [t for batch in calls for t in batch]
+        assert len(embedded_texts) == dropped
+
+        converged = col2._load_vectors()
+        assert converged.count == fts_chunks
+        by_path = converged.chunks_by_path()
+        assert "simple.md" in by_path
+        assert "unicode.md" in by_path
+        col2.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fts_index.py
+++ b/tests/test_fts_index.py
@@ -624,6 +624,51 @@ class TestGetNote:
         assert idx.get_note("nonexistent.md") is None
 
 
+class TestListChunks:
+    def test_list_chunks_returns_all_chunks_with_document_metadata(self) -> None:
+        """list_chunks() joins sections with document path/title/folder."""
+        idx = FTSIndex(":memory:")
+        idx.upsert_note(
+            make_note(
+                "Journal/entry.md",
+                title="My Entry",
+                chunks=[
+                    Chunk(heading=None, heading_level=0, content="intro", start_line=0),
+                    Chunk(
+                        heading="Details",
+                        heading_level=2,
+                        content="the details",
+                        start_line=5,
+                    ),
+                ],
+            )
+        )
+        idx.upsert_note(make_note("alpha.md", title="Alpha"))
+
+        rows = idx.list_chunks()
+
+        assert len(rows) == 3
+        # Ordered by path, then chunk position.
+        assert [r["path"] for r in rows] == [
+            "Journal/entry.md",
+            "Journal/entry.md",
+            "alpha.md",
+        ]
+        first = rows[0]
+        assert set(first) == {"path", "title", "folder", "heading", "content"}
+        assert first["title"] == "My Entry"
+        assert first["folder"] == "Journal"
+        assert first["heading"] is None
+        assert first["content"] == "intro"
+        assert rows[1]["heading"] == "Details"
+        assert rows[1]["content"] == "the details"
+
+    def test_list_chunks_empty_index_returns_empty_list(self) -> None:
+        """list_chunks() on an empty index returns []."""
+        idx = FTSIndex(":memory:")
+        assert idx.list_chunks() == []
+
+
 class TestInMemoryMode:
     def test_in_memory_mode_works(self) -> None:
         """FTSIndex with ':memory:' is functional end-to-end."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2455,6 +2455,95 @@ class TestLifespanAutoEmbeddings:
 
 
 # ---------------------------------------------------------------------------
+# Lifespan boot indexing (persistent index adoption, issue: slow boots)
+# ---------------------------------------------------------------------------
+
+
+class TestLifespanBootIndexing:
+    """Server restarts must not re-upsert an already-populated index."""
+
+    async def test_second_startup_does_not_reupsert(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With a persistent index on disk, a restart applies zero upserts."""
+        from unittest.mock import patch
+
+        from markdown_vault_mcp.fts_index import FTSIndex
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
+        for var in _CLEAR_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "index.db"))
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "state.json")
+        )
+
+        # First startup: full build into the persistent index.
+        server1 = create_server()
+        async with Client(server1) as client1:
+            r1 = await client1.call_tool_mcp("stats", {})
+        count1 = json.loads(r1.content[0].text)["document_count"]
+        assert count1 > 0
+
+        # Second startup: must adopt the on-disk index without upserting.
+        upsert_paths: list[str] = []
+        original_upsert = FTSIndex.upsert_note
+
+        def tracking_upsert(self: FTSIndex, note: Any) -> int:
+            upsert_paths.append(note.path)
+            return original_upsert(self, note)
+
+        with patch.object(FTSIndex, "upsert_note", tracking_upsert):
+            server2 = create_server()
+            async with Client(server2) as client2:
+                r2 = await client2.call_tool_mcp("stats", {})
+        count2 = json.loads(r2.content[0].text)["document_count"]
+
+        assert count2 == count1
+        assert upsert_paths == [], f"boot re-upserted {upsert_paths}"
+
+    async def test_second_startup_applies_offline_delta(
+        self,
+        vault_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Files changed while the server was down are indexed on restart."""
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
+        for var in _CLEAR_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "index.db"))
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "state.json")
+        )
+
+        server1 = create_server()
+        async with Client(server1) as client1:
+            r1 = await client1.call_tool_mcp("stats", {})
+        count1 = json.loads(r1.content[0].text)["document_count"]
+
+        # Add a file "while the server is down".
+        (vault_path / "offline_note.md").write_text(
+            "# Offline Note\n\nWritten while the server was down.\n"
+        )
+
+        server2 = create_server()
+        async with Client(server2) as client2:
+            r2 = await client2.call_tool_mcp("stats", {})
+            search = await client2.call_tool("search", {"query": "offline"})
+        count2 = json.loads(r2.content[0].text)["document_count"]
+
+        assert count2 == count1 + 1
+        paths = [r["path"] for r in _parse_tool_data(search)]
+        assert "offline_note.md" in paths
+
+
+# ---------------------------------------------------------------------------
 # Bearer token auth configuration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,96 @@
+"""Regression tests for the lazy (PEP 562) package root.
+
+``pytest --cov=markdown_vault_mcp.<submodule>`` used to fail dozens of tests
+with ``yaml.constructor.ConstructorError: could not determine a constructor
+for the tag None``: coverage.py resolves dotted source packages with
+``importlib.util.find_spec`` inside a sys.modules-restoring context, and the
+eager package ``__init__`` dragged PyYAML (including the cached single-phase
+``yaml._yaml`` C extension) into that disposable import. These tests pin the
+fix: importing the package root must stay light.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+import markdown_vault_mcp
+
+
+class TestLazyExports:
+    def test_all_public_attributes_resolve(self) -> None:
+        """Every name in __all__ resolves via the lazy __getattr__."""
+        for name in markdown_vault_mcp.__all__:
+            assert getattr(markdown_vault_mcp, name) is not None
+
+    def test_exports_map_matches_all(self) -> None:
+        """The lazy export map and __all__ stay in sync."""
+        assert set(markdown_vault_mcp._EXPORTS) == set(markdown_vault_mcp.__all__)
+
+    def test_unknown_attribute_raises(self) -> None:
+        """Unknown attributes raise AttributeError, as a normal module would."""
+        with pytest.raises(AttributeError, match="no attribute 'nope'"):
+            _ = markdown_vault_mcp.nope
+
+    def test_dir_includes_public_names(self) -> None:
+        """dir() advertises the lazily resolved public surface."""
+        listing = dir(markdown_vault_mcp)
+        assert "Collection" in listing
+        assert "ReindexResult" in listing
+
+
+class TestImportIsLight:
+    """The package root must not import the heavy dependency tree.
+
+    Run in a subprocess so the assertions see a clean interpreter rather
+    than whatever this test session has already imported.
+    """
+
+    def _run(self, code: str) -> None:
+        """Execute *code* in a fresh interpreter and assert it succeeds."""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_package_import_does_not_load_yaml(self) -> None:
+        """``import markdown_vault_mcp`` must not pull in PyYAML/frontmatter."""
+        self._run(
+            "import sys; import markdown_vault_mcp; "
+            "heavy = {'yaml', 'frontmatter'} & "
+            "{m.split('.')[0] for m in sys.modules}; "
+            "assert not heavy, f'package import loaded {heavy}'"
+        )
+
+    def test_find_spec_on_submodule_does_not_load_yaml(self) -> None:
+        """``find_spec('markdown_vault_mcp.tracker')`` must not import PyYAML.
+
+        This is exactly what coverage.py does (inside a sys.modules-restoring
+        context) to resolve ``--cov=markdown_vault_mcp.tracker``; if PyYAML
+        gets imported here it is subsequently unloaded, corrupting the cached
+        ``yaml._yaml`` C extension for the rest of the process.
+        """
+        self._run(
+            "import importlib.util, sys; "
+            "importlib.util.find_spec('markdown_vault_mcp.tracker'); "
+            "heavy = {'yaml', 'frontmatter'} & "
+            "{m.split('.')[0] for m in sys.modules}; "
+            "assert not heavy, f'find_spec loaded {heavy}'"
+        )
+
+    def test_yaml_survives_simulated_coverage_source_resolution(self) -> None:
+        """PyYAML still parses after coverage-style find_spec + module purge."""
+        self._run(
+            "import importlib.util, sys; "
+            "before = set(sys.modules); "
+            "importlib.util.find_spec('markdown_vault_mcp.collection'); "
+            "[sys.modules.pop(m) for m in set(sys.modules) - before]; "
+            "import frontmatter; "
+            "post = frontmatter.loads('---\\ntitle: Hello\\n---\\nbody\\n'); "
+            "assert post.metadata == {'title': 'Hello'}, post.metadata"
+        )

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -313,7 +313,7 @@ class TestMalformedStateFile:
             # Restore permissions so pytest can clean up tmp_path.
             state_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
-        assert result == {}
+        assert result == ({}, {})
         assert any("Cannot read state file" in r.message for r in caplog.records)
 
 
@@ -328,7 +328,7 @@ class TestSaveStateFailure:
             patch("json.dump", side_effect=RuntimeError("disk full")),
             pytest.raises(RuntimeError, match="disk full"),
         ):
-            tracker._save_state({"a.md": "abc123"})
+            tracker._save_state({"a.md": "abc123"}, {})
 
         # No leftover .tmp files.
         leftover = list(tmp_path.glob("*.tmp"))
@@ -336,24 +336,172 @@ class TestSaveStateFailure:
 
 
 class TestStateFileFormat:
-    def test_state_file_format_is_path_to_hash(self, tmp_path: Path) -> None:
-        """The JSON state file maps relative path strings to SHA256 hex strings."""
+    def test_state_file_format_is_versioned_maps(self, tmp_path: Path) -> None:
+        """The JSON state file holds versioned indexed/skipped path→hash maps."""
         vault = tmp_path / "vault"
         vault.mkdir()
         md = _write_md(vault, "check.md", "some content\n")
         expected_hash = hashlib.sha256(md.read_bytes()).hexdigest()
+        skipped_hash = hashlib.sha256(b"skipped\n").hexdigest()
 
         state_path = tmp_path / "state.json"
         tracker = ChangeTracker(state_path)
         note = _make_note("check.md", expected_hash)
-        tracker.update_state([note])
+        tracker.update_state([note], skipped={"skip.md": skipped_hash})
 
         raw = json.loads(state_path.read_text(encoding="utf-8"))
         assert isinstance(raw, dict)
-        assert "check.md" in raw
-        assert raw["check.md"] == expected_hash
+        assert raw["version"] == 2
+        assert raw["indexed"] == {"check.md": expected_hash}
+        assert raw["skipped"] == {"skip.md": skipped_hash}
         # All values should look like SHA256 hex digests (64 hex chars).
-        for value in raw.values():
+        for value in {**raw["indexed"], **raw["skipped"]}.values():
             assert isinstance(value, str)
             assert len(value) == 64
             int(value, 16)  # raises ValueError if not hex
+
+
+class TestSkippedFiles:
+    def _hash_of(self, path: Path) -> str:
+        """Return the SHA256 hex digest of a file's raw bytes."""
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def test_unchanged_skipped_file_not_rereported(self, tmp_path: Path) -> None:
+        """A recorded skipped file with unchanged content stays out of added."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+
+        changes = tracker.detect_changes(vault)
+        assert changes.added == []
+        assert changes.modified == []
+        assert changes.deleted == []
+        assert changes.unchanged == 0
+        assert changes.skipped_unchanged == 1
+
+    def test_changed_skipped_file_reported_added(self, tmp_path: Path) -> None:
+        """A skipped file whose content changes is re-reported as added."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+
+        md.write_text("---\nname: now valid\n---\nbody\n", encoding="utf-8")
+
+        changes = tracker.detect_changes(vault)
+        assert changes.added == ["skip.md"]
+        assert changes.modified == []
+        assert changes.skipped_unchanged == 0
+
+    def test_deleted_skipped_file_not_reported_deleted(self, tmp_path: Path) -> None:
+        """A skipped file removed from disk is dropped silently, not deleted."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+
+        md.unlink()
+
+        changes = tracker.detect_changes(vault)
+        assert changes.deleted == []
+        assert changes.skipped_unchanged == 0
+
+        # The dropped entry must not be carried into the next state write.
+        tracker.update_state([])
+        raw = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert raw["skipped"] == {}
+
+    def test_skipped_carry_persists_across_update_state(self, tmp_path: Path) -> None:
+        """Unchanged skipped entries survive update_state without re-passing them."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+
+        # Subsequent scan + state write without new skips keeps the entry.
+        tracker.detect_changes(vault)
+        tracker.update_state([])
+
+        raw = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert raw["skipped"] == {"skip.md": self._hash_of(md)}
+
+    def test_indexed_path_wins_over_skipped(self, tmp_path: Path) -> None:
+        """A path present in notes is dropped from the skipped map."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "doc.md", "content\n")
+        digest = hashlib.sha256(md.read_bytes()).hexdigest()
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        note = _make_note("doc.md", digest)
+        tracker.update_state([note], skipped={"doc.md": digest})
+
+        raw = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert raw["indexed"] == {"doc.md": digest}
+        assert raw["skipped"] == {}
+
+
+class TestLegacyStateFormat:
+    def test_legacy_flat_state_loads_as_indexed(self, tmp_path: Path) -> None:
+        """An old flat path→hash state file loads with all entries indexed."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "old.md", "legacy content\n")
+        digest = hashlib.sha256(md.read_bytes()).hexdigest()
+
+        state_path = tmp_path / "state.json"
+        state_path.write_text(json.dumps({"old.md": digest}), encoding="utf-8")
+
+        tracker = ChangeTracker(state_path)
+        changes = tracker.detect_changes(vault)
+
+        assert changes.added == []
+        assert changes.modified == []
+        assert changes.deleted == []
+        assert changes.unchanged == 1
+        assert changes.skipped_unchanged == 0
+
+    def test_legacy_flat_state_detects_modification(self, tmp_path: Path) -> None:
+        """Legacy state entries still participate in modification detection."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "old.md", "legacy content\n")
+        digest = hashlib.sha256(md.read_bytes()).hexdigest()
+
+        state_path = tmp_path / "state.json"
+        state_path.write_text(json.dumps({"old.md": digest}), encoding="utf-8")
+
+        md.write_text("changed content\n", encoding="utf-8")
+
+        tracker = ChangeTracker(state_path)
+        changes = tracker.detect_changes(vault)
+        assert changes.modified == ["old.md"]
+
+    def test_v2_state_with_non_dict_maps_resets(self, tmp_path: Path) -> None:
+        """A version-2 state file with malformed maps is treated as empty."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "a.md")
+
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            json.dumps({"version": 2, "indexed": [], "skipped": {}}),
+            encoding="utf-8",
+        )
+
+        tracker = ChangeTracker(state_path)
+        changes = tracker.detect_changes(vault)
+        assert "a.md" in changes.added

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -98,6 +98,48 @@ class TestVectorIndexAdd:
         assert index.count == 3
 
 
+class TestChunksByPath:
+    def test_chunks_by_path_groups_rows_in_storage_order(
+        self, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        """chunks_by_path() groups metadata rows by document path."""
+        index = VectorIndex(mock_provider)
+        index.add(
+            ["a-intro", "b-only", "a-details"],
+            [
+                _make_meta("a.md", heading=None),
+                _make_meta("b.md", heading="Only"),
+                _make_meta("a.md", heading="Details"),
+            ],
+        )
+
+        grouped = index.chunks_by_path()
+
+        assert set(grouped) == {"a.md", "b.md"}
+        assert [r["heading"] for r in grouped["a.md"]] == [None, "Details"]
+        assert len(grouped["b.md"]) == 1
+        assert set(grouped["a.md"][0]) == _METADATA_KEYS
+
+    def test_chunks_by_path_returns_copies(
+        self, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        """Mutating a returned row must not corrupt the stored metadata."""
+        index = VectorIndex(mock_provider)
+        index.add(["text"], [_make_meta("a.md")])
+
+        grouped = index.chunks_by_path()
+        grouped["a.md"][0]["content"] = "mutated"
+
+        assert index.chunks_by_path()["a.md"][0]["content"] != "mutated"
+
+    def test_chunks_by_path_empty_index(
+        self, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        """An empty index yields an empty mapping."""
+        index = VectorIndex(mock_provider)
+        assert index.chunks_by_path() == {}
+
+
 class TestVectorIndexAddVectors:
     """Tests for VectorIndex.add_vectors() — pre-computed vector ingestion."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "1.19.1"
+version = "1.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-frontmatter" },


### PR DESCRIPTION
## Summary

Root-caused from a production failure: the MCP server failed Claude Code's 30s connection timeout on a 181MB vault because every process boot re-indexed the entire vault despite a fully persisted index.

Four fixes, atomic commits:

- **Boot adopts the persistent index** (f07f8fb): `build_index()`'s skip-guard consulted the in-memory `_initialized` flag — always false in a fresh process — so every boot re-scanned and re-upserted all documents into the already-populated SQLite (slow boots, FTS bloat, `database is locked` contention across concurrent instances). Boot now adopts a populated on-disk index with zero upserts and runs incremental `reindex()` (ChangeTracker + persisted content hashes) to pick up offline changes.
- **Tracker remembers skipped files** (d4fa037): files failing required-frontmatter checks never entered tracker state, so every boot re-reported them as "added" and re-parsed them. State file is now versioned (`{version: 2, indexed, skipped}`, legacy format loads cleanly); unchanged skipped files are neither re-parsed nor re-logged; a skipped file that gains valid frontmatter is indexed on next scan.
- **Lazy package root** (e9a90a6): `--cov=markdown_vault_mcp.<submodule>` corrupted PyYAML — coverage.py's `find_spec` + `sys_modules_saved` purge unloads first-generation classes while CPython's extension cache resurrects the C parser holding references to them, failing every identity check in the resolver. PEP 562 lazy `__init__.py` keeps package-root resolution import-light.
- **Embedding convergence at boot** (555b095): `build_embeddings()` skipped whenever vectors existed, and the boot `reindex()` ran before the vector index loaded, so externally-added/modified/deleted docs never updated vectors (observed 78% drift in production). Boot now converges the vector index to the FTS chunk set: `+N added, -M removed, K up-to-date`.

## Measured impact (181MB / 729-file vault)

- Warm boot to MCP handshake: 30s+ (timeout) → **1–2s**
- Index size: 1.8GB → 4.7MB (with vault-side transcript exclusion)
- Embedding drift: converges to zero every boot

## Tests

1146 passed (plain, bare `--cov`, and dotted `--cov` forms); ruff + mypy clean. New coverage: persistent-index adoption (6), lifespan boot indexing (2), skip-state tracking, package import invariants, embedding convergence (5 scenarios incl. legacy-drift healing).