### PR TITLE
fix(security): close SSRF DNS-rebinding in fetch (resolve + validate + pin IP)

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -358,7 +358,7 @@ Download a file from a URL and save it to the vault as a note or attachment. Des
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `url` | string | required | Source URL to download. Only `http`/`https` schemes allowed; private/loopback IPs are blocked; redirects are not followed (SSRF protection) |
+| `url` | string | required | Source URL to download. Only `http`/`https` schemes allowed; the host is resolved and private or internal addresses are blocked; the validated IP is pinned for the connection; redirects are not followed (SSRF protection) |
 | `path` | string | required | Destination path in vault. Extension determines handling: `.md` for notes, anything else for attachments |
 | `frontmatter` | object | `null` | Optional YAML frontmatter dict for `.md` files. Ignored for attachments |
 | `if_match` | string | `null` | Optional etag from a previous `read` call for optimistic concurrency |

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -36,6 +36,10 @@ _BLOCKED_ADDR_MSG = (
     "are not allowed."
 )
 
+# Default ports per scheme — omitted from the Host header (RFC 7230 §5.4:
+# a client SHOULD NOT send a port that equals the scheme default).
+_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
+
 
 def _ip_is_blocked(ip: str) -> bool:
     """Return True if *ip* (an IP literal) is in a non-public range.
@@ -511,9 +515,19 @@ def register(mcp: FastMCP) -> None:
         # SNI so vhost routing and certificate verification still use the real
         # hostname. httpx then dials the pinned IP without re-resolving.
         ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+        # Rebuild netloc from the pinned IP + port only. Any userinfo
+        # (``user:pass@``) in the original URL is intentionally dropped — the
+        # fetch tool must not relay embedded credentials to the server.
         pinned_netloc = f"{ip_host}:{parsed.port}" if parsed.port else ip_host
         pinned_url = urlunparse(parsed._replace(netloc=pinned_netloc))
-        host_header = hostname if parsed.port is None else f"{hostname}:{parsed.port}"
+        # Host header carries the real hostname, omitting an explicit default
+        # port (RFC 7230 §5.4) so origin matching on strict servers still works.
+        if parsed.port is None or parsed.port == _SCHEME_DEFAULT_PORTS.get(
+            parsed.scheme
+        ):
+            host_header = hostname
+        else:
+            host_header = f"{hostname}:{parsed.port}"
 
         # Stream download — enforce size limit as chunks arrive.
         chunks: list[bytes] = []

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import ipaddress
 import logging
+import socket
 from dataclasses import asdict
 from typing import Any
 from urllib.parse import urlparse, urlunparse
@@ -30,30 +31,86 @@ _FETCH_BLOCKED_HOSTNAMES = frozenset(
 )
 
 
-def _is_private_url(url: str) -> bool:
-    """Return True if *url* targets a private, loopback, or link-local address.
+_BLOCKED_ADDR_MSG = (
+    "URLs targeting private, loopback, link-local, or reserved addresses "
+    "are not allowed."
+)
 
-    Uses :mod:`ipaddress` for IP-based hosts and a hostname blocklist for
-    well-known internal names. This is a best-effort SSRF guard — it does
-    **not** prevent DNS rebinding attacks.
+
+def _ip_is_blocked(ip: str) -> bool:
+    """Return True if *ip* (an IP literal) is in a non-public range.
+
+    Covers private, loopback, link-local, unspecified (``0.0.0.0`` — which
+    ``is_private`` misses on older Pythons), reserved, and multicast space,
+    for both IPv4 and IPv6.
     """
-    parsed = urlparse(url)
-    hostname = parsed.hostname or ""
+    addr = ipaddress.ip_address(ip)
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_unspecified
+        or addr.is_reserved
+        or addr.is_multicast
+    )
 
