### PR TITLE
fix(git): stage only updated originals into the conflict commit (closes #675)

### DIFF
--- a/src/markdown_vault_mcp/git/conflict.py
+++ b/src/markdown_vault_mcp/git/conflict.py
@@ -354,6 +354,10 @@ def write_conflict_files(
     timestamp = now.strftime("%Y%m%d-%H%M%S")
     conflict_date = now.isoformat(timespec="seconds")
     written: list[str] = []
+    # Originals we actually rewrote with conflict_with frontmatter. Only these
+    # get staged into the conflict commit — an original whose update was skipped
+    # (#662 OSError/UnicodeDecodeError guard) must NOT be re-staged here (#675).
+    updated_originals: list[str] = []
 
     for rel_path, mcp_content in saved:
         original = Path(rel_path)
@@ -403,6 +407,7 @@ def write_conflict_files(
                 orig_post.metadata["conflict_with"] = conflict_rel
                 orig_post.metadata["conflict_date"] = conflict_date
                 original_abs.write_text(frontmatter.dumps(orig_post), encoding="utf-8")
+                updated_originals.append(rel_path)
             except (OSError, UnicodeDecodeError):
                 # OSError: removed/inaccessible after exists() (TOCTOU), permission,
                 # or a write-back failure. UnicodeDecodeError (a ValueError, not an
@@ -422,9 +427,14 @@ def write_conflict_files(
     if not written:
         return written
 
-    # Stage only the files we touched — the original files (updated with
-    # conflict_with frontmatter) and the new conflict files.
-    paths_to_add = [rel_path for rel_path, _ in saved] + written
+    # Stage only the files we actually touched: originals we rewrote with
+    # conflict_with frontmatter (NOT ones whose update was skipped — #675;
+    # re-staging a skipped original here would needlessly re-add an untouched
+    # file, or stage a *deletion* for a TOCTOU-removed one) plus the new
+    # conflict siblings. A skipped original keeps whatever the rebase already
+    # staged for it (the upstream version), which the pathspec-less commit
+    # below still captures.
+    paths_to_add = updated_originals + written
     subprocess.run(
         ["git", "-C", root, "add", "--", *paths_to_add],
         capture_output=True,
@@ -438,6 +448,11 @@ def write_conflict_files(
     # Conflict resolution runs on the pull background thread, not inside a
     # request context, so _extract_claim would return None.  Use the static
     # server identity directly — per-user attribution does not apply here.
+    # NOTE: this commit is pathspec-less — it commits the whole staged index,
+    # not just ``paths_to_add``. That is intentional: it also captures upstream
+    # content already staged during conflict resolution (by the rebase's merge,
+    # or by the ``checkout @{upstream}`` restore on the rebase-abort path). It
+    # relies on the caller holding ``_lock`` so no unrelated change is staged.
     commit_result = subprocess.run(
         [
             "git",

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2230,6 +2230,101 @@ class TestGitSyncOnce:
             for r in caplog.records
         ), [r.message for r in caplog.records]
 
+    @staticmethod
+    def _head_commit_files(git_repo: Path) -> list[str]:
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "-C", str(git_repo), "show", "--name-only", "--format=", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return [line for line in result.stdout.strip().splitlines() if line]
+
+    def test_write_conflict_files_does_not_stage_skipped_original(
+        self, git_repo: Path
+    ) -> None:
+        """A skipped original (non-UTF-8) must NOT be staged into the conflict
+        commit — only its sibling is (#675). Staging it would commit a spurious
+        change (or a deletion, for a TOCTOU-removed original)."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        (git_repo / "note.md").write_bytes(b"\xff\xfe not valid utf-8 \x80\n")
+        saved = [("note.md", "# mcp body\n")]
+
+        written = strategy._write_conflict_files(git_repo, saved, env=None)
+
+        assert len(written) == 1
+        files = self._head_commit_files(git_repo)
+        assert written[0] in files, files  # sibling committed
+        assert "note.md" not in files, files  # skipped original NOT staged
+
+    def test_write_conflict_files_stages_updated_original(self, git_repo: Path) -> None:
+        """A successfully-updated original (conflict_with frontmatter written) IS
+        staged into the conflict commit alongside its sibling (#675 regression
+        guard — the fix must not stop staging originals it actually rewrote)."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        (git_repo / "note.md").write_text("# original\n", encoding="utf-8")
+        saved = [("note.md", "# mcp body\n")]
+
+        written = strategy._write_conflict_files(git_repo, saved, env=None)
+
+        assert len(written) == 1
+        files = self._head_commit_files(git_repo)
+        assert "note.md" in files, files  # updated original staged
+        assert written[0] in files, files  # sibling staged
+        # The original actually received the conflict_with frontmatter.
+        assert "conflict_with" in (git_repo / "note.md").read_text(encoding="utf-8")
+
+    def test_write_conflict_files_mixed_batch_stages_only_updated(
+        self, git_repo: Path
+    ) -> None:
+        """With a batch of one updatable + one skipped original, only the updated
+        one is staged — the conflict commit must partition per-element, not stage
+        all-or-nothing (#675). This pins the selective-staging contract that the
+        single-original tests cannot (a 'stage every saved original' regression
+        would still pass those)."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        (git_repo / "good.md").write_text("# good original\n", encoding="utf-8")
+        (git_repo / "bad.md").write_bytes(b"\xff\xfe not valid utf-8 \x80\n")
+        saved = [("good.md", "# good mcp\n"), ("bad.md", "# bad mcp\n")]
+
+        written = strategy._write_conflict_files(git_repo, saved, env=None)
+
+        assert len(written) == 2
+        files = self._head_commit_files(git_repo)
+        assert "good.md" in files, files  # updatable original staged
+        assert "bad.md" not in files, files  # skipped (non-UTF-8) original NOT staged
+        for sibling in written:  # both siblings always staged
+            assert sibling in files, files
+
+    def test_write_conflict_files_does_not_stage_removed_original(
+        self, git_repo: Path
+    ) -> None:
+        """A tracked original removed before write_conflict_files reads it (TOCTOU)
+        must NOT be staged — otherwise the conflict commit records a *deletion* of
+        the upstream file (the motivating data-loss shape in #675), distinct from
+        the non-UTF-8 spurious-change case."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        note = git_repo / "note.md"
+        note.write_text("# tracked original\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(git_repo), "add", "note.md"], check=True)
+        subprocess.run(
+            ["git", "-C", str(git_repo), "commit", "-m", "add note"],
+            check=True,
+            capture_output=True,
+        )
+        note.unlink()  # removed after it was committed/tracked
+        saved = [("note.md", "# mcp body\n")]
+
+        written = strategy._write_conflict_files(git_repo, saved, env=None)
+
+        assert len(written) == 1
+        files = self._head_commit_files(git_repo)
+        assert written[0] in files, files  # sibling committed
+        # The removed original is NOT staged — no spurious deletion in the commit.
+        assert "note.md" not in files, files
+
 
 class TestRebaseInProgress:
     """Tests for the _rebase_in_progress helper (refs #466)."""


### PR DESCRIPTION
**M4 (review-surfaced robustness) of the #577 epic.** Fixes the staging edge surfaced by claude-review on #672.

## The bug
`write_conflict_files` staged **every** saved original (`[rel_path for rel_path, _ in saved] + written`) even when an original's `conflict_with` frontmatter update was **skipped** by the #662 `except (OSError, UnicodeDecodeError)` guard (non-UTF-8, or removed/inaccessible after the `exists()` check). For a TOCTOU-removed tracked original this is real data loss: `git add -- <removed>` stages a **deletion**, so the conflict commit *deletes the upstream file from HEAD* (reproduced empirically in review).

## The fix
Track the originals actually rewritten (`updated_originals`, appended only after a successful `write_text`) and stage `updated_originals + written` instead. A skipped original keeps whatever conflict resolution already staged for it (the upstream version), which the pathspec-less commit still captures — so nothing is lost; the MCP version is always preserved in the `.conflict-mcp` sibling (unconditionally staged via `written`).

## Tests (4, behavioral — real git, assert on `git show --name-only HEAD`)
- skipped non-UTF-8 original → NOT in the commit (only the sibling);
- updated original → IS staged + got the frontmatter (regression guard);
- **mixed batch** (one updatable + one skipped) → only the updatable one staged — pins the per-element partitioning a single-element test can't (a "stage all saved" regression fails it);
- **TOCTOU-removed** tracked original → NOT staged as a deletion (the motivating data-loss shape).

## Verification
2162 passed; conflict/rebase suites unchanged; mypy + ruff clean. Preflight-circus (8 lenses incl. silent-failure-hunter — confirmed the fix *removes* a real data-loss path and loses nothing — + pr-test-analyzer, which mutation-verified the new tests catch the regression) clean at ≥80. The circus drove the mixed-batch + TOCTOU tests (the single-element pair couldn't pin the partitioning) and a pathspec-less-commit clarifying note.

Closes #675. Refs #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)