### PR TITLE
fix(packaging): lazy package root via PEP 562 stops dotted --cov from breaking the interpreter (#665 PR1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ The authoritative design specification lives at [`docs/design.md`](docs/design.m
 <!-- DOMAIN-START -->
 ```
 src/markdown_vault_mcp/
+  __init__.py        -- lazy (PEP 562) public API root; must stay import-light (#665)
   utils/
     text.py            -- text normalization, position mapping, fuzzy matching
     links.py           -- link target computation and replacement

--- a/docs/design.md
+++ b/docs/design.md
@@ -1310,6 +1310,26 @@ The MCP tool `get_connection_path` returns
 
 ## Module Design
 
+### `__init__.py` -- Lazy Package Root (PEP 562, #665)
+
+The package root resolves its public attributes lazily via module-level
+``__getattr__``/``__dir__`` (PEP 562) from an explicit name -> submodule map
+(`_EXPORTS`), instead of eagerly importing every exporting submodule. The
+public API is unchanged: ``from markdown_vault_mcp import Vault`` still works,
+``__all__`` lists the same names, and a test pins ``_EXPORTS`` == ``__all__``.
+
+Rationale: an eager root pulled the full dependency tree (``config`` ->
+``fastmcp_pvl_core`` -> ``beartype``; ``frontmatter`` -> PyYAML) into *any*
+import of the package. coverage.py resolves dotted ``--cov=`` source packages
+with ``importlib.util.find_spec`` inside a sys.modules-restoring context, so
+those dependencies were imported and then purged while their process-global
+side effects (beartype's claw entry in ``sys.path_hooks``, PyYAML's cached
+single-phase-init C extension) survived, breaking every subsequent import in
+the process. The package root must therefore stay import-light: it may not
+import (directly or transitively) ``fastmcp_pvl_core``, ``beartype``,
+``frontmatter``, or ``yaml``. Regression tests live in
+``tests/test_package_imports.py``.
+
 ### `vault.py` -- Thin Facade
 
 The main interface. Orchestrates specialized manager modules via dependency

--- a/src/markdown_vault_mcp/__init__.py
+++ b/src/markdown_vault_mcp/__init__.py
@@ -170,7 +170,11 @@ def __getattr__(name: str) -> Any:
     except KeyError:
         msg = f"module {__name__!r} has no attribute {name!r}"
         raise AttributeError(msg) from None
-    return getattr(importlib.import_module(module_name), name)
+    value = getattr(importlib.import_module(module_name), name)
+    # Cache so subsequent lookups hit the module __dict__ directly instead
+    # of re-entering __getattr__.
+    globals()[name] = value
+    return value
 
 
 def __dir__() -> list[str]:

--- a/src/markdown_vault_mcp/__init__.py
+++ b/src/markdown_vault_mcp/__init__.py
@@ -1,48 +1,113 @@
-"""Generic markdown vault with FTS5 + semantic search."""
+"""Generic markdown vault with FTS5 + semantic search.
 
-from markdown_vault_mcp.config import VaultConfig
-from markdown_vault_mcp.exceptions import (
-    ConcurrentModificationError,
-    ConfigurationError,
-    DocumentExistsError,
-    DocumentNotFoundError,
-    EditConflictError,
-    IndexUnavailableError,
-    IndexUnavailableReason,
-    MarkdownMCPError,
-    ReadOnlyError,
-)
-from markdown_vault_mcp.git import GitWriteStrategy, git_write_strategy
-from markdown_vault_mcp.types import (
-    AttachmentContent,
-    AttachmentInfo,
-    BacklinkInfo,
-    BrokenLinkInfo,
-    ChangeSet,
-    Chunk,
-    CommitDiff,
-    DeleteResult,
-    EditResult,
-    FTSResult,
-    GroupedResult,
-    HistoryEntry,
-    IndexStats,
-    LinkInfo,
-    MostLinkedNote,
-    NoteContent,
-    NoteContext,
-    NoteInfo,
-    OutlinkInfo,
-    ParsedNote,
-    ReindexResult,
-    RenameResult,
-    SearchResult,
-    SectionHit,
-    VaultStats,
-    WriteCallback,
-    WriteResult,
-)
-from markdown_vault_mcp.vault import Vault
+Public attributes are resolved lazily (PEP 562) instead of eagerly importing
+every submodule here. An eager package root pulled the full dependency tree
+(``config`` -> ``fastmcp_pvl_core`` -> ``beartype``, plus
+``python-frontmatter`` -> PyYAML) into *any* import of this package -- which
+broke ``pytest --cov=markdown_vault_mcp.<submodule>``: coverage.py resolves
+dotted source packages with :func:`importlib.util.find_spec` inside a
+sys.modules-restoring context (``coverage.misc.sys_modules_saved``), so the
+heavy dependencies were imported and then purged from ``sys.modules`` while
+their process-global side effects (beartype's claw ``sys.path_hooks`` entry,
+PyYAML's cached single-phase-init C extension) survived, corrupting the
+interpreter for every subsequent import. Keeping this module import-light
+avoids that interaction entirely (and speeds up CLI startup). See issue #665.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from markdown_vault_mcp.config import VaultConfig
+    from markdown_vault_mcp.exceptions import (
+        ConcurrentModificationError,
+        ConfigurationError,
+        DocumentExistsError,
+        DocumentNotFoundError,
+        EditConflictError,
+        IndexUnavailableError,
+        IndexUnavailableReason,
+        MarkdownMCPError,
+        ReadOnlyError,
+    )
+    from markdown_vault_mcp.git import GitWriteStrategy, git_write_strategy
+    from markdown_vault_mcp.types import (
+        AttachmentContent,
+        AttachmentInfo,
+        BacklinkInfo,
+        BrokenLinkInfo,
+        ChangeSet,
+        Chunk,
+        CommitDiff,
+        DeleteResult,
+        EditResult,
+        FTSResult,
+        GroupedResult,
+        HistoryEntry,
+        IndexStats,
+        LinkInfo,
+        MostLinkedNote,
+        NoteContent,
+        NoteContext,
+        NoteInfo,
+        OutlinkInfo,
+        ParsedNote,
+        ReindexResult,
+        RenameResult,
+        SearchResult,
+        SectionHit,
+        VaultStats,
+        WriteCallback,
+        WriteResult,
+    )
+    from markdown_vault_mcp.vault import Vault
+
+# Public attribute name -> defining submodule. Resolved on first access by
+# __getattr__ below. Must stay in sync with __all__ (pinned by a test).
+_EXPORTS: dict[str, str] = {
+    "VaultConfig": "markdown_vault_mcp.config",
+    "ConcurrentModificationError": "markdown_vault_mcp.exceptions",
+    "ConfigurationError": "markdown_vault_mcp.exceptions",
+    "DocumentExistsError": "markdown_vault_mcp.exceptions",
+    "DocumentNotFoundError": "markdown_vault_mcp.exceptions",
+    "EditConflictError": "markdown_vault_mcp.exceptions",
+    "IndexUnavailableError": "markdown_vault_mcp.exceptions",
+    "IndexUnavailableReason": "markdown_vault_mcp.exceptions",
+    "MarkdownMCPError": "markdown_vault_mcp.exceptions",
+    "ReadOnlyError": "markdown_vault_mcp.exceptions",
+    "GitWriteStrategy": "markdown_vault_mcp.git",
+    "git_write_strategy": "markdown_vault_mcp.git",
+    "AttachmentContent": "markdown_vault_mcp.types",
+    "AttachmentInfo": "markdown_vault_mcp.types",
+    "BacklinkInfo": "markdown_vault_mcp.types",
+    "BrokenLinkInfo": "markdown_vault_mcp.types",
+    "ChangeSet": "markdown_vault_mcp.types",
+    "Chunk": "markdown_vault_mcp.types",
+    "CommitDiff": "markdown_vault_mcp.types",
+    "DeleteResult": "markdown_vault_mcp.types",
+    "EditResult": "markdown_vault_mcp.types",
+    "FTSResult": "markdown_vault_mcp.types",
+    "GroupedResult": "markdown_vault_mcp.types",
+    "HistoryEntry": "markdown_vault_mcp.types",
+    "IndexStats": "markdown_vault_mcp.types",
+    "LinkInfo": "markdown_vault_mcp.types",
+    "MostLinkedNote": "markdown_vault_mcp.types",
+    "NoteContent": "markdown_vault_mcp.types",
+    "NoteContext": "markdown_vault_mcp.types",
+    "NoteInfo": "markdown_vault_mcp.types",
+    "OutlinkInfo": "markdown_vault_mcp.types",
+    "ParsedNote": "markdown_vault_mcp.types",
+    "ReindexResult": "markdown_vault_mcp.types",
+    "RenameResult": "markdown_vault_mcp.types",
+    "SearchResult": "markdown_vault_mcp.types",
+    "SectionHit": "markdown_vault_mcp.types",
+    "VaultStats": "markdown_vault_mcp.types",
+    "WriteCallback": "markdown_vault_mcp.types",
+    "WriteResult": "markdown_vault_mcp.types",
+    "Vault": "markdown_vault_mcp.vault",
+}
 
 __all__ = [
     "AttachmentContent",
@@ -86,3 +151,32 @@ __all__ = [
     "WriteResult",
     "git_write_strategy",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve a public attribute from its defining submodule.
+
+    Args:
+        name: Attribute name being looked up on the package.
+
+    Returns:
+        The resolved attribute.
+
+    Raises:
+        AttributeError: If ``name`` is not a public attribute of this package.
+    """
+    try:
+        module_name = _EXPORTS[name]
+    except KeyError:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg) from None
+    return getattr(importlib.import_module(module_name), name)
+
+
+def __dir__() -> list[str]:
+    """Expose lazily resolved public attributes to :func:`dir`.
+
+    Returns:
+        Sorted list of the package's attribute names, including lazy exports.
+    """
+    return sorted(set(__all__) | set(globals()))

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -52,6 +52,16 @@ class TestLazyExports:
         for name in markdown_vault_mcp.__all__:
             assert name in listing
 
+    def test_resolved_attribute_is_cached_in_module_dict(self):
+        """First resolution binds the name into the module __dict__ so later
+        lookups bypass __getattr__ entirely."""
+        name = "Vault"
+        vars(markdown_vault_mcp).pop(name, None)
+        assert name not in vars(markdown_vault_mcp)
+        first = getattr(markdown_vault_mcp, name)
+        assert name in vars(markdown_vault_mcp)
+        assert vars(markdown_vault_mcp)[name] is first
+
 
 class TestImportIsLight:
     """The package root must not import the heavy dependency tree.

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,153 @@
+"""Regression tests for the lazy (PEP 562) package root (#665, Problem 3).
+
+``pytest --cov=markdown_vault_mcp.<submodule>`` used to kill the whole test
+session at conftest load with ``ImportError: cannot import name 'claw_state'
+from partially initialized module 'beartype.claw._clawstate'``: coverage.py
+resolves dotted source packages with ``importlib.util.find_spec`` inside a
+sys.modules-restoring context (``coverage.misc.sys_modules_saved``), and the
+eager package ``__init__`` dragged the full dependency tree (``config`` ->
+``fastmcp_pvl_core`` -> ``beartype``, plus ``frontmatter`` -> PyYAML) into
+that disposable import. The purge on context exit removed beartype's modules
+but left its claw import hook in ``sys.path_hooks``, so the next import
+routed through an orphaned hook into a circular re-import. These tests pin
+the fix: importing (or find_spec-ing) the package root must stay light.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import markdown_vault_mcp
+
+# Top-level distributions that must never be imported by the package root.
+# beartype arrives via fastmcp_pvl_core (whose claw import hook survives a
+# sys.modules purge); yaml arrives via frontmatter (whose single-phase-init
+# C extension keeps first-generation class references across a purge).
+_HEAVY = "{'beartype', 'fastmcp_pvl_core', 'frontmatter', 'yaml'}"
+
+
+class TestLazyExports:
+    def test_all_public_attributes_resolve(self):
+        """Every name in __all__ resolves via the lazy __getattr__."""
+        for name in markdown_vault_mcp.__all__:
+            assert getattr(markdown_vault_mcp, name) is not None
+
+    def test_exports_map_matches_all(self):
+        """The lazy export map and __all__ stay in sync."""
+        assert set(markdown_vault_mcp._EXPORTS) == set(markdown_vault_mcp.__all__)
+
+    def test_unknown_attribute_raises(self):
+        """Unknown attributes raise AttributeError, as a normal module would."""
+        with pytest.raises(AttributeError, match="no attribute 'nope'"):
+            _ = markdown_vault_mcp.nope
+
+    def test_dir_includes_public_names(self):
+        """dir() advertises the lazily resolved public surface."""
+        listing = dir(markdown_vault_mcp)
+        for name in markdown_vault_mcp.__all__:
+            assert name in listing
+
+
+class TestImportIsLight:
+    """The package root must not import the heavy dependency tree.
+
+    Run in a subprocess so the assertions see a clean interpreter rather
+    than whatever this test session has already imported.
+    """
+
+    def _run(self, code: str) -> None:
+        """Execute code in a fresh interpreter and assert it succeeds."""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_package_import_is_light(self):
+        """``import markdown_vault_mcp`` must not pull in the heavy deps."""
+        self._run(
+            "import sys; import markdown_vault_mcp; "
+            f"heavy = {_HEAVY} & "
+            "{m.split('.')[0] for m in sys.modules}; "
+            "assert not heavy, f'package import loaded {heavy}'"
+        )
+
+    def test_find_spec_on_submodule_is_light(self):
+        """``find_spec('markdown_vault_mcp.tracker')`` must stay light.
+
+        This is exactly what coverage.py does (inside a sys.modules-restoring
+        context) to resolve ``--cov=markdown_vault_mcp.tracker``; anything
+        imported here is subsequently unloaded, orphaning beartype's claw
+        ``sys.path_hooks`` entry and PyYAML's cached C extension.
+        """
+        self._run(
+            "import importlib.util, sys; "
+            "importlib.util.find_spec('markdown_vault_mcp.tracker'); "
+            f"heavy = {_HEAVY} & "
+            "{m.split('.')[0] for m in sys.modules}; "
+            "assert not heavy, f'find_spec loaded {heavy}'"
+        )
+
+    def test_interpreter_survives_simulated_coverage_resolution(self):
+        """Imports still work after coverage-style find_spec + module purge.
+
+        Reproduces coverage.py's source-package resolution: find_spec on a
+        dotted submodule, then purge every newly imported module. The
+        interpreter must survive a subsequent heavy import (pre-fix this
+        died in beartype's orphaned claw hook) and PyYAML parsing must
+        still work (the 1.20.0-era symptom of the same root cause).
+        """
+        self._run(
+            "import importlib.util, sys; "
+            "before = set(sys.modules); "
+            "importlib.util.find_spec('markdown_vault_mcp.tracker'); "
+            "[sys.modules.pop(m) for m in set(sys.modules) - before]; "
+            "import markdown_vault_mcp.config; "
+            "import frontmatter; "
+            "post = frontmatter.loads('---\\ntitle: Hello\\n---\\nbody\\n'); "
+            "assert post.metadata == {'title': 'Hello'}, post.metadata"
+        )
+
+    def test_dotted_cov_invocation_passes(self, tmp_path):
+        """The previously-fatal dotted --cov pytest invocation succeeds.
+
+        End-to-end pin for #665 Problem 3: run the exact reported command in
+        a subprocess. Pre-fix it aborted at conftest load with the beartype
+        ``claw_state`` circular ImportError.
+        """
+        repo_root = Path(__file__).resolve().parent.parent
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            # Strip outer pytest-cov subprocess hooks so the inner run
+            # measures (and writes) its own coverage data only.
+            if not k.startswith(("COV_CORE_", "COVERAGE_"))
+        }
+        # Keep the inner run's data file out of the repo root.
+        env["COVERAGE_FILE"] = str(tmp_path / ".coverage")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "tests/test_scanner.py",
+                "--cov=markdown_vault_mcp.tracker",
+                "--cov-fail-under=0",
+                "-q",
+                "-p",
+                "no:cacheprovider",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo_root,
+            env=env,
+        )
+        assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## Summary

PR1 of 3 for #665 — fixes **Problem 3**: `pytest --cov=markdown_vault_mcp.<submodule>` killed the entire test session before running a single test. The package root (`src/markdown_vault_mcp/__init__.py`) is now lazy (PEP 562): a module-level `__getattr__`/`__dir__` resolves the existing public names on demand from an explicit name → submodule map. `__all__` is unchanged, `from markdown_vault_mcp import Vault` still works, and importing or `find_spec`-ing the package root no longer touches `fastmcp_pvl_core`, `beartype`, `frontmatter`, or `yaml`.

## Mechanism

coverage.py resolves dotted `--cov=` source packages by calling `importlib.util.find_spec()` inside a sys.modules-restoring context (`coverage.misc.sys_modules_saved`). `find_spec` on a submodule imports the parent package, and the eager `__init__` pulled the full dependency tree: `config` → `fastmcp_pvl_core` → `beartype`, which installs claw import hooks into `sys.path_hooks` as a process-global side effect. On context exit every newly imported module is purged from `sys.modules` — but the path hook survives, so the next import (conftest, in practice) routes through an orphaned hook into a circular beartype re-import. On 1.20.0 the same root cause instead corrupted PyYAML's cached single-phase-init C extension, breaking every `CSafeLoader` parse for the rest of the process. Keeping the package root import-light removes the disposable heavy import entirely (and lightens CLI startup as a bonus).

## Live repro

**Before (HEAD, 0aa876d):**

```
$ uv run pytest tests/test_scanner.py --cov=markdown_vault_mcp.tracker
ImportError while loading conftest '.../tests/conftest.py'.
E   ImportError: cannot import name 'claw_state' from partially initialized
    module 'beartype.claw._clawstate' (most likely due to a circular import)
```

**After (this branch):**

```
$ uv run pytest tests/test_scanner.py --cov=markdown_vault_mcp.tracker
======================== 33 passed, 1 skipped in 0.08s =========================
```

(The run then reports `Total coverage: 0.00%` against `fail_under` simply because scanner tests don't exercise `tracker` — the interpreter and session now survive, which is the bug being fixed.)

## Tests (`tests/test_package_imports.py`)

All five fix-dependent tests **fail at HEAD** and pass on this branch:

- `test_package_import_is_light` — importing the package root leaves `beartype`/`fastmcp_pvl_core`/`frontmatter`/`yaml` out of `sys.modules` (fresh subprocess).
- `test_find_spec_on_submodule_is_light` — same invariant for `find_spec('markdown_vault_mcp.tracker')`, exactly what coverage.py does.
- `test_interpreter_survives_simulated_coverage_resolution` — replays coverage's find_spec-then-purge sequence, then asserts a subsequent heavy import and a frontmatter/PyYAML parse still work.
- `test_dotted_cov_invocation_passes` — runs the exact reported command end-to-end in a subprocess.
- `test_exports_map_matches_all` — pins `_EXPORTS` ≡ `__all__`.

Plus: every public name resolves via the lazy `__getattr__`, unknown attributes raise `AttributeError`, and `dir()` lists the full public surface.

## Gates

- `uv run pytest -q` — 2081 passed, 1 skipped. (One run hit `test_mcp_apps_graph.py::TestGraphDataTools::test_hubs_returns_graph`, which is flaky **at pristine HEAD** too — 3/8 failures with an "Index not built" readiness race; unrelated to this change.)
- `ruff check --fix` → `ruff format` → `ruff format --check` — clean.
- `uv run mypy src/ tests/` — no issues in 128 files.
- Patch coverage: changed `__init__.py` at 100%.
- `uv run pre-commit run --all-files` — all hooks pass.
- Docs in the same commit: `docs/design.md` gains a Module Design subsection documenting the lazy root and its import-light contract; `CLAUDE.md` project structure lists `__init__.py` with the same note.

Refs #665