+
+async def _resolve_pinned_ip(hostname: str, port: int) -> str:
+    """Resolve *hostname* and return one validated public IP to pin to.
+
+    SSRF guard that also closes the DNS-rebinding (TOCTOU) window: the caller
+    connects to the returned IP literal rather than the hostname, so the
+    address validated here is the address actually connected to — there is no
+    second resolution at connect time for an attacker's DNS to swap.
+
+    Fails **closed**: raises :class:`ValueError` if resolution errors, returns
+    no records, or **any** resolved address is non-public. An IP-literal
+    *hostname* is validated directly without a DNS lookup.
+
+    Args:
+        hostname: The URL host (an IP literal or a domain name).
+        port: The target port, used for the ``getaddrinfo`` service hint.
+
+    Returns:
+        A validated, public IP literal to connect to.
+
+    Raises:
+        ValueError: If the host is blocklisted, resolves to a non-public
+            address, or cannot be resolved.
+    """
     if hostname in _FETCH_BLOCKED_HOSTNAMES:
-        return True
+        raise ValueError(_BLOCKED_ADDR_MSG)
 
+    # IP-literal fast path: validate directly, no DNS lookup.
     try:
-        addr = ipaddress.ip_address(hostname)
-        return (
-            addr.is_private
-            or addr.is_loopback
-            or addr.is_link_local
-            or addr.is_unspecified  # 0.0.0.0 — is_private misses this on Python 3.10
-        )
+        ipaddress.ip_address(hostname)
     except ValueError:
-        # Not an IP literal — allow (could be a public hostname).
-        return False
+        pass
+    else:
+        if _ip_is_blocked(hostname):
+            raise ValueError(_BLOCKED_ADDR_MSG)
+        return hostname
+
+    # Domain name: resolve and validate every returned address. Fail closed on
+    # any resolution error so a DNS hiccup can never become an SSRF bypass.
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except OSError as exc:  # socket.gaierror is an OSError subclass
+        raise ValueError(
+            f"Could not resolve host {hostname!r} for the fetch URL: {exc}"
+        ) from exc
+
+    resolved = [str(info[4][0]) for info in infos]
+    if not resolved:
+        raise ValueError(f"Host {hostname!r} did not resolve to any address.")
+    for ip in resolved:
+        if _ip_is_blocked(ip):
+            raise ValueError(
+                f"Host {hostname!r} resolves to a non-public address ({ip}); "
+                "refusing to fetch."
+            )
+    return resolved[0]
 
 
 def register(mcp: FastMCP) -> None:
@@ -384,8 +441,10 @@ def register(mcp: FastMCP) -> None:
 
         Args:
             url: Source URL to download from. Only http:// and https://
-                schemes are allowed. Private/loopback IPs are blocked.
-                Redirects are NOT followed (SSRF protection).
+                schemes are allowed. SSRF protection: the host is resolved and
+                rejected if any address is private, loopback, link-local, or
+                reserved, and the validated IP is pinned for the connection
+                (closing DNS rebinding). Redirects are NOT followed.
             path: Destination path in the vault (e.g. "notes/report.md"
                 or "assets/diagram.png"). Extension determines handling:
                 .md for notes, anything else for attachments.
@@ -419,11 +478,14 @@ def register(mcp: FastMCP) -> None:
             raise ValueError(
                 f"Only http and https URLs are allowed, got {parsed.scheme!r}"
             )
-        if _is_private_url(url):
-            raise ValueError(
-                "URLs targeting private, loopback, or link-local addresses "
-                "are not allowed."
-            )
+        hostname = parsed.hostname
+        if not hostname:
+            raise ValueError("The fetch URL has no host.")
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        # Resolve + validate the host now, and pin the resulting IP into the
+        # connection below: the address validated here is the one actually
+        # dialled, which closes the DNS-rebinding TOCTOU window. Fails closed.
+        pinned_ip = await _resolve_pinned_ip(hostname, port)
 
         # Conditional import — httpx is an optional dependency.
         try:
