### PR TITLE
ci(docs): versioned documentation with mike (stable + rolling unstable)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,6 +64,12 @@ jobs:
     #   2. Repo Settings -> Pages -> Deploy from a branch -> gh-pages / (root).
     if: github.event_name == 'release'
     needs: build
+    # Serialize all release deploys (no cancellation) so two releases close
+    # together never push to gh-pages concurrently, and an in-flight mike push
+    # is never cancelled mid-sequence.
+    concurrency:
+      group: ${{ github.workflow }}-deploy
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -92,6 +98,7 @@ jobs:
       - name: Publish versioned docs
         env:
           TAG: ${{ github.event.release.tag_name }}
+          # GitHub renders the JSON boolean as the string "true"/"false".
           PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           version="${TAG#v}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -106,6 +106,6 @@ jobs:
             uv run mike deploy --push --update-aliases unstable --title "unstable (${version})"
           else
             minor="$(echo "$version" | cut -d. -f1-2)"
-            uv run mike deploy --push --update-aliases "$minor" latest
+            uv run mike deploy --push --update-aliases --title "$version" "$minor" latest
             uv run mike set-default --push latest
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,13 +3,6 @@ name: Documentation
 on:
   push:
     branches: [main]
-    # Tag-push also deploys: whichever event fires first (tag-push or
-    # release:published) wins the concurrency group below and performs
-    # the full build+upload+deploy.  The release-event path can race
-    # against tag availability (deploy-pages fetch fails), so tag-push
-    # gives a deterministic second path.  Gates on the `upload-artifact`
-    # step and `deploy` job below accept either event.
-    tags: ["v*"]
   pull_request:
     branches: [main]
   release:
@@ -19,26 +12,20 @@ on:
 permissions:
   contents: read
 
-# Include github.event_name so tag-push and release runs don't share a
-# concurrency key — without this, the tag-push run fired by ``git push``
-# and the release run fired by ``release:published`` collide on the same
-# ref+workflow key and ``cancel-in-progress: true`` cancels whichever
-# arrived first (usually the one carrying the deployment).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
   build:
+    # Validation only: strict docs build + config-wizard browser smoke test.
+    # Never deploys; publishing happens in `deploy` on release.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           # On release events the triggering tag may move after the workflow is
-          # queued (the release workflow pushes a version-bump commit and
-          # updates the tag). Checkout main explicitly on releases to avoid the
-          # "ref does not point to the expected commit" error from
-          # actions/checkout's SHA-verification.
+          # queued (semantic-release pushes a version-bump commit); build main.
           ref: ${{ github.event_name == 'release' && 'main' || github.ref }}
 
       - name: Install uv
@@ -66,23 +53,52 @@ jobs:
       - name: Run config-wizard smoke test
         run: uv run pytest tests/test_config_wizard_smoke.py -v -m browser
 
-      - name: Upload artifact
-        if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: site/
-
   deploy:
-    if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    # Publish versioned docs with mike, serving from the gh-pages branch:
+    #   stable release (prerelease=false) -> version <major.minor> + `latest` alias (default)
+    #   rc prerelease  (prerelease=true)  -> single rolling `unstable` version
+    #
+    # One-time setup before the first release deploy takes effect:
+    #   1. Seed gh-pages locally:
+    #        uv run mike deploy --push --update-aliases unstable --title "unstable (<ver>)"
+    #   2. Repo Settings -> Pages -> Deploy from a branch -> gh-pages / (root).
+    if: github.event_name == 'release'
     needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --no-default-groups --group docs --frozen
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish versioned docs
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          version="${TAG#v}"
+          if [ "$PRERELEASE" = "true" ]; then
+            uv run mike deploy --push --update-aliases unstable --title "unstable (${version})"
+          else
+            minor="$(echo "$version" | cut -d. -f1-2)"
+            uv run mike deploy --push --update-aliases "$minor" latest
+            uv run mike set-default --push latest
+          fi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,11 @@ markdown_extensions:
   - attr_list
   - md_in_html
 
+extra:
+  version:
+    provider: mike
+    default: latest
+
 extra_javascript:
   - path: javascripts/config-wizard/wizard.js
     type: module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ docs = [
     "mkdocstrings[python]>=0.28",
     "mkdocs-llmstxt>=0.5",
     "pygments>=2,<2.21",
+    "mike>=2.1",
 ]
 browser = [
     "pytest-playwright>=0.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1373,6 +1373,7 @@ dev = [
     { name = "watchdog" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -1413,6 +1414,7 @@ dev = [
     { name = "watchdog", specifier = ">=4.0" },
 ]
 docs = [
+    { name = "mike", specifier = ">=2.1" },
     { name = "mkdocs-llmstxt", specifier = ">=0.5" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.28" },
@@ -1572,6 +1574,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
 ]
 
 [[package]]
@@ -3295,6 +3314,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #700.

## Summary
Introduces `mike` so the docs site publishes multiple versions with a Material version selector, served from a `gh-pages` branch:
- **Stable release** (`prerelease=false`) → version `<major.minor>` with the `latest` alias, set as the default.
- **RC prerelease** (`prerelease=true`) → a single rolling `unstable` version (mirrors the docker `unstable` tag).
- **`main`/PR builds** stay a strict-build + Playwright-smoke **validation gate only** — publishing happens exclusively on `release: published`.

## Changes
- `pyproject.toml` / `uv.lock` — add `mike` to the `docs` group.
- `mkdocs.yml` — `extra.version` (mike provider, default `latest`) for the version dropdown.
- `.github/workflows/docs.yml` — split into a validation `build` job and a mike-based `deploy` job (on release, `needs: build`, `contents: write`, branching on `prerelease`). Replaces the Pages Actions-artifact flow; drops the `v*` tag trigger. A job-level `concurrency` (cancel-in-progress: false) serializes deploys so two releases never push to `gh-pages` concurrently.

## Test plan
- [x] `uv run mkdocs build --strict` — green.
- [x] Local mike build on a scratch branch produces the expected `versions.json`: `2.0`+`latest` for stable, plus a rolling `unstable (2.1.0-rc.1)` entry; scratch branch deleted, no real `gh-pages` touched.
- [x] Workflow YAML validates.
- [ ] CI: the new `deploy` job only runs on a real `release` event, so it is not exercised by this PR's checks (the `build` validation job is).

## ⚠️ Two one-time operator steps after merge (cannot ship in the PR)
1. **Seed `gh-pages`** from `main` so the branch has content before flipping the source:
   `uv run mike deploy --push --update-aliases unstable --title "unstable (<current-version>)"`
   (this also puts the configuration generator live as `unstable`).
2. **Switch the Pages source:** Settings → Pages → Deploy from a branch → `gh-pages` / `(root)` (currently "GitHub Actions").

Order matters: seed (1) before flip (2) so the site is never empty. A follow-up will port this to `fastmcp-server-template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._