### PR TITLE
feat(write-callback): drain() primitive + fire write callbacks inside the file-write lock (refs #571)

### DIFF
--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -536,8 +536,8 @@ class DocumentManager:
                 self._mark_paths_dirty([path])
 
             result = WriteResult(path=path, created=created)
+            self._on_write_callback(abs_path, file_content, "write")
 
-        self._on_write_callback(abs_path, file_content, "write")
         return result
 
     def write_attachment(
@@ -731,7 +731,8 @@ class DocumentManager:
             if self._mark_paths_dirty is not None:
                 self._mark_paths_dirty([path])
 
-        self._on_write_callback(abs_path, new_content, "edit")
+            self._on_write_callback(abs_path, new_content, "edit")
+
         return EditResult(path=path, replacements=1, match_type=match_type)
 
     def _edit_with_lines(
@@ -895,7 +896,8 @@ class DocumentManager:
                         )
                 abs_path.unlink()
 
-        self._on_write_callback(abs_path, "", "delete")
+            self._on_write_callback(abs_path, "", "delete")
+
         return DeleteResult(path=path)
 
     def rename(
@@ -1004,9 +1006,9 @@ class DocumentManager:
 
                 callback_content = ""
 
-        self._on_write_callback(new_abs, callback_content, "rename")
-        for src_abs, src_content in backlink_callbacks:
-            self._on_write_callback(src_abs, src_content, "edit")
+            self._on_write_callback(new_abs, callback_content, "rename")
+            for src_abs, src_content in backlink_callbacks:
+                self._on_write_callback(src_abs, src_content, "edit")
 
         return RenameResult(
             old_path=old_path,

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -601,8 +601,8 @@ class DocumentManager:
                 Path(tmp_name).unlink(missing_ok=True)
                 raise
             result = WriteResult(path=path, created=created)
+            self._on_write_callback(abs_path, "", "write")
 
-        self._on_write_callback(abs_path, "", "write")
         return result
 
     def edit(

--- a/src/markdown_vault_mcp/write_callback.py
+++ b/src/markdown_vault_mcp/write_callback.py
@@ -159,6 +159,12 @@ class WriteCallbackDispatcher:
             # its sentinel ahead of this marker.
             self._queue.put(marker)
         if not marker.event.wait(timeout):
+            # On timeout the worker is blocked on an in-flight item (else it
+            # would have reached the marker), so qsize() counts the queued real
+            # items plus our still-queued marker but NOT that in-flight commit.
+            # The marker (+1) and the uncounted in-flight commit (-1) cancel, so
+            # qsize() equals the number of commits genuinely at risk — same
+            # accounting as close(). Do NOT "correct" this to qsize()-1.
             logger.warning(
                 "Write-callback drain did not finish within %s s; "
                 "%d pending git commit(s) not yet committed before pull.",

--- a/src/markdown_vault_mcp/write_callback.py
+++ b/src/markdown_vault_mcp/write_callback.py
@@ -24,6 +24,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _DrainMarker:
+    """Queue sentinel meaning 'all items enqueued before me are processed'.
+
+    Unlike the ``None`` close-sentinel, the worker does NOT exit on this: it
+    sets ``event`` and continues. FIFO ordering guarantees every real item
+    enqueued before the marker has been processed when the worker reaches it.
+    """
+
+    __slots__ = ("event",)
+
+    def __init__(self) -> None:
+        self.event = threading.Event()
+
+
 class WriteCallbackDispatcher:
     """Run write callbacks on a single background thread, in FIFO order.
 
@@ -41,9 +55,9 @@ class WriteCallbackDispatcher:
                 each fired write, or ``None`` to disable dispatch entirely.
         """
         self._on_write = on_write
-        self._queue: queue.Queue[tuple[Path, str, WriteOperation] | None] = (
-            queue.Queue()
-        )
+        self._queue: queue.Queue[
+            tuple[Path, str, WriteOperation] | None | _DrainMarker
+        ] = queue.Queue()
         self._worker: threading.Thread | None = None
         # Guards every read/write of ``_worker`` and ``_closed`` AND the
         # ``_queue.put`` of a real item, so ``fire`` is atomic with respect to
@@ -102,6 +116,9 @@ class WriteCallbackDispatcher:
             item = self._queue.get()
             if item is None:
                 break
+            if isinstance(item, _DrainMarker):
+                item.event.set()
+                continue
             abs_path, content, operation = item
             try:
                 on_write(abs_path, content, operation)
@@ -112,6 +129,42 @@ class WriteCallbackDispatcher:
                     operation,
                     exc_info=True,
                 )
+
+    def drain(self, timeout: float = 30.0) -> None:
+        """Block until all currently-queued callbacks have been processed.
+
+        Unlike :meth:`close`, the dispatcher stays open: the worker keeps
+        running and :meth:`fire` continues to work afterward. Used before a git
+        pull so every already-queued commit lands before the merge touches the
+        working tree.
+
+        No-op when no callback is configured, the worker was never started, or
+        the dispatcher is closed. Best-effort: if the queue does not drain
+        within ``timeout`` seconds, logs a WARNING (with the pending count) and
+        returns rather than blocking the caller indefinitely.
+
+        Args:
+            timeout: Seconds to wait for the queued items to drain.
+        """
+        if self._on_write is None:
+            return
+        with self._worker_lock:
+            if self._closed:
+                return
+            worker = self._worker
+            if worker is None or not worker.is_alive():
+                return
+            marker = _DrainMarker()
+            # Enqueue under the lock, mirroring fire(), so close() cannot slip
+            # its sentinel ahead of this marker.
+            self._queue.put(marker)
+        if not marker.event.wait(timeout):
+            logger.warning(
+                "Write-callback drain did not finish within %s s; "
+                "%d pending git commit(s) not yet committed before pull.",
+                timeout,
+                self._queue.qsize(),
+            )
 
     def close(self, timeout: float = 30.0) -> None:
         """Drain pending callbacks and join the worker (bounded by ``timeout``).

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import threading
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.managers.document import DocumentManager
@@ -166,4 +170,39 @@ def test_read_section_duplicate_heading_returns_first_by_start_line(tmp_path):
     nc = mgr.read("a.md", section="Repeat")
     assert nc is not None
     assert "first occurrence body" in nc.content
-    assert "second occurrence body" not in nc.content
+
+
+def test_write_fires_callback_while_holding_file_write_lock(tmp_path: Path) -> None:
+    """The write callback must fire INSIDE _file_write_lock (#571): a concurrent
+    thread must not be able to acquire the lock while the callback runs."""
+    import threading
+
+    write_lock = threading.RLock()
+    lock_free_during_callback = threading.Event()
+
+    def on_write(_abs_path, _content, _operation) -> None:
+        # Probe from another thread: if the lock is held (fix in place), the
+        # probe fails to acquire it; if fire ran outside the lock, it succeeds.
+        def probe() -> None:
+            if write_lock.acquire(blocking=False):
+                lock_free_during_callback.set()
+                write_lock.release()
+
+        t = threading.Thread(target=probe)
+        t.start()
+        t.join()
+
+    fts = FTSIndex(db_path=":memory:")
+    chunker = HeadingChunker()
+    mgr = DocumentManager(
+        fts=fts,
+        source_dir=tmp_path,
+        write_lock=write_lock,
+        chunk_strategy=chunker,
+        read_only=False,
+        on_write_callback=on_write,
+    )
+    mgr.write("note.md", "# hello\n")
+    assert not lock_free_during_callback.is_set(), (
+        "callback fired outside _file_write_lock"
+    )

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -170,6 +170,7 @@ def test_read_section_duplicate_heading_returns_first_by_start_line(tmp_path):
     nc = mgr.read("a.md", section="Repeat")
     assert nc is not None
     assert "first occurrence body" in nc.content
+    assert "second occurrence body" not in nc.content
 
 
 def test_write_fires_callback_while_holding_file_write_lock(tmp_path: Path) -> None:
@@ -240,4 +241,59 @@ def test_write_attachment_fires_callback_while_holding_file_write_lock(
     mgr.write_attachment("assets/pic.png", b"\x89PNG\r\n\x1a\n")
     assert not lock_free_during_callback.is_set(), (
         "write_attachment callback fired outside _file_write_lock"
+    )
+
+
+def test_edit_rename_delete_fire_callbacks_while_holding_file_write_lock(
+    tmp_path: Path,
+) -> None:
+    """edit/rename/delete must also fire their callbacks INSIDE _file_write_lock
+    (#571) — the probe thread must never acquire the lock during the callback."""
+    import threading
+
+    write_lock = threading.RLock()
+    lock_free_during_callback = threading.Event()
+
+    def on_write(_abs_path, _content, _operation) -> None:
+        def probe() -> None:
+            if write_lock.acquire(blocking=False):
+                lock_free_during_callback.set()
+                write_lock.release()
+
+        t = threading.Thread(target=probe)
+        t.start()
+        t.join()
+
+    fts = FTSIndex(db_path=":memory:")
+    chunker = HeadingChunker()
+    mgr = DocumentManager(
+        fts=fts,
+        source_dir=tmp_path,
+        write_lock=write_lock,
+        chunk_strategy=chunker,
+        read_only=False,
+        on_write_callback=on_write,
+    )
+
+    # Seed a file (the write itself fires under the lock); then probe each of
+    # edit/rename/delete in turn, clearing the flag immediately before each so
+    # the assertion isolates that op's callback.
+    mgr.write("note.md", "# hello\nold body\n")
+
+    lock_free_during_callback.clear()
+    mgr.edit("note.md", "old body", "new body")
+    assert not lock_free_during_callback.is_set(), (
+        "edit callback fired outside _file_write_lock"
+    )
+
+    lock_free_during_callback.clear()
+    mgr.rename("note.md", "renamed.md")
+    assert not lock_free_during_callback.is_set(), (
+        "rename callback fired outside _file_write_lock"
+    )
+
+    lock_free_during_callback.clear()
+    mgr.delete("renamed.md")
+    assert not lock_free_during_callback.is_set(), (
+        "delete callback fired outside _file_write_lock"
     )

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -206,3 +206,38 @@ def test_write_fires_callback_while_holding_file_write_lock(tmp_path: Path) -> N
     assert not lock_free_during_callback.is_set(), (
         "callback fired outside _file_write_lock"
     )
+
+
+def test_write_attachment_fires_callback_while_holding_file_write_lock(
+    tmp_path: Path,
+) -> None:
+    """write_attachment must also fire its callback INSIDE _file_write_lock (#571)."""
+    import threading
+
+    write_lock = threading.RLock()
+    lock_free_during_callback = threading.Event()
+
+    def on_write(_abs_path, _content, _operation) -> None:
+        def probe() -> None:
+            if write_lock.acquire(blocking=False):
+                lock_free_during_callback.set()
+                write_lock.release()
+
+        t = threading.Thread(target=probe)
+        t.start()
+        t.join()
+
+    fts = FTSIndex(db_path=":memory:")
+    chunker = HeadingChunker()
+    mgr = DocumentManager(
+        fts=fts,
+        source_dir=tmp_path,
+        write_lock=write_lock,
+        chunk_strategy=chunker,
+        read_only=False,
+        on_write_callback=on_write,
+    )
+    mgr.write_attachment("assets/pic.png", b"\x89PNG\r\n\x1a\n")
+    assert not lock_free_during_callback.is_set(), (
+        "write_attachment callback fired outside _file_write_lock"
+    )

--- a/tests/test_write_callback.py
+++ b/tests/test_write_callback.py
@@ -174,3 +174,64 @@ class TestThreadContract:
         dispatcher.close()  # second close: explicit no-op via the closed flag
         assert dispatcher._worker is worker  # unchanged
         assert calls == [(Path("a.md"), "x", "write")]
+
+
+class TestDrain:
+    def test_drain_waits_for_all_queued_items(self) -> None:
+        calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        for i in range(5):
+            dispatcher.fire(Path(f"{i}.md"), str(i), "write")
+        dispatcher.drain()  # must block until all 5 have run
+        assert [content for _, content, _ in calls] == ["0", "1", "2", "3", "4"]
+        dispatcher.close()
+
+    def test_drain_keeps_worker_alive(self) -> None:
+        calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.fire(Path("a.md"), "a", "write")
+        dispatcher.drain()
+        worker_after_drain = dispatcher._worker
+        dispatcher.fire(Path("b.md"), "b", "write")
+        dispatcher.drain()
+        assert dispatcher._worker is worker_after_drain
+        assert [content for _, content, _ in calls] == ["a", "b"]
+        dispatcher.close()
+
+    def test_drain_noop_when_worker_never_started(self) -> None:
+        _calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.drain()  # no fire -> no worker; must return immediately, not hang
+        assert dispatcher._worker is None
+        dispatcher.close()
+
+    def test_drain_noop_when_closed(self) -> None:
+        calls, cb = _recorder()
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.fire(Path("a.md"), "a", "write")
+        dispatcher.close()
+        dispatcher.drain()  # after close: immediate no-op, no hang
+        assert calls == [(Path("a.md"), "a", "write")]
+
+    def test_drain_noop_when_on_write_none(self) -> None:
+        dispatcher = WriteCallbackDispatcher(None)
+        dispatcher.drain()  # no callback configured -> immediate no-op
+        assert dispatcher._worker is None
+
+    def test_drain_timeout_warns(self, caplog) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def cb(_abs_path: Path, _content: str, _operation: str) -> None:
+            started.set()
+            release.wait(5)  # block the worker
+
+        dispatcher = WriteCallbackDispatcher(cb)
+        dispatcher.fire(Path("a.md"), "first", "write")
+        assert started.wait(2)  # worker blocked on the in-flight item
+        dispatcher.fire(Path("b.md"), "second", "write")  # queued behind the block
+        with caplog.at_level(logging.WARNING):
+            dispatcher.drain(timeout=0.05)  # cannot drain -> warn, return
+        assert any("drain did not finish" in r.getMessage() for r in caplog.records)
+        release.set()
+        dispatcher.close()


### PR DESCRIPTION
**PR1 of #571** (drain-before-pull). Two safe, additive prerequisites for the M2 fix that stops a git pull aborting on a dirty tree when an MCP write lands just before its deferred commit. **This PR does not change pull behavior yet** — PR2 wires the quiescer and closes #571.

## 1. `WriteCallbackDispatcher.drain(timeout=30.0)`
Block until all *currently-queued* write callbacks have been committed, **without closing** the dispatcher (it keeps running afterward). Mechanism: a `_DrainMarker` (a `threading.Event`-carrying sentinel) enqueued under `_worker_lock` exactly like `fire()`; the worker sets the event when it reaches the marker (FIFO ⇒ all prior commits done) and *continues* (doesn't exit). No-op when no callback is configured / closed / worker never started; best-effort with a WARNING (and pending count) on timeout rather than hanging. Faithfully reuses the #601 close/fire lock contract.

## 2. Fire the write callback inside `_file_write_lock`
All five write ops (`write`, `write_attachment`, `edit`, `delete`, `rename`) now fire `_on_write_callback(...)` as the last statement *inside* the `with self._file_write_lock:` block instead of just after it. This makes "file landed on disk" ⟺ "callback queued" **atomic**, so once a puller holds the lock (PR2), no landed write can still be un-queued. `fire()` is a non-blocking enqueue and the dispatcher worker never takes `_file_write_lock`, so it's deadlock-free and behavior-preserving (each op still fires exactly once).

## Tests
- `TestDrain` (6): waits-for-all, keeps-worker-alive, the three no-op guards, timeout-warns (worker blocked via an `Event`, deterministic).
- Fire-under-lock atomicity probes for **all five** ops (a separate probe thread must fail to acquire the `RLock` during the callback — a genuine cross-thread discriminator, not a tautology).
- Restored an assertion (`"second occurrence body" not in nc.content`) accidentally dropped from an unrelated read-section test.

## Verification
2079 → **2087 passed**, mypy + ruff clean. Two-round preflight-circus (9 lenses incl. silent-failure-hunter, concurrency-reviewed) clean at ≥80. Sub-threshold circus carryovers (worker BaseException-death observability, `drain`→`bool` return, a qsize count assertion) are recorded against PR2, where `drain` gains a caller and they become load-bearing.

Refs #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)