### PR TITLE
fix: enforce vector sidecar row-count parity; self-heal on both load paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ site/
 
 # --- Development / ecosystem ignores (don't ship)
 .mcpregistry_*
+.repowise/
 .worktrees/
 .claude/worktrees/
 .claude/settings.local.json

--- a/docs/design.md
+++ b/docs/design.md
@@ -1711,6 +1711,11 @@ Key methods:
   directory and atomically `replace()`s the final path (mirrors
   `tracker._save_state`), so an interrupted write can never corrupt a
   previously persisted index.
+  `load()` also verifies that the embeddings matrix and metadata
+  list agree on row count and raises `VectorIndexCorruptError` on a
+  mismatch (the residue of a crash between the two independent atomic
+  replaces), which the load-time self-heal routes to a `force=True`
+  rebuild (#734).
 
 ### `providers.py`: Embedding Providers
 

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -144,6 +144,7 @@ class IndexManager:
         from markdown_vault_mcp.vector_index import (
             VectorIndex,
             VectorIndexCompatibilityError,
+            VectorIndexCorruptError,
         )
 
         if self._embeddings_path is None or self._embedding_provider is None:
@@ -165,6 +166,7 @@ class IndexManager:
                         "Failed to rebuild vector index after a compatibility error."
                     ) from exc
             except (
+                VectorIndexCorruptError,
                 json.JSONDecodeError,
                 ValueError,
                 EOFError,
@@ -174,6 +176,9 @@ class IndexManager:
                 # rebuild (#720 follow-up): an interrupted save can leave a
                 # truncated or zero-byte file. Self-heal by routing to the same
                 # force-rebuild path as a compatibility mismatch.
+                #   VectorIndexCorruptError — embeddings/metadata row-count
+                #     mismatch (a crash between the two atomic sidecar
+                #     replaces; subclasses ValueError, listed for clarity).
                 #   ValueError — truncated/garbage .json (JSONDecodeError is a
                 #     ValueError subclass) and corrupt/bad-version .npy.
                 #   EOFError — a zero-byte .npy (the canonical interrupted-save

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -146,8 +146,10 @@ class IndexManager:
             A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
 
         Raises:
-            RuntimeError: If embedding support is not configured
-                (``_embedding_provider`` or ``_embeddings_path`` is ``None``).
+            RuntimeError: If called without a prior ``_require_vectors()``
+                (a call-ordering fault; ``_embedding_provider`` or
+                ``_embeddings_path`` is ``None`` at entry). ``_require_vectors``
+                itself raises ``ValueError`` for the unconfigured case.
             ValueError: If a self-heal rebuild fails to produce a usable index.
         """
         vectors = self._get_vectors()

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -132,10 +132,23 @@ class IndexManager:
             )
 
     def _load_vectors(self) -> VectorIndex:
-        """Load or return the cached VectorIndex.
+        """Load or return the cached VectorIndex, self-healing corrupt sidecars.
+
+        Returns the cached index if already loaded. Otherwise deserialises it
+        from disk; on an incompatible, corrupt, or incomplete sidecar
+        (``VectorIndexCompatibilityError``, ``VectorIndexCorruptError``,
+        ``json.JSONDecodeError``/``ValueError``, ``EOFError``,
+        ``FileNotFoundError``) it routes to a ``force=True`` rebuild. A vault
+        with no persisted index cold-builds an empty one. Environmental errors
+        (e.g. ``PermissionError``) are not caught and propagate.
 
         Returns:
             A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+
+        Raises:
+            RuntimeError: If called before ``_require_vectors()`` configured
+                both ``embedding_provider`` and ``embeddings_path``.
+            ValueError: If a self-heal rebuild fails to produce a usable index.
         """
         vectors = self._get_vectors()
         if vectors is not None:
@@ -178,9 +191,8 @@ class IndexManager:
                 # force-rebuild path as a compatibility mismatch.
                 #   VectorIndexCorruptError — embeddings/metadata row-count
                 #     mismatch (#734; a crash between the two atomic sidecar
-                #     replaces). Subclasses ValueError, so listed explicitly
-                #     here only so tightening this tuple cannot silently drop
-                #     the corrupt-index self-heal.
+                #     replaces). A RuntimeError, so this entry is load-bearing
+                #     — it is NOT covered by the ValueError arm below.
                 #   ValueError — truncated/garbage .json (JSONDecodeError is a
                 #     ValueError subclass) and corrupt/bad-version .npy.
                 #   EOFError — a zero-byte .npy (the canonical interrupted-save

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -146,8 +146,8 @@ class IndexManager:
             A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
 
         Raises:
-            RuntimeError: If called before ``_require_vectors()`` configured
-                both ``embedding_provider`` and ``embeddings_path``.
+            RuntimeError: If embedding support is not configured
+                (``_embedding_provider`` or ``_embeddings_path`` is ``None``).
             ValueError: If a self-heal rebuild fails to produce a usable index.
         """
         vectors = self._get_vectors()

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -177,8 +177,10 @@ class IndexManager:
                 # truncated or zero-byte file. Self-heal by routing to the same
                 # force-rebuild path as a compatibility mismatch.
                 #   VectorIndexCorruptError — embeddings/metadata row-count
-                #     mismatch (a crash between the two atomic sidecar
-                #     replaces; subclasses ValueError, listed for clarity).
+                #     mismatch (#734; a crash between the two atomic sidecar
+                #     replaces). Subclasses ValueError, so listed explicitly
+                #     here only so tightening this tuple cannot silently drop
+                #     the corrupt-index self-heal.
                 #   ValueError — truncated/garbage .json (JSONDecodeError is a
                 #     ValueError subclass) and corrupt/bad-version .npy.
                 #   EOFError — a zero-byte .npy (the canonical interrupted-save

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -297,8 +297,10 @@ class SearchManager:
         attachment_extensions: Allowed non-.md extensions.  ``None`` uses
             the default set.
         link_manager: Optional :class:`LinkManager` for context queries.
-        rebuild_embeddings: Callback to rebuild all embeddings from scratch
-            (used when vector index compatibility fails).
+        rebuild_embeddings: Callback to rebuild all embeddings from scratch.
+            Invoked by ``_load_vectors`` on any unrecoverable sidecar fault —
+            a provider/model mismatch, a row-count mismatch, or a
+            truncated/zero-byte/incomplete sidecar.
     """
 
     def __init__(
@@ -387,8 +389,10 @@ class SearchManager:
             A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
 
         Raises:
-            RuntimeError: If embedding support is not configured
-                (``_embedding_provider`` or ``_embeddings_path`` is ``None``).
+            RuntimeError: If called without a prior ``_require_vectors()``
+                (a call-ordering fault; ``_embedding_provider`` or
+                ``_embeddings_path`` is ``None`` at entry). ``_require_vectors``
+                itself raises ``ValueError`` for the unconfigured case.
             ValueError: If a self-heal rebuild fails to produce a usable index.
         """
         if self._vectors is not None:

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -371,10 +371,25 @@ class SearchManager:
             )
 
     def _load_vectors(self) -> VectorIndex:
-        """Load or return the cached VectorIndex.
+        """Load or return the cached VectorIndex, self-healing corrupt sidecars.
+
+        Returns the cached index if already loaded. Otherwise deserialises it
+        from disk; on an incompatible, corrupt, or incomplete sidecar
+        (``VectorIndexCompatibilityError``, ``VectorIndexCorruptError``,
+        ``json.JSONDecodeError``/``ValueError``, ``EOFError``,
+        ``FileNotFoundError``) it routes to the injected ``rebuild_embeddings``
+        callback. A vault with no persisted index cold-builds an empty one.
+        Environmental errors (e.g. ``PermissionError``) are not caught and
+        propagate. Mirrors ``IndexManager._load_vectors`` over the shared
+        index (#734); the two are tracked for unification in #736.
 
         Returns:
             A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+
+        Raises:
+            RuntimeError: If embedding support is not configured
+                (``_embedding_provider`` or ``_embeddings_path`` is ``None``).
+            ValueError: If a self-heal rebuild fails to produce a usable index.
         """
         if self._vectors is not None:
             return self._vectors

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -382,6 +382,7 @@ class SearchManager:
         from markdown_vault_mcp.vector_index import (
             VectorIndex,
             VectorIndexCompatibilityError,
+            VectorIndexCorruptError,
         )
 
         if self._embeddings_path is None or self._embedding_provider is None:
@@ -402,6 +403,35 @@ class SearchManager:
                 if self._vectors is None:
                     raise ValueError(
                         "Failed to rebuild vector index after a compatibility error."
+                    ) from exc
+            except (
+                VectorIndexCorruptError,
+                json.JSONDecodeError,
+                ValueError,
+                EOFError,
+                FileNotFoundError,
+            ) as exc:
+                # SearchManager loads the same shared sidecar as IndexManager and
+                # must self-heal the identical corruption set (#734); a search
+                # query can be the first access after a crash-interrupted save.
+                #   VectorIndexCorruptError — embeddings/metadata row-count
+                #     mismatch (a RuntimeError; not covered by the ValueError
+                #     entry, so this must be listed explicitly).
+                #   ValueError — truncated/garbage .json/.npy (JSONDecodeError
+                #     is a ValueError subclass).
+                #   EOFError — a zero-byte .npy (numpy raises EOFError).
+                #   FileNotFoundError — a missing .json while the .npy exists.
+                # Broad OSError stays uncaught: PermissionError / disk-IO faults
+                # are environmental and must propagate, not trigger a rebuild.
+                logger.warning(
+                    "vector_index_corrupt_rebuilding path=%s error=%s",
+                    self._embeddings_path,
+                    exc,
+                )
+                self._rebuild_embeddings()
+                if self._vectors is None:
+                    raise ValueError(
+                        "Failed to rebuild vector index after a corrupt sidecar."
                     ) from exc
         else:
             self._vectors = VectorIndex(self._embedding_provider)

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -26,14 +26,15 @@ class VectorIndexCompatibilityError(RuntimeError):
     """Raised when a persisted vector index is incompatible with current provider."""
 
 
-class VectorIndexCorruptError(ValueError):
+class VectorIndexCorruptError(RuntimeError):
     """A persisted index is internally inconsistent and must be rebuilt.
 
     Raised by :meth:`VectorIndex.load` when the embeddings sidecar
     (``.npy``) and the metadata sidecar (``.json``) disagree on row count
     — the residue of a crash between the two atomic sidecar replaces
-    (#734). Subclasses :class:`ValueError`; the load-time self-heal routes
-    it to a ``force=True`` rebuild (see the caller's catch block).
+    (#734). A :class:`RuntimeError` (like its sibling
+    :class:`VectorIndexCompatibilityError`), signalling a storage-integrity
+    fault rather than a caller value error.
     """
 
 

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -32,9 +32,8 @@ class VectorIndexCorruptError(ValueError):
     Raised by :meth:`VectorIndex.load` when the embeddings sidecar
     (``.npy``) and the metadata sidecar (``.json``) disagree on row count
     — the residue of a crash between the two atomic sidecar replaces
-    (#734). Subclasses :class:`ValueError` so the load-time self-heal in
-    :meth:`markdown_vault_mcp.managers.index.IndexManager._load_vectors`
-    routes it to a ``force=True`` rebuild.
+    (#734). Subclasses :class:`ValueError`; the load-time self-heal routes
+    it to a ``force=True`` rebuild (see the caller's catch block).
     """
 
 
@@ -139,16 +138,18 @@ class VectorIndex:
                     f"current model={expected_model!r}."
                 )
 
-        index = cls(provider)
-        index._embeddings = embeddings
-        index._metadata = metadata
-
+        # Gate the parity invariant before constructing the index, so a
+        # mismatched pair never yields even a transient inconsistent object.
         if embeddings.shape[0] != len(metadata):
             raise VectorIndexCorruptError(
                 "VectorIndex.load: sidecar row count mismatch at "
                 f"{path}: {embeddings.shape[0]} embedding rows vs "
                 f"{len(metadata)} metadata rows (incomplete atomic save)."
             )
+
+        index = cls(provider)
+        index._embeddings = embeddings
+        index._metadata = metadata
 
         logger.info(
             "VectorIndex.load: loaded %d vectors from %s",

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -26,6 +26,18 @@ class VectorIndexCompatibilityError(RuntimeError):
     """Raised when a persisted vector index is incompatible with current provider."""
 
 
+class VectorIndexCorruptError(ValueError):
+    """A persisted index is internally inconsistent and must be rebuilt.
+
+    Raised by :meth:`VectorIndex.load` when the embeddings sidecar
+    (``.npy``) and the metadata sidecar (``.json``) disagree on row count
+    — the residue of a crash between the two atomic sidecar replaces
+    (#734). Subclasses :class:`ValueError` so the load-time self-heal in
+    :meth:`markdown_vault_mcp.managers.index.IndexManager._load_vectors`
+    routes it to a ``force=True`` rebuild.
+    """
+
+
 class VectorIndex:
     """Cosine-similarity vector index backed by numpy.
 
@@ -85,6 +97,8 @@ class VectorIndex:
         Raises:
             ImportError: If ``numpy`` is not installed.
             FileNotFoundError: If either sidecar file is missing.
+            VectorIndexCorruptError: If the embeddings and metadata sidecars
+                disagree on row count (an incomplete atomic save).
         """
         if not _NUMPY_AVAILABLE:
             raise ImportError(
@@ -128,6 +142,13 @@ class VectorIndex:
         index = cls(provider)
         index._embeddings = embeddings
         index._metadata = metadata
+
+        if embeddings.shape[0] != len(metadata):
+            raise VectorIndexCorruptError(
+                "VectorIndex.load: sidecar row count mismatch at "
+                f"{path}: {embeddings.shape[0]} embedding rows vs "
+                f"{len(metadata)} metadata rows (incomplete atomic save)."
+            )
 
         logger.info(
             "VectorIndex.load: loaded %d vectors from %s",

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -899,7 +899,7 @@ class TestLoadVectorsSelfHeal:
             index_vault, tmp_path
         )
         payload = _json.loads(json_path.read_text(encoding="utf-8"))
-        # Drop the last metadata row, leaving more embedding rows than rows.
+        # Drop the last metadata row, leaving more embedding rows than metadata.
         payload["rows"] = payload["rows"][:-1]
         json_path.write_text(_json.dumps(payload), encoding="utf-8")
 

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -882,6 +882,38 @@ class TestLoadVectorsSelfHeal:
             "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
         )
 
+    def test_row_count_mismatch_triggers_rebuild(
+        self, index_vault: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A valid pair whose .json drops rows (count mismatch) rebuilds.
+
+        This is the residue of a crash between the two atomic sidecar
+        replaces: both files parse, but embeddings rows != metadata rows.
+        VectorIndex.load raises VectorIndexCorruptError (a ValueError), which
+        the self-heal catch routes to a force rebuild.
+        """
+        import json as _json
+
+        mgr, holder, _npy, json_path = self._build_persisted_index(
+            index_vault, tmp_path
+        )
+        payload = _json.loads(json_path.read_text(encoding="utf-8"))
+        # Drop the last metadata row, leaving more embedding rows than rows.
+        payload["rows"] = payload["rows"][:-1]
+        json_path.write_text(_json.dumps(payload), encoding="utf-8")
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            result = mgr._load_vectors()
+
+        assert result is holder["vectors"]
+        assert result.count >= 4  # repopulated, internally consistent
+        assert result.count == result._embeddings.shape[0]  # parity restored
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )
+
     def test_permission_error_propagates_without_rebuild(
         self, index_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -889,8 +889,9 @@ class TestLoadVectorsSelfHeal:
 
         This is the residue of a crash between the two atomic sidecar
         replaces: both files parse, but embeddings rows != metadata rows.
-        VectorIndex.load raises VectorIndexCorruptError (a ValueError), which
-        the self-heal catch routes to a force rebuild.
+        VectorIndex.load raises VectorIndexCorruptError (a RuntimeError,
+        caught by its explicit entry in the self-heal tuple), which routes
+        to a force rebuild.
         """
         import json as _json
 

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -851,6 +851,22 @@ class TestSearchLoadVectorsSelfHeal:
         payload["rows"] = payload["rows"][:-1]
         json_path.write_text(json.dumps(payload), encoding="utf-8")
 
+    @staticmethod
+    def _arm_rebuild(mgr: SearchManager) -> None:
+        """Wire a rebuild callback that repopulates the shared slot, then drop cache.
+
+        Mirrors what the coordinator's writer-routed rebuild does — sets
+        ``mgr.vectors`` to a populated index — so the self-heal path returns a
+        usable index rather than tripping the rebuild-failure guard.
+        """
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        assert mgr._embedding_provider is not None
+        rebuilt = VectorIndex(mgr._embedding_provider)
+        rebuilt.add(["alpha"], [{"path": "a.md", "title": "A", "heading": None}])
+        mgr._rebuild_embeddings = lambda: setattr(mgr, "vectors", rebuilt)
+        mgr._vectors = None  # force a re-read from disk
+
     def test_corrupt_sidecar_triggers_rebuild(
         self,
         search_mgr_with_embeddings: SearchManager,
@@ -898,3 +914,75 @@ class TestSearchLoadVectorsSelfHeal:
             ValueError, match="Failed to rebuild vector index after a corrupt sidecar"
         ):
             mgr._load_vectors()
+
+    def test_zero_byte_npy_triggers_rebuild(
+        self,
+        search_mgr_with_embeddings: SearchManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A zero-byte .npy raises EOFError from numpy — must rebuild, not propagate.
+
+        EOFError is neither a ValueError nor an OSError, so the SearchManager
+        catch tuple must name it explicitly (parity with IndexManager).
+        """
+        import logging
+
+        mgr = search_mgr_with_embeddings
+        npy_path = mgr._embeddings_path.with_suffix(".npy")  # type: ignore[union-attr]
+        npy_path.write_bytes(b"")
+        self._arm_rebuild(mgr)
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.search"
+        ):
+            result = mgr._load_vectors()
+
+        assert result.count >= 1
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )
+
+    def test_garbage_npy_triggers_rebuild(
+        self,
+        search_mgr_with_embeddings: SearchManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A garbage (non-numpy) .npy raises ValueError — must rebuild."""
+        import logging
+
+        mgr = search_mgr_with_embeddings
+        npy_path = mgr._embeddings_path.with_suffix(".npy")  # type: ignore[union-attr]
+        npy_path.write_bytes(b"this is not a numpy array at all")
+        self._arm_rebuild(mgr)
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.search"
+        ):
+            result = mgr._load_vectors()
+
+        assert result.count >= 1
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )
+
+    def test_missing_json_with_present_npy_triggers_rebuild(
+        self,
+        search_mgr_with_embeddings: SearchManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A missing .json while the .npy exists (incomplete pair) rebuilds."""
+        import logging
+
+        mgr = search_mgr_with_embeddings
+        mgr._embeddings_path.with_suffix(".json").unlink()  # type: ignore[union-attr]
+        self._arm_rebuild(mgr)
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.search"
+        ):
+            result = mgr._load_vectors()
+
+        assert result.count >= 1
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -828,3 +828,73 @@ def test_semantic_search_does_not_have_flush_embeddings_attr(tmp_path):
         col.reader.search(query="hello", mode="semantic")
     finally:
         col.close()
+
+
+class TestSearchLoadVectorsSelfHeal:
+    """SearchManager._load_vectors must self-heal a corrupt sidecar.
+
+    SearchManager owns the shared VectorIndex and has its own ``_load_vectors``
+    that loads the sidecar from disk; if a search query is the first access
+    after a crash-interrupted save, it — not IndexManager — sees the corrupt
+    pair. ``VectorIndex.load`` raises ``VectorIndexCorruptError`` (a
+    ``RuntimeError``) on a row-count mismatch, so this path must catch it and
+    route to the injected rebuild rather than crash the search call (#734).
+    """
+
+    @staticmethod
+    def _corrupt_json_drop_row(mgr: SearchManager) -> None:
+        """Drop the last metadata row from the on-disk .json (count mismatch)."""
+        import json
+
+        json_path = mgr._embeddings_path.with_suffix(".json")  # type: ignore[union-attr]
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+        payload["rows"] = payload["rows"][:-1]
+        json_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_corrupt_sidecar_triggers_rebuild(
+        self,
+        search_mgr_with_embeddings: SearchManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A count-mismatched sidecar routes to the rebuild callback, not a crash."""
+        import logging
+
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        mgr = search_mgr_with_embeddings
+        self._corrupt_json_drop_row(mgr)
+        mgr._vectors = None  # force a re-read from disk
+
+        # Mirror what the coordinator's rebuild does: repopulate the shared slot.
+        assert mgr._embedding_provider is not None
+        rebuilt = VectorIndex(mgr._embedding_provider)
+        rebuilt.add(["alpha"], [{"path": "a.md", "title": "A", "heading": None}])
+
+        def rebuild() -> None:
+            mgr.vectors = rebuilt
+
+        mgr._rebuild_embeddings = rebuild
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.search"
+        ):
+            result = mgr._load_vectors()
+
+        assert result is rebuilt
+        assert any(
+            "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
+        )
+
+    def test_corrupt_sidecar_rebuild_failure_raises(
+        self, search_mgr_with_embeddings: SearchManager
+    ) -> None:
+        """If the rebuild leaves no index, a corrupt sidecar surfaces a ValueError."""
+        mgr = search_mgr_with_embeddings
+        self._corrupt_json_drop_row(mgr)
+        mgr._vectors = None
+        mgr._rebuild_embeddings = lambda: None  # no-op leaves _vectors None
+
+        with pytest.raises(
+            ValueError, match="Failed to rebuild vector index after a corrupt sidecar"
+        ):
+            mgr._load_vectors()

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -986,3 +986,31 @@ class TestSearchLoadVectorsSelfHeal:
         assert any(
             "vector_index_corrupt_rebuilding" in r.getMessage() for r in caplog.records
         )
+
+    def test_permission_error_propagates_without_rebuild(
+        self,
+        search_mgr_with_embeddings: SearchManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An environmental OSError on load must propagate, not trigger a rebuild.
+
+        PermissionError is an OSError but not one of the corruption types, so it
+        is deliberately excluded from the catch tuple. Pins that contract on the
+        SearchManager path too (parity with IndexManager), so a future widening
+        to OSError cannot silently slip through here.
+        """
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        mgr = search_mgr_with_embeddings
+        mgr._vectors = None
+
+        def boom(*_args: object, **_kwargs: object) -> VectorIndex:
+            raise PermissionError("read denied")
+
+        monkeypatch.setattr(VectorIndex, "load", boom)
+        rebuild_calls: list[bool] = []
+        mgr._rebuild_embeddings = lambda: rebuild_calls.append(True)
+
+        with pytest.raises(PermissionError, match="read denied"):
+            mgr._load_vectors()
+        assert rebuild_calls == []  # no rebuild attempted

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -540,6 +540,93 @@ class TestVectorIndexPersistence:
         loaded = VectorIndex.load(base, mock_provider)
         assert loaded.count == 1
 
+    def test_load_raises_on_row_count_mismatch_more_embeddings(
+        self,
+        mock_provider: MockEmbeddingProvider,
+        tmp_path: Path,
+    ) -> None:
+        """More .npy rows than .json rows must raise VectorIndexCorruptError.
+
+        This is the IndexError-at-search shape: argsort over the embeddings
+        rows yields an index past the end of the shorter metadata list.
+        """
+        from markdown_vault_mcp.vector_index import VectorIndexCorruptError
+
+        index = VectorIndex(mock_provider)
+        index.add(
+            ["north star", "south star"],
+            [
+                _make_meta("stars.md", heading="North"),
+                _make_meta("stars.md", heading="South"),
+            ],
+        )
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        # Drop one metadata row, leaving 2 embedding rows vs 1 metadata row.
+        json_path = tmp_path / "embeddings.json"
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+        payload["rows"] = payload["rows"][:1]
+        json_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(VectorIndexCorruptError, match="row count"):
+            VectorIndex.load(base, mock_provider)
+
+    def test_load_raises_on_row_count_mismatch_more_metadata(
+        self,
+        mock_provider: MockEmbeddingProvider,
+        tmp_path: Path,
+    ) -> None:
+        """Fewer .npy rows than .json rows must also raise — invariant is equality."""
+        from markdown_vault_mcp.vector_index import VectorIndexCorruptError
+
+        index = VectorIndex(mock_provider)
+        index.add(["north star"], [_make_meta("stars.md", heading="North")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        # Duplicate the single metadata row → 2 metadata rows vs 1 embedding row.
+        json_path = tmp_path / "embeddings.json"
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+        payload["rows"] = payload["rows"] * 2
+        json_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(VectorIndexCorruptError, match="row count"):
+            VectorIndex.load(base, mock_provider)
+
+    def test_load_succeeds_on_matching_row_counts(
+        self,
+        mock_provider: MockEmbeddingProvider,
+        tmp_path: Path,
+    ) -> None:
+        """An equal, non-zero embeddings/metadata pair loads cleanly (no false positive)."""
+        index = VectorIndex(mock_provider)
+        index.add(
+            ["north star", "south star"],
+            [
+                _make_meta("stars.md", heading="North"),
+                _make_meta("stars.md", heading="South"),
+            ],
+        )
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        loaded = VectorIndex.load(base, mock_provider)
+        assert loaded.count == 2
+
+    def test_load_succeeds_on_empty_index(
+        self,
+        mock_provider: MockEmbeddingProvider,
+        tmp_path: Path,
+    ) -> None:
+        """An empty (0,0) index loads cleanly — shape[0] == 0 == len([])."""
+        index = VectorIndex(mock_provider)
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        loaded = VectorIndex.load(base, mock_provider)
+        assert loaded.count == 0
+
     def test_failed_save_leaves_no_temp_files(
         self,
         mock_provider: MockEmbeddingProvider,

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -594,6 +594,42 @@ class TestVectorIndexPersistence:
         with pytest.raises(VectorIndexCorruptError, match="row count"):
             VectorIndex.load(base, mock_provider)
 
+    def test_load_raises_on_row_count_mismatch_legacy_list_payload(
+        self,
+        mock_provider: MockEmbeddingProvider,
+        tmp_path: Path,
+    ) -> None:
+        """A legacy bare-list .json with a row count != .npy must also raise.
+
+        The parity check sits outside both the legacy (``isinstance(payload,
+        list)``) and modern (dict) metadata-decode branches. This pins that
+        placement: a future refactor that moved the check inside the modern
+        ``else`` branch would silently stop guarding legacy sidecars, and
+        this test would catch that regression.
+        """
+        from markdown_vault_mcp.vector_index import VectorIndexCorruptError
+
+        index = VectorIndex(mock_provider)
+        index.add(
+            ["north star", "south star"],
+            [
+                _make_meta("stars.md", heading="North"),
+                _make_meta("stars.md", heading="South"),
+            ],
+        )
+        base = tmp_path / "embeddings"
+        index.save(base)  # 2 embedding rows
+
+        # Overwrite with a legacy bare-list payload of a single row → 2 vs 1.
+        json_path = tmp_path / "embeddings.json"
+        json_path.write_text(
+            json.dumps([_make_meta("stars.md", heading="North")]),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(VectorIndexCorruptError, match="row count"):
+            VectorIndex.load(base, mock_provider)
+
     def test_load_succeeds_on_matching_row_counts(
         self,
         mock_provider: MockEmbeddingProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "3.0.0"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary
Follow-up to #732. The two `VectorIndex` sidecars (`embeddings.npy` / `embeddings.json`) are made atomic independently, so a crash between the two `os.replace()`s can leave a row-count-mismatched but individually-valid pair. Before this PR it loaded silently and then `IndexError`-ed at search time.

`VectorIndex.load` now enforces `embeddings.shape[0] == len(metadata)` **before constructing the index** and raises a new `VectorIndexCorruptError(RuntimeError)` on mismatch. Both consumers of `VectorIndex.load` self-heal it:

- `IndexManager._load_vectors` — already had #732's corrupt-sidecar self-heal; the new error is added to its catch tuple.
- `SearchManager._load_vectors` — the semantic-search path, which owns the shared `VectorIndex`. It had **never** received #732's self-heal (only `VectorIndexCompatibilityError`), so a corrupt sidecar reached first by a search query would crash. It now mirrors the full self-heal, so #734's goal — semantic search recovers from a corrupt sidecar — holds on both load paths.

`VectorIndexCorruptError` is a `RuntimeError` (matching its sibling `VectorIndexCompatibilityError`, signalling a storage-integrity fault, not a caller value error); its explicit entry in each catch tuple is therefore load-bearing, not redundant.

## Tests
- `VectorIndex.load`: raises on more-embeddings, more-metadata, and legacy bare-list mismatch; loads cleanly on equal and empty.
- `IndexManager` + `SearchManager` self-heal: corrupt-json / zero-byte-npy / garbage-npy / missing-json each rebuild + log `vector_index_corrupt_rebuilding`; `PermissionError` propagates without a rebuild; a failed rebuild surfaces a `ValueError`.

## Review
Five rounds of a local multi-lens pre-flight review converged this. The notable catch: `SearchManager` was a second, divergent consumer of `VectorIndex.load` that the original plan missed.

## Follow-ups filed
- #735 — pre-existing `_load_vectors` error-path debt (the `is None` rebuild-success guard can't detect an empty rebuilt index; the tail-guard message misattributes corrupt failures; `exc_info`/unlogged-rebuild observability).
- #736 — unify the two near-duplicate `_load_vectors` implementations (DRY).

Closes #734

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._