### PR TITLE
feat(git-tools): get_diff/get_history on attachments (closes #342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,8 +396,8 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `get_orphan_notes` | Find all notes with no inbound or outbound links |
 | `get_most_linked` | Find the most-linked-to notes ranked by backlink count |
 | `get_connection_path` | Find the shortest path between two notes via BFS on the undirected link graph (max 10 hops) |
-| `get_history` | List commits that touched a note or the whole vault (git-backed vaults only) |
-| `get_diff` | Return a unified diff of a note between a reference commit/timestamp and HEAD (git-backed vaults only) |
+| `get_history` | List commits that touched a note, attachment, or the whole vault (git-backed vaults only) |
+| `get_diff` | Return a diff of a note or attachment between a reference commit/timestamp and HEAD; binary attachments return a `--stat` size summary instead of a unified patch (git-backed vaults only) |
 | `git_sync` | Force an immediate git pull / push / both, bypassing the periodic loops. Returns structured state (SHAs, commit counts, Syncthing-style conflict file paths if any). Hidden when `MARKDOWN_VAULT_MCP_GIT_REPO_URL` isn't set or `READ_ONLY=true`. |
 | `fetch` | Download a file from a URL and save it to the vault as a note or attachment (MCP-to-MCP transfer) |
 | `create_download_link` | Mint a one-time capability URL to download a vault note or attachment (HTTP/SSE only; `BASE_URL` required) |

--- a/docs/design.md
+++ b/docs/design.md
@@ -2237,6 +2237,14 @@ Both methods use the existing `_git_env()` / `_cleanup_git_env()` pattern for cr
 
 **MCP response envelope**: the MCP wrappers for `get_history` and `get_diff(per_commit=True)` return a `{"commits": [...], "total": N}` envelope rather than a bare list, so the structured payload is self-describing on the wire. FastMCP otherwise auto-wraps list-typed tool returns under a synthetic `"result"` key (`x-fastmcp-wrap-result: true` in the output schema), which forces clients re-reading persisted MCP content to know FastMCP's wrapping convention to find the data. The Python facade (`ReaderFacet.get_history`, `ReaderFacet.get_diff`) stays list-returning — only the MCP-tool wrapper transforms to the envelope. `get_diff(per_commit=False)` keeps its existing `{"diff": str}` shape since it is already self-describing.
 
+**Attachment history & diff (#342).** `get_history` and `get_diff` accept a
+`.md` note OR a configured attachment, validated by `validate_history_path`
+(distinct from the strict-`.md` `validate_path` that the write/edit/read paths
+use). `get_diff` lets git classify each attachment: a binary file (git
+`--numstat` reports `-\t-`) returns a `git diff --stat` size/rename summary,
+while a text attachment (`.svg`, `.csv`, …) returns a full unified diff. `.md`
+notes are unchanged.
+
 ### Release channels
 
 The release workflow (`.github/workflows/release.yml`) publishes two

--- a/docs/design.md
+++ b/docs/design.md
@@ -2243,7 +2243,9 @@ Both methods use the existing `_git_env()` / `_cleanup_git_env()` pattern for cr
 use). `get_diff` lets git classify each attachment: a binary file (git
 `--numstat` reports `-\t-`) returns a `git diff --stat` size/rename summary,
 while a text attachment (`.svg`, `.csv`, …) returns a full unified diff. `.md`
-notes are unchanged.
+notes are unchanged. Per-commit diff of a *renamed* binary attachment currently
+renders a text-style stat for the rename commit instead of a `Bin` summary
+(tracked in #683).
 
 ### Release channels
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -28,8 +28,8 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`get_orphan_notes`](#get_orphan_notes) | Read | Find notes with no inbound or outbound links |
 | [`get_most_linked`](#get_most_linked) | Read | Find the most-linked-to notes ranked by backlink count |
 | [`get_connection_path`](#get_connection_path) | Read | Find the shortest path between two notes via link graph |
-| [`get_history`](#get_history) | Read (git) | List commits that touched a note or the whole vault |
-| [`get_diff`](#get_diff) | Read (git) | Return a unified diff of a note between two points in history |
+| [`get_history`](#get_history) | Read (git) | List commits that touched a note, attachment, or the whole vault |
+| [`get_diff`](#get_diff) | Read (git) | Return a diff of a note or attachment between two points in history |
 | [`reindex`](#reindex) | Admin | Force a full reindex of the vault |
 | [`build_embeddings`](#build_embeddings) | Admin | Build or rebuild vector embeddings |
 | [`write`](#write) | Write | Create or overwrite a document or attachment |
@@ -656,13 +656,13 @@ Find the shortest path between two notes via BFS on the undirected link graph (m
 
 ### `get_history`
 
-List commits that touched a note (or the whole vault) within an optional time window, up to a maximum count. Only available for git-backed vaults.
+List commits that touched a note or attachment (or the whole vault) within an optional time window, up to a maximum count. Only available for git-backed vaults.
 
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `path` | string | `null` | Relative vault path (e.g. `"notes/alpha.md"`). Omit for vault-wide history. Must end with `.md`. |
+| `path` | string | `null` | Relative vault path (e.g. `"notes/alpha.md"` or `"assets/diagram.png"`). May be a `.md` note or a configured attachment extension (png, pdf, svg, …). Omit for vault-wide history. An unsupported extension is rejected. |
 | `since` | string | `null` | ISO 8601 datetime string (`"2026-04-01T00:00:00"`) or git date expression (`"1 week ago"`). Passed as `--since` to `git log`. Inclusive at the boundary. |
 | `until` | string | `null` | ISO 8601 datetime string or git date expression, passed as `--until` to `git log`. Combined with `since` to bound a window. Inclusive at the boundary. |
 | `limit` | int | `20` | Maximum number of commits to return. Capped at 100. |
@@ -678,17 +678,17 @@ List commits that touched a note (or the whole vault) within an optional time wi
 | `message` | string | First line of the commit message |
 | `paths_changed` | list[string] | Files touched by the commit. Populated for vault-wide queries (`path=null`); always empty for single-note queries, since the path is already determined by the query arguments — callers know which file the commit touched without needing it echoed back. |
 
-**Raises:** `ToolError` if `path` is invalid.
+**Raises:** `ToolError` if `path` is invalid or uses an unsupported extension.
 
 ### `get_diff`
 
-Return the diff of a specific note between a reference point and `HEAD`. Only available for git-backed vaults.
+Return the diff of a specific note or attachment between a reference point and `HEAD`. Only available for git-backed vaults.
 
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `path` | string | required | Relative vault path. Must end with `.md`. |
+| `path` | string | required | Relative vault path (e.g. `"notes/alpha.md"` or `"assets/diagram.png"`). May be a `.md` note or a configured attachment extension (png, pdf, svg, …). An unsupported extension is rejected. |
 | `since_sha` | string | `null` | A commit SHA (full or abbreviated, at least 4 hex digits) to diff from. Mutually exclusive with `since_timestamp`. |
 | `since_timestamp` | string | `null` | ISO 8601 datetime string, resolved via `git rev-list --before=<ts> -1 HEAD` to the most recent commit at or before that instant. Boundary is **inclusive**: a commit whose committer date equals `since_timestamp` IS the resolved ref. Mutually exclusive with `since_sha`. |
 | `per_commit` | bool | `false` | When `false`, return a single unified diff. When `true`, return one diff per intervening commit, newest-first. |
@@ -698,10 +698,10 @@ Exactly one of `since_sha` / `since_timestamp` must be supplied.
 
 **Returns:**
 
-- `per_commit=false`: object with `diff` (string) — unified diff from reference to HEAD. May include `[diff truncated: N bytes omitted]` if output exceeds 50 KB.
+- `per_commit=false`: object with `diff` (string) — unified diff from reference to HEAD. For a **binary attachment**, this is a `git diff --stat` size/rename summary (e.g. `assets/x.png | Bin 1234 -> 5678 bytes`); for a **text attachment** (`.svg`, `.csv`, …) or `.md` note, it is a full unified patch. May include `[diff truncated: N bytes omitted]` if output exceeds 50 KB.
 - `per_commit=true`: object with `commits` (list of per-commit entries, newest-first — each containing `sha`, `short_sha`, `timestamp`, `message`, and `diff`) and `total` (count — always equals `len(commits)`; does NOT indicate how many commits exist beyond the `limit` cap). The envelope keeps the structured payload self-describing on the wire instead of relying on FastMCP's auto-wrapping `result` key.
 
-**Raises:** `ToolError` if parameters are invalid or the reference commit is not found.
+**Raises:** `ToolError` if parameters are invalid, the reference commit is not found, or the path uses an unsupported extension.
 
 ---
 

--- a/src/markdown_vault_mcp/_server_tools.py
+++ b/src/markdown_vault_mcp/_server_tools.py
@@ -1577,9 +1577,10 @@ def register_tools(mcp: FastMCP) -> None:
         whether git is configured, or call this and handle the error.
 
         Args:
-            path: Vault-relative path of the note to filter on (e.g.
-                "notes/alpha.md"). Must end with ".md". Omit (or pass null)
-                for vault-wide commit history.
+            path: Vault-relative path of the note or attachment to filter on
+                (e.g. "notes/alpha.md" or "assets/diagram.png"). May be a
+                `.md` note or a configured attachment extension (png, pdf,
+                svg, …). Omit (or pass null) for vault-wide commit history.
             since: ISO 8601 datetime string ("2026-04-01T00:00:00") or a git
                 date expression ("1 week ago"). Passed as --since to git log.
                 Omit for full history.
@@ -1610,7 +1611,7 @@ def register_tools(mcp: FastMCP) -> None:
               beyond the `limit` cap).
 
         Raises:
-            ToolError: If the path is invalid.
+            ToolError: If the path is invalid or uses an unsupported extension.
         """
         try:
             results = await asyncio.to_thread(
@@ -1648,8 +1649,13 @@ def register_tools(mcp: FastMCP) -> None:
         commit SHAs.
 
         Args:
-            path: Vault-relative path of the note to diff (e.g. "notes/alpha.md").
-                Must end with ".md".
+            path: Vault-relative path of the note or attachment to diff (e.g.
+                "notes/alpha.md" or "assets/diagram.png"). May be a `.md`
+                note or a configured attachment extension (png, pdf, svg, …).
+                A binary attachment returns a `--stat` size/rename summary
+                instead of a full unified patch; a text attachment (e.g.
+                `.svg`, `.csv`) returns a full unified diff. `.md` notes are
+                unchanged. An unsupported extension is rejected.
             since_sha: A commit SHA (full or abbreviated, at least 4 hex digits)
                 to diff from. Mutually exclusive with since_timestamp.
             since_timestamp: ISO 8601 datetime string, resolved via
@@ -1689,7 +1695,8 @@ def register_tools(mcp: FastMCP) -> None:
 
         Raises:
             ToolError: If neither or both reference parameters are supplied,
-                the SHA is invalid, or the reference commit is not found.
+                the SHA is invalid, the reference commit is not found, or the
+                path uses an unsupported extension.
         """
         try:
             result = await asyncio.to_thread(

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -363,6 +363,10 @@ class ReaderFacet:
             no changes in the given range, or when the vault's source
             directory is not inside a git repository.
 
+            Per-commit (``per_commit=True``) diff of a *renamed* binary
+            attachment currently shows a text-style stat for the rename commit
+            rather than a ``Bin`` summary (#683).
+
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is
                 not supplied, *since_sha* contains invalid characters, the

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -280,16 +280,15 @@ class ReaderFacet:
         until: str | None = None,
         limit: int = 20,
     ) -> list[HistoryEntry]:
-        """Return commits that touched a note or the whole vault.
+        """Return commits that touched a note, attachment, or the whole vault.
 
         When *path* is ``None``, queries the full vault history.  Returns an
         empty list for vaults whose source directory is not inside a git
         repository.
 
         Args:
-            path: Vault-relative path of the note to filter on (e.g.
-                ``"notes/alpha.md"``).  Must end with ``.md``.  ``None``
-                returns vault-wide history.
+            path: A ``.md`` note or a configured attachment (e.g.
+                ``assets/x.png``); ``None`` returns vault-wide history.
             since: ISO 8601 datetime string or git date expression (e.g.
                 ``"1 week ago"``).  Passed as ``--since`` to ``git log``.
                 ``None`` disables the filter.
@@ -312,7 +311,8 @@ class ReaderFacet:
             needing it echoed back.
 
         Raises:
-            ValueError: If *path* is provided but fails path validation.
+            ValueError: If *path* is provided but fails path validation
+                (unsupported extension or path traversal).
         """
         return self._git_query_mgr.get_history(
             path, since=since, until=until, limit=limit
@@ -326,13 +326,14 @@ class ReaderFacet:
         per_commit: bool = False,
         limit: int | None = None,
     ) -> str | list[CommitDiff]:
-        """Return the diff of a note between a reference point and HEAD.
+        """Return the diff of a note or attachment between a ref and HEAD.
 
         Exactly one of *since_sha* or *since_timestamp* must be supplied.
 
         Args:
-            path: Vault-relative path of the note to diff.  Must end with
-                ``.md``.
+            path: A ``.md`` note or a configured attachment (e.g.
+                ``assets/x.png``) to diff.  Unsupported extensions raise
+                ``ValueError``.
             since_sha: A commit SHA (full or abbreviated, at least 4 hex
                 digits) to diff from.  Mutually exclusive with
                 *since_timestamp*.
@@ -355,14 +356,19 @@ class ReaderFacet:
         Returns:
             A unified diff string when *per_commit* is ``False``, or a list of
             :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
-            ``True``.  Returns an empty string / empty list when the note has
+            ``True``.  For an attachment that git reports as binary, a
+            ``--stat`` summary is returned instead of a unified patch; a text
+            attachment returns a full unified diff, and ``.md`` notes are
+            unchanged.  Returns an empty string / empty list when the file has
             no changes in the given range, or when the vault's source
             directory is not inside a git repository.
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is
-                not supplied, *since_sha* contains invalid characters, or the
-                resolved ref is not found in history.
+                not supplied, *since_sha* contains invalid characters, the
+                resolved ref is not found in history, or *path* has an
+                extension that is neither ``.md`` nor a configured attachment
+                type.
         """
         return self._git_query_mgr.get_diff(
             path,

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -393,8 +393,8 @@ def get_file_diff(
             return diff
 
         # Binary attachments: per-commit patches are equally meaningless, so
-        # detect once up front and emit a --stat for each commit below.
-        # detection target (rename-aware), mirroring the non-per-commit branch
+        # detect binariness once up front (rename-aware, mirroring the
+        # non-per-commit branch) and emit a --stat per commit below.
         try:
             cur_rel = path.resolve().relative_to(git_root).as_posix()
         except ValueError:
@@ -455,6 +455,10 @@ def get_file_diff(
             # Recover the path the file had at this specific commit.
             # With --follow, this will be the old name for pre-rename commits.
             commit_path = next((ln.strip() for ln in lines[1:] if ln.strip()), path_str)
+            # NOTE: for a renamed binary the per-commit `git show --stat
+            # -- commit_path` pathspec defeats git's rename pairing and renders a
+            # text-style stat instead of `Bin … bytes` — known limitation, see #683.
+            # The non-per-commit path is rename-aware.
             show_cmd = [
                 "git",
                 "-C",

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -28,25 +28,18 @@ logger = logging.getLogger(__name__)
 
 
 def _diff_is_binary(
-    git_root: Path, ref: str, path_str: str, env: dict[str, str] | None
+    git_root: Path, diff_args: list[str], env: dict[str, str] | None
 ) -> bool:
-    """True if git reports *path_str* as a binary change over ``ref..HEAD``.
+    """True if git reports the diff target as binary.
 
-    ``git diff --numstat`` prints ``-\\t-\\t<path>`` for binary files and real
-    ``<added>\\t<deleted>`` counts for text. Empty output (no change) is treated
-    as non-binary.
+    *diff_args* is the ref/path portion of a ``git diff`` invocation — either
+    ``[f"{ref}..HEAD", "--", path_str]`` (no rename) or
+    ``[f"{ref}:{old_path}", f"HEAD:{cur_rel}"]`` (rename-recovered). ``git diff
+    --numstat`` prints ``-\\t-\\t<path>`` for binary and real counts for text;
+    empty output (no change) → non-binary.
     """
     result = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(git_root),
-            "diff",
-            "--numstat",
-            f"{ref}..HEAD",
-            "--",
-            path_str,
-        ],
+        ["git", "-C", str(git_root), "diff", "--numstat", *diff_args],
         capture_output=True,
         text=True,
         check=False,
@@ -343,22 +336,29 @@ def get_file_diff(
             raise ValueError("Either 'ref' or 'since_timestamp' must be provided")
 
         if not per_commit:
+            # Resolve the path-at-ref once so renames are handled uniformly for
+            # binary detection, the --stat summary, and the full diff.
+            try:
+                cur_rel = path.resolve().relative_to(git_root).as_posix()
+            except ValueError:
+                cur_rel = None
+            old_path = (
+                resolve_path_at_ref(git_root, ref, cur_rel, env)
+                if cur_rel is not None
+                else None
+            )
+            if old_path is None or cur_rel is None or old_path == cur_rel:
+                diff_args = [f"{ref}..HEAD", "--", path_str]
+            else:
+                diff_args = [f"{ref}:{old_path}", f"HEAD:{cur_rel}"]
+
             # Binary attachments: a unified patch is meaningless, so emit a
             # --stat summary instead.  Text attachments (and notes, since the
             # default is summarize_binary=False) fall through to the full diff.
-            if summarize_binary and _diff_is_binary(git_root, ref, path_str, env):
+            if summarize_binary and _diff_is_binary(git_root, diff_args, env):
                 try:
                     stat = subprocess.run(
-                        [
-                            "git",
-                            "-C",
-                            str(git_root),
-                            "diff",
-                            "--stat",
-                            f"{ref}..HEAD",
-                            "--",
-                            path_str,
-                        ],
+                        ["git", "-C", str(git_root), "diff", "--stat", *diff_args],
                         capture_output=True,
                         text=True,
                         check=True,
@@ -371,35 +371,7 @@ def get_file_diff(
                     ) from exc
                 return stat.stdout
 
-            # Recover path-at-ref so diffs across renames show real deltas.
-            try:
-                cur_rel = path.resolve().relative_to(git_root).as_posix()
-            except ValueError:
-                cur_rel = None
-            old_path = (
-                resolve_path_at_ref(git_root, ref, cur_rel, env)
-                if cur_rel is not None
-                else None
-            )
-            if old_path is None or cur_rel is None or old_path == cur_rel:
-                diff_cmd = [
-                    "git",
-                    "-C",
-                    str(git_root),
-                    "diff",
-                    f"{ref}..HEAD",
-                    "--",
-                    path_str,
-                ]
-            else:
-                diff_cmd = [
-                    "git",
-                    "-C",
-                    str(git_root),
-                    "diff",
-                    f"{ref}:{old_path}",
-                    f"HEAD:{cur_rel}",
-                ]
+            diff_cmd = ["git", "-C", str(git_root), "diff", *diff_args]
             try:
                 result = subprocess.run(
                     diff_cmd,
@@ -422,7 +394,21 @@ def get_file_diff(
 
         # Binary attachments: per-commit patches are equally meaningless, so
         # detect once up front and emit a --stat for each commit below.
-        binary = summarize_binary and _diff_is_binary(git_root, ref, path_str, env)
+        # detection target (rename-aware), mirroring the non-per-commit branch
+        try:
+            cur_rel = path.resolve().relative_to(git_root).as_posix()
+        except ValueError:
+            cur_rel = None
+        old_path = (
+            resolve_path_at_ref(git_root, ref, cur_rel, env)
+            if cur_rel is not None
+            else None
+        )
+        if old_path is None or cur_rel is None or old_path == cur_rel:
+            detect_args = [f"{ref}..HEAD", "--", path_str]
+        else:
+            detect_args = [f"{ref}:{old_path}", f"HEAD:{cur_rel}"]
+        binary = summarize_binary and _diff_is_binary(git_root, detect_args, env)
 
         # per_commit=True: enumerate commits in range then show each.
         # Use --name-only with a sentinel so we can recover the path the

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -347,22 +347,28 @@ def get_file_diff(
             # --stat summary instead.  Text attachments (and notes, since the
             # default is summarize_binary=False) fall through to the full diff.
             if summarize_binary and _diff_is_binary(git_root, ref, path_str, env):
-                stat = subprocess.run(
-                    [
-                        "git",
-                        "-C",
-                        str(git_root),
-                        "diff",
-                        "--stat",
-                        f"{ref}..HEAD",
-                        "--",
-                        path_str,
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=env,
-                )
+                try:
+                    stat = subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(git_root),
+                            "diff",
+                            "--stat",
+                            f"{ref}..HEAD",
+                            "--",
+                            path_str,
+                        ],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                        env=env,
+                    )
+                except subprocess.CalledProcessError as exc:
+                    raise ValueError(
+                        f"Could not compute diff summary against {ref!r}: invalid ref "
+                        "or path not present at that revision"
+                    ) from exc
                 return stat.stdout
 
             # Recover path-at-ref so diffs across renames show real deltas.

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -27,6 +27,35 @@ from markdown_vault_mcp.types import CommitDiff, HistoryEntry
 logger = logging.getLogger(__name__)
 
 
+def _diff_is_binary(
+    git_root: Path, ref: str, path_str: str, env: dict[str, str] | None
+) -> bool:
+    """True if git reports *path_str* as a binary change over ``ref..HEAD``.
+
+    ``git diff --numstat`` prints ``-\\t-\\t<path>`` for binary files and real
+    ``<added>\\t<deleted>`` counts for text. Empty output (no change) is treated
+    as non-binary.
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(git_root),
+            "diff",
+            "--numstat",
+            f"{ref}..HEAD",
+            "--",
+            path_str,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    first = result.stdout.strip().split("\n", 1)[0]
+    return first.startswith("-\t-")
+
+
 def get_file_history(
     git_root: Path | None,
     repo_path: Path,
@@ -225,6 +254,7 @@ def get_file_diff(
     *,
     token: str | None,
     username: str,
+    summarize_binary: bool = False,
 ) -> str | list[CommitDiff]:
     """Return a unified diff of *path* from *ref* to HEAD.
 
@@ -254,6 +284,11 @@ def get_file_diff(
         token: Personal access token for authenticated git operations, or
             ``None`` for unauthenticated access.
         username: Git username for authenticated operations.
+        summarize_binary: When ``True`` and git reports the file as a binary
+            change over the range, return a ``git diff --stat`` summary
+            instead of a (meaningless) binary patch.  Text files -- and every
+            note, since the default is ``False`` -- fall through to the normal
+            full unified diff (#342).
 
     Returns:
         A unified diff string when *per_commit* is ``False``, or a list of
@@ -308,6 +343,28 @@ def get_file_diff(
             raise ValueError("Either 'ref' or 'since_timestamp' must be provided")
 
         if not per_commit:
+            # Binary attachments: a unified patch is meaningless, so emit a
+            # --stat summary instead.  Text attachments (and notes, since the
+            # default is summarize_binary=False) fall through to the full diff.
+            if summarize_binary and _diff_is_binary(git_root, ref, path_str, env):
+                stat = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(git_root),
+                        "diff",
+                        "--stat",
+                        f"{ref}..HEAD",
+                        "--",
+                        path_str,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=env,
+                )
+                return stat.stdout
+
             # Recover path-at-ref so diffs across renames show real deltas.
             try:
                 cur_rel = path.resolve().relative_to(git_root).as_posix()
@@ -357,6 +414,10 @@ def get_file_diff(
                 diff += f"\n[diff truncated: {omitted} bytes omitted]"
             return diff
 
+        # Binary attachments: per-commit patches are equally meaningless, so
+        # detect once up front and emit a --stat for each commit below.
+        binary = summarize_binary and _diff_is_binary(git_root, ref, path_str, env)
+
         # per_commit=True: enumerate commits in range then show each.
         # Use --name-only with a sentinel so we can recover the path the
         # file had at each commit — critical for correct diffs across
@@ -402,19 +463,20 @@ def get_file_diff(
             # Recover the path the file had at this specific commit.
             # With --follow, this will be the old name for pre-rename commits.
             commit_path = next((ln.strip() for ln in lines[1:] if ln.strip()), path_str)
+            show_cmd = [
+                "git",
+                "-C",
+                str(git_root),
+                "show",
+                "--format=",
+                "--stat" if binary else "-p",
+                sha,
+                "--",
+                commit_path,
+            ]
             try:
                 show_result = subprocess.run(
-                    [
-                        "git",
-                        "-C",
-                        str(git_root),
-                        "show",
-                        "--format=",
-                        "-p",
-                        sha,
-                        "--",
-                        commit_path,
-                    ],
+                    show_cmd,
                     capture_output=True,
                     text=True,
                     check=True,

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1747,6 +1747,8 @@ class GitWriteStrategy:
         per_commit: bool,
         since_timestamp: str | None = None,
         limit: int | None = None,
+        *,
+        summarize_binary: bool = False,
     ) -> str | list[CommitDiff]:
         """Return a unified diff of *path* from *ref* to HEAD.
 
@@ -1771,6 +1773,8 @@ class GitWriteStrategy:
                 ``[1, 100]``).  Ignored when *per_commit* is ``False``.
                 ``None`` means unbounded (still capped by the underlying
                 ``ref..HEAD`` range).
+            summarize_binary: When True and the file is binary, return a
+                ``--stat`` summary instead of a patch (#342).
 
         Returns:
             A unified diff string when *per_commit* is ``False``, or a list of
@@ -1789,6 +1793,7 @@ class GitWriteStrategy:
             limit,
             token=self._token,
             username=self._username,
+            summarize_binary=summarize_binary,
         )
 
 

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -13,9 +13,13 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from markdown_vault_mcp.utils import validate_path
+from markdown_vault_mcp.utils import (
+    effective_attachment_extensions,
+    validate_history_path,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from markdown_vault_mcp.git import GitWriteStrategy
@@ -30,11 +34,24 @@ class GitQueryManager:
             source directory is not inside a git repository (queries then
             return empty results rather than raising).
         source_dir: Absolute path to the vault root directory.
+        attachment_extensions: Allowed attachment file extensions (lowercase,
+            without leading dot, e.g. ``["png", "pdf"]``).  ``None`` uses the
+            default set from :data:`~markdown_vault_mcp.types.DEFAULT_ATTACHMENT_EXTENSIONS`.
+            Passed to :func:`~markdown_vault_mcp.utils.validate_history_path`
+            so that history/diff queries accept attachments as well as notes.
     """
 
-    def __init__(self, git_strategy: GitWriteStrategy | None, source_dir: Path) -> None:
+    def __init__(
+        self,
+        git_strategy: GitWriteStrategy | None,
+        source_dir: Path,
+        attachment_extensions: Sequence[str] | None = None,
+    ) -> None:
         self._git_strategy = git_strategy
         self._source_dir = source_dir
+        self._attachment_extensions = effective_attachment_extensions(
+            attachment_extensions
+        )
 
     def get_history(
         self,
@@ -50,9 +67,10 @@ class GitQueryManager:
         repository.
 
         Args:
-            path: Vault-relative path of the note to filter on (e.g.
-                ``"notes/alpha.md"``).  Must end with ``.md``.  ``None``
-                returns vault-wide history.
+            path: Vault-relative path of the note or attachment to filter on
+                (e.g. ``"notes/alpha.md"`` or ``"assets/x.png"``).  A ``.md``
+                note or a configured attachment (e.g. ``assets/x.png``).
+                ``None`` returns vault-wide history.
             since: ISO 8601 datetime string or git date expression (e.g.
                 ``"1 week ago"``).  Passed as ``--since`` to ``git log``.
                 ``None`` disables the filter.
@@ -75,13 +93,16 @@ class GitQueryManager:
             needing it echoed back.
 
         Raises:
-            ValueError: If *path* is provided but fails path validation.
+            ValueError: If *path* is provided but fails path validation
+                (unknown extension or path traversal).
         """
         if self._git_strategy is None:
             return []
         abs_path: Path | None = None
         if path is not None:
-            abs_path = validate_path(path, self._source_dir)
+            abs_path = validate_history_path(
+                path, self._source_dir, self._attachment_extensions
+            )
         return self._git_strategy.get_file_history(
             self._source_dir, abs_path, since, limit, until=until
         )
@@ -99,8 +120,9 @@ class GitQueryManager:
         Exactly one of *since_sha* or *since_timestamp* must be supplied.
 
         Args:
-            path: Vault-relative path of the note to diff.  Must end with
-                ``.md``.
+            path: Vault-relative path of the note or attachment to diff.
+                A ``.md`` note or a configured attachment (e.g.
+                ``assets/x.png``).  Unknown extensions raise ``ValueError``.
             since_sha: A commit SHA (full or abbreviated, at least 4 hex
                 digits) to diff from.  Mutually exclusive with
                 *since_timestamp*.
@@ -123,14 +145,18 @@ class GitQueryManager:
         Returns:
             A unified diff string when *per_commit* is ``False``, or a list of
             :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
-            ``True``.  Returns an empty string / empty list when the note has
-            no changes in the given range, or when the vault's source
-            directory is not inside a git repository.
+            ``True``.  For binary attachments (any non-``.md`` path),
+            ``--stat`` summary lines are returned instead of a unified patch.
+            Returns an empty string / empty list when the file has no changes
+            in the given range, or when the vault's source directory is not
+            inside a git repository.
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is
-                not supplied, *since_sha* contains invalid characters, or the
-                resolved ref is not found in history.
+                not supplied, *since_sha* contains invalid characters, the
+                resolved ref is not found in history, or *path* has an
+                extension that is neither ``.md`` nor a configured attachment
+                type.
         """
         if self._git_strategy is None:
             return [] if per_commit else ""
@@ -140,7 +166,9 @@ class GitQueryManager:
                 "Exactly one of 'since_sha' or 'since_timestamp' must be provided"
             )
 
-        abs_path = validate_path(path, self._source_dir)
+        abs_path = validate_history_path(
+            path, self._source_dir, self._attachment_extensions
+        )
 
         if since_sha is not None and not re.fullmatch(r"[0-9a-f]{4,40}", since_sha):
             raise ValueError(
@@ -154,4 +182,5 @@ class GitQueryManager:
             per_commit=per_commit,
             since_timestamp=since_timestamp,
             limit=limit if per_commit else None,
+            summarize_binary=not path.endswith(".md"),
         )

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -60,7 +60,7 @@ class GitQueryManager:
         until: str | None = None,
         limit: int = 20,
     ) -> list[HistoryEntry]:
-        """Return commits that touched a note or the whole vault.
+        """Return commits that touched a note, attachment, or the whole vault.
 
         When *path* is ``None``, queries the full vault history.  Returns an
         empty list for vaults whose source directory is not inside a git
@@ -115,7 +115,7 @@ class GitQueryManager:
         per_commit: bool = False,
         limit: int | None = None,
     ) -> str | list[CommitDiff]:
-        """Return the diff of a note between a reference point and HEAD.
+        """Return the diff of a note or attachment between a reference point and HEAD.
 
         Exactly one of *since_sha* or *since_timestamp* must be supplied.
 
@@ -152,6 +152,10 @@ class GitQueryManager:
             Returns an empty string / empty list when the file has no changes
             in the given range, or when the vault's source directory is not
             inside a git repository.
+
+            Per-commit (``per_commit=True``) diff of a *renamed* binary
+            attachment currently shows a text-style stat for the rename commit
+            rather than a ``Bin`` summary (#683).
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -145,8 +145,10 @@ class GitQueryManager:
         Returns:
             A unified diff string when *per_commit* is ``False``, or a list of
             :class:`~markdown_vault_mcp.types.CommitDiff` when *per_commit* is
-            ``True``.  For binary attachments (any non-``.md`` path),
-            ``--stat`` summary lines are returned instead of a unified patch.
+            ``True``.  For an attachment that git reports as binary, a
+            ``--stat`` summary is returned (per-commit: ``--stat`` lines per
+            commit) instead of a unified patch; a text attachment returns a
+            full unified diff like a ``.md`` note.
             Returns an empty string / empty list when the file has no changes
             in the given range, or when the vault's source directory is not
             inside a git repository.

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -184,5 +184,6 @@ class GitQueryManager:
             per_commit=per_commit,
             since_timestamp=since_timestamp,
             limit=limit if per_commit else None,
+            # True for any non-.md path; get_file_diff only emits --stat if git also reports it binary — text attachments fall through to a full diff.
             summarize_binary=not path.endswith(".md"),
         )

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import fnmatch
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.types import DEFAULT_ATTACHMENT_EXTENSIONS
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 from markdown_vault_mcp.utils.fts import fts_row_to_note_info
 from markdown_vault_mcp.utils.links import (
     apply_link_replacement,
@@ -105,7 +105,7 @@ def validate_history_path(
         ValueError: *path* is neither ``.md`` nor an allowed attachment
             extension, or it escapes *source_dir*.
     """
-    suffix = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    suffix = Path(path).suffix.lstrip(".").lower()
     if not (
         path.endswith(".md")
         or "*" in attachment_extensions

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -79,6 +79,40 @@ def validate_path(path: str, source_dir: Path) -> Path:
     return abs_path
 
 
+def validate_history_path(
+    path: str, source_dir: Path, attachment_extensions: frozenset[str]
+) -> Path:
+    """Resolve a vault-relative path for read-only git history/diff queries.
+
+    Unlike :func:`validate_path` (which is strictly ``.md`` and is used by the
+    write/edit/read paths), this accepts a ``.md`` note OR a path whose suffix
+    (lowercased, without the dot) is in *attachment_extensions*. Applies the same
+    traversal guard. Does not require the path to exist — history of a
+    since-deleted file is still queryable.
+
+    Args:
+        path: Vault-relative path (note or attachment).
+        source_dir: Absolute vault root.
+        attachment_extensions: Allowed attachment extensions (lowercase, no dot).
+
+    Returns:
+        The resolved absolute path.
+
+    Raises:
+        ValueError: *path* is neither ``.md`` nor an allowed attachment
+            extension, or it escapes *source_dir*.
+    """
+    suffix = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    if not (path.endswith(".md") or suffix in attachment_extensions):
+        raise ValueError(
+            f"Path must be a .md note or a configured attachment type: {path}"
+        )
+    abs_path = (source_dir / path).resolve()
+    if not abs_path.is_relative_to(source_dir.resolve()):
+        raise ValueError(f"Path traversal detected: {path}")
+    return abs_path
+
+
 __all__ = [
     "CHAR_SUBS",
     "apply_link_replacement",
@@ -89,5 +123,6 @@ __all__ = [
     "fts_row_to_note_info",
     "is_path_excluded",
     "normalize_text",
+    "validate_history_path",
     "validate_path",
 ]

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -86,14 +86,17 @@ def validate_history_path(
 
     Unlike :func:`validate_path` (which is strictly ``.md`` and is used by the
     write/edit/read paths), this accepts a ``.md`` note OR a path whose suffix
-    (lowercased, without the dot) is in *attachment_extensions*. Applies the same
-    traversal guard. Does not require the path to exist — history of a
-    since-deleted file is still queryable.
+    (lowercased, without the dot) is in *attachment_extensions* (or
+    *attachment_extensions* contains ``"*"``, meaning all non-``.md`` files).
+    Applies the same traversal guard. Does not require the path to exist —
+    history of a since-deleted file is still queryable.
 
     Args:
         path: Vault-relative path (note or attachment).
         source_dir: Absolute vault root.
         attachment_extensions: Allowed attachment extensions (lowercase, no dot).
+            The special value ``frozenset({"*"})`` accepts every non-``.md``
+            extension.
 
     Returns:
         The resolved absolute path.
@@ -103,7 +106,11 @@ def validate_history_path(
             extension, or it escapes *source_dir*.
     """
     suffix = path.rsplit(".", 1)[-1].lower() if "." in path else ""
-    if not (path.endswith(".md") or suffix in attachment_extensions):
+    if not (
+        path.endswith(".md")
+        or "*" in attachment_extensions
+        or suffix in attachment_extensions
+    ):
         raise ValueError(
             f"Path must be a .md note or a configured attachment type: {path}"
         )

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -271,7 +271,11 @@ class Vault:
         # 1. LinkManager (no deps)
         self._link_mgr = LinkManager(fts=self._fts, source_dir=self._source_dir)
         # 1b. GitQueryManager (git history/diff reads; needs git_strategy + source_dir)
-        self._git_query_mgr = GitQueryManager(self._git_strategy, self._source_dir)
+        self._git_query_mgr = GitQueryManager(
+            self._git_strategy,
+            self._source_dir,
+            attachment_extensions=self._attachment_extensions,
+        )
         # 2. IndexManager (needs fts, tracker — NOT search_mgr)
         #    get_vectors/set_vectors use late-binding lambdas that capture
         #    self._search_mgr; they are only called at runtime after all

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3285,6 +3285,94 @@ class TestGetFileDiff:
         assert "-Original line" in diff
         assert "+Modified line" in diff
 
+    def test_get_file_diff_binary_attachment_stat_across_rename(
+        self, tmp_path: Path
+    ) -> None:
+        """A binary attachment renamed within the range still yields a --stat.
+
+        Regression for #342: with rename-unaware binary detection, ``git diff
+        {ref}..HEAD -- assets/y.png`` reports the renamed binary as a plain add
+        (text-style counts, not ``-\t-``), so detection returned False and the
+        code fell through to the full-diff path, emitting the meaningless
+        ``Binary files ... differ`` patch the feature exists to suppress.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(repo), "init"], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.email", "t@t.com"],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.name", "T"],
+            capture_output=True,
+            check=True,
+        )
+        assets = repo / "assets"
+        assets.mkdir()
+        # The original blob carries a NUL byte, so git classifies *it* as
+        # binary; the renamed blob keeps the bulk of the bytes (so git's
+        # --find-renames=30 still pairs the two paths) but drops the NUL.  This
+        # is the discriminating case: `git diff {ref}..HEAD -- assets/y.png`
+        # treats y.png as a plain add and reports text counts (3\t0), so
+        # rename-unaware detection returns False and the old code fell through
+        # to the full diff, emitting "Binary files ... differ".  The rename-
+        # aware blob-pair form `git diff {ref}:assets/x.png HEAD:assets/y.png`
+        # reports the pair as binary (-\t-), so detection now yields a --stat.
+        common = b"\x89PNG\r\n\x1a\n" + (b"\xaa" * 200)
+        v1 = common + b"\x00" + (b"\xbb" * 50)  # NUL -> git sees x.png as binary
+        v2 = common + b"\x11" + (b"\xcc" * 50)  # no NUL, high similarity to v1
+        # Commit 1: add the binary attachment under its original name.
+        (assets / "x.png").write_bytes(v1)
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add x.png"],
+            capture_output=True,
+            check=True,
+        )
+        first_sha = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        # Commit 2: rename x.png -> y.png AND tweak its bytes (a rename-with-edit
+        # within the range that git still detects as a rename at the 30%
+        # threshold used by resolve_path_at_ref).
+        subprocess.run(
+            ["git", "-C", str(repo), "mv", "assets/x.png", "assets/y.png"],
+            capture_output=True,
+            check=True,
+        )
+        (assets / "y.png").write_bytes(v2)
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "rename+edit x.png -> y.png"],
+            capture_output=True,
+            check=True,
+        )
+
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "y.png",
+            ref=first_sha,
+            per_commit=False,
+            summarize_binary=True,
+        )
+        assert isinstance(out, str)
+        # Rename-aware --stat summary, not the garbage binary patch.
+        assert " -> " in out  # stat-only marker (e.g. "Bin 12 -> 13 bytes")
+        assert "Binary files" not in out  # full binary patch marker must be absent
+        assert "@@" not in out
+
     def test_resolve_path_at_ref_handles_tab_in_filename(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2971,7 +2971,10 @@ class TestGetFileDiff:
             summarize_binary=True,
         )
         assert isinstance(out, str)
-        assert "Bin" in out and "x.png" in out
+        assert "x.png" in out
+        # --stat summary contains "Bin N -> M bytes" arrow; full binary patch does not.
+        assert " -> " in out  # stat-only marker (e.g. "Bin 12 -> 13 bytes")
+        assert "Binary files" not in out  # full binary patch marker must be absent
         assert "@@" not in out  # NOT a unified patch
 
     def test_get_file_diff_text_attachment_returns_full_diff(
@@ -3019,7 +3022,47 @@ class TestGetFileDiff:
         )
         assert isinstance(out, list) and out
         assert all("@@" not in cd.diff for cd in out)
-        assert any(("Bin" in cd.diff) or ("x.png" in cd.diff) for cd in out)
+        # --stat summary contains "Bin N -> M bytes" arrow; full binary patch does not.
+        assert any(" -> " in cd.diff for cd in out)  # stat-only marker
+        assert all("Binary files" not in cd.diff for cd in out)  # no full binary patch
+
+    def test_get_file_diff_text_attachment_per_commit_returns_full_diff(
+        self, tmp_path: Path
+    ) -> None:
+        """Text attachments with per_commit=True return real patches, not --stat."""
+        repo, first_sha = self._make_repo_with_attachments(tmp_path)
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "diagram.svg",
+            ref=first_sha,
+            per_commit=True,
+            summarize_binary=True,
+        )
+        assert isinstance(out, list)
+        # Text attachment: each CommitDiff must contain a real unified-diff hunk
+        assert any("@@" in cd.diff for cd in out)
+
+    def test_get_file_diff_binary_no_change_in_range_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Diffing a binary against its own HEAD SHA returns an empty string."""
+        repo, _first_sha = self._make_repo_with_attachments(tmp_path)
+        head_sha = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "x.png",
+            ref=head_sha,
+            per_commit=False,
+            summarize_binary=True,
+        )
+        assert out == ""
 
     def test_single_diff(self, tmp_path: Path) -> None:
         """get_file_diff with per_commit=False returns a unified diff string."""

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2902,6 +2902,125 @@ class TestGetFileDiff:
         )
         return repo, first_sha
 
+    def _make_repo_with_attachments(self, tmp_path: Path) -> tuple[Path, str]:
+        """Create a repo with a note plus a binary and a text attachment.
+
+        Across two commits this changes ``note.md`` (text), ``assets/x.png``
+        (binary -- distinct PNG bytes) and ``assets/diagram.svg`` (text).
+        Returns the repo path and the SHA of the first commit (before the
+        second-commit changes).
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(repo), "init"], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.name", "Test"],
+            capture_output=True,
+            check=True,
+        )
+        assets = repo / "assets"
+        assets.mkdir()
+        (repo / "note.md").write_text("# Note v1\n")
+        # A minimal but valid-looking PNG header plus distinct payload bytes.
+        (assets / "x.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x01\x02\x03")
+        (assets / "diagram.svg").write_text("<svg>1</svg>\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add note + attachments"],
+            capture_output=True,
+            check=True,
+        )
+        first_sha = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        # Commit 2: change all three with DIFFERENT bytes/content.
+        (repo / "note.md").write_text("# Note v2\n")
+        (assets / "x.png").write_bytes(b"\x89PNG\r\n\x1a\n\xff\xfe\xfd\xfc\xfb")
+        (assets / "diagram.svg").write_text("<svg>2</svg>\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "edit note + attachments"],
+            capture_output=True,
+            check=True,
+        )
+        return repo, first_sha
+
+    def test_get_file_diff_binary_attachment_returns_stat(self, tmp_path: Path) -> None:
+        """A binary attachment with summarize_binary=True returns a --stat summary."""
+        repo, first_sha = self._make_repo_with_attachments(tmp_path)
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "x.png",
+            ref=first_sha,
+            per_commit=False,
+            summarize_binary=True,
+        )
+        assert isinstance(out, str)
+        assert "Bin" in out and "x.png" in out
+        assert "@@" not in out  # NOT a unified patch
+
+    def test_get_file_diff_text_attachment_returns_full_diff(
+        self, tmp_path: Path
+    ) -> None:
+        """A text attachment with summarize_binary=True still returns a full diff."""
+        repo, first_sha = self._make_repo_with_attachments(tmp_path)
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "diagram.svg",
+            ref=first_sha,
+            per_commit=False,
+            summarize_binary=True,
+        )
+        assert isinstance(out, str)
+        assert "@@" in out and "Bin" not in out
+
+    def test_get_file_diff_note_unchanged_with_summarize_false(
+        self, tmp_path: Path
+    ) -> None:
+        """summarize_binary=False (default) leaves note diffs as full patches."""
+        repo, first_sha = self._make_repo_with_attachments(tmp_path)
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "note.md",
+            ref=first_sha,
+            per_commit=False,
+            summarize_binary=False,
+        )
+        assert isinstance(out, str)
+        assert "@@" in out
+
+    def test_get_file_diff_binary_per_commit_stat_lines(self, tmp_path: Path) -> None:
+        """per_commit=True + binary returns CommitDiffs whose diff is a --stat."""
+        repo, first_sha = self._make_repo_with_attachments(tmp_path)
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "x.png",
+            ref=first_sha,
+            per_commit=True,
+            summarize_binary=True,
+        )
+        assert isinstance(out, list) and out
+        assert all("@@" not in cd.diff for cd in out)
+        assert any(("Bin" in cd.diff) or ("x.png" in cd.diff) for cd in out)
+
     def test_single_diff(self, tmp_path: Path) -> None:
         """get_file_diff with per_commit=False returns a unified diff string."""
         repo, first_sha = self._make_repo_with_commits(tmp_path)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3373,6 +3373,99 @@ class TestGetFileDiff:
         assert "Binary files" not in out  # full binary patch marker must be absent
         assert "@@" not in out
 
+    def test_get_file_diff_per_commit_renamed_binary_degraded_stat(
+        self, tmp_path: Path
+    ) -> None:
+        """KNOWN LIMITATION (#683): per-commit --stat of a RENAMED binary shows a
+        text-style stat for the rename commit, not a ``Bin`` summary, because the
+        single-path pathspec defeats git's rename pairing in ``git show``. The
+        non-per-commit path IS rename-aware. Flip this assertion to require
+        ``' -> '``/``Bin`` when #683 is fixed.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(repo), "init"], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.email", "t@t.com"],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.name", "T"],
+            capture_output=True,
+            check=True,
+        )
+        assets = repo / "assets"
+        assets.mkdir()
+        # Same fixture as test_get_file_diff_binary_attachment_stat_across_rename:
+        # NUL-carrying v1 (binary) renamed to y.png with tweaked bytes (v2,
+        # no NUL, high similarity so --find-renames=30 pairs them).
+        common = b"\x89PNG\r\n\x1a\n" + (b"\xaa" * 200)
+        v1 = common + b"\x00" + (b"\xbb" * 50)
+        v2 = common + b"\x11" + (b"\xcc" * 50)
+        (assets / "x.png").write_bytes(v1)
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add x.png"],
+            capture_output=True,
+            check=True,
+        )
+        first_sha = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "-C", str(repo), "mv", "assets/x.png", "assets/y.png"],
+            capture_output=True,
+            check=True,
+        )
+        (assets / "y.png").write_bytes(v2)
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "rename+edit x.png -> y.png"],
+            capture_output=True,
+            check=True,
+        )
+
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "y.png",
+            ref=first_sha,
+            per_commit=True,
+            summarize_binary=True,
+        )
+        assert isinstance(out, list) and out
+        # Currently NO Bin/arrow marker on any per-commit entry (the #683 bug):
+        # git show --stat -- commit_path defeats rename pairing and shows a
+        # text-style count instead of "Bin N -> M bytes".
+        assert not any(" -> " in cd.diff for cd in out)
+
+    def test_get_file_diff_summarize_binary_invalid_ref_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """summarize_binary=True with a bad ref still raises ValueError (the
+        _diff_is_binary check=False swallow is re-surfaced downstream).
+        """
+        repo, _ = self._make_repo_with_attachments(tmp_path)
+        strategy = GitWriteStrategy()
+        with pytest.raises(ValueError):
+            strategy.get_file_diff(
+                repo,
+                repo / "assets" / "x.png",
+                ref="deadbeef",
+                per_commit=False,
+                summarize_binary=True,
+            )
+
     def test_resolve_path_at_ref_handles_tab_in_filename(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_git_query.py
+++ b/tests/test_git_query.py
@@ -24,6 +24,7 @@ class _RecordingStrategy:
     def __init__(self) -> None:
         self.history_calls: list[tuple[Any, ...]] = []
         self.diff_calls: list[tuple[Any, ...]] = []
+        self.diff_kwargs: list[dict[str, Any]] = []
 
     def get_file_history(
         self,
@@ -44,10 +45,13 @@ class _RecordingStrategy:
         per_commit: bool,
         since_timestamp: str | None = None,
         limit: int | None = None,
+        *,
+        summarize_binary: bool = False,
     ) -> str | list[str]:
         self.diff_calls.append(
             (source_dir, abs_path, ref, per_commit, since_timestamp, limit)
         )
+        self.diff_kwargs.append({"summarize_binary": summarize_binary})
         return ["CD"] if per_commit else "DIFF"
 
 
@@ -121,3 +125,72 @@ class TestForwarding:
             "2026-01-01",
             5,
         )
+
+
+class TestAttachmentExtensions:
+    """Verify that GitQueryManager validates paths with attachment_extensions."""
+
+    def test_get_diff_rejects_unknown_extension(self, tmp_path: Path) -> None:
+        """Manager built with png (not exe) must reject .exe paths."""
+        mgr = GitQueryManager(
+            _RecordingStrategy(),  # type: ignore[arg-type]
+            tmp_path,
+            attachment_extensions=["png"],
+        )
+        with pytest.raises(ValueError, match=r"\.md note or a configured attachment"):
+            mgr.get_diff("evil.exe", since_sha="abcd1234")
+
+    def test_get_diff_attachment_passes_summarize_binary_true(
+        self, tmp_path: Path
+    ) -> None:
+        """get_diff on an attachment path must forward summarize_binary=True."""
+        strat = _RecordingStrategy()
+        mgr = GitQueryManager(
+            strat,  # type: ignore[arg-type]
+            tmp_path,
+            attachment_extensions=["png"],
+        )
+        mgr.get_diff("assets/diagram.png", since_sha="abcd1234")
+        assert strat.diff_kwargs[0]["summarize_binary"] is True
+
+    def test_get_diff_md_passes_summarize_binary_false(self, tmp_path: Path) -> None:
+        """get_diff on a .md path must forward summarize_binary=False."""
+        strat = _RecordingStrategy()
+        mgr = GitQueryManager(
+            strat,  # type: ignore[arg-type]
+            tmp_path,
+            attachment_extensions=["png"],
+        )
+        mgr.get_diff("note.md", since_sha="abcd1234")
+        assert strat.diff_kwargs[0]["summarize_binary"] is False
+
+    def test_get_history_attachment_does_not_raise(self, tmp_path: Path) -> None:
+        """get_history on a known attachment extension must succeed."""
+        strat = _RecordingStrategy()
+        mgr = GitQueryManager(
+            strat,  # type: ignore[arg-type]
+            tmp_path,
+            attachment_extensions=["png"],
+        )
+        result = mgr.get_history("assets/photo.png")
+        assert result == ["HIST"]
+
+    def test_get_diff_no_extensions_rejects_attachment(self, tmp_path: Path) -> None:
+        """Manager with empty attachment_extensions must reject any non-.md path."""
+        mgr = GitQueryManager(
+            _RecordingStrategy(),  # type: ignore[arg-type]
+            tmp_path,
+            attachment_extensions=[],
+        )
+        with pytest.raises(ValueError, match=r"\.md note or a configured attachment"):
+            mgr.get_diff("image.png", since_sha="abcd1234")
+
+    def test_get_history_no_extensions_rejects_attachment(self, tmp_path: Path) -> None:
+        """get_history with empty attachment_extensions must reject non-.md path."""
+        mgr = GitQueryManager(
+            _RecordingStrategy(),  # type: ignore[arg-type]
+            tmp_path,
+            attachment_extensions=[],
+        )
+        with pytest.raises(ValueError, match=r"\.md note or a configured attachment"):
+            mgr.get_history("image.png")

--- a/tests/test_utils_validate_history_path.py
+++ b/tests/test_utils_validate_history_path.py
@@ -38,3 +38,10 @@ def test_rejects_attachment_when_allowlist_empty(tmp_path):
 def test_rejects_traversal(tmp_path):
     with pytest.raises(ValueError, match="traversal"):
         validate_history_path("../escape.png", tmp_path, frozenset({"png"}))
+
+
+def test_accepts_any_attachment_under_wildcard(tmp_path):
+    assert (
+        validate_history_path("assets/photo.heic", tmp_path, frozenset({"*"}))
+        == (tmp_path / "assets/photo.heic").resolve()
+    )

--- a/tests/test_utils_validate_history_path.py
+++ b/tests/test_utils_validate_history_path.py
@@ -1,0 +1,40 @@
+import pytest
+
+from markdown_vault_mcp.utils import validate_history_path
+
+
+def test_accepts_md(tmp_path):
+    assert (
+        validate_history_path("notes/a.md", tmp_path, frozenset())
+        == (tmp_path / "notes/a.md").resolve()
+    )
+
+
+def test_accepts_allowed_attachment(tmp_path):
+    exts = frozenset({"png", "pdf"})
+    assert (
+        validate_history_path("assets/x.png", tmp_path, exts)
+        == (tmp_path / "assets/x.png").resolve()
+    )
+
+
+def test_attachment_extension_is_case_insensitive(tmp_path):
+    assert (
+        validate_history_path("assets/X.PNG", tmp_path, frozenset({"png"}))
+        == (tmp_path / "assets/X.PNG").resolve()
+    )
+
+
+def test_rejects_unknown_extension(tmp_path):
+    with pytest.raises(ValueError, match="\\.md note or a configured attachment"):
+        validate_history_path("a.exe", tmp_path, frozenset({"png"}))
+
+
+def test_rejects_attachment_when_allowlist_empty(tmp_path):
+    with pytest.raises(ValueError, match="\\.md note or a configured attachment"):
+        validate_history_path("a.png", tmp_path, frozenset())
+
+
+def test_rejects_traversal(tmp_path):
+    with pytest.raises(ValueError, match="traversal"):
+        validate_history_path("../escape.png", tmp_path, frozenset({"png"}))


### PR DESCRIPTION
**M3 (features) of the #577 git epic — the final epic issue.**

## What
`get_history` and `get_diff` now accept attachment paths (configured non-`.md` extensions), not just notes:
- **`get_history`** returns an attachment's commit history (replacement/rename lineage).
- **`get_diff`** lets **git classify each file** (`git diff --numstat` → `-\t-`): a **binary** attachment returns a `git diff --stat` summary (`assets/x.png | Bin 1234 -> 5678 bytes`), a **text** attachment (`.svg`, `.csv`, …) returns a real unified diff, and **`.md` notes are completely unchanged** (`summarize_binary=False` default → byte-identical code path).

## Design
- A new scoped `validate_history_path` (accepts `.md` + configured attachment extensions, incl. the `"*"` wildcard) — the strict-`.md` `validate_path` used by write/edit/read is **untouched** (issue Q4).
- `GitQueryManager` gains `attachment_extensions` (wired from `Vault`); passes `summarize_binary=not path.endswith(".md")`.
- `get_file_diff` resolves the rename target once (`resolve_path_at_ref`) and reuses it for binary detection + `--stat` + the full diff, so the **non-per-commit binary diff is rename-aware** (a renamed binary still gets a `--stat`, not the meaningless `Binary files … differ` patch). New `--stat` subprocess wraps `CalledProcessError → ValueError` (the #337 contract).

## Tests
Real-git fixtures (binary png, text svg, note across commits): binary→`--stat` (markers `" -> "` present / `"Binary files"` absent — verified discriminators), text→full diff, note unchanged, per-commit variants, no-change→`""`, a **rename discriminator** (NUL-byte fixture, mutation-verified it reproduces the garbage patch when reverted), a bad-ref+`summarize_binary` error test, and the full `validate_history_path` suite. 2198 passed; mypy + ruff clean.

## Known limitation (documented + tracked: #683)
`per_commit=True` diff of a **renamed binary** currently renders a text-style stat for the rename commit (the single-path pathspec defeats git's rename pairing in `git show`). It's documented in the code/docstrings/design.md and **pinned by a test** that flips when #683 is fixed — narrow (per-commit + renamed + binary), graceful (not a crash), and the non-per-commit path handles it correctly.

## Verification
Preflight-circus (5 core + code-reviewer + silent-failure-hunter + pr-test-analyzer + comment-analyzer) clean at ≥80 over four rounds — it drove the wildcard fix, the binary-test discriminators, the rename-awareness, and the #683 binding. Docs updated (README, `docs/tools/index.md`, `docs/design.md`, all docstring layers). Designed via brainstorm→spec→plan.

Closes #342. Refs #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)