@@ -445,12 +507,25 @@ def register(mcp: FastMCP) -> None:
             else int(vault.max_attachment_size_mb * 1024 * 1024)
         )
 
+        # Connect to the validated IP, but keep the original Host header and TLS
+        # SNI so vhost routing and certificate verification still use the real
+        # hostname. httpx then dials the pinned IP without re-resolving.
+        ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+        pinned_netloc = f"{ip_host}:{parsed.port}" if parsed.port else ip_host
+        pinned_url = urlunparse(parsed._replace(netloc=pinned_netloc))
+        host_header = hostname if parsed.port is None else f"{hostname}:{parsed.port}"
+
         # Stream download — enforce size limit as chunks arrive.
         chunks: list[bytes] = []
         downloaded = 0
         async with (
             httpx.AsyncClient(timeout=timeout_s, follow_redirects=False) as client,
-            client.stream("GET", url) as response,
+            client.stream(
+                "GET",
+                pinned_url,
+                headers={"Host": host_header},
+                extensions={"sni_hostname": hostname},
+            ) as response,
         ):
             response.raise_for_status()
             content_type = response.headers.get("content-type")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import json
 import logging
+import socket
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import patch
 
 import pytest
 from fastmcp import Client
@@ -1071,6 +1074,31 @@ class TestFetchTool:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         return mock_client
 
