### PR TITLE
fix(git): write_conflict_files reads original once + guards read failures (closes #662)

### DIFF
--- a/src/markdown_vault_mcp/git/conflict.py
+++ b/src/markdown_vault_mcp/git/conflict.py
@@ -336,7 +336,10 @@ def write_conflict_files(
     1. Write the MCP version as ``<stem>.conflict-mcp-<timestamp><ext>``
        with ``conflict_with`` and ``conflict_date`` frontmatter.
     2. Merge ``conflict_with`` and ``conflict_date`` into the original
-       file's existing frontmatter.
+       file's existing frontmatter.  If the original cannot be read or
+       rewritten (removed/inaccessible after the existence check, or not
+       valid UTF-8), its update is skipped with a logged warning — the
+       conflict sibling is still written and counted.
 
     Returns:
         List of conflict file relative paths that were written and
@@ -380,17 +383,39 @@ def write_conflict_files(
         original_abs = git_root / rel_path
         if original_abs.exists():
             try:
-                orig_post = frontmatter.loads(original_abs.read_text(encoding="utf-8"))
-            except Exception:
+                # Read once and reuse this content for the parse-failure
+                # fallback below (the prior version re-read the file there). The
+                # read_text and write_text both sit inside this try, so if the
+                # original was removed/became inaccessible after the exists()
+                # check (TOCTOU) or is not valid UTF-8, the error is caught below
+                # and skips just this original's update instead of crashing the
+                # whole pull.
+                content = original_abs.read_text(encoding="utf-8")
+                try:
+                    orig_post = frontmatter.loads(content)
+                except Exception:
+                    logger.warning(
+                        "Git pull: failed to parse frontmatter for original file %s; treating as plain content",
+                        rel_path,
+                        exc_info=True,
+                    )
+                    orig_post = frontmatter.Post(content)
+                orig_post.metadata["conflict_with"] = conflict_rel
+                orig_post.metadata["conflict_date"] = conflict_date
+                original_abs.write_text(frontmatter.dumps(orig_post), encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                # OSError: removed/inaccessible after exists() (TOCTOU), permission,
+                # or a write-back failure. UnicodeDecodeError (a ValueError, not an
+                # OSError): the original is not valid UTF-8, so we cannot read it as
+                # text to merge frontmatter. Either way, skip just this original's
+                # update; the conflict sibling is already written.
                 logger.warning(
-                    "Git pull: failed to parse frontmatter for original file %s; treating as plain content",
+                    "Git pull: could not read or update original file %s with "
+                    "conflict frontmatter (inaccessible, removed, or not UTF-8); "
+                    "skipping its update",
                     rel_path,
                     exc_info=True,
                 )
-                orig_post = frontmatter.Post(original_abs.read_text(encoding="utf-8"))
-            orig_post.metadata["conflict_with"] = conflict_rel
-            orig_post.metadata["conflict_date"] = conflict_date
-            original_abs.write_text(frontmatter.dumps(orig_post), encoding="utf-8")
 
         written.append(conflict_rel)
 

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -767,7 +767,10 @@ class GitWriteStrategy:
         1. Write the MCP version as ``<stem>.conflict-mcp-<timestamp><ext>``
            with ``conflict_with`` and ``conflict_date`` frontmatter.
         2. Merge ``conflict_with`` and ``conflict_date`` into the original
-           file's existing frontmatter.
+           file's existing frontmatter.  If the original cannot be read or
+           rewritten (removed/inaccessible after the existence check, or not
+           valid UTF-8), its update is skipped with a logged warning — the
+           conflict sibling is still written and counted.
 
         Returns:
             List of conflict file relative paths that were written and

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2130,6 +2130,106 @@ class TestGitSyncOnce:
         warnings = [r for r in caplog.records if "frontmatter" in r.message]
         assert len(warnings) >= 1
 
+    def test_write_conflict_files_reads_original_once(
+        self,
+        git_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The original file is read exactly once when updating its frontmatter,
+        even if the parse fails — no double read_text (#662)."""
+        from pathlib import Path
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        (git_repo / "note.md").write_text("# original body\n")
+        saved = [("note.md", "# mcp body\n")]
+
+        reads = {"n": 0}
+        real_read_text = Path.read_text
+
+        def counting_read_text(self_path: Path, *a: object, **k: object) -> str:
+            if self_path.name == "note.md":
+                reads["n"] += 1
+            return real_read_text(self_path, *a, **k)  # type: ignore[arg-type]
+
+        def _raise(*_a: object, **_k: object) -> object:
+            raise ValueError("parse error")
+
+        monkeypatch.setattr(Path, "read_text", counting_read_text)
+        # Force the original-file frontmatter parse to fail so the fallback runs;
+        # the old code re-read the file in that branch.
+        monkeypatch.setattr("markdown_vault_mcp.git.conflict.frontmatter.loads", _raise)
+
+        written = strategy._write_conflict_files(git_repo, saved, env=None)
+
+        assert len(written) == 1
+        assert reads["n"] == 1, f"original file read {reads['n']} times, expected 1"
+
+    def test_write_conflict_files_skips_original_on_read_error(
+        self,
+        git_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """If the original file becomes unreadable (TOCTOU delete / permission)
+        after the exists() check, the update is skipped with a WARNING rather
+        than crashing, and the conflict sibling is still written (#662)."""
+        from pathlib import Path
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        (git_repo / "note.md").write_text("# original body\n")
+        saved = [("note.md", "# mcp body\n")]
+
+        # A narrow read_text substitution (gated on the original's name, falling
+        # through otherwise) to exercise the observable skip-on-read-error
+        # behaviour — not an attempt to reproduce the TOCTOU race itself.
+        real_read_text = Path.read_text
+
+        def failing_read_text(self_path: Path, *a: object, **k: object) -> str:
+            if self_path.name == "note.md":
+                raise OSError("simulated read failure")
+            return real_read_text(self_path, *a, **k)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", failing_read_text)
+
+        with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"):
+            written = strategy._write_conflict_files(git_repo, saved, env=None)
+
+        # No crash; the conflict sibling was still written.
+        assert len(written) == 1
+        assert (git_repo / written[0]).exists()
+        # The original-file update was skipped with a warning naming the file.
+        assert any(
+            "note.md" in r.message and "skip" in r.message.lower()
+            for r in caplog.records
+        ), [r.message for r in caplog.records]
+
+    def test_write_conflict_files_skips_non_utf8_original(
+        self,
+        git_repo: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A non-UTF-8 original is skipped, not crashed on (#662).
+
+        The original is read as UTF-8; non-UTF-8 bytes raise ``UnicodeDecodeError``
+        (a ``ValueError``, NOT an ``OSError``), so the guard must catch it too —
+        otherwise it bypasses the handler and crashes the whole pull. Uses a real
+        non-UTF-8 file (no mocking), exercising the actual decode path.
+        """
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        (git_repo / "note.md").write_bytes(b"\xff\xfe not valid utf-8 \x80\n")
+        saved = [("note.md", "# mcp body\n")]
+
+        with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"):
+            written = strategy._write_conflict_files(git_repo, saved, env=None)
+
+        # No crash; the conflict sibling was still written.
+        assert len(written) == 1
+        assert (git_repo / written[0]).exists()
+        assert any(
+            "note.md" in r.message and "skip" in r.message.lower()
+            for r in caplog.records
+        ), [r.message for r in caplog.records]
+
 
 class TestRebaseInProgress:
     """Tests for the _rebase_in_progress helper (refs #466)."""


### PR DESCRIPTION
M2 (git-robustness) of the #577 epic. Fixes the pre-existing `write_conflict_files` double-read / crash-on-read-failure that Gemini flagged HIGH on PR #661.

## The bug
When stamping `conflict_with` frontmatter onto the **original** file, `write_conflict_files` read it **twice** — once for `frontmatter.loads`, and again in the parse-failure fallback (`frontmatter.Post(read_text())`). If the read raised `OSError` (a TOCTOU delete after the `exists()` check, or a permission error), the `except` re-read the file → re-raised the same `OSError` uncaught → **crashed the whole pull**.

## The fix
- **Read once** into a local; parse it in an inner `try/except` (`Post(content)` on failure — no re-read).
- Wrap the original-file update in **`except (OSError, UnicodeDecodeError)`** → log a WARNING and skip just that update. `OSError` covers TOCTOU/permission/write-back; **`UnicodeDecodeError`** (a `ValueError`, *not* an `OSError`) covers a non-UTF-8 original — without it, that `read_text(encoding="utf-8")` would bypass the guard and still crash.
- The conflict **sibling** is written earlier and is unaffected; the `exists()` fast-path is preserved (a genuinely-absent original is still a silent skip).

## Tests (3 new, failure-mode-driven)
- read-once: force the parse to fail, assert `read_text` is called once;
- OSError-skip: read raises `OSError` → no crash, sibling written, warning;
- non-UTF-8: a **real** non-UTF-8 file → `UnicodeDecodeError` → no crash, sibling written, warning (no mocking — exercises the actual decode path; would crash on an `OSError`-only guard).

## Verification
- 2076 → **2079 passed**, mypy + ruff clean.
- Two-round preflight-circus (8 lenses, incl. silent-failure-hunter twice) clean at ≥80. The first round caught that an `OSError`-only guard still crashed on non-UTF-8 (`UnicodeDecodeError`) — widened the guard and added the real-file test; the re-validation confirmed the guard is correctly narrow (no over-broad swallow) and the gap closed.

Closes #662. Refs #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)