### PR TITLE
test(git): de-flake test_multiple_writes_single_push deterministically (closes #430)

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -406,45 +406,62 @@ class TestGitWriteStrategyClass:
         strategy.close()
 
     def test_multiple_writes_single_push(
-        self, git_repo_with_remote: tuple[Path, Path]
+        self,
+        git_repo_with_remote: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Multiple rapid writes result in a single deferred push."""
+        """Multiple rapid writes coalesce into a single deferred push (#430).
+
+        Verified deterministically rather than by racing the debounce timer: a
+        long ``push_delay_s`` guarantees the timer never fires during the
+        synchronous body, the pending state is asserted directly, and the push
+        is then forced via ``flush()`` while counting the underlying ``_push``
+        calls. (The earlier "assert not-yet-in-the-bare-log right after the
+        writes" approach raced the 0.3 s timer and was flaky on Python 3.14.)
+        """
+        import markdown_vault_mcp.git.strategy as git_strategy
 
         work, bare = git_repo_with_remote
 
-        strategy = GitWriteStrategy(token=None, push_delay_s=0.3)
+        push_calls: list[tuple[object, ...]] = []
+        real_push = git_strategy._push
 
-        for i in range(5):
-            md_file = work / f"note_{i}.md"
-            md_file.write_text(f"# Note {i}\n")
-            strategy(md_file, f"# Note {i}\n", "write")
+        def counting_push(*args: object, **kwargs: object) -> None:
+            push_calls.append(args)
+            real_push(*args, **kwargs)  # type: ignore[arg-type]
 
-        # Not pushed yet.
-        result = subprocess.run(
-            ["git", "-C", str(bare), "log", "--oneline"],
-            capture_output=True,
-            text=True,
-        )
-        assert "note_4.md" not in result.stdout
+        monkeypatch.setattr(git_strategy, "_push", counting_push)
 
-        # Poll until push lands (max 3s).
-        for _ in range(30):
-            time.sleep(0.1)
+        # 30 s delay: the idle timer cannot fire during the writes below, so
+        # there is no timer race to lose.
+        strategy = GitWriteStrategy(token=None, push_delay_s=30.0)
+        try:
+            for i in range(5):
+                md_file = work / f"note_{i}.md"
+                md_file.write_text(f"# Note {i}\n")
+                strategy(md_file, f"# Note {i}\n", "write")
+
+            # The 5 rapid writes coalesced into exactly one pending push (each
+            # write cancelled + rescheduled the single idle timer), and nothing
+            # has been pushed yet — deterministic, not timer-dependent.
+            assert strategy._push_pending is True
+            assert strategy._timer is not None
+            assert push_calls == []
+
+            # Force the single deferred push.
+            strategy.flush()
+
+            # One push call delivered all 5 commits — coalesced, not 5 pushes.
+            assert len(push_calls) == 1
             result = subprocess.run(
                 ["git", "-C", str(bare), "log", "--oneline"],
                 capture_output=True,
                 text=True,
             )
-            if "note_4.md" in result.stdout:
-                break
-        else:
-            pytest.fail("Deferred push did not fire within 3 seconds")
-
-        # All 5 commits pushed in a single push.
-        for i in range(5):
-            assert f"write: note_{i}.md" in result.stdout
-
-        strategy.close()
+            for i in range(5):
+                assert f"write: note_{i}.md" in result.stdout
+        finally:
+            strategy.close()
 
     def test_push_with_token_to_bare_remote(
         self, git_repo_with_remote: tuple[Path, Path]


### PR DESCRIPTION
M2 (git-robustness) of the #577 epic. De-flakes `test_multiple_writes_single_push`, which raced the push-debounce timer.

## The flake
The test asserted "`note_4.md` not yet in the bare-repo log" immediately after 5 rapid writes — relying on the 0.3 s debounce timer NOT firing in the microseconds before the assertion. On Python 3.14 the process slips past 0.3 s first, the deferred push has already fired, and the assertion fails. It was `xfail`'d on 3.14 in #428; that marker was dropped during the git decomposition, leaving it unguarded and latently flaky.

## The fix — remove the timer race entirely
- `push_delay_s=30.0` so the idle timer **cannot** fire during the synchronous body.
- Assert the coalesced pending state directly: `_push_pending is True`, a single `_timer`, and zero pushes so far (`push_calls == []`).
- Force the single deferred push via `flush()`, then assert `len(push_calls) == 1` (coalesced — one push, not five) and all 5 commits in the bare repo (a counting `_push` wrapper calls through to the real push, so delivery is genuinely exercised).

The contract — *5 rapid writes coalesce into one push delivering all 5 commits* — is now verified by direct state + a push-call count, with no wall-clock dependence. (The issue's literal "check `_timer` right after the writes" suggestion is itself still racy with a short delay; long-delay + `flush()` + push-count is the deterministic realization.) The 3 s poll loop is gone too, so the test is faster, and `strategy.close()` moved into a `finally` so the timer can't leak on assertion failure.

## Verification
- New test runs **10/10 deterministically** (~0.2 s each); full suite **2076 passed**; mypy + ruff clean.
- Local preflight-circus (7 lenses incl. pr-test-analyzer) clean at ≥80 — determinism, preserved/strengthened coverage, and coalescing soundness independently confirmed.

Closes #430. Refs #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)