### PR TITLE
fix: break file-watcher reindex self-feedback loop

### DIFF
--- a/src/markdown_vault_mcp/_file_watcher.py
+++ b/src/markdown_vault_mcp/_file_watcher.py
@@ -24,10 +24,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 try:
-    from watchdog.events import FileSystemEvent, FileSystemEventHandler
+    from watchdog.events import (
+        EVENT_TYPE_CREATED,
+        EVENT_TYPE_DELETED,
+        EVENT_TYPE_MODIFIED,
+        EVENT_TYPE_MOVED,
+        FileSystemEvent,
+        FileSystemEventHandler,
+    )
     from watchdog.observers import Observer
 
     _WATCHDOG_AVAILABLE = True
+
+    # Only these event types represent an actual mutation of the vault.
+    # Read-only events (``opened``, ``closed``, ``closed_no_write``, access)
+    # must be ignored: ``reindex()`` walks the whole vault read-only, and on
+    # Linux that walk emits inotify read events (OPEN / CLOSE_NOWRITE, also on
+    # directories) for every entry it touches. Forwarding those to the
+    # debounce scheduler would make each reindex re-arm the watcher, which
+    # fires another reindex — an endless self-feedback loop that pins the CPU
+    # with no real file changes (#720).
+    _MUTATING_EVENT_TYPES = frozenset(
+        {
+            EVENT_TYPE_CREATED,
+            EVENT_TYPE_MODIFIED,
+            EVENT_TYPE_MOVED,
+            EVENT_TYPE_DELETED,
+        }
+    )
 except ImportError:
     _WATCHDOG_AVAILABLE = False
 
@@ -197,7 +221,12 @@ class VaultFileWatcher:
 if _WATCHDOG_AVAILABLE:
 
     class _VaultEventHandler(FileSystemEventHandler):
-        """Forward non-hidden filesystem events to the debounce scheduler."""
+        """Forward mutating, non-hidden filesystem events to the scheduler.
+
+        Read-only events (``opened`` / ``closed`` / ``closed_no_write``) are
+        dropped before the hidden-path check so the read-only vault walk that
+        ``reindex()`` performs cannot re-trigger itself (#720).
+        """
 
         def __init__(self, schedule: Callable[[], None], source_dir: Path) -> None:
             super().__init__()
@@ -205,6 +234,8 @@ if _WATCHDOG_AVAILABLE:
             self._source_dir = source_dir
 
         def on_any_event(self, event: FileSystemEvent) -> None:
+            if event.event_type not in _MUTATING_EVENT_TYPES:
+                return
             path = getattr(event, "src_path", "") or ""
             try:
                 rel = Path(path).relative_to(self._source_dir)

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -500,7 +500,19 @@ class IndexManager:
                 if texts:
                     vectors.add(texts, meta)
 
-        if vectors is not None and self._embeddings_path is not None:
+        # Persist the vector index only when this pass actually mutated it.
+        # An empty-diff reindex (0 added/modified/deleted) touches no vectors,
+        # so re-serialising the whole index to disk every run is pure churn —
+        # particularly under a file watcher that may fire reindex repeatedly
+        # (#720).
+        vector_index_changed = bool(
+            indexed_added or indexed_modified or changes.deleted
+        )
+        if (
+            vectors is not None
+            and self._embeddings_path is not None
+            and vector_index_changed
+        ):
             vectors.save(self._embeddings_path)
 
         # Re-resolve vault-wide wikilinks.

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -501,12 +501,14 @@ class IndexManager:
                     vectors.add(texts, meta)
 
         # Persist the vector index only when this pass actually mutated it.
