### PR TITLE
refactor: unify the two _load_vectors implementations (#736)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ src/markdown_vault_mcp/
     index.py           -- IndexManager: build_index, reindex, embeddings, flush
     document.py        -- DocumentManager: CRUD, attachments, path validation, backlinks
     git_query.py       -- GitQueryManager: git history/diff reads (#610)
+    _vector_loader.py  -- shared load-or-self-heal routine for the vector sidecar (#736)
   indexing/
     index_writer.py    -- IndexWriter: single-owner FIFO writer thread + job dataclasses/runners
     readiness.py       -- ReadinessState: build-readiness state machine (#576)

--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -1,0 +1,124 @@
+"""Shared load-or-self-heal routine for the vector sidecar (#736).
+
+Both :class:`~markdown_vault_mcp.managers.index.IndexManager` and
+:class:`~markdown_vault_mcp.managers.search.SearchManager` load the same shared
+:class:`~markdown_vault_mcp.vector_index.VectorIndex` from disk and self-heal a
+corrupt or incompatible sidecar by rebuilding. This module holds that one
+routine so the logic lives in a single place.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+    from collections.abc import Callable
+
+    from markdown_vault_mcp.providers import EmbeddingProvider
+    from markdown_vault_mcp.vector_index import VectorIndex
+
+
+def load_or_self_heal(
+    *,
+    embeddings_path: Path,
+    embedding_provider: EmbeddingProvider,
+    get_vectors: Callable[[], VectorIndex | None],
+    set_vectors: Callable[[VectorIndex], None],
+    rebuild: Callable[[], None],
+    logger: logging.Logger,
+) -> VectorIndex:
+    """Load the vector sidecar into the caller's slot, self-healing corruption.
+
+    Returns the cached index if ``get_vectors()`` is already populated.
+    Otherwise deserialises it from ``{embeddings_path}.npy``/``.json``; on an
+    incompatible, corrupt, or incomplete sidecar
+    (``VectorIndexCompatibilityError``, ``VectorIndexCorruptError``,
+    ``json.JSONDecodeError``/``ValueError``, ``EOFError``,
+    ``FileNotFoundError``) it calls ``rebuild`` and re-reads the slot. A vault
+    with no persisted index cold-builds an empty one. Environmental errors
+    (e.g. ``PermissionError``) are not caught and propagate.
+
+    Args:
+        embeddings_path: Base path for the sidecar files (``.npy``/``.json``
+            are appended).
+        embedding_provider: Provider attached to a freshly-built index.
+        get_vectors: Reads the caller's cached index slot (``None`` if empty).
+        set_vectors: Writes a loaded/empty index into the caller's slot.
+        rebuild: Zero-arg callback that rebuilds embeddings from scratch and
+            repopulates the slot.
+        logger: The caller's logger, so records are attributed to the calling
+            manager's module.
+
+    Returns:
+        A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+
+    Raises:
+        ValueError: If a self-heal rebuild fails to produce a usable index.
+    """
+    cached = get_vectors()
+    if cached is not None:
+        return cached
+
+    from markdown_vault_mcp.vector_index import (
+        VectorIndex,
+        VectorIndexCompatibilityError,
+        VectorIndexCorruptError,
+    )
+
+    npy_path = Path(str(embeddings_path) + ".npy")
+    if npy_path.exists():
+        try:
+            set_vectors(VectorIndex.load(embeddings_path, embedding_provider))
+            logger.info("Loaded vector index from %s", embeddings_path)
+        except VectorIndexCompatibilityError as exc:
+            logger.warning("%s Rebuilding embeddings.", exc)
+            rebuild()
+            if get_vectors() is None:
+                raise ValueError(
+                    "Failed to rebuild vector index after a compatibility error."
+                ) from exc
+        except (
+            VectorIndexCorruptError,
+            json.JSONDecodeError,
+            ValueError,
+            EOFError,
+            FileNotFoundError,
+        ) as exc:
+            # A corrupt/incomplete sidecar wedges every boot until a rebuild
+            # (#720/#734): an interrupted save can leave a truncated, zero-byte,
+            # or count-mismatched file. Self-heal by routing to the same rebuild
+            # path as a compatibility mismatch.
+            #   VectorIndexCorruptError — embeddings/metadata row-count mismatch
+            #     (#734). A RuntimeError, so this entry is load-bearing — it is
+            #     NOT covered by the ValueError arm below.
+            #   ValueError — truncated/garbage .json (JSONDecodeError is a
+            #     ValueError subclass) and corrupt/bad-version .npy.
+            #   EOFError — a zero-byte .npy (numpy raises EOFError, not
+            #     ValueError/OSError).
+            #   FileNotFoundError — a missing .json while the .npy exists (an
+            #     incomplete pair); the .npy-exists guard means it can only be
+            #     the gone .json sidecar.
+            # Deliberately NOT broad OSError: PermissionError / disk-IO errors
+            # are environmental — a destructive rebuild would be futile and mask
+            # the real problem, so they must propagate.
+            logger.warning(
+                "vector_index_corrupt_rebuilding path=%s error=%s",
+                embeddings_path,
+                exc,
+            )
+            rebuild()
+            if get_vectors() is None:
+                raise ValueError(
+                    "Failed to rebuild vector index after a corrupt sidecar."
+                ) from exc
+    else:
+        set_vectors(VectorIndex(embedding_provider))
+        logger.info("No vector index on disk; created empty VectorIndex")
+
+    result = get_vectors()
+    if result is None:
+        raise ValueError("Failed to rebuild vector index after a compatibility error.")
+    return result

--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -27,7 +27,7 @@ def load_or_self_heal(
     embedding_provider: EmbeddingProvider,
     get_vectors: Callable[[], VectorIndex | None],
     set_vectors: Callable[[VectorIndex], None],
-    rebuild: Callable[[], None],
+    rebuild: Callable[[], object],
     logger: logging.Logger,
 ) -> VectorIndex:
     """Load the vector sidecar into the caller's slot, self-healing corruption.

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -147,6 +147,9 @@ class IndexManager:
                 (``_embedding_provider`` or ``_embeddings_path`` is ``None``).
             ValueError: If a self-heal rebuild fails to produce a usable index.
         """
+        vectors = self._get_vectors()
+        if vectors is not None:
+            return vectors
         if self._embeddings_path is None or self._embedding_provider is None:
             raise RuntimeError(
                 "_require_vectors() must be called before _load_vectors()"

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -20,6 +20,7 @@ import yaml
 
 from markdown_vault_mcp.fts_index import _derive_folder, should_optimize
 from markdown_vault_mcp.hashing import compute_file_hash
+from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
 from markdown_vault_mcp.scanner import parse_note, scan_directory
 from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult
 from markdown_vault_mcp.utils import is_path_excluded
@@ -134,98 +135,30 @@ class IndexManager:
     def _load_vectors(self) -> VectorIndex:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
 
-        Returns the cached index if already loaded. Otherwise deserialises it
-        from disk; on an incompatible, corrupt, or incomplete sidecar
-        (``VectorIndexCompatibilityError``, ``VectorIndexCorruptError``,
-        ``json.JSONDecodeError``/``ValueError``, ``EOFError``,
-        ``FileNotFoundError``) it routes to a ``force=True`` rebuild. A vault
-        with no persisted index cold-builds an empty one. Environmental errors
-        (e.g. ``PermissionError``) are not caught and propagate.
+        Delegates to
+        :func:`markdown_vault_mcp.managers._vector_loader.load_or_self_heal`;
+        see there for the full self-heal contract.
 
         Returns:
             A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
 
         Raises:
             RuntimeError: If called without a prior ``_require_vectors()``
-                (a call-ordering fault; ``_embedding_provider`` or
-                ``_embeddings_path`` is ``None`` at entry). ``_require_vectors``
-                itself raises ``ValueError`` for the unconfigured case.
+                (``_embedding_provider`` or ``_embeddings_path`` is ``None``).
             ValueError: If a self-heal rebuild fails to produce a usable index.
         """
-        vectors = self._get_vectors()
-        if vectors is not None:
-            return vectors
-
-        from markdown_vault_mcp.vector_index import (
-            VectorIndex,
-            VectorIndexCompatibilityError,
-            VectorIndexCorruptError,
-        )
-
         if self._embeddings_path is None or self._embedding_provider is None:
             raise RuntimeError(
                 "_require_vectors() must be called before _load_vectors()"
             )
-
-        npy_path = Path(str(self._embeddings_path) + ".npy")
-        if npy_path.exists():
-            try:
-                vi = VectorIndex.load(self._embeddings_path, self._embedding_provider)
-                self._set_vectors(vi)
-                logger.info("Loaded vector index from %s", self._embeddings_path)
-            except VectorIndexCompatibilityError as exc:
-                logger.warning("%s Rebuilding embeddings.", exc)
-                self.build_embeddings(force=True)
-                if self._get_vectors() is None:
-                    raise ValueError(
-                        "Failed to rebuild vector index after a compatibility error."
-                    ) from exc
-            except (
-                VectorIndexCorruptError,
-                json.JSONDecodeError,
-                ValueError,
-                EOFError,
-                FileNotFoundError,
-            ) as exc:
-                # A corrupt/incomplete sidecar wedges every boot until a manual
-                # rebuild (#720 follow-up): an interrupted save can leave a
-                # truncated or zero-byte file. Self-heal by routing to the same
-                # force-rebuild path as a compatibility mismatch.
-                #   VectorIndexCorruptError — embeddings/metadata row-count
-                #     mismatch (#734; a crash between the two atomic sidecar
-                #     replaces). A RuntimeError, so this entry is load-bearing
-                #     — it is NOT covered by the ValueError arm below.
-                #   ValueError — truncated/garbage .json (JSONDecodeError is a
-                #     ValueError subclass) and corrupt/bad-version .npy.
-                #   EOFError — a zero-byte .npy (the canonical interrupted-save
-                #     residue; numpy raises EOFError, not ValueError/OSError).
-                #   FileNotFoundError — a missing .json while the .npy exists
-                #     (an incomplete pair); the .npy-exists guard above means a
-                #     FileNotFoundError here can only be the gone .json sidecar.
-                # Deliberately NOT broad OSError: PermissionError / disk-IO
-                # errors are environmental — a destructive rebuild would be
-                # futile and mask the real problem, so they must propagate.
-                logger.warning(
-                    "vector_index_corrupt_rebuilding path=%s error=%s",
-                    self._embeddings_path,
-                    exc,
-                )
-                self.build_embeddings(force=True)
-                if self._get_vectors() is None:
-                    raise ValueError(
-                        "Failed to rebuild vector index after a corrupt sidecar."
-                    ) from exc
-        else:
-            vi = VectorIndex(self._embedding_provider)
-            self._set_vectors(vi)
-            logger.info("No vector index on disk; created empty VectorIndex")
-
-        result = self._get_vectors()
-        if result is None:
-            raise ValueError(
-                "Failed to rebuild vector index after a compatibility error."
-            )
-        return result
+        return load_or_self_heal(
+            embeddings_path=self._embeddings_path,
+            embedding_provider=self._embedding_provider,
+            get_vectors=self._get_vectors,
+            set_vectors=self._set_vectors,
+            rebuild=lambda: self.build_embeddings(force=True),  # type: ignore[arg-type]
+            logger=logger,
+        )
 
     # ------------------------------------------------------------------
     # Index building

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -156,7 +156,7 @@ class IndexManager:
             embedding_provider=self._embedding_provider,
             get_vectors=self._get_vectors,
             set_vectors=self._set_vectors,
-            rebuild=lambda: self.build_embeddings(force=True),  # type: ignore[arg-type]
+            rebuild=lambda: self.build_embeddings(force=True),
             logger=logger,
         )
 

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -389,6 +389,8 @@ class SearchManager:
                 (``_embedding_provider`` or ``_embeddings_path`` is ``None``).
             ValueError: If a self-heal rebuild fails to produce a usable index.
         """
+        if self._vectors is not None:
+            return self._vectors
         if self._embeddings_path is None or self._embedding_provider is None:
             raise RuntimeError(
                 "_require_vectors() must be called before _load_vectors()"

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -21,6 +21,7 @@ from dataclasses import replace as _dc_replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 
+from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
 from markdown_vault_mcp.types import (
     AttachmentInfo,
     BacklinkInfo,
@@ -375,88 +376,31 @@ class SearchManager:
     def _load_vectors(self) -> VectorIndex:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
 
-        Returns the cached index if already loaded. Otherwise deserialises it
-        from disk; on an incompatible, corrupt, or incomplete sidecar
-        (``VectorIndexCompatibilityError``, ``VectorIndexCorruptError``,
-        ``json.JSONDecodeError``/``ValueError``, ``EOFError``,
-        ``FileNotFoundError``) it routes to the injected ``rebuild_embeddings``
-        callback. A vault with no persisted index cold-builds an empty one.
-        Environmental errors (e.g. ``PermissionError``) are not caught and
-        propagate. Mirrors ``IndexManager._load_vectors`` over the shared
-        index (#734); the two are tracked for unification in #736.
+        Delegates to
+        :func:`markdown_vault_mcp.managers._vector_loader.load_or_self_heal`
+        over this manager's shared index slot; see there for the full
+        self-heal contract.
 
         Returns:
             A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
 
         Raises:
             RuntimeError: If called without a prior ``_require_vectors()``
-                (a call-ordering fault; ``_embedding_provider`` or
-                ``_embeddings_path`` is ``None`` at entry). ``_require_vectors``
-                itself raises ``ValueError`` for the unconfigured case.
+                (``_embedding_provider`` or ``_embeddings_path`` is ``None``).
             ValueError: If a self-heal rebuild fails to produce a usable index.
         """
-        if self._vectors is not None:
-            return self._vectors
-
-        from markdown_vault_mcp.vector_index import (
-            VectorIndex,
-            VectorIndexCompatibilityError,
-            VectorIndexCorruptError,
-        )
-
         if self._embeddings_path is None or self._embedding_provider is None:
             raise RuntimeError(
                 "_require_vectors() must be called before _load_vectors()"
             )
-
-        npy_path = Path(str(self._embeddings_path) + ".npy")
-        if npy_path.exists():
-            try:
-                self._vectors = VectorIndex.load(
-                    self._embeddings_path, self._embedding_provider
-                )
-                logger.info("Loaded vector index from %s", self._embeddings_path)
-            except VectorIndexCompatibilityError as exc:
-                logger.warning("%s Rebuilding embeddings.", exc)
-                self._rebuild_embeddings()
-                if self._vectors is None:
-                    raise ValueError(
-                        "Failed to rebuild vector index after a compatibility error."
-                    ) from exc
-            except (
-                VectorIndexCorruptError,
-                json.JSONDecodeError,
-                ValueError,
-                EOFError,
-                FileNotFoundError,
-            ) as exc:
-                # SearchManager loads the same shared sidecar as IndexManager and
-                # must self-heal the identical corruption set (#734); a search
-                # query can be the first access after a crash-interrupted save.
-                #   VectorIndexCorruptError — embeddings/metadata row-count
-                #     mismatch (a RuntimeError; not covered by the ValueError
-                #     entry, so this must be listed explicitly).
-                #   ValueError — truncated/garbage .json/.npy (JSONDecodeError
-                #     is a ValueError subclass).
-                #   EOFError — a zero-byte .npy (numpy raises EOFError).
-                #   FileNotFoundError — a missing .json while the .npy exists.
-                # Broad OSError stays uncaught: PermissionError / disk-IO faults
-                # are environmental and must propagate, not trigger a rebuild.
-                logger.warning(
-                    "vector_index_corrupt_rebuilding path=%s error=%s",
-                    self._embeddings_path,
-                    exc,
-                )
-                self._rebuild_embeddings()
-                if self._vectors is None:
-                    raise ValueError(
-                        "Failed to rebuild vector index after a corrupt sidecar."
-                    ) from exc
-        else:
-            self._vectors = VectorIndex(self._embedding_provider)
-            logger.info("No vector index on disk; created empty VectorIndex")
-
-        return self._vectors
+        return load_or_self_heal(
+            embeddings_path=self._embeddings_path,
+            embedding_provider=self._embedding_provider,
+            get_vectors=lambda: self._vectors,
+            set_vectors=lambda v: setattr(self, "_vectors", v),
+            rebuild=self._rebuild_embeddings,
+            logger=logger,
+        )
 
     def _get_frontmatter(self, path: str) -> dict[str, Any]:
         """Return the frontmatter dict for a document from the FTS index.

--- a/tests/test_vector_loader.py
+++ b/tests/test_vector_loader.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
+from markdown_vault_mcp.vector_index import (
+    VectorIndex,
+    VectorIndexCompatibilityError,
+    VectorIndexCorruptError,
+)
+from tests.conftest import MockEmbeddingProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+_LOGGER_NAME = "test.vector_loader"
+_LOG = logging.getLogger(_LOGGER_NAME)
+
+
+def _slot() -> tuple[
+    dict, Callable[[], VectorIndex | None], Callable[[VectorIndex], None]
+]:
+    """A dict-backed cache slot plus get/set accessors over it."""
+    box: dict = {"v": None}
+    return box, (lambda: box["v"]), (lambda v: box.__setitem__("v", v))
+
+
+def _populated(provider: MockEmbeddingProvider) -> VectorIndex:
+    vi = VectorIndex(provider)
+    vi.add(["x"], [{"path": "x.md", "title": "X", "heading": None}])
+    return vi
+
+
+def test_cache_hit_returns_cached_without_rebuild(tmp_path: Path) -> None:
+    provider = MockEmbeddingProvider()
+    cached = _populated(provider)
+    box, get, set_ = _slot()
+    box["v"] = cached
+    calls: list[int] = []
+    result = load_or_self_heal(
+        embeddings_path=tmp_path / "embeddings",
+        embedding_provider=provider,
+        get_vectors=get,
+        set_vectors=set_,
+        rebuild=lambda: calls.append(1),
+        logger=_LOG,
+    )
+    assert result is cached
+    assert calls == []
+
+
+def test_cold_build_when_no_sidecar(tmp_path: Path) -> None:
+    provider = MockEmbeddingProvider()
+    box, get, set_ = _slot()
+    calls: list[int] = []
+    result = load_or_self_heal(
+        embeddings_path=tmp_path / "embeddings",
+        embedding_provider=provider,
+        get_vectors=get,
+        set_vectors=set_,
+        rebuild=lambda: calls.append(1),
+        logger=_LOG,
+    )
+    assert isinstance(result, VectorIndex)
+    assert result.count == 0
+    assert calls == []
+    assert box["v"] is result
+
+
+def test_clean_load_returns_loaded_index(tmp_path: Path) -> None:
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    _populated(provider).save(base)
+    _box, get, set_ = _slot()
+    calls: list[int] = []
+    result = load_or_self_heal(
+        embeddings_path=base,
+        embedding_provider=provider,
+        get_vectors=get,
+        set_vectors=set_,
+        rebuild=lambda: calls.append(1),
+        logger=_LOG,
+    )
+    assert result.count == 1
+    assert calls == []
+
+
+def test_compatibility_error_triggers_rebuild(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    (tmp_path / "embeddings.npy").touch()  # satisfy the npy-exists gate
+
+    def boom(*_a: object, **_k: object) -> VectorIndex:
+        raise VectorIndexCompatibilityError("mismatch")
+
+    monkeypatch.setattr(VectorIndex, "load", boom)
+    box, get, set_ = _slot()
+    rebuilt = _populated(provider)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        result = load_or_self_heal(
+            embeddings_path=base,
+            embedding_provider=provider,
+            get_vectors=get,
+            set_vectors=set_,
+            rebuild=lambda: box.__setitem__("v", rebuilt),
+            logger=_LOG,
+        )
+
+    assert result is rebuilt
+    assert any("Rebuilding embeddings" in r.getMessage() for r in caplog.records)
+
+
+def test_corrupt_error_triggers_rebuild(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    (tmp_path / "embeddings.npy").touch()
+
+    def boom(*_a: object, **_k: object) -> VectorIndex:
+        raise VectorIndexCorruptError("row count mismatch")
+
+    monkeypatch.setattr(VectorIndex, "load", boom)
+    box, get, set_ = _slot()
+    rebuilt = _populated(provider)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        result = load_or_self_heal(
+            embeddings_path=base,
+            embedding_provider=provider,
+            get_vectors=get,
+            set_vectors=set_,
+            rebuild=lambda: box.__setitem__("v", rebuilt),
+            logger=_LOG,
+        )
+
+    assert result is rebuilt
+    # Pins both the event name AND that the PASSED logger emitted it (#736).
+    assert any(
+        r.name == _LOGGER_NAME and "vector_index_corrupt_rebuilding" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_rebuild_failure_raises_value_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    (tmp_path / "embeddings.npy").touch()
+
+    def boom(*_a: object, **_k: object) -> VectorIndex:
+        raise VectorIndexCorruptError("row count mismatch")
+
+    monkeypatch.setattr(VectorIndex, "load", boom)
+    _box, get, set_ = _slot()
+
+    with pytest.raises(ValueError, match="corrupt sidecar"):
+        load_or_self_heal(
+            embeddings_path=base,
+            embedding_provider=provider,
+            get_vectors=get,
+            set_vectors=set_,
+            rebuild=lambda: None,  # no-op: slot stays None
+            logger=_LOG,
+        )
+
+
+def test_permission_error_propagates_without_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    (tmp_path / "embeddings.npy").touch()
+
+    def boom(*_a: object, **_k: object) -> VectorIndex:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(VectorIndex, "load", boom)
+    _box, get, set_ = _slot()
+    calls: list[int] = []
+
+    with pytest.raises(PermissionError, match="denied"):
+        load_or_self_heal(
+            embeddings_path=base,
+            embedding_provider=provider,
+            get_vectors=get,
+            set_vectors=set_,
+            rebuild=lambda: calls.append(1),
+            logger=_LOG,
+        )
+    assert calls == []

--- a/tests/test_vector_loader.py
+++ b/tests/test_vector_loader.py
@@ -177,6 +177,30 @@ def test_rebuild_failure_raises_value_error(
         )
 
 
+def test_compatibility_rebuild_failure_raises_value_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    (tmp_path / "embeddings.npy").touch()
+
+    def boom(*_a: object, **_k: object) -> VectorIndex:
+        raise VectorIndexCompatibilityError("mismatch")
+
+    monkeypatch.setattr(VectorIndex, "load", boom)
+    _box, get, set_ = _slot()
+
+    with pytest.raises(ValueError, match="compatibility error"):
+        load_or_self_heal(
+            embeddings_path=base,
+            embedding_provider=provider,
+            get_vectors=get,
+            set_vectors=set_,
+            rebuild=lambda: None,  # no-op: slot stays None
+            logger=_LOG,
+        )
+
+
 def test_permission_error_propagates_without_rebuild(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_vector_loader.py
+++ b/tests/test_vector_loader.py
@@ -75,7 +75,7 @@ def test_clean_load_returns_loaded_index(tmp_path: Path) -> None:
     provider = MockEmbeddingProvider()
     base = tmp_path / "embeddings"
     _populated(provider).save(base)
-    _box, get, set_ = _slot()
+    box, get, set_ = _slot()
     calls: list[int] = []
     result = load_or_self_heal(
         embeddings_path=base,
@@ -87,6 +87,7 @@ def test_clean_load_returns_loaded_index(tmp_path: Path) -> None:
     )
     assert result.count == 1
     assert calls == []
+    assert box["v"] is result  # set_vectors persisted the loaded index
 
 
 def test_compatibility_error_triggers_rebuild(
@@ -116,7 +117,10 @@ def test_compatibility_error_triggers_rebuild(
         )
 
     assert result is rebuilt
-    assert any("Rebuilding embeddings" in r.getMessage() for r in caplog.records)
+    assert any(
+        r.name == _LOGGER_NAME and "Rebuilding embeddings" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 def test_corrupt_error_triggers_rebuild(


### PR DESCRIPTION
## Summary
Follow-up to #734. `IndexManager._load_vectors` and `SearchManager._load_vectors` were near-identical load-or-self-heal routines over the same shared `VectorIndex` — duplication that already caused a live gap (#732 hardened only one; #734 patched the other by hand). This extracts the routine into one `load_or_self_heal` in the new `managers/_vector_loader.py`, parameterized by each manager's `get_vectors`/`set_vectors` accessors, `rebuild` callback, and `logger`. Each manager keeps only its cache early-return + `RuntimeError` precondition check and delegates.

Pure behavior-preserving refactor:
- The existing `TestLoadVectorsSelfHeal` / `TestSearchLoadVectorsSelfHeal` classes pass **unchanged** (the integration regression net), and a new `tests/test_vector_loader.py` covers the helper directly (cache-hit, cold-build, clean-load, compat/corrupt rebuild, both rebuild-failure arms, `PermissionError` propagation, and that the passed-in `logger` is the one that emits).
- The passed-in `logger` keeps log attribution identical (records stay under `managers.index` / `managers.search`).
- After unifying, `vector_index_corrupt_rebuilding` appears in exactly one place.

## Pre-flight review notes (deliberately out of scope)
A local multi-lens review surfaced several items that are **pre-existing and intentionally not touched here** to keep this a pure refactor:
- The tail-guard `ValueError` message ("...after a compatibility error.") and missing `exc_info` / unlogged rebuild-failure are tracked in **#735** — now fixable in the single unified place.
- A few load/cold-build log lines (`"Loaded vector index from %s"`, `"%s Rebuilding embeddings."`, `"No vector index on disk..."`) are verbatim moves that pre-date this change and do not follow event-name-first format; changing their text would alter observable log output and break asserting tests, so they're left as-is.
- The module intentionally takes an **injected `logger`** (rather than a module-level `getLogger(__name__)`) so records attribute to the calling manager, not to `_vector_loader`.

The review did catch one real refactor-faithfulness issue, now fixed: both managers must check the cache **before** the `RuntimeError` precondition (the originals did), so the order is restored exactly.

Closes #736

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._