### PR TITLE
chore(copier): update to v2.3.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.1.2
+_commit: v2.3.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Build documentation
         run: uv run mkdocs build --strict
 
+      - name: Install browser test deps
+        run: uv sync --no-default-groups --all-extras --group docs --group browser --frozen
+
+      - name: Install Chromium
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run config-wizard smoke test
+        run: uv run pytest tests/test_config_wizard_smoke.py -v -m browser
+
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:
     #   stable release (prerelease=false) -> version <major.minor> + `latest` alias (default)

--- a/docs/configuration-generator.md
+++ b/docs/configuration-generator.md
@@ -5,6 +5,7 @@ deployment. Everything runs in your browser; nothing you type is sent anywhere.
 Secret fields (tokens, keys) are never included in the shareable link; replace
 the `<YOUR_...>` placeholders if you leave them blank.
 
+<!-- The relative path relies on MkDocs' default use_directory_urls: true -->
 <div id="cfg-wizard" data-spec-url="../javascripts/config-wizard/wizard-spec.json">
   Loading the configuration generator…
 </div>

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -1,17 +1,16 @@
-// Pure config-output generators. No DOM, no spec knowledge beyond the emit map.
+// Pure config-output generators. No DOM. All per-project data comes from
+// spec.meta; Docker path behaviour comes from per-question dockerVolume /
+// dockerPath. This file is template-owned and identical across all consumers.
 
-const IMAGE = "ghcr.io/pvliesdonk/markdown-vault-mcp:latest";
+const FASTMCP_HOME = "/data/state/fastmcp";
+// The named state volume, mounted in every Docker/Compose artifact.
+const STATE_VOLUME = "state-data:/data/state";
 
