### PR TITLE
fix: atomic VectorIndex sidecar writes + self-heal corrupt sidecars on load

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1707,6 +1707,10 @@ Key methods:
   embeddings have been computed outside a lock section (see Thread Safety).
 - `delete_by_path(path)`: removes all rows for a document.
 - `save(path)` / `load(path, provider)`: persist/restore sidecar files.
+  `save()` writes each sidecar (`.npy`, `.json`) to a temp file in the same
+  directory and atomically `replace()`s the final path (mirrors
+  `tracker._save_state`), so an interrupted write can never corrupt a
+  previously persisted index.
 
 ### `providers.py`: Embedding Providers
 

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -164,6 +164,36 @@ class IndexManager:
                     raise ValueError(
                         "Failed to rebuild vector index after a compatibility error."
                     ) from exc
+            except (
+                json.JSONDecodeError,
+                ValueError,
+                EOFError,
+                FileNotFoundError,
+            ) as exc:
+                # A corrupt/incomplete sidecar wedges every boot until a manual
+                # rebuild (#720 follow-up): an interrupted save can leave a
+                # truncated or zero-byte file. Self-heal by routing to the same
+                # force-rebuild path as a compatibility mismatch.
+                #   ValueError — truncated/garbage .json (JSONDecodeError is a
+                #     ValueError subclass) and corrupt/bad-version .npy.
+                #   EOFError — a zero-byte .npy (the canonical interrupted-save
+                #     residue; numpy raises EOFError, not ValueError/OSError).
+                #   FileNotFoundError — a missing .json while the .npy exists
+                #     (an incomplete pair); the .npy-exists guard above means a
+                #     FileNotFoundError here can only be the gone .json sidecar.
+                # Deliberately NOT broad OSError: PermissionError / disk-IO
+                # errors are environmental — a destructive rebuild would be
+                # futile and mask the real problem, so they must propagate.
+                logger.warning(
+                    "vector_index_corrupt_rebuilding path=%s error=%s",
+                    self._embeddings_path,
+                    exc,
+                )
+                self.build_embeddings(force=True)
+                if self._get_vectors() is None:
+                    raise ValueError(
+                        "Failed to rebuild vector index after a corrupt sidecar."
+                    ) from exc
         else:
             vi = VectorIndex(self._embedding_provider)
             self._set_vectors(vi)

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from markdown_vault_mcp.providers import EmbeddingProvider
 
 try:
@@ -417,6 +418,11 @@ class VectorIndex:
         Writes ``{path}.npy`` (the embedding matrix) and ``{path}.json``
         (the metadata list).  An empty index is saved as a zero-row array.
 
+        Each sidecar is written to a temp file in the same directory and
+        atomically ``replace()``-d onto its final path (mirrors
+        :meth:`tracker.ChangeTracker._save_state`), so an interrupted write
+        can never corrupt a previously persisted index.
+
         Args:
             path: Base path for the sidecar files.  Parent directory must
                 exist.
@@ -424,12 +430,13 @@ class VectorIndex:
         npy_path = path.with_suffix(".npy")
         json_path = path.with_suffix(".json")
 
-        if self._embeddings.size == 0:
-            # Save a zero-shape array so load() can always read it back.
-            empty = np.empty((0, 0), dtype=np.float32)
-            np.save(str(npy_path), empty)
-        else:
-            np.save(str(npy_path), self._embeddings)
+        # An empty index is saved as a zero-shape array so load() can always
+        # read it back.
+        array_to_save = (
+            np.empty((0, 0), dtype=np.float32)
+            if self._embeddings.size == 0
+            else self._embeddings
+        )
 
         payload = {
             "rows": self._metadata,
@@ -442,8 +449,29 @@ class VectorIndex:
             },
         }
 
