### PR TITLE
perf: parallelize vault_graph_hubs fetches (#285) + drop README sentinel-name leak (#486)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For reverse proxy (Traefik) and deployment setup, see [`docs/deployment.md`](doc
 
 ### Server info
 
-The server registers a built-in `get_server_info` tool (via `fastmcp_pvl_core.register_server_info_tool`) so operators can confirm the deployed version with a single MCP call. The response carries `server_name`, `server_version`, and `core_version`. Wire upstream version reporting (when applicable) inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/markdown_vault_mcp/server.py`.
+The server registers a built-in `get_server_info` tool (via `fastmcp_pvl_core.register_server_info_tool`) so operators can confirm the deployed version with a single MCP call. The response carries `server_name`, `server_version`, and `core_version`.
 
 ## Configuration
 

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -644,14 +644,39 @@ def register_apps(mcp: FastMCP) -> None:
                 "folder": hub.folder,
             }
 
-            # Get immediate connections for each hub
+        # Fetch every hub's backlinks concurrently. Each call is an independent
+        # read and FTS uses per-thread sqlite connections, so the to_thread
+        # calls run in parallel safely instead of one-at-a-time (#285).
+        async def _backlinks(path: str) -> list[Any]:
             try:
-                backlinks = await asyncio.to_thread(vault.graph.get_backlinks, hub.path)
+                return await asyncio.to_thread(vault.graph.get_backlinks, path)
             except ValueError:
-                backlinks = []
+                return []
+
+        backlinks_per_hub = await asyncio.gather(*(_backlinks(h.path) for h in hubs))
+
+        # Collect the non-hub source paths that need a note read, preserving
+        # first-seen order so labels/folders are assigned deterministically,
+        # then read them all concurrently (deduplicated — a source linking
+        # several hubs is read once).
+        to_read: list[str] = []
+        seen_read: set[str] = set()
+        for backlinks in backlinks_per_hub:
+            for bl in backlinks:
+                if bl.source_path not in nodes and bl.source_path not in seen_read:
+                    seen_read.add(bl.source_path)
+                    to_read.append(bl.source_path)
+        read_results = await asyncio.gather(
+            *(asyncio.to_thread(vault.reader.read, p) for p in to_read)
+        )
+        notes_by_path = dict(zip(to_read, read_results, strict=True))
+
+        # Build nodes + edges in the original (hub, backlink) order so the
+        # output is identical to the sequential version.
+        for hub, backlinks in zip(hubs, backlinks_per_hub, strict=True):
             for bl in backlinks:
                 if bl.source_path not in nodes:
-                    note = await asyncio.to_thread(vault.reader.read, bl.source_path)
+                    note = notes_by_path.get(bl.source_path)
                     label = (
                         note.title
                         if note

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -192,6 +192,48 @@ class TestGraphDataTools:
             f"hub documents should not be read directly; read={read_paths}"
         )
 
+    async def test_hubs_reads_each_backlink_source_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#285: the parallelized hub fetch still de-duplicates note reads — a
+        source backlinking several hubs is read at most once."""
+        from markdown_vault_mcp.facets.reader import ReaderFacet
+
+        original_read = ReaderFacet.read
+        read_paths: list[str] = []
+
+        def _spy(self: ReaderFacet, path: str) -> Any:
+            read_paths.append(path)
+            return original_read(self, path)
+
+        monkeypatch.setattr(ReaderFacet, "read", _spy)
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            await client.call_tool(_hashed("vault_graph_hubs"), {})
+        assert len(read_paths) == len(set(read_paths)), (
+            f"backlink sources should be read once each; reads={read_paths}"
+        )
+
+    async def test_hubs_tolerates_backlinks_valueerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#285: a hub whose get_backlinks raises ValueError degrades to no
+        connections rather than failing the whole graph."""
+        from markdown_vault_mcp.facets.graph import GraphFacet
+
+        def _boom(self: GraphFacet, path: str) -> Any:  # noqa: ARG001
+            raise ValueError("no such note")
+
+        monkeypatch.setattr(GraphFacet, "get_backlinks", _boom)
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(_hashed("vault_graph_hubs"), {})
+            data = _parse_tool_data(result)
+        assert "nodes" in data  # hubs still returned
+        assert data["edges"] == []  # no backlinks resolved → no edges
+
     async def test_edges_have_type(self) -> None:
         server = make_server()
         async with Client(server) as client:

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "2.0.0rc3"
+version = "2.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Two v2.0-polish items bundled (the user allowed combining issues).

## #285 — parallelize `vault_graph_hubs`

`vault_graph_hubs` fetched each hub's backlinks, and each connected note, with **sequential** awaits in nested loops. FTS uses **per-thread sqlite connections** (`threading.local()`, `check_same_thread=False`), so these independent reads are safe to run concurrently:

- `asyncio.gather` all hubs' backlink fetches,
- then `gather` the **deduplicated** note reads,
- then build nodes/edges in the original `(hub, backlink)` order → output byte-identical to the sequential version.

The other two #285 items were **already shipped**, verified:
- **CDN pinning:** every SPA dep is version-pinned (`vis-network@10.0.2`, `marked@17.0.5`, `dompurify@3.3.3`, `ext-apps@1.3.1` — no `@latest`) and vendored into `app.html` as base64 (the shipped file has **0** runtime CDN refs).
- **Neighborhood `max_nodes`:** `vault_graph_neighborhood` already carries the soft cap + `truncated` flag (and its BFS is inherently sequential, so `gather` doesn't apply).

**Tests:** backlink sources read once each (dedup preserved under parallel fetch); a hub whose `get_backlinks` raises `ValueError` degrades to no connections. Existing `test_hubs_does_not_read_hub_documents` (hubs never read) still holds.

## #486 — drop sentinel marker name from README

README's *Server info* section named the internal copier sentinel (`DOMAIN-UPSTREAM-START`/`-END`) in user-facing prose. That template machinery already lives in `CLAUDE.md` (dev-facing); removed the sentence, kept the user-facing `get_server_info` description. The other leaks #486 listed (`docs/guides/file-exchange.md`) are already gone — that guide was removed when file-exchange was replaced by transfer-links.

Acceptance grep over `README.md` + `docs/` returns no sentinel-name matches (HTML-comment markers kept); `CLAUDE.md` unchanged.

## Verification

Full suite: **2231 passed, 1 skipped**. `_server_apps.py` patch coverage ~100% on the changed lines; ruff + mypy clean.

Closes #285, closes #486.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)