+    @staticmethod
+    def _getaddrinfo_returning(
+        *ips: str,
+    ) -> Callable[..., list[tuple[int, int, int, str, tuple[str, int]]]]:
+        """Build a fake ``socket.getaddrinfo`` that resolves to *ips*."""
+
+        def fake(
+            _host: str, port: int, *_args: object, **_kwargs: object
+        ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+            out = []
+            for ip in ips:
+                family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+                out.append((family, socket.SOCK_STREAM, 6, "", (ip, port or 0)))
+            return out
+
+        return fake
+
+    @pytest.fixture(autouse=True)
+    def _stub_public_dns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Resolve any hostname to a fixed public IP so success-path fetch tests
+        never hit real DNS. SSRF tests override this with a private resolution."""
+        monkeypatch.setattr(
+            socket, "getaddrinfo", self._getaddrinfo_returning("93.184.216.34")
+        )
+
     async def test_fetch_markdown_note(
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
@@ -1348,6 +1376,111 @@ class TestFetchTool:
                     "fetch",
                     {"url": "http://0.0.0.0/admin", "path": "stolen.md"},
                 )
+
+    async def test_fetch_rejects_resolve_to_private(
+        self,
+        _mcp_env_writable_with_attachments: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A public hostname resolving to a private IP is blocked (DNS rebinding)."""
+        import httpx
+
+        monkeypatch.setattr(
+            socket, "getaddrinfo", self._getaddrinfo_returning("10.0.0.5")
+        )
+        mock_client = self._mock_httpx_stream(b"x", {})
+        with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            server = make_server()
+            async with Client(server) as client:
+                with pytest.raises(ToolError, match="non-public"):
+                    await client.call_tool(
+                        "fetch",
+                        {"url": "https://evil.example.com/x", "path": "x.md"},
+                    )
+        mock_client.stream.assert_not_called()
+
+    async def test_fetch_rejects_mixed_public_and_private(
+        self,
+        _mcp_env_writable_with_attachments: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If ANY resolved address is private, the fetch is blocked."""
+        import httpx
+
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            self._getaddrinfo_returning("93.184.216.34", "192.168.1.10"),
+        )
+        mock_client = self._mock_httpx_stream(b"x", {})
+        with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            server = make_server()
+            async with Client(server) as client:
+                with pytest.raises(ToolError, match="non-public"):
+                    await client.call_tool(
+                        "fetch",
+                        {"url": "https://evil.example.com/x", "path": "x.md"},
+                    )
+        mock_client.stream.assert_not_called()
+
+    async def test_fetch_rejects_resolve_to_ipv6_loopback(
+        self,
+        _mcp_env_writable_with_attachments: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An IPv6 loopback resolution is blocked."""
+        monkeypatch.setattr(socket, "getaddrinfo", self._getaddrinfo_returning("::1"))
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(ToolError, match="non-public"):
+                await client.call_tool(
+                    "fetch",
+                    {"url": "https://evil.example.com/x", "path": "x.md"},
+                )
+
+    async def test_fetch_fails_closed_on_resolution_error(
+        self,
+        _mcp_env_writable_with_attachments: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A DNS resolution error blocks the fetch (fail-closed, not fail-open)."""
+
+        def boom(_host: str, _port: int, *_args: object, **_kwargs: object) -> object:
+            raise socket.gaierror("name resolution failed")
+
+        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(ToolError, match="resolve"):
+                await client.call_tool(
+                    "fetch",
+                    {"url": "https://unresolvable.example/x", "path": "x.md"},
+                )
+
+    async def test_fetch_pins_validated_ip_with_host_and_sni(
+        self,
+        _mcp_env_writable_with_attachments: Path,
+    ) -> None:
+        """A public host is dialled by IP, with the original Host header + SNI."""
+        import httpx
+
+        # _stub_public_dns resolves any host to 93.184.216.34.
+        mock_client = self._mock_httpx_stream(
+            b"# Ok\n", {"content-type": "text/markdown"}
+        )
+        with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            server = make_server()
+            async with Client(server) as client:
+                await client.call_tool(
+                    "fetch",
+                    {"url": "https://example.com/note.md", "path": "pinned.md"},
+                )
+        mock_client.stream.assert_called_once()
+        call = mock_client.stream.call_args
+        assert call.args[0] == "GET"
+        assert call.args[1] == "https://93.184.216.34/note.md"
+        assert call.kwargs["headers"]["Host"] == "example.com"
+        assert call.kwargs["extensions"]["sni_hostname"] == "example.com"
 
     async def test_fetch_unicode_decode_error(
         self, _mcp_env_writable_with_attachments: Path

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ verifying end-to-end behaviour through the full Vault stack.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import socket
@@ -1074,30 +1075,56 @@ class TestFetchTool:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         return mock_client
 
+    # getaddrinfo sockaddr is a 2-tuple (host, port) for AF_INET and a 4-tuple
+    # (host, port, flowinfo, scope_id) for AF_INET6; the resolver only reads
+    # ``info[4][0]`` but the fake emits the real shapes so the annotation holds.
+    _Sockaddr = tuple[str, int] | tuple[str, int, int, int]
+
     @staticmethod
     def _getaddrinfo_returning(
         *ips: str,
-    ) -> Callable[..., list[tuple[int, int, int, str, tuple[str, int]]]]:
-        """Build a fake ``socket.getaddrinfo`` that resolves to *ips*."""
+    ) -> Callable[..., list[tuple[int, int, int, str, TestFetchTool._Sockaddr]]]:
+        """Build a fake ``getaddrinfo`` that resolves to *ips*."""
 
         def fake(
             _host: str, port: int, *_args: object, **_kwargs: object
-        ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
-            out = []
+        ) -> list[tuple[int, int, int, str, TestFetchTool._Sockaddr]]:
+            out: list[tuple[int, int, int, str, TestFetchTool._Sockaddr]] = []
             for ip in ips:
-                family = socket.AF_INET6 if ":" in ip else socket.AF_INET
-                out.append((family, socket.SOCK_STREAM, 6, "", (ip, port or 0)))
+                sockaddr: TestFetchTool._Sockaddr
+                if ":" in ip:
+                    family = socket.AF_INET6
+                    sockaddr = (ip, port or 0, 0, 0)
+                else:
+                    family = socket.AF_INET
+                    sockaddr = (ip, port or 0)
+                out.append((family, socket.SOCK_STREAM, 6, "", sockaddr))
             return out
 
         return fake
 
+    def _patch_resolves_to(self, monkeypatch: pytest.MonkeyPatch, *ips: str) -> None:
+        """Patch the running loop's ``getaddrinfo`` to resolve to *ips*.
+
+        Targets ``loop.getaddrinfo`` — what the resolver actually calls — rather
+        than ``socket.getaddrinfo``, so the stub holds under any event-loop
+        implementation (e.g. uvloop), not only CPython's selector loop where
+        ``loop.getaddrinfo`` happens to delegate to ``socket.getaddrinfo``.
+        """
+        fake = self._getaddrinfo_returning(*ips)
+
+        async def _aio_getaddrinfo(
+            host: str, port: int, *_args: object, **_kwargs: object
+        ) -> list[tuple[int, int, int, str, TestFetchTool._Sockaddr]]:
+            return fake(host, port)
+
+        monkeypatch.setattr(asyncio.get_running_loop(), "getaddrinfo", _aio_getaddrinfo)
+
     @pytest.fixture(autouse=True)
-    def _stub_public_dns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _stub_public_dns(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Resolve any hostname to a fixed public IP so success-path fetch tests
         never hit real DNS. SSRF tests override this with a private resolution."""
-        monkeypatch.setattr(
-            socket, "getaddrinfo", self._getaddrinfo_returning("93.184.216.34")
-        )
+        self._patch_resolves_to(monkeypatch, "93.184.216.34")
 
     async def test_fetch_markdown_note(
         self, _mcp_env_writable_with_attachments: Path
@@ -1385,9 +1412,7 @@ class TestFetchTool:
         """A public hostname resolving to a private IP is blocked (DNS rebinding)."""
         import httpx
 
-        monkeypatch.setattr(
-            socket, "getaddrinfo", self._getaddrinfo_returning("10.0.0.5")
-        )
+        self._patch_resolves_to(monkeypatch, "10.0.0.5")
         mock_client = self._mock_httpx_stream(b"x", {})
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
             server = make_server()
@@ -1407,11 +1432,7 @@ class TestFetchTool:
         """If ANY resolved address is private, the fetch is blocked."""
         import httpx
 
-        monkeypatch.setattr(
-            socket,
-            "getaddrinfo",
-            self._getaddrinfo_returning("93.184.216.34", "192.168.1.10"),
-        )
+        self._patch_resolves_to(monkeypatch, "93.184.216.34", "192.168.1.10")
         mock_client = self._mock_httpx_stream(b"x", {})
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
             server = make_server()
@@ -1429,7 +1450,7 @@ class TestFetchTool:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """An IPv6 loopback resolution is blocked."""
-        monkeypatch.setattr(socket, "getaddrinfo", self._getaddrinfo_returning("::1"))
+        self._patch_resolves_to(monkeypatch, "::1")
         server = make_server()
         async with Client(server) as client:
             with pytest.raises(ToolError, match="non-public"):
@@ -1445,16 +1466,33 @@ class TestFetchTool:
     ) -> None:
         """A DNS resolution error blocks the fetch (fail-closed, not fail-open)."""
 
-        def boom(_host: str, _port: int, *_args: object, **_kwargs: object) -> object:
+        async def boom(
+            _host: str, _port: int, *_args: object, **_kwargs: object
+        ) -> object:
             raise socket.gaierror("name resolution failed")
 
-        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        monkeypatch.setattr(asyncio.get_running_loop(), "getaddrinfo", boom)
         server = make_server()
         async with Client(server) as client:
             with pytest.raises(ToolError, match="resolve"):
                 await client.call_tool(
                     "fetch",
                     {"url": "https://unresolvable.example/x", "path": "x.md"},
+                )
+
+    async def test_fetch_fails_closed_on_empty_resolution(
+        self,
+        _mcp_env_writable_with_attachments: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A host that resolves to zero addresses blocks the fetch (fail-closed)."""
+        self._patch_resolves_to(monkeypatch)  # resolves to nothing
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(ToolError, match="did not resolve"):
+                await client.call_tool(
+                    "fetch",
+                    {"url": "https://empty.example/x", "path": "x.md"},
                 )
 
     async def test_fetch_pins_validated_ip_with_host_and_sni(
@@ -1481,6 +1519,28 @@ class TestFetchTool:
         assert call.args[1] == "https://93.184.216.34/note.md"
         assert call.kwargs["headers"]["Host"] == "example.com"
         assert call.kwargs["extensions"]["sni_hostname"] == "example.com"
+
+    async def test_fetch_host_header_port_handling(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        """The Host header omits an explicit default port (RFC 7230 §5.4) but
+        keeps a non-default one."""
+        import httpx
+
+        for url, expected_host in (
+            ("https://example.com:443/n.md", "example.com"),  # default → omitted
+            ("https://example.com:8443/n.md", "example.com:8443"),  # kept
+        ):
+            mock_client = self._mock_httpx_stream(
+                b"# Ok\n", {"content-type": "text/markdown"}
+            )
+            with patch.object(httpx, "AsyncClient", return_value=mock_client):
+                server = make_server()
+                async with Client(server) as client:
+                    await client.call_tool("fetch", {"url": url, "path": "p.md"})
+            assert (
+                mock_client.stream.call_args.kwargs["headers"]["Host"] == expected_host
+            )
 
     async def test_fetch_unicode_decode_error(
         self, _mcp_env_writable_with_attachments: Path

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "2.0.0rc3"
+version = "2.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

The `fetch` tool's SSRF guard (`_is_private_url`) only inspected the **URL host literal**. A public hostname that resolves to a private/internal address (`internal.example.com → 10.0.0.5`) sailed through the check, and even a host that passed could be re-pointed between the check and the connection (classic DNS-rebinding TOCTOU). The old helper's own docstring conceded it "does not prevent DNS rebinding attacks."

This closes both gaps:

- **Resolve before connecting.** `_resolve_pinned_ip` runs `getaddrinfo` and rejects the request if **any** resolved address is private, loopback, link-local, unspecified, reserved, or multicast. IP-literal hosts are validated directly (fast path).
- **Fail closed.** A resolution error or an empty result raises (blocks) — a DNS hiccup can never degrade into a bypass.
- **Pin the validated IP.** `fetch` then dials the exact IP that was validated, carrying the original `Host` header and TLS SNI via httpx `extensions={"sni_hostname": ...}`. The address validated *is* the address dialled, so the rebinding window is gone. Redirects remain disabled.

`_is_private_url` is removed (no remaining references in `src/` or `tests/`).

## Test Plan

New `TestFetchTool` cases (autouse fixture stubs DNS to a public IP so success paths don't hit the network):

- [x] `test_fetch_rejects_resolve_to_private` — host resolving to `10.0.0.5` is blocked; `stream` never called
- [x] `test_fetch_rejects_mixed_public_and_private` — public + private in the same answer is blocked
- [x] `test_fetch_rejects_resolve_to_ipv6_loopback` — `::1` is blocked
- [x] `test_fetch_fails_closed_on_resolution_error` — `gaierror` blocks (fail-closed)
- [x] `test_fetch_pins_validated_ip_with_host_and_sni` — connects to the pinned IP URL with the original `Host` header and `sni_hostname` extension
- [x] Existing IP-literal rejection tests (127.0.0.1, 169.254.169.254, 0.0.0.0) still pass

`uv run pytest tests/test_server.py::TestFetchTool` → 21 passed. Full `tests/test_server.py` → 215 passed. ruff + mypy clean; `mkdocs build --strict` passes.

## Docs

- `docs/tools/index.md` — `fetch` `url` row reflects the strengthened guard
- `fetch` docstring updated
- `loopback` added to the Vale vocabulary (HTTP/URL terms)

Closes #690.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)