### PR TITLE
chore(copier): update template v1.6.1 → v1.8.0 (rc2 release support + Vale gate)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.6.1
+_commit: v1.8.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,3 +221,72 @@ jobs:
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  vale:
+    name: Docs Prose (Vale)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # vale-cli/vale-action posts findings as PR annotations via reviewdog.
+      # The default reporter (`github-pr-annotations`) uses the GitHub Checks
+      # API — `checks: write` is sufficient. If a downstream switches the
+      # reporter to `github-pr-review` (inline PR review comments), they
+      # need to add `pull-requests: write` here too.
+      checks: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Vale style packages
+        # Vale style packs are ~30 MB total and re-downloaded on every run
+        # without caching. Cache key invalidates when .vale.ini changes
+        # (Packages line edited, ai-tells URL bumped, etc.) OR when any
+        # vocab file under .vale/styles/config/ changes (added/removed
+        # accepted terms). Without the config/** hash, cache restore would
+        # silently clobber a newly-added vocab term on disk with the stale
+        # snapshot, making Vale flag the new term as unknown in CI even
+        # though the file is checked in. The `v1-` prefix is a manual
+        # escape hatch: bump it to force re-sync if Vale ever changes
+        # pack format backward-incompatibly.
+        uses: actions/cache@v4
+        with:
+          path: .vale/styles
+          key: vale-styles-v1-${{ hashFiles('.vale.ini', '.vale/styles/config/**') }}
+          # Fallback to any prior `vale-styles-v1-*` cache as a warm start
+          # when the exact key misses. `vale sync` will then only fetch the
+          # packs that actually changed instead of re-downloading all four.
+          restore-keys: vale-styles-v1-
+
+      - name: Run Vale
+        # SHA pin matches the gitleaks-action pattern earlier in this file.
+        # The current release is named "v2.1.2" in the GitHub UI but the
+        # underlying git tag is `2.1.2` (no `v` prefix) — pinning to the
+        # SHA sidesteps that mismatch and provides supply-chain hygiene.
+        uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a  # v2.1.2
+        with:
+          # Pin Vale CLI version explicitly. Bump in lockstep with the
+          # pre-commit hook `rev:` in .pre-commit-config.yaml — template-ci
+          # asserts the two stay synchronized.
+          version: "3.14.2"
+          files: docs
+          # Working specs follow internal conventions, not user-facing prose
+          # style — exclude from linting. NO inner single quotes around the
+          # glob value: vale-action splits `vale_flags` on whitespace and
+          # passes argv elements directly (no shell), so literal quotes here
+          # would be passed through to Vale, the glob would match no files,
+          # and CI would silently exit 0. Verified empirically.
+          vale_flags: "--glob=!docs/superpowers/**"
+          # Failure gating is controlled by MinAlertLevel = error in
+          # .vale.ini (governs both what Vale prints AND its exit code)
+          # combined with fail_on_error below — only error-severity
+          # findings fail CI; warnings and suggestions surface as advisory
+          # annotations. (The action also accepts a `level:` input, but at
+          # the pinned SHA that input is declared but never read — the
+          # reviewdog level is derived from Vale's exit code and
+          # fail_on_error. Setting it here would be a no-op.)
+          fail_on_error: true
+          # filter_mode defaults to `added` — only findings on lines this PR
+          # adds or modifies fail the build. Pre-existing prose debt isn't a
+          # blocker for new contributions; downstream's own untouched docs
+          # don't gate PRs that don't touch them. To enforce repo-wide
+          # cleanliness, set this to `nofilter`.
+          filter_mode: added

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,14 @@ on:
 
 jobs:
   claude-review:
+    # Skip PRs from forks: GitHub does not expose repository secrets
+    # (including CLAUDE_CODE_OAUTH_TOKEN) to workflows running in fork-PR
+    # context, regardless of maintainer approval. Running anyway produces
+    # a hard-failing check on every external contribution. Maintainers who
+    # want a bot review on a fork PR can push the contributor's branch to
+    # this repo under a topic name and the workflow will run.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,17 @@ on:
 
 jobs:
   claude:
