### PR TITLE
fix(indexing): reconcile offline changes at boot; tracker remembers skipped files (#665 PR2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 
 > **Upgrading.** As of this release, `search` returns query-relevant snippets in the `content` field by default (approximately 200 words). Pass `snippet_words=0` to recover the prior full-chunk behaviour, or use `read(path, section=heading)` to fetch a specific chunk after seeing a snippet. Documents are also re-chunked on next `reindex` to honour the adaptive `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` threshold (default 400).
 - **Frontmatter-aware** — indexes YAML frontmatter fields, supports required field enforcement
-- **Incremental reindexing** — hash-based change detection, only re-processes modified files
+- **Incremental reindexing** — hash-based change detection, only re-processes modified files; an automatic boot-time reconciliation pass picks up changes made while no server was running
 - **Write operations** — create, edit, delete, rename documents with automatic index updates
 - **Attachment support** — read, write, delete, and list non-markdown files (PDFs, images, etc.)
 - **Git integration** — optional auto-commit and push on every write via `GIT_ASKPASS`

--- a/docs/design.md
+++ b/docs/design.md
@@ -342,7 +342,10 @@ for built-in names, or pass a custom instance.
 **Hash-based**, not git-based. Works with any directory, no git dependency.
 
 - **State file** (the JSON persistence layer for hash-based change detection):
-  `{relative_path: sha256_hash}` as JSON.
+  versioned format `{"version": 2, "indexed": {relative_path: sha256_hash},
+  "skipped": {relative_path: sha256_hash}}` as JSON (#665). The legacy flat
+  `{relative_path: sha256_hash}` format still loads — every entry is treated
+  as indexed — so upgrades need no migration step.
 - **Default path**: `{source_dir}/.markdown_vault_mcp/state.json` (when
   `state_path=None`).
 - On `reindex()`: scan all files, compare hashes to stored state, re-parse and
@@ -350,10 +353,22 @@ for built-in names, or pass a custom instance.
   `exclude_patterns` are skipped during re-parsing (mirroring `scan_directory`
   behaviour). Any previously indexed documents that now match `exclude_patterns`
   are purged from the FTS and vector indexes.
+- **Skipped-file memory (#665)**: deterministic skips — missing required
+  frontmatter, exclude-pattern matches, decode/parse errors — are recorded in
+  the `skipped` map with the file's content hash, during both full builds and
+  incremental reindexes. An unchanged skipped file is neither re-parsed nor
+  re-logged on later scans and is reported in the `skipped` count of
+  `ReindexResult` instead of `added`; it is re-evaluated (and indexed, if it
+  gained valid frontmatter) only when its content hash changes. Transient
+  `OSError` skips are deliberately *not* recorded, so those files retry on
+  every scan. A skipped file deleted from disk is dropped silently — it was
+  never indexed, so it is not counted as `deleted`.
 
-**Trigger model**: startup scan + explicit `reindex` tool call. No background
-polling in Phase 1. Architecture supports adding `watch_interval` or watchdog
-integration later without refactoring.
+**Trigger model**: boot reconciliation reindex (submitted by the server
+lifespan behind the initial build job, #665) + explicit `reindex` tool call
++ file watcher / git pull / webhook events. No background polling in Phase 1.
+Architecture supports adding `watch_interval` or watchdog integration later
+without refactoring.
 
 ### Incremental Reindex
 
@@ -550,7 +565,20 @@ Submission returns a `concurrent.futures.Future`; callers wait via
 `reindex()`, `build_embeddings()`) or fire-and-forget via the `*_async`
 counterparts (e.g. MCP-tool-level `reindex` and `build_embeddings`, both of
 which return `{"status": "queued"}` immediately and let the writer thread
-do the work). Follow-up submissions issued from inside the writer thread
+do the work).
+
+**Boot reconciliation (#665).** The server lifespan submits
+`reindex_async()` immediately after `build_index_async()`. On a warm
+restart the build short-circuits in O(1) via the FTS sentinel and scans
+nothing, so the queued `ReindexAll` job is what picks up files added,
+modified, or deleted while no server was running (the file watcher only
+sees future events). FIFO ordering guarantees build-before-reindex; on a
+cold boot the full build has just recorded tracker state — including
+skipped files — so the reindex degenerates to a hash scan with zero
+re-parses and zero re-upserts. While the boot reindex is pending or in
+flight the writer is non-drained, so the `_meta.index_stale` signal
+(#646) honestly reports `true` to early readers until offline changes are
+reconciled — no extra staleness bookkeeping is needed. Follow-up submissions issued from inside the writer thread
 itself succeed even during shutdown drain, so `ProcessDirtyPaths` can
 chain into `FlushDirtyEmbeddings` and both flush before the sentinel
 terminates the worker loop.
@@ -1086,6 +1114,7 @@ class ReindexResult:
     modified: int
     deleted: int
     unchanged: int
+    skipped: int = 0                  # deliberately not indexed (#665)
 
 @dataclass
 class VaultStats:
@@ -1109,6 +1138,7 @@ class ChangeSet:
     modified: list[str]
     deleted: list[str]
     unchanged: int
+    skipped_unchanged: int = 0        # recorded skips, content unchanged (#665)
 
 # --- Graph types ---
 
@@ -1584,12 +1614,16 @@ class ChangeTracker:
     def __init__(self, state_path: Path): ...
     def detect_changes(self, source_dir: Path,
                        glob_pattern: str = "**/*.md") -> ChangeSet: ...
-    def update_state(self, notes: list[ParsedNote]) -> None: ...
+    def update_state(self, notes: list[ParsedNote],
+                     skipped: dict[str, str] | None = None) -> None: ...
     def reset(self) -> None: ...
 ```
 
 `tracker.py` is entirely new code (no ifcraftcorpus equivalent). State file
-format: `{"Journal/note.md": "sha256hex", ...}` as JSON.
+format (version 2, #665): `{"version": 2, "indexed": {"Journal/note.md":
+"sha256hex", ...}, "skipped": {"CLAUDE.md": "sha256hex", ...}}` as JSON.
+The legacy flat `{"Journal/note.md": "sha256hex", ...}` format loads with
+every entry treated as indexed.
 
 ### `server.py` -- Generic MCP Server
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -235,9 +235,12 @@ build attempt.
 
 ### `reindex`
 
-Incrementally update the full-text search index to reflect file changes made outside this server. Only processes changed files — unchanged documents are skipped.
+Incrementally update the full-text search index to reflect file changes made outside this server. Only processes changed files — unchanged documents are skipped, and files deliberately excluded from the index (missing required frontmatter, exclude-pattern matches, unparseable content) are remembered across scans so they are not re-parsed or re-reported until their content changes (#665).
 
 If semantic search is configured, the queued reindex job re-embeds the changed documents on the writer thread. Poll `get_index_status` and watch the `dirty_embeddings` counter to observe completion.
+
+!!! note "Boot reconciliation"
+    The server lifespan automatically queues one incremental reindex at every startup (#665), so files added, modified, or deleted while no server was running are reconciled without a manual `reindex` call. Reads served before that job completes report `index_stale: true` in `_meta`.
 
 **Returns:** `{"status": "queued"}`. The reindex runs asynchronously on the single-owner :class:`IndexWriter` thread (#559); poll `get_server_info` or `get_index_status` for completion. `get_index_status` exposes `queue_depth`, `in_flight`, `dirty_paths`, and `dirty_embeddings` so you can observe progress without blocking.
 

--- a/src/markdown_vault_mcp/_cli_impl.py
+++ b/src/markdown_vault_mcp/_cli_impl.py
@@ -170,15 +170,17 @@ def _cmd_reindex(args: argparse.Namespace) -> None:
     vault.index.build_index()
     result = vault.index.reindex()
     logger.info(
-        "Reindex complete: %d added, %d modified, %d deleted, %d unchanged",
+        "Reindex complete: %d added, %d modified, %d deleted, %d unchanged, %d skipped",
         result.added,
         result.modified,
         result.deleted,
         result.unchanged,
+        result.skipped,
     )
     print(
         f"Reindex: {result.added} added, {result.modified} modified, "
-        f"{result.deleted} deleted, {result.unchanged} unchanged"
+        f"{result.deleted} deleted, {result.unchanged} unchanged, "
+        f"{result.skipped} skipped"
     )
     try:
         should_force = result.added > 0 or result.modified > 0 or result.deleted > 0

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -111,6 +111,20 @@ def make_vault_lifespan(config: VaultConfig) -> Any:
         vault.index.build_index_async()
         logger.info("Submitted BuildIndex job to writer")
 
+        # Reconcile offline changes (#665): files added, modified, or
+        # deleted while no server was running are invisible to both the
+        # warm-restart short-circuit above (O(1), no filesystem scan) and
+        # the file watcher below (future events only).  Enqueue an
+        # incremental reindex behind the build: the writer's FIFO ordering
+        # guarantees build-before-reindex, and on a cold boot the full
+        # build has just recorded tracker state (including skipped files),
+        # so the reindex degenerates to a cheap hash scan instead of a
+        # second full parse.  While this job is pending, the writer is
+        # non-drained, so #646's out-of-band `index_stale` meta signal
+        # honestly reports True until the boot reconciliation completes.
+        vault.index.reindex_async()
+        logger.info("Submitted boot Reindex job to writer")
+
         if kwargs.get("embedding_provider") is not None:
             vault.index.build_embeddings_async()
             logger.info("Submitted BuildEmbeddings job to writer")

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from markdown_vault_mcp.fts_index import _derive_folder
+from markdown_vault_mcp.hashing import compute_file_hash
 from markdown_vault_mcp.scanner import parse_note, scan_directory
 from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult
 from markdown_vault_mcp.utils import is_path_excluded
@@ -264,8 +265,28 @@ class IndexManager:
         # Resolve vault-wide wikilinks now that all documents are indexed.
         self._fts.resolve_vault_wikilinks()
 
+        # Record skipped files (excluded, missing frontmatter, unparseable)
+        # in tracker state too, so the first reindex() — including the boot
+        # reconciliation pass after a cold build (#665) — does not re-report
+        # them as added and re-log every skip.
+        skipped_state: dict[str, str] = {}
+        for abs_path in all_files:
+            if not abs_path.is_file():
+                continue
+            rel_str = abs_path.relative_to(self._source_dir).as_posix()
+            if rel_str in indexed_paths:
+                continue
+            try:
+                skipped_state[rel_str] = compute_file_hash(abs_path)
+            except OSError as exc:
+                # Possibly transient — leave unrecorded so the next scan
+                # retries the file.
+                logger.debug(
+                    "build_index_skip_hash_failed path=%s err=%s", rel_str, exc
+                )
+
         # Update tracker state so reindex() knows the baseline.
-        self._tracker.update_state(notes)
+        self._tracker.update_state(notes, skipped=skipped_state)
 
         if errored:
             logger.warning(
@@ -323,25 +344,47 @@ class IndexManager:
         # Phase 1: scan filesystem (read-only walk + hashing).
         changes = self._tracker.detect_changes(self._source_dir)
         logger.info(
-            "reindex: %d added, %d modified, %d deleted, %d unchanged",
+            "reindex: %d added, %d modified, %d deleted, %d unchanged, %d skipped",
             len(changes.added),
             len(changes.modified),
             len(changes.deleted),
             changes.unchanged,
+            changes.skipped_unchanged,
         )
+
+        # Files seen this scan but deliberately not indexed (#665).  Recording
+        # their content hash in tracker state means an unchanged skipped file
+        # is neither re-parsed nor re-reported (or re-logged) on the next
+        # scan; it is only re-evaluated when its content changes.  Transient
+        # I/O errors are NOT recorded, so those files retry on every scan.
+        newly_skipped: dict[str, str] = {}
+
+        def _record_skip(rel_path: str, abs_file: Path) -> None:
+            """Record a deterministically skipped file's current hash."""
+            try:
+                newly_skipped[rel_path] = compute_file_hash(abs_file)
+            except OSError as exc:
+                logger.debug("reindex_skip_hash_failed path=%s err=%s", rel_path, exc)
 
         # Pre-parse notes outside the lock to minimise lock hold time.
         parsed: list[tuple[str, ParsedNote]] = []
         for path in changes.added + changes.modified:
+            abs_path = self._source_dir / path
+
             if self._is_path_excluded(path):
                 logger.debug("reindex: excluding %s (matched exclude pattern)", path)
+                _record_skip(path, abs_path)
                 continue
 
-            abs_path = self._source_dir / path
             try:
                 note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-            except (UnicodeDecodeError, OSError) as exc:
+            except OSError as exc:
+                # Possibly transient — do not record; retry on the next scan.
                 logger.warning("reindex: skipping %s — %s", path, exc)
+                continue
+            except UnicodeDecodeError as exc:
+                logger.warning("reindex: skipping %s — %s", path, exc)
+                _record_skip(path, abs_path)
                 continue
             except Exception as exc:
                 logger.warning(
@@ -350,6 +393,7 @@ class IndexManager:
                     exc,
                     exc_info=True,
                 )
+                _record_skip(path, abs_path)
                 continue
 
             if self._required_frontmatter:
@@ -362,6 +406,7 @@ class IndexManager:
                         path,
                         missing,
                     )
+                    newly_skipped[path] = note.content_hash
                     continue
 
             parsed.append((path, note))
@@ -447,13 +492,14 @@ class IndexManager:
             )
             for r in self._fts.list_notes()
         ]
-        self._tracker.update_state(state_notes)
+        self._tracker.update_state(state_notes, skipped=newly_skipped)
 
         return ReindexResult(
             added=indexed_added,
             modified=indexed_modified,
             deleted=len(changes.deleted),
             unchanged=changes.unchanged,
+            skipped=changes.skipped_unchanged + len(newly_skipped),
         )
 
     # ------------------------------------------------------------------

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -273,7 +273,12 @@ class IndexManager:
         for abs_path in all_files:
             if not abs_path.is_file():
                 continue
-            rel_str = abs_path.relative_to(self._source_dir).as_posix()
+            try:
+                rel_str = abs_path.relative_to(self._source_dir).as_posix()
+            except ValueError:
+                # Symlink target outside the vault — mirror detect_changes.
+                logger.warning("File outside source_dir, skipping: %s", abs_path)
+                continue
             if rel_str in indexed_paths:
                 continue
             try:

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -186,6 +186,10 @@ class ChangeTracker:
             if path not in new_indexed
         }
         self._save_state(new_indexed, new_skipped)
+        # The carry is consumed by exactly one update_state call; clearing it
+        # keeps a later call without a fresh detect_changes (e.g. a full
+        # build_index) from merging stale skipped entries into its snapshot.
+        self._skipped_carry = {}
         logger.debug(
             "update_state: wrote state for %d indexed, %d skipped document(s)",
             len(new_indexed),

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -14,20 +14,29 @@ from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS
 
 logger = logging.getLogger(__name__)
 
+# Current on-disk state file format version. Version 2 splits the flat
+# path → digest map into separate "indexed" and "skipped" maps (#665).
+_STATE_VERSION = 2
+
 
 class ChangeTracker:
     """Detects file additions, modifications, and deletions using SHA256 hashes.
 
-    State is persisted as a JSON file mapping relative document paths to their
-    last-seen SHA256 hex digest. On the first run (no state file), every file
-    on disk is treated as newly added.
+    State is persisted as a JSON file with two maps of relative document path
+    to last-seen SHA256 hex digest: ``indexed`` (files that made it into the
+    index) and ``skipped`` (files seen on disk but deliberately not indexed,
+    e.g. missing required frontmatter). A skipped file is only re-reported as
+    added when its content changes, so it can be re-evaluated. Legacy state
+    files (a flat path-to-hash object) load fine; all entries are treated as
+    indexed. On the first run (no state file), every file on disk is treated
+    as newly added.
 
     Example::
 
         tracker = ChangeTracker(Path("/data/vault/.markdown_vault_mcp/state.json"))
         changes = tracker.detect_changes(Path("/data/vault"))
         # process changes ...
-        tracker.update_state(notes)
+        tracker.update_state(notes, skipped=newly_skipped)
     """
 
     def __init__(self, state_path: Path) -> None:
@@ -38,6 +47,9 @@ class ChangeTracker:
                 yet; the parent directory is created on first write.
         """
         self._state_path = state_path
+        # Skipped entries from the last detect_changes() that are still on
+        # disk with unchanged content; carried forward by update_state().
+        self._skipped_carry: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -52,15 +64,21 @@ class ChangeTracker:
 
         Algorithm:
 
-        1. Load existing state (empty dict if state file does not exist).
+        1. Load existing state (empty maps if state file does not exist).
         2. Scan *source_dir* for all files matching *glob_pattern*.
         3. Compute SHA256 of each file's raw bytes.
         4. Categorise each path:
 
            - present on disk but absent from state → **added**
-           - present in both and hash differs → **modified**
-           - present in state but absent from disk → **deleted**
-           - present in both and hash matches → **unchanged** (counted only)
+           - in indexed state and hash differs → **modified**
+           - in indexed state and hash matches → **unchanged** (counted only)
+           - in skipped state and hash matches → **skipped_unchanged**
+             (counted only; not re-reported)
+           - in skipped state and hash differs → **added** (re-evaluated;
+             it may now qualify for indexing)
+           - in indexed state but absent from disk → **deleted**
+           - in skipped state but absent from disk → dropped silently (it
+             was never indexed, so nothing needs deleting)
 
         5. Return a :class:`~markdown_vault_mcp.types.ChangeSet`.
 
@@ -72,7 +90,7 @@ class ChangeTracker:
         Returns:
             A :class:`~markdown_vault_mcp.types.ChangeSet` describing the delta.
         """
-        stored_state = self._load_state()
+        indexed_state, skipped_state = self._load_state()
 
         # Build a mapping of relative path → sha256 for current disk contents.
         disk_state: dict[str, str] = {}
@@ -94,25 +112,37 @@ class ChangeTracker:
         added: list[str] = []
         modified: list[str] = []
         unchanged: int = 0
+        skipped_unchanged: int = 0
+        self._skipped_carry = {}
 
         for rel_path, current_hash in disk_state.items():
-            if rel_path not in stored_state:
-                added.append(rel_path)
-            elif stored_state[rel_path] != current_hash:
-                modified.append(rel_path)
+            if rel_path in indexed_state:
+                if indexed_state[rel_path] != current_hash:
+                    modified.append(rel_path)
+                else:
+                    unchanged += 1
+            elif rel_path in skipped_state:
+                if skipped_state[rel_path] != current_hash:
+                    # Content changed since the skip — re-evaluate it.
+                    added.append(rel_path)
+                else:
+                    skipped_unchanged += 1
+                    self._skipped_carry[rel_path] = current_hash
             else:
-                unchanged += 1
+                added.append(rel_path)
 
         deleted: list[str] = [
-            rel_path for rel_path in stored_state if rel_path not in disk_state
+            rel_path for rel_path in indexed_state if rel_path not in disk_state
         ]
 
         logger.debug(
-            "detect_changes: %d added, %d modified, %d deleted, %d unchanged",
+            "detect_changes: %d added, %d modified, %d deleted, %d unchanged, "
+            "%d skipped-unchanged",
             len(added),
             len(modified),
             len(deleted),
             unchanged,
+            skipped_unchanged,
         )
 
         return ChangeSet(
@@ -120,29 +150,54 @@ class ChangeTracker:
             modified=modified,
             deleted=deleted,
             unchanged=unchanged,
+            skipped_unchanged=skipped_unchanged,
         )
 
-    def update_state(self, notes: list[ParsedNote]) -> None:
+    def update_state(
+        self,
+        notes: list[ParsedNote],
+        skipped: dict[str, str] | None = None,
+    ) -> None:
         """Persist the current hash state derived from *notes*.
 
-        Overwrites the entire state file with the hashes from *notes*. Call
-        this after successfully (re)indexing a set of documents to record their
-        current content hashes.
+        Overwrites the entire state file. The indexed map comes from *notes*;
+        the skipped map merges the unchanged skipped entries observed by the
+        preceding :meth:`detect_changes` call with *skipped*. Call this after
+        successfully (re)indexing a set of documents to record their current
+        content hashes.
 
         Args:
             notes: Parsed notes whose ``path`` and ``content_hash`` attributes
-                form the new state. Any paths not in this list are dropped from
-                state (treated as deleted on the next scan).
+                form the new indexed state. Any indexed paths not in this list
+                are dropped from state (treated as deleted on the next scan).
+            skipped: Mapping of relative path to SHA256 hex digest for files
+                seen during this scan but deliberately not indexed (missing
+                required frontmatter, excluded, unparseable). Indexed paths
+                always win: any path also present in *notes* is dropped from
+                the skipped map.
         """
-        new_state = {note.path: note.content_hash for note in notes}
-        self._save_state(new_state)
-        logger.debug("update_state: wrote state for %d document(s)", len(notes))
+        new_indexed = {note.path: note.content_hash for note in notes}
+        new_skipped = {
+            path: content_hash
+            for path, content_hash in {
+                **self._skipped_carry,
+                **(skipped or {}),
+            }.items()
+            if path not in new_indexed
+        }
+        self._save_state(new_indexed, new_skipped)
+        logger.debug(
+            "update_state: wrote state for %d indexed, %d skipped document(s)",
+            len(new_indexed),
+            len(new_skipped),
+        )
 
     def reset(self) -> None:
         """Delete the state file so the next scan treats all files as added.
 
         If the state file does not exist, this is a no-op.
         """
+        self._skipped_carry = {}
         if self._state_path.exists():
             self._state_path.unlink()
             logger.debug("reset: deleted state file %s", self._state_path)
@@ -153,18 +208,24 @@ class ChangeTracker:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _load_state(self) -> dict[str, str]:
+    def _load_state(self) -> tuple[dict[str, str], dict[str, str]]:
         """Load the persisted state from disk.
 
+        Supports two formats: the current versioned object
+        (``{"version": 2, "indexed": {...}, "skipped": {...}}``) and the
+        legacy flat mapping of path to digest, which is loaded with every
+        entry treated as indexed.
+
         Returns:
-            Mapping of relative document path to SHA256 hex digest.
-            Returns an empty dict when the state file does not exist.
+            Tuple of ``(indexed, skipped)`` maps of relative document path to
+            SHA256 hex digest. Both are empty when the state file does not
+            exist or is malformed.
         """
         if not self._state_path.exists():
             logger.debug(
                 "No state file at %s; treating all files as added", self._state_path
             )
-            return {}
+            return {}, {}
         try:
             with self._state_path.open(encoding="utf-8") as fh:
                 state = json.load(fh)
@@ -173,24 +234,39 @@ class ChangeTracker:
                     "State file %s is malformed (expected object); resetting",
                     self._state_path,
                 )
-                return {}
-            return state
+                return {}, {}
+            if state.get("version") == _STATE_VERSION:
+                indexed = state.get("indexed", {})
+                skipped = state.get("skipped", {})
+                if not isinstance(indexed, dict) or not isinstance(skipped, dict):
+                    logger.warning(
+                        "State file %s is malformed (expected object maps); resetting",
+                        self._state_path,
+                    )
+                    return {}, {}
+                return indexed, skipped
+            # Legacy flat format: every entry is an indexed path → digest.
+            return state, {}
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning(
                 "Cannot read state file %s (%s); treating all files as added",
                 self._state_path,
                 exc,
             )
-            return {}
+            return {}, {}
 
-    def _save_state(self, state: dict[str, str]) -> None:
-        """Write *state* to the state file as JSON.
+    def _save_state(self, indexed: dict[str, str], skipped: dict[str, str]) -> None:
+        """Write the indexed and skipped maps to the state file as JSON.
 
         Creates parent directories if they do not exist.
 
         Args:
-            state: Mapping of relative document path to SHA256 hex digest.
+            indexed: Mapping of relative document path to SHA256 hex digest
+                for documents present in the index.
+            skipped: Mapping of relative document path to SHA256 hex digest
+                for files seen on disk but deliberately not indexed.
         """
+        state = {"version": _STATE_VERSION, "indexed": indexed, "skipped": skipped}
         self._state_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_path = tempfile.mkstemp(dir=self._state_path.parent, suffix=".tmp")
         try:
@@ -200,7 +276,12 @@ class ChangeTracker:
         except:
             Path(tmp_path).unlink(missing_ok=True)
             raise
-        logger.debug("Saved state for %d path(s) to %s", len(state), self._state_path)
+        logger.debug(
+            "Saved state for %d indexed, %d skipped path(s) to %s",
+            len(indexed),
+            len(skipped),
+            self._state_path,
+        )
 
     def _compute_hash(self, path: Path) -> str:
         """Compute the SHA256 hex digest of *path* using chunked reads.

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -302,12 +302,17 @@ class ReindexResult:
         modified: Documents that changed since the last index.
         deleted: Documents removed since the last index.
         unchanged: Documents with no changes.
+        skipped: Files present on disk that were deliberately not indexed
+            (missing required frontmatter, matching an exclude pattern, or
+            unparseable), whether newly skipped this scan or unchanged since
+            they were last skipped (#665).
     """
 
     added: int
     modified: int
     deleted: int
     unchanged: int
+    skipped: int = 0
 
 
 @dataclass
@@ -388,12 +393,16 @@ class ChangeSet:
         modified: Paths of documents whose content changed.
         deleted: Paths of documents that no longer exist on disk.
         unchanged: Count of documents with no changes (not listed individually).
+        skipped_unchanged: Count of files previously recorded as skipped
+            (never indexed) whose content has not changed since; they appear
+            in no other bucket and need no re-evaluation (#665).
     """
 
     added: list[str]
     modified: list[str]
     deleted: list[str]
     unchanged: int
+    skipped_unchanged: int = 0
 
 
 @dataclass

--- a/tests/test_boot_reconciliation.py
+++ b/tests/test_boot_reconciliation.py
@@ -1,0 +1,277 @@
+"""Boot-time reconciliation of offline changes (#665).
+
+A warm restart short-circuits ``build_index_async()`` in O(1) via the FTS
+sentinel (#526), so nothing scans the filesystem at boot.  The lifespan now
+also submits an incremental ``reindex_async()`` job behind the build: files
+added, modified, or deleted while no server was running are reconciled as
+soon as the writer drains, instead of staying invisible until an unrelated
+watcher event, git pull, or manual reindex.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from fastmcp import Client
+
+from markdown_vault_mcp.vault import Vault
+from tests.conftest import _parse_tool_data, wait_for_mcp_writer_drain
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _make_vault_dir(tmp_path: Path, n_docs: int = 3) -> Path:
+    """Create a vault directory with *n_docs* indexable notes."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for i in range(n_docs):
+        (vault / f"note_{i}.md").write_text(
+            f"# Note {i}\n\nOriginal body {i}.\n", encoding="utf-8"
+        )
+    return vault
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, vault: Path, tmp_path: Path) -> None:
+    """Point the server env at *vault* with persistent index + state files."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
+
+
+def _prebuild(vault: Path, tmp_path: Path) -> int:
+    """Simulate a previous server run: full build into the persistent index."""
+    pre = Vault(
+        source_dir=vault,
+        index_path=tmp_path / "fts.db",
+        state_path=tmp_path / "s.json",
+    )
+    pre.index.build_index()
+    count = len(pre._fts.list_notes())
+    pre.close()
+    return count
+
+
+class TestWarmBootReconciliation:
+    """Warm boots must apply the offline delta after startup settles."""
+
+    def test_offline_add_modify_delete_reconciled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp.server import make_server
+
+        vault = _make_vault_dir(tmp_path, n_docs=3)
+        _prebuild(vault, tmp_path)
+
+        # Offline changes while no server runs.
+        (vault / "offline_added.md").write_text(
+            "# Offline\n\nWritten while the server was down.\n", encoding="utf-8"
+        )
+        (vault / "note_1.md").write_text(
+            "# Note 1\n\nModified offline body.\n", encoding="utf-8"
+        )
+        (vault / "note_2.md").unlink()
+
+        _set_env(monkeypatch, vault, tmp_path)
+        server = make_server()
+
+        async def _run() -> tuple[dict[str, Any], list[str], list[str]]:
+            async with Client(server) as client:
+                await wait_for_mcp_writer_drain(client)
+                status_res = await client.call_tool("get_index_status", {})
+                added = await client.call_tool("search", {"query": "Offline"})
+                modified = await client.call_tool(
+                    "search", {"query": "Modified offline body"}
+                )
+                return (
+                    status_res.structured_content or {},
+                    [r["path"] for r in _parse_tool_data(added)],
+                    [r["path"] for r in _parse_tool_data(modified)],
+                )
+
+        status, added_paths, modified_paths = asyncio.run(_run())
+        # 3 originals - 1 deleted + 1 added = 3 documents.
+        assert status["documents_indexed"] == 3
+        assert "offline_added.md" in added_paths
+        assert "note_1.md" in modified_paths
+
+    def test_unchanged_vault_zero_reupserts_and_zero_reparse(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Warm boot of an unchanged vault applies zero upserts and re-parses
+        nothing — including files skipped for missing required frontmatter."""
+        from unittest.mock import patch
+
+        import markdown_vault_mcp.managers.index as index_module
+        from markdown_vault_mcp.fts_index import FTSIndex
+        from markdown_vault_mcp.server import make_server
+
+        vault = _make_vault_dir(tmp_path, n_docs=3)
+        (vault / "no_frontmatter.md").write_text(
+            "# Skipped\n\nIntentionally lacks required frontmatter.\n",
+            encoding="utf-8",
+        )
+        for i in range(3):
+            (vault / f"note_{i}.md").write_text(
+                f"---\ntitle: Note {i}\n---\n# Note {i}\n\nbody {i}\n",
+                encoding="utf-8",
+            )
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_REQUIRED_FIELDS", "title")
+
+        pre = Vault(
+            source_dir=vault,
+            index_path=tmp_path / "fts.db",
+            state_path=tmp_path / "s.json",
+            required_frontmatter=["title"],
+        )
+        pre.index.build_index()
+        pre.close()
+
+        _set_env(monkeypatch, vault, tmp_path)
+        server = make_server()
+
+        upsert_paths: list[str] = []
+        original_upsert = FTSIndex.upsert_note
+
+        def tracking_upsert(self: FTSIndex, note: Any) -> int:
+            upsert_paths.append(note.path)
+            return original_upsert(self, note)
+
+        parse_calls: list[str] = []
+        original_parse = index_module.parse_note
+
+        def tracking_parse(abs_path: Any, source_dir: Any, chunk_strategy: Any):
+            parse_calls.append(str(abs_path))
+            return original_parse(abs_path, source_dir, chunk_strategy)
+
+        async def _run() -> dict[str, Any]:
+            async with Client(server) as client:
+                await wait_for_mcp_writer_drain(client)
+                res = await client.call_tool("get_index_status", {})
+                return res.structured_content or {}
+
+        with (
+            patch.object(FTSIndex, "upsert_note", tracking_upsert),
+            patch.object(index_module, "parse_note", tracking_parse),
+        ):
+            status = asyncio.run(_run())
+
+        assert status["documents_indexed"] == 3
+        assert upsert_paths == [], f"warm boot re-upserted {upsert_paths}"
+        assert parse_calls == [], f"warm boot re-parsed {parse_calls}"
+
+    def test_warm_boot_lifespan_submits_boot_reindex(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The lifespan logs the boot Reindex submission after BuildIndex."""
+        import logging
+
+        from markdown_vault_mcp.server import make_server
+
+        vault = _make_vault_dir(tmp_path, n_docs=1)
+        _prebuild(vault, tmp_path)
+        _set_env(monkeypatch, vault, tmp_path)
+        server = make_server()
+        caplog.set_level(logging.INFO)
+
+        async def _run() -> None:
+            async with Client(server) as client:
+                await wait_for_mcp_writer_drain(client)
+
+        asyncio.run(_run())
+        messages = [record.message for record in caplog.records]
+        build_idx = next(
+            i for i, m in enumerate(messages) if "Submitted BuildIndex job" in m
+        )
+        reindex_idx = next(
+            i for i, m in enumerate(messages) if "Submitted boot Reindex job" in m
+        )
+        assert build_idx < reindex_idx, "reindex must be enqueued after the build"
+
+
+class TestColdBootReconciliation:
+    """Cold boots must not pay for the reconciliation pass twice."""
+
+    def test_cold_boot_no_double_full_scan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The boot reindex after a cold build upserts/parses nothing extra.
+
+        The full build records tracker state (including skipped files), so
+        the queued reindex job degenerates to a hash scan: every path is
+        upserted exactly once, and the skipped file is parsed exactly once
+        (by scan_directory during the build).
+        """
+        from unittest.mock import patch
+
+        from markdown_vault_mcp.fts_index import FTSIndex
+        from markdown_vault_mcp.server import make_server
+
+        vault = _make_vault_dir(tmp_path, n_docs=4)
+        _set_env(monkeypatch, vault, tmp_path)
+        server = make_server()
+
+        upsert_paths: list[str] = []
+        original_upsert = FTSIndex.upsert_note
+
+        def tracking_upsert(self: FTSIndex, note: Any) -> int:
+            upsert_paths.append(note.path)
+            return original_upsert(self, note)
+
+        async def _run() -> dict[str, Any]:
+            async with Client(server) as client:
+                await wait_for_mcp_writer_drain(client)
+                res = await client.call_tool("get_index_status", {})
+                return res.structured_content or {}
+
+        with patch.object(FTSIndex, "upsert_note", tracking_upsert):
+            status = asyncio.run(_run())
+
+        assert status["documents_indexed"] == 4
+        assert sorted(upsert_paths) == sorted(f"note_{i}.md" for i in range(4)), (
+            f"cold boot upserted each path more than once: {sorted(upsert_paths)}"
+        )
+        assert status["last_reindex_error"] is None
+
+
+class TestConcurrentWarmBoots:
+    """Concurrent server instances booting against the same index must not
+    fail with lock errors (production pattern: several MCP clients spawn
+    their own server processes against one shared vault)."""
+
+    def test_two_concurrent_warm_boots_no_lock_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp.server import make_server
+
+        vault = _make_vault_dir(tmp_path, n_docs=3)
+        _prebuild(vault, tmp_path)
+        (vault / "offline_added.md").write_text(
+            "# Offline\n\nadded while down\n", encoding="utf-8"
+        )
+
+        _set_env(monkeypatch, vault, tmp_path)
+        server_a = make_server()
+        server_b = make_server()
+
+        async def _boot(server: Any) -> dict[str, Any]:
+            async with Client(server) as client:
+                await wait_for_mcp_writer_drain(client, timeout=15.0)
+                res = await client.call_tool("get_index_status", {})
+                return res.structured_content or {}
+
+        async def _run() -> tuple[dict[str, Any], dict[str, Any]]:
+            return await asyncio.gather(_boot(server_a), _boot(server_b))
+
+        status_a, status_b = asyncio.run(_run())
+        for status in (status_a, status_b):
+            assert status["status"] == "queryable"
+            assert status["last_reindex_error"] is None
+            assert status["error"] is None
+            assert status["documents_indexed"] == 4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -905,6 +905,7 @@ class TestCmdReindex:
         mock_result.modified = 1
         mock_result.deleted = 2
         mock_result.unchanged = 10
+        mock_result.skipped = 4
 
         mock_vault = MagicMock()
         mock_vault.index.reindex.return_value = mock_result
@@ -918,6 +919,7 @@ class TestCmdReindex:
         assert "1 modified" in captured.out
         assert "2 deleted" in captured.out
         assert "10 unchanged" in captured.out
+        assert "4 skipped" in captured.out
 
     @patch("markdown_vault_mcp._cli_impl._build_vault")
     def test_reindex_builds_embeddings_when_configured(

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -234,6 +234,252 @@ class TestReindex:
 
 
 # ---------------------------------------------------------------------------
+# Skip-state memory (#665): skipped files are remembered in tracker state
+# ---------------------------------------------------------------------------
+
+
+class TestSkipStateMemory:
+    """reindex() must not re-report/re-parse deterministically skipped files."""
+
+    def _vault_with_skip(self, tmp_path: Path) -> Path:
+        """Vault with one indexable note and one missing required frontmatter."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text(
+            "---\ntitle: Good\n---\n# Good\n\nbody\n", encoding="utf-8"
+        )
+        (vault / "skip.md").write_text("# No frontmatter\n\nbody\n", encoding="utf-8")
+        return vault
+
+    def test_build_index_records_skips_so_first_reindex_is_quiet(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reindex right after a full build re-parses nothing (boot path)."""
+        vault = self._vault_with_skip(tmp_path)
+        mgr, _fts, _ = _make_index_mgr(vault, tmp_path, required_frontmatter=["title"])
+        mgr.build_index()
+
+        import markdown_vault_mcp.managers.index as index_module
+
+        parse_calls: list[str] = []
+        original_parse = index_module.parse_note
+
+        def counting_parse(abs_path, source_dir, chunk_strategy):
+            parse_calls.append(str(abs_path))
+            return original_parse(abs_path, source_dir, chunk_strategy)
+
+        monkeypatch.setattr(index_module, "parse_note", counting_parse)
+
+        result = mgr.reindex()
+        assert result.added == 0
+        assert result.modified == 0
+        assert result.deleted == 0
+        assert result.unchanged == 1
+        assert result.skipped == 1
+        assert parse_calls == [], f"reindex re-parsed {parse_calls}"
+
+    def test_unchanged_skipped_file_not_relogged(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The missing-frontmatter skip is logged once, not on every scan."""
+        vault = self._vault_with_skip(tmp_path)
+        mgr, _fts, _ = _make_index_mgr(vault, tmp_path, required_frontmatter=["title"])
+        # Cold tracker state: build via reindex so the skip is logged once.
+        mgr.build_index()
+        mgr._tracker.reset()
+
+        with caplog.at_level(logging.INFO, logger="markdown_vault_mcp.managers.index"):
+            mgr.reindex()
+        first_run_skips = [
+            r for r in caplog.records if "missing frontmatter" in r.getMessage()
+        ]
+        assert len(first_run_skips) == 1
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="markdown_vault_mcp.managers.index"):
+            result = mgr.reindex()
+        second_run_skips = [
+            r for r in caplog.records if "missing frontmatter" in r.getMessage()
+        ]
+        assert second_run_skips == []
+        assert result.skipped == 1
+
+    def test_skipped_file_gaining_frontmatter_is_indexed(self, tmp_path: Path) -> None:
+        """A skipped file whose content gains valid frontmatter is indexed."""
+        vault = self._vault_with_skip(tmp_path)
+        mgr, fts, _ = _make_index_mgr(vault, tmp_path, required_frontmatter=["title"])
+        mgr.build_index()
+        assert mgr.reindex().skipped == 1
+
+        (vault / "skip.md").write_text(
+            "---\ntitle: Now Valid\n---\n# Valid\n\nbody\n", encoding="utf-8"
+        )
+
+        result = mgr.reindex()
+        assert result.added == 1
+        assert result.skipped == 0
+        paths = {n["path"] for n in fts.list_notes()}
+        assert "skip.md" in paths
+
+    def test_excluded_file_recorded_as_skip(self, tmp_path: Path) -> None:
+        """A file matching exclude_patterns is skipped once, then remembered."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text("# Good\n\nbody\n", encoding="utf-8")
+        mgr, _fts, _ = _make_index_mgr(vault, tmp_path, exclude_patterns=["drafts/**"])
+        mgr.build_index()
+
+        drafts = vault / "drafts"
+        drafts.mkdir()
+        (drafts / "wip.md").write_text("# WIP\n", encoding="utf-8")
+
+        first = mgr.reindex()
+        assert first.added == 0
+        assert first.skipped == 1
+
+        second = mgr.reindex()
+        assert second.added == 0
+        assert second.skipped == 1
+
+    def test_transient_oserror_skip_is_retried(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An OSError during parse is NOT recorded; the file retries next scan."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "flaky.md").write_text("# Flaky\n\nbody\n", encoding="utf-8")
+        mgr, fts, _ = _make_index_mgr(vault, tmp_path)
+
+        import markdown_vault_mcp.managers.index as index_module
+
+        original_parse = index_module.parse_note
+
+        def failing_parse(abs_path, source_dir, chunk_strategy):  # noqa: ARG001
+            raise OSError("transient I/O error")
+
+        monkeypatch.setattr(index_module, "parse_note", failing_parse)
+        first = mgr.reindex()
+        assert first.added == 0
+        assert first.skipped == 0  # not recorded — must retry
+
+        monkeypatch.setattr(index_module, "parse_note", original_parse)
+        second = mgr.reindex()
+        assert second.added == 1
+        paths = {n["path"] for n in fts.list_notes()}
+        assert "flaky.md" in paths
+
+    def test_parse_error_skip_is_recorded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A deterministic parse error is recorded; no re-parse next scan."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "broken.md").write_text("# Broken\n\nbody\n", encoding="utf-8")
+        mgr, _fts, _ = _make_index_mgr(vault, tmp_path)
+
+        import markdown_vault_mcp.managers.index as index_module
+
+        parse_calls: list[str] = []
+
+        def broken_parse(abs_path, source_dir, chunk_strategy):  # noqa: ARG001
+            parse_calls.append(str(abs_path))
+            raise ValueError("malformed note")
+
+        monkeypatch.setattr(index_module, "parse_note", broken_parse)
+        first = mgr.reindex()
+        assert first.added == 0
+        assert first.skipped == 1
+        assert len(parse_calls) == 1
+
+        second = mgr.reindex()
+        assert second.skipped == 1
+        assert len(parse_calls) == 1, "unchanged broken file must not re-parse"
+
+    def test_undecodable_file_skip_is_recorded(self, tmp_path: Path) -> None:
+        """A UnicodeDecodeError is deterministic: recorded, not re-parsed."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "binary.md").write_bytes(b"\xff\xfe\x00\x00 not utf-8")
+        mgr, fts, _ = _make_index_mgr(vault, tmp_path)
+
+        first = mgr.reindex()
+        assert first.added == 0
+        assert first.skipped == 1
+
+        second = mgr.reindex()
+        assert second.added == 0
+        assert second.skipped == 1
+        assert fts.list_notes() == []
+
+    def test_record_skip_hash_oserror_is_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An OSError while hashing a skip leaves it unrecorded (retry later)."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        drafts = vault / "drafts"
+        drafts.mkdir()
+        (drafts / "wip.md").write_text("# WIP\n", encoding="utf-8")
+        mgr, _fts, _ = _make_index_mgr(vault, tmp_path, exclude_patterns=["drafts/**"])
+
+        import markdown_vault_mcp.managers.index as index_module
+
+        def failing_hash(path):  # noqa: ARG001
+            raise OSError("unreadable")
+
+        monkeypatch.setattr(index_module, "compute_file_hash", failing_hash)
+        first = mgr.reindex()
+        assert first.added == 0
+        assert first.skipped == 0  # hash failed → skip not recorded
+
+        monkeypatch.undo()
+        second = mgr.reindex()
+        assert second.skipped == 1  # retried and recorded this time
+
+    def test_build_index_skip_hash_oserror_is_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """build_index tolerates a hash failure while recording skips."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text(
+            "---\ntitle: Good\n---\n# Good\n\nbody\n", encoding="utf-8"
+        )
+        (vault / "skip.md").write_text("# No frontmatter\n", encoding="utf-8")
+        mgr, _fts, _ = _make_index_mgr(vault, tmp_path, required_frontmatter=["title"])
+
+        import markdown_vault_mcp.managers.index as index_module
+
+        def failing_hash(path):  # noqa: ARG001
+            raise OSError("unreadable")
+
+        monkeypatch.setattr(index_module, "compute_file_hash", failing_hash)
+        stats = mgr.build_index()
+        assert stats.documents_indexed == 1
+        monkeypatch.undo()
+
+        # The skip was not recorded, so the next scan re-evaluates it.
+        result = mgr.reindex()
+        assert result.added == 0  # still lacks frontmatter → skipped again
+        assert result.skipped == 1
+
+    def test_build_index_ignores_directory_matching_glob(self, tmp_path: Path) -> None:
+        """A directory whose name matches *.md is not recorded as a skip."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text(
+            "---\ntitle: Good\n---\n# Good\n\nbody\n", encoding="utf-8"
+        )
+        (vault / "folder.md").mkdir()
+        mgr, _fts, _ = _make_index_mgr(vault, tmp_path, required_frontmatter=["title"])
+        mgr.build_index()
+
+        result = mgr.reindex()
+        assert result.added == 0
+        assert result.skipped == 0
+
+
+# ---------------------------------------------------------------------------
 # build_embeddings
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -438,6 +438,26 @@ class TestSkippedFiles:
         raw = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
         assert raw["skipped"] == {"skip.md": self._hash_of(md)}
 
+    def test_carry_consumed_by_one_update_state(self, tmp_path: Path) -> None:
+        """A second update_state without a fresh detect_changes (a full
+        build_index) must not merge the previous scan's skipped carry."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+        tracker.detect_changes(vault)  # populates the carry with skip.md
+        tracker.update_state([])  # consumes the carry
+
+        md.unlink()
+        # Full-build-style call: no detect_changes beforehand, and the file
+        # is gone from disk — its stale entry must not reappear.
+        tracker.update_state([])
+
+        raw = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert raw["skipped"] == {}
+
     def test_indexed_path_wins_over_skipped(self, tmp_path: Path) -> None:
         """A path present in notes is dropped from the skipped map."""
         vault = tmp_path / "vault"

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -313,7 +313,7 @@ class TestMalformedStateFile:
             # Restore permissions so pytest can clean up tmp_path.
             state_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
-        assert result == {}
+        assert result == ({}, {})
         assert any("Cannot read state file" in r.message for r in caplog.records)
 
 
@@ -328,7 +328,7 @@ class TestSaveStateFailure:
             patch("json.dump", side_effect=RuntimeError("disk full")),
             pytest.raises(RuntimeError, match="disk full"),
         ):
-            tracker._save_state({"a.md": "abc123"})
+            tracker._save_state({"a.md": "abc123"}, {})
 
         # No leftover .tmp files.
         leftover = list(tmp_path.glob("*.tmp"))
@@ -336,24 +336,226 @@ class TestSaveStateFailure:
 
 
 class TestStateFileFormat:
-    def test_state_file_format_is_path_to_hash(self, tmp_path: Path) -> None:
-        """The JSON state file maps relative path strings to SHA256 hex strings."""
+    def test_state_file_format_is_versioned_maps(self, tmp_path: Path) -> None:
+        """The JSON state file holds versioned indexed/skipped path→hash maps."""
         vault = tmp_path / "vault"
         vault.mkdir()
         md = _write_md(vault, "check.md", "some content\n")
         expected_hash = hashlib.sha256(md.read_bytes()).hexdigest()
+        skipped_hash = hashlib.sha256(b"skipped\n").hexdigest()
 
         state_path = tmp_path / "state.json"
         tracker = ChangeTracker(state_path)
         note = _make_note("check.md", expected_hash)
-        tracker.update_state([note])
+        tracker.update_state([note], skipped={"skip.md": skipped_hash})
 
         raw = json.loads(state_path.read_text(encoding="utf-8"))
         assert isinstance(raw, dict)
-        assert "check.md" in raw
-        assert raw["check.md"] == expected_hash
+        assert raw["version"] == 2
+        assert raw["indexed"] == {"check.md": expected_hash}
+        assert raw["skipped"] == {"skip.md": skipped_hash}
         # All values should look like SHA256 hex digests (64 hex chars).
-        for value in raw.values():
+        for value in {**raw["indexed"], **raw["skipped"]}.values():
             assert isinstance(value, str)
             assert len(value) == 64
             int(value, 16)  # raises ValueError if not hex
+
+
+class TestSkippedFiles:
+    def _hash_of(self, path: Path) -> str:
+        """Return the SHA256 hex digest of a file's raw bytes."""
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def test_unchanged_skipped_file_not_rereported(self, tmp_path: Path) -> None:
+        """A recorded skipped file with unchanged content stays out of added."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+
+        changes = tracker.detect_changes(vault)
+        assert changes.added == []
+        assert changes.modified == []
+        assert changes.deleted == []
+        assert changes.unchanged == 0
+        assert changes.skipped_unchanged == 1
+
+    def test_changed_skipped_file_reported_added(self, tmp_path: Path) -> None:
+        """A skipped file whose content changes is re-reported as added."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+
+        md.write_text("---\nname: now valid\n---\nbody\n", encoding="utf-8")
+
+        changes = tracker.detect_changes(vault)
+        assert changes.added == ["skip.md"]
+        assert changes.modified == []
+        assert changes.skipped_unchanged == 0
+
+    def test_deleted_skipped_file_not_reported_deleted(self, tmp_path: Path) -> None:
+        """A skipped file removed from disk is dropped silently, not deleted."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+
+        md.unlink()
+
+        changes = tracker.detect_changes(vault)
+        assert changes.deleted == []
+        assert changes.skipped_unchanged == 0
+
+        # The dropped entry must not be carried into the next state write.
+        tracker.update_state([])
+        raw = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert raw["skipped"] == {}
+
+    def test_skipped_carry_persists_across_update_state(self, tmp_path: Path) -> None:
+        """Unchanged skipped entries survive update_state without re-passing them."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "skip.md", "no frontmatter\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        tracker.update_state([], skipped={"skip.md": self._hash_of(md)})
+
+        # Subsequent scan + state write without new skips keeps the entry.
+        tracker.detect_changes(vault)
+        tracker.update_state([])
+
+        raw = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert raw["skipped"] == {"skip.md": self._hash_of(md)}
+
+    def test_indexed_path_wins_over_skipped(self, tmp_path: Path) -> None:
+        """A path present in notes is dropped from the skipped map."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "doc.md", "content\n")
+        digest = hashlib.sha256(md.read_bytes()).hexdigest()
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        note = _make_note("doc.md", digest)
+        tracker.update_state([note], skipped={"doc.md": digest})
+
+        raw = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert raw["indexed"] == {"doc.md": digest}
+        assert raw["skipped"] == {}
+
+
+class TestUnreadableFiles:
+    def test_unreadable_file_skipped_with_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A file that raises OSError on read is skipped from the scan."""
+        import logging
+        import os
+        import stat
+
+        if os.getuid() == 0:
+            pytest.skip("chmod-based permission test skipped when running as root")
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "ok.md")
+        locked = _write_md(vault, "locked.md")
+        locked.chmod(0o000)
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        try:
+            with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.tracker"):
+                changes = tracker.detect_changes(vault)
+        finally:
+            locked.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+        assert changes.added == ["ok.md"]
+        assert any("Cannot read" in r.message for r in caplog.records)
+
+    def test_file_outside_source_dir_skipped(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A glob hit resolving outside source_dir is skipped with a warning."""
+        import logging
+        from unittest.mock import patch as mock_patch
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        outside = _write_md(tmp_path, "outside.md")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+
+        def fake_glob(self, pattern, **kwargs):  # noqa: ARG001
+            return iter([outside])
+
+        with (
+            mock_patch.object(type(vault), "glob", fake_glob),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.tracker"),
+        ):
+            changes = tracker.detect_changes(vault)
+
+        assert changes.added == []
+        assert any("File outside source_dir" in r.message for r in caplog.records)
+
+
+class TestLegacyStateFormat:
+    def test_legacy_flat_state_loads_as_indexed(self, tmp_path: Path) -> None:
+        """An old flat path→hash state file loads with all entries indexed."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "old.md", "legacy content\n")
+        digest = hashlib.sha256(md.read_bytes()).hexdigest()
+
+        state_path = tmp_path / "state.json"
+        state_path.write_text(json.dumps({"old.md": digest}), encoding="utf-8")
+
+        tracker = ChangeTracker(state_path)
+        changes = tracker.detect_changes(vault)
+
+        assert changes.added == []
+        assert changes.modified == []
+        assert changes.deleted == []
+        assert changes.unchanged == 1
+        assert changes.skipped_unchanged == 0
+
+    def test_legacy_flat_state_detects_modification(self, tmp_path: Path) -> None:
+        """Legacy state entries still participate in modification detection."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "old.md", "legacy content\n")
+        digest = hashlib.sha256(md.read_bytes()).hexdigest()
+
+        state_path = tmp_path / "state.json"
+        state_path.write_text(json.dumps({"old.md": digest}), encoding="utf-8")
+
+        md.write_text("changed content\n", encoding="utf-8")
+
+        tracker = ChangeTracker(state_path)
+        changes = tracker.detect_changes(vault)
+        assert changes.modified == ["old.md"]
+
+    def test_v2_state_with_non_dict_maps_resets(self, tmp_path: Path) -> None:
+        """A version-2 state file with malformed maps is treated as empty."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "a.md")
+
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            json.dumps({"version": 2, "indexed": [], "skipped": {}}),
+            encoding="utf-8",
+        )
+
+        tracker = ChangeTracker(state_path)
+        changes = tracker.detect_changes(vault)
+        assert "a.md" in changes.added


### PR DESCRIPTION
## Summary

PR2 of the series in #665 — fixes Problems 1 and 2.

**Problem 1 — warm boots never reconcile offline changes.** The #526/#559 warm-restart short-circuit is O(1) and never scans the filesystem; the file watcher only sees future events. Files added/modified/deleted while no server was running stayed invisible indefinitely in a read-mostly session, and the #646 `index_stale` meta signal reported fresh on a drift-stale boot.

Fix: the lifespan enqueues `reindex_async()` immediately behind `build_index_async()`. Writer FIFO ordering guarantees build-before-reindex; on a cold boot the full build has just recorded tracker state, so the follow-up reindex degenerates to a cheap hash scan rather than a second full parse. While the boot reindex job is pending the writer is non-drained, so `index_stale` now honestly reports `true` until reconciliation completes — no changes to #646's design needed.

**Problem 2 — ChangeTracker re-reports skipped files as "added" on every scan.** Frontmatter-skipped files never enter FTS, and tracker state was rebuilt from FTS contents only, so every reindex re-detected them as added, re-parsed each, and re-logged the skip at INFO (161 phantom "added" + 161 log lines per scan on the vault that motivated #665). With Problem 1 fixed this would have run at every boot — which is why both fixes are one PR.

Fix: versioned tracker state (`{"version": 2, "indexed": {...}, "skipped": {...}}`; legacy flat format loads as all-indexed). Deterministic skips (missing required frontmatter, exclude patterns, parse errors) are recorded by content hash; transient OSError skips are deliberately not recorded so they retry. Unchanged skipped files are not re-parsed, not re-logged, and reported in a new `ReindexResult.skipped` count (surfaced in the MCP tool and CLI output) instead of inflating `added`. A skipped file whose content changes is re-evaluated and indexed if it gained valid frontmatter. Full builds record skips too, so the first reindex after a cold build is quiet.

## Measured impact (the production vault from #665, on our 1.20.0 port of these fixes)

- Offline drift (docs written between sessions): reconciled at every boot, 1-2s warm boot on a 181MB / 729-file vault
- Steady-state boot log: `reindex: 0 added, 0 modified, 0 deleted, 567 unchanged, 162 skipped` with zero per-file skip lines

## Tests

`tests/test_boot_reconciliation.py` (lifespan-level: warm boot reconciles offline add/modify/delete; unchanged vault is a no-op; cold boot does not double-scan), plus tracker state-v2 coverage in `tests/test_tracker.py` (legacy migration, skip memory, skipped→valid-frontmatter transition, transient-error retry) and reindex-count/integration coverage in `tests/test_managers_index.py`. Full suite: 2098 passed, 1 skipped; ruff check/format and mypy (src+tests) clean.

Refs #665