### PR TITLE
fix(io): normalize UTF-8 BOM on all vault-markdown reads (closes #673)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1653,6 +1653,15 @@ matched against relative paths from `source_dir` using `pathlib.Path.match()`.
 a `WARNING` log message. `scan_directory()` is fault-tolerant; a single bad
 file does not abort the scan.
 
+**UTF-8 BOM normalization (#673).** All vault-markdown reads strip a leading
+UTF-8 BOM via `utils.text.read_text_utf8` (path → str) and `decode_utf8`
+(bytes → str), both using the `utf-8-sig` codec. The scanner hashes the raw
+on-disk bytes (BOM included) but decodes the text without the BOM, so a
+BOM-prefixed file's frontmatter parses and is indexed correctly. Writes are
+plain `utf-8` (no BOM), so the vault normalizes to no-BOM: a BOM-prefixed file
+loses its BOM the next time it is rewritten. A genuinely non-UTF-8 file still
+raises `UnicodeDecodeError`.
+
 ### `fts_index.py` -- SQLite FTS5
 
 ```python

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -19,6 +19,7 @@ import frontmatter
 from fastmcp import FastMCP
 
 from ._icons import _TOOL_ICONS
+from .utils.text import read_text_utf8
 
 _BUILTIN_PROMPTS_DIR = importlib.resources.files("markdown_vault_mcp").joinpath(
     "static/prompts"
@@ -64,7 +65,7 @@ def _load_user_prompt_defs(prompts_folder: str | None) -> dict[str, dict[str, An
     for md_file in sorted(folder.glob("*.md")):
         name = md_file.stem
         try:
-            post = frontmatter.loads(md_file.read_text(encoding="utf-8"))
+            post = frontmatter.loads(read_text_utf8(md_file))
         except Exception:
             logger.warning(
                 "Failed to parse user prompt file %r — skipping",
@@ -191,7 +192,12 @@ def _register_one_user_prompt(mcp: FastMCP, name: str, defn: dict[str, Any]) -> 
 def _load_builtin_prompt(name: str) -> dict[str, Any] | None:
     """Load a built-in prompt definition from ``static/prompts/{name}.md``."""
     try:
-        text = _BUILTIN_PROMPTS_DIR.joinpath(f"{name}.md").read_text(encoding="utf-8")
+        # Built-in prompts are importlib.resources Traversables (not Path), so
+        # read directly with the same BOM-stripping codec rather than the
+        # Path-typed read_text_utf8 helper (#673).
+        text = _BUILTIN_PROMPTS_DIR.joinpath(f"{name}.md").read_text(
+            encoding="utf-8-sig"
+        )
     except FileNotFoundError:
         logger.warning("Built-in prompt file %s.md not found — skipping", name)
         return None

--- a/src/markdown_vault_mcp/git/conflict.py
+++ b/src/markdown_vault_mcp/git/conflict.py
@@ -23,6 +23,7 @@ from markdown_vault_mcp.git.types import (
     PULL_REASON_CONFLICT_RESOLUTION_FAILED,
     PullResult,
 )
+from markdown_vault_mcp.utils.text import read_text_utf8
 
 if TYPE_CHECKING:
     import collections.abc
@@ -394,7 +395,7 @@ def write_conflict_files(
                 # check (TOCTOU) or is not valid UTF-8, the error is caught below
                 # and skips just this original's update instead of crashing the
                 # whole pull.
-                content = original_abs.read_text(encoding="utf-8")
+                content = read_text_utf8(original_abs)
                 try:
                     orig_post = frontmatter.loads(content)
                 except Exception:

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -57,6 +57,9 @@ from markdown_vault_mcp.utils.text import (
 from markdown_vault_mcp.utils.text import (
     normalize_text as _normalize_text,
 )
+from markdown_vault_mcp.utils.text import (
+    read_text_utf8 as _read_text_utf8,
+)
 
 if TYPE_CHECKING:
     import threading
@@ -292,7 +295,7 @@ class DocumentManager:
             logger.warning("read(%s): could not parse file — %s", path, exc)
             return None
 
-        raw_content = abs_path.read_text(encoding="utf-8")
+        raw_content = _read_text_utf8(abs_path)
         etag = note.content_hash
         folder = str(Path(path).parent)
         if folder == ".":
@@ -694,7 +697,7 @@ class DocumentManager:
                         path, expected=if_match, actual=current_hash
                     )
 
-            file_content = abs_path.read_text(encoding="utf-8")
+            file_content = _read_text_utf8(abs_path)
 
             if has_lines:
                 assert line_start is not None and line_end is not None
@@ -973,7 +976,7 @@ class DocumentManager:
 
                 note = parse_note(new_abs, self._source_dir, self._chunk_strategy)
 
-                callback_content = new_abs.read_text(encoding="utf-8")
+                callback_content = _read_text_utf8(new_abs)
 
                 backlink_callbacks, backlink_paths = self._update_backlinks(
                     old_path, new_path, backlinks
@@ -1069,7 +1072,7 @@ class DocumentManager:
                         source_path,
                     )
                     continue
-                content = source_abs.read_text(encoding="utf-8")
+                content = _read_text_utf8(source_abs)
                 for row in rows:
                     new_raw = _compute_new_raw_target(
                         row["link_type"],

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -14,6 +14,7 @@ import yaml
 from markdown_vault_mcp.hashing import compute_etag
 from markdown_vault_mcp.types import Chunk, LinkInfo, ParsedNote
 from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS
+from markdown_vault_mcp.utils.text import decode_utf8
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -848,8 +849,10 @@ def parse_note(
     content_hash = compute_etag(raw_bytes)
     modified_at = path.stat().st_mtime
 
-    # May raise UnicodeDecodeError — propagated to caller.
-    text = raw_bytes.decode("utf-8")
+    # Decode for frontmatter parsing, stripping a leading BOM (#673). The hash
+    # above is over the raw on-disk bytes (BOM included). May raise
+    # UnicodeDecodeError — propagated to caller.
+    text = decode_utf8(raw_bytes)
 
     # python-frontmatter strips the YAML block and returns the body separately.
     post = frontmatter.loads(text)

--- a/src/markdown_vault_mcp/utils/text.py
+++ b/src/markdown_vault_mcp/utils/text.py
@@ -9,7 +9,46 @@ from __future__ import annotations
 import re
 import unicodedata
 from difflib import SequenceMatcher
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def read_text_utf8(path: Path) -> str:
+    """Read a text file as UTF-8, stripping a leading BOM if present (#673).
+
+    Uses ``utf-8-sig``: a leading UTF-8 BOM (``\\ufeff``) is stripped, and a
+    file without one decodes identically to plain ``utf-8``. The vault
+    normalizes to no-BOM (writes are plain ``utf-8``), so a BOM-prefixed file
+    read here parses correctly and loses its BOM on the next rewrite. A
+    non-UTF-8 file still raises ``UnicodeDecodeError``, exactly as ``utf-8``
+    would.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The file's text with any leading UTF-8 BOM removed.
+    """
+    return path.read_text(encoding="utf-8-sig")
+
+
+def decode_utf8(data: bytes) -> str:
+    """Decode bytes as UTF-8, stripping a leading BOM if present (#673).
+
+    The bytes form of :func:`read_text_utf8`, for callers that hold the raw
+    bytes separately (e.g. the scanner hashes the on-disk bytes — BOM included
+    — then decodes the text without the BOM for frontmatter parsing).
+
+    Args:
+        data: Raw file bytes.
+
+    Returns:
+        The decoded text with any leading UTF-8 BOM removed.
+    """
+    return data.decode("utf-8-sig")
+
 
 # Direct single-character substitutions applied during normalization.
 # Used by build_position_map to avoid calling normalize_text() per

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -297,3 +297,41 @@ def test_edit_rename_delete_fire_callbacks_while_holding_file_write_lock(
     assert not lock_free_during_callback.is_set(), (
         "delete callback fired outside _file_write_lock"
     )
+
+
+# ---------------------------------------------------------------------------
+# UTF-8 BOM normalization (#673)
+# ---------------------------------------------------------------------------
+
+
+def test_read_and_rewrite_normalizes_bom(tmp_path: Path) -> None:
+    """read() returns BOM-free content; a rewrite drops the BOM on disk (#673)."""
+    src = tmp_path / "vault"
+    src.mkdir()
+    (src / "note.md").write_bytes(b"\xef\xbb\xbf# Title\n\noriginal body\n")
+
+    fts = FTSIndex(db_path=":memory:")
+    chunker = HeadingChunker()
+    mgr = DocumentManager(
+        fts=fts,
+        source_dir=src,
+        write_lock=threading.RLock(),
+        chunk_strategy=chunker,
+        read_only=False,
+    )
+
+    # Seed FTS so read() can locate the document.
+    for note in scan_directory(src, chunk_strategy=chunker):
+        fts.upsert_note(note)
+
+    nc = mgr.read("note.md")
+    assert nc is not None
+    # BOM must be stripped on read — content must not start with the BOM char.
+    assert not nc.content.startswith("﻿"), "read() returned BOM-prefixed content"
+    assert nc.content.startswith("# Title")
+
+    # Rewrite via edit(); the on-disk file must also lose the BOM.
+    mgr.edit("note.md", old_text="original body", new_text="new body")
+    raw = (src / "note.md").read_bytes()
+    assert not raw.startswith(b"\xef\xbb\xbf"), "rewritten file still has BOM"
+    assert b"new body" in raw

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -327,7 +327,7 @@ def test_read_and_rewrite_normalizes_bom(tmp_path: Path) -> None:
     nc = mgr.read("note.md")
     assert nc is not None
     # BOM must be stripped on read — content must not start with the BOM char.
-    assert not nc.content.startswith("﻿"), "read() returned BOM-prefixed content"
+    assert not nc.content.startswith("\ufeff"), "read() returned BOM-prefixed content"
     assert nc.content.startswith("# Title")
 
     # Rewrite via edit(); the on-disk file must also lose the BOM.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -15,7 +15,10 @@ from pathlib import Path  # noqa: TC003
 import pytest
 from fastmcp import Client
 
-from markdown_vault_mcp._server_prompts import _load_user_prompt_defs
+from markdown_vault_mcp._server_prompts import (
+    _load_builtin_prompt,
+    _load_user_prompt_defs,
+)
 from markdown_vault_mcp.server import make_server
 
 # ---------------------------------------------------------------------------
@@ -124,6 +127,36 @@ class TestLoadUserPromptDefs:
             result = _load_user_prompt_defs(str(tmp_path))
         assert "broken" not in result
         assert "Failed to parse" in caplog.text
+
+    def test_strips_bom_from_user_prompt(self, tmp_path: Path) -> None:
+        """A UTF-8 BOM before the frontmatter must not break parsing (#673)."""
+        (tmp_path / "greet.md").write_bytes(
+            b"\xef\xbb\xbf---\ndescription: Greeter\n---\n\nHello\n"
+        )
+        result = _load_user_prompt_defs(str(tmp_path))
+        assert "greet" in result
+        assert (
+            result["greet"]["description"] == "Greeter"
+        )  # frontmatter parsed past the BOM
+
+
+class TestLoadBuiltinPrompt:
+    """Unit tests for _load_builtin_prompt."""
+
+    def test_strips_bom_from_builtin_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The built-in prompt loader's hand-rolled utf-8-sig read strips a BOM (#673)."""
+        from markdown_vault_mcp import _server_prompts
+
+        (tmp_path / "demo.md").write_bytes(
+            b"\xef\xbb\xbf---\ndescription: Demo\n---\n\nbody\n"
+        )
+        monkeypatch.setattr(_server_prompts, "_BUILTIN_PROMPTS_DIR", tmp_path)
+        result = _load_builtin_prompt("demo")
+        assert result is not None
+        assert result["description"] == "Demo"  # frontmatter parsed past the BOM
+        assert result["content"] == "body"
 
 
 class TestRegisterOneUserPromptArgValidation:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -616,3 +616,23 @@ def test_unsplittable_token_emitted_intact_over_budget() -> None:
     # Every other chunk respects the budget; only the giant token may exceed.
     for c in chunks:
         assert c.content == giant or not chunker._over_budget(c.content)
+
+
+# ---------------------------------------------------------------------------
+# UTF-8 BOM normalization (#673)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_note_strips_bom_so_frontmatter_parses(tmp_path: Path) -> None:
+    """A UTF-8 BOM before the frontmatter fence must not prevent parsing (#673)."""
+    p = tmp_path / "bom.md"
+    p.write_bytes(b"\xef\xbb\xbf---\ntitle: BOM Note\ntags: [x]\n---\n\n# Body\n")
+
+    note = parse_note(p, tmp_path)
+
+    # BOM must not swallow the frontmatter — title and tags must be parsed.
+    assert note.frontmatter.get("title") == "BOM Note"
+    assert note.frontmatter.get("tags") == ["x"]
+    # The YAML block must not appear in any body chunk.
+    all_body = "".join(c.content for c in note.chunks)
+    assert "title:" not in all_body

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -190,3 +190,54 @@ class TestFindClosestMatch:
         file_content = "intro\nalpha\nbeta\ngamma\ntail"
         result = find_closest_match(old, file_content)
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# BOM-stripping helpers
+# ---------------------------------------------------------------------------
+
+
+class TestUtf8BomHelpers:
+    def test_read_text_utf8_strips_leading_bom(self, tmp_path) -> None:
+        from markdown_vault_mcp.utils.text import read_text_utf8
+
+        p = tmp_path / "bom.md"
+        p.write_bytes(b"\xef\xbb\xbf# Title\n\nbody\n")  # UTF-8 BOM + content
+        assert read_text_utf8(p) == "# Title\n\nbody\n"
+
+    def test_read_text_utf8_passes_through_without_bom(self, tmp_path) -> None:
+        from markdown_vault_mcp.utils.text import read_text_utf8
+
+        p = tmp_path / "plain.md"
+        p.write_text("# Title\n\nbody\n", encoding="utf-8")
+        assert read_text_utf8(p) == "# Title\n\nbody\n"
+
+    def test_read_text_utf8_raises_on_non_utf8(self, tmp_path) -> None:
+        import pytest
+
+        from markdown_vault_mcp.utils.text import read_text_utf8
+
+        p = tmp_path / "bad.bin"
+        p.write_bytes(b"\xff\xfe not valid utf-8 \x80\n")
+        with pytest.raises(UnicodeDecodeError):
+            read_text_utf8(p)
+
+    def test_decode_utf8_strips_leading_bom(self) -> None:
+        from markdown_vault_mcp.utils.text import decode_utf8
+
+        assert (
+            decode_utf8(b"\xef\xbb\xbf---\ntitle: x\n---\n") == "---\ntitle: x\n---\n"
+        )
+
+    def test_decode_utf8_passes_through_without_bom(self) -> None:
+        from markdown_vault_mcp.utils.text import decode_utf8
+
+        assert decode_utf8(b"plain text\n") == "plain text\n"
+
+    def test_decode_utf8_raises_on_non_utf8(self) -> None:
+        import pytest
+
+        from markdown_vault_mcp.utils.text import decode_utf8
+
+        with pytest.raises(UnicodeDecodeError):
+            decode_utf8(b"\xff\xfe\x80")


### PR DESCRIPTION
**M4 (review-surfaced robustness) of the #577 epic — final M4 item.** Fixes the codebase-wide BOM-on-read flaw surfaced as a Gemini HIGH on #672.

## The bug
`read_text(encoding="utf-8")` / `bytes.decode("utf-8")` keep a leading UTF-8 BOM. When a markdown file carries one (common from Windows editors), the `﻿` sits before the `---` fence, so `frontmatter.loads` doesn't detect the frontmatter and treats the whole file as body. Most damaging in the **scanner**: every BOM-prefixed file was indexed *without* its title/tags.

## The fix
Two helpers in `utils/text.py` — `read_text_utf8(path)` and `decode_utf8(bytes)`, both `utf-8-sig` (strips a leading BOM; identical to `utf-8` otherwise; still raises `UnicodeDecodeError` on non-UTF-8). The **8 vault-markdown read sites** adopt them: scanner (`decode_utf8(raw_bytes)`), `document.py` ×4, `conflict.py`, the user-prompt read; the built-in-prompt read (an `importlib.resources` Traversable, not a `Path`) reads `utf-8-sig` directly. The scanner still hashes the **raw on-disk bytes** (`compute_etag(raw_bytes)`) — only the decoded text drops the BOM. Writes are already plain `utf-8`, so the vault **normalizes to no-BOM**: a BOM-prefixed file parses correctly immediately and loses its BOM on the next rewrite.

## Tests
Helper unit matrix (strip / pass-through / raise-on-non-UTF-8 for both); scanner BOM-frontmatter parses (title present, YAML not in body); document read + round-trip (read is BOM-free, rewrite drops the BOM on disk); user- and built-in-prompt loaders strip the BOM (the built-in via a monkeypatched `_BUILTIN_PROMPTS_DIR`, covering the one hand-rolled codec site). All are verified discriminators (fail on the pre-fix plain-`utf-8` reads).

## Verification
2174 passed, mypy + ruff clean. The #662 conflict.py non-UTF-8 skip guard is preserved (`utf-8-sig` still raises on `\xff\xfe…`). Preflight-circus (5 core + code-reviewer + silent-failure-hunter + comment-analyzer + pr-test-analyzer) clean at ≥80; pr-test-analyzer drove the two prompt BOM tests. `docs/design.md` documents the policy. Designed via brainstorm→spec→plan.

Out of scope (deliberate, will file a follow-up): the `fetch`/transfer **ingress** paths still decode external bodies as plain `utf-8` — #673 is scoped to vault *reads*; an ingested BOM self-heals on next rewrite.

Closes #673. Refs #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)