### PR TITLE
feat(git): quiesce writes (pause + drain) before a pull so the merge runs on a clean tree (closes #571)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -598,7 +598,11 @@ The contract is:
   `.conflict-mcp-*` sibling on the eventual reconcile). The write callback now
   fires *inside* `_file_write_lock`, so once the puller holds that lock no
   landed write can still be unqueued; `WriteCallbackDispatcher.drain()` then
-  blocks until the queue is empty before the merge takes the git lock.
+  blocks until the queue is empty before the merge takes the git lock. The
+  drain is **best-effort and bounded**: if it does not finish within the
+  timeout (or the dispatcher worker has died), the pull logs a WARNING and
+  proceeds anyway, accepting the pre-fix dirty-tree behavior for the
+  still-pending commit rather than blocking the pull indefinitely.
 - The `on_write` callback fires in a **background thread** — it must not
   itself call write methods on the same Vault instance (deadlock).
 - Callbacks must not raise; exceptions are logged and swallowed.

--- a/docs/design.md
+++ b/docs/design.md
@@ -590,6 +590,15 @@ The contract is:
 - Concurrent file-write tools on the same path are serialised by
   `_file_write_lock`; the IndexWriter's FIFO queue serialises everything
   else.
+- Before a git pull (periodic `sync_once` or interactive `force_pull`), the
+  strategy **pauses new writes and drains the deferred-commit queue** so the
+  merge runs on a clean working tree (#571). A write that landed on disk just
+  before the pull is committed first, rather than aborting the merge on a dirty
+  tree (which previously caused a non-fast-forward push rejection and a spurious
+  `.conflict-mcp-*` sibling on the eventual reconcile). The write callback now
+  fires *inside* `_file_write_lock`, so once the puller holds that lock no
+  landed write can still be unqueued; `WriteCallbackDispatcher.drain()` then
+  blocks until the queue is empty before the merge takes the git lock.
 - The `on_write` callback fires in a **background thread** — it must not
   itself call write methods on the same Vault instance (deadlock).
 - Callbacks must not raise; exceptions are logged and swallowed.

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -80,8 +80,9 @@ dry-run push always returns `applied=false` with
 
 !!! note "Writes landing during a pull"
     A write whose deferred git commit has not yet run when a pull starts is
-    never lost. Before every pull (periodic or `git_sync`), the server pauses
-    new writes and drains the deferred-commit queue, so in the normal case the
+    never lost. Before every real (non-dry-run) pull (periodic or `git_sync`),
+    the server pauses new writes and drains the deferred-commit queue (a
+    `dry_run` preview only fetches and never quiesces), so in the normal case the
     just-written file is committed first and the merge runs on a clean tree
     ([#571](https://github.com/pvliesdonk/markdown-vault-mcp/issues/571)). If
     that write and the remote touched the same file, it flows through the

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -78,6 +78,15 @@ dry-run push always returns `applied=false` with
     sibling(s), reconcile the local content against the remote, and
     `delete` the sibling once merged.
 
+!!! note "Writes landing during a pull"
+    A write whose deferred git commit has not yet run when a pull starts is
+    **not** lost and does not abort the pull. Before every pull (periodic or
+    `git_sync`), the server pauses new writes and drains the deferred-commit
+    queue, so the just-written file is committed first and the merge runs on a
+    clean tree ([#571](https://github.com/pvliesdonk/markdown-vault-mcp/issues/571)).
+    If that write and the remote touched the same file, it flows through the
+    Syncthing-style sibling resolution above rather than failing.
+
 The full enumeration of `pull.reason` and `push.reason` values lives in
 the [`git_sync` tool reference](../tools/index.md#git_sync).
 

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -80,12 +80,16 @@ dry-run push always returns `applied=false` with
 
 !!! note "Writes landing during a pull"
     A write whose deferred git commit has not yet run when a pull starts is
-    **not** lost and does not abort the pull. Before every pull (periodic or
-    `git_sync`), the server pauses new writes and drains the deferred-commit
-    queue, so the just-written file is committed first and the merge runs on a
-    clean tree ([#571](https://github.com/pvliesdonk/markdown-vault-mcp/issues/571)).
-    If that write and the remote touched the same file, it flows through the
-    Syncthing-style sibling resolution above rather than failing.
+    never lost. Before every pull (periodic or `git_sync`), the server pauses
+    new writes and drains the deferred-commit queue, so in the normal case the
+    just-written file is committed first and the merge runs on a clean tree
+    ([#571](https://github.com/pvliesdonk/markdown-vault-mcp/issues/571)). If
+    that write and the remote touched the same file, it flows through the
+    Syncthing-style sibling resolution above rather than failing. The drain is
+    best-effort and time-bounded: if it cannot finish in time, the pull logs a
+    warning and proceeds anyway — the write is still safely on disk and is
+    committed on the next opportunity, at worst reverting to the pre-#571
+    behavior (a non-fast-forward push that the next reconcile resolves).
 
 The full enumeration of `pull.reason` and `push.reason` values lives in
 the [`git_sync` tool reference](../tools/index.md#git_sync).

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1545,8 +1545,11 @@ class GitWriteStrategy:
             if not self._drain_writes():
                 logger.warning(
                     "Git pull: write-callback queue did not fully drain before "
-                    "the merge; proceeding anyway (a still-pending commit may "
-                    "cause the pre-fix dirty-tree churn)."
+                    "the merge; proceeding anyway. A still-pending commit may "
+                    "cause the pre-fix dirty-tree churn for this one merge. If "
+                    "this recurs on every pull, the dispatcher worker may be "
+                    "dead (see the prior 'dead worker' ERROR) and pending "
+                    "commits will never land."
                 )
             yield
 

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1336,7 +1336,10 @@ class GitWriteStrategy:
         Self-quiesces before the merge via :meth:`_quiesce_writes` (pause new
         writes + drain the deferred-commit queue, best-effort/time-bounded) so a
         write racing the periodic pull is committed first and the merge runs on
-        a clean tree (#571).
+        a clean tree (#571). As with :meth:`force_pull`, the pause is held for
+        the whole fetch + merge — including the network round-trip — so MCP
+        writes block for the pull's duration; acceptable for a periodic
+        background pull (default every 600 s) and a fast fetch.
         """
         if self._closed or not self._enable_pull:
             return False

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
     from markdown_vault_mcp.types import CommitDiff, HistoryEntry
 
@@ -175,6 +175,7 @@ class GitWriteStrategy:
         self._pause_writes: (
             Callable[[], contextlib.AbstractContextManager[None]] | None
         ) = None
+        self._drain_writes: Callable[[], bool] | None = None
         self._on_pull: Callable[[], object] | None = None
         if repo_path is not None:
             if self._managed:
@@ -1500,6 +1501,54 @@ class GitWriteStrategy:
             return False
         finally:
             self._cleanup_git_env(env)
+
+    def set_write_quiescer(
+        self,
+        pause_writes: Callable[[], contextlib.AbstractContextManager[None]],
+        drain_writes: Callable[[], bool],
+    ) -> None:
+        """Wire the write-quiescing callables used before a pull (#571).
+
+        Called once by the owner (``Vault``) after the write-callback
+        dispatcher exists, so both the interactive ``force_pull`` and the
+        periodic ``sync_once`` can pause new writes and drain pending commits
+        before the merge — independent of whether the periodic pull loop is
+        started.
+
+        Args:
+            pause_writes: Context manager that blocks new file mutations while
+                held (acquires the shared file-write lock).
+            drain_writes: Blocks until all already-queued write callbacks have
+                been committed; returns ``True`` when the queue drained (or
+                there was nothing to drain), ``False`` if it did not finish or
+                the dispatcher worker has died.
+        """
+        self._pause_writes = pause_writes
+        self._drain_writes = drain_writes
+
+    @contextlib.contextmanager
+    def _quiesce_writes(self, *, skip: bool = False) -> Iterator[None]:
+        """Pause new writes and drain pending commits for the duration.
+
+        Enters ``pause_writes`` (blocking new writes + their callback enqueues),
+        drains the queued commits, then yields so the caller's merge runs on a
+        clean working tree. If the drain does not complete, logs a WARNING and
+        proceeds anyway — a stalled drain must never block the pull; the worst
+        case is the pre-fix dirty-tree churn for the still-pending commit. No-op
+        when ``skip`` is set (e.g. a dry-run pull) or when no quiescer was wired
+        (standalone / tests).
+        """
+        if skip or self._pause_writes is None or self._drain_writes is None:
+            yield
+            return
+        with self._pause_writes():
+            if not self._drain_writes():
+                logger.warning(
+                    "Git pull: write-callback queue did not fully drain before "
+                    "the merge; proceeding anyway (a still-pending commit may "
+                    "cause the pre-fix dirty-tree churn)."
+                )
+            yield
 
     def start(
         self,

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -873,6 +873,12 @@ class GitWriteStrategy:
         round-trip; that is acceptable for the interactive ``git_sync``
         tool and mirrors what :meth:`sync_once` already does.
 
+        Before the merge it self-quiesces via :meth:`_quiesce_writes`: new
+        writes are paused and the deferred-commit queue is drained (best-effort,
+        time-bounded) so a write that landed just before the pull is committed
+        first and the merge runs on a clean tree (#571). Skipped under
+        ``dry_run`` (which only fetches and never touches the working tree).
+
         On ``ff-only`` failure (divergent history) the implementation
         falls through to the same rebase + Syncthing-style sibling write
         path used by :meth:`sync_once` (see :meth:`_resolve_rebase_conflicts`
@@ -1326,6 +1332,11 @@ class GitWriteStrategy:
         Tries fast-forward first; falls back to rebase when the local
         and upstream branches have diverged (e.g. Obsidian and MCP both
         committed on different files).  Aborts on true conflicts.
+
+        Self-quiesces before the merge via :meth:`_quiesce_writes` (pause new
+        writes + drain the deferred-commit queue, best-effort/time-bounded) so a
+        write racing the periodic pull is committed first and the merge runs on
+        a clean tree (#571).
         """
         if self._closed or not self._enable_pull:
             return False
@@ -1537,6 +1548,14 @@ class GitWriteStrategy:
         case is the pre-fix dirty-tree churn for the still-pending commit. No-op
         when ``skip`` is set (e.g. a dry-run pull) or when no quiescer was wired
         (standalone / tests).
+
+        DEADLOCK INVARIANT: the drain runs *before* the caller acquires
+        ``self._lock`` (callers use ``with self._quiesce_writes(...), self._lock:``,
+        which enters this context manager first). The drain blocks on the
+        dispatcher worker, whose commit path acquires ``self._lock`` — so the
+        caller must NOT already hold ``self._lock`` here, and the write callback
+        must NEVER acquire the file-write lock that ``pause_writes`` holds.
+        Reverse either and a pull with a pending commit deadlocks.
         """
         if skip or self._pause_writes is None or self._drain_writes is None:
             yield

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -904,7 +904,7 @@ class GitWriteStrategy:
         git_root = self._resolve_force_repo()
         env = self._git_env()
         try:
-            with self._lock:
+            with self._quiesce_writes(skip=dry_run), self._lock:
                 from_sha = self._head_sha(git_root)
 
                 # Always fetch first — both dry-run and real-pull need the
@@ -1337,7 +1337,7 @@ class GitWriteStrategy:
         env = None
         try:
             env = self._git_env()
-            with self._lock:
+            with self._quiesce_writes(), self._lock:
                 upstream_check = subprocess.run(
                     [
                         "git",
@@ -1555,8 +1555,6 @@ class GitWriteStrategy:
         *,
         repo_path: Path,
         pull_interval_s: int,
-        pause_writes: Callable[[], contextlib.AbstractContextManager[None]]
-        | None = None,
         on_pull: Callable[[], object] | None = None,
     ) -> None:
         """Start a periodic fetch + ff-only update loop in a daemon thread."""
@@ -1597,7 +1595,6 @@ class GitWriteStrategy:
                 return
             self._pull_repo_path = repo_path
             self._pull_interval_s = pull_interval_s
-            self._pause_writes = pause_writes
             self._on_pull = on_pull
             self._pull_stop.clear()
             self._pull_thread = threading.Thread(

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -459,15 +459,12 @@ class Vault:
         Thin public facade over :meth:`GitWriteStrategy.force_pull` used by
         the GitHub webhook handler so the strategy stays an implementation detail.
 
-        Acquires :meth:`pause_writes` for the duration of the pull so that new
-        MCP writes cannot write to disk while git is modifying the working tree
-        (``git merge --ff-only`` or ``git rebase`` overwrites files in-place).
-        This prevents the race where a write hits disk during the merge and
-        the git checkout then silently discards it.
-
-        Note: writes that have *already* completed (file on disk, callback
-        queued but not yet processed by the background worker) are still subject
-        to a narrower race — see issue #571 for the full fix.
+        The strategy self-quiesces around its own merge: it pauses new writes
+        (via the :meth:`pause_writes` callable wired in :meth:`__init__` through
+        ``set_write_quiescer``) and drains the deferred-commit queue before the
+        merge, so a write that landed just before the pull is committed first
+        and the merge runs on a clean tree (#571). This facade therefore no
+        longer wraps ``pause_writes`` itself.
 
         Returns:
             :class:`~markdown_vault_mcp.git.PullResult` from the strategy, or

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -330,6 +330,15 @@ class Vault:
         # the FTS update.  Constructed before DocumentManager, whose
         # ``on_write_callback`` is wired to ``fire`` (#599).
         self._write_callback = WriteCallbackDispatcher(self._on_write)
+        # #571: let the puller pause new writes and drain pending commits
+        # before a merge so it runs on a clean tree. Wired here (not in start())
+        # so the interactive force_pull is covered even when the periodic pull
+        # loop is disabled. drain is late-bound to the dispatcher just built.
+        if self._git_strategy is not None:
+            self._git_strategy.set_write_quiescer(
+                pause_writes=self.pause_writes,
+                drain_writes=self._write_callback.drain,
+            )
 
         # 4. DocumentManager (mark_paths_dirty routes through the writer)
         self._doc_mgr = DocumentManager(
@@ -441,7 +450,6 @@ class Vault:
         self._git_strategy.start(
             repo_path=self._source_dir,
             pull_interval_s=self._git_pull_interval_s,
-            pause_writes=self.pause_writes,
             on_pull=self._index_facet.reindex,
         )
 
@@ -467,8 +475,9 @@ class Vault:
         """
         if self._git_strategy is None:
             return None
-        with self.pause_writes():
-            return self._git_strategy.force_pull()
+        # The strategy now self-quiesces (pause + drain) around the merge (#571),
+        # so the previous outer pause_writes() wrap here is redundant.
+        return self._git_strategy.force_pull()
 
     def stop(self) -> None:
         """Stop background tasks (e.g. git pull loop) without closing the vault.

--- a/src/markdown_vault_mcp/write_callback.py
+++ b/src/markdown_vault_mcp/write_callback.py
@@ -169,9 +169,12 @@ class WriteCallbackDispatcher:
                 # Worker exits only via the None sentinel (close, which sets
                 # _closed -- handled above) or a BaseException death (logged in
                 # _run). Reaching here means it died; do NOT report success.
+                # No item is in-flight (the worker is gone), so qsize() is the
+                # exact stranded-commit backlog.
                 logger.error(
                     "Write-callback drain found a dead worker; "
-                    "pending git commit(s) will not be committed."
+                    "%d pending git commit(s) will never be committed.",
+                    self._queue.qsize(),
                 )
                 return False
             marker = _DrainMarker()

--- a/src/markdown_vault_mcp/write_callback.py
+++ b/src/markdown_vault_mcp/write_callback.py
@@ -169,12 +169,16 @@ class WriteCallbackDispatcher:
                 # Worker exits only via the None sentinel (close, which sets
                 # _closed -- handled above) or a BaseException death (logged in
                 # _run). Reaching here means it died; do NOT report success.
-                # No item is in-flight (the worker is gone), so qsize() is the
-                # exact stranded-commit backlog.
+                # It typically died on an in-flight commit that was already
+                # dequeued (so NOT counted by qsize()), so the stranded backlog
+                # is the queued items plus that one: qsize() + 1. (If it instead
+                # died while idle this over-reports by one -- acceptable for an
+                # alert; do NOT "simplify" it back to qsize(), which undercounts
+                # the common case.)
                 logger.error(
-                    "Write-callback drain found a dead worker; "
-                    "%d pending git commit(s) will never be committed.",
-                    self._queue.qsize(),
+                    "Write-callback drain found a dead worker; ~%d pending git "
+                    "commit(s) will never be committed.",
+                    self._queue.qsize() + 1,
                 )
                 return False
             marker = _DrainMarker()

--- a/src/markdown_vault_mcp/write_callback.py
+++ b/src/markdown_vault_mcp/write_callback.py
@@ -112,25 +112,33 @@ class WriteCallbackDispatcher:
         # set once in ``__init__`` and never reassigned, so it is non-None here.
         on_write = self._on_write
         assert on_write is not None
-        while True:
-            item = self._queue.get()
-            if item is None:
-                break
-            if isinstance(item, _DrainMarker):
-                item.event.set()
-                continue
-            abs_path, content, operation = item
-            try:
-                on_write(abs_path, content, operation)
-            except Exception:
-                logger.error(
-                    "Write callback failed for %s (%s)",
-                    abs_path,
-                    operation,
-                    exc_info=True,
-                )
+        try:
+            while True:
+                item = self._queue.get()
+                if item is None:
+                    break
+                if isinstance(item, _DrainMarker):
+                    item.event.set()
+                    continue
+                abs_path, content, operation = item
+                try:
+                    on_write(abs_path, content, operation)
+                except Exception:
+                    logger.error(
+                        "Write callback failed for %s (%s)",
+                        abs_path,
+                        operation,
+                        exc_info=True,
+                    )
+        except BaseException:
+            # A BaseException (SystemExit/KeyboardInterrupt/MemoryError) kills the
+            # worker thread. Log it so drain()/close() are not the only signal —
+            # otherwise the death is silent and a later drain() can only report a
+            # generic timeout (or, worse, return success against a dead worker).
+            logger.error("write_callback_worker_died", exc_info=True)
+            raise
 
-    def drain(self, timeout: float = 30.0) -> None:
+    def drain(self, timeout: float = 30.0) -> bool:
         """Block until all currently-queued callbacks have been processed.
 
         Unlike :meth:`close`, the dispatcher stays open: the worker keeps
@@ -138,39 +146,53 @@ class WriteCallbackDispatcher:
         pull so every already-queued commit lands before the merge touches the
         working tree.
 
-        No-op when no callback is configured, the worker was never started, or
-        the dispatcher is closed. Best-effort: if the queue does not drain
-        within ``timeout`` seconds, logs a WARNING (with the pending count) and
-        returns rather than blocking the caller indefinitely.
+        Returns:
+            ``True`` when there was nothing to drain (no callback configured,
+            already closed, or the worker was never started) or the queue
+            drained within ``timeout``. ``False`` when the drain did not finish
+            in time, or the worker thread has died — the caller should treat a
+            ``False`` as "pending commits may not have landed" and decide
+            accordingly (e.g. warn and proceed). Never blocks beyond ``timeout``.
 
         Args:
             timeout: Seconds to wait for the queued items to drain.
         """
         if self._on_write is None:
-            return
+            return True
         with self._worker_lock:
             if self._closed:
-                return
+                return True
             worker = self._worker
-            if worker is None or not worker.is_alive():
-                return
+            if worker is None:
+                return True  # never started -> nothing was ever queued
+            if not worker.is_alive():
+                # Worker exits only via the None sentinel (close, which sets
+                # _closed -- handled above) or a BaseException death (logged in
+                # _run). Reaching here means it died; do NOT report success.
+                logger.error(
+                    "Write-callback drain found a dead worker; "
+                    "pending git commit(s) will not be committed."
+                )
+                return False
             marker = _DrainMarker()
             # Enqueue under the lock, mirroring fire(), so close() cannot slip
             # its sentinel ahead of this marker.
             self._queue.put(marker)
-        if not marker.event.wait(timeout):
-            # On timeout the worker is blocked on an in-flight item (else it
-            # would have reached the marker), so qsize() counts the queued real
-            # items plus our still-queued marker but NOT that in-flight commit.
-            # The marker (+1) and the uncounted in-flight commit (-1) cancel, so
-            # qsize() equals the number of commits genuinely at risk — same
-            # accounting as close(). Do NOT "correct" this to qsize()-1.
-            logger.warning(
-                "Write-callback drain did not finish within %s s; "
-                "%d pending git commit(s) not yet committed before pull.",
-                timeout,
-                self._queue.qsize(),
-            )
+        if marker.event.wait(timeout):
+            return True
+        # On timeout the worker is blocked on an in-flight item (else it would
+        # have reached the marker), so qsize() counts the queued real items plus
+        # our still-queued marker but NOT that in-flight commit. The marker (+1)
+        # and the uncounted in-flight commit (-1) cancel, so qsize() equals the
+        # number of commits genuinely at risk -- same accounting as close().
+        # Do NOT "correct" this to qsize()-1.
+        logger.warning(
+            "Write-callback drain did not finish within %s s; "
+            "%d pending git commit(s) not yet committed before pull.",
+            timeout,
+            self._queue.qsize(),
+        )
+        return False
 
     def close(self, timeout: float = 30.0) -> None:
         """Drain pending callbacks and join the worker (bounded by ``timeout``).

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4134,3 +4134,76 @@ class TestOidcClaimAuthorCommitterSplit:
         assert a_email == "bot@srv.com"
         assert c_name == "bot"
         assert c_email == "bot@srv.com"
+
+
+class TestWriteQuiescer:
+    def test_quiesce_writes_pauses_then_drains_then_yields(self) -> None:
+        """_quiesce_writes enters pause_writes, calls drain, then yields — in order (#571)."""
+        import contextlib
+
+        events: list[str] = []
+
+        @contextlib.contextmanager
+        def fake_pause():
+            events.append("pause-enter")
+            try:
+                yield
+            finally:
+                events.append("pause-exit")
+
+        def fake_drain() -> bool:
+            events.append("drain")
+            return True
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy.set_write_quiescer(pause_writes=fake_pause, drain_writes=fake_drain)
+        with strategy._quiesce_writes():
+            events.append("body")
+        assert events == ["pause-enter", "drain", "body", "pause-exit"]
+
+    def test_quiesce_writes_noop_when_unset(self) -> None:
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        ran: list[str] = []
+        with strategy._quiesce_writes():
+            ran.append("body")
+        assert ran == ["body"]  # no pause/drain wired -> just runs
+
+    def test_quiesce_writes_skip_bypasses_pause_and_drain(self) -> None:
+        import contextlib
+
+        events: list[str] = []
+
+        @contextlib.contextmanager
+        def fake_pause():
+            events.append("pause")
+            yield
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy.set_write_quiescer(
+            pause_writes=fake_pause, drain_writes=lambda: events.append("drain") or True
+        )
+        with strategy._quiesce_writes(skip=True):
+            events.append("body")
+        assert events == ["body"]  # skip -> no pause, no drain
+
+    def test_quiesce_writes_warns_and_proceeds_when_drain_incomplete(
+        self, caplog
+    ) -> None:
+        """If drain_writes() returns False (queue didn't fully drain), the merge
+        still proceeds, with a WARNING (#571 — never block the pull)."""
+        import contextlib
+        import logging
+
+        @contextlib.contextmanager
+        def fake_pause():
+            yield
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy.set_write_quiescer(pause_writes=fake_pause, drain_writes=lambda: False)
+        ran: list[str] = []
+        with caplog.at_level(logging.WARNING), strategy._quiesce_writes():
+            ran.append("body")
+        assert ran == ["body"]  # proceeded despite incomplete drain
+        assert any("did not fully drain" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4205,3 +4205,168 @@ class TestWriteQuiescer:
         assert any("did not fully drain" in r.getMessage() for r in caplog.records), [
             r.getMessage() for r in caplog.records
         ]
+
+
+class TestDrainBeforePull:
+    """#571: a write that lands on disk just before a pull is drained (committed)
+    by the quiescer so the merge runs on a clean tree — no dirty-tree abort, no
+    spurious conflict-sibling churn."""
+
+    @staticmethod
+    def _advance_upstream(bare: Path, work: Path, rel: str, content: str) -> None:
+        """Make the bare remote one commit ahead on *rel*, leaving *work* behind."""
+        import subprocess
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            subprocess.run(
+                ["git", "clone", str(bare), tmp], check=True, capture_output=True
+            )
+            (Path(tmp) / rel).write_text(content)
+            subprocess.run(
+                ["git", "-C", tmp, "add", "-A"], check=True, capture_output=True
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    tmp,
+                    "-c",
+                    "user.email=up@e",
+                    "-c",
+                    "user.name=up",
+                    "commit",
+                    "-m",
+                    f"upstream: {rel}",
+                ],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "-C", tmp, "push", "origin", "HEAD"],
+                check=True,
+                capture_output=True,
+            )
+        subprocess.run(
+            ["git", "-C", str(work), "fetch", "origin"], check=True, capture_output=True
+        )
+
+    @staticmethod
+    def _commit_dirty(work: Path) -> bool:
+        """Stand-in for the dispatcher worker: commit whatever is on disk in *work*.
+        Returns True so the quiescer treats the drain as complete."""
+        import subprocess
+
+        subprocess.run(
+            ["git", "-C", str(work), "add", "-A"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(work), "commit", "-m", "write: deferred"],
+            check=True,
+            capture_output=True,
+        )
+        return True
+
+    def test_force_pull_quiesces_dirty_write_upstream_untouched(
+        self, git_repo_with_remote: tuple[Path, Path]
+    ) -> None:
+        """Write lands uncommitted; upstream advanced a DIFFERENT file. The drain
+        commits the local write first, so the pull applies cleanly, the write
+        survives, and no conflict sibling is produced."""
+        import contextlib
+
+        work, bare = git_repo_with_remote
+        self._advance_upstream(bare, work, "upstream.md", "# upstream\n")
+        (work / "local.md").write_text("# local mcp write\n")  # dirty (uncommitted)
+
+        strategy = GitWriteStrategy(
+            token=None, enable_push=False, push_delay_s=0, repo_path=work
+        )
+        strategy.set_write_quiescer(
+            pause_writes=contextlib.nullcontext,
+            drain_writes=lambda: self._commit_dirty(work),
+        )
+        try:
+            result = strategy.force_pull()
+            assert result.applied is True
+            assert result.reason != "conflict_resolution_failed"
+            assert (work / "local.md").read_text() == "# local mcp write\n"
+            assert not list(work.glob("*.conflict-mcp-*.md"))
+        finally:
+            strategy.close()
+
+    def test_force_pull_quiesces_dirty_write_upstream_touched_same_file(
+        self, git_repo_with_remote: tuple[Path, Path]
+    ) -> None:
+        """Same race but upstream touched the SAME file. Pre-fix this aborted the
+        pull on the dirty tree (conflict_resolution_failed). With drain-before-pull
+        the write is committed first, so the divergence is handled by rebase + the
+        Syncthing-style sibling machinery (#232): HEAD advances and the MCP write
+        is preserved as a .conflict-mcp sibling."""
+        import contextlib
+
+        work, bare = git_repo_with_remote
+        self._advance_upstream(bare, work, "local.md", "# upstream version\n")
+        (work / "local.md").write_text("# local mcp write\n")  # dirty (uncommitted)
+
+        strategy = GitWriteStrategy(
+            token=None, enable_push=False, push_delay_s=0, repo_path=work
+        )
+        strategy.set_write_quiescer(
+            pause_writes=contextlib.nullcontext,
+            drain_writes=lambda: self._commit_dirty(work),
+        )
+        try:
+            result = strategy.force_pull()
+            # NOT a dirty-tree abort (the pre-fix failure mode).
+            assert result.reason != "conflict_resolution_failed"
+            assert result.applied is True
+            # The MCP write is preserved as a conflict sibling.
+            siblings = list(work.glob("local.conflict-mcp-*.md"))
+            assert siblings, "MCP write was not preserved as a conflict sibling"
+            assert any("# local mcp write" in s.read_text() for s in siblings)
+        finally:
+            strategy.close()
+
+    def test_force_pull_drains_real_dispatcher_via_strategy_no_deadlock(
+        self, git_repo_with_remote: tuple[Path, Path]
+    ) -> None:
+        """End-to-end lock-order guard: the real WriteCallbackDispatcher worker
+        commits via the strategy (taking _lock) while force_pull drains BEFORE
+        acquiring _lock for the merge — so the worker commits freely during the
+        drain. force_pull completes (no deadlock) and the queued write lands."""
+        import contextlib
+        import subprocess
+
+        from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
+
+        work, bare = git_repo_with_remote
+        self._advance_upstream(bare, work, "upstream.md", "# upstream\n")
+
+        strategy = GitWriteStrategy(
+            token=None, enable_push=False, push_delay_s=0, repo_path=work
+        )
+        # The dispatcher's callback IS the strategy: the worker thread commits via
+        # strategy.__call__ -> _stage_and_commit, which takes strategy._lock.
+        dispatcher = WriteCallbackDispatcher(strategy)
+        (work / "local.md").write_text("# local mcp write\n")
+        dispatcher.fire(work / "local.md", "# local mcp write\n", "write")
+        strategy.set_write_quiescer(
+            pause_writes=contextlib.nullcontext,
+            drain_writes=lambda: dispatcher.drain(timeout=10.0),
+        )
+        try:
+            result = strategy.force_pull()  # drains (worker commits) THEN merges
+            assert result.applied is True
+            assert (work / "local.md").exists()
+            log = subprocess.run(
+                ["git", "-C", str(work), "log", "--oneline"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            assert "write: local.md" in log.stdout
+        finally:
+            dispatcher.close()
+            strategy.close()

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4370,3 +4370,32 @@ class TestDrainBeforePull:
         finally:
             dispatcher.close()
             strategy.close()
+
+    def test_sync_once_quiesces_dirty_write_upstream_touched_same_file(
+        self, git_repo_with_remote: tuple[Path, Path]
+    ) -> None:
+        """The PERIODIC pull path (sync_once) also quiesces (#571): a dirty write
+        racing the periodic sync is committed first, so the same-file divergence
+        rebases with a .conflict-mcp sibling instead of aborting on the dirty tree
+        (pre-fix: sync_once would return False with HEAD unchanged)."""
+        import contextlib
+
+        work, bare = git_repo_with_remote
+        self._advance_upstream(bare, work, "local.md", "# upstream version\n")
+        (work / "local.md").write_text("# local mcp write\n")  # dirty (uncommitted)
+
+        strategy = GitWriteStrategy(
+            token=None, enable_push=False, push_delay_s=0, repo_path=work
+        )
+        strategy.set_write_quiescer(
+            pause_writes=contextlib.nullcontext,
+            drain_writes=lambda: self._commit_dirty(work),
+        )
+        try:
+            advanced = strategy.sync_once(work)
+            assert advanced is True  # HEAD moved (rebased) — not a dirty-tree abort
+            siblings = list(work.glob("local.conflict-mcp-*.md"))
+            assert siblings, "MCP write was not preserved as a conflict sibling"
+            assert any("# local mcp write" in s.read_text() for s in siblings)
+        finally:
+            strategy.close()

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2304,10 +2304,10 @@ class TestGitPullLoop:
         def on_pull() -> None:
             on_pull_calls.append("pull")
 
+        strategy.set_write_quiescer(pause_writes=pause, drain_writes=lambda: True)
         strategy.start(
             repo_path=tmp_path,
             pull_interval_s=3600,
-            pause_writes=pause,  # type: ignore[arg-type]
             on_pull=on_pull,
         )
         time.sleep(0.05)
@@ -2352,7 +2352,6 @@ class TestGitPullLoop:
         strategy.start(
             repo_path=tmp_path,
             pull_interval_s=3600,
-            pause_writes=None,
             on_pull=on_pull,
         )
         time.sleep(0.05)
@@ -2394,7 +2393,6 @@ class TestGitPullLoop:
         strategy.start(
             repo_path=tmp_path,
             pull_interval_s=3600,
-            pause_writes=pause,  # type: ignore[arg-type]
             on_pull=lambda: None,
         )
         time.sleep(0.05)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4399,3 +4399,35 @@ class TestDrainBeforePull:
             assert any("# local mcp write" in s.read_text() for s in siblings)
         finally:
             strategy.close()
+
+    def test_force_pull_dry_run_skips_quiesce(
+        self, git_repo_with_remote: tuple[Path, Path]
+    ) -> None:
+        """A dry-run pull inspects only and must NOT pause writes or drain (#571);
+        otherwise a read-only `is there anything new?` probe would needlessly
+        block writers."""
+        import contextlib
+
+        work, _bare = git_repo_with_remote
+        calls = {"pause": 0, "drain": 0}
+
+        @contextlib.contextmanager
+        def counting_pause():
+            calls["pause"] += 1
+            yield
+
+        def counting_drain() -> bool:
+            calls["drain"] += 1
+            return True
+
+        strategy = GitWriteStrategy(
+            token=None, enable_push=False, push_delay_s=0, repo_path=work
+        )
+        strategy.set_write_quiescer(
+            pause_writes=counting_pause, drain_writes=counting_drain
+        )
+        try:
+            strategy.force_pull(dry_run=True)
+            assert calls == {"pause": 0, "drain": 0}
+        finally:
+            strategy.close()

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -423,7 +423,8 @@ def test_vault_wires_pause_writes_into_git_strategy(tmp_path: Path) -> None:
     mock_strategy.set_write_quiescer.assert_called_once()
     kwargs = mock_strategy.set_write_quiescer.call_args.kwargs
     assert kwargs["pause_writes"] == col.pause_writes
-    assert callable(kwargs["drain_writes"])
+    # Wired to the dispatcher's drain specifically (not just any callable).
+    assert kwargs["drain_writes"] == col._write_callback.drain
 
     # The facade delegates straight to the strategy (no Vault-level pause wrap).
     pull_result = PullResult(

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -410,35 +410,27 @@ def test_vault_force_pull_delegates_to_strategy(tmp_path: Path) -> None:
     mock_strategy.force_pull.assert_called_once_with()
 
 
-def test_vault_force_pull_acquires_pause_writes(tmp_path: Path) -> None:
-    """force_pull holds pause_writes for the duration of the git strategy call."""
-    from contextlib import contextmanager
-
+def test_vault_wires_pause_writes_into_git_strategy(tmp_path: Path) -> None:
+    """Vault wires its pause_writes (and the dispatcher drain) into the git
+    strategy at construction via set_write_quiescer, so the strategy self-quiesces
+    around its own merge (#571). The pull facade no longer wraps pause_writes."""
     vault = tmp_path / "vault"
     vault.mkdir()
 
-    pull_result = PullResult(
-        applied=True, fast_forward=True, commits_pulled=1, from_sha="aaa", to_sha="bbb"
-    )
     mock_strategy = MagicMock()
     col = Vault(source_dir=vault, git_strategy=mock_strategy)
 
-    call_order: list[str] = []
+    mock_strategy.set_write_quiescer.assert_called_once()
+    kwargs = mock_strategy.set_write_quiescer.call_args.kwargs
+    assert kwargs["pause_writes"] == col.pause_writes
+    assert callable(kwargs["drain_writes"])
 
-    @contextmanager
-    def tracking_pause_writes():
-        call_order.append("pause_enter")
-        yield
-        call_order.append("pause_exit")
+    # The facade delegates straight to the strategy (no Vault-level pause wrap).
+    pull_result = PullResult(
+        applied=True, fast_forward=True, commits_pulled=1, from_sha="aaa", to_sha="bbb"
+    )
+    mock_strategy.force_pull.return_value = pull_result
+    assert col.force_pull() is pull_result
+    mock_strategy.force_pull.assert_called_once_with()
 
-    def tracking_force_pull():
-        call_order.append("force_pull")
-        return pull_result
-
-    mock_strategy.force_pull.side_effect = tracking_force_pull
-
-    with patch.object(col, "pause_writes", tracking_pause_writes):
-        result = col.force_pull()
-
-    assert result is pull_result
-    assert call_order == ["pause_enter", "force_pull", "pause_exit"]
+    col.close()

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1750,18 +1750,25 @@ class TestConcurrentWrites:
                 self.stopped = False
                 self.closed = False
 
+            def set_write_quiescer(
+                self, *, pause_writes: object, drain_writes: object
+            ) -> None:
+                # Vault wires the write-quiescer here at construction (#571).
+                self.quiescer = {
+                    "pause_writes": pause_writes,
+                    "drain_writes": drain_writes,
+                }
+
             def start(
                 self,
                 *,
                 repo_path: Path,
                 pull_interval_s: int,
-                pause_writes: object,
                 on_pull: object,
             ) -> None:
                 self.started = {
                     "repo_path": repo_path,
                     "pull_interval_s": pull_interval_s,
-                    "pause_writes": pause_writes,
                     "on_pull": on_pull,
                 }
 
@@ -1802,6 +1809,12 @@ class TestConcurrentWrites:
         class DummyGitStrategy:
             def __init__(self) -> None:
                 self.calls: list[Path] = []
+
+            def set_write_quiescer(
+                self, *, pause_writes: object, drain_writes: object
+            ) -> None:
+                # Vault wires the write-quiescer here at construction (#571).
+                pass
 
             def sync_once(self, repo_path: Path) -> bool:
                 self.calls.append(repo_path)

--- a/tests/test_write_callback.py
+++ b/tests/test_write_callback.py
@@ -264,9 +264,13 @@ class TestDrain:
             dispatcher.fire(Path("a.md"), "x", "write")
             assert dispatcher._worker is not None
             dispatcher._worker.join(timeout=2)  # wait for the worker to die
-        assert not dispatcher._worker.is_alive()
-        assert dispatcher.drain(timeout=0.5) is False
-        assert any(
-            "write_callback_worker_died" in r.getMessage() for r in caplog.records
-        ), [r.getMessage() for r in caplog.records]
+            assert not dispatcher._worker.is_alive()
+            assert dispatcher.drain(timeout=0.5) is False
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("write_callback_worker_died" in m for m in messages), messages
+        # The dead-worker drain reports the stranded backlog including the
+        # in-flight commit the worker died on (already dequeued, so qsize()+1).
+        assert any("found a dead worker" in m and "1 pending" in m for m in messages), (
+            messages
+        )
         dispatcher.close()

--- a/tests/test_write_callback.py
+++ b/tests/test_write_callback.py
@@ -14,6 +14,8 @@ import logging
 import threading
 from pathlib import Path
 
+import pytest
+
 from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
 
 
@@ -182,7 +184,7 @@ class TestDrain:
         dispatcher = WriteCallbackDispatcher(cb)
         for i in range(5):
             dispatcher.fire(Path(f"{i}.md"), str(i), "write")
-        dispatcher.drain()  # must block until all 5 have run
+        assert dispatcher.drain() is True  # must block until all 5 have run
         assert [content for _, content, _ in calls] == ["0", "1", "2", "3", "4"]
         dispatcher.close()
 
@@ -201,7 +203,9 @@ class TestDrain:
     def test_drain_noop_when_worker_never_started(self) -> None:
         _calls, cb = _recorder()
         dispatcher = WriteCallbackDispatcher(cb)
-        dispatcher.drain()  # no fire -> no worker; must return immediately, not hang
+        assert (
+            dispatcher.drain() is True
+        )  # no fire -> no worker; must return immediately, not hang
         assert dispatcher._worker is None
         dispatcher.close()
 
@@ -210,12 +214,12 @@ class TestDrain:
         dispatcher = WriteCallbackDispatcher(cb)
         dispatcher.fire(Path("a.md"), "a", "write")
         dispatcher.close()
-        dispatcher.drain()  # after close: immediate no-op, no hang
+        assert dispatcher.drain() is True  # after close: immediate no-op, no hang
         assert calls == [(Path("a.md"), "a", "write")]
 
     def test_drain_noop_when_on_write_none(self) -> None:
         dispatcher = WriteCallbackDispatcher(None)
-        dispatcher.drain()  # no callback configured -> immediate no-op
+        assert dispatcher.drain() is True  # no callback configured -> immediate no-op
         assert dispatcher._worker is None
 
     def test_drain_timeout_warns(self, caplog) -> None:
@@ -231,7 +235,38 @@ class TestDrain:
         assert started.wait(2)  # worker blocked on the in-flight item
         dispatcher.fire(Path("b.md"), "second", "write")  # queued behind the block
         with caplog.at_level(logging.WARNING):
-            dispatcher.drain(timeout=0.05)  # cannot drain -> warn, return
-        assert any("drain did not finish" in r.getMessage() for r in caplog.records)
+            drained = dispatcher.drain(
+                timeout=0.05
+            )  # cannot drain -> warn, return False
+        assert drained is False
+        warning = next(
+            r.getMessage()
+            for r in caplog.records
+            if "drain did not finish" in r.getMessage()
+        )
+        assert "2 pending" in warning, warning
         release.set()
+        dispatcher.close()
+
+    @pytest.mark.filterwarnings(
+        # The SystemExit intentionally terminates the write-callback worker.
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    def test_drain_returns_false_when_worker_died(self, caplog) -> None:
+        """If the worker thread dies on a BaseException, drain() must report
+        False (not silently succeed) and the death must have been logged (#571)."""
+
+        def cb(_abs_path: Path, _content: str, _operation: str) -> None:
+            raise SystemExit("worker dies")  # BaseException kills the thread
+
+        dispatcher = WriteCallbackDispatcher(cb)
+        with caplog.at_level(logging.ERROR):
+            dispatcher.fire(Path("a.md"), "x", "write")
+            assert dispatcher._worker is not None
+            dispatcher._worker.join(timeout=2)  # wait for the worker to die
+        assert not dispatcher._worker.is_alive()
+        assert dispatcher.drain(timeout=0.5) is False
+        assert any(
+            "write_callback_worker_died" in r.getMessage() for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
         dispatcher.close()


### PR DESCRIPTION
**PR2 of #571** (drain-before-pull) — the integration that **closes #571**, built on PR1 (#676, merged). Eliminates the churn where an MCP write that lands on disk just before its deferred commit, concurrent with a git pull, aborts the pull on a dirty tree (→ non-fast-forward push rejection → spurious `.conflict-mcp-*` sibling on the reconcile).

## What it does
Before the fetch/merge in **both** pull paths (`force_pull` and the periodic `sync_once`), `GitWriteStrategy` now **pauses new writes and drains the deferred-commit queue** so the merge always runs on a clean tree — "dirty-at-merge" becomes "clean + already-committed-locally," which the existing rebase + #232 sibling machinery handles.

- **`WriteCallbackDispatcher.drain(timeout) → bool`** — block until the queue is empty *without closing*; `True` = drained/nothing-to-drain, `False` = timeout or dead worker. `_run` now logs + re-raises a `BaseException` worker death (previously silent), and the dead-worker drain returns `False` + logs the `~qsize()+1` stranded count.
- **`GitWriteStrategy.set_write_quiescer()` + `_quiesce_writes(skip)`** — `with self._quiesce_writes(skip=dry_run), self._lock:` enters pause → drain *before* `_lock`, so the dispatcher worker (which takes `_lock` to commit) drains freely while the puller holds only the file-write lock. The deadlock invariant is documented at the call site. Best-effort: a stalled/dead drain logs a WARNING and proceeds (never blocks the pull).
- **Wiring:** `Vault.__init__` calls `set_write_quiescer(pause_writes=…, drain_writes=self._write_callback.drain)` (so `force_pull` is covered even when the periodic loop is disabled); `Vault.force_pull`'s now-redundant pause-wrap is removed; `start()` drops its `pause_writes` param.

## Why this is the right prerequisite shape
The atomicity comes from PR1 (fire the write callback *inside* `_file_write_lock`): once the puller holds that lock, no landed write can still be un-queued, so the drain provably commits the whole backlog. (We deliberately did **not** take the issue's "worker holds `_file_write_lock` during commit" route — it would deadlock the drain.)

## Tests
Headline interleaving tests (the issue's TDD mandate): write-lands-uncommitted then a pull where upstream touched a **different** file (clean apply, no sibling) and the **same** file (the pre-fix `conflict_resolution_failed` discriminator → now rebased with the MCP write preserved as a `.conflict-mcp` sibling), for **both** `force_pull` and `sync_once`; a real-dispatcher cross-thread **no-deadlock** test (worker commits via the strategy taking `_lock` while the pull drains before acquiring `_lock`); dry-run-skips-quiesce; `drain` bool/timeout/dead-worker contract.

## Verification
2087 → **2098 passed**, mypy + ruff clean, docs updated (`design.md` + git-integration guide). Executed subagent-driven (implementer → spec-review → quality-review per task); **five full preflight-circus rounds**, final round clean at ≥80 across all lenses (the rounds caught a missed 5th write op, a stale docstring, and a self-introduced dead-worker count off-by-one — all fixed and re-verified).

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)