### PR TITLE
fix(git): per-commit attachment diff is rename-aware (closes #683)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -2250,7 +2250,14 @@ to_ref=sha)`) and diffs the two blobs (`git diff {sha}^:old {sha}:new`),
 classifying binariness per commit — so a renamed binary pairs into
 `{old => new} | Bin OLD -> NEW` instead of an add/text stat. Non-rename commits
 use `git diff {sha}^..{sha} -- path` (behaviour-preserving), and a parent-less
-(root) commit falls back to the add-form `git show`.
+(root) commit falls back to the add-form `git show`. A pure rename with
+byte-identical content produces an empty two-blob diff; the per-commit path
+synthesizes a `{old} => {new} (renamed, no content change)` marker in that case
+(#683). Known bounds: per-commit rename pairing relies on git's
+`--find-renames=30` similarity threshold (a binary rename with a very large edit
+may render as separate add/delete rather than a paired `{old => new}` stat), and
+a per-commit diff of a merge commit renders the first-parent diff rather than a
+combined diff.
 
 ### Release channels
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -2243,9 +2243,14 @@ Both methods use the existing `_git_env()` / `_cleanup_git_env()` pattern for cr
 use). `get_diff` lets git classify each attachment: a binary file (git
 `--numstat` reports `-\t-`) returns a `git diff --stat` size/rename summary,
 while a text attachment (`.svg`, `.csv`, …) returns a full unified diff. `.md`
-notes are unchanged. Per-commit diff of a *renamed* binary attachment currently
-renders a text-style stat for the rename commit instead of a `Bin` summary
-(tracked in #683).
+notes are unchanged. The per-commit path (`per_commit=True`) is rename/copy-aware
+per commit (#683): for each commit it resolves the path's rename/copy against
+that commit's parent (`resolve_path_at_ref(git_root, "{sha}^", commit_path, …,
+to_ref=sha)`) and diffs the two blobs (`git diff {sha}^:old {sha}:new`),
+classifying binariness per commit — so a renamed binary pairs into
+`{old => new} | Bin OLD -> NEW` instead of an add/text stat. Non-rename commits
+use `git diff {sha}^..{sha} -- path` (behaviour-preserving), and a parent-less
+(root) commit falls back to the add-form `git show`.
 
 ### Release channels
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -2243,13 +2243,15 @@ Both methods use the existing `_git_env()` / `_cleanup_git_env()` pattern for cr
 use). `get_diff` lets git classify each attachment: a binary file (git
 `--numstat` reports `-\t-`) returns a `git diff --stat` size/rename summary,
 while a text attachment (`.svg`, `.csv`, …) returns a full unified diff. `.md`
-notes are unchanged. The per-commit path (`per_commit=True`) is rename/copy-aware
-per commit (#683): for each commit it resolves the path's rename/copy against
+notes are unchanged. The per-commit path (`per_commit=True`) is rename-aware
+per commit (#683): for each commit it resolves the path's rename against
 that commit's parent (`resolve_path_at_ref(git_root, "{sha}^", commit_path, …,
 to_ref=sha)`) and diffs the two blobs (`git diff {sha}^:old {sha}:new`),
 classifying binariness per commit — so a renamed binary pairs into
-`{old => new} | Bin OLD -> NEW` instead of an add/text stat. Non-rename commits
-use `git diff {sha}^..{sha} -- path` (behaviour-preserving), and a parent-less
+`{old => new} | Bin OLD -> NEW` instead of an add/text stat. A copied file
+renders as a plain add (binary classification still correct; copy records are
+skipped by `resolve_path_at_ref`). Non-rename commits use
+`git diff {sha}^..{sha} -- path` (behaviour-preserving), and a parent-less
 (root) commit falls back to the add-form `git show`. A pure rename with
 byte-identical content produces an empty two-blob diff; the per-commit path
 synthesizes a `{old} => {new} (renamed, no content change)` marker in that case

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -362,7 +362,8 @@ class ReaderFacet:
             unchanged.  Returns an empty string / empty list when the file has
             no changes in the given range, or when the vault's source
             directory is not inside a git repository.  Per-commit
-            (``per_commit=True``) attachment diffs are rename/copy-aware.
+            (``per_commit=True``) attachment diffs are rename-aware (a copied
+            file renders as an add).
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -361,11 +361,8 @@ class ReaderFacet:
             attachment returns a full unified diff, and ``.md`` notes are
             unchanged.  Returns an empty string / empty list when the file has
             no changes in the given range, or when the vault's source
-            directory is not inside a git repository.
-
-            Per-commit (``per_commit=True``) diff of a *renamed* binary
-            attachment currently shows a text-style stat for the rename commit
-            rather than a ``Bin`` summary (#683).
+            directory is not inside a git repository.  Per-commit
+            (``per_commit=True``) attachment diffs are rename/copy-aware.
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -231,7 +231,12 @@ def resolve_path_at_ref(
         )
     except subprocess.CalledProcessError:
         return None
-    # Stream: <status>\0<path>\0  (R* adds a second path before the closing NUL).
+    # Stream: <status>\0<path>\0 — R*/C* records add a second path
+    # (\0<old>\0<new>\0).  Copies (C*) are skipped, not resolved (a copy is
+    # an add, not a rename); the branch keeps the parser in sync if git ever
+    # emits one (e.g. if ``--find-copies`` were added in future).  Without
+    # ``--find-copies`` / ``--find-copies-harder`` git does not emit C* records,
+    # so this branch is defensive dead-code today.
     items = result.stdout.split("\0")[:-1]
     i = 0
     while i < len(items):

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -37,10 +37,12 @@ def _diff_is_binary(
     """True if git reports the diff target as binary.
 
     *diff_args* is the ref/path portion of a ``git diff`` invocation — either
-    ``[f"{ref}..HEAD", "--", path_str]`` (no rename) or
-    ``[f"{ref}:{old_path}", f"HEAD:{cur_rel}"]`` (rename-recovered). ``git diff
-    --numstat`` prints ``-\\t-\\t<path>`` for binary and real counts for text;
-    empty output (no change) → non-binary.
+    a range/path form (``["<from>..<to>", "--", path_str]``) or a two-endpoint
+    blob/tree-spec form (``[f"{a}:{old}", f"{b}:{new}"]``, or a tree SHA such as
+    the empty-tree constant).  The endpoints may be a ref and ``HEAD``, two
+    commit SHAs (e.g. a commit and its parent), or a commit and the empty tree.
+    ``git diff --numstat`` prints ``-\\t-\\t<path>`` for binary and real counts
+    for text; empty output (no change) → non-binary.
     A non-zero git exit (e.g. a bad ref) yields empty stdout, so it is classified
     non-binary; the error is then surfaced by the subsequent checked ``git diff``
     call. This is a detection probe, not the final word.
@@ -530,6 +532,17 @@ def get_file_diff(
                         f"Could not retrieve diff for commit {sha!r}"
                     ) from exc2
             commit_diff = show_result.stdout.lstrip("\n")
+            if (
+                not commit_diff
+                and old_at_parent is not None
+                and old_at_parent != commit_path
+            ):
+                # Pure rename/copy with byte-identical content: the two-blob diff
+                # of identical blobs is empty, so the rename would otherwise be
+                # invisible. Synthesize a marker rather than emit an empty diff (#683).
+                commit_diff = (
+                    f"{old_at_parent} => {commit_path} (renamed, no content change)\n"
+                )
             if len(commit_diff.encode()) > _DIFF_MAX_BYTES:
                 omitted = len(commit_diff.encode()) - _DIFF_MAX_BYTES
                 commit_diff = commit_diff.encode()[:_DIFF_MAX_BYTES].decode(

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -443,6 +443,15 @@ def get_file_diff(
         except subprocess.CalledProcessError as exc:
             raise ValueError(f"Commit {ref!r} not found in history") from exc
 
+        # Repo-relative posix path — the correct fallback when a --name-only
+        # block has no path line (git returns posix-relative paths, so the
+        # absolute platform-native path_str would break rename resolution on
+        # Windows).
+        try:
+            rel_fallback = path.resolve().relative_to(git_root).as_posix()
+        except ValueError:
+            rel_fallback = path_str
+
         diffs: list[CommitDiff] = []
         for block in log_result.stdout.split(_PC_SENTINEL):
             block = block.strip()
@@ -457,7 +466,9 @@ def get_file_diff(
             sha, short_sha, timestamp, message = parts[:4]
             # Recover the path the file had at this specific commit.
             # With --follow, this will be the old name for pre-rename commits.
-            commit_path = next((ln.strip() for ln in lines[1:] if ln.strip()), path_str)
+            commit_path = next(
+                (ln.strip() for ln in lines[1:] if ln.strip()), rel_fallback
+            )
 
             # Build a rename-aware diff target for THIS commit vs its parent,
             # mirroring the non-per-commit branch, so a renamed binary pairs into
@@ -513,8 +524,32 @@ def get_file_diff(
                     ) from exc
                 # Genuinely parent-less: classify against the empty tree (so a root
                 # binary still gets --stat) and render the add-form.
+                # Resolve the empty-tree object for this repo's hash algorithm
+                # (the hardcoded SHA-1 constant is invalid in SHA-256 repos);
+                # fall back to the SHA-1 constant if resolution fails.
+                empty_tree = _EMPTY_TREE_SHA
+                try:
+                    res = subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(git_root),
+                            "hash-object",
+                            "-t",
+                            "tree",
+                            "--stdin",
+                        ],
+                        input="",
+                        capture_output=True,
+                        text=True,
+                        env=env,
+                        check=True,
+                    )
+                    empty_tree = res.stdout.strip() or _EMPTY_TREE_SHA
+                except subprocess.CalledProcessError:
+                    pass
                 root_binary = summarize_binary and _diff_is_binary(
-                    git_root, [_EMPTY_TREE_SHA, sha, "--", commit_path], env
+                    git_root, [empty_tree, sha, "--", commit_path], env
                 )
                 fallback_cmd = [
                     "git",

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -36,11 +36,12 @@ def _diff_is_binary(
 ) -> bool:
     """True if git reports the diff target as binary.
 
-    *diff_args* is the ref/path portion of a ``git diff`` invocation — either
-    a range/path form (``["<from>..<to>", "--", path_str]``) or a two-endpoint
-    blob/tree-spec form (``[f"{a}:{old}", f"{b}:{new}"]``, or a tree SHA such as
-    the empty-tree constant).  The endpoints may be a ref and ``HEAD``, two
-    commit SHAs (e.g. a commit and its parent), or a commit and the empty tree.
+    *diff_args* is the ref/path portion of a ``git diff`` invocation — such as
+    a range/path form (``["<from>..<to>", "--", path_str]``), a two-endpoint
+    blob/tree-spec form (``[f"{a}:{old}", f"{b}:{new}"]``), or two revs followed
+    by a pathspec (e.g. the empty-tree SHA and a commit SHA followed by
+    ``["--", commit_path]``, used for parent-less commits).  The endpoints may
+    be refs, commit SHAs, blob specs, or the empty-tree constant.
     ``git diff --numstat`` prints ``-\\t-\\t<path>`` for binary and real counts
     for text; empty output (no change) → non-binary.
     A non-zero git exit (e.g. a bad ref) yields empty stdout, so it is classified
@@ -203,10 +204,10 @@ def resolve_path_at_ref(
     *,
     to_ref: str = "HEAD",
 ) -> str | None:
-    """Return the path *cur_rel* had at *ref* via rename/copy detection, else None.
+    """Return the path *cur_rel* had at *ref* via rename detection, else None.
 
     Diffs ``ref..to_ref`` (``to_ref`` defaults to ``HEAD``).  Pass a specific
-    commit as *to_ref* to resolve a rename/copy a single commit introduced.
+    commit as *to_ref* to resolve a rename a single commit introduced.
     """
     try:
         result = subprocess.run(
@@ -218,8 +219,6 @@ def resolve_path_at_ref(
                 "--name-status",
                 # 30% threshold: catch rename-with-edits per #338, avoid template false-positives.
                 "--find-renames=30",
-                # --find-copies (not -harder): only detects copies whose source was modified in the same commit; an unchanged-source copy appears as a plain add.
-                "--find-copies=30",
                 # -z: NUL-terminated fields, tolerates tabs/newlines in paths.
                 "-z",
                 ref,
@@ -232,16 +231,20 @@ def resolve_path_at_ref(
         )
     except subprocess.CalledProcessError:
         return None
-    # Stream: <status>\0<path>\0  (R*/C* add a second path before the closing NUL).
+    # Stream: <status>\0<path>\0  (R* adds a second path before the closing NUL).
     items = result.stdout.split("\0")[:-1]
     i = 0
     while i < len(items):
         status = items[i]
-        if status.startswith(("R", "C")):
+        if status.startswith("R"):
             if i + 2 >= len(items):
                 break
             if items[i + 2] == cur_rel:
                 return items[i + 1]
+            i += 3
+        elif status.startswith("C"):
+            if i + 2 >= len(items):
+                break
             i += 3
         else:
             if i + 1 >= len(items):
@@ -451,7 +454,7 @@ def get_file_diff(
             # With --follow, this will be the old name for pre-rename commits.
             commit_path = next((ln.strip() for ln in lines[1:] if ln.strip()), path_str)
 
-            # Build a rename/copy-aware diff target for THIS commit vs its parent,
+            # Build a rename-aware diff target for THIS commit vs its parent,
             # mirroring the non-per-commit branch, so a renamed binary pairs into
             # `{old => new} | Bin OLD -> NEW` instead of an add/text stat (#683).
             parent = f"{sha}^"
@@ -537,7 +540,7 @@ def get_file_diff(
                 and old_at_parent is not None
                 and old_at_parent != commit_path
             ):
-                # Pure rename/copy with byte-identical content: the two-blob diff
+                # Pure rename with byte-identical content: the two-blob diff
                 # of identical blobs is empty, so the rename would otherwise be
                 # invisible. Synthesize a marker rather than emit an empty diff (#683).
                 commit_diff = (

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -26,6 +26,10 @@ from markdown_vault_mcp.types import CommitDiff, HistoryEntry
 
 logger = logging.getLogger(__name__)
 
+# Git's well-known empty-tree SHA: a real object in every repository.
+# Used to diff a parent-less (root/orphan) commit against "nothing".
+_EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
 
 def _diff_is_binary(
     git_root: Path, diff_args: list[str], env: dict[str, str] | None
@@ -212,7 +216,7 @@ def resolve_path_at_ref(
                 "--name-status",
                 # 30% threshold: catch rename-with-edits per #338, avoid template false-positives.
                 "--find-renames=30",
-                # Enable copy detection at the same threshold.
+                # --find-copies (not -harder): only detects copies whose source was modified in the same commit; an unchanged-source copy appears as a plain add.
                 "--find-copies=30",
                 # -z: NUL-terminated fields, tolerates tabs/newlines in paths.
                 "-z",
@@ -472,16 +476,43 @@ def get_file_diff(
                 show_result = subprocess.run(
                     diff_cmd, capture_output=True, text=True, check=True, env=env
                 )
-            except subprocess.CalledProcessError:
-                # Parent-less (root) commit: {sha}^ does not resolve. Fall back to
-                # the add-form `git show` (the original behaviour for this case).
+            except subprocess.CalledProcessError as exc:
+                # A failure here is expected ONLY for a parent-less (root/orphan)
+                # commit, where `{sha}^` can't resolve. Any other failure is real
+                # and must surface rather than silently degrade to an add-form,
+                # rename-unaware diff.
+                parent_exists = (
+                    subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(git_root),
+                            "rev-parse",
+                            "--verify",
+                            "--quiet",
+                            f"{sha}^",
+                        ],
+                        capture_output=True,
+                        env=env,
+                    ).returncode
+                    == 0
+                )
+                if parent_exists:
+                    raise ValueError(
+                        f"Could not retrieve diff for commit {sha!r}"
+                    ) from exc
+                # Genuinely parent-less: classify against the empty tree (so a root
+                # binary still gets --stat) and render the add-form.
+                root_binary = summarize_binary and _diff_is_binary(
+                    git_root, [_EMPTY_TREE_SHA, sha, "--", commit_path], env
+                )
                 fallback_cmd = [
                     "git",
                     "-C",
                     str(git_root),
                     "show",
                     "--format=",
-                    "--stat" if commit_binary else "-p",
+                    "--stat" if root_binary else "-p",
                     sha,
                     "--",
                     commit_path,
@@ -494,10 +525,10 @@ def get_file_diff(
                         check=True,
                         env=env,
                     )
-                except subprocess.CalledProcessError as exc:
+                except subprocess.CalledProcessError as exc2:
                     raise ValueError(
                         f"Could not retrieve diff for commit {sha!r}"
-                    ) from exc
+                    ) from exc2
             commit_diff = show_result.stdout.lstrip("\n")
             if len(commit_diff.encode()) > _DIFF_MAX_BYTES:
                 omitted = len(commit_diff.encode()) - _DIFF_MAX_BYTES

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -191,8 +191,14 @@ def resolve_path_at_ref(
     ref: str,
     cur_rel: str,
     env: dict[str, str] | None,
+    *,
+    to_ref: str = "HEAD",
 ) -> str | None:
-    """Return the path *cur_rel* had at *ref* via rename detection, else None."""
+    """Return the path *cur_rel* had at *ref* via rename/copy detection, else None.
+
+    Diffs ``ref..to_ref`` (``to_ref`` defaults to ``HEAD``).  Pass a specific
+    commit as *to_ref* to resolve a rename/copy a single commit introduced.
+    """
     try:
         result = subprocess.run(
             [
@@ -203,10 +209,12 @@ def resolve_path_at_ref(
                 "--name-status",
                 # 30% threshold: catch rename-with-edits per #338, avoid template false-positives.
                 "--find-renames=30",
+                # Enable copy detection at the same threshold.
+                "--find-copies=30",
                 # -z: NUL-terminated fields, tolerates tabs/newlines in paths.
                 "-z",
                 ref,
-                "HEAD",
+                to_ref,
             ],
             capture_output=True,
             text=True,
@@ -220,15 +228,11 @@ def resolve_path_at_ref(
     i = 0
     while i < len(items):
         status = items[i]
-        if status.startswith("R"):
+        if status.startswith(("R", "C")):
             if i + 2 >= len(items):
                 break
             if items[i + 2] == cur_rel:
                 return items[i + 1]
-            i += 3
-        elif status.startswith("C"):
-            if i + 2 >= len(items):
-                break
             i += 3
         else:
             if i + 1 >= len(items):

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -396,24 +396,6 @@ def get_file_diff(
                 diff += f"\n[diff truncated: {omitted} bytes omitted]"
             return diff
 
-        # Binary attachments: per-commit patches are equally meaningless, so
-        # detect binariness once up front (rename-aware, mirroring the
-        # non-per-commit branch) and emit a --stat per commit below.
-        try:
-            cur_rel = path.resolve().relative_to(git_root).as_posix()
-        except ValueError:
-            cur_rel = None
-        old_path = (
-            resolve_path_at_ref(git_root, ref, cur_rel, env)
-            if cur_rel is not None
-            else None
-        )
-        if old_path is None or cur_rel is None or old_path == cur_rel:
-            detect_args = [f"{ref}..HEAD", "--", path_str]
-        else:
-            detect_args = [f"{ref}:{old_path}", f"HEAD:{cur_rel}"]
-        binary = summarize_binary and _diff_is_binary(git_root, detect_args, env)
-
         # per_commit=True: enumerate commits in range then show each.
         # Use --name-only with a sentinel so we can recover the path the
         # file had at each commit — critical for correct diffs across
@@ -459,31 +441,60 @@ def get_file_diff(
             # Recover the path the file had at this specific commit.
             # With --follow, this will be the old name for pre-rename commits.
             commit_path = next((ln.strip() for ln in lines[1:] if ln.strip()), path_str)
-            # NOTE: for a renamed binary the per-commit `git show --stat
-            # -- commit_path` pathspec defeats git's rename pairing and renders a
-            # text-style stat instead of `Bin … bytes` — known limitation, see #683.
-            # The non-per-commit path is rename-aware.
-            show_cmd = [
+
+            # Build a rename/copy-aware diff target for THIS commit vs its parent,
+            # mirroring the non-per-commit branch, so a renamed binary pairs into
+            # `{old => new} | Bin OLD -> NEW` instead of an add/text stat (#683).
+            parent = f"{sha}^"
+            old_at_parent = resolve_path_at_ref(
+                git_root, parent, commit_path, env, to_ref=sha
+            )
+            if old_at_parent is not None and old_at_parent != commit_path:
+                commit_args = [f"{parent}:{old_at_parent}", f"{sha}:{commit_path}"]
+            else:
+                commit_args = [f"{parent}..{sha}", "--", commit_path]
+            # Classify binariness for THIS commit (not the whole range).
+            commit_binary = summarize_binary and _diff_is_binary(
+                git_root, commit_args, env
+            )
+            diff_cmd = [
                 "git",
                 "-C",
                 str(git_root),
-                "show",
-                "--format=",
-                "--stat" if binary else "-p",
-                sha,
-                "--",
-                commit_path,
+                "diff",
+                "--stat" if commit_binary else "-p",
+                *commit_args,
             ]
             try:
                 show_result = subprocess.run(
-                    show_cmd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=env,
+                    diff_cmd, capture_output=True, text=True, check=True, env=env
                 )
-            except subprocess.CalledProcessError as exc:
-                raise ValueError(f"Could not retrieve diff for commit {sha!r}") from exc
+            except subprocess.CalledProcessError:
+                # Parent-less (root) commit: {sha}^ does not resolve. Fall back to
+                # the add-form `git show` (the original behaviour for this case).
+                fallback_cmd = [
+                    "git",
+                    "-C",
+                    str(git_root),
+                    "show",
+                    "--format=",
+                    "--stat" if commit_binary else "-p",
+                    sha,
+                    "--",
+                    commit_path,
+                ]
+                try:
+                    show_result = subprocess.run(
+                        fallback_cmd,
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                        env=env,
+                    )
+                except subprocess.CalledProcessError as exc:
+                    raise ValueError(
+                        f"Could not retrieve diff for commit {sha!r}"
+                    ) from exc
             commit_diff = show_result.stdout.lstrip("\n")
             if len(commit_diff.encode()) > _DIFF_MAX_BYTES:
                 omitted = len(commit_diff.encode()) - _DIFF_MAX_BYTES

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -37,6 +37,9 @@ def _diff_is_binary(
     ``[f"{ref}:{old_path}", f"HEAD:{cur_rel}"]`` (rename-recovered). ``git diff
     --numstat`` prints ``-\\t-\\t<path>`` for binary and real counts for text;
     empty output (no change) → non-binary.
+    A non-zero git exit (e.g. a bad ref) yields empty stdout, so it is classified
+    non-binary; the error is then surfaced by the subsequent checked ``git diff``
+    call. This is a detection probe, not the final word.
     """
     result = subprocess.run(
         ["git", "-C", str(git_root), "diff", "--numstat", *diff_args],

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -151,11 +151,8 @@ class GitQueryManager:
             full unified diff like a ``.md`` note.
             Returns an empty string / empty list when the file has no changes
             in the given range, or when the vault's source directory is not
-            inside a git repository.
-
-            Per-commit (``per_commit=True``) diff of a *renamed* binary
-            attachment currently shows a text-style stat for the rename commit
-            rather than a ``Bin`` summary (#683).
+            inside a git repository.  Per-commit (``per_commit=True``)
+            attachment diffs are rename/copy-aware.
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -152,7 +152,7 @@ class GitQueryManager:
             Returns an empty string / empty list when the file has no changes
             in the given range, or when the vault's source directory is not
             inside a git repository.  Per-commit (``per_commit=True``)
-            attachment diffs are rename/copy-aware.
+            attachment diffs are rename-aware (a copied file renders as an add).
 
         Raises:
             ValueError: If exactly one of *since_sha* / *since_timestamp* is

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3657,6 +3657,96 @@ class TestGetFileDiff:
         assert show_seen
         assert any("+hello" in cd.diff for cd in out)
 
+    def test_get_file_diff_per_commit_parent_less_fallback_show_also_fails_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """When the primary per-commit diff fails AND the parent-less ``git show``
+        fallback also fails, ``ValueError("Could not retrieve diff for commit …")``
+        is raised (the nested ``exc2`` path).
+
+        Setup mirrors ``test_get_file_diff_per_commit_parent_less_falls_back_to_git_show``:
+        ``rev-parse --verify {sha}^`` returns non-zero (parent-less), so the
+        code takes the fallback branch — but then the fallback ``git show`` also
+        raises, triggering the inner ``except CalledProcessError as exc2`` re-raise.
+        """
+        from unittest.mock import patch
+
+        repo = tmp_path / "r"
+        repo.mkdir()
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
+        (repo / "seed.txt").write_text("seed\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "seed"],
+            check=True,
+            capture_output=True,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        (repo / "note.md").write_text("# added\nhello\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add note"],
+            check=True,
+            capture_output=True,
+        )
+
+        real_run = subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            # Force the primary per-commit diff (-p) to fail.
+            if (
+                isinstance(cmd, list)
+                and "diff" in cmd
+                and "-p" in cmd
+                and "--numstat" not in cmd
+            ):
+                raise subprocess.CalledProcessError(128, cmd)
+            # Return non-zero for `rev-parse --verify {sha}^` → parent-less.
+            if (
+                isinstance(cmd, list)
+                and "rev-parse" in cmd
+                and "--verify" in cmd
+                and any(a.endswith("^") for a in cmd)
+            ):
+                import subprocess as _sp
+
+                return _sp.CompletedProcess(
+                    args=cmd, returncode=1, stdout=b"", stderr=b""
+                )
+            # Force the fallback `git show` to also fail.
+            if isinstance(cmd, list) and "show" in cmd:
+                raise subprocess.CalledProcessError(128, cmd)
+            return real_run(cmd, *args, **kwargs)
+
+        strategy = GitWriteStrategy()
+        with (
+            patch("markdown_vault_mcp.git.subprocess.run", side_effect=fake_run),
+            pytest.raises(ValueError, match="Could not retrieve diff for commit"),
+        ):
+            strategy.get_file_diff(
+                repo,
+                repo / "note.md",
+                ref=first,
+                per_commit=True,
+                summarize_binary=False,
+            )
+
     def test_get_file_diff_per_commit_non_parent_less_diff_failure_raises(
         self, tmp_path: Path
     ) -> None:
@@ -3808,10 +3898,15 @@ class TestGetFileDiff:
             is None
         )
 
-    def test_resolve_path_at_ref_resolves_copy_entries(
+    def test_resolve_path_at_ref_skips_copy_entries(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """C<score> entries (copies) resolve to the copy source, same as renames."""
+        """C<score> entries (copies) are skipped — a copy is not a rename.
+
+        A copied file renders as a plain add in git's numstat output, so its
+        source path is not recovered.  The parser must advance past the
+        three-token C* record (status + old + new) without returning a result.
+        """
         fake_stdout = "C092\0source.md\0target.md\0"
 
         def fake_run(*_args: object, **_kw: object) -> subprocess.CompletedProcess[str]:
@@ -3824,7 +3919,7 @@ class TestGetFileDiff:
             GitWriteStrategy._resolve_path_at_ref(
                 tmp_path, "deadbeef", "target.md", env=None
             )
-            == "source.md"
+            is None
         )
 
     def test_resolve_path_at_ref_handles_truncated_rename_output(
@@ -4088,117 +4183,6 @@ def test_resolve_path_at_ref_to_ref_resolves_single_commit_rename(
         text=True,
     ).stdout.strip()
     assert resolve_path_at_ref(repo, f"{sha}^", "y.txt", None, to_ref=sha) == "x.txt"
-
-
-def test_resolve_path_at_ref_recovers_copy_source(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A git-detected copy (C*) resolves its source path (not skipped).
-
-    Git copy detection is heuristic and requires --find-copies, which may not
-    emit a C record for identical files on all platforms/versions.  This test
-    drives the parse branch directly via a monkeypatched subprocess.run that
-    returns a synthetic C100\\0src.txt\\0dst.txt\\0 stdout, ensuring the C*
-    branch actually returns the source rather than skipping the record.
-    """
-    from markdown_vault_mcp.git.query import resolve_path_at_ref
-
-    fake_stdout = "C100\0src.txt\0dst.txt\0"
-
-    def fake_run(*_args: object, **_kw: object) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(
-            args=[], returncode=0, stdout=fake_stdout, stderr=""
-        )
-
-    monkeypatch.setattr("markdown_vault_mcp.git.query.subprocess.run", fake_run)
-    assert resolve_path_at_ref(tmp_path, "deadbeef", "dst.txt", None) == "src.txt"
-
-
-def test_resolve_path_at_ref_real_git_copy(tmp_path: Path) -> None:
-    """resolve_path_at_ref resolves a C* entry using a real git repo.
-
-    --find-copies=30 (not -harder) only emits a C record when the copy source
-    was ALSO MODIFIED in the same commit.  This test builds exactly that
-    shape: commit 1 adds ``src.txt``; commit 2 both modifies ``src.txt`` and
-    adds an identical-content ``dst.txt`` so that git detects the copy.
-
-    If the local git version does not emit a ``C`` record (returns ``None``
-    instead of ``"src.txt"``), the test is skipped with a note about what git
-    actually emitted, so the synthetic test above remains the primary
-    behavioural guard.
-    """
-    import subprocess as _sp
-
-    from markdown_vault_mcp.git.query import resolve_path_at_ref
-
-    repo = tmp_path / "r"
-    repo.mkdir()
-    for a in (
-        ["init"],
-        ["config", "user.email", "t@t"],
-        ["config", "user.name", "t"],
-    ):
-        _sp.run(["git", "-C", str(repo), *a], check=True, capture_output=True)
-    (repo / "src.txt").write_text("hello world this is the source\n")
-    _sp.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True)
-    _sp.run(
-        ["git", "-C", str(repo), "commit", "-m", "c1 add src"],
-        check=True,
-        capture_output=True,
-    )
-    c1 = _sp.run(
-        ["git", "-C", str(repo), "rev-parse", "HEAD"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-    # Modify src.txt AND add dst.txt as a copy of its pre-modification content.
-    # For copy detection we need dst.txt to be similar-enough to the original
-    # src.txt content; appending to src gives git the modified-source signal.
-    (repo / "dst.txt").write_text("hello world this is the source\n")
-    (repo / "src.txt").write_text("hello world this is the source\nmodified\n")
-    _sp.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True)
-    _sp.run(
-        ["git", "-C", str(repo), "commit", "-m", "c2 modify src copy to dst"],
-        check=True,
-        capture_output=True,
-    )
-    c2 = _sp.run(
-        ["git", "-C", str(repo), "rev-parse", "HEAD"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-
-    # Verify what git actually emits — if no C record is emitted on this git
-    # version, skip rather than assert a wrong outcome.
-    probe = _sp.run(
-        [
-            "git",
-            "-C",
-            str(repo),
-            "diff",
-            "--name-status",
-            "--find-renames=30",
-            "--find-copies=30",
-            c1,
-            c2,
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    has_copy_record = any(line.startswith("C") for line in probe.stdout.splitlines())
-    if not has_copy_record:
-        pytest.skip(
-            f"git did not emit a C record for this copy shape on this version; "
-            f"git output: {probe.stdout.strip()!r}"
-        )
-
-    result = resolve_path_at_ref(repo, c1, "dst.txt", None, to_ref=c2)
-    assert result == "src.txt", (
-        f"Expected 'src.txt' but got {result!r}; git output: {probe.stdout.strip()!r}"
-    )
 
 
 class TestGetFileHistoryVaultScope:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4163,6 +4163,57 @@ class TestGetFileDiff:
         assert isinstance(out, list) and out
         assert any("Bin" in cd.diff for cd in out)
 
+    def test_empty_tree_resolution_matches_repo_object_format(
+        self, tmp_path: Path
+    ) -> None:
+        """The empty-tree object resolved via ``git hash-object`` matches the repo's
+        hash algorithm: the SHA-1 constant for a sha1 repo, a distinct 64-hex SHA for
+        a sha256 repo (the hardcoded SHA-1 constant is invalid there) (#683).
+
+        This pins the load-bearing change behind FIX 2: the parent-less root-binary
+        fallback now classifies against the dynamically-resolved empty tree instead of
+        the hardcoded SHA-1 constant, so SHA-256 repos no longer fail ``git diff``.
+        """
+        from markdown_vault_mcp.git.query import _EMPTY_TREE_SHA
+
+        sha1_repo = tmp_path / "sha1"
+        sha1_repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(sha1_repo), "init"], check=True, capture_output=True
+        )
+        sha1_empty = subprocess.run(
+            ["git", "-C", str(sha1_repo), "hash-object", "-t", "tree", "--stdin"],
+            input="",
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+        assert sha1_empty == _EMPTY_TREE_SHA
+
+        sha256_repo = tmp_path / "sha256"
+        sha256_repo.mkdir()
+        init = subprocess.run(
+            ["git", "-C", str(sha256_repo), "init", "--object-format=sha256"],
+            capture_output=True,
+            text=True,
+        )
+        if init.returncode != 0:
+            pytest.skip(
+                "local git does not support --object-format=sha256: "
+                f"{(init.stderr or '').strip()}"
+            )
+        sha256_empty = subprocess.run(
+            ["git", "-C", str(sha256_repo), "hash-object", "-t", "tree", "--stdin"],
+            input="",
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+        # A 64-hex SHA, distinct from the SHA-1 constant — proving the hardcoded
+        # constant would be the wrong object to diff against in a sha256 repo.
+        assert len(sha256_empty) == 64
+        assert sha256_empty != _EMPTY_TREE_SHA
+
     def test_get_file_diff_per_commit_copy_renders_as_add(self, tmp_path: Path) -> None:
         """A copied binary renders as a plain ``Bin`` add, not a mislabelled rename (#683).
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3901,13 +3901,25 @@ class TestGetFileDiff:
     def test_resolve_path_at_ref_skips_copy_entries(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """C<score> entries (copies) are skipped — a copy is not a rename.
+        """C<score> entries (copies) are skipped and the parser stays in sync.
 
-        A copied file renders as a plain add in git's numstat output, so its
-        source path is not recovered.  The parser must advance past the
-        three-token C* record (status + old + new) without returning a result.
+        A copied file renders as a plain add (git does not emit C* records
+        without ``--find-copies``), so its source path is not recovered.
+        The parser must advance past the three-token C* record (status + old +
+        new) with ``i += 3``, NOT ``i += 2``.
+
+        A single-entry fixture is insufficient: a lone C* record returns None
+        regardless of whether the C-branch exists (the loop just ends).  This
+        two-record fixture — a copy followed by a DIFFERENT rename — requires
+        the correct three-field advance to land on and parse the following R*
+        record.  With a wrong ``i += 2`` advance the loop desyncs and returns
+        None instead of the expected "old.md".
         """
-        fake_stdout = "C092\0source.md\0target.md\0"
+        # C* (3 fields) followed immediately by R* (3 fields).
+        # The C* copy must be skipped with i += 3 so the R* is reached.
+        fake_stdout = (
+            "C092\x00copied_src.md\x00copied_dst.md\x00R100\x00old.md\x00wanted.md\x00"
+        )
 
         def fake_run(*_args: object, **_kw: object) -> subprocess.CompletedProcess[str]:
             return subprocess.CompletedProcess(
@@ -3915,11 +3927,20 @@ class TestGetFileDiff:
             )
 
         monkeypatch.setattr("markdown_vault_mcp.git.subprocess.run", fake_run)
+        # The copy target ("copied_dst.md") must NOT be resolved.
         assert (
             GitWriteStrategy._resolve_path_at_ref(
-                tmp_path, "deadbeef", "target.md", env=None
+                tmp_path, "deadbeef", "copied_dst.md", env=None
             )
             is None
+        )
+        # The rename target ("wanted.md") MUST be resolved — only reachable if
+        # the C* record was consumed with the correct i += 3 advance.
+        assert (
+            GitWriteStrategy._resolve_path_at_ref(
+                tmp_path, "deadbeef", "wanted.md", env=None
+            )
+            == "old.md"
         )
 
     def test_resolve_path_at_ref_handles_truncated_rename_output(
@@ -4141,6 +4162,66 @@ class TestGetFileDiff:
         assert empty_tree_numstat_seen
         assert isinstance(out, list) and out
         assert any("Bin" in cd.diff for cd in out)
+
+    def test_get_file_diff_per_commit_copy_renders_as_add(self, tmp_path: Path) -> None:
+        """A copied binary renders as a plain ``Bin`` add, not a mislabelled rename (#683).
+
+        Without ``--find-copies`` git reports a ``cp``-based copy as ``A``
+        (add), so ``resolve_path_at_ref`` sees no rename and falls back to the
+        plain ``{sha}^..{sha} -- path`` diff form.  The ``--stat`` output must
+        contain ``Bin`` (binary add) and must NOT contain ``=>`` (which would
+        indicate a spurious rename pairing).
+        """
+        repo = tmp_path / "r"
+        repo.mkdir()
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
+        assets = repo / "assets"
+        assets.mkdir()
+        (assets / "orig.png").write_bytes(b"PNG\x00" + b"\xaa" * 300)
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add orig"],
+            check=True,
+            capture_output=True,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        import shutil
+
+        shutil.copyfile(assets / "orig.png", assets / "copy.png")  # source unchanged
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add copy.png"],
+            check=True,
+            capture_output=True,
+        )
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "copy.png",
+            ref=first,
+            per_commit=True,
+            summarize_binary=True,
+        )
+        assert isinstance(out, list) and out
+        copy_entry = out[0]  # newest = the copy-add commit
+        assert "Bin" in copy_entry.diff
+        assert "=>" not in copy_entry.diff  # plain add, NOT a mislabelled rename
 
 
 def test_resolve_path_at_ref_to_ref_resolves_single_commit_rename(

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3169,7 +3169,14 @@ class TestGetFileDiff:
         assert not diffs[0].diff.startswith("\n")
 
     def test_per_commit_diff_across_rename(self, tmp_path: Path) -> None:
-        """Per-commit diffs are non-empty even for commits before a rename."""
+        """A per-commit rename+edit shows the content delta, not a full-file add.
+
+        The per-commit path is now rename-aware (mirrors the non-per-commit
+        branch, #683): for the rename commit it diffs the old blob against the
+        new blob (``git diff <sha>^:old <sha>:new``), so a rename-with-edit
+        yields a real content delta — ``-Original`` / ``+Modified`` — instead of
+        the old, rename-unaware full-file add (``git show -- new``).
+        """
         from markdown_vault_mcp.types import CommitDiff
 
         repo = tmp_path / "repo"
@@ -3188,7 +3195,7 @@ class TestGetFileDiff:
             check=True,
         )
         # Commit 1: add note.md
-        (repo / "note.md").write_text("# v1\n")
+        (repo / "note.md").write_text("# Title\nOriginal line\n")
         subprocess.run(
             ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
         )
@@ -3203,14 +3210,18 @@ class TestGetFileDiff:
             text=True,
             check=True,
         ).stdout.strip()
-        # Commit 2: rename note.md -> renamed.md
+        # Commit 2: rename note.md -> renamed.md AND edit its content.
         subprocess.run(
             ["git", "-C", str(repo), "mv", "note.md", "renamed.md"],
             capture_output=True,
             check=True,
         )
+        (repo / "renamed.md").write_text("# Title\nModified line\n")
         subprocess.run(
-            ["git", "-C", str(repo), "commit", "-m", "rename to renamed.md"],
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "rename+edit renamed.md"],
             capture_output=True,
             check=True,
         )
@@ -3222,8 +3233,9 @@ class TestGetFileDiff:
         assert isinstance(diffs, list)
         assert len(diffs) == 1
         assert isinstance(diffs[0], CommitDiff)
-        # The rename commit should produce a non-empty diff
-        assert diffs[0].diff
+        # Rename-aware content delta, not a full-file add.
+        assert "-Original line" in diffs[0].diff
+        assert "+Modified line" in diffs[0].diff
 
     def test_single_diff_across_rename(self, tmp_path: Path) -> None:
         """Single diff shows content delta across renames, not a full-file add."""
@@ -3373,81 +3385,327 @@ class TestGetFileDiff:
         assert "Binary files" not in out  # full binary patch marker must be absent
         assert "@@" not in out
 
-    def test_get_file_diff_per_commit_renamed_binary_degraded_stat(
-        self, tmp_path: Path
-    ) -> None:
-        """KNOWN LIMITATION (#683): per-commit --stat of a RENAMED binary shows a
-        text-style stat for the rename commit, not a ``Bin`` summary, because the
-        single-path pathspec defeats git's rename pairing in ``git show``. The
-        non-per-commit path IS rename-aware. Flip this assertion to require
-        ``' -> '``/``Bin`` when #683 is fixed.
+    def _bin_rename_repo(self, tmp_path: Path) -> tuple[Path, str]:
+        """Repo where a STAYS-binary attachment is renamed across commits.
+
+        v1 and v2 both carry a NUL (both binary); high similarity so
+        ``--find-renames=30`` pairs them.  Returns the repo path and the first
+        (pre-rename) commit SHA.
         """
-        repo = tmp_path / "repo"
+        repo = tmp_path / "r"
         repo.mkdir()
-        subprocess.run(
-            ["git", "-C", str(repo), "init"], capture_output=True, check=True
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "config", "user.email", "t@t.com"],
-            capture_output=True,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "config", "user.name", "T"],
-            capture_output=True,
-            check=True,
-        )
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
         assets = repo / "assets"
         assets.mkdir()
-        # Same fixture as test_get_file_diff_binary_attachment_stat_across_rename:
-        # NUL-carrying v1 (binary) renamed to y.png with tweaked bytes (v2,
-        # no NUL, high similarity so --find-renames=30 pairs them).
         common = b"\x89PNG\r\n\x1a\n" + (b"\xaa" * 200)
-        v1 = common + b"\x00" + (b"\xbb" * 50)
-        v2 = common + b"\x11" + (b"\xcc" * 50)
-        (assets / "x.png").write_bytes(v1)
+        (assets / "x.png").write_bytes(common + b"\x00" + (b"\xbb" * 50))
         subprocess.run(
-            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
         )
         subprocess.run(
             ["git", "-C", str(repo), "commit", "-m", "add x.png"],
-            capture_output=True,
             check=True,
+            capture_output=True,
         )
-        first_sha = subprocess.run(
+        first = subprocess.run(
             ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
             capture_output=True,
             text=True,
-            check=True,
         ).stdout.strip()
         subprocess.run(
             ["git", "-C", str(repo), "mv", "assets/x.png", "assets/y.png"],
-            capture_output=True,
             check=True,
-        )
-        (assets / "y.png").write_bytes(v2)
-        subprocess.run(
-            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "commit", "-m", "rename+edit x.png -> y.png"],
             capture_output=True,
-            check=True,
         )
+        (assets / "y.png").write_bytes(common + b"\x00" + (b"\xcc" * 50))
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "rename + edit"],
+            check=True,
+            capture_output=True,
+        )
+        return repo, first
 
+    def test_get_file_diff_per_commit_renamed_binary_is_rename_paired(
+        self, tmp_path: Path
+    ) -> None:
+        """#683 FIXED: per-commit --stat of a renamed binary is a paired rename stat."""
+        repo, first = self._bin_rename_repo(tmp_path)
         strategy = GitWriteStrategy()
         out = strategy.get_file_diff(
             repo,
             repo / "assets" / "y.png",
-            ref=first_sha,
+            ref=first,
             per_commit=True,
             summarize_binary=True,
         )
         assert isinstance(out, list) and out
-        # Currently NO Bin/arrow marker on any per-commit entry (the #683 bug):
-        # git show --stat -- commit_path defeats rename pairing and shows a
-        # text-style count instead of "Bin N -> M bytes".
-        assert not any(" -> " in cd.diff for cd in out)
+        rename_entry = out[0]  # newest-first = the rename+edit commit
+        assert " -> " in rename_entry.diff and "=>" in rename_entry.diff
+        assert "@@" not in rename_entry.diff
+
+    def test_get_file_diff_per_commit_classifies_binariness_per_commit(
+        self, tmp_path: Path
+    ) -> None:
+        """A file binary at one commit and text at another is labelled per-commit."""
+        repo = tmp_path / "r"
+        repo.mkdir()
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
+        assets = repo / "assets"
+        assets.mkdir()
+        (assets / "f.dat").write_text("plain text v1\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "c1 text"],
+            check=True,
+            capture_output=True,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        (assets / "f.dat").write_text("plain text v2\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-am", "c2 text edit"],
+            check=True,
+            capture_output=True,
+        )
+        (assets / "f.dat").write_bytes(b"now\x00binary\x00bytes")
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-am", "c3 becomes binary"],
+            check=True,
+            capture_output=True,
+        )
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "f.dat",
+            ref=first,
+            per_commit=True,
+            summarize_binary=True,
+        )
+        assert isinstance(out, list)
+        assert any(
+            "Bin" in cd.diff and "@@" not in cd.diff for cd in out
+        )  # binary commit
+        assert any("@@" in cd.diff for cd in out)  # text commit
+
+    def test_get_file_diff_per_commit_binary_added_in_first_in_range_commit(
+        self, tmp_path: Path
+    ) -> None:
+        """A binary added in the first in-range commit still produces a Bin stat
+        (no {sha}^ crash when the parent resolution / two-blob form can't apply).
+        """
+        repo = tmp_path / "r"
+        repo.mkdir()
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
+        (repo / "seed.txt").write_text("seed\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "seed"],
+            check=True,
+            capture_output=True,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assets = repo / "assets"
+        assets.mkdir()
+        (assets / "z.png").write_bytes(b"PNG\x00data")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add z.png"],
+            check=True,
+            capture_output=True,
+        )
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "z.png",
+            ref=first,
+            per_commit=True,
+            summarize_binary=True,
+        )
+        assert isinstance(out, list) and out
+        assert any("Bin" in cd.diff for cd in out)
+
+    def test_get_file_diff_per_commit_falls_back_to_git_show_when_parent_diff_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """When the parent-relative ``git diff`` can't run (e.g. a parent-less
+        commit whose ``{sha}^`` does not resolve), the per-commit branch falls
+        back to the add-form ``git show`` rather than crashing (#683)."""
+        from unittest.mock import patch
+
+        repo = tmp_path / "r"
+        repo.mkdir()
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
+        (repo / "seed.txt").write_text("seed\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "seed"],
+            check=True,
+            capture_output=True,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        (repo / "note.md").write_text("# added\nhello\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add note"],
+            check=True,
+            capture_output=True,
+        )
+
+        real_run = subprocess.run
+        show_seen: list[bool] = []
+
+        def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            # Force ONLY the parent-relative per-commit diff to fail (the
+            # `git diff -p <parent>..<sha> -- <path>` / blob-pair command), so
+            # the fallback `git show` branch is exercised.  The `git diff
+            # --numstat` binariness probe runs check=False and must pass through.
+            if (
+                isinstance(cmd, list)
+                and "diff" in cmd
+                and "-p" in cmd
+                and "--numstat" not in cmd
+            ):
+                raise subprocess.CalledProcessError(128, cmd)
+            if isinstance(cmd, list) and "show" in cmd:
+                show_seen.append(True)
+            return real_run(cmd, *args, **kwargs)
+
+        strategy = GitWriteStrategy()
+        with patch("markdown_vault_mcp.git.subprocess.run", side_effect=fake_run):
+            out = strategy.get_file_diff(
+                repo,
+                repo / "note.md",
+                ref=first,
+                per_commit=True,
+                summarize_binary=False,
+            )
+        assert isinstance(out, list) and out
+        # Fallback used and produced the add-form diff for the note.
+        assert show_seen
+        assert any("+hello" in cd.diff for cd in out)
+
+    def test_get_file_diff_per_commit_falls_back_then_raises_on_show_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """If both the parent-relative diff AND the fallback ``git show`` fail,
+        the per-commit branch raises a ValueError naming the commit (#683)."""
+        from unittest.mock import patch
+
+        repo = tmp_path / "r"
+        repo.mkdir()
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
+        (repo / "seed.txt").write_text("seed\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "seed"],
+            check=True,
+            capture_output=True,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        (repo / "note.md").write_text("# added\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add note"],
+            check=True,
+            capture_output=True,
+        )
+
+        real_run = subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            # Fail both the per-commit diff (-p, not the --numstat probe) and the
+            # fallback `git show`; let log enumeration / numstat pass through.
+            if isinstance(cmd, list) and (
+                ("diff" in cmd and "-p" in cmd and "--numstat" not in cmd)
+                or "show" in cmd
+            ):
+                raise subprocess.CalledProcessError(128, cmd)
+            return real_run(cmd, *args, **kwargs)
+
+        strategy = GitWriteStrategy()
+        with (
+            patch("markdown_vault_mcp.git.subprocess.run", side_effect=fake_run),
+            pytest.raises(ValueError, match="Could not retrieve diff for commit"),
+        ):
+            strategy.get_file_diff(
+                repo,
+                repo / "note.md",
+                ref=first,
+                per_commit=True,
+                summarize_binary=False,
+            )
 
     def test_get_file_diff_summarize_binary_invalid_ref_raises(
         self, tmp_path: Path

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3451,7 +3451,9 @@ class TestGetFileDiff:
         )
         assert isinstance(out, list) and out
         rename_entry = out[0]  # newest-first = the rename+edit commit
-        assert " -> " in rename_entry.diff and "=>" in rename_entry.diff
+        # `{x.png => y.png}` (the => rename-pair marker) appears ONLY in the paired
+        # form; the old broken `Bin 0 -> N bytes` add-stat does not contain it.
+        assert "=>" in rename_entry.diff and "Bin" in rename_entry.diff
         assert "@@" not in rename_entry.diff
 
     def test_get_file_diff_per_commit_classifies_binariness_per_commit(
@@ -3514,8 +3516,8 @@ class TestGetFileDiff:
     def test_get_file_diff_per_commit_binary_added_in_first_in_range_commit(
         self, tmp_path: Path
     ) -> None:
-        """A binary added in the first in-range commit still produces a Bin stat
-        (no {sha}^ crash when the parent resolution / two-blob form can't apply).
+        """A plain binary add (no rename) in an in-range commit still yields a
+        ``Bin`` stat via the non-rename ``git diff {sha}^..{sha} -- path`` form.
         """
         repo = tmp_path / "r"
         repo.mkdir()
@@ -3564,12 +3566,16 @@ class TestGetFileDiff:
         assert isinstance(out, list) and out
         assert any("Bin" in cd.diff for cd in out)
 
-    def test_get_file_diff_per_commit_falls_back_to_git_show_when_parent_diff_fails(
+    def test_get_file_diff_per_commit_parent_less_falls_back_to_git_show(
         self, tmp_path: Path
     ) -> None:
-        """When the parent-relative ``git diff`` can't run (e.g. a parent-less
-        commit whose ``{sha}^`` does not resolve), the per-commit branch falls
-        back to the add-form ``git show`` rather than crashing (#683)."""
+        """For a genuinely parent-less (root/orphan) commit the per-commit branch
+        falls back to the add-form ``git show`` rather than crashing (#683).
+
+        The ``rev-parse --verify {sha}^`` probe returns non-zero (no parent),
+        so the code classifies this as an orphan commit and uses the fallback
+        instead of surfacing the diff failure as a ``ValueError``.
+        """
         from unittest.mock import patch
 
         repo = tmp_path / "r"
@@ -3611,10 +3617,10 @@ class TestGetFileDiff:
         show_seen: list[bool] = []
 
         def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
-            # Force ONLY the parent-relative per-commit diff to fail (the
-            # `git diff -p <parent>..<sha> -- <path>` / blob-pair command), so
-            # the fallback `git show` branch is exercised.  The `git diff
-            # --numstat` binariness probe runs check=False and must pass through.
+            # Simulate a parent-less commit by:
+            # 1. Forcing the parent-relative per-commit diff (-p, not --numstat) to fail.
+            # 2. Returning non-zero for the `rev-parse --verify {sha}^` parent probe,
+            #    so the code classifies the commit as parent-less and uses the fallback.
             if (
                 isinstance(cmd, list)
                 and "diff" in cmd
@@ -3622,6 +3628,17 @@ class TestGetFileDiff:
                 and "--numstat" not in cmd
             ):
                 raise subprocess.CalledProcessError(128, cmd)
+            if (
+                isinstance(cmd, list)
+                and "rev-parse" in cmd
+                and "--verify" in cmd
+                and any(a.endswith("^") for a in cmd)
+            ):
+                import subprocess as _sp
+
+                return _sp.CompletedProcess(
+                    args=cmd, returncode=1, stdout=b"", stderr=b""
+                )
             if isinstance(cmd, list) and "show" in cmd:
                 show_seen.append(True)
             return real_run(cmd, *args, **kwargs)
@@ -3640,11 +3657,16 @@ class TestGetFileDiff:
         assert show_seen
         assert any("+hello" in cd.diff for cd in out)
 
-    def test_get_file_diff_per_commit_falls_back_then_raises_on_show_failure(
+    def test_get_file_diff_per_commit_non_parent_less_diff_failure_raises(
         self, tmp_path: Path
     ) -> None:
-        """If both the parent-relative diff AND the fallback ``git show`` fail,
-        the per-commit branch raises a ValueError naming the commit (#683)."""
+        """A per-commit diff failure on a commit that HAS a parent raises
+        ``ValueError`` immediately (not a silent fallback to an add-form diff).
+
+        This is the scoping introduced by #683: the old broad ``except`` silently
+        degraded any diff failure; the new code checks whether the commit is
+        parent-less and only falls back for genuine root/orphan commits.  Any
+        other diff failure is a real error and must surface."""
         from unittest.mock import patch
 
         repo = tmp_path / "r"
@@ -3685,11 +3707,11 @@ class TestGetFileDiff:
         real_run = subprocess.run
 
         def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
-            # Fail both the per-commit diff (-p, not the --numstat probe) and the
-            # fallback `git show`; let log enumeration / numstat pass through.
+            # Fail the per-commit diff (-p, not the --numstat probe); let everything
+            # else including `rev-parse --verify` pass through so the code sees a
+            # commit that HAS a parent → ValueError rather than fallback.
             if isinstance(cmd, list) and (
-                ("diff" in cmd and "-p" in cmd and "--numstat" not in cmd)
-                or "show" in cmd
+                "diff" in cmd and "-p" in cmd and "--numstat" not in cmd
             ):
                 raise subprocess.CalledProcessError(128, cmd)
             return real_run(cmd, *args, **kwargs)
@@ -3926,6 +3948,93 @@ def test_resolve_path_at_ref_recovers_copy_source(
 
     monkeypatch.setattr("markdown_vault_mcp.git.query.subprocess.run", fake_run)
     assert resolve_path_at_ref(tmp_path, "deadbeef", "dst.txt", None) == "src.txt"
+
+
+def test_resolve_path_at_ref_real_git_copy(tmp_path: Path) -> None:
+    """resolve_path_at_ref resolves a C* entry using a real git repo.
+
+    --find-copies=30 (not -harder) only emits a C record when the copy source
+    was ALSO MODIFIED in the same commit.  This test builds exactly that
+    shape: commit 1 adds ``src.txt``; commit 2 both modifies ``src.txt`` and
+    adds an identical-content ``dst.txt`` so that git detects the copy.
+
+    If the local git version does not emit a ``C`` record (returns ``None``
+    instead of ``"src.txt"``), the test is skipped with a note about what git
+    actually emitted, so the synthetic test above remains the primary
+    behavioural guard.
+    """
+    import subprocess as _sp
+
+    from markdown_vault_mcp.git.query import resolve_path_at_ref
+
+    repo = tmp_path / "r"
+    repo.mkdir()
+    for a in (
+        ["init"],
+        ["config", "user.email", "t@t"],
+        ["config", "user.name", "t"],
+    ):
+        _sp.run(["git", "-C", str(repo), *a], check=True, capture_output=True)
+    (repo / "src.txt").write_text("hello world this is the source\n")
+    _sp.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True)
+    _sp.run(
+        ["git", "-C", str(repo), "commit", "-m", "c1 add src"],
+        check=True,
+        capture_output=True,
+    )
+    c1 = _sp.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    # Modify src.txt AND add dst.txt as a copy of its pre-modification content.
+    # For copy detection we need dst.txt to be similar-enough to the original
+    # src.txt content; appending to src gives git the modified-source signal.
+    (repo / "dst.txt").write_text("hello world this is the source\n")
+    (repo / "src.txt").write_text("hello world this is the source\nmodified\n")
+    _sp.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True)
+    _sp.run(
+        ["git", "-C", str(repo), "commit", "-m", "c2 modify src copy to dst"],
+        check=True,
+        capture_output=True,
+    )
+    c2 = _sp.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    # Verify what git actually emits — if no C record is emitted on this git
+    # version, skip rather than assert a wrong outcome.
+    probe = _sp.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "diff",
+            "--name-status",
+            "--find-renames=30",
+            "--find-copies=30",
+            c1,
+            c2,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    has_copy_record = any(line.startswith("C") for line in probe.stdout.splitlines())
+    if not has_copy_record:
+        pytest.skip(
+            f"git did not emit a C record for this copy shape on this version; "
+            f"git output: {probe.stdout.strip()!r}"
+        )
+
+    result = resolve_path_at_ref(repo, c1, "dst.txt", None, to_ref=c2)
+    assert result == "src.txt", (
+        f"Expected 'src.txt' but got {result!r}; git output: {probe.stdout.strip()!r}"
+    )
 
 
 class TestGetFileHistoryVaultScope:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3528,10 +3528,10 @@ class TestGetFileDiff:
             is None
         )
 
-    def test_resolve_path_at_ref_skips_copy_entries(
+    def test_resolve_path_at_ref_resolves_copy_entries(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """C<score> entries (copies) are skipped, never returned as a rename match."""
+        """C<score> entries (copies) resolve to the copy source, same as renames."""
         fake_stdout = "C092\0source.md\0target.md\0"
 
         def fake_run(*_args: object, **_kw: object) -> subprocess.CompletedProcess[str]:
@@ -3544,7 +3544,7 @@ class TestGetFileDiff:
             GitWriteStrategy._resolve_path_at_ref(
                 tmp_path, "deadbeef", "target.md", env=None
             )
-            is None
+            == "source.md"
         )
 
     def test_resolve_path_at_ref_handles_truncated_rename_output(
@@ -3602,6 +3602,72 @@ class TestGetFileDiff:
             pytest.raises(ValueError, match="git log failed"),
         ):
             strategy.get_file_history(repo, path=None, since=None, limit=20)
+
+
+def test_resolve_path_at_ref_to_ref_resolves_single_commit_rename(
+    tmp_path: Path,
+) -> None:
+    """resolve_path_at_ref with to_ref resolves a rename a single commit made."""
+    import subprocess as _sp
+
+    from markdown_vault_mcp.git.query import resolve_path_at_ref
+
+    repo = tmp_path / "r"
+    repo.mkdir()
+    for a in (
+        ["init"],
+        ["config", "user.email", "t@t"],
+        ["config", "user.name", "t"],
+    ):
+        _sp.run(["git", "-C", str(repo), *a], check=True, capture_output=True)
+    (repo / "x.txt").write_text("hello\n")
+    _sp.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True)
+    _sp.run(
+        ["git", "-C", str(repo), "commit", "-m", "c1"],
+        check=True,
+        capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(repo), "mv", "x.txt", "y.txt"],
+        check=True,
+        capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(repo), "commit", "-m", "c2"],
+        check=True,
+        capture_output=True,
+    )
+    sha = _sp.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert resolve_path_at_ref(repo, f"{sha}^", "y.txt", None, to_ref=sha) == "x.txt"
+
+
+def test_resolve_path_at_ref_recovers_copy_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A git-detected copy (C*) resolves its source path (not skipped).
+
+    Git copy detection is heuristic and requires --find-copies, which may not
+    emit a C record for identical files on all platforms/versions.  This test
+    drives the parse branch directly via a monkeypatched subprocess.run that
+    returns a synthetic C100\\0src.txt\\0dst.txt\\0 stdout, ensuring the C*
+    branch actually returns the source rather than skipping the record.
+    """
+    from markdown_vault_mcp.git.query import resolve_path_at_ref
+
+    fake_stdout = "C100\0src.txt\0dst.txt\0"
+
+    def fake_run(*_args: object, **_kw: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=fake_stdout, stderr=""
+        )
+
+    monkeypatch.setattr("markdown_vault_mcp.git.query.subprocess.run", fake_run)
+    assert resolve_path_at_ref(tmp_path, "deadbeef", "dst.txt", None) == "src.txt"
 
 
 class TestGetFileHistoryVaultScope:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3883,6 +3883,170 @@ class TestGetFileDiff:
         ):
             strategy.get_file_history(repo, path=None, since=None, limit=20)
 
+    def test_get_file_diff_per_commit_pure_rename_emits_marker(
+        self, tmp_path: Path
+    ) -> None:
+        """A pure rename with no content change shows a rename marker, not an empty
+        diff (the two-blob diff of identical blobs is empty) (#683)."""
+        repo = tmp_path / "r"
+        repo.mkdir()
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
+        assets = repo / "assets"
+        assets.mkdir()
+        (assets / "a.txt").write_text("stable content, never edited\n" * 5)
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add a"],
+            check=True,
+            capture_output=True,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "-C", str(repo), "mv", "assets/a.txt", "assets/b.txt"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "pure rename"],
+            check=True,
+            capture_output=True,
+        )
+        strategy = GitWriteStrategy()
+        out = strategy.get_file_diff(
+            repo,
+            repo / "assets" / "b.txt",
+            ref=first,
+            per_commit=True,
+            summarize_binary=True,
+        )
+        assert isinstance(out, list) and out
+        # The rename commit must NOT be an empty diff; it shows the rename marker.
+        assert any(cd.diff.strip() for cd in out)
+        assert any("=>" in cd.diff and "renamed" in cd.diff for cd in out)
+
+    def test_get_file_diff_per_commit_root_binary_classification_fires(
+        self, tmp_path: Path
+    ) -> None:
+        """parent-less + summarize_binary=True classifies the file against the empty
+        tree so a root binary commit gets a Bin --stat rather than a raw patch (#683).
+
+        The mock forces the primary diff to fail and the parent-probe to return
+        non-zero (orphan), then presents the empty-tree numstat as binary and the
+        fallback git-show --stat as a Bin line.
+        """
+        from unittest.mock import patch
+
+        repo = tmp_path / "r"
+        repo.mkdir()
+        for a in (
+            ["init"],
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "t"],
+        ):
+            subprocess.run(
+                ["git", "-C", str(repo), *a], check=True, capture_output=True
+            )
+        (repo / "seed.txt").write_text("seed\n")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "seed"],
+            check=True,
+            capture_output=True,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assets = repo / "assets"
+        assets.mkdir()
+        (assets / "z.bin").write_bytes(b"BIN\x00DATA")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "add z.bin"],
+            check=True,
+            capture_output=True,
+        )
+
+        real_run = subprocess.run
+        empty_tree_numstat_seen: list[bool] = []
+
+        def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            # 1. Force the primary per-commit diff (--stat or -p, not --numstat) to fail.
+            if isinstance(cmd, list) and "diff" in cmd and "--numstat" not in cmd:
+                raise subprocess.CalledProcessError(128, cmd)
+            # 2. Make the parent-probe return non-zero so the code treats it as orphan.
+            if (
+                isinstance(cmd, list)
+                and "rev-parse" in cmd
+                and "--verify" in cmd
+                and any(a.endswith("^") for a in cmd)
+            ):
+                import subprocess as _sp
+
+                return _sp.CompletedProcess(
+                    args=cmd, returncode=1, stdout=b"", stderr=b""
+                )
+            # 3. Make the empty-tree numstat classify the file as binary.
+            from markdown_vault_mcp.git.query import _EMPTY_TREE_SHA
+
+            if (
+                isinstance(cmd, list)
+                and "diff" in cmd
+                and "--numstat" in cmd
+                and _EMPTY_TREE_SHA in cmd
+            ):
+                empty_tree_numstat_seen.append(True)
+                import subprocess as _sp
+
+                return _sp.CompletedProcess(
+                    args=cmd, returncode=0, stdout="-\t-\tassets/z.bin\n", stderr=""
+                )
+            # 4. The fallback git-show --stat returns a Bin line.
+            if isinstance(cmd, list) and "show" in cmd and "--stat" in cmd:
+                import subprocess as _sp
+
+                return _sp.CompletedProcess(
+                    args=cmd,
+                    returncode=0,
+                    stdout=" assets/z.bin | Bin 0 -> 8 bytes\n",
+                    stderr="",
+                )
+            return real_run(cmd, *args, **kwargs)
+
+        strategy = GitWriteStrategy()
+        with patch("markdown_vault_mcp.git.subprocess.run", side_effect=fake_run):
+            out = strategy.get_file_diff(
+                repo,
+                repo / "assets" / "z.bin",
+                ref=first,
+                per_commit=True,
+                summarize_binary=True,
+            )
+        # The empty-tree numstat probe fired (load-bearing: classifies the root binary).
+        assert empty_tree_numstat_seen
+        assert isinstance(out, list) and out
+        assert any("Bin" in cd.diff for cd in out)
+
 
 def test_resolve_path_at_ref_to_ref_resolves_single_commit_rename(
     tmp_path: Path,

--- a/tests/test_utils_validate_history_path.py
+++ b/tests/test_utils_validate_history_path.py
@@ -45,3 +45,9 @@ def test_accepts_any_attachment_under_wildcard(tmp_path):
         validate_history_path("assets/photo.heic", tmp_path, frozenset({"*"}))
         == (tmp_path / "assets/photo.heic").resolve()
     )
