### PR TITLE
feat(server): MARKDOWN_VAULT_MCP_DISABLE_APPS_UI env var to hide MCP-Apps tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` pr
 |----------|---------|-------------|
 | `MARKDOWN_VAULT_MCP_SERVER_NAME` | `markdown-vault-mcp` | MCP server name shown to clients; useful for multi-instance setups |
 | `MARKDOWN_VAULT_MCP_INSTRUCTIONS` | (auto) | System-level instructions injected into LLM context; defaults to a description that reflects read-only vs read-write state |
+| `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` | `false` | Hide MCP-Apps UI tools (`browse_vault`, `show_context`) from the tool listing for clients that do not render MCP Apps panels (saves a few listing tokens) |
 | `MARKDOWN_VAULT_MCP_HTTP_PATH` | `/mcp` | HTTP endpoint path for streamable HTTP transport (used by `serve --transport http`) |
 | `MARKDOWN_VAULT_MCP_KV_STORE_URL` | `file:///data/state` | Unified key-value backend for HTTP session persistence (the `events` keyspace is namespaced inside the directory). `file:///path` (default) survives restarts; `memory://` for dev (lost on restart). Preferred over `EVENT_STORE_URL`. |
 | `MARKDOWN_VAULT_MCP_EVENT_STORE_URL` | (unset) | Legacy alias for `KV_STORE_URL`; honoured only when `KV_STORE_URL` is unset, and logs a one-shot deprecation warning. Prefer `KV_STORE_URL`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ chronic backlog.
 |----------|------|---------|-------------|
 | `MARKDOWN_VAULT_MCP_SERVER_NAME` | string | `markdown-vault-mcp` | MCP server name shown to clients; useful for multi-instance setups |
 | `MARKDOWN_VAULT_MCP_INSTRUCTIONS` | string | (auto) | System-level instructions injected into LLM context; defaults to a description that reflects read-only vs read-write state |
+| `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` | bool | `false` | Hide MCP-Apps UI tools (`browse_vault`, `show_context`) from the tool listing for clients that do not render MCP Apps panels (saves a few listing tokens) |
 | `MARKDOWN_VAULT_MCP_HTTP_PATH` | path | `/mcp` | HTTP endpoint path for streamable HTTP transport (`serve --transport http`) |
 | `MARKDOWN_VAULT_MCP_BASE_URL` | url | — | Public base URL of the server (e.g. `https://mcp.example.com`). Required for OIDC auth, MCP Apps domain computation, and the one-time transfer link tools |
 | `MARKDOWN_VAULT_MCP_KV_STORE_URL` | url | `file:///data/state` | Unified key-value backend for HTTP session persistence (the `events` keyspace is namespaced inside the directory). `file:///path` survives restarts; `memory://` for dev (lost on restart). Preferred over `EVENT_STORE_URL`. |

--- a/docs/design.md
+++ b/docs/design.md
@@ -1780,6 +1780,12 @@ This also hides any prompts sharing the ``write`` tag (e.g. ``research``,
 ``discuss``, ``create_from_template``). The Vault still raises ``ReadOnlyError`` as a defence-in-depth
 guard if a write method is somehow called on a read-only instance.
 
+The MCP-Apps UI tools ``browse_vault`` and ``show_context`` are tagged with
+``tags={"apps-ui"}``. When ``MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=true``, the
+server calls ``mcp.disable(tags={"apps-ui"})`` to hide them from the tool
+listing for clients that don't render MCP Apps panels. This composes as a
+set-union with the ``write`` and ``git-managed`` disable passes.
+
 **Dynamic instructions**: the server's MCP `instructions` string varies with
 `read_only` mode. When `read_only=True`, the instructions state this is a
 read-only instance; when `read_only=False`, they describe write tool semantics.
@@ -1875,6 +1881,7 @@ For MCP server deployment:
 |----------|-------------|---------|
 | `MARKDOWN_VAULT_MCP_SERVER_NAME` | MCP server name shown to clients | `markdown-vault-mcp` |
 | `MARKDOWN_VAULT_MCP_INSTRUCTIONS` | System-level instructions for LLM context | generic description |
+| `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` | Hide MCP-Apps UI tools (`browse_vault`, `show_context`) from the listing | `false` |
 | `MARKDOWN_VAULT_MCP_SOURCE_DIR` | Path to markdown files | required |
 | `MARKDOWN_VAULT_MCP_READ_ONLY` | Disable write tools | `true` |
 | `MARKDOWN_VAULT_MCP_INDEX_PATH` | SQLite index path | in-memory |

