### PR TITLE
fix: guard whole-document read()'s content read against mid-read failure (#745)

### DIFF
--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -297,16 +297,21 @@ class DocumentManager:
                     f"full document in context."
                 )
 
+        # Guard both on-disk reads (parse_note's, and the content read below)
+        # in one try: a file removed/truncated/made-unparseable on disk between
+        # the size check and here — or between the two reads — degrades to None
+        # rather than leaking the raw exception (#742, #745). yaml.YAMLError
+        # covers frontmatter that became malformed after indexing.
+        # (parse_note decodes without universal-newline translation; the content
+        # is read separately via _read_text_utf8, which applies it, so the two
+        # reads are intentionally not collapsed — see #745.)
         try:
             note = parse_note(abs_path, self._source_dir, self._chunk_strategy)
+            raw_content = _read_text_utf8(abs_path)
         except (UnicodeDecodeError, OSError, yaml.YAMLError) as exc:
-            # yaml.YAMLError covers a file whose frontmatter became malformed on
-            # disk after indexing (the stale-index window) — degrade to None like
-            # the decode/IO failures rather than leak the raw exception (#742).
             logger.warning("read(%s): could not parse file — %s", path, exc)
             return None
 
-        raw_content = _read_text_utf8(abs_path)
         etag = note.content_hash
         folder = str(Path(path).parent)
         if folder == ".":

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -142,6 +142,20 @@ class TestRead:
         assert result is not None
         assert result.folder == ""
 
+    def test_read_degrades_to_none_if_content_read_fails(
+        self, doc_mgr: DocumentManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the post-parse content read fails (e.g. the file is removed or
+        truncated between parse_note and the content read), read() degrades to
+        None rather than leaking the raw OSError/UnicodeDecodeError (#745)."""
+        import markdown_vault_mcp.managers.document as doc_mod
+
+        def _boom(_path: Path) -> str:
+            raise OSError("file vanished between reads")
+
+        monkeypatch.setattr(doc_mod, "_read_text_utf8", _boom)
+        assert doc_mgr.read("alpha.md") is None
+
     def test_read_malformed_frontmatter_returns_none(
         self, doc_mgr: DocumentManager, doc_vault: Path
     ) -> None:


### PR DESCRIPTION
## What

`DocumentManager.read(path)` (whole-document mode) read the file from disk twice: `parse_note(abs_path)` inside a `try/except`, then `_read_text_utf8(abs_path)` **outside** it. A file removed, truncated, or made non-UTF-8 between the two reads raised an unguarded `UnicodeDecodeError`/`OSError` into the MCP error middleware — the same leak class #742 closed for the first read.

## Fix

Move the content read inside the same `try`, so both on-disk reads degrade to `None` with a logged warning (consistent with the not-found / decode / IO / malformed-YAML degradation the `read()` Returns docstring already documents).

The two reads are **deliberately not collapsed into one** (the alternative the #745 Open Question raised): `parse_note` decodes via `decode_utf8` (`bytes.decode("utf-8-sig")`, no universal-newline translation) for hashing/chunking, whereas the returned content comes from `_read_text_utf8` (`Path.read_text(...)`, text mode → `\r\n` → `\n`). Reusing `parse_note`'s decoded text would silently change CRLF files' content. The extra read of a small, user-initiated whole-document read is negligible; the inline comment records the rationale.

## Tests

`TestRead::test_read_degrades_to_none_if_content_read_fails` monkeypatches `_read_text_utf8` to raise `OSError` while `parse_note` still succeeds (the only way to deterministically hit the between-reads window) and asserts `read()` returns `None`. The happy path (content returned correctly) remains covered by `test_read_existing`.

Full suite green (2358 passed, 2 skipped); ruff + mypy clean. Pre-push five-lens circus + four supplementary reviewers run to clean (zero ≥80 findings).

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
