### PR TITLE
fix: return the whole section from read(section=), not just its first chunk (#741)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **Full-text search** — SQLite FTS5 with BM25 scoring, porter stemming
 - **Semantic search** — cosine similarity over embedding vectors (FastEmbed, Ollama, or OpenAI)
 - **Hybrid search** — Reciprocal Rank Fusion combining FTS5 and vector results
-- **Diversity-aware ranking** — each search result list caps a single document at 2 chunks (configurable), downweights chunks of long documents, and returns sentence-scale snippets — bounded LLM context cost per query, with full chunk recovery via `read(path, section=heading)`
+- **Diversity-aware ranking** — each search result list caps a single document at 2 chunks (configurable), downweights chunks of long documents, and returns sentence-scale snippets — bounded LLM context cost per query, with full-section recovery via `read(path, section=heading)`
 - **Adaptive heading-level chunking** — long sections are recursively re-split at deeper heading levels (H1 → H6) until each chunk fits a configurable word budget, improving retrieval precision on synthesising essays without manual restructuring
 
-> **Upgrading.** As of this release, `search` returns query-relevant snippets in the `content` field by default (approximately 200 words). Pass `snippet_words=0` to recover the prior full-chunk behaviour, or use `read(path, section=heading)` to fetch a specific chunk after seeing a snippet. Documents are also re-chunked on next `reindex` to honour the adaptive `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` threshold (default 400).
+> **Upgrading.** As of this release, `search` returns query-relevant snippets in the `content` field by default (approximately 200 words). Pass `snippet_words=0` to recover the prior full-chunk behaviour, or use `read(path, section=heading)` to fetch the full section after seeing a snippet. Documents are also re-chunked on next `reindex` to honour the adaptive `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` threshold (default 400).
 - **Frontmatter-aware** — indexes YAML frontmatter fields, supports required field enforcement
 - **Incremental reindexing** — hash-based change detection, only re-processes modified files; an automatic boot-time reconciliation pass picks up changes made while no server was running, and the vector index converges to the reconciled chunk set (embedding exactly the delta)
 - **Write operations** — create, edit, delete, rename documents with automatic index updates

--- a/docs/design.md
+++ b/docs/design.md
@@ -220,7 +220,10 @@ Four complementary mechanisms improve result diversity and bound LLM context cos
    `snippet_words` words (default 200). For keyword and hybrid results, FTS5's built-in
    `snippet()` function selects a tokenizer-aware window centered on query terms. For
    semantic-only results, a Python word-window scan picks the densest-matching window.
-   Full chunk recovery is available via `read(path, section=heading)`.
+   Full-section recovery is available via `read(path, section=heading)`, which
+   reconstructs the whole section (body plus any sub-sections) from the document
+   on disk regardless of how the chunker fragmented it, so a section longer than
+   the chunk budget is returned intact rather than truncated to its first chunk.
 4. **Adaptive heading-level chunking.** The `HeadingChunker` recursively re-splits
    oversize chunks at deeper heading levels (H1 → H6) until each fits `max_chunk_words`
    words. When heading-based refinement cannot make further progress (a leaf section
@@ -2055,7 +2058,7 @@ Attachments are **not indexed or searched**: only direct path-based read/write/d
 
 The cap is enforced by the `read`, `write`, and `fetch` MCP tools, the layer where attachment bytes flow through the LLM context as base64. The vault library's `read_attachment()` / `write_attachment()` accept any size, so out-of-band byte movement (such as an HTTP transfer route) is not gated by it. Set `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB=0` to disable the limit. The default was tightened from 10 MB to 1 MB in #442 to keep LLM context bounded; most contexts can't survive a 10 MB base64-encoded attachment, so the old default was a silent context-blow-up. The error message names `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` as the knob to raise if the bytes are needed in context.
 
-A parallel cap on whole-document `read()` for `.md` files (`MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES`, default 256 KB) raises `ValueError` with a message pointing at `read(path, section=heading)` for partial reads. Section reads bypass the cap because they only load one chunk.
+A parallel cap on whole-document `read()` for `.md` files (`MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES`, default 256 KB) raises `ValueError` with a message pointing at `read(path, section=heading)` for partial reads. Section reads bypass the cap because they return only the requested section, not the whole document.
 
 #### MCP Apps
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -69,7 +69,7 @@ Find documents matching a query using full-text or semantic search.
     Each file appears at most once in results, with up to `chunks_per_file` sections nested under `sections`. The top-level `score` is the maximum of the section scores (MaxP aggregation). Iterate `sections` to drill into individual matches.
 
 !!! note "Snippet content and full-chunk recovery"
-    By default, each section's `content` is a snippet of approximately 200 words centered on the query terms (not the full chunk). Pass `snippet_words=0` to receive the complete chunk. To read the full section after receiving a search result, call `read(path=result["path"], section=result["sections"][0]["heading"])`; this returns the entire chunk from the index without re-reading the whole document.
+    By default, each section's `content` is a snippet of approximately 200 words centered on the query terms (not the full chunk). Pass `snippet_words=0` to receive the complete chunk. To read the full section after receiving a search result, call `read(path=result["path"], section=result["sections"][0]["heading"])`; this returns the entire section (body plus any sub-sections) reconstructed from the document.
 
 !!! tip "Choosing a search mode"
     - Use `mode="hybrid"` when semantic search is available, combining keyword precision with semantic understanding
@@ -90,17 +90,17 @@ Find documents matching a query using full-text or semantic search.
 
 ### `read`
 
-Read the full content of a document or attachment by path. When combined with search, the optional `section` parameter lets you retrieve the full content of a specific chunk without loading the entire document.
+Read the full content of a document or attachment by path. When combined with search, the optional `section` parameter lets you retrieve a single section in full (its body and any sub-sections) without loading the entire document.
 
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `path` | string | required | Relative path to the document or attachment (such as `"Journal/note.md"` or `"assets/diagram.pdf"`) |
-| `section` | string | `null` | Optional heading to select a single section chunk. Pass the `heading` field from a `search` result to retrieve the full chunk content. Matching collapses internal whitespace on both sides: `"1.3.  Reducing..."` (two spaces) matches a stored `"1.3. Reducing..."` (one space) and vice versa. On miss, the error lists the document's actual stored headings so callers can recover. Raises an error if the heading is not found or is empty. |
+| `section` | string | `null` | Optional heading selecting one section. The whole section is returned (every paragraph, list, and sub-section from the heading up to the next heading at the same or higher level), reconstructed from the document on disk, so a section longer than the chunk budget comes back intact rather than truncated to its first chunk. Pass the `heading` field from a `search` result. Matching collapses internal whitespace on both sides: `"1.3.  Reducing..."` (two spaces) matches a stored `"1.3. Reducing..."` (one space) and vice versa. On miss, the error lists the document's actual headings so callers can recover. Raises an error if the heading is not found or is empty. |
 
-!!! tip "Recovering full chunks after search"
-    When `search` returns a snippet result, pass `result["heading"]` as the `section` parameter to recover the complete chunk: `read(path=result["path"], section=result["heading"])`. If the document has no sub-headings (preamble content), omit `section` to read the whole document.
+!!! tip "Recovering the full section after search"
+    When `search` returns a snippet result, pass `result["heading"]` as the `section` parameter to recover the complete section: `read(path=result["path"], section=result["heading"])`. If the document has no sub-headings (preamble content), omit `section` to read the whole document.
 
 !!! note "Heading matching tolerates whitespace differences"
     The `section` lookup compares heading strings after collapsing all whitespace runs to single spaces (and stripping leading/trailing whitespace). This handles the common case where an LLM caller infers a heading from a rendered TOC that normalises whitespace differently from the source markdown. Markdown emphasis (`**bold**`, `_italic_`) and case still matter; pass the heading as it would appear in the document source.

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -171,12 +171,13 @@ def register(mcp: FastMCP) -> None:
             path: Relative path to the document or attachment
                 (e.g. "Journal/note.md" or "assets/diagram.pdf").
                 Case-sensitive.
-            section: When provided, return only the section whose heading
-                matches *section* (case-sensitive; internal whitespace is
-                collapsed before comparison). Pass the ``heading`` value
-                from a ``search`` result unchanged for guaranteed match.
-                ``None`` (the default) returns the whole document.
-                Ignored for non-.md paths.
+            section: When provided, return the whole section whose heading
+                matches *section* — every paragraph, list, and sub-section
+                from the heading up to the next heading at the same or higher
+                level (case-sensitive; internal whitespace is collapsed before
+                comparison). Pass the ``heading`` value from a ``search``
+                result unchanged for guaranteed match. ``None`` (the default)
+                returns the whole document. Ignored for non-.md paths.
 
         Returns:
             For .md: dict with path, title, folder, content (markdown body

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -302,18 +302,6 @@ def _derive_folder(path: str) -> str:
     return "" if folder == "." else folder
 
 
-def _normalize_heading(heading: str) -> str:
-    """Collapse all whitespace runs in *heading* to single spaces and strip.
-
-    Used by :meth:`FTSIndex.get_section` to compare stored vs queried
-    heading strings tolerantly: rendered TOCs and markdown editors
-    normalise whitespace inconsistently (single vs double space after
-    a numbered prefix, tabs vs spaces, trailing whitespace), but the
-    semantic identity of the heading is unchanged.
-    """
-    return " ".join(heading.split())
-
-
 def _resolve_connect_uri(db_path: Path | str) -> tuple[str, bool, bool]:
     """Resolve a db_path into (connect_string, uses_uri, is_memory).
 
@@ -1943,104 +1931,6 @@ class FTSIndex:
             .fetchall()
         )
         return {r["path"]: int(r["chunk_count"]) for r in rows}
-
-    @_retry_on_locked
-    def get_section(self, path: str, heading: str) -> dict[str, Any] | None:
-        """Return the first section row for (path, heading), or ``None``.
-
-        Returns a dict with keys ``'content'``, ``'heading'``,
-        ``'heading_level'`` on hit; ``None`` when the heading is not found
-        in the document.  Tie-breaks by ``start_line ASC``.
-
-        Matching collapses internal whitespace on both sides — the lookup
-        ``"1.3.  Reducing..."`` (two spaces) hits a stored heading
-        ``"1.3. Reducing..."`` (one space) and vice versa.  Markdown
-        editors and rendered TOC widgets normalise whitespace
-        unpredictably, so LLM callers rarely reproduce the on-disk byte
-        sequence; this collapse closes that gap without changing storage.
-
-        Args:
-            path: Relative document path.
-            heading: Heading string to match (internal whitespace
-                collapsed before comparison).
-
-        Performance: comparison runs in Python after fetching all section
-        rows for ``path``, since SQLite has no portable regex-collapse
-        operator that would let us push the normalisation into the WHERE
-        clause.  ``idx_sections_docid`` keeps the per-doc fetch cheap (a
-        few tens to low hundreds of rows for a typical note); documents
-        with thousands of sections would prefer a stored ``heading_norm``
-        column.  Not optimising preemptively — the chunker's
-        ``chunks_per_file`` ceiling and adaptive splitting make very
-        deeply-sectioned documents rare.
-
-        Returns:
-            A dict with the following fields, or ``None`` when not found:
-
-            * ``content``: The section's text content.
-            * ``heading``: The matched heading string (as stored).
-            * ``heading_level``: The heading level (1-6).
-        """
-        norm_query = _normalize_heading(heading)
-        if not norm_query:
-            return None
-        rows = (
-            self._conn()
-            .execute(
-                """
-            SELECT s.content, s.heading, s.heading_level
-            FROM sections s
-            JOIN documents d ON d.id = s.document_id
-            WHERE d.path = ? AND s.heading IS NOT NULL
-            ORDER BY s.start_line ASC
-            """,
-                (path,),
-            )
-            .fetchall()
-        )
-        for row in rows:
-            if _normalize_heading(row["heading"]) == norm_query:
-                return {
-                    "content": row["content"],
-                    "heading": row["heading"],
-                    "heading_level": row["heading_level"],
-                }
-        return None
-
-    @_retry_on_locked
-    def list_section_headings(self, path: str, *, limit: int = 50) -> list[str]:
-        """Return up to *limit* section headings for *path*, in document order.
-
-        Used to build "did you mean" suggestions when
-        :meth:`get_section` misses.  Sections without a heading
-        (preamble) are skipped — only string headings worth suggesting
-        to a caller are returned.
-
-        Args:
-            path: Relative document path.
-            limit: Maximum number of headings to return.
-
-        Returns:
-            List of heading strings in document order, deduplicated while
-            preserving the first-occurrence order.
-        """
-        rows = (
-            self._conn()
-            .execute(
-                """
-            SELECT s.heading
-            FROM sections s
-            JOIN documents d ON d.id = s.document_id
-            WHERE d.path = ? AND s.heading IS NOT NULL
-            GROUP BY s.heading
-            ORDER BY MIN(s.start_line) ASC
-            LIMIT ?
-            """,
-                (path, limit),
-            )
-            .fetchall()
-        )
-        return [row["heading"] for row in rows]
 
     def close(self) -> None:
         """Close every per-thread connection and mark this index closed.

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import frontmatter as fm
+import yaml
 
 from markdown_vault_mcp.exceptions import (
     ConcurrentModificationError,
@@ -341,7 +342,8 @@ class DocumentManager:
 
         Raises:
             ValueError: If the document is not indexed, its file cannot be
-                read, or the heading is not found.
+                read or decoded, its frontmatter cannot be parsed, or the
+                heading is not found.
         """
         doc_row = self._fts.get_note(path)
         if doc_row is None:
@@ -351,16 +353,31 @@ class DocumentManager:
             )
 
         abs_path = self._validate_path(path)
+        # The file decoded and parsed cleanly when it was indexed, but it may
+        # have changed on disk since (the stale-index window). Map the same
+        # failure classes the whole-document read path handles —
+        # UnicodeDecodeError/OSError on read, yaml.YAMLError on frontmatter
+        # parse — to a user-facing ValueError instead of leaking the raw
+        # exception into the MCP error middleware.
         try:
             text = _read_text_utf8(abs_path)
-        except OSError as exc:
+        except (UnicodeDecodeError, OSError) as exc:
             raise ValueError(
                 f"Section '{heading}' not found in document {path}: "
                 "document file is not readable"
             ) from exc
 
-        content = extract_section(text, heading)
+        try:
+            content = extract_section(text, heading)
+        except yaml.YAMLError as exc:
+            raise ValueError(
+                f"Section '{heading}' not found in document {path}: "
+                "document frontmatter is not parseable"
+            ) from exc
+
         if content is None:
+            # extract_section already parsed the frontmatter successfully above,
+            # so list_section_headings (same parse) cannot raise here.
             available = list_section_headings(text)[:10]
             if available:
                 suggestion = " — available headings include: " + ", ".join(

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -354,11 +354,10 @@ class DocumentManager:
 
         abs_path = self._validate_path(path)
         # The file decoded and parsed cleanly when it was indexed, but it may
-        # have changed on disk since (the stale-index window). Map the same
-        # failure classes the whole-document read path handles —
-        # UnicodeDecodeError/OSError on read, yaml.YAMLError on frontmatter
-        # parse — to a user-facing ValueError instead of leaking the raw
-        # exception into the MCP error middleware.
+        # have changed on disk since (the stale-index window). Map read failures
+        # (UnicodeDecodeError/OSError) and malformed-frontmatter failures
+        # (yaml.YAMLError) to a user-facing ValueError instead of leaking the
+        # raw exception into the MCP error middleware.
         try:
             text = _read_text_utf8(abs_path)
         except (UnicodeDecodeError, OSError) as exc:
@@ -377,8 +376,9 @@ class DocumentManager:
 
         if content is None:
             # extract_section already parsed the frontmatter successfully above,
-            # so list_section_headings (same parse) cannot raise here.
-            available = list_section_headings(text)[:10]
+            # so list_section_headings (same parse) cannot raise here. Dedupe
+            # so a repeated heading is suggested once and does not crowd the cap.
+            available = list(dict.fromkeys(list_section_headings(text)))[:10]
             if available:
                 suggestion = " — available headings include: " + ", ".join(
                     repr(h) for h in available

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -27,7 +27,11 @@ from markdown_vault_mcp.exceptions import (
     ReadOnlyError,
 )
 from markdown_vault_mcp.hashing import compute_etag, compute_file_hash
-from markdown_vault_mcp.scanner import parse_note
+from markdown_vault_mcp.scanner import (
+    extract_section,
+    list_section_headings,
+    parse_note,
+)
 from markdown_vault_mcp.types import (
     AttachmentContent,
     DeleteResult,
@@ -232,10 +236,11 @@ class DocumentManager:
 
         Args:
             path: Relative document path (e.g. ``"Journal/note.md"``).
-            section: When provided, return only the chunk whose heading
-                matches *section* (case-sensitive; internal whitespace is
-                collapsed before comparison). ``None`` returns the whole
-                document (today's behaviour).
+            section: When provided, return the whole section whose heading
+                matches *section* — its body and any sub-sections, up to the
+                next heading at the same or higher level (case-sensitive;
+                internal whitespace is collapsed before comparison). ``None``
+                returns the whole document.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent`, or ``None`` if
@@ -247,7 +252,7 @@ class DocumentManager:
 
         Raises:
             ValueError: When *section* is provided and is empty / whitespace,
-                or when the document does not contain a chunk with that
+                or when the document does not contain a section with that
                 heading. (Path-not-found also raises in section mode rather
                 than returning ``None``, since "no document" implies "no
                 section".)
@@ -312,14 +317,20 @@ class DocumentManager:
         )
 
     def _read_section(self, path: str, heading: str) -> NoteContent:
-        """Return a NoteContent containing only the named section's chunk.
+        """Return a NoteContent containing the full named section.
+
+        The section is reconstructed from the document on disk: its span runs
+        from just after the heading line to the next heading at the same or
+        higher level (or end of document), so the *whole* section is returned
+        even when the chunker fragmented it into several rows — an over-budget
+        body split on paragraphs, or a parent split at its sub-headings (#741).
+        Sub-sections under the requested heading are included.
 
         Args:
             path: Relative document path.
-            heading: Exact heading string to match in the sections table.
-                When a document contains multiple sections with the same
-                heading text (rare in practice), the first occurrence by
-                ``start_line`` is returned.
+            heading: Heading string to match (internal whitespace collapsed;
+                case-sensitive). When a document contains multiple sections
+                with the same heading text, the first occurrence is returned.
 
         Returns:
             A :class:`~markdown_vault_mcp.types.NoteContent` with the
@@ -329,8 +340,8 @@ class DocumentManager:
             frontmatter.
 
         Raises:
-            ValueError: If the document is not indexed or the heading is
-                not found.
+            ValueError: If the document is not indexed, its file cannot be
+                read, or the heading is not found.
         """
         doc_row = self._fts.get_note(path)
         if doc_row is None:
@@ -338,20 +349,25 @@ class DocumentManager:
                 f"Section '{heading}' not found in document {path}: "
                 "document is not indexed or does not exist"
             )
-        section_row = self._fts.get_section(path, heading)
-        if section_row is None:
-            # Miss path only — fires a second SELECT over the same rows
-            # get_section already fetched. Acceptable because the miss
-            # path is by definition rare (LLM caller already gave us a
-            # bad heading) and consolidating the queries would couple
-            # get_section's return shape to error-message rendering.
-            available = self._fts.list_section_headings(path, limit=10)
+
+        abs_path = self._validate_path(path)
+        try:
+            text = _read_text_utf8(abs_path)
+        except OSError as exc:
+            raise ValueError(
+                f"Section '{heading}' not found in document {path}: "
+                "document file is not readable"
+            ) from exc
+
+        content = extract_section(text, heading)
+        if content is None:
+            available = list_section_headings(text)[:10]
             if available:
                 suggestion = " — available headings include: " + ", ".join(
                     repr(h) for h in available
                 )
             else:
-                suggestion = " (document has no indexed headings)"
+                suggestion = " (document has no headings)"
             raise ValueError(
                 f"Section '{heading}' not found in document {path}{suggestion}"
             )
@@ -364,7 +380,7 @@ class DocumentManager:
             path=path,
             title=doc_row["title"],
             folder=folder,
-            content=section_row["content"],
+            content=content,
             frontmatter={},  # section reads do not synthesise frontmatter
             modified_at=doc_row["modified_at"],
             etag="",  # ETag is whole-file; not meaningful for a section

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -585,6 +585,104 @@ class HeadingChunker:
             _emit(cur)
 
 
+# ATX heading detection, matching ``HeadingChunker._split_at_levels``: an
+# ``#``-run of 1-6 followed by whitespace and text, tested against the
+# right-stripped line.  Deliberately *not* code-fence aware, so a section's
+# span here matches the boundaries the chunker used when indexing.
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
+
+
+def normalize_heading(heading: str) -> str:
+    """Collapse internal whitespace runs to single spaces and strip.
+
+    Rendered TOCs and markdown editors normalise whitespace inconsistently
+    (single vs double space after a numbered prefix, tabs vs spaces, trailing
+    whitespace), so an LLM caller rarely reproduces the on-disk byte sequence.
+    Normalising both sides before comparison closes that gap.
+
+    Args:
+        heading: Heading string to normalise.
+
+    Returns:
+        The heading with whitespace runs collapsed to single spaces, stripped.
+    """
+    return " ".join(heading.split())
+
+
+def _scan_headings(lines: list[str]) -> list[tuple[int, int, str]]:
+    """Return ``(line_index, level, heading_text)`` for each ATX heading.
+
+    Heading detection mirrors :meth:`HeadingChunker._split_at_levels` so the
+    section spans derived here line up with how the document was chunked.
+
+    Args:
+        lines: Document body lines (``splitlines(keepends=True)``).
+
+    Returns:
+        One tuple per heading, in document order.
+    """
+    out: list[tuple[int, int, str]] = []
+    for idx, line in enumerate(lines):
+        m = _HEADING_RE.match(line.rstrip())
+        if m:
+            out.append((idx, len(m.group(1)), m.group(2).strip()))
+    return out
+
+
+def list_section_headings(text: str) -> list[str]:
+    """Return the document's ATX heading texts in document order.
+
+    Frontmatter is stripped before scanning. Used to build "did you mean"
+    suggestions when a section lookup misses.
+
+    Args:
+        text: Raw markdown file text (frontmatter included).
+
+    Returns:
+        Heading strings as written (whitespace not normalised), in order.
+    """
+    body = frontmatter.loads(text).content
+    return [h for _, _, h in _scan_headings(body.splitlines(keepends=True))]
+
+
+def extract_section(text: str, heading: str) -> str | None:
+    """Return the full body of the first section matching *heading*.
+
+    The span runs from just after the matched heading line to the line before
+    the next heading at the same or higher level (or end of document). The
+    heading line itself is excluded, matching the chunker's section-content
+    convention. Matching collapses internal whitespace and is case-sensitive.
+    Frontmatter is stripped before scanning.
+
+    Unlike a per-chunk lookup, this reconstructs the whole section regardless of
+    how the chunker fragmented it (an over-budget body split on paragraphs, or a
+    parent split at its sub-headings), so the complete section is returned (#741).
+
+    Args:
+        text: Raw markdown file text (frontmatter included).
+        heading: Heading to match (internal whitespace collapsed).
+
+    Returns:
+        The section's body text, or ``None`` when no heading matches.
+    """
+    norm_query = normalize_heading(heading)
+    if not norm_query:
+        return None
+    body = frontmatter.loads(text).content
+    lines = body.splitlines(keepends=True)
+    headings = _scan_headings(lines)
+    for i, (idx, level, htext) in enumerate(headings):
+        if normalize_heading(htext) != norm_query:
+            continue
+        end = len(lines)
+        for nxt_idx, nxt_level, _ in headings[i + 1 :]:
+            if nxt_level <= level:
+                end = nxt_idx
+                break
+        return "".join(lines[idx + 1 : end])
+    return None
+
+
 def _resolve_title(metadata: dict[str, Any], content: str, path: Path) -> str:
     """Resolve the document title using the priority order from the design spec.
 

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -366,6 +366,23 @@ def test_read_section_raises_when_indexed_file_missing_on_disk(tmp_path):
         mgr.read("a.md", section="Section One")
 
 
+def test_read_empty_but_present_section_returns_empty_content(tmp_path):
+    """A heading with no body (immediately followed by a same-level heading) is
+    a present-but-empty section: it returns NoteContent with empty content, NOT
+    a 'section not found' ValueError (#741)."""
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Empty\n## Next\nmarker_next body.\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+
+    nc = mgr.read("a.md", section="Empty")
+    assert nc is not None
+    assert nc.content.strip() == ""
+    assert "marker_next" not in nc.content
+
+
 def test_read_unknown_section_suggestion_dedupes_headings(tmp_path):
     """The 'did you mean' suggestion lists each heading once even when the
     document repeats a heading."""

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -366,6 +366,24 @@ def test_read_section_raises_when_indexed_file_missing_on_disk(tmp_path):
         mgr.read("a.md", section="Section One")
 
 
+def test_read_unknown_section_suggestion_dedupes_headings(tmp_path):
+    """The 'did you mean' suggestion lists each heading once even when the
+    document repeats a heading."""
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Repeat\nfirst.\n"
+        + "## Other\nmid.\n"
+        + "## Repeat\nsecond.\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+
+    with pytest.raises(ValueError) as excinfo:
+        mgr.read("a.md", section="No Such Heading")
+    message = str(excinfo.value)
+    assert message.count("'Repeat'") == 1
+
+
 def test_read_section_raises_on_non_utf8_file(tmp_path):
     """A file that decodes cleanly at index time but is later overwritten with
     invalid UTF-8 yields a ValueError, not a leaked UnicodeDecodeError (#741).

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -366,6 +366,51 @@ def test_read_section_raises_when_indexed_file_missing_on_disk(tmp_path):
         mgr.read("a.md", section="Section One")
 
 
+def test_read_section_raises_on_non_utf8_file(tmp_path):
+    """A file that decodes cleanly at index time but is later overwritten with
+    invalid UTF-8 yields a ValueError, not a leaked UnicodeDecodeError (#741).
+
+    ``UnicodeDecodeError`` subclasses ``ValueError`` but does not subclass
+    ``OSError``; matching on the message pins the friendly error rather than the
+    raw decode failure.
+    """
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Section One\n"
+        + "first body word\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+    # Corrupt the file with invalid UTF-8 bytes after indexing.
+    (tmp_path / "a.md").write_bytes(b"\xff\xfe invalid \x80\x81 bytes")
+
+    with pytest.raises(ValueError, match="not readable"):
+        mgr.read("a.md", section="Section One")
+
+
+def test_read_section_raises_on_malformed_frontmatter(tmp_path):
+    """A file with valid frontmatter at index time, later overwritten with a
+    malformed YAML block, yields a ValueError rather than a leaked
+    yaml.YAMLError (#741)."""
+    body = (
+        "---\n"
+        "title: A\n"
+        "---\n"
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Section One\n"
+        + "first body word\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+    # Overwrite with an unclosed YAML flow sequence after indexing.
+    (tmp_path / "a.md").write_text(
+        "---\ntitle: [unclosed\n---\n## Section One\nbody\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="not parseable"):
+        mgr.read("a.md", section="Section One")
+
+
 def test_write_fires_callback_while_holding_file_write_lock(tmp_path: Path) -> None:
     """The write callback must fire INSIDE _file_write_lock (#571): a concurrent
     thread must not be able to acquire the lock while the callback runs."""

--- a/tests/test_documents_read_section.py
+++ b/tests/test_documents_read_section.py
@@ -139,7 +139,7 @@ def test_read_section_no_headings_message(tmp_path):
 
     with pytest.raises(ValueError) as excinfo:
         mgr.read("a.md", section="Anything")
-    assert "document has no indexed headings" in str(excinfo.value)
+    assert "document has no headings" in str(excinfo.value)
 
 
 def test_read_section_duplicate_heading_returns_first_by_start_line(tmp_path):
@@ -171,6 +171,199 @@ def test_read_section_duplicate_heading_returns_first_by_start_line(tmp_path):
     assert nc is not None
     assert "first occurrence body" in nc.content
     assert "second occurrence body" not in nc.content
+
+
+def _make_mgr(tmp_path, body: str) -> DocumentManager:
+    """Write *body* to ``a.md``, index it, and return a DocumentManager.
+
+    Uses a budgeted chunker (mirroring the production vault's
+    ``max_chunk_words=400`` default) so long sections are split into multiple
+    same-heading rows — the configuration under which #741 reproduces.
+    """
+    (tmp_path / "a.md").write_text(body, encoding="utf-8")
+    fts = FTSIndex(db_path=":memory:")
+    chunker = HeadingChunker(max_chunk_words=400, max_chunk_chars=6000)
+    for note in scan_directory(tmp_path, chunk_strategy=chunker):
+        fts.upsert_note(note)
+    return DocumentManager(
+        fts=fts,
+        source_dir=tmp_path,
+        write_lock=threading.RLock(),
+        chunk_strategy=chunker,
+        read_only=False,
+    )
+
+
+def test_read_section_returns_full_body_when_budget_split(tmp_path):
+    """A section whose body exceeds the chunk budget (no sub-headings) is
+    returned in full, not truncated to its first chunk (#741)."""
+    intro = "marker_intro opening paragraph."
+    bullets = "\n".join(f"- bullet{i} " + "word " * 30 for i in range(20))
+    closing = "marker_closing final paragraph."
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Section One\n"
+        + intro
+        + "\n\n"
+        + bullets
+        + "\n\n"
+        + closing
+        + "\n## Section Two\n"
+        + "second body word\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+
+    nc = mgr.read("a.md", section="Section One")
+    assert nc is not None
+    # The whole section comes back: intro paragraph, the last bullet, and the
+    # closing paragraph — not merely the first chunk.
+    assert "marker_intro" in nc.content
+    assert "bullet19" in nc.content
+    assert "marker_closing" in nc.content
+    # The next sibling section is excluded.
+    assert "second body word" not in nc.content
+
+
+def test_read_section_includes_subsections(tmp_path):
+    """Reading a parent heading whose body was split at sub-headings returns
+    the sub-sections too, stopping at the next same-or-higher heading (#741)."""
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Parent\n"
+        + "marker_pre parent preamble.\n"
+        + "### Child One\n"
+        + "marker_c1 "
+        + "word " * 250
+        + "\n"
+        + "### Child Two\n"
+        + "marker_c2 "
+        + "word " * 250
+        + "\n"
+        + "## Sibling\n"
+        + "marker_sib sibling body.\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+
+    nc = mgr.read("a.md", section="Parent")
+    assert nc is not None
+    assert "marker_pre" in nc.content
+    assert "marker_c1" in nc.content
+    assert "marker_c2" in nc.content
+    # Stops at the next H2.
+    assert "marker_sib" not in nc.content
+
+
+def test_read_subsection_stops_at_next_same_level(tmp_path):
+    """A sub-heading read returns only its own span, stopping at the next
+    heading of the same or higher level (#741)."""
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Parent\n"
+        + "### X\n"
+        + "marker_x body.\n"
+        + "### Y\n"
+        + "marker_y body.\n"
+        + "## Z\n"
+        + "marker_z body.\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+
+    nc = mgr.read("a.md", section="X")
+    assert nc is not None
+    assert "marker_x" in nc.content
+    assert "marker_y" not in nc.content
+    assert "marker_z" not in nc.content
+
+
+def test_read_section_spans_to_end_of_document(tmp_path):
+    """The last section in a document spans to EOF (#741)."""
+    last_body = "marker_last " + "word " * 250
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## First\n"
+        + "marker_first body.\n"
+        + "## Last\n"
+        + last_body
+        + "\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+
+    nc = mgr.read("a.md", section="Last")
+    assert nc is not None
+    assert "marker_last" in nc.content
+    assert "marker_first" not in nc.content
+
+
+def test_read_section_works_in_short_document(tmp_path):
+    """Section read works even for short docs the chunker keeps as a single
+    whole-document chunk (#741)."""
+    body = "# Title\n## Alpha\nmarker_a body.\n## Beta\nmarker_b body.\n"
+    mgr = _make_mgr(tmp_path, body)
+
+    nc = mgr.read("a.md", section="Alpha")
+    assert nc is not None
+    assert "marker_a" in nc.content
+    assert "marker_b" not in nc.content
+
+
+def test_read_section_excludes_heading_line(tmp_path):
+    """The section's own heading line is not part of the returned content."""
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Section One\n"
+        + "first body word\n"
+        + "## Section Two\n"
+        + "second body word\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+
+    nc = mgr.read("a.md", section="Section One")
+    assert nc is not None
+    assert "## Section One" not in nc.content
+    assert "first body word" in nc.content
+
+
+def test_read_section_ignores_frontmatter(tmp_path):
+    """Frontmatter is stripped before heading scanning; section content is the
+    body only."""
+    body = (
+        "---\n"
+        "title: A doc\n"
+        "tags: [x]\n"
+        "---\n"
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Section One\n"
+        + "first body word\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+
+    nc = mgr.read("a.md", section="Section One")
+    assert nc is not None
+    assert "first body word" in nc.content
+    assert "tags:" not in nc.content
+
+
+def test_read_section_raises_when_indexed_file_missing_on_disk(tmp_path):
+    """If the index still has the doc but its file is gone, section read raises
+    a ValueError rather than leaking the underlying OSError (#741)."""
+    body = (
+        "# A\n"
+        + "\n".join(["preamble"] * 12)
+        + "\n## Section One\n"
+        + "first body word\n"
+    )
+    mgr = _make_mgr(tmp_path, body)
+    # Remove the file from disk without reindexing — get_note still hits.
+    (tmp_path / "a.md").unlink()
+
+    with pytest.raises(ValueError, match="not readable"):
+        mgr.read("a.md", section="Section One")
 
 
 def test_write_fires_callback_while_holding_file_write_lock(tmp_path: Path) -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -13,6 +13,9 @@ from markdown_vault_mcp.scanner import (
     ChunkStrategy,
     HeadingChunker,
     WholeDocumentChunker,
+    extract_section,
+    list_section_headings,
+    normalize_heading,
     parse_note,
     scan_directory,
 )
@@ -636,3 +639,87 @@ def test_parse_note_strips_bom_so_frontmatter_parses(tmp_path: Path) -> None:
     # The YAML block must not appear in any body chunk.
     all_body = "".join(c.content for c in note.chunks)
     assert "title:" not in all_body
+
+
+# ---------------------------------------------------------------------------
+# Section extraction helpers (#741)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSection:
+    def test_spans_subsections_until_next_same_level(self) -> None:
+        """A section's span includes its sub-sections and stops at the next
+        heading of the same or higher level."""
+        text = (
+            "# Title\n"
+            "## Parent\n"
+            "parent preamble.\n"
+            "### Child\n"
+            "child body.\n"
+            "## Sibling\n"
+            "sibling body.\n"
+        )
+        out = extract_section(text, "Parent")
+        assert out is not None
+        assert "parent preamble." in out
+        assert "child body." in out
+        assert "sibling body." not in out
+        # The heading line itself is excluded.
+        assert "## Parent" not in out
+
+    def test_last_section_spans_to_end(self) -> None:
+        text = "# Title\n## First\nfirst.\n## Last\nlast line one.\nlast line two.\n"
+        out = extract_section(text, "Last")
+        assert out is not None
+        # Spans both lines of the final section, excludes the earlier section.
+        # (Frontmatter parsing may drop a trailing newline, so compare loosely.)
+        assert out.splitlines() == ["last line one.", "last line two."]
+
+    def test_returns_none_for_missing_heading(self) -> None:
+        assert extract_section("# A\nbody.\n", "Nope") is None
+
+    def test_returns_none_for_empty_heading(self) -> None:
+        assert extract_section("# A\nbody.\n", "   ") is None
+
+    def test_whitespace_normalized_match(self) -> None:
+        text = "# Title\n## 1.3.  Reducing deps\nbody content.\n"
+        out = extract_section(text, "1.3. Reducing deps")
+        assert out is not None
+        assert "body content." in out
+
+    def test_strips_frontmatter_before_scanning(self) -> None:
+        text = "---\ntitle: Doc\ntags: [x]\n---\n# Title\n## Section\nsection body.\n"
+        out = extract_section(text, "Section")
+        assert out is not None
+        assert "section body." in out
+        assert "tags:" not in out
+
+    def test_first_occurrence_when_duplicate(self) -> None:
+        text = (
+            "# Title\n"
+            "## Repeat\nfirst body.\n"
+            "## Middle\nmid.\n"
+            "## Repeat\nsecond body.\n"
+        )
+        out = extract_section(text, "Repeat")
+        assert out is not None
+        assert "first body." in out
+        assert "second body." not in out
+
+
+class TestListSectionHeadings:
+    def test_returns_headings_in_order(self) -> None:
+        text = "# A\n## One\nx\n### Deep\ny\n## Two\nz\n"
+        assert list_section_headings(text) == ["A", "One", "Deep", "Two"]
+
+    def test_empty_when_no_headings(self) -> None:
+        assert list_section_headings("just plain text\nno headings here\n") == []
+
+    def test_strips_frontmatter(self) -> None:
+        text = "---\ntitle: Doc\n---\n# Only\nbody\n"
+        assert list_section_headings(text) == ["Only"]
+
+
+def test_normalize_heading_collapses_whitespace() -> None:
+    assert normalize_heading("1.3.   Reducing   deps  ") == "1.3. Reducing deps"
+    assert normalize_heading("\tA\nB\t") == "A B"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -675,6 +675,28 @@ class TestExtractSection:
         # (Frontmatter parsing may drop a trailing newline, so compare loosely.)
         assert out.splitlines() == ["last line one.", "last line two."]
 
+    def test_fenced_hash_line_acts_as_boundary(self) -> None:
+        """A '#'-prefixed line inside a code fence ends the span, matching the
+        (deliberately non-code-fence-aware) chunker. Characterises the current
+        contract so a future fence-aware change to one side cannot silently
+        desync extraction from indexing."""
+        text = (
+            "# Title\n"
+            "## Section\n"
+            "before fence.\n"
+            "```sh\n"
+            "# not really a heading\n"
+            "```\n"
+            "after fence.\n"
+            "## Next\nnext body.\n"
+        )
+        out = extract_section(text, "Section")
+        assert out is not None
+        assert "before fence." in out
+        # The fenced '#' line is treated as an H1 boundary, so the span ends
+        # there — content after the fence is not part of this section.
+        assert "after fence." not in out
+
     def test_returns_none_for_missing_heading(self) -> None:
         assert extract_section("# A\nbody.\n", "Nope") is None
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -697,6 +697,15 @@ class TestExtractSection:
         # there — content after the fence is not part of this section.
         assert "after fence." not in out
 
+    def test_empty_section_returns_empty_string_not_none(self) -> None:
+        """A present-but-empty section (heading immediately followed by a
+        same-or-higher heading) returns "" — distinct from the None that a
+        *missing* heading returns. _read_section keys 'not found' on None, so
+        this `"" is not None` boundary must hold."""
+        text = "# A\n## Empty\n## Next\nnext body.\n"
+        assert extract_section(text, "Empty") == ""
+        assert extract_section(text, "Missing") is None
+
     def test_returns_none_for_missing_heading(self) -> None:
         assert extract_section("# A\nbody.\n", "Nope") is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## What

`read(path, section=H)` returned only the **first chunk** bearing heading `H`. Any section longer than the chunk budget (default `max_chunk_words=400`) is split by the chunker into several same-heading rows, and a parent section with sub-headings is split into a preamble row plus per-subsection rows; `FTSIndex.get_section` returned the first row in `start_line` order, silently dropping the rest of the section. The reported symptom: a long "Policy corroboration" section returned only its opening paragraph, dropping the bullet list and closing paragraph.

This reconstructs the section from the document **on disk** instead of from index chunks:

- New `scanner.extract_section(text, heading)` scans the frontmatter-stripped body and returns everything from just after the heading line to the next heading at the **same or higher level** (or EOF), so the full section — body **plus any sub-sections** — comes back intact, independent of how the chunker fragmented it. Heading detection mirrors `HeadingChunker._split_at_levels` (same regex, same non-code-fence-aware behaviour) so spans line up with how documents were indexed. Section reads now also work for short documents the chunker keeps as a single whole-document chunk.
- `DocumentManager._read_section` rewritten to use it, and hardened to map the stale-index failure window — `UnicodeDecodeError`/`OSError` on read and `yaml.YAMLError` on frontmatter parse — to a clean user-facing `ValueError` instead of leaking the raw exception into the MCP error middleware. The "did you mean" suggestion list deduplicates headings (restoring the convention the removed SQL `GROUP BY` provided).
- The index-side `FTSIndex.get_section` / `list_section_headings` and the now-unused `_normalize_heading` (only used by `_read_section`) are removed; heading normalisation now lives in `scanner.normalize_heading`.

## Tests

New unit tests (`tests/test_scanner.py`): `extract_section` sub-section spanning, same/higher-level boundary, EOF span, frontmatter stripping, whitespace-normalised match, first-occurrence-on-duplicate, empty-section `""`-vs-`None` boundary, fenced-code-block boundary characterisation; `list_section_headings` ordering/dedup; `normalize_heading`.

New integration tests (`tests/test_documents_read_section.py`): budget-split full-section recovery (the regression), sub-section inclusion, sub-heading boundary, last-section-to-EOF, short-document read, heading-line exclusion, frontmatter ignored, empty-but-present section, deduped suggestions, and the unreadable-file / non-UTF-8 / malformed-frontmatter error paths.

Full suite green (2354 passed, 2 skipped); ruff + mypy clean.

## Docs

`README.md`, `docs/design.md`, `docs/tools/index.md`, and the `read` tool / `DocumentManager.read` docstrings updated from "full chunk recovery" to "full-section reconstruction".

## Review

Pre-push five-lens circus + supplementary reviewers (code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer) run to clean over three rounds; the error-path hardening, comment accuracy, dedup convention, and empty-section test gap were each surfaced and addressed before opening.

Closes #741
Refs #742 (a genuinely pre-existing, separate `yaml.YAMLError` leak in the whole-document `read()` path, surfaced during review and filed rather than bundled here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
