### PR TITLE
perf(indexing): run FTS5 optimize after bulk purges (#669)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -408,6 +408,26 @@ Two methods manage the index:
   adds/modifies/deletes since the last scan and applies only the delta.
   Applies `exclude_patterns` filtering and purges stale excluded documents.
 
+**FTS5 segment hygiene after bulk purges**: deleting rows from an FTS5 table
+only marks their tokens as deleted — the dead entries remain in the on-disk
+inverted-index segments until FTS5's lazy merge gets around to them, which it
+may never do. A bulk purge (e.g. newly-configured `exclude_patterns` expelling
+previously indexed documents, issue #255) can therefore leave large dead
+segments that bloat the index file and slow keyword queries. When a single
+purge pass removes ≥ 25 documents or ≥ 10% of the pre-purge corpus
+(`should_optimize()` in `fts_index.py`), the purge call sites in
+`IndexManager.build_index()` and `IndexManager.reindex()` run
+`FTSIndex.optimize()` — `INSERT INTO notes_fts(notes_fts)
+VALUES('optimize')` — which merges all segments and drops the dead entries.
+The merge frees pages inside the file; the file itself only shrinks after a
+`VACUUM`, which is never run automatically because it takes an exclusive lock
+and multiple server processes may share one index file — `optimize()` logs
+the reclaimable size (freelist × page size) at INFO so operators can decide
+whether a manual `VACUUM` is worthwhile. Both call sites run on the
+single-owner IndexWriter thread, like all other index mutations; lock
+contention beyond the retry budget is tolerated (skip with a warning; the
+next bulk purge retries).
+
 **Readiness contract (issue #525)**: `Vault.__init__` does not
 populate the index. Callers must invoke `build_index()` explicitly
 before bucket-3 relational/FTS-backed queries (`get_backlinks`,

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -102,6 +102,40 @@ def _retry_on_locked(method: Callable[..., _T]) -> Callable[..., _T]:
     return wrapper
 
 
+# Thresholds for running FTS5 'optimize' after a bulk purge.  Deleting rows
+# from an FTS5 table only marks their tokens as deleted inside the inverted
+# index — the dead entries stay in the on-disk segment b-trees until segments
+# are merged, which FTS5 does lazily and may never get around to.  A purge
+# pass that removes many documents (e.g. newly-configured exclude patterns
+# expelling previously indexed files at boot, issue #255) can therefore leave
+# hundreds of megabytes of dead segments that bloat the database file and
+# slow keyword queries.  'optimize' merges everything into one clean segment.
+# An optimize pass is cheap relative to the bloat it removes, so the
+# thresholds err toward running it: a purge of at least
+# ``OPTIMIZE_MIN_PURGED_DOCS`` documents, or at least
+# ``OPTIMIZE_MIN_PURGED_FRACTION`` of the pre-purge corpus, qualifies.
+OPTIMIZE_MIN_PURGED_DOCS = 25
+OPTIMIZE_MIN_PURGED_FRACTION = 0.10
+
+
+def should_optimize(purged: int, total_before: int) -> bool:
+    """Decide whether a bulk purge warrants an FTS5 'optimize' pass.
+
+    Args:
+        purged: Number of documents removed in a single purge pass.
+        total_before: Number of indexed documents before the purge.
+
+    Returns:
+        ``True`` when ``purged`` is at least :data:`OPTIMIZE_MIN_PURGED_DOCS`
+        or at least :data:`OPTIMIZE_MIN_PURGED_FRACTION` of ``total_before``.
+    """
+    if purged <= 0 or total_before <= 0:
+        return False
+    if purged >= OPTIMIZE_MIN_PURGED_DOCS:
+        return True
+    return purged / total_before >= OPTIMIZE_MIN_PURGED_FRACTION
+
+
 def _json_default(obj: Any) -> str:
     """Handle non-JSON-native types from YAML frontmatter.
 
@@ -904,6 +938,56 @@ class FTSIndex:
         if deleted:
             logger.debug("delete_by_path: removed %s", path)
         return deleted
+
+    def optimize(self) -> bool:
+        """Merge FTS5 inverted-index segments, dropping deleted-document tokens.
+
+        Runs ``INSERT INTO notes_fts(notes_fts) VALUES('optimize')``, which
+        merges all FTS5 segments into one and discards entries for deleted
+        rows.  Call this after a bulk purge (see :func:`should_optimize`) so
+        dead segments do not accumulate in the database file.
+
+        The merge frees pages *inside* the database file; the file itself
+        only shrinks after a ``VACUUM``.  ``VACUUM`` is never run
+        automatically because it takes an exclusive lock and multiple server
+        processes may share one index file — instead the reclaimable size
+        (freelist pages times page size) is logged at INFO so operators can
+        decide whether a manual vacuum is worthwhile.
+
+        Lock contention beyond the retry budget is tolerated: the optimize
+        is skipped with a warning and the next bulk purge retries.
+
+        Returns:
+            ``True`` when the optimize ran, ``False`` when it was skipped
+            because the database stayed busy or locked.
+        """
+        conn = self._conn()
+
+        def _do() -> None:
+            with conn:
+                conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('optimize')")
+
+        try:
+            _retry_on_sqlite_locked(_do)
+        except sqlite3.OperationalError as exc:
+            msg = str(exc).lower()
+            if "busy" in msg or "locked" in msg:
+                logger.warning(
+                    "optimize: skipped — database contended (%s); "
+                    "next bulk purge will retry",
+                    exc,
+                )
+                return False
+            raise
+        freelist = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+        reclaimable = int(freelist) * int(page_size)
+        logger.info(
+            "optimize: merged FTS5 segments — %d bytes reclaimable "
+            "(run VACUUM on the index file to reclaim disk space)",
+            reclaimable,
+        )
+        return True
 
     # ------------------------------------------------------------------
     # Build completeness sentinel (issue #525)

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from markdown_vault_mcp.fts_index import _derive_folder
+from markdown_vault_mcp.fts_index import _derive_folder, should_optimize
 from markdown_vault_mcp.scanner import parse_note, scan_directory
 from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult
 from markdown_vault_mcp.utils import is_path_excluded
@@ -244,8 +244,9 @@ class IndexManager:
                 self._load_vectors()
                 vectors = self._get_vectors()
 
+            rows = self._fts.list_notes()
             purged = 0
-            for row in self._fts.list_notes():
+            for row in rows:
                 if row["path"] not in indexed_paths and self._is_path_excluded(
                     row["path"]
                 ):
@@ -256,6 +257,12 @@ class IndexManager:
 
             if purged and vectors is not None and self._embeddings_path is not None:
                 vectors.save(self._embeddings_path)
+
+            # A bulk purge (e.g. exclude patterns newly configured on an
+            # existing index, issue #255) leaves dead FTS5 segments behind;
+            # merge them away when the purge crossed the optimize threshold.
+            if should_optimize(purged, len(rows)):
+                self._fts.optimize()
 
         # Count how many files were skipped due to required_frontmatter.
         all_files = list(self._source_dir.glob("**/*.md", **GLOB_SYMLINK_KWARGS))
@@ -369,8 +376,12 @@ class IndexManager:
         # Phase 2: apply mutations (writer is sole mutator; no lock needed).
         vectors = self._get_vectors()
 
+        # Corpus size before this purge pass, for the optimize threshold.
+        docs_before_purge = len(self._fts.list_notes())
+
+        deleted_purged = 0
         for path in changes.deleted:
-            self._fts.delete_by_path(path)
+            deleted_purged += self._fts.delete_by_path(path)
             if vectors is not None:
                 vectors.delete_by_path(path)
 
@@ -396,6 +407,13 @@ class IndexManager:
                     "reindex: purged %d stale excluded document(s)",
                     stale_excluded,
                 )
+
+        # A bulk purge leaves dead FTS5 segments behind; merge them away
+        # when this pass crossed the optimize threshold (issue #255
+        # follow-up: the exclusion upgrade path can purge most of the
+        # corpus at boot and bloat the index file with dead segments).
+        if should_optimize(deleted_purged + stale_excluded, docs_before_purge):
+            self._fts.optimize()
 
         indexed_added = 0
         indexed_modified = 0

--- a/tests/test_fts_optimize.py
+++ b/tests/test_fts_optimize.py
@@ -1,0 +1,389 @@
+"""Tests for FTS5 optimize after bulk purges (dead-segment hygiene).
+
+Deleting rows from an FTS5 table only marks their tokens as deleted; the
+dead entries stay in the on-disk segment b-trees until a merge. These tests
+cover ``should_optimize`` thresholding, ``FTSIndex.optimize()`` behaviour,
+and the bulk-purge call sites in ``IndexManager`` (including the issue #255
+exclusion upgrade path).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from markdown_vault_mcp.fts_index import (
+    FTSIndex,
+    should_optimize,
+)
+from markdown_vault_mcp.managers.index import IndexManager
+from markdown_vault_mcp.scanner import HeadingChunker
+from markdown_vault_mcp.tracker import ChangeTracker
+from markdown_vault_mcp.types import Chunk, ParsedNote
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_note(
+    path: str = "test.md",
+    title: str = "Test",
+    chunks: list[Chunk] | None = None,
+    content_hash: str = "abc123",
+) -> ParsedNote:
+    """Create a ParsedNote for testing.
+
+    Args:
+        path: Relative document path including ``.md`` extension.
+        title: Document title.
+        chunks: List of chunks. Defaults to a single generic chunk.
+        content_hash: Hash string stored in the note.
+
+    Returns:
+        A fully-populated :class:`ParsedNote` suitable for indexing.
+    """
+    if chunks is None:
+        chunks = [
+            Chunk(heading="Test", heading_level=1, content="Test content", start_line=0)
+        ]
+    return ParsedNote(
+        path=path,
+        frontmatter={},
+        title=title,
+        chunks=chunks,
+        content_hash=content_hash,
+        modified_at=1000.0,
+    )
+
+
+class _FailingConnection:
+    """Stand-in connection whose every execute raises OperationalError.
+
+    ``sqlite3.Connection.execute`` cannot be patched on an instance (the
+    attribute is read-only), so contention tests swap the whole connection
+    for this stub instead.
+    """
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def __enter__(self) -> _FailingConnection:
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+    def execute(self, *_args: object, **_kwargs: object) -> None:
+        raise sqlite3.OperationalError(self._message)
+
+
+def _make_index_mgr(
+    vault: Path,
+    state_dir: Path,
+    **overrides: object,
+) -> tuple[IndexManager, FTSIndex]:
+    """Build an IndexManager with default wiring.
+
+    Args:
+        vault: Source directory containing markdown files.
+        state_dir: Directory for the change-tracker state file.
+        **overrides: Keyword overrides for the IndexManager constructor;
+            ``fts`` may be passed to share an index between managers.
+
+    Returns:
+        Tuple of (manager, fts index).
+    """
+    fts = overrides.pop("fts", None) or FTSIndex(db_path=":memory:")
+    vectors_holder: dict = {"vectors": None}
+    defaults: dict = {
+        "fts": fts,
+        "tracker": ChangeTracker(state_dir / ".state" / "state.json"),
+        "source_dir": vault,
+        "chunk_strategy": HeadingChunker(),
+        "get_vectors": lambda: vectors_holder["vectors"],
+        "set_vectors": lambda v: vectors_holder.__setitem__("vectors", v),
+    }
+    defaults.update(overrides)
+    return IndexManager(**defaults), fts
+
+
+def _write_docs(directory: Path, count: int, prefix: str = "doc") -> list[Path]:
+    """Write *count* small markdown files into *directory*.
+
+    Args:
+        directory: Target directory (created if missing).
+        count: Number of files to create.
+        prefix: Filename prefix.
+
+    Returns:
+        List of created file paths.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    files = []
+    for i in range(count):
+        f = directory / f"{prefix}{i}.md"
+        f.write_text(
+            f"# {prefix} {i}\n\nUnique content {prefix}{i} body text.\n",
+            encoding="utf-8",
+        )
+        files.append(f)
+    return files
+
+
+def _dbstat_fts_data_size(db_path: Path) -> int | None:
+    """Return SUM(pgsize) of the notes_fts_data shadow table via dbstat.
+
+    Returns ``None`` when this SQLite build lacks the dbstat virtual table,
+    so callers can skip size assertions in environments without it.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT SUM(pgsize) FROM dbstat WHERE name = 'notes_fts_data'"
+        ).fetchone()
+        return int(row[0] or 0)
+    except sqlite3.OperationalError:
+        return None
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# should_optimize thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestShouldOptimize:
+    """Unit tests for the bulk-purge optimize threshold."""
+
+    def test_purge_at_absolute_threshold_triggers(self) -> None:
+        """Purging OPTIMIZE_MIN_PURGED_DOCS documents qualifies."""
+        assert should_optimize(25, 1000) is True
+
+    def test_purge_below_both_thresholds_does_not_trigger(self) -> None:
+        """A small purge of a large corpus does not qualify."""
+        assert should_optimize(24, 1000) is False
+
+    def test_purge_at_fractional_threshold_triggers(self) -> None:
+        """Purging >= 10% of a small corpus qualifies."""
+        assert should_optimize(3, 20) is True  # 15% of corpus.
+
+    def test_purge_below_fractional_threshold_does_not_trigger(self) -> None:
+        """Purging < 10% of a small corpus does not qualify."""
+        assert should_optimize(1, 20) is False  # 5% of corpus.
+
+    def test_zero_purged_never_triggers(self) -> None:
+        """No purge, no optimize."""
+        assert should_optimize(0, 100) is False
+
+    def test_empty_corpus_never_triggers(self) -> None:
+        """Guard against division by zero on an empty corpus."""
+        assert should_optimize(5, 0) is False
+
+
+# ---------------------------------------------------------------------------
+# FTSIndex.optimize()
+# ---------------------------------------------------------------------------
+
+
+class TestOptimize:
+    """Unit tests for FTSIndex.optimize()."""
+
+    def test_optimize_runs_and_returns_true(self) -> None:
+        """optimize() executes the FTS5 optimize command and reports success."""
+        idx = FTSIndex(":memory:")
+        idx.build_from_notes([make_note("a.md"), make_note("b.md")])
+        idx.delete_by_path("a.md")
+
+        assert idx.optimize() is True
+
+    def test_optimize_preserves_search_results(self) -> None:
+        """Surviving documents remain searchable after optimize()."""
+        idx = FTSIndex(":memory:")
+        idx.build_from_notes(
+            [
+                make_note(
+                    "keep.md",
+                    chunks=[
+                        Chunk(
+                            heading="K",
+                            heading_level=1,
+                            content="zanzibar survives",
+                            start_line=0,
+                        )
+                    ],
+                ),
+                make_note("drop.md"),
+            ]
+        )
+        idx.delete_by_path("drop.md")
+        idx.optimize()
+
+        results = idx.search("zanzibar")
+        assert [r.path for r in results] == ["keep.md"]
+
+    def test_optimize_shrinks_dead_segments(self, tmp_path: Path) -> None:
+        """After a bulk delete, optimize() shrinks the FTS5 segment b-trees.
+
+        Measured via the dbstat virtual table; the size assertion is skipped
+        when this SQLite build does not provide dbstat.
+        """
+        db_path = tmp_path / "index.db"
+        idx = FTSIndex(db_path)
+        # Index enough distinct-token content for measurable segments.
+        notes = [
+            make_note(
+                f"doc{i}.md",
+                chunks=[
+                    Chunk(
+                        heading=f"Heading {i}",
+                        heading_level=1,
+                        content=" ".join(f"token{i}word{j}" for j in range(200)),
+                        start_line=0,
+                    )
+                ],
+                content_hash=f"hash{i}",
+            )
+            for i in range(40)
+        ]
+        idx.build_from_notes(notes)
+
+        for i in range(40):
+            idx.delete_by_path(f"doc{i}.md")
+        size_before = _dbstat_fts_data_size(db_path)
+
+        assert idx.optimize() is True
+        size_after = _dbstat_fts_data_size(db_path)
+        idx.close()
+
+        if size_before is None or size_after is None:
+            pytest.skip("dbstat virtual table not available in this SQLite build")
+        assert size_after < size_before
+
+    def test_optimize_tolerates_busy_database(self, monkeypatch) -> None:
+        """A busy database skips the optimize instead of raising."""
+        idx = FTSIndex(":memory:")
+        idx.build_from_notes([make_note("a.md")])
+
+        monkeypatch.setattr(
+            idx, "_conn", lambda: _FailingConnection("database is busy")
+        )
+        assert idx.optimize() is False
+
+    def test_optimize_tolerates_locked_past_retry_budget(self, monkeypatch) -> None:
+        """A lock held past the retry budget skips the optimize."""
+        idx = FTSIndex(":memory:")
+        idx.build_from_notes([make_note("a.md")])
+
+        def _exhausted(_operation, **_kwargs):
+            raise sqlite3.OperationalError("database table is locked: notes_fts")
+
+        monkeypatch.setattr(
+            "markdown_vault_mcp.fts_index._retry_on_sqlite_locked", _exhausted
+        )
+        assert idx.optimize() is False
+
+    def test_optimize_propagates_other_operational_errors(self, monkeypatch) -> None:
+        """Non-lock OperationalErrors are not swallowed."""
+        idx = FTSIndex(":memory:")
+
+        monkeypatch.setattr(idx, "_conn", lambda: _FailingConnection("disk I/O error"))
+        with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+            idx.optimize()
+
+
+# ---------------------------------------------------------------------------
+# IndexManager bulk-purge call sites
+# ---------------------------------------------------------------------------
+
+
+class TestBulkPurgeOptimize:
+    """Integration tests for the optimize trigger in IndexManager."""
+
+    def test_reindex_bulk_delete_triggers_optimize(self, tmp_path: Path) -> None:
+        """Deleting >= threshold docs in one reindex pass runs FTS optimize."""
+        vault = tmp_path / "vault"
+        files = _write_docs(vault, 30)
+        mgr, fts = _make_index_mgr(vault, tmp_path)
+        mgr.build_index()
+
+        # Remove 26 files (>= OPTIMIZE_MIN_PURGED_DOCS) from disk.
+        for f in files[:26]:
+            f.unlink()
+
+        with patch.object(fts, "optimize", wraps=fts.optimize) as spy:
+            result = mgr.reindex()
+
+        assert result.deleted == 26
+        assert spy.call_count == 1
+
+    def test_reindex_small_delete_does_not_optimize(self, tmp_path: Path) -> None:
+        """A purge below both thresholds skips the FTS optimize."""
+        vault = tmp_path / "vault"
+        files = _write_docs(vault, 30)
+        mgr, fts = _make_index_mgr(vault, tmp_path)
+        mgr.build_index()
+
+        # Remove 1 of 30 files: below 25 docs and below 10% of the corpus.
+        files[0].unlink()
+
+        with patch.object(fts, "optimize", wraps=fts.optimize) as spy:
+            result = mgr.reindex()
+
+        assert result.deleted == 1
+        assert spy.call_count == 0
+
+    def test_exclusion_upgrade_purge_triggers_optimize(self, tmp_path: Path) -> None:
+        """Newly-configured exclude patterns purging >= threshold docs
+        (issue #255 upgrade path) trigger an FTS optimize on build_index."""
+        vault = tmp_path / "vault"
+        _write_docs(vault, 5)
+        _write_docs(vault / ".claude", 26, prefix="transcript")
+
+        # Phase 1: index WITHOUT exclude_patterns (old configuration).
+        mgr1, fts = _make_index_mgr(vault, tmp_path / "s1")
+        mgr1.build_index()
+        assert len(fts.list_notes()) == 31
+
+        # Phase 2: rebuild WITH exclude_patterns on the same index.
+        mgr2, _ = _make_index_mgr(
+            vault,
+            tmp_path / "s2",
+            fts=fts,
+            exclude_patterns=[".claude/**"],
+        )
+        with patch.object(fts, "optimize", wraps=fts.optimize) as spy:
+            mgr2.build_index()
+
+        assert len(fts.list_notes()) == 5
+        assert spy.call_count == 1
+
+    def test_exclusion_upgrade_small_purge_does_not_optimize(
+        self, tmp_path: Path
+    ) -> None:
+        """An exclusion purge below both thresholds skips the FTS optimize."""
+        vault = tmp_path / "vault"
+        _write_docs(vault, 30)
+        _write_docs(vault / ".claude", 1, prefix="transcript")
+
+        mgr1, fts = _make_index_mgr(vault, tmp_path / "s1")
+        mgr1.build_index()
+
+        mgr2, _ = _make_index_mgr(
+            vault,
+            tmp_path / "s2",
+            fts=fts,
+            exclude_patterns=[".claude/**"],
+        )
+        with patch.object(fts, "optimize", wraps=fts.optimize) as spy:
+            mgr2.build_index()
+
+        assert len(fts.list_notes()) == 30
+        assert spy.call_count == 0


### PR DESCRIPTION
## Summary

Deleting rows from an FTS5 table only marks their tokens as deleted — the dead entries remain in the on-disk inverted-index segment b-trees until FTS5's lazy merge gets around to them, which it may never do. The bulk-purge paths (notably the #255 exclusion upgrade scenario: previously-indexed docs matching newly-configured `MARKDOWN_VAULT_MCP_EXCLUDE` patterns are deleted at boot) never request a merge, so the index file grows unbounded and keyword queries slow down scanning bloated segment b-trees.

**Production numbers** (found while validating the #665 series, but independent of it): ~180 MB of raw transcripts purged by a new exclusion; `notes_fts_content` clean at 1 MB / 1105 rows, but `notes_fts_data` held 134 MB of dead segments; index file at 561 MB. Manual `INSERT INTO notes_fts(notes_fts) VALUES('optimize'); VACUUM;` → 4.9 MB.

## Changes

- **`FTSIndex.optimize()`** — runs `INSERT INTO notes_fts(notes_fts) VALUES('optimize')` through `_retry_on_sqlite_locked` (same retry discipline as the other write methods). Contention past the retry budget is tolerated: skip with a warning, the next bulk purge retries. After a successful merge it logs the reclaimable size (`freelist_count × page_size`) at INFO with a manual-VACUUM pointer.
- **Threshold-gated trigger at the bulk-purge call sites** — `IndexManager.build_index()` (exclude purge) and `IndexManager.reindex()` (deleted docs + stale-excluded purge) run `optimize()` when a single purge pass removes **≥ 25 documents OR ≥ 10% of the pre-purge corpus** (`should_optimize()`, constants `OPTIMIZE_MIN_PURGED_DOCS` / `OPTIMIZE_MIN_PURGED_FRACTION` in `fts_index.py`). Both call sites run on the single-owner IndexWriter thread, like all other index mutations.
- **No auto-VACUUM** — multiple server processes can share one index file and `VACUUM` takes an exclusive lock; the INFO log lets operators decide when a manual vacuum is worthwhile.
- **Docs** — `docs/design.md` Index Lifecycle: new "FTS5 segment hygiene after bulk purges" paragraph, same commit.

## Tests (`tests/test_fts_optimize.py`)

- `should_optimize()` threshold matrix (absolute, fractional, zero/empty-corpus guards).
- `optimize()` runs and preserves search results; **segment shrink verified via `dbstat`** (`SUM(pgsize)` of `notes_fts_data` before/after a 40-doc bulk delete), feature-detected and skipped when the SQLite build lacks dbstat.
- Busy skip, locked-past-retry-budget skip, and propagation of non-lock `OperationalError`s.
- `IndexManager` level: reindex bulk delete ≥ threshold triggers optimize; small delete does not; exclusion-upgrade purge in `build_index` (#255 path) ≥ threshold triggers; below threshold does not.

## Gates

- `uv run pytest -q` — 2089 passed, 1 skipped
- `ruff check` / `ruff format --check` — clean
- `mypy src/` — clean
- `diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80` — **100% patch coverage** (36/36 lines)

Closes #669