-// Vars whose value is fixed to a container path in Docker/Compose output.
-const CONTAINER_PATHS = {
-  MARKDOWN_VAULT_MCP_SOURCE_DIR: "/data/vault",
-  MARKDOWN_VAULT_MCP_INDEX_PATH: "/data/state/index.db",
-  MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH: "/data/state/embeddings/embeddings",
-  MARKDOWN_VAULT_MCP_STATE_PATH: "/data/state/state.json",
-  MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR: "/data/state/fastembed",
+const secretPlaceholder = (key, envPrefix) => {
+  const prefix = `${envPrefix}_`;
+  const short = key.startsWith(prefix) ? key.slice(prefix.length) : key;
+  return `<YOUR_${short}>`;
 };
-
-const SECRET_PLACEHOLDER = (key) => `<YOUR_${key.replace(/^MARKDOWN_VAULT_MCP_/, "")}>`;
 
 // Single-quote a value for a POSIX shell `-e KEY=value` argument, but only when
 // it contains characters outside the shell-safe set (keeps clean output tidy).
@@ -20,11 +19,22 @@ const shellQuote = (v) => {
   return /^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${s.replace(/'/g, "'\\''")}'`;
 };
 
-// Quote a YAML scalar only when it contains characters that would otherwise
-// break parsing (or has surrounding whitespace, or is empty).
+// Bare tokens that YAML 1.1 parsers (used by Docker Compose) coerce to
+// bool/null/number. Env values are always strings, so these must be quoted to
+// stay strings — `KEY: true` would otherwise load as a boolean, `KEY: 8080` as
+// an int. Case-insensitive; covers bool, null, decimal/hex/octal ints, floats
+// (incl. exponent and ±.inf/.nan).
+const YAML_TYPED =
+  /^(?:y|n|yes|no|on|off|true|false|null|~|[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?|0x[0-9a-fA-F]+|0o[0-7]+|[-+]?\.(?:inf|nan))$/i;
+
+// Quote a YAML scalar when it contains characters that would otherwise break
+// parsing (or has surrounding whitespace, or is empty), or when it is a bare
+// token a YAML 1.1 parser would type-coerce.
 const yamlScalar = (v) => {
   const s = String(v);
-  return /[:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s) ? JSON.stringify(s) : s;
+  return YAML_TYPED.test(s) || /[\n:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s)
+    ? JSON.stringify(s)
+    : s;
 };
 
 // A systemd `Environment=` line. systemd does NOT expand `$` in Environment=
@@ -44,7 +54,8 @@ const systemdLine = (k, v) => {
 // dropped; a visible secret left empty becomes a placeholder so the artifact is
 // still complete and signals "replace me".
 export function buildEnvMap(spec, answers) {
-  const secrets = new Set(spec.secretKeys);
+  const secrets = new Set(spec.secretKeys ?? []);
+  const envPrefix = spec.meta.envPrefix;
   const map = {};
   for (const q of spec.questions) {
     if (!isVisible(q, answers)) continue;
@@ -55,7 +66,7 @@ export function buildEnvMap(spec, answers) {
     if (q.var) {
       const raw = answers[q.id];
       if (raw !== undefined && raw !== "") map[q.var] = raw;
-      else if (secrets.has(q.var)) map[q.var] = SECRET_PLACEHOLDER(q.var);
+      else if (secrets.has(q.var)) map[q.var] = secretPlaceholder(q.var, envPrefix);
     }
   }
   return map;
@@ -66,67 +77,88 @@ export function isVisible(q, answers) {
   return Object.entries(q.showIf).every(([k, allowed]) => allowed.includes(answers[k]));
 }
 
-function dockerEnvMap(map) {
-  const out = { ...map };
-  // SOURCE_DIR is always forced to its container path; the remaining container
-  // paths override only when the user supplied a value (else the server default
-  // under /data applies).
-  out.MARKDOWN_VAULT_MCP_SOURCE_DIR = CONTAINER_PATHS.MARKDOWN_VAULT_MCP_SOURCE_DIR;
-  for (const [k, v] of Object.entries(CONTAINER_PATHS)) {
-    if (k !== "MARKDOWN_VAULT_MCP_SOURCE_DIR" && k in out) out[k] = v;
+// Bind mounts for visible dockerVolume questions: [[hostPath, containerPath]].
+// An empty answer yields a `/path/to/<id>` placeholder so the artifact still
+// reads as "replace me".
+export function dockerVolumes(spec, answers) {
+  const vols = [];
+  for (const q of spec.questions) {
+    if (!q.dockerVolume || !isVisible(q, answers)) continue;
+    const host = answers[q.id] || `/path/to/${q.id}`;
+    vols.push([host, q.dockerVolume]);
   }
-  out.FASTMCP_HOME = "/data/state/fastmcp";
+  return vols;
+}
+
+// Rewrite the env map for Docker/Compose output. A dockerVolume question's var
+// is always fixed to its container path (the bind mount makes that path real).
+// A dockerPath question's var is fixed only when already present (the user
+// opted into the value); dockerPath never adds a mount. FASTMCP_HOME is injected.
+function dockerEnvMap(spec, answers, map) {
+  const out = { ...map };
+  for (const q of spec.questions) {
+    if (!isVisible(q, answers) || !q.var) continue;
+    if (q.dockerVolume) {
+      out[q.var] = q.dockerVolume;
+    } else if (q.dockerPath && q.var in out) {
+      out[q.var] = q.dockerPath;
+    }
+  }
+  out.FASTMCP_HOME = FASTMCP_HOME;
   return out;
 }
 
 // Quote a .env value when it contains characters that common dotenv parsers
 // treat specially (notably `#`, which starts an inline comment in an unquoted
-// value and would silently truncate the value on load).
+// value and would silently truncate the value on load, and `$`, which triggers
+// variable expansion when the file is shell-sourced).
 const dotenvQuote = (v) => {
   const s = String(v);
-  if (!/[#"'\\\s]/.test(s)) return s;
-  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  if (!/[#"'\\\s$]/.test(s)) return s;
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, '\\$')}"`;
 };
 
 export function generateDotenv(map) {
   return Object.entries(map).map(([k, v]) => `${k}=${dotenvQuote(v)}`).join("\n") + "\n";
 }
 
-export function generateClaudeJson(map) {
+export function generateClaudeJson(meta, map) {
   return JSON.stringify(
-    { mcpServers: { "markdown-vault": { command: "markdown-vault-mcp", args: ["serve"], env: map } } },
+    { mcpServers: { [meta.projectName]: { command: meta.projectName, args: ["serve"], env: map } } },
     null, 2,
   );
 }
 
-export function generateDockerRun(map, hostVaultPath) {
-  const env = dockerEnvMap(map);
+export function generateDockerRun(spec, answers, map) {
+  const env = dockerEnvMap(spec, answers, map);
   const lines = [
-    "docker run -d --name markdown-vault-mcp",
+    `docker run -d --name ${spec.meta.projectName}`,
     "  -p 8000:8000",
-    `  -v ${shellQuote(hostVaultPath || "/path/to/vault")}:/data/vault`,
-    "  -v state-data:/data/state",
+    `  -v ${STATE_VOLUME}`,
   ];
+  for (const [host, container] of dockerVolumes(spec, answers)) {
+    lines.push(`  -v ${shellQuote(host)}:${container}`);
+  }
   for (const [k, v] of Object.entries(env)) lines.push(`  -e ${k}=${shellQuote(v)}`);
-  lines.push(`  ${IMAGE}`);
+  lines.push(`  ${spec.meta.dockerImage}`);
   return lines.join(" \\\n");
 }
 
-export function generateCompose(map, hostVaultPath) {
-  const env = dockerEnvMap(map);
+export function generateCompose(spec, answers, map) {
+  const env = dockerEnvMap(spec, answers, map);
+  const volLines = [`      - ${STATE_VOLUME}`];
+  for (const [host, container] of dockerVolumes(spec, answers)) {
+    volLines.push(`      - ${yamlScalar(`${host}:${container}`)}`);
+  }
   const envLines = Object.entries(env).map(([k, v]) => `      ${k}: ${yamlScalar(v)}`).join("\n");
-  // Quote the whole "host:/data/vault" mount when the host path needs it.
-  const mount = `${hostVaultPath || "/path/to/vault"}:/data/vault`;
-  const mountLine = /[\s"#]/.test(mount) ? `      - ${JSON.stringify(mount)}` : `      - ${mount}`;
   return [
     "services:",
-    "  markdown-vault-mcp:",
-    `    image: ${IMAGE}`,
+    `  ${spec.meta.projectName}:`,
+    `    image: ${spec.meta.dockerImage}`,
     "    ports:",
     '      - "8000:8000"',
     "    volumes:",
-    mountLine,
-    "      - state-data:/data/state",
+    ...volLines,
     "    environment:",
     envLines,
     "volumes:",
@@ -134,18 +166,19 @@ export function generateCompose(map, hostVaultPath) {
   ].join("\n");
 }
 
-export function generateSystemd(map) {
+export function generateSystemd(meta, map) {
+  const name = meta.projectName;
   const envLines = Object.entries(map).map(([k, v]) => systemdLine(k, v)).join("\n");
   return [
     "[Unit]",
-    "Description=markdown-vault-mcp",
+    `Description=${name}`,
     "After=network.target",
     "",
     "[Service]",
     "Type=simple",
-    "# Create this user first: sudo useradd --system --no-create-home markdown-vault-mcp",
-    "User=markdown-vault-mcp",
-    "ExecStart=/opt/markdown-vault-mcp/venv/bin/markdown-vault-mcp serve --transport http",
+    `# Create this user first: sudo useradd --system --no-create-home ${name}`,
+    `User=${name}`,
+    `ExecStart=/opt/${name}/venv/bin/${name} serve --transport http`,
     envLines,
     "Restart=on-failure",
     "",

--- a/docs/javascripts/config-wizard/wizard-spec-schema.json
+++ b/docs/javascripts/config-wizard/wizard-spec-schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pvliesdonk.github.io/fastmcp-server-template/wizard-spec-schema.json",
+  "title": "fastmcp config-wizard spec",
+  "$comment": "Runtime convention not expressible here: wizard.js keys local-vs-server output off a question with id 'deployment' whose 'server' value selects the HTTP/Docker/systemd tabs. A spec omitting it degrades to local-only output.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "meta", "questions"],
+  "properties": {
+    "version": { "const": 1 },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["projectName", "dockerImage", "envPrefix"],
+      "properties": {
+        "projectName": { "type": "string", "minLength": 1 },
+        "dockerImage": { "type": "string", "minLength": 1 },
+        "envPrefix": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]*[A-Z0-9]$",
+          "description": "Mirrors the copier.yml env_prefix validator: uppercase/digits/underscore, ≥2 chars, no trailing underscore."
+        }
+      }
+    },
+    "secretKeys": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "questions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/question" }
+    },
+    "guards": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/guard" }
+    }
+  },
+  "$defs": {
+    "question": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "type"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+        "label": { "type": "string", "minLength": 1 },
+        "help": { "type": "string", "minLength": 1 },
+        "type": { "enum": ["text", "select", "bool", "number"] },
+        "var": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" },
+        "advancedGroup": { "type": "string", "minLength": 1 },
+        "showIf": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/option" }
+        },
+        "dockerVolume": { "type": "string", "pattern": "^/" },
+        "dockerPath": { "type": "string", "pattern": "^/" }
+      },
+      "allOf": [
+        {
+          "if": { "required": ["type"], "properties": { "type": { "const": "select" } } },
+          "then": { "required": ["options"] }
+        }
+      ],
+      "not": { "required": ["dockerVolume", "dockerPath"] }
+    },
+    "option": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "label"],
+      "properties": {
+        "value": { "type": "string" },
+        "label": { "type": "string", "minLength": 1 },
+        "emit": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "guard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "message", "when"],
+      "properties": {
+        "level": { "enum": ["warning", "info", "error"] },
+        "message": { "type": "string", "minLength": 1 },
+        "when": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -1,5 +1,10 @@
 {
   "version": 1,
+  "meta": {
+    "projectName": "markdown-vault-mcp",
+    "dockerImage": "ghcr.io/pvliesdonk/markdown-vault-mcp:latest",
+    "envPrefix": "MARKDOWN_VAULT_MCP"
+  },
   "secretKeys": [
     "MARKDOWN_VAULT_MCP_GIT_TOKEN",
     "OPENAI_API_KEY",
@@ -15,8 +20,14 @@
       "help": "Local stdio for Claude Desktop/Code, or an HTTP server for Docker/systemd.",
       "type": "select",
       "options": [
-        { "value": "local", "label": "Local (Claude Desktop / Claude Code, stdio)" },
-        { "value": "server", "label": "Server (HTTP — Docker / Compose / systemd)" }
+        {
+          "value": "local",
+          "label": "Local (Claude Desktop / Claude Code, stdio)"
+        },
+        {
+          "value": "server",
+          "label": "Server (HTTP \u2014 Docker / Compose / systemd)"
+        }
       ]
     },
     {
@@ -24,7 +35,8 @@
       "label": "Vault directory (host path)",
       "help": "Absolute path to your markdown vault on the host.",
       "type": "text",
-      "var": "MARKDOWN_VAULT_MCP_SOURCE_DIR"
+      "var": "MARKDOWN_VAULT_MCP_SOURCE_DIR",
+      "dockerVolume": "/data/vault"
     },
     {
       "id": "read_only",
@@ -32,8 +44,20 @@
       "help": "Read-only is safest; read-write enables write/edit/delete and git commits.",
       "type": "select",
       "options": [
-        { "value": "true", "label": "Read-only", "emit": { "MARKDOWN_VAULT_MCP_READ_ONLY": "true" } },
-        { "value": "false", "label": "Read-write", "emit": { "MARKDOWN_VAULT_MCP_READ_ONLY": "false" } }
+        {
+          "value": "true",
+          "label": "Read-only",
+          "emit": {
+            "MARKDOWN_VAULT_MCP_READ_ONLY": "true"
+          }
+        },
+        {
+          "value": "false",
+          "label": "Read-write",
+          "emit": {
+            "MARKDOWN_VAULT_MCP_READ_ONLY": "false"
+          }
+        }
       ]
     },
     {
@@ -42,10 +66,31 @@
       "help": "FTS-only needs no model. fastembed is local & zero-config. ollama/openai need a backend.",
       "type": "select",
       "options": [
-        { "value": "none", "label": "None (keyword/FTS only)" },
-        { "value": "fastembed", "label": "fastembed (local, zero-config)", "emit": { "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "fastembed" } },
-        { "value": "ollama", "label": "Ollama", "emit": { "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "ollama" } },
-        { "value": "openai", "label": "OpenAI / compatible", "emit": { "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "openai" } }
+        {
+          "value": "none",
+          "label": "None (keyword/FTS only)"
+        },
+        {
+          "value": "fastembed",
+          "label": "fastembed (local, zero-config)",
+          "emit": {
+            "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "fastembed"
+          }
+        },
+        {
+          "value": "ollama",
+          "label": "Ollama",
+          "emit": {
+            "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "ollama"
+          }
+        },
+        {
+          "value": "openai",
+          "label": "OpenAI / compatible",
+          "emit": {
+            "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "openai"
+          }
+        }
       ]
     },
     {
@@ -54,7 +99,14 @@
       "help": "Required to persist semantic vectors. On Docker this is fixed to the state volume.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
-      "showIf": { "embeddings": ["fastembed", "ollama", "openai"] }
+      "showIf": {
+        "embeddings": [
+          "fastembed",
+          "ollama",
+          "openai"
+        ]
+      },
+      "dockerPath": "/data/state/embeddings/embeddings"
     },
     {
       "id": "ollama_host",
@@ -62,21 +114,33 @@
       "help": "Ollama server URL (bare OLLAMA_HOST, not prefixed).",
       "type": "text",
       "var": "OLLAMA_HOST",
-      "showIf": { "embeddings": ["ollama"] }
+      "showIf": {
+        "embeddings": [
+          "ollama"
+        ]
+      }
     },
     {
       "id": "ollama_model",
       "label": "Ollama embedding model",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OLLAMA_MODEL",
-      "showIf": { "embeddings": ["ollama"] }
+      "showIf": {
+        "embeddings": [
+          "ollama"
+        ]
+      }
     },
     {
       "id": "ollama_cpu_only",
       "label": "Force Ollama CPU-only",
       "type": "bool",
       "var": "MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY",
-      "showIf": { "embeddings": ["ollama"] },
+      "showIf": {
+        "embeddings": [
+          "ollama"
+        ]
+      },
       "advancedGroup": "Embeddings"
     },
     {
@@ -85,14 +149,22 @@
       "help": "Browser-only; never sent anywhere and never put in the shareable link.",
       "type": "text",
       "var": "OPENAI_API_KEY",
-      "showIf": { "embeddings": ["openai"] }
+      "showIf": {
+        "embeddings": [
+          "openai"
+        ]
+      }
     },
     {
       "id": "openai_base_url",
       "label": "OpenAI-compatible base URL",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OPENAI_BASE_URL",
-      "showIf": { "embeddings": ["openai"] },
+      "showIf": {
+        "embeddings": [
+          "openai"
+        ]
+      },
       "advancedGroup": "Embeddings"
     },
     {
@@ -100,7 +172,11 @@
       "label": "OpenAI embedding model",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL",
-      "showIf": { "embeddings": ["openai"] },
+      "showIf": {
+        "embeddings": [
+          "openai"
+        ]
+      },
       "advancedGroup": "Embeddings"
     },
     {
@@ -108,7 +184,11 @@
       "label": "FastEmbed model",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_FASTEMBED_MODEL",
-      "showIf": { "embeddings": ["fastembed"] },
+      "showIf": {
+        "embeddings": [
+          "fastembed"
+        ]
+      },
       "advancedGroup": "Embeddings"
     },
     {
@@ -116,8 +196,13 @@
       "label": "FastEmbed cache dir",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR",
-      "showIf": { "embeddings": ["fastembed"] },
-      "advancedGroup": "Embeddings"
+      "showIf": {
+        "embeddings": [
+          "fastembed"
+        ]
+      },
+      "advancedGroup": "Embeddings",
+      "dockerPath": "/data/state/fastembed"
     },
     {
       "id": "git",
@@ -125,18 +210,31 @@
       "help": "no-git: plain dir. commit-only: local commits. managed: server clones/pulls/pushes.",
       "type": "select",
       "options": [
-        { "value": "none", "label": "No git" },
-        { "value": "commit", "label": "Commit-only (unmanaged)" },
-        { "value": "managed", "label": "Managed (clone / pull / push)" }
+        {
+          "value": "none",
+          "label": "No git"
+        },
+        {
+          "value": "commit",
+          "label": "Commit-only (unmanaged)"
+        },
+        {
+          "value": "managed",
+          "label": "Managed (clone / pull / push)"
+        }
       ]
     },
     {
       "id": "git_repo_url",
       "label": "Git repo URL (HTTPS)",
-      "help": "HTTPS only — token auth rejects SSH remotes.",
+      "help": "HTTPS only \u2014 token auth rejects SSH remotes.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_REPO_URL",
-      "showIf": { "git": ["managed"] }
+      "showIf": {
+        "git": [
+          "managed"
+        ]
+      }
     },
     {
       "id": "git_token",
@@ -144,7 +242,11 @@
       "help": "Browser-only; never in the shareable link.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_TOKEN",
-      "showIf": { "git": ["managed"] }
+      "showIf": {
+        "git": [
+          "managed"
+        ]
+      }
     },
     {
       "id": "git_username",
@@ -152,7 +254,11 @@
       "help": "x-access-token (GitHub), oauth2 (GitLab), account name (Bitbucket).",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_USERNAME",
-      "showIf": { "git": ["managed"] },
+      "showIf": {
+        "git": [
+          "managed"
+        ]
+      },
       "advancedGroup": "Git"
     },
     {
@@ -160,21 +266,35 @@
       "label": "Commit author name",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME",
-      "showIf": { "git": ["commit", "managed"] }
+      "showIf": {
+        "git": [
+          "commit",
+          "managed"
+        ]
+      }
     },
     {
       "id": "git_commit_email",
       "label": "Commit author email",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL",
-      "showIf": { "git": ["commit", "managed"] }
+      "showIf": {
+        "git": [
+          "commit",
+          "managed"
+        ]
+      }
     },
     {
       "id": "git_commit_name_claim",
       "label": "Commit name OIDC claim",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM",
-      "showIf": { "git": ["managed"] },
+      "showIf": {
+        "git": [
+          "managed"
+        ]
+      },
       "advancedGroup": "Git"
     },
     {
@@ -182,7 +302,11 @@
       "label": "Commit email OIDC claim",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM",
-      "showIf": { "git": ["managed"] },
+      "showIf": {
+        "git": [
+          "managed"
+        ]
+      },
       "advancedGroup": "Git"
     },
     {
@@ -190,7 +314,11 @@
       "label": "Pull interval (s)",
       "type": "number",
       "var": "MARKDOWN_VAULT_MCP_GIT_PULL_INTERVAL_S",
-      "showIf": { "git": ["managed"] },
+      "showIf": {
+        "git": [
+          "managed"
+        ]
+      },
       "advancedGroup": "Git"
     },
     {
@@ -198,7 +326,11 @@
       "label": "Push delay (s)",
       "type": "number",
       "var": "MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S",
-      "showIf": { "git": ["managed"] },
+      "showIf": {
+        "git": [
+          "managed"
+        ]
+      },
       "advancedGroup": "Git"
     },
     {
@@ -206,7 +338,12 @@
       "label": "Run git-lfs pull on startup",
       "type": "bool",
       "var": "MARKDOWN_VAULT_MCP_GIT_LFS",
-      "showIf": { "git": ["commit", "managed"] },
+      "showIf": {
+        "git": [
+          "commit",
+          "managed"
+        ]
+      },
       "advancedGroup": "Git"
     },
     {
@@ -215,35 +352,66 @@
       "help": "Enables POST /github-webhook for push-triggered pull. Browser-only.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GITHUB_WEBHOOK_SECRET",
-      "showIf": { "deployment": ["server"], "git": ["managed"] },
+      "showIf": {
+        "deployment": [
+          "server"
+        ],
+        "git": [
+          "managed"
+        ]
+      },
       "advancedGroup": "Git"
     },
     {
       "id": "base_url",
       "label": "Public base URL",
-      "help": "e.g. https://mcp.example.com — required for OIDC, transfer links, MCP Apps.",
+      "help": "e.g. https://mcp.example.com \u2014 required for OIDC, transfer links, MCP Apps.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_BASE_URL",
-      "showIf": { "deployment": ["server"] }
+      "showIf": {
+        "deployment": [
+          "server"
+        ]
+      }
     },
     {
       "id": "http_path",
       "label": "HTTP endpoint path",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_HTTP_PATH",
-      "showIf": { "deployment": ["server"] },
+      "showIf": {
+        "deployment": [
+          "server"
+        ]
+      },
       "advancedGroup": "Server"
     },
     {
       "id": "auth",
       "label": "Authentication",
       "type": "select",
-      "showIf": { "deployment": ["server"] },
+      "showIf": {
+        "deployment": [
+          "server"
+        ]
+      },
       "options": [
-        { "value": "none", "label": "None" },
-        { "value": "bearer", "label": "Bearer token" },
-        { "value": "oidc", "label": "OIDC" },
-        { "value": "both", "label": "Bearer + OIDC" }
+        {
+          "value": "none",
+          "label": "None"
+        },
+        {
+          "value": "bearer",
+          "label": "Bearer token"
+        },
+        {
+          "value": "oidc",
+          "label": "OIDC"
+        },
+        {
+          "value": "both",
+          "label": "Bearer + OIDC"
+        }
       ]
     },
     {
@@ -252,21 +420,36 @@
       "help": "Any non-empty string enables bearer auth. Browser-only.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
-      "showIf": { "auth": ["bearer", "both"] }
+      "showIf": {
+        "auth": [
+          "bearer",
+          "both"
+        ]
+      }
     },
     {
       "id": "oidc_config_url",
       "label": "OIDC discovery URL",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
-      "showIf": { "auth": ["oidc", "both"] }
+      "showIf": {
+        "auth": [
+          "oidc",
+          "both"
+        ]
+      }
     },
     {
       "id": "oidc_client_id",
       "label": "OIDC client ID",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
-      "showIf": { "auth": ["oidc", "both"] }
+      "showIf": {
+        "auth": [
+          "oidc",
+          "both"
+        ]
+      }
     },
     {
       "id": "oidc_client_secret",
@@ -274,22 +457,37 @@
       "help": "Browser-only; never in the shareable link.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
-      "showIf": { "auth": ["oidc", "both"] }
+      "showIf": {
+        "auth": [
+          "oidc",
+          "both"
+        ]
+      }
     },
     {
       "id": "oidc_jwt_signing_key",
       "label": "OIDC JWT signing key",
-      "help": "Required on Linux/Docker — default is ephemeral. Generate: openssl rand -hex 32.",
+      "help": "Required on Linux/Docker \u2014 default is ephemeral. Generate: openssl rand -hex 32.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
-      "showIf": { "auth": ["oidc", "both"] }
+      "showIf": {
+        "auth": [
+          "oidc",
+          "both"
+        ]
+      }
     },
     {
       "id": "oidc_audience",
       "label": "OIDC audience",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
-      "showIf": { "auth": ["oidc", "both"] },
+      "showIf": {
+        "auth": [
+          "oidc",
+          "both"
+        ]
+      },
       "advancedGroup": "Auth"
     },
     {
@@ -297,7 +495,12 @@
       "label": "OIDC required scopes (CSV)",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
-      "showIf": { "auth": ["oidc", "both"] },
+      "showIf": {
+        "auth": [
+          "oidc",
+          "both"
+        ]
+      },
       "advancedGroup": "Auth"
     },
     {
@@ -305,7 +508,12 @@
       "label": "Verify access token (not id token)",
       "type": "bool",
       "var": "MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN",
-      "showIf": { "auth": ["oidc", "both"] },
+      "showIf": {
+        "auth": [
+          "oidc",
+          "both"
+        ]
+      },
       "advancedGroup": "Auth"
     },
     {
@@ -314,21 +522,27 @@
       "help": "Set for persistence across restarts. Fixed on Docker to the state volume.",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_INDEX_PATH",
-      "advancedGroup": "Persistence"
+      "advancedGroup": "Persistence",
+      "dockerPath": "/data/state/index.db"
     },
     {
       "id": "state_path",
       "label": "Change-tracking state path",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_STATE_PATH",
-      "advancedGroup": "Persistence"
+      "advancedGroup": "Persistence",
+      "dockerPath": "/data/state/state.json"
     },
     {
       "id": "kv_store_url",
       "label": "KV store URL (HTTP session persistence)",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_KV_STORE_URL",
-      "showIf": { "deployment": ["server"] },
+      "showIf": {
+        "deployment": [
+          "server"
+        ]
+      },
       "advancedGroup": "Persistence"
     },
     {
@@ -455,7 +669,11 @@
       "label": "Transfer TTL default (s)",
       "type": "number",
       "var": "MARKDOWN_VAULT_MCP_TRANSFER_TTL_DEFAULT_S",
-      "showIf": { "deployment": ["server"] },
+      "showIf": {
+        "deployment": [
+          "server"
+        ]
+      },
       "advancedGroup": "Transfer links"
     },
     {
@@ -463,7 +681,11 @@
       "label": "Transfer TTL max (s)",
       "type": "number",
       "var": "MARKDOWN_VAULT_MCP_TRANSFER_TTL_MAX_S",
-      "showIf": { "deployment": ["server"] },
+      "showIf": {
+        "deployment": [
+          "server"
+        ]
+      },
       "advancedGroup": "Transfer links"
     },
     {
@@ -471,7 +693,11 @@
       "label": "Transfer max upload bytes",
       "type": "number",
       "var": "MARKDOWN_VAULT_MCP_TRANSFER_MAX_UPLOAD_BYTES",
-      "showIf": { "deployment": ["server"] },
+      "showIf": {
+        "deployment": [
+          "server"
+        ]
+      },
       "advancedGroup": "Transfer links"
     },
     {
@@ -513,17 +739,30 @@
   ],
   "guards": [
     {
-      "when": { "git": ["managed"] },
-      "level": "warn",
-      "message": "Token auth requires an HTTPS repo URL — SSH remotes are rejected."
+      "when": {
+        "git": [
+          "managed"
+        ]
+      },
+      "level": "warning",
+      "message": "Token auth requires an HTTPS repo URL \u2014 SSH remotes are rejected."
     },
     {
-      "when": { "auth": ["oidc", "both"] },
-      "level": "warn",
-      "message": "OIDC needs BASE_URL set and (on Linux/Docker) OIDC_JWT_SIGNING_KEY — the default key is ephemeral and invalidates tokens on restart."
+      "when": {
+        "auth": [
+          "oidc",
+          "both"
+        ]
+      },
+      "level": "warning",
+      "message": "OIDC needs BASE_URL set and (on Linux/Docker) OIDC_JWT_SIGNING_KEY \u2014 the default key is ephemeral and invalidates tokens on restart."
     },
     {
-      "when": { "git": ["managed"] },
+      "when": {
+        "git": [
+          "managed"
+        ]
+      },
       "level": "info",
       "message": "When the git pull loop is active the file watcher is automatically disabled."
     }

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -24,7 +24,11 @@ function writeUrlState(spec) {
     if (answers[q.id] !== undefined && answers[q.id] !== "") params.set(q.id, answers[q.id]);
   }
   const qs = params.toString();
-  history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+  try {
+    history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+  } catch {
+    // history.replaceState throws in sandboxed iframes — safe to ignore.
+  }
 }
 
 function field(q, secrets) {
@@ -78,6 +82,7 @@ function field(q, secrets) {
 
 let SPEC = null;
 let ROOT = null;
+let _writeTimer = null;
 
 function render() {
   const spec = SPEC;
@@ -119,15 +124,15 @@ function render() {
     els.forEach((e) => drawer.appendChild(e));
   }
 
+  const meta = spec.meta;
   const map = buildEnvMap(spec, answers);
-  const hostVault = map["MARKDOWN_VAULT_MCP_SOURCE_DIR"];
   const local = answers.deployment !== "server";
   const tabs = local
-    ? [["Claude config", generateClaudeJson(map)], [".env", generateDotenv(map)]]
+    ? [["Claude config", generateClaudeJson(meta, map)], [".env", generateDotenv(map)]]
     : [
-        ["docker run", generateDockerRun(map, hostVault)],
-        ["compose", generateCompose(map, hostVault)],
-        ["systemd", generateSystemd(map)],
+        ["docker run", generateDockerRun(spec, answers, map)],
+        ["compose", generateCompose(spec, answers, map)],
+        ["systemd", generateSystemd(meta, map)],
         [".env", generateDotenv(map)],
       ];
   const out = document.createElement("div");
@@ -152,9 +157,11 @@ function render() {
         // Fallback for non-secure contexts: select the block so Ctrl/Cmd-C works.
         const range = document.createRange();
         range.selectNodeContents(pre);
-        const sel = getSelection();
-        sel.removeAllRanges();
-        sel.addRange(range);
+        const sel = window.getSelection();
+        if (sel) {
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
       }
     });
     head.appendChild(copy);
@@ -165,7 +172,7 @@ function render() {
 
   const warnings = document.createElement("div");
   warnings.className = "cfg-warnings";
-  for (const g of spec.guards) {
+  for (const g of (spec.guards ?? [])) {
     if (Object.entries(g.when).every(([k, vals]) => vals.includes(answers[k]))) {
       const w = document.createElement("div");
       w.className = `cfg-${g.level}`;
@@ -174,13 +181,21 @@ function render() {
     }
   }
 
-  ROOT.replaceChildren(core, drawer, warnings, out);
-  writeUrlState(spec);
+  if (Object.keys(advanced).length > 0) {
+    ROOT.replaceChildren(core, drawer, warnings, out);
+  } else {
+    ROOT.replaceChildren(core, warnings, out);
+  }
+  // Debounce URL writes: browsers throttle history.replaceState to ~100
+  // calls/10 s, and URL sync is a "share" feature, not live feedback.
+  clearTimeout(_writeTimer);
+  _writeTimer = setTimeout(() => writeUrlState(spec), 300);
 
   // Restore focus + caret to the field the user was editing.
   if (activeQid) {
+    const escaped = CSS.escape(activeQid);
     const restored = ROOT.querySelector(
-      `.cfg-field[data-qid="${activeQid}"] input, .cfg-field[data-qid="${activeQid}"] select`,
+      `.cfg-field[data-qid="${escaped}"] input, .cfg-field[data-qid="${escaped}"] select`,
     );
     if (restored) {
       restored.focus();
@@ -202,12 +217,34 @@ async function init() {
   try {
     const resp = await fetch(specUrl);
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
-    SPEC = await resp.json();
+    const spec = await resp.json();
+    if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
+      throw new Error("wizard-spec.json is malformed (missing questions array)");
+    }
+    if (!spec.meta || typeof spec.meta !== "object") {
+      // The generators read project identity from spec.meta; a spec missing it
+      // (e.g. mid-migration) must fail loudly here rather than throw an
+      // uncaught TypeError deep inside render().
+      throw new Error("wizard-spec.json is malformed (missing meta block)");
+    }
+    SPEC = spec;
   } catch (e) {
     ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;
     return;
   }
   readUrlState(SPEC);
+  // Initialize all answers so guards that match [""] fire on the first render.
+  // Secrets are excluded from URL hydration (readUrlState skips them) so they
+  // also need this default, ensuring guards referencing secret question IDs
+  // evaluate correctly before the user has typed anything.
+  for (const q of SPEC.questions) {
+    if (answers[q.id] !== undefined) continue;
+    if (q.type === "select" && q.options?.length) {
+      answers[q.id] = q.options[0].value;
+    } else {
+      answers[q.id] = "";
+    }
+  }
   render();
 }
 

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -14,6 +14,8 @@
 .cfg-tab-head { display: flex; justify-content: space-between; align-items: center; font-weight: 600; }
 .cfg-copy { cursor: pointer; padding: 0.2rem 0.6rem; border-radius: 4px; border: 1px solid var(--md-default-fg-color--lighter); background: var(--md-default-bg-color); }
 .cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
-.cfg-warn { color: #b26a00; }
-[data-md-color-scheme="slate"] .cfg-warn { color: #e0a83a; }
+.cfg-warning { color: #b26a00; }
+[data-md-color-scheme="slate"] .cfg-warning { color: #e0a83a; }
+.cfg-error { color: #c0392b; }
+[data-md-color-scheme="slate"] .cfg-error { color: #e74c3c; }
 .cfg-info { color: var(--md-default-fg-color--light); }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "pre-commit>=3.0",
     "pip-audit>=2.7",
     "watchdog>=4.0",
+    "jsonschema>=4.18",
 ]
 docs = [
     "mike>=2",
@@ -192,6 +193,10 @@ ignore_missing_imports = true
 # template v1.2.0).  Typing the full test suite is tracked separately.
 module = ["tests.*"]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = ["jsonschema", "jsonschema.*"]
+ignore_missing_imports = true
 
 [tool.pyright]
 # Point Pyright at the uv-managed venv so editor diagnostics resolve

--- a/tests/test_config_wizard_domain.py
+++ b/tests/test_config_wizard_domain.py
@@ -1,0 +1,25 @@
+"""Domain-specific config-wizard tests for Markdown Vault MCP.
+
+This file is owned by the generated project (kept across ``copier update`` via
+``_skip_if_exists``). The template seeds it once with a single skipped
+placeholder test; add browser assertions here that depend on *this project's*
+``wizard-spec.json`` — e.g. that a specific field renders, that a chosen option
+emits the expected env var, or that a guard message appears. The generic
+framework tests live in ``test_config_wizard_smoke.py`` (template-owned) and
+must not be edited here.
+
+See ``test_config_wizard_smoke.py`` for the page/browser fixtures to import.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_domain_placeholder() -> None:
+    # Placeholder: the template seeds this file with one skipped test so the
+    # path exists and is kept across copier updates, while neither failing CI
+    # on an empty file nor reporting a hollow "passing" test. Replace this skip
+    # with real domain assertions (field renders, option emits the expected env
+    # var, guard message appears).
+    pytest.skip("No domain-specific wizard tests yet -- add them here.")

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -1,8 +1,19 @@
-"""Browser smoke test for the built config-wizard page.
+"""Browser smoke tests for the built config-wizard page.
 
 Marked ``browser``; requires the ``browser`` dependency group and
 ``playwright install chromium``. Runs against the built ``site/`` directory, so
 ``mkdocs build`` must have run first.
+
+Two kinds of tests live here, both template-owned and spec-agnostic:
+
+* Framework tests drive the actual rendered page and assert only on invariants
+  every spec shares (the ``deployment`` question exists; output carries the
+  project identity from ``meta``).
+* Generator unit tests import ``generators.js`` directly and feed it synthetic
+  specs, so they exercise ``dockerVolume`` / ``dockerPath`` behaviour without
+  depending on this project's questions.
+
+Domain-specific assertions belong in ``test_config_wizard_domain.py``.
 """
 
 from __future__ import annotations
@@ -11,11 +22,15 @@ import functools
 import http.server
 import socketserver
 import threading
+import typing
 from pathlib import Path
 
 import pytest
 
 pytest.importorskip("playwright.sync_api")
+
+if typing.TYPE_CHECKING:
+    from playwright.sync_api import Browser, Page
 
 SITE = Path(__file__).resolve().parent.parent / "site"
 
@@ -23,7 +38,7 @@ pytestmark = pytest.mark.browser
 
 
 @pytest.fixture(scope="module")
-def site_url():
+def site_url() -> typing.Iterator[str]:
     if not (SITE / "configuration-generator" / "index.html").exists():
         pytest.skip("site/ not built -- run `uv run mkdocs build` first")
     handler = functools.partial(
@@ -40,7 +55,7 @@ def site_url():
 
 
 @pytest.fixture(scope="module")
-def browser(site_url):  # noqa: ARG001 — depended on only for fixture ordering
+def browser(site_url: str) -> typing.Iterator[Browser]:  # noqa: ARG001 — depended on only for fixture ordering
     # Depend on site_url so its "site not built" skip runs BEFORE we try to
     # launch Chromium. In the main CI test lane (no built site, no installed
     # browser) this makes the smoke tests skip cleanly instead of erroring.
@@ -53,7 +68,7 @@ def browser(site_url):  # noqa: ARG001 — depended on only for fixture ordering
 
 
 @pytest.fixture
-def page(browser, site_url):
+def page(browser: Browser, site_url: str) -> typing.Iterator[Page]:
     # Fresh page per test: the wizard keeps answer state in a module-level JS
     # object, so each test must start from a clean load to stay order-independent.
     pg = browser.new_page()
@@ -63,21 +78,156 @@ def page(browser, site_url):
     pg.close()
 
 
-def test_local_path_emits_claude_json(page):
+# --- Framework tests: drive the real page, assert only on universal invariants.
+
+
+def test_local_emits_claude_config_with_project_name(page: Page) -> None:
     page.select_option('[data-qid="deployment"] select', "local")
-    page.fill('[data-qid="source_dir"] input', "/vault")
-    page.select_option('[data-qid="embeddings"] select', "fastembed")
     text = page.inner_text(".cfg-output")
+    # meta.projectName renders into the Claude config server key + command.
     assert "markdown-vault-mcp" in text
-    assert "MARKDOWN_VAULT_MCP_SOURCE_DIR" in text
-    assert "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER" in text
 
 
-def test_server_docker_path_emits_image_and_oidc_guard(page):
+def test_server_emits_docker_image_from_meta(page: Page) -> None:
     page.select_option('[data-qid="deployment"] select', "server")
-    page.fill('[data-qid="source_dir"] input', "/vault")
-    page.select_option('[data-qid="auth"] select', "oidc")
     text = page.inner_text("#cfg-wizard")
     assert "ghcr.io/pvliesdonk/markdown-vault-mcp:latest" in text
-    assert "/data/vault" in text
-    assert "OIDC needs BASE_URL" in text
+
+
+# --- Generator unit tests: import generators.js with synthetic specs.
+
+_GEN_IMPORT = "/javascripts/config-wizard/generators.js"
+
+
+def _eval_generators(page: Page, body: str) -> typing.Any:
+    """Run `body` (an arrow function source) with generators.js imported.
+
+    `body` is JS source of the form `(g) => { ...; return ...; }`; it receives
+    the imported generators module as `g`.
+    """
+    script = (
+        "async () => { const g = await import('"
+        + _GEN_IMPORT
+        + "'); return ("
+        + body
+        + ")(g); }"
+    )
+    return page.evaluate(script)
+
+
+def test_docker_volume_adds_mount_and_fixes_container_path(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'data_dir', label: 'D', type: 'text', var: 'DEMO_DATA_DIR', dockerVolume: '/data/app' }],
+            guards: [] };
+          const answers = { deployment: 'server', data_dir: '/host/data' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateDockerRun(spec, answers, map);
+        }""",
+    )
+    assert "-v /host/data:/data/app" in result
+    # env var is fixed to the container path, NOT the host path.
+    assert "DEMO_DATA_DIR=/data/app" in result
+    assert "DEMO_DATA_DIR=/host/data" not in result
+
+
+def test_docker_volume_empty_answer_uses_placeholder(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'data_dir', label: 'D', type: 'text', var: 'DEMO_DATA_DIR', dockerVolume: '/data/app' }],
+            guards: [] };
+          const answers = { deployment: 'server' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateDockerRun(spec, answers, map);
+        }""",
+    )
+    assert "-v /path/to/data_dir:/data/app" in result
+
+
+def test_docker_path_fixes_present_var_without_mount(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'index_path', label: 'I', type: 'text', var: 'DEMO_INDEX_PATH', dockerPath: '/data/state/index.db' }],
+            guards: [] };
+          const answers = { deployment: 'server', index_path: '/host/index.db' };
+          const map = g.buildEnvMap(spec, answers);
+          return { docker: g.generateDockerRun(spec, answers, map) };
+        }""",
+    )
+    assert "DEMO_INDEX_PATH=/data/state/index.db" in result["docker"]
+    # dockerPath never adds a -v mount.
+    assert "/data/state/index.db:" not in result["docker"]
+    assert "-v /host/index.db" not in result["docker"]
+
+
+def test_docker_path_absent_var_stays_absent(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'index_path', label: 'I', type: 'text', var: 'DEMO_INDEX_PATH', dockerPath: '/data/state/index.db' }],
+            guards: [] };
+          const answers = { deployment: 'server' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateDockerRun(spec, answers, map);
+        }""",
+    )
+    # User left it blank → dockerPath does not inject it (persistence not opted in).
+    assert "DEMO_INDEX_PATH" not in result
+
+
+def test_systemd_uses_raw_host_path_not_container(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'data_dir', label: 'D', type: 'text', var: 'DEMO_DATA_DIR', dockerVolume: '/data/app' }],
+            guards: [] };
+          const answers = { deployment: 'server', data_dir: '/host/data' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateSystemd(spec.meta, map);
+        }""",
+    )
+    # systemd is a host-path context: no container-path rewrite.
+    assert "DEMO_DATA_DIR=/host/data" in result
+    assert "/data/app" not in result
+
+
+def test_compose_quotes_yaml_typed_env_values(page: Page) -> None:
+    result = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [
+              { id: 'flag', label: 'F', type: 'text', var: 'DEMO_FLAG' },
+              { id: 'port', label: 'P', type: 'text', var: 'DEMO_PORT' },
+            ],
+            guards: [] };
+          const answers = { deployment: 'server', flag: 'true', port: '8080' };
+          const map = g.buildEnvMap(spec, answers);
+          return g.generateCompose(spec, answers, map);
+        }""",
+    )
+    # YAML 1.1 parsers coerce bare true/8080 to bool/int; env values are
+    # strings, so compose must emit them quoted.
+    assert 'DEMO_FLAG: "true"' in result
+    assert "DEMO_FLAG: true\n" not in result
+    assert 'DEMO_PORT: "8080"' in result

--- a/tests/test_config_wizard_spec_schema.py
+++ b/tests/test_config_wizard_spec_schema.py
@@ -1,0 +1,155 @@
+"""Validate the shipped wizard-spec.json against the canonical JSON Schema.
+
+Template-owned and generic: loads whatever ``wizard-spec.json`` this project
+ships and checks it against ``wizard-spec-schema.json`` plus the cross-reference
+rules JSON Schema cannot express (unique ids, dangling references, secret keys
+declared by a question). Runs in the main test lane (no browser required), so it
+is the gate that catches spec drift — e.g. a guard ``level`` outside {warning,
+info, error} or a ``meta`` block that a stale spec never added.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import jsonschema
+import pytest
+
+_WIZARD_DIR = (
+    Path(__file__).resolve().parent.parent / "docs" / "javascripts" / "config-wizard"
+)
+_SPEC_PATH = _WIZARD_DIR / "wizard-spec.json"
+_SCHEMA_PATH = _WIZARD_DIR / "wizard-spec-schema.json"
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict[str, Any]:
+    return cast("dict[str, Any]", json.loads(_SPEC_PATH.read_text(encoding="utf-8")))
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return cast("dict[str, Any]", json.loads(_SCHEMA_PATH.read_text(encoding="utf-8")))
+
+
+def _minimal_valid_spec() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "meta": {
+            "projectName": "demo",
+            "dockerImage": "ghcr.io/acme/demo:latest",
+            "envPrefix": "DEMO",
+        },
+        "secretKeys": [],
+        "questions": [
+            {
+                "id": "deployment",
+                "label": "Where?",
+                "type": "select",
+                "options": [
+                    {"value": "local", "label": "Local"},
+                    {"value": "server", "label": "Server"},
+                ],
+            }
+        ],
+        "guards": [],
+    }
+
+
+def test_schema_itself_is_valid(schema: dict[str, Any]) -> None:
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_shipped_spec_matches_schema(
+    spec: dict[str, Any], schema: dict[str, Any]
+) -> None:
+    jsonschema.validate(spec, schema)
+
+
+def test_question_ids_are_unique(spec: dict[str, Any]) -> None:
+    ids = [q["id"] for q in spec["questions"]]
+    assert len(ids) == len(set(ids)), f"duplicate question id(s): {ids}"
+
+
+def test_showif_references_existing_ids(spec: dict[str, Any]) -> None:
+    ids = {q["id"] for q in spec["questions"]}
+    for q in spec["questions"]:
+        for key in q.get("showIf") or {}:
+            assert key in ids, f"showIf references unknown question id: {key}"
+
+
+def test_guard_when_references_existing_ids(spec: dict[str, Any]) -> None:
+    ids = {q["id"] for q in spec["questions"]}
+    for guard in spec.get("guards", []):
+        for key in guard["when"]:
+            assert key in ids, f"guard.when references unknown question id: {key}"
+
+
+def test_secret_keys_are_declared_vars(spec: dict[str, Any]) -> None:
+    declared = {q.get("var") for q in spec["questions"]}
+    for key in spec.get("secretKeys", []):
+        assert key in declared, f"secretKey not declared by any question var: {key}"
+
+
+def test_schema_rejects_unknown_guard_level(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    bad["guards"] = [
+        {"level": "warn", "message": "x", "when": {"deployment": ["server"]}}
+    ]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_rejects_missing_meta(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    del bad["meta"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_rejects_dockervolume_and_dockerpath_together(
+    schema: dict[str, Any],
+) -> None:
+    bad = _minimal_valid_spec()
+    bad["questions"].append(
+        {
+            "id": "data_dir",
+            "label": "Data",
+            "type": "text",
+            "var": "DEMO_DATA_DIR",
+            "dockerVolume": "/data/app",
+            "dockerPath": "/data/state/app",
+        }
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_accepts_dockervolume_alone(schema: dict[str, Any]) -> None:
+    spec = _minimal_valid_spec()
+    spec["questions"].append(
+        {
+            "id": "data_dir",
+            "label": "Data",
+            "type": "text",
+            "var": "DEMO_DATA_DIR",
+            "dockerVolume": "/data/app",
+        }
+    )
+    jsonschema.validate(spec, schema)
+
+
+def test_schema_accepts_dockerpath_alone(schema: dict[str, Any]) -> None:
+    spec = _minimal_valid_spec()
+    spec["questions"].append(
+        {
+            "id": "index_path",
+            "label": "Index",
+            "type": "text",
+            "var": "DEMO_INDEX_PATH",
+            "dockerPath": "/data/state/index.db",
+        }
+    )
+    jsonschema.validate(spec, schema)

--- a/uv.lock
+++ b/uv.lock
@@ -1364,6 +1364,7 @@ browser = [
 ]
 dev = [
     { name = "diff-cover" },
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pre-commit" },
@@ -1406,6 +1407,7 @@ provides-extras = ["mcp", "embeddings-api", "embeddings", "file-watcher", "all",
 browser = [{ name = "pytest-playwright", specifier = ">=0.5" }]
 dev = [
     { name = "diff-cover", specifier = ">=9.0" },
+    { name = "jsonschema", specifier = ">=4.18" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "pre-commit", specifier = ">=3.0" },


### PR DESCRIPTION
Brings the config-wizard from contributed upstream work, now with strict ownership boundaries (v2.3.0 design spec).

## What changed

**v2.1.2:**
- CVE-2026-42561 pip-audit ignore (python-multipart)
- RC revision auto-advance in release workflow
- Copier-update bot identity fix
- Aggregator silent-failure surfacing

**v2.2.0 / v2.2.1** — in-browser configuration wizard:
- MkDocs-hosted decision-tree wizard generating Claude JSON / .env / Docker / Compose / systemd configs
- Five correctness bug fixes to the wizard runtime

**v2.3.0** — strict config-wizard ownership (design spec `2026-06-19-config-wizard-spec-ownership-design.md`):
- Runtime files (`generators.js`, `wizard.js`, `config-wizard.css`, `wizard-spec-schema.json`) are byte-identical across all consumers — no domain code
- `wizard-spec.json` is `_skip_if_exists` — the sole file that varies between consumers
- New vocabulary: `meta` block, `dockerVolume` (bind-mount host path), `dockerPath` (fixed container path in state volume)
- New `wizard-spec-schema.json` + `test_config_wizard_spec_schema.py` (11 assertions) — fails loudly on un-migrated specs
- New `test_config_wizard_domain.py` placeholder (`_skip_if_exists`) for domain browser assertions

## Migration applied to `wizard-spec.json`

- Added `meta` block (`projectName`, `dockerImage`, `envPrefix`)
- `source_dir` → `"dockerVolume": "/data/vault"` (bind-mount)
- `index_path`, `embeddings_path`, `state_path`, `fastembed_cache_dir` → `"dockerPath": "<container path>"`
- Fixed guard `level: "warn"` → `"warning"` (caught immediately by new schema test)

## Conflict resolutions

| File | Resolution |
|---|---|
| `ci.yml` | Merged both CVE ignore lists |
| `pyproject.toml` | Kept `watchdog>=4.0` + added `jsonschema>=4.18`; kept `tests.*` mypy override + added `jsonschema` override; removed duplicate `browser` group |
| `mkdocs.yml` | Kept descriptive llmstxt labels; removed early duplicate `extra_javascript`/`extra_css` block (template owns position) |
| `configuration-generator.md` | Took template's MkDocs path comment |
| `generators.js`, `wizard.js`, `config-wizard.css`, `test_config_wizard_smoke.py` | Took template verbatim (template-owned, no domain additions) |

## Gates
- 2265 tests pass, 1 skipped
- `test_config_wizard_spec_schema.py`: 11/11 pass
- ruff, mypy, pre-commit clean

Closes #714

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._