### PR TITLE
perf: filter excluded paths in detect_changes (#257) + single config read on HTTP serve (#609)

### DIFF
--- a/src/markdown_vault_mcp/_cli_impl.py
+++ b/src/markdown_vault_mcp/_cli_impl.py
@@ -84,7 +84,11 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     maybe_start_debugpy(_ENV_PREFIX)
 
     transport = args.transport
-    server = make_server(transport=transport)
+    # The HTTP path needs config.server for the event store, and make_server
+    # needs the full config — read it once and share it so the environment is
+    # parsed a single time (#609). stdio lets make_server own the single read.
+    config = VaultConfig.from_env() if transport == "http" else None
+    server = make_server(transport=transport, config=config)
     env_http_path = os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
     http_path = normalise_http_path(args.http_path or env_http_path)
     if transport != "http" and (
@@ -96,7 +100,7 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     if transport == "http":
         import uvicorn
 
-        config = VaultConfig.from_env()
+        assert config is not None  # built above for the http transport
         event_store = build_event_store(config.server)
         # FastMCP's run() doesn't pass event_store through to http_app(),
         # so we build the ASGI app and run uvicorn directly.

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -354,8 +354,12 @@ class IndexManager:
             :class:`~markdown_vault_mcp.types.ReindexResult` with counts
             of changes applied.
         """
-        # Phase 1: scan filesystem (read-only walk + hashing).
-        changes = self._tracker.detect_changes(self._source_dir)
+        # Phase 1: scan filesystem (read-only walk + hashing). Excluded
+        # subtrees are filtered before hashing so they neither churn the
+        # tracker nor get reported as changes (#257).
+        changes = self._tracker.detect_changes(
+            self._source_dir, exclude_patterns=self._exclude_patterns
+        )
         logger.info(
             "reindex: %d added, %d modified, %d deleted, %d unchanged, %d skipped",
             len(changes.added),
@@ -381,13 +385,11 @@ class IndexManager:
 
         # Pre-parse notes outside the lock to minimise lock hold time.
         parsed: list[tuple[str, ParsedNote]] = []
+        # Excluded paths are filtered inside detect_changes (before hashing,
+        # #257), so they never reach this loop; the only skips recorded here
+        # are parse/decode failures and missing-frontmatter files below.
         for path in changes.added + changes.modified:
             abs_path = self._source_dir / path
-
-            if self._is_path_excluded(path):
-                logger.debug("reindex: excluding %s (matched exclude pattern)", path)
-                _record_skip(path, abs_path)
-                continue
 
             try:
                 note = parse_note(abs_path, self._source_dir, self._chunk_strategy)

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -117,7 +117,7 @@ def _build_default_instructions(*, read_only: bool) -> str:
     )
 
 
-def make_server(transport: str = "stdio") -> FastMCP:
+def make_server(transport: str = "stdio", config: VaultConfig | None = None) -> FastMCP:
     """Create and configure the FastMCP server.
 
     Reads configuration from environment variables via
@@ -139,11 +139,17 @@ def make_server(transport: str = "stdio") -> FastMCP:
         transport: ``"stdio"`` / ``"http"`` / ``"sse"`` / ``"streamable-http"``.
             Used to gate HTTP-only wiring (e.g. the GitHub webhook route) and
             as ``transport=%s`` in the startup log.
+        config: A pre-built :class:`~markdown_vault_mcp.config.VaultConfig`.
+            When ``None`` (the default) the config is read from the environment
+            via ``from_env``. Callers that already hold a config (e.g. the HTTP
+            serve path, which also needs ``config.server`` for the event store)
+            pass it here to avoid parsing the environment twice (#609).
 
     Returns:
         A fully configured :class:`~fastmcp.FastMCP` instance ready to run.
     """
-    config = VaultConfig.from_env()
+    if config is None:
+        config = VaultConfig.from_env()
     is_read_only = config.read_only
 
     server_name = config.server_name

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -85,6 +85,13 @@ class ChangeTracker:
            - in indexed state but absent from disk → **deleted**
            - in skipped state but absent from disk → dropped silently (it
              was never indexed, so nothing needs deleting)
+           - matches *exclude_patterns* → **filtered before hashing**: absent
+             from every result list, including **deleted**. A path that was
+             previously indexed and is now excluded is *withheld* from
+             ``deleted`` (it is excluded, not removed) so the reindex
+             stale-purge (#255) — which loads vectors before purging — remains
+             its sole remover; reporting it as deleted would leak its
+             embedding (#257).
 
         5. Return a :class:`~markdown_vault_mcp.types.ChangeSet`.
 
@@ -93,9 +100,11 @@ class ChangeTracker:
             glob_pattern: Glob pattern used to discover files, relative to
                 *source_dir*. Defaults to ``"**/*.md"``.
             exclude_patterns: Glob patterns (matched against the relative POSIX
-                path) whose files are skipped before hashing, so excluded
-                subtrees (e.g. ``.obsidian/**``) are neither hashed nor
-                reported as changes (#257). ``None`` excludes nothing.
+                path via :func:`~markdown_vault_mcp.utils.is_path_excluded`,
+                which uses :func:`fnmatch.fnmatch` — use a ``**`` suffix such as
+                ``.obsidian/**`` to match a whole subtree). Matching files are
+                skipped before hashing, so excluded subtrees are neither hashed
+                nor reported as changes (#257). ``None`` excludes nothing.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.ChangeSet` describing the delta.

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -7,10 +7,15 @@ import logging
 import os
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.hashing import compute_file_hash
 from markdown_vault_mcp.types import ChangeSet, ParsedNote
+from markdown_vault_mcp.utils import is_path_excluded
 from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +64,7 @@ class ChangeTracker:
         self,
         source_dir: Path,
         glob_pattern: str = "**/*.md",
+        exclude_patterns: Sequence[str] | None = None,
     ) -> ChangeSet:
         """Compare files on disk against stored state and return the delta.
 
@@ -86,6 +92,10 @@ class ChangeTracker:
             source_dir: Root directory of the markdown vault.
             glob_pattern: Glob pattern used to discover files, relative to
                 *source_dir*. Defaults to ``"**/*.md"``.
+            exclude_patterns: Glob patterns (matched against the relative POSIX
+                path) whose files are skipped before hashing, so excluded
+                subtrees (e.g. ``.obsidian/**``) are neither hashed nor
+                reported as changes (#257). ``None`` excludes nothing.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.ChangeSet` describing the delta.
@@ -101,6 +111,10 @@ class ChangeTracker:
                 rel_str = abs_path.relative_to(source_dir).as_posix()
             except ValueError:
                 logger.warning("File outside source_dir, skipping: %s", abs_path)
+                continue
+            # Skip excluded subtrees before hashing — saves the I/O and keeps
+            # them out of the ChangeSet (#257).
+            if is_path_excluded(rel_str, exclude_patterns):
                 continue
             try:
                 content_hash = self._compute_hash(abs_path)
@@ -131,8 +145,17 @@ class ChangeTracker:
             else:
                 added.append(rel_path)
 
+        # An excluded path that was previously indexed is filtered out of
+        # disk_state above, so it would otherwise look "deleted". It is not
+        # deleted — it is excluded — and the reindex stale-purge (#255) is the
+        # designated remover (it lazy-loads vectors before purging). Reporting
+        # it as deleted instead would route it through the delete loop, which
+        # does not load vectors, leaking its embedding (#257).
         deleted: list[str] = [
-            rel_path for rel_path in indexed_state if rel_path not in disk_state
+            rel_path
+            for rel_path in indexed_state
+            if rel_path not in disk_state
+            and not is_path_excluded(rel_path, exclude_patterns)
         ]
 
         logger.debug(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -433,6 +433,45 @@ class TestCmdServe:
         _cmd_serve(args)
         mock_server.run.assert_called_once_with(transport="stdio")
 
+    @patch("uvicorn.run")
+    @patch("markdown_vault_mcp.server.build_event_store")
+    @patch("markdown_vault_mcp._cli_impl.VaultConfig")
+    @patch("markdown_vault_mcp.server.make_server")
+    def test_serve_http_reads_config_once_and_reuses_it(
+        self,
+        mock_create: MagicMock,
+        mock_vault_config: MagicMock,
+        mock_build_es: MagicMock,
+        _mock_uvicorn_run: MagicMock,
+    ) -> None:
+        """#609: the HTTP path reads config once and hands the same object to
+        make_server() and build_event_store(), instead of parsing env twice."""
+        mock_server = MagicMock()
+        mock_create.return_value = mock_server
+        mock_config = MagicMock()
+        mock_vault_config.from_env.return_value = mock_config
+        mock_server.http_app.return_value = MagicMock()
+
+        args = _build_parser().parse_args(["serve", "--transport", "http"])
+        _cmd_serve(args)
+
+        mock_vault_config.from_env.assert_called_once()
+        assert mock_create.call_args.kwargs.get("config") is mock_config
+        mock_build_es.assert_called_once_with(mock_config.server)
+
+    @patch("markdown_vault_mcp._cli_impl.VaultConfig")
+    @patch("markdown_vault_mcp.server.make_server")
+    def test_serve_stdio_does_not_read_config(
+        self, mock_create: MagicMock, mock_vault_config: MagicMock
+    ) -> None:
+        """#609: the stdio path lets make_server own the single config read —
+        _cmd_serve must not call VaultConfig.from_env itself."""
+        mock_create.return_value = MagicMock()
+        args = _build_parser().parse_args(["serve"])
+        _cmd_serve(args)
+        mock_vault_config.from_env.assert_not_called()
+        assert mock_create.call_args.kwargs.get("config") is None
+
 
 class TestCmdIndex:
     """Test the index subcommand."""

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -321,25 +321,25 @@ class TestSkipStateMemory:
         paths = {n["path"] for n in fts.list_notes()}
         assert "skip.md" in paths
 
-    def test_excluded_file_recorded_as_skip(self, tmp_path: Path) -> None:
-        """A file matching exclude_patterns is skipped once, then remembered."""
+    def test_excluded_file_not_hashed_or_reported(self, tmp_path: Path) -> None:
+        """A file matching exclude_patterns is filtered before hashing (#257):
+        it is neither indexed nor surfaced as a change, so it is not even
+        skip-counted (detect_changes drops it entirely)."""
         vault = tmp_path / "vault"
         vault.mkdir()
         (vault / "good.md").write_text("# Good\n\nbody\n", encoding="utf-8")
-        mgr, _fts, _ = _make_index_mgr(vault, tmp_path, exclude_patterns=["drafts/**"])
+        mgr, fts, _ = _make_index_mgr(vault, tmp_path, exclude_patterns=["drafts/**"])
         mgr.build_index()
 
         drafts = vault / "drafts"
         drafts.mkdir()
         (drafts / "wip.md").write_text("# WIP\n", encoding="utf-8")
 
-        first = mgr.reindex()
-        assert first.added == 0
-        assert first.skipped == 1
-
-        second = mgr.reindex()
-        assert second.added == 0
-        assert second.skipped == 1
+        result = mgr.reindex()
+        assert result.added == 0
+        assert result.skipped == 0  # excluded files are invisible, not skip-counted
+        indexed = {row["path"] for row in fts.list_notes()}
+        assert "drafts/wip.md" not in indexed
 
     def test_transient_oserror_skip_is_retried(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -414,15 +414,22 @@ class TestSkipStateMemory:
     def test_record_skip_hash_oserror_is_swallowed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """An OSError while hashing a skip leaves it unrecorded (retry later)."""
+        """An OSError while hashing a deterministically-skipped file (a parse
+        error) leaves it unrecorded, so it retries on the next scan."""
         vault = tmp_path / "vault"
         vault.mkdir()
-        drafts = vault / "drafts"
-        drafts.mkdir()
-        (drafts / "wip.md").write_text("# WIP\n", encoding="utf-8")
-        mgr, _fts, _ = _make_index_mgr(vault, tmp_path, exclude_patterns=["drafts/**"])
+        (vault / "bad.md").write_text("# Bad\n", encoding="utf-8")
+        mgr, _fts, _ = _make_index_mgr(vault, tmp_path)
 
         import markdown_vault_mcp.managers.index as index_module
+
+        # A non-OSError parse failure is a deterministic skip recorded via
+        # _record_skip (the path that hashes the file).
+        def failing_parse(abs_path, source_dir, chunk_strategy):  # noqa: ARG001
+            raise ValueError("unparseable")
+
+        monkeypatch.setattr(index_module, "parse_note", failing_parse)
+        real_hash = index_module.compute_file_hash
 
         def failing_hash(path):  # noqa: ARG001
             raise OSError("unreadable")
@@ -432,7 +439,7 @@ class TestSkipStateMemory:
         assert first.added == 0
         assert first.skipped == 0  # hash failed → skip not recorded
 
-        monkeypatch.undo()
+        monkeypatch.setattr(index_module, "compute_file_hash", real_hash)
         second = mgr.reindex()
         assert second.skipped == 1  # retried and recorded this time
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3545,3 +3545,33 @@ async def test_transfer_download_present_upload_hidden_in_readonly():
         names = {t.name for t in await client.list_tools()}
     assert "create_download_link" in names
     assert "create_upload_link" not in names
+
+
+# ---------------------------------------------------------------------------
+# #609: make_server reuses a provided config instead of re-reading env
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_mcp_env")
+def test_make_server_reuses_provided_config_without_re_reading_env() -> None:
+    """make_server(config=...) must not call VaultConfig.from_env again (#609)."""
+    from unittest.mock import patch
+
+    from markdown_vault_mcp.config import VaultConfig
+
+    config = VaultConfig.from_env()
+    with patch.object(VaultConfig, "from_env", wraps=VaultConfig.from_env) as spy:
+        make_server(config=config)
+    spy.assert_not_called()
+
+
+@pytest.mark.usefixtures("_mcp_env")
+def test_make_server_reads_config_from_env_once_when_not_provided() -> None:
+    """make_server() with no config reads env exactly once."""
+    from unittest.mock import patch
+
+    from markdown_vault_mcp.config import VaultConfig
+
+    with patch.object(VaultConfig, "from_env", wraps=VaultConfig.from_env) as spy:
+        make_server()
+    spy.assert_called_once()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -579,3 +579,71 @@ class TestLegacyStateFormat:
         tracker = ChangeTracker(state_path)
         changes = tracker.detect_changes(vault)
         assert "a.md" in changes.added
+
+
+class TestExcludePatterns:
+    """#257: detect_changes filters paths matching exclude_patterns."""
+
+    def test_excluded_paths_not_reported(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "note.md")
+        _write_md(vault, ".claude/test.md")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        changes = tracker.detect_changes(vault, exclude_patterns=[".claude/**"])
+
+        assert "note.md" in changes.added
+        assert ".claude/test.md" not in changes.added
+
+    def test_default_none_includes_all(self, tmp_path: Path) -> None:
+        # Back-compat: callers that pass no exclude_patterns see every file.
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "note.md")
+        _write_md(vault, ".claude/test.md")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        changes = tracker.detect_changes(vault)
+
+        assert ".claude/test.md" in changes.added
+
+    def test_excluded_paths_not_hashed(self, tmp_path: Path) -> None:
+        # The perf win: excluded files are skipped BEFORE hashing.
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "note.md")
+        _write_md(vault, ".obsidian/cache.md")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        hashed: list[str] = []
+        original = tracker._compute_hash
+
+        def spy(path: Path) -> str:
+            hashed.append(path.name)
+            return original(path)
+
+        with patch.object(tracker, "_compute_hash", side_effect=spy):
+            tracker.detect_changes(vault, exclude_patterns=[".obsidian/**"])
+
+        assert "note.md" in hashed
+        assert "cache.md" not in hashed
+
+    def test_excluded_path_in_state_not_reported_deleted(self, tmp_path: Path) -> None:
+        # A previously-indexed path that is now excluded is filtered, not
+        # "deleted" — the reindex stale-purge (#255) removes it (and its
+        # vectors). Reporting it as deleted would leak its embedding (#257).
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "note.md")
+        _write_md(vault, ".claude/old.md")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.update_state(
+            [_make_note("note.md", "h1"), _make_note(".claude/old.md", "h2")]
+        )
+
+        changes = tracker.detect_changes(vault, exclude_patterns=[".claude/**"])
+        assert ".claude/old.md" not in changes.deleted
+        assert ".claude/old.md" not in changes.added
+        assert ".claude/old.md" not in changes.modified

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "2.0.0rc3"
+version = "2.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Two independent startup/reindex perf cleanups, bundled per the no-orphan-PR rule.

## #257 — `exclude_patterns` in `ChangeTracker.detect_changes()`

`detect_changes()` scanned every `**/*.md` and hashed it, even files under excluded subtrees (`.obsidian/**`, `.claude/**`); they were reported as "added" each `reindex()` then filtered downstream — wasted I/O and tracker churn.

- `detect_changes()` gains `exclude_patterns: Sequence[str] | None = None` (default `None` = nothing excluded → existing callers unaffected) and skips matching paths **before hashing**.
- `reindex()` passes the manager's `exclude_patterns`.
- Excluded paths are also filtered from the **`deleted`** list: a previously-indexed-now-excluded file is *filtered*, not *deleted*, so the #255 stale-purge (which lazy-loads vectors before purging) stays its sole remover. Routing it through the delete loop would leak its embedding (the delete loop doesn't load vectors) — caught by `test_reindex_purges_stale_excluded_docs_with_embeddings`.
- The now-dead `excluded → _record_skip` branch in `reindex()` is removed (detect_changes filters those paths before they can reach it). `_record_skip` still covers parse/decode failures.

**Behavior change:** excluded files are no longer counted in `reindex`'s `skipped` (they're invisible to change-detection now), and no longer hashed.

## #609 — single config read on the HTTP serve path

`_cmd_serve` (HTTP) called `VaultConfig.from_env()` and `make_server()` also called it internally → env parsed twice per process.

- `make_server(transport, config=None)`: builds its own config from env when `config is None` (default); reuses a provided one otherwise. Backward-compatible — every existing caller passes no config.
- `_cmd_serve` builds the config once on the HTTP path and hands the same object to `make_server()` and `build_event_store()`. stdio is unchanged (make_server owns the single read).

## Tests

- `TestExcludePatterns`: excluded paths not hashed (spy on `_compute_hash`), not reported, not deleted-when-previously-indexed.
- Updated reindex skip tests for the new excluded-file behavior (excluded = invisible, not skip-counted); `_record_skip`'s OSError-swallow re-routed through a parse-error path.
- `make_server` reuses a provided config without re-reading env; `_cmd_serve` reads config once on HTTP and not at all on stdio.

Full suite: **2238 passed, 1 skipped**. `tracker.py` patch coverage 100%; ruff + mypy clean.

Closes #257, closes #609.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)