--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -96,6 +96,8 @@ The app integrates with the host client via the ext-apps SDK:
 
 MCP Apps views require a client that supports the MCP Apps protocol. Currently supported by Claude on claude.ai. Clients without Apps support receive a text-only fallback from `browse_vault` and `show_context`.
 
+To hide `browse_vault` and `show_context` from the tool listing entirely (for clients that never render Apps panels), set `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=true`. See [Configuration](../configuration.md).
+
 ### Firing prompts from Claude.ai's `+` menu
 
 MCP Apps surface interactive views, but this server also ships MCP *prompts* — `summarize`, `research`, `propose-links`, and the workflow prompts from the PARA and Zettelkasten packs. On Claude.ai, every prompt appears in the compose area's `+` menu once the server is added as a connector. Click `+`, select **connectors**, pick the server, pick a prompt — Claude opens with the invocation scaffolded. See [How to invoke prompts](../prompts.md#how-to-invoke-prompts).

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -489,6 +489,14 @@
       "advancedGroup": "Server identity"
     },
     {
+      "id": "disable_apps_ui",
+      "label": "Hide MCP-Apps UI tools",
+      "help": "Hide browse_vault and show_context from the tool listing for clients that don't render MCP Apps panels.",
+      "type": "bool",
+      "var": "MARKDOWN_VAULT_MCP_DISABLE_APPS_UI",
+      "advancedGroup": "Server identity"
+    },
+    {
       "id": "log_level",
       "label": "Log level",
       "type": "text",

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -238,6 +238,7 @@ def register_apps(mcp: FastMCP) -> None:
     # -- Primary tool: browse_vault -----------------------------------------
 
     @mcp.tool(
+        tags={"apps-ui"},
         icons=_TOOL_ICONS["browse_vault"],
         annotations={
             "readOnlyHint": True,
@@ -338,6 +339,7 @@ def register_apps(mcp: FastMCP) -> None:
         return asdict(ctx)
 
     @mcp.tool(
+        tags={"apps-ui"},
         icons=_TOOL_ICONS["show_context"],
         annotations={
             "readOnlyHint": True,

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -86,6 +86,10 @@ class VaultConfig:
         sync: File-watcher and GitHub-webhook settings.
         content: Attachment/note-read limits and template/prompt folder paths.
         transfer: One-time upload/download transfer-link TTL and size settings.
+        disable_apps_ui: When ``True``, hides MCP-Apps UI tools
+            (``browse_vault``, ``show_context``) from the tool listing so
+            clients that don't render MCP Apps panels don't see them
+            (default ``False``).
         server: Shared server-level configuration (transport, host/port,
             auth, base URL, event store URL, MCP App domain) populated
             from ``MARKDOWN_VAULT_MCP_*`` env vars by
@@ -109,6 +113,7 @@ class VaultConfig:
     sync: SyncConfig = field(default_factory=SyncConfig)
     content: ContentConfig = field(default_factory=ContentConfig)
     transfer: TransferConfig = field(default_factory=TransferConfig)
+    disable_apps_ui: bool = False
     # CONFIG-FIELDS-END
 
     # Universal server fields delegated to fastmcp_pvl_core.ServerConfig.
@@ -391,6 +396,18 @@ class VaultConfig:
         read_only = _parse_bool(raw_read_only) if raw_read_only is not None else True
         logger.debug("from_env: read_only=%s (raw=%r)", read_only, raw_read_only)
 
+        raw_disable_apps_ui = _env(prefix, "DISABLE_APPS_UI")
+        disable_apps_ui = (
+            _parse_bool(raw_disable_apps_ui)
+            if raw_disable_apps_ui is not None
+            else False
+        )
+        logger.debug(
+            "from_env: disable_apps_ui=%s (raw=%r)",
+            disable_apps_ui,
+            raw_disable_apps_ui,
+        )
+
         raw_server_name = (_env(prefix, "SERVER_NAME") or "").strip()
         server_name = raw_server_name or "markdown-vault-mcp"
         logger.debug("from_env: server_name=%s", server_name)
@@ -428,6 +445,7 @@ class VaultConfig:
             sync=sync,
             content=content,
             transfer=transfer,
+            disable_apps_ui=disable_apps_ui,
             # CONFIG-FROM-ENV-END
             server=server,
         )

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -280,4 +280,11 @@ def make_server(transport: str = "stdio") -> FastMCP:
     if config.git.repo_url is None:
         mcp.disable(tags={"git-managed"})
 
+    # Hide MCP-Apps UI tools (browse_vault, show_context) when the client
+    # does not render the MCP Apps panels. Set
+    # MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=true to remove them from the tool
+    # listing (saves a few tokens; the LLM cannot call them anyway).
+    if config.disable_apps_ui:
+        mcp.disable(tags={"apps-ui"})
+
     return mcp

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,6 +145,30 @@ class TestParseHelpers:
             assert config.read_only is False, f"Expected False for {val!r}"
 
 
+class TestDisableAppsUi:
+    """Cover the MARKDOWN_VAULT_MCP_DISABLE_APPS_UI env-var path."""
+
+    def test_default_is_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_DISABLE_APPS_UI", raising=False)
+        config = VaultConfig.from_env()
+        assert config.disable_apps_ui is False
+
+    def test_true_variants(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for val in ("true", "1", "yes", "on", "TRUE"):
+            monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
+            monkeypatch.setenv("MARKDOWN_VAULT_MCP_DISABLE_APPS_UI", val)
+            config = VaultConfig.from_env()
+            assert config.disable_apps_ui is True, f"Expected True for {val!r}"
+
+    def test_false_variants(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for val in ("false", "0", "no", ""):
+            monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", "/tmp/vault")
+            monkeypatch.setenv("MARKDOWN_VAULT_MCP_DISABLE_APPS_UI", val)
+            config = VaultConfig.from_env()
+            assert config.disable_apps_ui is False, f"Expected False for {val!r}"
+
+
 class TestLoadConfig:
     def test_missing_source_dir_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", raising=False)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -181,6 +181,34 @@ class TestToolListing:
         assert "rename" in names
 
 
+class TestDisableAppsUi:
+    """Cover the MARKDOWN_VAULT_MCP_DISABLE_APPS_UI gate in make_server."""
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_apps_ui_tools_present_by_default(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            tools = await client.list_tools()
+            names = {t.name for t in tools}
+        assert "browse_vault" in names
+        assert "show_context" in names
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_apps_ui_tools_hidden_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_DISABLE_APPS_UI", "true")
+        server = make_server()
+        async with Client(server) as client:
+            tools = await client.list_tools()
+            names = {t.name for t in tools}
+        assert "browse_vault" not in names
+        assert "show_context" not in names
+        # Non-apps-ui tools must remain available.
+        assert "search" in names
+        assert "read" in names
+
+
 class TestToolManifest:
     """Pin the exact set of tools register_tools() registers.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "2.0.0rc2"
+version = "2.0.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

Adds `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` env var that hides the `browse_vault` and `show_context` MCP-Apps UI tools from the tool listing. Useful for clients that don't render MCP Apps panels (the tool description already tells the LLM not to call them programmatically, but they still cost a few listing tokens).

- New `apps-ui` tag on `browse_vault` and `show_context` in `_server_apps.py`
- New `disable_apps_ui: bool` field on `VaultConfig`, populated in `from_env` via the project's standard `_env()` + `_parse_bool()` helpers (same pattern as `read_only`)
- `make_server` reads `config.disable_apps_ui` and calls `mcp.disable(tags={"apps-ui"})` when set — composes set-union with the existing `write` and `git-managed` disable passes
- Docs in `README.md` and `docs/configuration.md`
- Tests for both the config parsing (`TestDisableAppsUi` in `tests/test_config.py`) and the server-side tool-listing gate (`TestDisableAppsUi` in `tests/test_server.py`)

No behavior change when the env var is unset.

## Context

This supersedes #527, which was opened against an older state of `main` and ran into a structural conflict after the `VaultConfig` refactor into nested config sections. Reopened cleanly on top of current `main`, with all review feedback from #527 incorporated:

- @pvliesdonk: env-var reading moved into `config.py` using `_env()` + `_parse_bool()`; `server.py` stays a pure wiring layer; field documented in `README.md` + `docs/configuration.md`.
- @gemini-code-assist[bot]: obsolete now that the env var is read through the standard config helpers (no more hardcoded prefix in `server.py`).
- codecov patch coverage: 97% on the touched modules (`config.py` 100%, `server.py` 93%).

Closes #527.

## Test plan

- [x] `uv run pytest -x -q` — 2215 passed, 1 skipped
- [x] `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/ tests/` — no issues
- [x] Patch coverage ≥ 80% — `config.py` 100%, `server.py` 93% on touched lines
- [x] Docs updated — `README.md`, `docs/configuration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)