+
+
+def test_rejects_extensionless_path(tmp_path):
+    """A path with no extension (suffix '') is rejected without a wildcard."""
+    with pytest.raises(ValueError, match="\\.md note or a configured attachment"):
+        validate_history_path("README", tmp_path, frozenset({"png"}))


### PR DESCRIPTION
Follow-up to #342/#684 (M3 of the #577 git epic). Brings the **per-commit** attachment diff (`get_diff(..., per_commit=True)`) to parity with the non-per-commit path that #342 already made rename-aware.

## The bug
The per-commit loop ran `git show --format= {--stat|-p} <sha> -- <commit_path>`. The single-path pathspec defeats git's rename pairing inside `git show`, so a renamed binary's per-commit entry rendered an add/text stat instead of the paired `{x.png => y.png} | Bin OLD -> NEW`. Binariness was also classified once over the whole range, not per commit.

## The fix
- **`resolve_path_at_ref`** gains a keyword-only `to_ref` (default `HEAD`, so existing callers are unchanged), letting the loop resolve each commit's rename against its **parent**.
- **Per commit:** build a rename-aware two-blob target (`<sha>^:<old>` vs `<sha>:<new>` for a rename, else `<sha>^..<sha> -- <path>`), classify binariness **per commit**, and render `--stat` (binary) / `-p` (text). The non-rename text path is byte-identical to the old `git show` form.
- **Scoped fallback:** a per-commit diff failure runs `git rev-parse --verify <sha>^` — a genuine failure (commit *has* a parent) raises `ValueError`; only a true root/orphan commit falls back to the add-form `git show` (classifying the root binary against the empty tree). No more silent degradation.
- **Pure rename:** a byte-identical rename's two-blob diff is empty, so a `{old} => {new} (renamed, no content change)` marker is synthesized rather than emitting an empty entry.
- **Copies render as adds.** I verified that a copied binary already classifies correctly as a `Bin` add via the add-form numstat (#684's finding #5 premise — that copy-origin binaries misclassify — does not hold). So no copy-resolution machinery is added: a copy renders as a plain add (truthful — the source still exists), avoiding mislabeling it as a rename.

## Tests
Real-git fixtures: renamed-binary paired stat (`=>`+`Bin`), per-commit binary-vs-text classification across a type change, plain binary add, parent-less fallback (success + nested-failure→`ValueError`), non-parent-less-failure→`ValueError`, pure-rename marker, empty-tree root-binary classification, a mutation-verified two-record copy-skip, and an end-to-end "copy renders as a `Bin` add (not a mislabeled rename)". 2208 passed; mypy + ruff clean. `docs/design.md` documents the behaviour + bounds (the `--find-renames=30` similarity threshold; merge commits render first-parent). Designed via brainstorm→spec→plan; preflight-circus clean at ≥80.

Closes #683. Refs #342, #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)