### PR TITLE
fix: degrade whole-document read() to None on malformed frontmatter (#742)

### DIFF
--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -244,12 +244,14 @@ class DocumentManager:
                 returns the whole document.
 
         Returns:
-            A :class:`~markdown_vault_mcp.types.NoteContent`, or ``None`` if
-            the file does not exist (whole-document mode). When ``section`` is
-            provided, the returned ``NoteContent.frontmatter`` is an empty dict
-            ``{}`` because section reads do not synthesise per-section frontmatter.
-            Call ``read(path)`` without ``section=`` to get the full document's
-            frontmatter.
+            A :class:`~markdown_vault_mcp.types.NoteContent`, or ``None`` in
+            whole-document mode if the file does not exist or exists but cannot
+            be parsed (invalid UTF-8, an I/O error, or malformed YAML
+            frontmatter — a warning is logged in those cases). When ``section``
+            is provided, the returned ``NoteContent.frontmatter`` is an empty
+            dict ``{}`` because section reads do not synthesise per-section
+            frontmatter. Call ``read(path)`` without ``section=`` to get the
+            full document's frontmatter.
 
         Raises:
             ValueError: When *section* is provided and is empty / whitespace,
@@ -297,7 +299,10 @@ class DocumentManager:
 
         try:
             note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
-        except (UnicodeDecodeError, OSError) as exc:
+        except (UnicodeDecodeError, OSError, yaml.YAMLError) as exc:
+            # yaml.YAMLError covers a file whose frontmatter became malformed on
+            # disk after indexing (the stale-index window) — degrade to None like
+            # the decode/IO failures rather than leak the raw exception (#742).
             logger.warning("read(%s): could not parse file — %s", path, exc)
             return None
 

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -142,6 +142,17 @@ class TestRead:
         assert result is not None
         assert result.folder == ""
 
+    def test_read_malformed_frontmatter_returns_none(
+        self, doc_mgr: DocumentManager, doc_vault: Path
+    ) -> None:
+        """A whole-document read of a file with a malformed YAML frontmatter
+        block degrades to None (logged warning), rather than leaking a
+        yaml.YAMLError into the caller (#742)."""
+        (doc_vault / "bad_fm.md").write_text(
+            "---\ntitle: [unclosed\n---\n# Body\ntext\n", encoding="utf-8"
+        )
+        assert doc_mgr.read("bad_fm.md") is None
+
 
 # ---------------------------------------------------------------------------
 # Write tests


### PR DESCRIPTION
## What

`DocumentManager.read(path)` (whole-document mode) wrapped `parse_note(...)` in `except (UnicodeDecodeError, OSError)`, but `parse_note` calls `frontmatter.loads(...)`, which raises `yaml.YAMLError` on a malformed YAML block. A file that was valid at index time but edited to malformed frontmatter on disk (the stale-index window) therefore leaked a raw `yaml.YAMLError` into the MCP error middleware instead of degrading like the decode/IO failure classes.

This was surfaced during the review of #743 (which hardened the parallel **section**-read path against exactly this class) and filed as #742 rather than bundled.

## Fix

Add `yaml.YAMLError` to the catch so such a file degrades to `None` with a logged warning, consistent with the existing `UnicodeDecodeError`/`OSError` handling here and with the indexing path (`scan_directory` / `process_dirty_paths` already treat `yaml.YAMLError` as a tolerable per-file failure). The `read()` Returns docstring is updated to document the None-on-unparseable degradation (which previously went unmentioned for the decode/IO cases too).

The whole-document path deliberately returns `None` (the "document unavailable" sentinel); the section path raises `ValueError` — that asymmetry is intentional and pre-existing.

## Tests

`TestRead::test_read_malformed_frontmatter_returns_none` writes a file with an unclosed YAML flow sequence into the vault and asserts `read()` returns `None` (fails by leaking `yaml.ParserError` without the fix).

Full suite green (2357 passed, 2 skipped); ruff + mypy clean. Pre-push five-lens circus + supplementary reviewers run to clean.

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
