### PR TITLE
fix(io): normalize UTF-8 BOM on ingress (fetch + transfer-upload) (closes #681)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1660,7 +1660,10 @@ on-disk bytes (BOM included) but decodes the text without the BOM, so a
 BOM-prefixed file's frontmatter parses and is indexed correctly. Writes are
 plain `utf-8` (no BOM), so the vault normalizes to no-BOM: a BOM-prefixed file
 loses its BOM the next time it is rewritten. A genuinely non-UTF-8 file still
-raises `UnicodeDecodeError`.
+raises `UnicodeDecodeError`. The same `decode_utf8` is applied on **ingress**
+(#681) — the `fetch` tool and the transfer-upload route decode externally
+supplied markdown bodies through it, so a fetched/uploaded file is written
+BOM-free rather than carrying its BOM until the next rewrite.
 
 ### `fts_index.py` -- SQLite FTS5
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -23,6 +23,7 @@ from fastmcp.tools import ToolResult
 
 from markdown_vault_mcp.exceptions import EditConflictError
 from markdown_vault_mcp.git import GitWriteStrategy, PullResult, PushResult
+from markdown_vault_mcp.utils.text import decode_utf8
 from markdown_vault_mcp.vault import Vault
 
 if TYPE_CHECKING:
@@ -2333,7 +2334,7 @@ def register_tools(mcp: FastMCP) -> None:
         # Dispatch to the appropriate write method.
         if is_markdown:
             try:
-                text = raw_bytes.decode("utf-8")
+                text = decode_utf8(raw_bytes)  # strips a leading BOM (#681)
             except UnicodeDecodeError as exc:
                 ct = content_type or "unknown"
                 raise ValueError(

--- a/src/markdown_vault_mcp/transfer/routes.py
+++ b/src/markdown_vault_mcp/transfer/routes.py
@@ -14,6 +14,7 @@ from starlette.background import BackgroundTask
 from starlette.responses import JSONResponse, Response
 
 from markdown_vault_mcp._server_deps import get_vault_singleton
+from markdown_vault_mcp.utils.text import decode_utf8
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -152,7 +153,7 @@ async def _handle_upload(
             await asyncio.to_thread(vault.writer.write_attachment, record.path, body)
         else:
             try:
-                text = body.decode("utf-8")
+                text = decode_utf8(body)  # strips a leading BOM (#681)
             except UnicodeDecodeError:
                 store.release(token)
                 return Response(status_code=415)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1022,6 +1022,35 @@ class TestFetchTool:
         )
         assert "# Fetched" in written
 
+    async def test_fetch_markdown_note_strips_bom(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        """A fetched markdown body with a leading UTF-8 BOM is normalized on write (#681).
+
+        Asserts the on-disk bytes: the #673 read path already strips a BOM, so
+        only inspecting disk proves the *ingress* write dropped it.
+        """
+        from unittest.mock import patch
+
+        import httpx
+
+        body = b"\xef\xbb\xbf# Fetched\n\nContent from remote.\n"
+        mock_client = self._mock_httpx_stream(
+            body, {"content-type": "text/markdown; charset=utf-8"}
+        )
+
+        with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            server = make_server()
+            async with Client(server) as client:
+                result = await client.call_tool(
+                    "fetch",
+                    {"url": "https://example.com/bom.md", "path": "fetched-bom.md"},
+                )
+        assert result.data["path"] == "fetched-bom.md"
+        on_disk = (_mcp_env_writable_with_attachments / "fetched-bom.md").read_bytes()
+        assert not on_disk.startswith(b"\xef\xbb\xbf"), "ingested BOM not stripped"
+        assert on_disk.startswith(b"# Fetched")
+
     async def test_fetch_attachment(
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:

--- a/tests/test_transfer_routes.py
+++ b/tests/test_transfer_routes.py
@@ -125,6 +125,24 @@ def test_upload_note_commits_201(vault):
     assert vault.reader.read("out.md") is not None
 
 
+def test_upload_note_strips_bom(vault, tmp_path):
+    """An uploaded note body with a leading UTF-8 BOM is normalized away on write (#681).
+
+    Asserts the on-disk bytes (not the read-back content): the #673 read path
+    already strips a BOM, so only inspecting disk proves the *ingress* write
+    dropped it.
+    """
+    store = TransferStore()
+    rec = store.create("upload", "bom.md", False, 60, max_upload_bytes=1000)
+    resp = _client(store, vault).post(
+        f"/transfer/{rec.token}", content=b"\xef\xbb\xbf# New\n\nx\n"
+    )
+    assert resp.status_code == 201
+    on_disk = (tmp_path / "vault" / "bom.md").read_bytes()
+    assert not on_disk.startswith(b"\xef\xbb\xbf"), "ingested BOM not stripped on write"
+    assert on_disk.startswith(b"# New")
+
+
 def test_upload_attachment_via_put_alias(vault):
     """PUT is accepted as an upload alias and writes an attachment."""
     store = TransferStore()


### PR DESCRIPTION
**M4 (review-surfaced robustness) of the #577 epic — the ingress follow-up the #680 circus surfaced.**

## What
#673 (#680) normalized UTF-8 BOM on all vault-markdown **reads**. The two **ingress** paths still decoded externally-supplied markdown bodies with plain `utf-8`, so a fetched/uploaded file carrying a leading BOM was written to disk **with** its BOM (self-heals only on the next rewrite):
- `_server_tools.py` — the `fetch` tool (markdown branch).
- `transfer/routes.py` — the transfer-upload route (note branch).

Both now decode through the existing `decode_utf8` helper (`utf-8-sig`), so ingress normalizes to no-BOM at write time, uniform with reads. The existing non-UTF-8 error contracts are unchanged — `utf-8-sig` still raises `UnicodeDecodeError`, so the fetch `ValueError` ("Only UTF-8 encoded responses…") and the upload `415` still fire. Binary attachments are untouched (the decode is inside the markdown-only branch — a binary payload that happens to start with `EF BB BF` is preserved byte-for-byte).

## Tests
A test per site asserting the **on-disk bytes** have no BOM after a BOM-prefixed fetch/upload — deliberately *not* the read-back content, since the #673 read path already strips a BOM on read (so a content assertion wouldn't discriminate the ingress fix). Both are verified discriminators (fail on the pre-fix plain-`utf-8` ingress). The pre-existing non-UTF-8 rejection tests (fetch ValueError, upload 415) still pass.

## Verification
2176 passed, mypy + ruff clean. `docs/design.md` BOM section updated to note ingress normalization. Preflight-circus (5 core + code-reviewer + silent-failure-hunter + pr-test-analyzer + comment-analyzer) clean at ≥80.

Closes #681. Refs #577, #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)