+    # Trigger only on @claude mentions, AND on the two PR-context events
+    # (`pull_request_review*`) only when the PR head is in this repo. Those
+    # events run in PR context for fork PRs, where GitHub withholds repository
+    # secrets (incl. CLAUDE_CODE_OAUTH_TOKEN) and the action would auth-fail.
+    # `issues` and `issue_comment` always run in base-repo context, so secrets
+    # are available — no fork check needed there.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force version bump (leave empty for auto)'
+        description: 'Force version bump (empty = auto; "prerelease" advances the rc revision e.g. rc.1 → rc.2 — keep the pre-release box below checked)'
         type: choice
         default: ''
         options:
           - ''
+          - prerelease
           - patch
           - minor
           - major
@@ -32,6 +33,12 @@ jobs:
       id-token: write
 
     steps:
+      - name: Reject contradictory dispatch inputs
+        if: inputs.force == 'prerelease' && inputs.prerelease == false
+        run: |
+          echo "::error::force=prerelease advances the rc revision and requires the pre-release box to stay checked"
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ site/
 .claude/worktrees/
 .claude/settings.local.json
 docs/superpowers/
+
+# Vale-synced style packages (downloaded by `vale sync`). Custom config
+# (vocabularies, ini overrides) under .vale/styles/config/ stays tracked.
+.vale/styles/*
+!.vale/styles/config/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,62 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
       - id: check-json
+
+  # Vale prose lint for docs/**. Requires Vale on PATH (`brew install vale`,
+  # `apt install vale`, or download from https://vale.sh/docs/install).
+  # First commit touching docs/ or .vale.ini auto-runs `vale sync` because
+  # the style-pack dirs are missing; subsequent commits are no-ops. Adding a
+  # new package to .vale.ini's `Packages =` line, or bumping a pinned URL
+  # version, does NOT re-sync automatically — the four hard-coded pack-dir
+  # checks below don't see the new package, and bumped-version dirs still
+  # exist on disk. After such .vale.ini edits, run `vale sync` manually
+  # (or `rm -rf .vale/styles/<pack>` to force re-sync via the hook).
+  - repo: local
+    hooks:
+      - id: vale-sync
+        name: vale sync (download style packages if missing)
+        # Loud-fail if Vale isn't on PATH OR if `vale sync` fails (network,
+        # bad URL, etc.). Both error modes silently exited 0 in earlier
+        # iterations: bash's brace-group returns the exit status of its
+        # LAST command, which was `break` (always 0), masking sync failures
+        # and "vale: command not found". `command -v vale` plus `exit 1` on
+        # sync failure plug both holes — without them the next hook (`vale`)
+        # would run against un-synced packs, where Vale prints E201 config
+        # errors and itself exits 0, the exact silent-pass this hook exists
+        # to prevent.
+        language: system
+        entry: |
+          bash -c '
+            command -v vale >/dev/null 2>&1 || {
+              echo "vale not on PATH — install: https://vale.sh/docs/install" >&2
+              exit 1
+            }
+            for p in Google proselint write-good ai-tells; do
+              if [ ! -d ".vale/styles/$p" ]; then
+                vale sync || exit 1
+                break
+              fi
+            done
+          '
+        pass_filenames: false
+        files: ^(docs/|\.vale\.ini$)
+        # Align trigger scope with the `vale` lint hook below — no point
+        # checking sync state on commits that only touch the excluded
+        # working-specs subtree.
+        exclude: ^docs/superpowers/
+
+  - repo: https://github.com/vale-cli/vale
+    rev: v3.14.2
+    hooks:
+      - id: vale
+        # MUST run after `vale-sync` above. Pre-commit runs hooks in
+        # declaration order; if vale precedes vale-sync on a fresh clone
+        # the packs aren't populated, Vale prints E201 config errors and
+        # exits 0 — silent pass.
+        # Upstream hook has `types: [text]`; this `files:` scopes to docs/.
+        # Together: any text file under docs/ except the working-specs
+        # subtree. Matches the CI step's `vale ... --glob='!docs/superpowers/**' docs/`
+        # scope exactly (both lint markdown + asciidoc + rst + plain
+        # text — every format Vale supports — under docs/).
+        files: ^docs/
+        exclude: ^docs/superpowers/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,48 @@
+# Vale prose linter — https://vale.sh
+#
+# Lints `docs/**` for prose issues. Working specs under `docs/superpowers/**`
+# are excluded by the pre-commit hook (`exclude:` pattern) and the CI step
+# (`--glob='!docs/superpowers/**'`); Vale itself has no notion of "skip this
+# subtree", so the exclusion lives at the invocation site.
+#
+# `MinAlertLevel = error` governs both what Vale prints AND its exit code —
+# warnings and suggestions are advisory (visible in `vale --minAlertLevel=
+# warning` runs) but do not fail CI / pre-commit. Tune individual rules
+# (e.g. disable a noisy one) via per-rule overrides:
+#
+#     [*.md]
+#     Google.Spelling = NO
+#
+# See https://vale.sh/docs/keys/format for the full key reference and
+# https://vale.sh/docs/topics/styles for rule-tuning syntax.
+#
+# Project-specific accepted vocabulary lives at
+# `.vale/styles/config/vocabularies/Base/accept.txt` (one term per line,
+# matched case-insensitively). The `Vocab = Base` line below activates it.
+# The config/ subtree is preserved across `vale sync`; see .gitignore for
+# the include/exclude rules.
+
+StylesPath = .vale/styles
+MinAlertLevel = error
+Vocab = Base
+
+# `Vale` is a built-in style, always available without listing here.
+# `Google`, `proselint`, `write-good` are upstream packages fetched by
+# `vale sync` from Vale's package registry — listed by name without an
+# `@version` suffix means they resolve to the latest registry release on
+# each sync. Intentional: keeps style rules current. To pin for
+# reproducibility, append a version (e.g. `Google@1.0.0`).
+# `ai-tells` (https://github.com/tbhb/vale-ai-tells) catches common
+# LLM-prose tells; pinned to a release URL since it is not in Vale's
+# package index.
+Packages = Google, proselint, write-good, https://github.com/tbhb/vale-ai-tells/releases/download/v1.9.0/ai-tells.zip
+
+[*.md]
+BasedOnStyles = Vale, Google, proselint, write-good, ai-tells
+
+# Vale.Terms enforces strict casing of every accept.txt entry — useful for
+# product names (e.g. "GitHub" not "Github") but overzealous for generic
+# tech vocab where sentence-start, heading-start, and mid-sentence usages
+# legitimately appear with different casing. Vale.Spelling still accepts
+# all entries case-insensitively; we just don't enforce one canonical form.
+Vale.Terms = NO

--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -1,0 +1,43 @@
+# Project vocabulary — accepted tech terms that Vale's default spell-check
+# would otherwise flag as unknown words. One term per line. Vale matches
+# case-insensitively by default. See https://vale.sh/docs/topics/vocab.
+#
+# Add new accepted terms below as your docs corpus grows. Keep entries
+# alphabetical within their category for easy review.
+
+# --- Identity providers and auth-stack tooling ---
+Authelia
+Keycloak
+OAuth
+OIDC
+Traefik
+
+# --- HTTP / URL terminology ---
+hostname
+subpath
+URIs
+
+# --- OAuth / OIDC token fields ---
+access_token
+id_token
+
+# --- Python / runtime ecosystem ---
+debugpy
+mypy
+namespace
+namespaced
+pytest
+ruff
+
+# --- Operational / config jargon ---
+config
+deployer
+env
+truthy
+uncommented
+uncommenting
+unprefixed
+validators
+
+# --- Diagnostics / observability ---
+traceback


### PR DESCRIPTION
## Summary

Updates the copier template **v1.6.1 → v1.8.0**. The driving need is the **rc2 release blocker**: the current `release.yml` cannot cut a second release candidate.

Closes #687.

## Why now: the rc2 blocker

We are at `2.0.0-rc.1`. With v1.6.1's `release.yml`, dispatching a pre-release with a patch/fix-worthy commit makes python-semantic-release **re-emit `2.0.0-rc.1`** (it bumps the base version and re-appends `rc.1`) rather than advancing to `rc.2` — the `force` input only offers `patch/minor/major`. Template **v1.7.0 (#136 upstream)** fixes this by exposing **`prerelease` as a `force` option** that advances the rc revision, plus a guard rejecting the contradictory `force=prerelease` + pre-release-box-unchecked combination.

**To cut rc.2 after this merges:** run the Release workflow with **`force: prerelease`** and the **pre-release box checked**.

## What v1.6.1 → v1.8.0 brings

- **v1.7.0 (#136)** — `release.yml`: `prerelease` force option (the rc2 fix) + contradiction guard.
- **v1.8.0 (#142/#145)** — new **Vale prose linter** for `docs/**`: `.vale.ini`, `.vale/styles/config/` vocab, a `vale` CI job, and the matching `vale-sync` + `vale` pre-commit hooks. Wired `filter_mode: added`, so pre-existing prose debt is **non-blocking** — only PR-touched doc lines gate.
- **v1.8.0 (#140)** — `claude.yml` / `claude-code-review.yml`: skip on fork PRs (GitHub withholds secrets in fork-PR context, so the bot would hard-fail every external PR).

## Scope decisions

- **Docs reverted to `main` — this PR touches 0 doc prose lines.** Copier's 3-way merge applied incidental Vale prose edits (em-dash→colon, `e.g.`→`such as`) to a handful of domain docs and conflicted on others. These were reverted to keep the PR focused on infra and avoid shipping unreviewed style changes. The actual prose cleanup (1769 pre-existing error-level alerts) is tracked deliberately in **#686**.
- **`.pre-commit-config.yaml` reconciled** (a `_skip_if_exists` starter) by adding the template's Vale hooks (`vale-sync` + `vale` @ `rev: v3.14.2`). The new `.vale.ini`/`ci.yml` comments reference this hook (exclude pattern, version lockstep), and CLAUDE.md's *"clean pre-commit run implies a clean CI lane"* invariant requires it. (Surfaced by the pre-push review circus.)
- **`.gitignore`** gains `.vale/styles/*` + `!.vale/styles/config/` — the template ships it in `.gitignore.jinja`, but our root `.gitignore` is `_skip_if_exists`, so it didn't propagate. Keeps `vale sync`'s ~30 MB of style packs out of git while tracking the custom vocab.

## Known imported template issue (filed upstream, not patched here)

The pre-push circus flagged (conf 82) that the new Vale **cache step** in `ci.yml` caches `path: .vale/styles`, which contains the tracked `config/` subtree — so `restore-keys` can clobber a newly-added vocab term with a stale snapshot. This is template-owned code imported verbatim; per CLAUDE.md's *"Contributing fixes upstream"* rule, the fix belongs in the template and propagates via `copier update`. Filed as **pvliesdonk/fastmcp-server-template#147**. Low severity (self-correcting CI flake, only on vocab-adding PRs); not patched locally to avoid copier divergence.

## Supersedes

Replaces the stale bot PR **#504** (`copier/update`, generated 2026-05-18 — 29 commits behind, with doc edits computed against docs since rewritten by #653). This is a fresh update against current `main`.

## Verification

- `uv run pytest -x -q` → **2209 passed, 1 skipped**
- `uv run ruff check .` / `ruff format --check .` → clean
- `uv run mypy src/ tests/` → no issues
- `uv run pre-commit validate-config` → valid; `vale-sync` hook passes
- PR touches 0 `docs/**/*.md` lines → Vale gate (`filter_mode: added`) finds nothing to fail
- Pre-push review circus (5 core lenses + code-reviewer) → clean at ≥80 after the pre-commit reconciliation; remaining ≥80 finding is the upstream cache bug above

## Documentation

The rc2 release-process change is self-documenting in the `release.yml` dispatch description. Vale-linting adoption + any contributor-facing Vale docs are deferred to #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