-        # An empty-diff reindex (0 added/modified/deleted) touches no vectors,
-        # so re-serialising the whole index to disk every run is pure churn —
-        # particularly under a file watcher that may fire reindex repeatedly
-        # (#720).
+        # An empty-diff reindex (0 added/modified/deleted) that purged no
+        # stale-excluded entries touches no vectors, so re-serialising the
+        # whole index to disk every run is pure churn — particularly under a
+        # file watcher that may fire reindex repeatedly (#720). ``stale_excluded``
+        # must be included: purging excluded docs calls ``vectors.delete_by_path``
+        # above, mutating the in-memory index even when the file diff is empty.
         vector_index_changed = bool(
-            indexed_added or indexed_modified or changes.deleted
+            indexed_added or indexed_modified or changes.deleted or stale_excluded
         )
         if (
             vectors is not None

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -22,10 +22,21 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from watchdog.events import (
+    DirModifiedEvent,
+    FileClosedEvent,
+    FileClosedNoWriteEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+    FileOpenedEvent,
+)
 
 from markdown_vault_mcp._file_watcher import (
     VaultFileWatcher,
     _has_hidden_component,
+    _VaultEventHandler,
     should_start_file_watcher,
 )
 from markdown_vault_mcp._server_deps import make_vault_lifespan
@@ -76,6 +87,58 @@ def test_has_hidden_component_visible_file() -> None:
 def test_has_hidden_component_hidden_inside_visible() -> None:
     """visible/subdir/.git/file has a hidden ancestor."""
     assert _has_hidden_component(("visible", ".git", "file")) is True
+
+
+# ---------------------------------------------------------------------------
+# Event-type filtering (#720 — read events must not re-trigger reindex)
+# ---------------------------------------------------------------------------
+
+
+def _record_handler(source_dir: Path) -> tuple[_VaultEventHandler, list[int]]:
+    """Return a handler whose schedule appends to a call-log list."""
+    calls: list[int] = []
+    handler = _VaultEventHandler(lambda: calls.append(1), source_dir)
+    return handler, calls
+
+
+def test_read_only_events_do_not_schedule(tmp_path: Path) -> None:
+    """OPEN / CLOSE_NOWRITE / CLOSE events from the reindex walk are ignored.
+
+    These are exactly the inotify events the read-only vault walk inside
+    ``reindex()`` emits; forwarding them would re-arm the watcher and spin
+    the reindex self-feedback loop (#720).
+    """
+    handler, calls = _record_handler(tmp_path)
+    visible = str(tmp_path / "note.md")
+    for event in (
+        FileOpenedEvent(visible),
+        FileClosedNoWriteEvent(visible),
+        FileClosedEvent(visible),
+    ):
+        handler.on_any_event(event)
+    assert calls == [], "read-only events must not schedule a reindex"
+
+
+def test_mutating_events_schedule(tmp_path: Path) -> None:
+    """A real create/modify/move/delete on a visible path triggers a reindex."""
+    visible = str(tmp_path / "note.md")
+    for event in (
+        FileCreatedEvent(visible),
+        FileModifiedEvent(visible),
+        FileDeletedEvent(visible),
+        FileMovedEvent(visible, str(tmp_path / "renamed.md")),
+        DirModifiedEvent(str(tmp_path / "subdir")),
+    ):
+        handler, calls = _record_handler(tmp_path)
+        handler.on_any_event(event)
+        assert calls == [1], f"{type(event).__name__} should schedule a reindex"
+
+
+def test_mutating_event_in_hidden_dir_still_ignored(tmp_path: Path) -> None:
+    """The hidden-path filter still applies to mutating events."""
+    handler, calls = _record_handler(tmp_path)
+    handler.on_any_event(FileModifiedEvent(str(tmp_path / ".git" / "HEAD")))
+    assert calls == [], "mutations inside hidden dirs must not schedule a reindex"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -485,6 +485,61 @@ class TestSkipStateMemory:
         assert result.added == 0
         assert result.skipped == 0
 
+    def _mgr_with_embeddings(self, vault: Path, state_dir: Path):
+        """Build an IndexManager wired with a mock embedding provider."""
+        from tests.conftest import MockEmbeddingProvider
+
+        holder: dict = {"vectors": None}
+        mgr, _fts, _ = _make_index_mgr(
+            vault,
+            state_dir,
+            embeddings_path=state_dir / "embeddings",
+            embedding_provider=MockEmbeddingProvider(),
+            get_vectors=lambda: holder["vectors"],
+            set_vectors=lambda v: holder.__setitem__("vectors", v),
+        )
+        return mgr, holder
+
+    def test_empty_diff_reindex_does_not_save_vectors(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """A reindex with no file changes must not re-serialise the vector index.
+
+        The unconditional save churned the embeddings file on every watcher
+        wake-up, feeding the reindex self-feedback loop (#720).
+        """
+        mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+
+        vectors.save = MagicMock(wraps=vectors.save)  # type: ignore[method-assign]
+        result = mgr.reindex()
+
+        assert (result.added, result.modified, result.deleted) == (0, 0, 0)
+        vectors.save.assert_not_called()
+
+    def test_real_change_reindex_saves_vectors(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """A reindex that indexes a real change still persists the vector index."""
+        mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+
+        vectors.save = MagicMock(wraps=vectors.save)  # type: ignore[method-assign]
+        (index_vault / "alpha.md").write_text(
+            "---\ntitle: Alpha\n---\n# Alpha\n\nChanged body content.\n",
+            encoding="utf-8",
+        )
+        result = mgr.reindex()
+
+        assert result.modified == 1
+        vectors.save.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # build_embeddings

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -540,6 +540,56 @@ class TestSkipStateMemory:
         assert result.modified == 1
         vectors.save.assert_called_once()
 
+    def test_stale_excluded_reindex_saves_vectors(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """A reindex that only purges stale-excluded entries must still save.
+
+        Purging an excluded-but-already-indexed doc calls
+        ``vectors.delete_by_path`` (mutating the in-memory index) while the
+        file diff stays empty (the file is still on disk, just filtered).
+        Skipping the save would leave the stale vectors on disk to reload on
+        the next startup (#720 follow-up).
+        """
+        mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+
+        vectors.save = MagicMock(wraps=vectors.save)  # type: ignore[method-assign]
+        # Exclude a note that is already indexed; the file remains on disk so
+        # the tracker reports no add/modify/delete — only the stale-excluded
+        # purge mutates the vector index.
+        mgr._exclude_patterns = ["alpha.md"]
+        result = mgr.reindex()
+
+        assert (result.added, result.modified, result.deleted) == (0, 0, 0)
+        vectors.save.assert_called_once()
+
+    def test_deletion_only_reindex_saves_vectors(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """A reindex whose only change is a deleted file must still save.
+
+        A pure deletion purges vectors via ``vectors.delete_by_path`` while
+        ``indexed_added``/``indexed_modified``/``stale_excluded`` all stay 0, so
+        ``changes.deleted`` is the sole term that must keep the save alive (#720).
+        """
+        mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+
+        vectors.save = MagicMock(wraps=vectors.save)  # type: ignore[method-assign]
+        (index_vault / "beta.md").unlink()
+        result = mgr.reindex()
+
+        assert (result.added, result.modified) == (0, 0)
+        assert result.deleted == 1
+        vectors.save.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # build_embeddings


### PR DESCRIPTION
Closes #720

## Problem

On a non-git vault with the file watcher active, the server reindexes in an endless loop at idle (~20–30 % CPU), with no real file changes:

```
reindex: 0 added, 0 modified, 0 deleted, N unchanged, 0 skipped
```

### Root cause (verified with py-spy + inotifywait)

1. `reindex()` → `tracker.detect_changes()` walks the whole vault read-only.
2. On Linux that walk emits inotify **read** events (`opened` / `closed_no_write`, also on directories).
3. `_VaultEventHandler.on_any_event` filtered only hidden paths, **not the event type**, so those reads were forwarded to the debounce scheduler → reindex → walk → more reads → loop.

## Changes

1. **`_file_watcher.py`** — `on_any_event` now forwards only an allowlist of mutating event types (`created` / `modified` / `moved` / `deleted`); read-only events (`opened` / `closed` / `closed_no_write`) are dropped before the hidden-path check. This breaks the loop. The hidden-path filter is unchanged.
2. **`managers/index.py`** — `reindex()` no longer calls `vectors.save()` on an empty-diff pass; it saves only when the vector index was actually mutated (added/modified/deleted > 0), removing needless disk churn on every watcher wake-up.

## Tests

- `test_file_watcher.py`: `opened`/`closed_no_write`/`closed` events do **not** schedule a reindex; `created`/`modified`/`moved`/`deleted` (+ `DirModified`) do; a mutating event inside a hidden dir is still ignored.
- `test_managers_index.py`: an empty-diff reindex does **not** call `vectors.save()`; a real change calls it exactly once.

All gates pass locally: `pytest`, `ruff check`/`format`, `mypy --strict`, patch coverage 100 % on both changed files.

## Documentation

Behavioural bug fix in internal watcher/indexing logic — no user-facing config, tool, resource, or env-var surface changes; no docs pages require updates.