-        with json_path.open("w", encoding="utf-8") as fh:
-            json.dump(payload, fh, ensure_ascii=False)
+        # Write each sidecar to a temp file in the same directory, then
+        # atomically replace the final file. A mid-write interruption can then
+        # never corrupt a previously persisted index (mirrors
+        # tracker._save_state). np.save appends ".npy" unless the path already
+        # ends in it, so the temp file uses a ".npy" suffix and we write
+        # through the open fd to avoid any suffix ambiguity.
+        npy_fd, npy_tmp = tempfile.mkstemp(dir=npy_path.parent, suffix=".npy")
+        try:
+            with os.fdopen(npy_fd, "wb") as fh:
+                np.save(fh, array_to_save)
+            Path(npy_tmp).replace(npy_path)
+        except BaseException:
+            Path(npy_tmp).unlink(missing_ok=True)
+            raise
+
+        json_fd, json_tmp = tempfile.mkstemp(dir=json_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(json_fd, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, ensure_ascii=False)
+            Path(json_tmp).replace(json_path)
+        except BaseException:
+            Path(json_tmp).unlink(missing_ok=True)
+            raise
 
         logger.info(
             "VectorIndex.save: saved %d vectors to %s",

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -747,6 +747,212 @@ class TestBuildEmbeddings:
 
 
 # ---------------------------------------------------------------------------
+# _load_vectors self-heal of a corrupt/incomplete sidecar
+# ---------------------------------------------------------------------------
+
+
+class TestLoadVectorsSelfHeal:
+    """A corrupt/incomplete vector sidecar must rebuild instead of wedging boot.
+
+    An interrupted save can leave a truncated or zero-byte sidecar; before the
+    self-heal the corrupt file propagated out of ``_load_vectors`` and kept
+    semantic search down until a manual rebuild. These tests pin the broadened
+    catch — ``(json.JSONDecodeError, ValueError, EOFError, FileNotFoundError)``
+    route to the same ``force=True`` rebuild — while confirming environmental
+    errors (``PermissionError`` / generic ``OSError``) still propagate.
+    """
+
+    def _build_persisted_index(
+        self, vault: Path, state_dir: Path
+    ) -> tuple[IndexManager, dict, Path, Path]:
+        """Build an index + embeddings and return (mgr, holder, npy, json).
+
+        After this helper the sidecars exist on disk and the in-memory cache
+        is cleared, so a subsequent ``_load_vectors()`` re-reads from disk.
+        """
+        from tests.conftest import MockEmbeddingProvider
+
+        embeddings_path = state_dir / "embeddings"
+        holder: dict = {"vectors": None}
+        mgr, _fts, _ = _make_index_mgr(
+            vault,
+            state_dir,
+            embeddings_path=embeddings_path,
+            embedding_provider=MockEmbeddingProvider(),
+            get_vectors=lambda: holder["vectors"],
+            set_vectors=lambda v: holder.__setitem__("vectors", v),
+        )
+        mgr.build_index()
+        mgr.build_embeddings()
+        assert holder["vectors"] is not None
+        # Drop the cache so _load_vectors() re-reads the sidecars from disk.
+        holder["vectors"] = None
+
+        npy_path = embeddings_path.with_suffix(".npy")
+        json_path = embeddings_path.with_suffix(".json")
+        assert npy_path.exists() and json_path.exists()
+        return mgr, holder, npy_path, json_path
+
+    def test_corrupt_json_triggers_rebuild(
+        self, index_vault: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A truncated .json with a valid .npy rebuilds rather than propagating."""
+        mgr, holder, _npy, json_path = self._build_persisted_index(
+            index_vault, tmp_path
+        )
+        json_path.write_text('{"rows": [{"path"', encoding="utf-8")
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            result = mgr._load_vectors()
+
+        assert result is holder["vectors"]
+        assert result.count >= 4  # a usable, repopulated index
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )
+
+    def test_zero_byte_npy_triggers_rebuild(
+        self, index_vault: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A zero-byte .npy raises EOFError from numpy — must rebuild, not propagate.
+
+        EOFError is neither a ValueError nor an OSError, so it has to be named
+        explicitly in the catch; this is the canonical interrupted-save residue.
+        """
+        mgr, holder, npy_path, _json = self._build_persisted_index(
+            index_vault, tmp_path
+        )
+        npy_path.write_bytes(b"")  # truncate to zero bytes
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            result = mgr._load_vectors()
+
+        assert result is holder["vectors"]
+        assert result.count >= 4
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )
+
+    def test_garbage_npy_triggers_rebuild(
+        self, index_vault: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A garbage (non-numpy) .npy raises ValueError — must rebuild."""
+        mgr, holder, npy_path, _json = self._build_persisted_index(
+            index_vault, tmp_path
+        )
+        npy_path.write_bytes(b"this is not a numpy array at all")
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            result = mgr._load_vectors()
+
+        assert result is holder["vectors"]
+        assert result.count >= 4
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )
+
+    def test_missing_json_with_present_npy_triggers_rebuild(
+        self, index_vault: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A missing .json while the .npy exists (incomplete pair) rebuilds.
+
+        With the .npy-exists guard satisfied, the FileNotFoundError raised when
+        VectorIndex.load opens the absent .json can only mean an incomplete pair
+        — so a rebuild is the correct response.
+        """
+        mgr, holder, _npy, json_path = self._build_persisted_index(
+            index_vault, tmp_path
+        )
+        json_path.unlink()
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            result = mgr._load_vectors()
+
+        assert result is holder["vectors"]
+        assert result.count >= 4
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )
+
+    def test_permission_error_propagates_without_rebuild(
+        self, index_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An environmental OSError on load must propagate, not trigger a rebuild.
+
+        PermissionError is an OSError but not one of the corruption types, so it
+        is deliberately left out of the catch: a destructive rebuild would be
+        futile against a disk/permission fault and would mask the real problem.
+        """
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        mgr, _holder, _npy, _json = self._build_persisted_index(index_vault, tmp_path)
+
+        def boom(*_args: object, **_kwargs: object) -> VectorIndex:
+            raise PermissionError("read denied")
+
+        monkeypatch.setattr(VectorIndex, "load", boom)
+        rebuild_calls: list[bool] = []
+        original_build = mgr.build_embeddings
+
+        def tracking_build(*args: object, **kwargs: object) -> int:
+            rebuild_calls.append(True)
+            return original_build(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(mgr, "build_embeddings", tracking_build)
+
+        with pytest.raises(PermissionError, match="read denied"):
+            mgr._load_vectors()
+        assert rebuild_calls == []  # no rebuild attempted
+
+    def test_missing_index_cold_builds_without_rebuild_loop(
+        self, index_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fully-missing index (.npy absent) takes the cold-build path, not rebuild.
+
+        The .npy-exists guard must still steer a never-built vault to an empty
+        VectorIndex rather than a force rebuild — verify the broadened catch did
+        not disturb that branch.
+        """
+        from markdown_vault_mcp.vector_index import VectorIndex
+        from tests.conftest import MockEmbeddingProvider
+
+        embeddings_path = tmp_path / "embeddings"
+        holder: dict = {"vectors": None}
+        mgr, _fts, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=MockEmbeddingProvider(),
+            get_vectors=lambda: holder["vectors"],
+            set_vectors=lambda v: holder.__setitem__("vectors", v),
+        )
+        # No build_embeddings() call — sidecars never written.
+        assert not embeddings_path.with_suffix(".npy").exists()
+
+        rebuild_calls: list[bool] = []
+        original_build = mgr.build_embeddings
+
+        def tracking_build(*args: object, **kwargs: object) -> int:
+            rebuild_calls.append(True)
+            return original_build(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(mgr, "build_embeddings", tracking_build)
+        result = mgr._load_vectors()
+
+        assert isinstance(result, VectorIndex)
+        assert result.count == 0  # empty cold-build index
+        assert rebuild_calls == []  # cold path, not a rebuild
+
+
+# ---------------------------------------------------------------------------
 # embeddings_status
 # ---------------------------------------------------------------------------
 

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -468,6 +468,103 @@ class TestVectorIndexPersistence:
         with pytest.raises(VectorIndexCompatibilityError, match="mismatch"):
             VectorIndex.load(base, mock_provider)
 
+    def test_failed_save_preserves_prior_files_json(
+        self,
+        mock_provider: MockEmbeddingProvider,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A json.dump failure during save leaves the prior sidecars intact and loadable."""
+        index = VectorIndex(mock_provider)
+        index.add(["north star"], [_make_meta("stars.md", heading="North")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        npy_path = tmp_path / "embeddings.npy"
+        json_path = tmp_path / "embeddings.json"
+        original_npy = npy_path.read_bytes()
+        original_json = json_path.read_bytes()
+
+        # Re-saving the same index, but json.dump raises before the .json temp
+        # is committed. The .json sidecar's atomic replace must never fire, and
+        # the .npy replace (which writes byte-identical content for an unchanged
+        # array) must leave the prior file intact.
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(json, "dump", boom)
+        with pytest.raises(OSError, match="disk full"):
+            index.save(base)
+        monkeypatch.undo()
+
+        # Prior sidecars are byte-for-byte intact.
+        assert npy_path.read_bytes() == original_npy
+        assert json_path.read_bytes() == original_json
+
+        # And the preserved index still loads cleanly.
+        loaded = VectorIndex.load(base, mock_provider)
+        assert loaded.count == 1
+
+    def test_failed_save_preserves_prior_files_npy(
+        self,
+        mock_provider: MockEmbeddingProvider,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An np.save failure during save leaves the prior sidecars intact and loadable."""
+        index = VectorIndex(mock_provider)
+        index.add(["north star"], [_make_meta("stars.md", heading="North")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        npy_path = tmp_path / "embeddings.npy"
+        json_path = tmp_path / "embeddings.json"
+        original_npy = npy_path.read_bytes()
+        original_json = json_path.read_bytes()
+
+        # np.save is the first write in save(); it raises before either atomic
+        # replace can fire, so both prior sidecars must be untouched.
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(np, "save", boom)
+        with pytest.raises(OSError, match="disk full"):
+            index.save(base)
+        monkeypatch.undo()
+
+        # Prior sidecars are byte-for-byte intact.
+        assert npy_path.read_bytes() == original_npy
+        assert json_path.read_bytes() == original_json
+
+        # And the preserved index still loads cleanly.
+        loaded = VectorIndex.load(base, mock_provider)
+        assert loaded.count == 1
+
+    def test_failed_save_leaves_no_temp_files(
+        self,
+        mock_provider: MockEmbeddingProvider,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed save cleans up its temp files, leaving only the originals."""
+        index = VectorIndex(mock_provider)
+        index.add(["north star"], [_make_meta("stars.md", heading="North")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(json, "dump", boom)
+        with pytest.raises(OSError, match="disk full"):
+            index.save(base)
+        monkeypatch.undo()
+
+        # Only the two original sidecars remain — no .tmp scratch and no stray
+        # temp .npy left behind by the aborted write.
+        remaining = sorted(p.name for p in tmp_path.iterdir())
+        assert remaining == ["embeddings.json", "embeddings.npy"]
+
 
 class TestSearchByPath:
     """Tests for VectorIndex.search_by_path."""


### PR DESCRIPTION
## Summary
`VectorIndex.save()` writes the embeddings sidecars (`embeddings.npy`, `embeddings.json`) directly to their final paths. An interrupted write (process kill / sleep mid-save) can leave a truncated or zero-byte sidecar. We hit this in production: a quit mid-write left a truncated `embeddings.json`, which on a synchronous-load path crashed the server with a -32000 connection failure (JSON parse error). On current `main` the async embeddings build no longer crashes for this — but it does not self-heal: `_load_vectors` only rebuilds on `VectorIndexCompatibilityError`, so the corrupt sidecar is re-read every boot and semantic search stays down until a manual force rebuild.

This PR addresses both halves — prevention and recovery.

## Prevention — atomic sidecar writes
`save()` writes each sidecar to a temp file and `os.replace()`s it into place, mirroring the existing `tracker._save_state` / `managers/document.py` idiom (the atomic-write pass in #322 covered the document writes but left the vector sidecars non-atomic). A failed write unlinks its temp and re-raises, so a previously persisted index is left intact.

## Recovery — self-heal on load
`_load_vectors` now treats a corrupt/incomplete sidecar like a compatibility miss: it catches `json.JSONDecodeError`/`ValueError` (truncated/garbage `.json`, corrupt or bad-version `.npy`), `EOFError` (a zero-byte `.npy` — the canonical interrupted-save residue), and `FileNotFoundError` (a missing `.json` while `.npy` exists), routing to the same `force=True` rebuild. Broad `OSError` is deliberately not caught — `PermissionError`/disk-IO faults are environmental and continue to propagate rather than triggering a futile destructive rebuild. A fully-missing index still cold-builds.

## Notes
- Sidecars are made atomic independently, not as a unit; this closes the truncation window (a crash between the two replaces can still leave a count-mismatched but individually valid pair, which still loads).
- No `fsync` before replace — consistent with the existing `tracker`/`document` pattern; guards against process-kill, not power-loss.

## Tests
- Atomic save: prior sidecars survive a `json.dump` failure, survive an `np.save` failure, and a failed save leaves no temp files behind.
- Self-heal: corrupt `.json`, zero-byte `.npy`, garbage `.npy`, and missing `.json` each trigger a rebuild; a `PermissionError` on load propagates (no rebuild); a fully-missing index cold-builds.
- Full suite green; `ruff` + `mypy` clean.

---
Closes #733. Residual count-mismatch parity gap (acknowledged in Notes above) tracked as follow-up in #734.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
