### PR TITLE
chore(copier): update to v2.5.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,9 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.3.0
+_commit: v2.5.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search
+enable_authorization: false
 env_prefix: MARKDOWN_VAULT_MCP
 github_org: pvliesdonk
 human_name: Markdown Vault MCP

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,8 +50,12 @@ jobs:
       - name: Install Chromium
         run: uv run playwright install --with-deps chromium
 
-      - name: Run config-wizard smoke test
-        run: uv run pytest tests/test_config_wizard_smoke.py -v -m browser
+      - name: Run config-wizard browser tests
+        # Both the template-owned smoke suite and the project-owned domain suite
+        # (test_config_wizard_domain.py). -m browser selects the browser-marked
+        # tests in each; the seeded domain placeholder is skipped until a
+        # consumer replaces it with real assertions.
+        run: uv run pytest tests/test_config_wizard_smoke.py tests/test_config_wizard_domain.py -v -m browser
 
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,18 @@ The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, ya
 
 Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
+<!-- TEMPLATE-TRACKING-START -->
+**Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
+<!-- TEMPLATE-TRACKING-END -->
+
+## GitHub Review Types
+
+GitHub has two distinct review mechanisms — **both must be read and addressed**:
+
+- **Inline review comments** (`get_review_comments`): attached to specific lines of the diff. Appear in the "Files changed" tab. Use `get_review_comments` to fetch these.
+- **PR-level comments** (`get_comments`): posted on the Conversation tab, not tied to a line. Review summary posts, bot analysis, and blocking issues are often posted here. Use `get_comments` to fetch these.
+
+Always fetch both before declaring a review round complete.
 ## Documentation Discipline
 
 Every issue, PR, and code change must consider documentation impact. Before closing any issue or creating any PR, check whether the following need updating:
