### PR TITLE
fix: harden load_or_self_heal error path (#735)

### DIFF
--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -68,6 +68,23 @@ def load_or_self_heal(
         VectorIndexCorruptError,
     )
 
+    def _run_rebuild() -> None:
+        """Run the rebuild callback; if it raises, log and re-raise unchanged.
+
+        Ties a rebuild failure (e.g. provider/FTS error inside the rebuild)
+        to the corruption event in the log instead of letting it propagate
+        unlogged (#735).
+        """
+        try:
+            rebuild()
+        except Exception:
+            logger.error(
+                "vector_index_rebuild_failed path=%s",
+                embeddings_path,
+                exc_info=True,
+            )
+            raise
+
     npy_path = Path(str(embeddings_path) + ".npy")
     if npy_path.exists():
         try:
@@ -75,7 +92,12 @@ def load_or_self_heal(
             logger.info("Loaded vector index from %s", embeddings_path)
         except VectorIndexCompatibilityError as exc:
             logger.warning("%s Rebuilding embeddings.", exc)
-            rebuild()
+            _run_rebuild()
+            # An empty-but-populated index is accepted, not an error: the
+            # degraded "every batch failed" case is surfaced by
+            # build_embeddings' build_embeddings_all_batches_failed warning
+            # (#649/#735). This guard only catches a rebuild that left the slot
+            # entirely unpopulated (None).
             if get_vectors() is None:
                 raise ValueError(
                     "Failed to rebuild vector index after a compatibility error."
@@ -108,8 +130,9 @@ def load_or_self_heal(
                 "vector_index_corrupt_rebuilding path=%s error=%s",
                 embeddings_path,
                 exc,
+                exc_info=True,
             )
-            rebuild()
+            _run_rebuild()
             if get_vectors() is None:
                 raise ValueError(
                     "Failed to rebuild vector index after a corrupt sidecar."
@@ -120,5 +143,7 @@ def load_or_self_heal(
 
     result = get_vectors()
     if result is None:
-        raise ValueError("Failed to rebuild vector index after a compatibility error.")
+        raise ValueError(
+            "Failed to obtain a usable vector index (slot empty after load/rebuild)."
+        )
     return result

--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -56,7 +56,9 @@ def load_or_self_heal(
         A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
 
     Raises:
-        ValueError: If a self-heal rebuild fails to produce a usable index.
+        ValueError: If a self-heal rebuild completes but leaves the slot empty.
+        Exception: Any exception raised by the ``rebuild`` callback is logged
+            at ERROR and re-raised unchanged.
     """
     cached = get_vectors()
     if cached is not None:
@@ -69,7 +71,7 @@ def load_or_self_heal(
     )
 
     def _run_rebuild() -> None:
-        """Run the rebuild callback; if it raises, log and re-raise unchanged.
+        """Run the rebuild callback; if it raises, log at ERROR and re-raise the original exception without wrapping.
 
         Ties a rebuild failure (e.g. provider/FTS error inside the rebuild)
         to the corruption event in the log instead of letting it propagate
@@ -77,6 +79,9 @@ def load_or_self_heal(
         """
         try:
             rebuild()
+        # Broad by design: the rebuild callback (build_embeddings / a provider
+        # call) raises heterogeneous types; log then re-raise unchanged. Mirrors
+        # IndexManager.build_embeddings' own broad per-batch except (#735).
         except Exception:
             logger.error(
                 "vector_index_rebuild_failed path=%s",
@@ -91,11 +96,11 @@ def load_or_self_heal(
             set_vectors(VectorIndex.load(embeddings_path, embedding_provider))
             logger.info("Loaded vector index from %s", embeddings_path)
         except VectorIndexCompatibilityError as exc:
-            logger.warning("%s Rebuilding embeddings.", exc)
+            logger.warning("%s Rebuilding embeddings.", exc, exc_info=True)
             _run_rebuild()
             # An empty-but-populated index is accepted, not an error: the
             # degraded "every batch failed" case is surfaced by
-            # build_embeddings' build_embeddings_all_batches_failed warning
+            # IndexManager.build_embeddings' build_embeddings_all_batches_failed warning
             # (#649/#735). This guard only catches a rebuild that left the slot
             # entirely unpopulated (None).
             if get_vectors() is None:

--- a/tests/test_vector_loader.py
+++ b/tests/test_vector_loader.py
@@ -117,8 +117,12 @@ def test_compatibility_error_triggers_rebuild(
         )
 
     assert result is rebuilt
+    # Pin the warning AND that it carries a traceback (exc_info) for the
+    # destructive rebuild (#735).
     assert any(
-        r.name == _LOGGER_NAME and "Rebuilding embeddings" in r.getMessage()
+        r.name == _LOGGER_NAME
+        and "Rebuilding embeddings" in r.getMessage()
+        and r.exc_info is not None
         for r in caplog.records
     )
 
@@ -150,9 +154,13 @@ def test_corrupt_error_triggers_rebuild(
         )
 
     assert result is rebuilt
-    # Pins both the event name AND that the PASSED logger emitted it (#736).
+    # Pins the event name, that the PASSED logger emitted it (#736), AND that
+    # the warning carries a traceback (exc_info) for the destructive rebuild
+    # (#735).
     assert any(
-        r.name == _LOGGER_NAME and "vector_index_corrupt_rebuilding" in r.getMessage()
+        r.name == _LOGGER_NAME
+        and "vector_index_corrupt_rebuilding" in r.getMessage()
+        and r.exc_info is not None
         for r in caplog.records
     )
 

--- a/tests/test_vector_loader.py
+++ b/tests/test_vector_loader.py
@@ -248,7 +248,7 @@ def test_empty_rebuild_is_accepted_not_an_error(
         raise VectorIndexCorruptError("row count mismatch")
 
     monkeypatch.setattr(VectorIndex, "load", boom)
-    box, get, set_ = _slot()
+    _box, get, set_ = _slot()
     empty = VectorIndex(provider)  # count == 0
 
     result = load_or_self_heal(
@@ -256,7 +256,7 @@ def test_empty_rebuild_is_accepted_not_an_error(
         embedding_provider=provider,
         get_vectors=get,
         set_vectors=set_,
-        rebuild=lambda: box.__setitem__("v", empty),
+        rebuild=lambda: set_(empty),
         logger=_LOG,
     )
     assert result is empty
@@ -296,6 +296,43 @@ def test_rebuild_that_raises_is_logged_then_propagates(
 
     def boom(*_a: object, **_k: object) -> VectorIndex:
         raise VectorIndexCorruptError("row count mismatch")
+
+    monkeypatch.setattr(VectorIndex, "load", boom)
+    _box, get, set_ = _slot()
+
+    def rebuild_explodes() -> None:
+        raise RuntimeError("provider down")
+
+    with (
+        caplog.at_level(logging.ERROR, logger=_LOGGER_NAME),
+        pytest.raises(RuntimeError, match="provider down"),
+    ):
+        load_or_self_heal(
+            embeddings_path=base,
+            embedding_provider=provider,
+            get_vectors=get,
+            set_vectors=set_,
+            rebuild=rebuild_explodes,
+            logger=_LOG,
+        )
+    assert any(
+        r.name == _LOGGER_NAME and "vector_index_rebuild_failed" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_compat_rebuild_that_raises_is_logged_then_propagates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising rebuild on the compatibility arm is also logged + propagated."""
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    (tmp_path / "embeddings.npy").touch()
+
+    def boom(*_a: object, **_k: object) -> VectorIndex:
+        raise VectorIndexCompatibilityError("mismatch")
 
     monkeypatch.setattr(VectorIndex, "load", boom)
     _box, get, set_ = _slot()

--- a/tests/test_vector_loader.py
+++ b/tests/test_vector_loader.py
@@ -229,3 +229,93 @@ def test_permission_error_propagates_without_rebuild(
             logger=_LOG,
         )
     assert calls == []
+
+
+def test_empty_rebuild_is_accepted_not_an_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rebuild that populates an EMPTY index returns it without raising.
+
+    Respects #649 graceful degradation: a provider-down rebuild yields an
+    empty (but populated) slot, which build_embeddings already warns about;
+    load_or_self_heal must not turn that into a hard failure.
+    """
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    (tmp_path / "embeddings.npy").touch()
+
+    def boom(*_a: object, **_k: object) -> VectorIndex:
+        raise VectorIndexCorruptError("row count mismatch")
+
+    monkeypatch.setattr(VectorIndex, "load", boom)
+    box, get, set_ = _slot()
+    empty = VectorIndex(provider)  # count == 0
+
+    result = load_or_self_heal(
+        embeddings_path=base,
+        embedding_provider=provider,
+        get_vectors=get,
+        set_vectors=set_,
+        rebuild=lambda: box.__setitem__("v", empty),
+        logger=_LOG,
+    )
+    assert result is empty
+    assert result.count == 0
+
+
+def test_tail_guard_uses_scenario_neutral_message(tmp_path: Path) -> None:
+    """The cold-build tail guard must not misattribute to 'compatibility error'.
+
+    A no-op set_vectors leaves the slot None after the cold-build branch, so
+    the trailing guard fires. Its message must be scenario-neutral.
+    """
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"  # no .npy on disk -> cold-build path
+
+    with pytest.raises(ValueError, match="slot empty after load/rebuild"):
+        load_or_self_heal(
+            embeddings_path=base,
+            embedding_provider=provider,
+            get_vectors=lambda: None,  # slot never populated
+            set_vectors=lambda _v: None,  # no-op: drops the cold-build index
+            rebuild=lambda: None,
+            logger=_LOG,
+        )
+
+
+def test_rebuild_that_raises_is_logged_then_propagates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A rebuild callback that itself raises logs vector_index_rebuild_failed
+    and propagates the original exception (does not swallow it)."""
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings"
+    (tmp_path / "embeddings.npy").touch()
+
+    def boom(*_a: object, **_k: object) -> VectorIndex:
+        raise VectorIndexCorruptError("row count mismatch")
+
+    monkeypatch.setattr(VectorIndex, "load", boom)
+    _box, get, set_ = _slot()
+
+    def rebuild_explodes() -> None:
+        raise RuntimeError("provider down")
+
+    with (
+        caplog.at_level(logging.ERROR, logger=_LOGGER_NAME),
+        pytest.raises(RuntimeError, match="provider down"),
+    ):
+        load_or_self_heal(
+            embeddings_path=base,
+            embedding_provider=provider,
+            get_vectors=get,
+            set_vectors=set_,
+            rebuild=rebuild_explodes,
+            logger=_LOG,
+        )
+    assert any(
+        r.name == _LOGGER_NAME and "vector_index_rebuild_failed" in r.getMessage()
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
Follow-up to #736 (which unified the self-heal into `managers/_vector_loader.py`). Fixes the error-path items #735 tracked, all in the single helper:

- **Misattributed tail-guard message** — the trailing `ValueError` is reachable from the cold-build and corrupt paths, not just compatibility, so its "compatibility error" wording was wrong. Now scenario-neutral: "Failed to obtain a usable vector index (slot empty after load/rebuild)."
- **Traceback on the rebuild warnings** — `exc_info=True` on **both** the corrupt-arm (`vector_index_corrupt_rebuilding`) and compatibility-arm (`%s Rebuilding embeddings.`) warnings, so a destructive rebuild always carries stack context (consistent with `IndexManager.build_embeddings`' own `build_embeddings_skip_batch` warning).
- **Rebuild-exception logging** — a new nested `_run_rebuild()` wraps the rebuild callback: if it raises, log `vector_index_rebuild_failed` (with traceback) then re-raise the original exception unchanged, instead of leaving the rebuild failure unlogged next to the corruption warning.

**Deliberately not changed (respects #649):** an empty-but-populated rebuild is intentionally accepted — no hard-raise. `build_embeddings(force=True)` already degrades gracefully and logs `build_embeddings_all_batches_failed` for the provider-down case; erroring here would take semantic search down for a recoverable, already-warned condition. The `is None` guards stay (they enforce "rebuild populated the slot", not emptiness). A test pins this acceptance.

Behavior-preserving except the added logging and the one neutralized message; the existing self-heal regression tests (`TestLoadVectorsSelfHeal` / `TestSearchLoadVectorsSelfHeal`) pass unchanged. New direct tests cover the neutral tail message, both arms' rebuild-raises logging, and the accept-empty contract.

### Pre-flight notes
`except Exception` in `_run_rebuild` and `exc_info=True` on a `WARNING` are both deliberate and match the established `IndexManager.build_embeddings` idiom (`except Exception as exc` + `logger.warning(..., exc_info=True)` at `index.py:647/652`) — the rebuild callback raises heterogeneous provider/build types, and the warning is for a destructive rebuild where a traceback is warranted.

Closes #735

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._