### PR TITLE
fix: strip escaped-pipe backslash from wikilink targets (#731)

### DIFF
--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -776,13 +776,10 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
     # --- Wikilinks ---
     for m in _RE_WIKILINK.finditer(clean):
         raw_path = m.group(1).strip()
-        # Obsidian escapes the alias pipe as `\|` when a wikilink sits in a
-        # table cell (e.g. `[[notes/foo\|Foo]]`); `[^\]|]+` does not exclude
-        # backslashes, so the trailing `\` flows into group(1) (#731). Strip one
-        # trailing backslash — this fires for ANY trailing backslash, not only
-        # the aliased-table case. Must run BEFORE `wikilink_raw_target` is built
-        # below: raw_target is the anchor for `resolve_vault_wikilinks()`, so a
-        # `notes/foo\` anchor would never resolve.
+        # Obsidian escapes the alias pipe as `\|` in table cells, so the target
+        # keeps a trailing `\` (#731). Strip it BEFORE wikilink_raw_target is
+        # built — raw_target is the resolve_vault_wikilinks() anchor and must be
+        # the clean stem, else the link never resolves.
         if raw_path.endswith("\\"):
             raw_path = raw_path[:-1]
         alias = m.group(2)

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -776,6 +776,13 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
     # --- Wikilinks ---
     for m in _RE_WIKILINK.finditer(clean):
         raw_path = m.group(1).strip()
+        # Obsidian requires the alias pipe to be escaped as `\|` when an
+        # aliased wikilink sits in a table cell, so the canonical target carries
+        # a trailing escape backslash the regex captures (#731). Drop it so
+        # `[[notes/foo\|Foo]]` resolves to `notes/foo`, not the literal
+        # `notes/foo\`.
+        if raw_path.endswith("\\"):
+            raw_path = raw_path[:-1]
         alias = m.group(2)
         link_text = alias.strip() if alias else raw_path
 

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -627,7 +627,7 @@ _RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
 _RE_REF_USAGE = re.compile(r"\[([^\]]*)\]\[([^\]]*)\]")
 # Reference definition: [ref]: target  (at start of line, optional leading whitespace)
 _RE_REF_DEF = re.compile(r"^\s*\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
-# Wikilink: [[path]] or [[path|alias]]
+# Wikilink: [[path]], [[path|alias]], or [[path\|alias]] (Obsidian table-cell escape)
 _RE_WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
 
 
@@ -776,11 +776,13 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
     # --- Wikilinks ---
     for m in _RE_WIKILINK.finditer(clean):
         raw_path = m.group(1).strip()
-        # Obsidian requires the alias pipe to be escaped as `\|` when an
-        # aliased wikilink sits in a table cell, so the canonical target carries
-        # a trailing escape backslash the regex captures (#731). Drop it so
-        # `[[notes/foo\|Foo]]` resolves to `notes/foo`, not the literal
-        # `notes/foo\`.
+        # Obsidian escapes the alias pipe as `\|` when a wikilink sits in a
+        # table cell (e.g. `[[notes/foo\|Foo]]`); `[^\]|]+` does not exclude
+        # backslashes, so the trailing `\` flows into group(1) (#731). Strip one
+        # trailing backslash — this fires for ANY trailing backslash, not only
+        # the aliased-table case. Must run BEFORE `wikilink_raw_target` is built
+        # below: raw_target is the anchor for `resolve_vault_wikilinks()`, so a
+        # `notes/foo\` anchor would never resolve.
         if raw_path.endswith("\\"):
             raw_path = raw_path[:-1]
         alias = m.group(2)

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -299,6 +299,41 @@ class TestExtractWikilinks:
         assert len(links) == 1
         assert links[0].raw_target == "note.md"
 
+    def test_wikilink_escaped_pipe_alias_in_table(self) -> None:
+        """[[path\\|alias]] (Obsidian table escape) drops the trailing backslash.
+
+        Obsidian requires the alias pipe to be escaped as ``\\|`` inside a table
+        cell; the regex would otherwise capture ``notes/foo\\`` as the target
+        (#731).
+        """
+        links = extract_links("| [[notes/foo\\|Foo]] |", "hub.md")
+        assert len(links) == 1
+        assert links[0].target_path == "notes/foo.md"
+        assert links[0].raw_target == "notes/foo"
+        assert links[0].link_text == "Foo"
+
+    def test_wikilink_escaped_pipe_with_fragment(self) -> None:
+        """[[note#sec\\|Alias]] strips the escape and still splits the fragment."""
+        links = extract_links("[[note#sec\\|Alias]]", "index.md")
+        assert len(links) == 1
+        assert links[0].target_path == "note.md"
+        assert links[0].fragment == "sec"
+        assert links[0].raw_target == "note#sec"
+        assert links[0].link_text == "Alias"
+
+    def test_wikilink_unescaped_pipe_unchanged(self) -> None:
+        """A normal [[path|alias]] (no backslash) is unaffected by the strip."""
+        links = extract_links("[[notes/topic|My Topic]]", "index.md")
+        assert len(links) == 1
+        assert links[0].target_path == "notes/topic.md"
+        assert links[0].raw_target == "notes/topic"
+
+    def test_wikilink_mid_path_backslash_not_stripped(self) -> None:
+        """Only a TRAILING backslash is stripped; a mid-target one is kept."""
+        links = extract_links("[[a\\b]]", "index.md")
+        assert len(links) == 1
+        assert links[0].target_path == "a\\b.md"
+
 
 # ---------------------------------------------------------------------------
 # extract_links: code block exclusion
@@ -411,6 +446,29 @@ class TestFTSIndexLinks:
         assert rows[0]["source_title"] == "Source Doc"
         assert rows[0]["link_text"] == "the target"
         assert rows[0]["link_type"] == "markdown"
+
+    def test_escaped_pipe_wikilink_not_broken_and_backlinked(self) -> None:
+        """End-to-end (#731): a table-escaped aliased wikilink resolves cleanly.
+
+        Reproduces the reported symptom: ``[[notes/foo\\|Foo]]`` in a source
+        note, with ``notes/foo.md`` indexed, must NOT be reported broken and the
+        backlink edge to ``notes/foo.md`` must be present.
+        """
+        idx = FTSIndex(":memory:")
+        source_links = extract_links("| [[notes/foo\\|Foo]] |", "hub.md")
+        assert len(source_links) == 1  # sanity: the wikilink was extracted
+        idx.build_from_notes(
+            [
+                make_note(path="hub.md", title="Hub", links=source_links),
+                make_note(path="notes/foo.md", title="Foo"),
+            ]
+        )
+        idx.resolve_vault_wikilinks()
+
+        assert idx.get_broken_links() == []
+        assert idx.get_outlinks("hub.md")[0]["target_path"] == "notes/foo.md"
+        backlinks = idx.get_backlinks("notes/foo.md")
+        assert [r["source_path"] for r in backlinks] == ["hub.md"]
 
     def test_build_from_notes_populates_links(self) -> None:
         """build_from_notes bulk indexes links for all notes."""

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -329,10 +329,33 @@ class TestExtractWikilinks:
         assert links[0].raw_target == "notes/topic"
 
     def test_wikilink_mid_path_backslash_not_stripped(self) -> None:
-        """Only a TRAILING backslash is stripped; a mid-target one is kept."""
+        """A mid-target backslash (`[[a\\b]]`) does not trigger the strip.
+
+        `endswith("\\")` is False, so the strip is never reached — pins that
+        only a *trailing* backslash is removed.
+        """
         links = extract_links("[[a\\b]]", "index.md")
         assert len(links) == 1
         assert links[0].target_path == "a\\b.md"
+
+    def test_wikilink_escaped_pipe_dotmd_explicit_extension(self) -> None:
+        """[[note.md\\|Alias]] strips the escape; .md is not doubled."""
+        links = extract_links("| [[note.md\\|Alias]] |", "index.md")
+        assert len(links) == 1
+        assert links[0].target_path == "note.md"
+        assert links[0].raw_target == "note.md"  # extension preserved, not doubled
+        assert links[0].link_text == "Alias"
+
+    def test_wikilinks_mixed_escaped_and_plain_same_line(self) -> None:
+        """A table row with one escaped and one plain wikilink resolves each independently."""
+        links = extract_links("| [[a/b\\|Escaped]] | [[c/d|Plain]] |", "hub.md")
+        assert len(links) == 2
+        escaped = next(link for link in links if link.raw_target == "a/b")
+        plain = next(link for link in links if link.raw_target == "c/d")
+        assert escaped.target_path == "a/b.md"
+        assert escaped.link_text == "Escaped"
+        assert plain.target_path == "c/d.md"
+        assert plain.link_text == "Plain"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #731 (reported by @Denzilla04). Obsidian **requires** the alias pipe to be escaped as `\|` when an aliased wikilink sits in a Markdown table cell, so `[[notes/foo\|Foo]]` is the canonical on-disk form. `scanner.py`'s `_RE_WIKILINK` target group `[^\]|]+` does not exclude `\`, so it captured `notes/foo\` — the trailing escape backslash flowed into both the resolved `target_path` (→ false broken link from `get_broken_links`) and `raw_target` (→ dropped edge from `get_backlinks`/`get_outlinks`/`get_context`). The reporter saw ~190 false broken links from this alone.

The fix drops a single trailing backslash from the captured wikilink target (the contributor's recommended option 1), placed **before** `wikilink_raw_target` is assembled — because `raw_target` is the anchor `resolve_vault_wikilinks()` matches on, so it must be the clean stem `notes/foo` (a `notes/foo\` anchor would never resolve). The comment pins that ordering invariant.

## Scope
- Wikilink-only; markdown `[text](path)` and reference links untouched.
- Strips exactly one *trailing* backslash; a mid-path backslash (`[[a\b]]`) is left alone (`endswith` is False).
- The unescaped-pipe-in-table case (`[[a|b]]` without `\`) is out of scope — that's an author markdown error Obsidian itself mis-renders.
- Note: a local review suggested capturing `raw_target` *before* the strip to preserve the literal source text. That is intentionally **not** done — it would reintroduce #731, since `raw_target` is the resolution anchor. (Perfect round-tripping of the `\|alias` form for the rename tool is a separate, pre-existing concern, not regressed here.)

## Tests
Unit (`TestExtractWikilinks`): escaped-pipe alias in a table, escape+fragment, explicit `.md`+escape (no doubling), mixed escaped/plain wikilinks in one table row, unescaped-pipe no-regression, mid-path-backslash-not-stripped. Integration (`TestFTSIndexLinks`): end-to-end — the escaped-pipe link is not broken and the backlink edge is present after `resolve_vault_wikilinks`.

Closes #731

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._