@@ -186,6 +198,7 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 
 For services that talk to a remote upstream (e.g. paperless, an HTTP API), wire the upstream version inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/markdown_vault_mcp/server.py`. Pass `upstream_version=` (a zero-arg callable returning a dict / str / None) and optionally `upstream_label="<service>"` (default `"upstream"`). The simplest pattern is a module-level upstream client (typically constructed from env vars at import time) whose version method is referenced from the callable — `CurrentContext()` is a FastMCP DI marker that only resolves inside parameter defaults, so it cannot be called directly from a zero-arg provider. The block is preserved across `copier update`.
 
+<!-- TEMPLATE-TRACKING-START -->
 ## Shared Infrastructure
 
 Shared infrastructure (auth providers, middleware stack, logging bootstrap, event store factory, CLI scaffolding, release pipeline, Docker entrypoint, nfpm packaging, mcpb bundle) lives upstream in two places:
@@ -202,6 +215,7 @@ Fixes and improvements to shared code land in those repos and propagate here via
 - **Domain-only fix** (anything inside a `DOMAIN-*`, `CONFIG-*`, or `PROJECT-*` sentinel block, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
+<!-- TEMPLATE-TRACKING-END -->
 
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 

--- a/FORKING.md
+++ b/FORKING.md
@@ -1,0 +1,88 @@
+# Forking: detaching from the template
+
+This project was generated from the
+[`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template)
+copier template and, by default, **tracks** it: the weekly
+`copier-update` workflow opens PRs that pull in template and `fastmcp-pvl-core`
+improvements, and `CLAUDE.md` routes fixes back upstream.
+
+A **fork** is different. If you are taking sole ownership of this server, or
+want an opinionated variant that no longer follows the fleet, you should
+**detach**: stop tracking the template and remove the fleet-wide automation and
+guidance that no longer applies. A fork is not a downstream — after detaching,
+template and `fastmcp-pvl-core` changes are yours to port manually.
+
+Detaching is mechanical. Run the steps below once, then commit.
+
+## Step 1 — Stop tracking the template
+
+```bash
+rm -f .copier-answers.yml
+```
+
+This removes the link copier uses to reattach. The weekly cron that ran
+`copier update` is deleted in Step 2.
+
+## Step 2 — Prune template-origin CI and fleet review wiring
+
+```bash
+rm -f .github/workflows/copier-update.yml \
+      .github/workflows/claude.yml \
+      .github/workflows/claude-code-review.yml
+rm -rf .gemini
+rm -f scripts/copier_update_aggregator.py
+rm -rf scripts/copier_update_prompts
+```
+
+What this removes and why:
+
+- `copier-update.yml` — template-update automation; meaningless once detached.
+- `claude.yml`, `claude-code-review.yml` — fleet review-bot wiring.
+- `.gemini/` — gemini-code-assist fleet scope control.
+- `scripts/copier_update_aggregator.py`, `scripts/copier_update_prompts/` —
+  the orchestration that only `copier-update.yml` invoked; dead weight once
+  that workflow is gone.
+
+**Keep** your own CI and release workflows: `ci.yml`, `codeql.yml`,
+`coverage-status.yml`, `docs.yml`, and `release.yml`. (`release.yml` still needs
+the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
+
+## Step 3 — Scrub template-tracking guidance from `CLAUDE.md`
+
+```bash
+# -i.bak + rm keeps this portable across GNU sed (Linux) and BSD sed (macOS),
+# which disagree on the in-place flag's syntax.
+sed -i.bak '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md && rm -f CLAUDE.md.bak
+```
+
+This deletes the template-coupled sections — the bot-reviewer merge-gate
+paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** —
+while keeping the fork-neutral contributor guidance (Conventions, the PR
+acceptance gates, the Logging Standard, the config contract, GitHub Review
+Types). If your fork added its own `.claude/CLAUDE.md`, apply the same scrub
+there.
+
+## Step 4 — README cleanup (optional)
+
+These leftover references are harmless but now misleading:
+
+- The **Template** badge at the top of `README.md` (the
+  `![Template](https://img.shields.io/badge/dynamic/yaml?...&label=template)`
+  entry) points at the now-deleted `.copier-answers.yml`. Remove it.
+- In the secrets table, the `RELEASE_TOKEN` row lists `copier-update.yml` as a
+  consumer. Drop that workflow from the row.
+- The `### \`uv.lock\` refresh after \`copier update\`` subsection no longer
+  applies. Remove it.
+
+## You are now standalone
+
+Remove this guide (it no longer applies once detached) and commit the result:
+
+```bash
+rm -f FORKING.md
+git add -A
+git commit -m "chore: detach from fastmcp-server-template"
+```
+
+Future template or `fastmcp-pvl-core` fixes are no longer delivered
+automatically — pull in anything you want by hand.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- DOMAIN-START -->
 A generic markdown vault [MCP](https://modelcontextprotocol.io/) server with FTS5 full-text search, semantic vector search, frontmatter-aware indexing, incremental reindexing, and non-markdown attachment support.
 
-**[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
+**[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[Config wizard](https://pvliesdonk.github.io/markdown-vault-mcp/latest/configuration-generator/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
 
 Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Zettelkasten, a PARA vault) and it exposes search, read, write, and edit tools over the Model Context Protocol.
 <!-- DOMAIN-END -->

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -75,8 +75,6 @@ The bearer-token mode above shares one subject across every authenticated caller
 
 Each token resolves to a distinct subject string for downstream attribution. Subject strings are opaque: the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only. When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present). A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
 
-For the per-tool authorization that consumes these subjects, see [Authorization (opt-in)](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/README.md#authorization-opt-in) in the project README.
-
 ---
 
 ## OIDC
@@ -111,10 +109,10 @@ Client → markdown-vault-mcp (present JWT → validate via JWKS)
 
 ### How it works (oidc-proxy mode)
 
-The server uses FastMCP's built-in `OIDCProxy` (no external auth sidecar needed):
+The server proxies OIDC itself — no external auth sidecar to deploy:
 
 ```
-Client → markdown-vault-mcp (OIDCProxy) → OIDC Provider
+Client → mcp-server → OIDC Provider
 ```
 
 1. Client connects to the server

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -50,6 +50,28 @@ const systemdLine = (k, v) => {
   return `Environment="${k}=${escaped}"`;
 };
 
+// Validate a loaded wizard spec before any generator runs. The generators
+// iterate spec.questions and dereference spec.meta.{projectName,dockerImage,
+// envPrefix} with no per-field guard at the use site, so an incomplete spec
+// (hand-edited, or served mid-migration) must fail loudly here rather than
+// reach the generators and emit
+// undefined-laden artifacts the user copy-pastes. The JSON Schema enforces the
+// same shape, but only in the Python test lane — never at runtime, which is what
+// this guards. Throws Error with a specific message on the first violation.
+export function validateSpec(spec) {
+  if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
+    throw new Error("wizard-spec.json is malformed (missing questions array)");
+  }
+  if (!spec.meta || typeof spec.meta !== "object") {
+    throw new Error("wizard-spec.json is malformed (missing meta block)");
+  }
+  for (const k of ["projectName", "dockerImage", "envPrefix"]) {
+    if (typeof spec.meta[k] !== "string" || spec.meta[k] === "") {
+      throw new Error(`wizard-spec.json is malformed (meta.${k} missing or empty)`);
+    }
+  }
+}
+
 // Build {VAR: value} from the spec + answers. Empty non-secret answers are
 // dropped; a visible secret left empty becomes a placeholder so the artifact is
 // still complete and signals "replace me".

--- a/docs/javascripts/config-wizard/wizard-spec-schema.json
+++ b/docs/javascripts/config-wizard/wizard-spec-schema.json
@@ -68,6 +68,15 @@
         {
           "if": { "required": ["type"], "properties": { "type": { "const": "select" } } },
           "then": { "required": ["options"] }
+        },
+        {
+          "$comment": "A dockerVolume/dockerPath question binds its var to the container path (generators.js dockerEnvMap). Without var that binding never happens — reject rather than accept a question that silently emits a dead bind mount (dockerVolume) or a no-op (dockerPath).",
+          "if": { "required": ["dockerVolume"] },
+          "then": { "required": ["var"] }
+        },
+        {
+          "if": { "required": ["dockerPath"] },
+          "then": { "required": ["var"] }
         }
       ],
       "not": { "required": ["dockerVolume", "dockerPath"] }

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -1,5 +1,5 @@
 import {
-  buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
+  validateSpec, buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
   generateDockerRun, generateCompose, generateSystemd,
 } from "./generators.js";
 
@@ -26,8 +26,12 @@ function writeUrlState(spec) {
   const qs = params.toString();
   try {
     history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
-  } catch {
-    // history.replaceState throws in sandboxed iframes — safe to ignore.
+  } catch (e) {
+    // Benign in a sandboxed iframe (SecurityError, no allow-same-origin). But
+    // replaceState also throws SecurityError when its ~100-calls/10 s throttle
+    // is breached — a real signal the 300 ms debounce is insufficient — so log
+    // the cause at debug level rather than swallow it blind.
+    console.debug("config-wizard: history.replaceState failed", e);
   }
 }
 
@@ -151,10 +155,18 @@ function render() {
     copy.className = "cfg-copy";
     copy.textContent = "Copy";
     copy.addEventListener("click", () => {
-      if (navigator.clipboard) {
-        navigator.clipboard.writeText(text).catch(() => {});
-      } else {
-        // Fallback for non-secure contexts: select the block so Ctrl/Cmd-C works.
+      // Flash a transient affordance on the button, then restore its label.
+      const flash = (msg) => {
+        copy.textContent = msg;
+        setTimeout(() => {
+          copy.textContent = "Copy";
+        }, 1500);
+      };
+      // Select the block so the user can finish with Ctrl/Cmd-C themselves.
+      // Used both when the Clipboard API is absent (non-secure context) and when
+      // writeText rejects (permission/focus) — without it the empty catch left
+      // the user believing a failed copy had succeeded.
+      const selectFallback = () => {
         const range = document.createRange();
         range.selectNodeContents(pre);
         const sel = window.getSelection();
@@ -162,6 +174,12 @@ function render() {
           sel.removeAllRanges();
           sel.addRange(range);
         }
+        flash("Press Ctrl-C");
+      };
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(() => flash("Copied!"), selectFallback);
+      } else {
+        selectFallback();
       }
     });
     head.appendChild(copy);
@@ -218,15 +236,10 @@ async function init() {
     const resp = await fetch(specUrl);
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
     const spec = await resp.json();
-    if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
-      throw new Error("wizard-spec.json is malformed (missing questions array)");
-    }
-    if (!spec.meta || typeof spec.meta !== "object") {
-      // The generators read project identity from spec.meta; a spec missing it
-      // (e.g. mid-migration) must fail loudly here rather than throw an
-      // uncaught TypeError deep inside render().
-      throw new Error("wizard-spec.json is malformed (missing meta block)");
-    }
+    // The generators read project identity from spec.meta and dereference its
+    // required fields unconditionally; validateSpec fails loudly here rather
+    // than let render() emit undefined-laden output (see generators.js).
+    validateSpec(spec);
     SPEC = spec;
   } catch (e) {
     ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "fastmcp-pvl-core>=3.2.0,<4",
+    "fastmcp-pvl-core>=4.0.0,<5",
     "typer>=0.12",
 
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -201,22 +201,6 @@ def make_server(transport: str = "stdio", config: VaultConfig | None = None) -> 
     # 3.x: kwargs removed; installs one tool-aware logging middleware.
     wire_middleware_stack(mcp)
 
-    # Optional: enable opt-in per-subject authorization on tools / resources /
-    # prompts.  See fastmcp-pvl-core's README "Authorization" section for the
-    # design.  Tools, resources, and prompts opt in by setting
-    # ``meta={"required_scope": "<scope>"}``; absence of the key means
-    # unrestricted.  The middleware is only installed when ``acl_path`` is set.
-    #
-    # from fastmcp_pvl_core import (
-    #     AuthorizationMiddleware,
-    #     load_acl,
-    #     make_acl_authorizer,
-    # )
-    #
-    # if config.acl_path is not None:
-    #     authorizer = make_acl_authorizer(load_acl(config.acl_path))
-    #     mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
-
     register_tools(mcp)
     register_resources(mcp)
     register_apps(mcp)

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -10,8 +10,9 @@ Two kinds of tests live here, both template-owned and spec-agnostic:
   every spec shares (the ``deployment`` question exists; output carries the
   project identity from ``meta``).
 * Generator unit tests import ``generators.js`` directly and feed it synthetic
-  specs, so they exercise ``dockerVolume`` / ``dockerPath`` behaviour without
-  depending on this project's questions.
+  specs, so they exercise generator behaviour (``dockerVolume`` / ``dockerPath``
+  mapping, ``validateSpec`` rejection of malformed specs) without depending on
+  this project's questions.
 
 Domain-specific assertions belong in ``test_config_wizard_domain.py``.
 """
@@ -113,6 +114,75 @@ def _eval_generators(page: Page, body: str) -> typing.Any:
         + ")(g); }"
     )
     return page.evaluate(script)
+
+
+def test_validate_spec_accepts_complete_spec(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }],
+            guards: [] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is None
+
+
+def test_validate_spec_rejects_missing_questions(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' } };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "missing questions array" in err
+
+
+def test_validate_spec_rejects_missing_meta(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1, questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "missing meta block" in err
+
+
+def test_validate_spec_rejects_empty_meta(page: Page) -> None:
+    # meta is an object but lacks the fields the generators dereference: the
+    # exact gap the old `typeof meta === 'object'` guard let through.
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1, meta: {},
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "meta.projectName missing or empty" in err
+
+
+def test_validate_spec_rejects_empty_meta_field(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: '', envPrefix: 'DEMO' },
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "meta.dockerImage missing or empty" in err
 
 
 def test_docker_volume_adds_mount_and_fixes_container_path(page: Page) -> None:

--- a/tests/test_config_wizard_spec_schema.py
+++ b/tests/test_config_wizard_spec_schema.py
@@ -141,6 +141,29 @@ def test_schema_accepts_dockervolume_alone(schema: dict[str, Any]) -> None:
     jsonschema.validate(spec, schema)
 
 
+def test_schema_rejects_dockervolume_without_var(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    bad["questions"].append(
+        {"id": "data_dir", "label": "Data", "type": "text", "dockerVolume": "/data/app"}
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_rejects_dockerpath_without_var(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    bad["questions"].append(
+        {
+            "id": "index_path",
+            "label": "Index",
+            "type": "text",
+            "dockerPath": "/data/state/index.db",
+        }
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
 def test_schema_accepts_dockerpath_alone(schema: dict[str, Any]) -> None:
     spec = _minimal_valid_spec()
     spec["questions"].append(


### PR DESCRIPTION
## Template update: `v2.3.0` → `v2.5.1`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v2.3.0...v2.5.1)

<details><summary>Release notes (v2.5.1)</summary>

- #183 feat(scaffold): document and enable clean detach from the template (closes #182)

</details>

<details><summary>Files changed (13)</summary>

```
 .copier-answers.yml                                |  3 +-
 .github/workflows/docs.yml                         |  8 +-
 CLAUDE.md                                          | 14 ++++
 FORKING.md                                         | 88 ++++++++++++++++++++++
 README.md                                          |  2 +-
 docs/guides/authentication.md                      |  6 +-
 docs/javascripts/config-wizard/generators.js       | 22 ++++++
 .../config-wizard/wizard-spec-schema.json          |  9 +++
 docs/javascripts/config-wizard/wizard.js           | 45 +++++++----
 pyproject.toml                                     |  2 +-
 src/markdown_vault_mcp/server.py                   | 16 ----
 tests/test_config_wizard_smoke.py                  | 74 +++++++++++++++++-
 tests/test_config_wizard_spec_schema.py            | 23 ++++++
 13 files changed, 269 insertions(+), 43 deletions(-)
```

</details>

### ⚠️ 4 file(s) with unresolved conflict markers

The `<<<<<<< before updating` markers **are committed to this branch** — resolve them before merging:

- `CLAUDE.md`
- `README.md`
- `docs/guides/authentication.md`
- `src/markdown_vault_mcp/config.py`

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

---

## Agent analysis

### 🔧 Conflict resolutions

**Auto-committed by claude-code** — VERIFY before merging:

- `CLAUDE.md` (commit 78e111d5f9c2357daa431c1e5cd630c6e9a8eab3): _Template v2.5.1 added TEMPLATE-TRACKING sentinel markers around the 'Bot reviewers' paragraph and inserted the '## GitHub Review Types' section; the downstream had removed both from this template-owned block, so the 'after updating' (template) side is accepted unchanged._
- `docs/guides/authentication.md` (commit 78e111d5f9c2357daa431c1e5cd630c6e9a8eab3): _Template v2.5.1 de-branded the oidc-proxy prose from 'FastMCP’s built-in OIDCProxy (no external auth sidecar needed)' to a generic 'The server proxies OIDC itself — no external auth sidecar to deploy'; the downstream had only cosmetically renamed 'mcp-server' to 'markdown-vault-mcp' in the diagram; template-owned content takes the 'after updating' wording._
- `src/markdown_vault_mcp/config.py` (commit 78e111d5f9c2357daa431c1e5cd630c6e9a8eab3): _Accept the downstream ('before updating') side: preserves the docstring Example closing and all domain fields inside the CONFIG-FIELDS-START sentinel, discarding the template's scaffold-only placeholder content, since both the docstring example and CONFIG-FIELDS block are downstream-owned by sentinel contract._
- `src/markdown_vault_mcp/config.py` (commit 78e111d5f9c2357daa431c1e5cd630c6e9a8eab3): _Accept the downstream's CONFIG-FROM-ENV-START content (all domain field assignments), discarding the template's scaffold placeholder and its premature inline 'server=ServerConfig.from_env()' call, since the downstream computes 'server' separately before 'return cls(...)' and the existing 'server=server' line after the sentinel end remains valid._

**Needs review** — conflict markers remain, operator must resolve:

- `README.md`: Cannot auto-resolve because both sides contain substantial unique content: the 'before updating' side has the downstream's full OIDC configuration variable table plus an entire '## CLI Reference' section (never in the template), while the 'after updating' side has the template's new brief '## Authentication' summary line. Picking either side outright destroys valuable documentation — taking 'after' loses the OIDC config table and the entire CLI Reference, while taking 'before' omits the template's new '## Authentication' pointer. The correct merge requires structural reorganisation (keeping the OIDC table while also inserting the template's new auth summary), which cannot be expressed as a single unambiguous sentence-level transformation. Additionally, the '### Reverse Proxy Subpath Mounts' section was split by the conflict markers (intro in 'before updating', bullet-point continuation outside the markers), so the right structural assembly also requires repairing that split — adding a second dimension of operator judgment.
  Recommended approach: The downstream-added '### OIDC authentication' variable table and '## CLI Reference' section both live in the template-owned area of README.md. The template v2.5.1 replaced that area with a brief '## Authentication' pointer section ('Callers authenticate via a bearer token or OIDC (mutually exclusive). See the Authentication guide...'). The recommended resolution is: (1) keep the downstream's '### OIDC authentication' variable table and '## CLI Reference' section intact since they are detailed downstream-authored user documentation, (2) insert the template's new brief '## Authentication' summary line as an introductory sentence or sub-note within the existing '## Authentication' section that already exists lower in the file (around L554-L565), and (3) remove the now-redundant '### OIDC authentication' heading under the Configuration section and fold its variable table into a new dedicated auth-configuration section. The 'ours' side (downstream content) was staged as-is to unblock the commit; the operator must still apply the template's '## Authentication' pointer text.

### ✨ New features in this update

**Needs your attention** (action-required):

- #181 feat(scaffold): migrate authorization to pvl-core v4 native AuthChecks — needs opt-in.
  The template's `pyproject.toml.jinja` was bumped from `fastmcp-pvl-core>=3.2.0,<4` to `>=4.0.0,<5`. This constraint change ships automatically via copier's 3-way merge on `pyproject.toml` (confirmed: the downstream `pyproject.toml` already shows `>=4.0.0,<5`). However, pvl-core v4 is a major-version upgrade and may carry breaking API changes beyond AuthChecks — operators must run `uv run pytest -x -q` and `uv run mypy src/ tests/` to confirm all existing server wiring (`build_auth`, `wire_middleware_stack`, `resolve_auth_mode`, `build_kv_store`, `register_server_info_tool`) remains compatible. Because this project has `enable_authorization: false`, the AuthChecks scaffold (ACL middleware stubs in `config.py`, `docs/guides/authorization.md` AUTHZ sections, `*_ACL_PATH` env var in `.env.example`) does not render, so no authorization-specific migration is needed unless the operator later sets `enable_authorization: true`.

**Ships through automatically** (informational):

- #174 fix(config-wizard): deep meta validation + dockerVolume/dockerPath var constraint (closes #172, #173) — applied this run
- #177 feat(scaffold): gate Authorization scaffold behind enable_authorization (closes #176) — applied this run
- #179 feat(scaffold): co-locate authentication + authorization (closes #178) — applied this run
- #183 feat(scaffold): document and enable clean detach from the template (closes #182) — applied this run

