### PR TITLE
chore(copier): update to v2.5.3

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.5.1
+_commit: v2.5.3
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -21,7 +21,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -54,7 +54,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -92,7 +92,7 @@ jobs:
           - python-version: "3.14"
             experimental: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -100,7 +100,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # `uv python install` writes to UV_PYTHON_INSTALL_DIR, which is
           # separate from the uv package cache and not covered by setup-uv's
@@ -214,7 +214,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -222,7 +222,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -254,7 +254,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -275,7 +275,7 @@ jobs:
       # need to add `pull-requests: write` here too.
       checks: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cache Vale style packages
         # Cache only the downloaded pack directories — NOT .vale/styles/config/.
@@ -286,7 +286,7 @@ jobs:
         # Pack list mirrors the Packages = line in .vale.ini; if you add or
         # remove a pack, update both. Bump the v1- prefix to evict all cached
         # packs if Vale changes pack format backward-incompatibly.
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .vale/styles/Google

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     # in `deploy` on release:published.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # On release events the triggering tag may move after the workflow is
           # queued (semantic-release pushes a version-bump commit); build main.
@@ -80,14 +80,14 @@ jobs:
     steps:
       # `needs: build` is a sequencing gate only — mike drives its own
       # build internally; no artifact is passed from the build job.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Full history required: mike reads and pushes the gh-pages branch.
           fetch-depth: 0
           ref: main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.release.outputs.tag }}
           fetch-depth: 1
@@ -265,7 +265,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.release.outputs.tag }}
           fetch-depth: 1
@@ -319,7 +319,7 @@ jobs:
     env:
       MCPB_VERSION: "2.1.2"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release.outputs.tag }}
       - name: Install mcpb CLI
@@ -398,7 +398,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout catalog repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: pvliesdonk/claude-plugins
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -459,7 +459,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 1

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -109,7 +109,7 @@ Client → markdown-vault-mcp (present JWT → validate via JWKS)
 
 ### How it works (oidc-proxy mode)
 
-The server proxies OIDC itself — no external auth sidecar to deploy:
+The server proxies OIDC itself, with no external auth sidecar to deploy:
 
 ```
 Client → mcp-server → OIDC Provider

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -34,14 +34,47 @@ if typing.TYPE_CHECKING:
     from playwright.sync_api import Browser, Page
 
 SITE = Path(__file__).resolve().parent.parent / "site"
+_DOCS_WIZARD = (
+    Path(__file__).resolve().parent.parent / "docs" / "javascripts" / "config-wizard"
+)
+_SITE_WIZARD = SITE / "javascripts" / "config-wizard"
 
 pytestmark = pytest.mark.browser
+
+
+def _stale_wizard_assets() -> list[str]:
+    """Names of wizard assets whose built copy is missing or differs from source.
+
+    mkdocs copies the ``docs/javascripts/config-wizard`` files into ``site/``
+    verbatim, so a byte mismatch means ``site/`` is stale relative to the source
+    these tests actually exercise. Comparing bytes (not mtimes) is robust across
+    fresh checkouts, where mtimes carry no build ordering.
+    """
+    stale: list[str] = []
+    for src in sorted(_DOCS_WIZARD.glob("*")):
+        if not src.is_file():
+            continue
+        built = _SITE_WIZARD / src.name
+        if not built.is_file() or built.read_bytes() != src.read_bytes():
+            stale.append(src.name)
+    return stale
 
 
 @pytest.fixture(scope="module")
 def site_url() -> typing.Iterator[str]:
     if not (SITE / "configuration-generator" / "index.html").exists():
         pytest.skip("site/ not built -- run `uv run mkdocs build` first")
+    # A built-but-stale site/ (source edited under docs/ without rebuilding)
+    # would silently run these tests against outdated assets and false-fail.
+    # Skip with an actionable message instead. CI always builds fresh, so this
+    # only ever trips locally.
+    stale = _stale_wizard_assets()
+    if stale:
+        pytest.skip(
+            "site/ is stale relative to docs/ ("
+            + ", ".join(stale)
+            + ") -- rebuild with `uv run mkdocs build`"
+        )
     handler = functools.partial(
         http.server.SimpleHTTPRequestHandler, directory=str(SITE)
     )


### PR DESCRIPTION
## Template update: `v2.5.1` → `v2.5.3`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v2.5.1...v2.5.3)

<details><summary>Release notes (v2.5.3)</summary>

- #189 ci: bump pinned GitHub Actions (checkout v7, cache v5, setup-uv v8.2)
- #187 fix(docs): replace spaced em-dash in authentication guide to satisfy Vale

</details>

<details><summary>Files changed (10)</summary>

```
 .copier-answers.yml                      |  2 +-
 .github/workflows/ci.yml                 | 22 ++++++++++-----------
 .github/workflows/claude-code-review.yml |  2 +-
 .github/workflows/claude.yml             |  2 +-
 .github/workflows/codeql.yml             |  2 +-
 .github/workflows/copier-update.yml      |  2 +-
 .github/workflows/docs.yml               |  6 +++---
 .github/workflows/release.yml            | 12 ++++++------
 docs/guides/authentication.md            |  2 +-
 tests/test_config_wizard_smoke.py        | 33 ++++++++++++++++++++++++++++++++
 10 files changed, 59 insertions(+), 26 deletions(-)
```

</details>

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

---

## Agent analysis

### ✨ New features in this update

**Ships through automatically** (informational):

- #186 fix(config-wizard): skip smoke tests on a stale site/ instead of false-failing — applied this run
- #187 fix(docs): replace spaced em-dash in authentication guide to satisfy Vale — applied this run
- #189 ci: bump pinned GitHub Actions (checkout v7, cache v5, setup-uv v8.2) — applied this run

