### PR TITLE
fix: resolve git sync ref as origin/<branch> not @{upstream}

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -2192,7 +2192,7 @@ local commits are pushed in a single `git push`. On shutdown,
 `Vault.close()` flushes any pending push.
 
 Startup recovery: `GitWriteStrategy` checks for unpushed local commits
-(`git log @{upstream}..HEAD`) on first invocation and pushes them before
+(`git log origin/<branch>..HEAD`) on first invocation and pushes them before
 accepting new writes.
 
 **Deferred push mechanics**: `GitWriteStrategy` uses a `threading.Timer` that
@@ -2243,6 +2243,17 @@ Set `MARKDOWN_VAULT_MCP_GIT_LFS=false` for repos that do not use LFS, or when
   enables concurrent readers during index writes).
 - If `MARKDOWN_VAULT_MCP_GIT_LFS=true`, each successful pull tick ends with
   `git lfs pull` so LFS pointer files are resolved before reads and indexing.
+
+**Tracking-independent remote ref**: all sync operations (startup unpushed
+check, periodic `sync_once`, interactive `force_pull`/`force_push`, and the
+rebase-abort upstream restore) target `origin/<current-branch>` rather than the
+branch's configured upstream (`@{upstream}`). A managed clone is created and
+maintained by the server and may be a detached or `git clone --branch` checkout
+with no upstream tracking configured; deriving the ref from the current branch
+name (`git symbolic-ref --short HEAD`) keeps sync working regardless. When HEAD
+is detached, or the current branch has no counterpart on `origin`, resolution
+falls back to `origin/HEAD` (the remote's default branch); when neither
+resolves, the operation reports `no_remote` and is skipped.
 
 Safety branch mode for push failures is tracked separately (see #119).
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -488,8 +488,8 @@ failures; `null` for clean fast-forwards and dry-runs):
 | Reason | Meaning | `applied` |
 |--------|---------|-----------|
 | `"fetch_failed"` | `git fetch origin` exited non-zero (network / auth / proxy). HEAD did not move. | `false` |
-| `"no_remote"` | Neither `@{upstream}` nor `origin/HEAD` could be resolved on the local clone. | `false` |
-| `"rebased"` | Local and remote diverged but `git rebase @{upstream}` replayed local commits cleanly. `conflict_files` empty. | `true` |
+| `"no_remote"` | No remote-tracking ref (`origin/<branch>`, or `origin/HEAD` for a detached checkout) could be resolved on the local clone. | `false` |
+| `"rebased"` | Local and remote diverged but `git rebase origin/<branch>` replayed local commits cleanly. `conflict_files` empty. | `true` |
 | `"conflicts_resolved_with_siblings"` | Rebase hit real conflicts; resolved by accepting upstream and writing local versions as `.conflict-mcp-*` siblings (#232). `conflict_files` populated. | `true` |
 | `"conflict_resolution_failed"` | The conflict-resolution loop could not produce a recoverable working tree; rebase was aborted. HEAD did not move. | `false` |
 | `"non_fast_forward_with_conflicts"` | Rare catastrophic fallback when even the conflict-resolution path could not stabilise the working tree. HEAD did not move. | `false` |
@@ -500,7 +500,7 @@ already-up-to-date no-op):
 | Reason | Meaning | `applied` |
 |--------|---------|-----------|
 | `"dry_run_unsupported"` | Caller passed `dry_run=true`. Git has no safe local probe for "would the remote accept this," so the push leg is a deliberate no-op. | `false` |
-| `"no_remote"` | Upstream tracking branch could not be resolved (no `@{upstream}` and no `origin/HEAD`). Push not attempted. | `false` |
+| `"no_remote"` | No remote-tracking ref could be resolved (no `origin/<branch>` and no `origin/HEAD`). Push not attempted. | `false` |
 | `"non_fast_forward"` | Remote rejected the push because the local branch is not a strict descendant of the remote tip. `hint` points at `git_sync(direction='pull')` to reconcile first. | `false` |
 | `"push_failed"` | `git push origin` exited non-zero for any other reason (network, auth, server-side hook). `hint` carries the truncated stderr. | `false` |
 

--- a/src/markdown_vault_mcp/git/_run.py
+++ b/src/markdown_vault_mcp/git/_run.py
@@ -164,6 +164,59 @@ def run_git(git_root: Path, *args: str, env: dict[str, str] | None = None) -> st
     return result.stdout
 
 
+def resolve_tracking_ref(
+    git_root: Path, env: dict[str, str] | None = None
+) -> str | None:
+    """Resolve the remote-tracking ref to sync against, tracking-independent.
+
+    Managed-git sync targets ``origin/<current-branch>`` rather than the
+    branch's configured upstream (``@{upstream}``).  A managed clone is created
+    and maintained by the server, so it may be a detached or
+    ``git clone --branch`` checkout that never had upstream tracking set; in
+    that case ``@{upstream}`` does not resolve and fetch/merge/rebase silently
+    skip.  Deriving the ref from the current branch name keeps sync working
+    regardless of whether tracking was configured.
+
+    Resolution order:
+
+    1. ``origin/<branch>`` where *branch* is ``git symbolic-ref --short HEAD``
+       — the normal case.
+    2. ``origin/HEAD`` (the remote's default branch) when HEAD is detached or
+       the current branch has no counterpart on ``origin``.
+
+    Args:
+        git_root: Working-tree root used for ``git -C``.
+        env: Optional environment (e.g. from :func:`git_env`).  Pure-local ref
+            lookups do not touch the network, but the env is threaded through
+            for consistency with the rest of the call sites.
+
+    Returns:
+        The verified remote-tracking ref name (e.g. ``"origin/main"`` or
+        ``"origin/HEAD"``), or ``None`` when neither could be resolved.
+    """
+    branch_proc = run_git_capturing(
+        git_root, "symbolic-ref", "--quiet", "--short", "HEAD", env=env
+    )
+    if branch_proc.returncode == 0:
+        branch = branch_proc.stdout.strip()
+        if branch:
+            candidate = f"origin/{branch}"
+            verify = run_git_capturing(
+                git_root, "rev-parse", "--verify", "--quiet", candidate, env=env
+            )
+            if verify.returncode == 0:
+                return candidate
+
+    # Detached HEAD, or branch has no origin counterpart — fall back to the
+    # remote's default branch.
+    fallback = run_git_capturing(
+        git_root, "rev-parse", "--verify", "--quiet", "origin/HEAD", env=env
+    )
+    if fallback.returncode == 0:
+        return "origin/HEAD"
+    return None
+
+
 def run_git_capturing(
     git_root: Path, *args: str, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:

--- a/src/markdown_vault_mcp/git/conflict.py
+++ b/src/markdown_vault_mcp/git/conflict.py
@@ -37,7 +37,8 @@ def resolve_rebase_conflicts(
 ) -> list[tuple[str, str]]:
     """Resolve rebase conflicts by accepting theirs and saving ours.
 
-    Called when ``git rebase @{upstream}`` has stopped at a conflict.
+    Called when ``git rebase <ref>`` (the resolved ``origin/<branch>``
+    remote-tracking ref) has stopped at a conflict.
     For each conflicting file, saves the MCP version from
     ``REBASE_HEAD``, then accepts the upstream version via
     ``git checkout --ours``.  Continues the rebase, looping if
@@ -454,7 +455,8 @@ def write_conflict_files(
     # NOTE: this commit is pathspec-less — it commits the whole staged index,
     # not just ``paths_to_add``. That is intentional: it also captures upstream
     # content already staged during conflict resolution (by the rebase's merge,
-    # or by the ``checkout @{upstream}`` restore on the rebase-abort path). It
+    # or by the ``checkout <ref>`` (``origin/<branch>``) restore on the
+    # rebase-abort path). It
     # relies on the caller holding ``_lock`` so no unrelated change is staged.
     commit_result = subprocess.run(
         [

--- a/src/markdown_vault_mcp/git/conflict.py
+++ b/src/markdown_vault_mcp/git/conflict.py
@@ -267,6 +267,7 @@ def restore_upstream_paths(
     git_root: Path,
     env: dict[str, str] | None,
     saved: list[tuple[str, str]],
+    ref: str,
     *,
     token: str | None,
 ) -> list[tuple[str, str]]:
@@ -275,7 +276,7 @@ def restore_upstream_paths(
     After ``git rebase --abort`` the working tree reverts to the
     pre-rebase MCP state — every file in ``saved`` again contains the
     MCP version, not the upstream version.  For each path we run
-    ``git checkout @{upstream} -- <path>`` to bring back the upstream
+    ``git checkout <ref> -- <path>`` to bring back the upstream
     bytes so :func:`write_conflict_files` reads the right side
     (canonical = upstream, sibling = MCP).
 
@@ -291,6 +292,7 @@ def restore_upstream_paths(
         env: Optional GIT_ASKPASS environment.
         saved: List of ``(rel_path, mcp_content)`` tuples returned by
             :func:`resolve_conflicts_safely`.
+        ref: Remote-tracking ref to restore from (``origin/<branch>``).
         token: PAT used for redacting sensitive text in log messages.
 
     Returns:
@@ -302,7 +304,7 @@ def restore_upstream_paths(
         checkout_proc = run_git_capturing(
             git_root,
             "checkout",
-            "@{upstream}",
+            ref,
             "--",
             rel_path,
             env=env,

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -32,6 +32,7 @@ from markdown_vault_mcp.git._run import (
     cleanup_git_env,
     git_env,
     redact,
+    resolve_tracking_ref,
     run_git,
     run_git_capturing,
 )
@@ -510,6 +511,11 @@ class GitWriteStrategy:
             return
 
         try:
+            ref = self._tracking_ref(self._git_root)
+            if ref is None:
+                # No remote-tracking ref resolvable — not an error at startup.
+                logger.debug("Git: no remote ref to check for unpushed commits")
+                return
             result = subprocess.run(
                 [
                     "git",
@@ -517,7 +523,7 @@ class GitWriteStrategy:
                     str(self._git_root),
                     "log",
                     "--oneline",
-                    "@{upstream}..HEAD",
+                    f"{ref}..HEAD",
                 ],
                 capture_output=True,
                 text=True,
@@ -527,8 +533,8 @@ class GitWriteStrategy:
             return
 
         if result.returncode != 0:
-            # No upstream or no remote — not an error at startup.
-            logger.debug("Git: no upstream to check for unpushed commits")
+            # No remote-tracking ref or no remote — not an error at startup.
+            logger.debug("Git: no remote ref to check for unpushed commits")
             return
 
         if result.stdout.strip():
@@ -681,13 +687,14 @@ class GitWriteStrategy:
         git_root: Path,
         env: dict[str, str] | None,
         saved: list[tuple[str, str]],
+        ref: str,
     ) -> list[tuple[str, str]]:
         """Restore upstream content for each conflict path after rebase abort.
 
         After ``git rebase --abort`` the working tree reverts to the
         pre-rebase MCP state — every file in ``saved`` again contains the
         MCP version, not the upstream version.  For each path we run
-        ``git checkout @{upstream} -- <path>`` to bring back the upstream
+        ``git checkout <ref> -- <path>`` to bring back the upstream
         bytes so :meth:`_write_conflict_files` reads the right side
         (canonical = upstream, sibling = MCP).
 
@@ -703,12 +710,16 @@ class GitWriteStrategy:
             env: Optional GIT_ASKPASS environment.
             saved: List of ``(rel_path, mcp_content)`` tuples returned by
                 :meth:`_resolve_conflicts_safely`.
+            ref: Remote-tracking ref to restore from (``origin/<branch>``),
+                resolved by :meth:`_tracking_ref`.
 
         Returns:
             Subset of ``saved`` whose upstream restore succeeded.  May be
             empty if every checkout failed.
         """
-        return conflict.restore_upstream_paths(git_root, env, saved, token=self._token)
+        return conflict.restore_upstream_paths(
+            git_root, env, saved, ref, token=self._token
+        )
 
     def _build_pull_result_advanced(
         self,
@@ -860,12 +871,26 @@ class GitWriteStrategy:
         """
         return run_git_capturing(git_root, *args, env=env)
 
+    def _tracking_ref(
+        self, git_root: Path, env: dict[str, str] | None = None
+    ) -> str | None:
+        """Resolve the remote-tracking ref to sync against (``origin/<branch>``).
+
+        Thin instance wrapper over :func:`resolve_tracking_ref`.  Returns the
+        verified ref name (e.g. ``"origin/main"``), falling back to
+        ``origin/HEAD`` for detached / non-tracking checkouts, or ``None`` when
+        neither resolves.  Used in place of ``@{upstream}`` so sync does not
+        depend on branch tracking being configured.
+        """
+        return resolve_tracking_ref(git_root, env)
+
     def force_pull(self, *, dry_run: bool = False) -> PullResult:
         """Pull from ``origin`` synchronously and return a structured result.
 
-        The remote-tracking branch is identified by reading the upstream of
-        the current branch (``@{upstream}``) so this method works even when
-        ``origin/HEAD`` has not been set on the local clone.
+        The remote-tracking branch is resolved as ``origin/<current-branch>``
+        (see :meth:`_tracking_ref`) so this method works even when branch
+        tracking (``@{upstream}``) was never configured on the local clone —
+        falling back to ``origin/HEAD`` for a detached checkout.
 
         Acquires :attr:`_lock` for the duration so the periodic pull loop
         and the per-write commit path cannot race against the fetch /
@@ -932,23 +957,20 @@ class GitWriteStrategy:
                         from_sha, PULL_REASON_FETCH_FAILED
                     )
 
-                # Resolve the upstream-tracking branch.  Falls back to
-                # ``origin/HEAD`` so callers with a non-tracking checkout
-                # still get a reasonable answer; both yield the remote-side
-                # SHA.
+                # Resolve the remote-tracking ref (``origin/<branch>``,
+                # falling back to ``origin/HEAD`` for a non-tracking or
+                # detached checkout) and read its SHA.
+                ref = self._tracking_ref(git_root, env)
+                if ref is None:
+                    return PullResult.head_unchanged_failure(
+                        from_sha, PULL_REASON_NO_REMOTE
+                    )
                 try:
-                    remote_sha = self._git(
-                        git_root, "rev-parse", "@{upstream}", env=env
-                    ).strip()
+                    remote_sha = self._git(git_root, "rev-parse", ref, env=env).strip()
                 except subprocess.CalledProcessError:
-                    try:
-                        remote_sha = self._git(
-                            git_root, "rev-parse", "origin/HEAD", env=env
-                        ).strip()
-                    except subprocess.CalledProcessError:
-                        return PullResult.head_unchanged_failure(
-                            from_sha, PULL_REASON_NO_REMOTE
-                        )
+                    return PullResult.head_unchanged_failure(
+                        from_sha, PULL_REASON_NO_REMOTE
+                    )
 
                 if remote_sha == from_sha:
                     # Already up to date — successful no-op (applied=True even on dry_run).
@@ -1060,11 +1082,16 @@ class GitWriteStrategy:
             ``"non_fast_forward_with_conflicts"`` (rebase started but
             could not be cleanly resolved or aborted, ``applied=False``).
         """
+        # Resolve the remote-tracking ref once for the rebase target and the
+        # post-abort upstream-restore below.  ``force_pull`` already verified a
+        # ref resolves before delegating here, but fall back defensively.
+        ref = self._tracking_ref(git_root, env) or "@{upstream}"
+
         # First try a plain rebase — this handles the common case where
         # local commits touch *different* files than the upstream commits
         # and replay cleanly with no manual intervention.
         try:
-            self._git(git_root, "rebase", "@{upstream}", env=env)
+            self._git(git_root, "rebase", ref, env=env)
         except subprocess.CalledProcessError:
             # Real conflicts during rebase — resolve by accepting upstream
             # and saving the local MCP versions as Syncthing-style siblings.
@@ -1095,7 +1122,7 @@ class GitWriteStrategy:
                     return PullResult.head_unchanged_failure(
                         from_sha, PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS
                     )
-                saved = self._restore_upstream_paths(git_root, env, saved)
+                saved = self._restore_upstream_paths(git_root, env, saved, ref)
 
             if not saved:
                 logger.warning(
@@ -1188,33 +1215,29 @@ class GitWriteStrategy:
             local_head = self._head_sha(git_root)
 
             # Resolve the remote-tracking SHA before the push.  Mirrors
-            # :meth:`force_pull` — prefer ``@{upstream}`` (set when the
-            # branch was created via ``git push -u``), fall back to
-            # ``origin/HEAD`` for non-tracking checkouts.  ``origin/HEAD``
-            # alone is unreliable on freshly-pushed clones, hence the
-            # two-step lookup.
+            # :meth:`force_pull` — derive ``origin/<branch>`` from the current
+            # branch (see :meth:`_tracking_ref`), falling back to
+            # ``origin/HEAD`` for a detached checkout, so the lookup does not
+            # depend on ``@{upstream}`` tracking being configured.
+            ref = self._tracking_ref(git_root)
             try:
-                remote_sha_before = self._git(
-                    git_root, "rev-parse", "@{upstream}"
-                ).strip()
+                if ref is None:
+                    raise subprocess.CalledProcessError(1, "git rev-parse")
+                remote_sha_before = self._git(git_root, "rev-parse", ref).strip()
             except subprocess.CalledProcessError:
-                try:
-                    remote_sha_before = self._git(
-                        git_root, "rev-parse", "origin/HEAD"
-                    ).strip()
-                except subprocess.CalledProcessError:
-                    return PushResult(
-                        applied=False,
-                        commits_pushed=0,
-                        remote_sha_before="",
-                        remote_sha_after="",
-                        reason=PUSH_REASON_NO_REMOTE,
-                        hint=(
-                            "No upstream tracking branch is configured for the "
-                            "current branch.  Run `git push -u origin <branch>` "
-                            "from the working tree once to establish tracking."
-                        ),
-                    )
+                return PushResult(
+                    applied=False,
+                    commits_pushed=0,
+                    remote_sha_before="",
+                    remote_sha_after="",
+                    reason=PUSH_REASON_NO_REMOTE,
+                    hint=(
+                        "No remote-tracking branch (origin/<branch>) could be "
+                        "resolved for the current branch.  Push the branch to "
+                        "origin once (`git push -u origin <branch>`) so the "
+                        "remote-tracking ref exists."
+                    ),
+                )
 
             if dry_run:
                 # Document the limitation rather than fake a result.
@@ -1352,21 +1375,11 @@ class GitWriteStrategy:
         try:
             env = self._git_env()
             with self._quiesce_writes(), self._lock:
-                upstream_check = subprocess.run(
-                    [
-                        "git",
-                        "-C",
-                        str(git_root),
-                        "rev-parse",
-                        "--verify",
-                        "@{upstream}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    env=env,
-                )
-                if upstream_check.returncode != 0:
-                    logger.info("Git pull: no upstream configured; skipping fetch")
+                ref = self._tracking_ref(git_root, env)
+                if ref is None:
+                    logger.info(
+                        "Git pull: no remote-tracking ref resolvable; skipping fetch"
+                    )
                     return False
 
                 old_head = subprocess.run(
@@ -1393,7 +1406,7 @@ class GitWriteStrategy:
                             str(git_root),
                             "merge",
                             "--ff-only",
-                            "@{upstream}",
+                            ref,
                         ],
                         capture_output=True,
                         text=True,
@@ -1416,7 +1429,7 @@ class GitWriteStrategy:
                                 "-C",
                                 str(git_root),
                                 "rebase",
-                                "@{upstream}",
+                                ref,
                             ],
                             capture_output=True,
                             text=True,
@@ -1460,7 +1473,7 @@ class GitWriteStrategy:
                                         "-C",
                                         str(git_root),
                                         "checkout",
-                                        "@{upstream}",
+                                        ref,
                                         "--",
                                         rel_path,
                                     ],
@@ -1590,24 +1603,20 @@ class GitWriteStrategy:
         if git_root is None:
             return
 
-        # Guard: do not start the loop if there is no upstream configured.
+        # Guard: do not start the loop if no remote-tracking ref resolves.
         # This check is intentionally independent of the sync_once() call in
         # sync_from_remote_before_index() — start() may be called even when
         # the startup sync was skipped (pull_interval_s changed at runtime,
         # or Vault.start() called directly by library users).  The double
-        # upstream check is harmless (costs one git subprocess) and avoids
-        # noisy "no upstream" logs on every tick.
+        # check is harmless (costs one git subprocess) and avoids noisy
+        # "no remote ref" logs on every tick.
         env = None
         try:
             env = self._git_env()
-            upstream_check = subprocess.run(
-                ["git", "-C", str(git_root), "rev-parse", "--verify", "@{upstream}"],
-                capture_output=True,
-                text=True,
-                env=env,
-            )
-            if upstream_check.returncode != 0:
-                logger.info("Git pull: no upstream configured; pull loop disabled")
+            if self._tracking_ref(git_root, env) is None:
+                logger.info(
+                    "Git pull: no remote-tracking ref resolvable; pull loop disabled"
+                )
                 return
         except FileNotFoundError:
             logger.info("Git pull: git not found on PATH; pull loop disabled")

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -591,7 +591,8 @@ class GitWriteStrategy:
     ) -> list[tuple[str, str]]:
         """Resolve rebase conflicts by accepting theirs and saving ours.
 
-        Called when ``git rebase @{upstream}`` has stopped at a conflict.
+        Called when ``git rebase <ref>`` (the resolved ``origin/<branch>``
+        remote-tracking ref) has stopped at a conflict.
         For each conflicting file, saves the MCP version from
         ``REBASE_HEAD``, then accepts the upstream version via
         ``git checkout --ours``.  Continues the rebase, looping if
@@ -1034,6 +1035,7 @@ class GitWriteStrategy:
                         git_root=git_root,
                         env=env,
                         from_sha=from_sha,
+                        ref=ref,
                     )
 
                 # Fast-forward succeeded.  ``remote_sha`` is the new HEAD —
@@ -1055,6 +1057,7 @@ class GitWriteStrategy:
         git_root: Path,
         env: dict[str, str] | None,
         from_sha: str,
+        ref: str,
     ) -> PullResult:
         """Attempt rebase + Syncthing-style sibling resolution.
 
@@ -1070,6 +1073,10 @@ class GitWriteStrategy:
             git_root: Working-tree root used for git ``-C``.
             env: Optional GIT_ASKPASS environment for token auth.
             from_sha: HEAD SHA captured before the fetch.
+            ref: Remote-tracking ref (``origin/<branch>``) already resolved
+                and verified non-``None`` by :meth:`force_pull` before
+                delegating here.  Used as the rebase target and the
+                post-abort upstream-restore ref.
 
         Returns:
             :class:`PullResult` whose ``reason`` is one of
@@ -1082,11 +1089,6 @@ class GitWriteStrategy:
             ``"non_fast_forward_with_conflicts"`` (rebase started but
             could not be cleanly resolved or aborted, ``applied=False``).
         """
-        # Resolve the remote-tracking ref once for the rebase target and the
-        # post-abort upstream-restore below.  ``force_pull`` already verified a
-        # ref resolves before delegating here, but fall back defensively.
-        ref = self._tracking_ref(git_root, env) or "@{upstream}"
-
         # First try a plain rebase — this handles the common case where
         # local commits touch *different* files than the upstream commits
         # and replay cleanly with no manual intervention.

--- a/src/markdown_vault_mcp/git/types.py
+++ b/src/markdown_vault_mcp/git/types.py
@@ -57,13 +57,14 @@ class PullResult:
 
             * ``"fetch_failed"`` — ``git fetch origin`` exited non-zero
               (network error, auth failure, etc.); HEAD did not move.
-            * ``"no_remote"`` — neither ``@{upstream}`` nor
-              ``origin/HEAD`` could be resolved on the local clone.
+            * ``"no_remote"`` — no remote-tracking ref
+              (``origin/<branch>``, or ``origin/HEAD`` for a detached
+              checkout) could be resolved on the local clone.
             * ``"non_fast_forward_with_conflicts"`` — local and remote
               histories diverged and the conflict-resolution path
               failed to produce a usable result; HEAD did not move.
             * ``"rebased"`` — local and remote histories diverged but
-              ``git rebase @{upstream}`` replayed local commits cleanly
+              ``git rebase origin/<branch>`` replayed local commits cleanly
               on top of the upstream with no manual intervention.
               ``applied`` is ``True``; ``conflict_files`` is empty.
             * ``"conflicts_resolved_with_siblings"`` — local and remote
@@ -152,9 +153,9 @@ class PushResult:
               this push be accepted by the remote", so the call is a
               no-op that sets this code.  HEAD and the remote are not
               touched.
-            * ``"no_remote"`` — the upstream tracking branch could not
-              be resolved (no ``@{upstream}`` and no ``origin/HEAD``);
-              the push was not attempted.
+            * ``"no_remote"`` — no remote-tracking ref could be resolved
+              (no ``origin/<branch>`` and no ``origin/HEAD``); the push
+              was not attempted.
             * ``"non_fast_forward"`` — the remote rejected the push
               because the local branch is not a strict descendant of
               the remote tip.  ``hint`` points the caller at

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -471,7 +471,7 @@ class TestForceMethodsErrorBranches:
     def test_force_pull_checkout_failure_drops_path_from_siblings(
         self, git_repo_pair: GitRepoPair, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Failed ``git checkout @{upstream} -- <path>`` drops the path from siblings.
+        """Failed ``git checkout origin/<branch> -- <path>`` drops the path from siblings.
 
         After the rebase-in-progress check trips the defensive abort, the
         working tree reverts to the pre-rebase MCP content.
@@ -489,7 +489,7 @@ class TestForceMethodsErrorBranches:
           calling ``git rebase --continue`` (so the next ``rebase_in_progress``
           probe returns True and the abort + restored loop both fire);
         * stubs ``subprocess.run`` to fail specifically on the
-          ``checkout @{upstream}`` invocation that the restored loop runs.
+          ``checkout origin/<branch>`` invocation that the restored loop runs.
 
         With every checkout failing, the saved list ends up empty and
         ``_force_pull_rebase_fallback`` surfaces ``conflict_resolution_failed``
@@ -530,14 +530,14 @@ class TestForceMethodsErrorBranches:
 
         monkeypatch.setattr(strategy, "_resolve_rebase_conflicts", _stub_resolve)
 
-        # Patch subprocess.run on the git module to fail the checkout
-        # ``@{upstream}`` call.  All other subprocess.run calls (including
-        # the rebase --abort the fallback runs) pass through to the real
-        # implementation.
+        # Patch subprocess.run on the git module to fail the
+        # ``checkout origin/main -- <path>`` restore call.  All other
+        # subprocess.run calls (including the rebase --abort the fallback
+        # runs) pass through to the real implementation.
         real_run = _real_subprocess.run
 
         def _patched_run(args: list[str], **kwargs: object) -> object:
-            if isinstance(args, list) and "checkout" in args and "@{upstream}" in args:
+            if isinstance(args, list) and "checkout" in args and "origin/main" in args:
                 return _real_subprocess.CompletedProcess(
                     args=args,
                     returncode=1,

--- a/tests/test_git_tracking_ref.py
+++ b/tests/test_git_tracking_ref.py
@@ -11,6 +11,7 @@ whose upstream tracking has been unset.
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.git._run import resolve_tracking_ref
@@ -43,8 +44,6 @@ class TestResolveTrackingRef:
         """
         _run_git(git_repo_pair.local_path, "branch", "--unset-upstream")
         # Sanity: @{upstream} no longer resolves.
-        import subprocess
-
         upstream = subprocess.run(
             ["git", "-C", str(git_repo_pair.local_path), "rev-parse", "@{upstream}"],
             capture_output=True,
@@ -132,3 +131,84 @@ class TestForcePullWithoutTracking:
         assert result.fast_forward is True
         assert result.commits_pulled == 1
         assert (git_repo_pair.local_path / "new.md").exists()
+
+    def test_force_pull_rebases_on_non_tracking_checkout(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """Divergent histories rebase via the derived ref without ``@{upstream}``.
+
+        The rebase fallback targets the resolved ``origin/<branch>`` ref, not
+        ``@{upstream}``.  This drives ``git rebase origin/main`` on a clone
+        whose upstream tracking has been unset — the exact path the fix exists
+        for, which the fast-forward case above never reaches.
+        """
+        from markdown_vault_mcp.git import (
+            PULL_REASON_REBASED,
+            GitWriteStrategy,
+        )
+
+        # Remote advances on file A; local commits a different file B.
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_nt_rebase",
+            file_name="remote_only.md",
+            body="remote\n",
+        )
+        (git_repo_pair.local_path / "local_only.md").write_text("local\n")
+        _run_git(git_repo_pair.local_path, "add", "local_only.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local divergent")
+        _run_git(git_repo_pair.local_path, "branch", "--unset-upstream")
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_pull()
+
+        assert result.applied is True
+        assert result.fast_forward is False
+        assert result.reason == PULL_REASON_REBASED
+        assert (git_repo_pair.local_path / "remote_only.md").exists()
+        assert (git_repo_pair.local_path / "local_only.md").exists()
+
+    def test_force_pull_resolves_conflict_with_siblings_on_non_tracking_checkout(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """Same-file divergence resolves to siblings via the derived ref.
+
+        Drives the rebase fallback's conflict-resolution branch (rebase onto
+        ``origin/main`` then Syncthing-style sibling write) on a clone with
+        upstream tracking unset, so the ``ref``-threaded rebase target is
+        exercised end-to-end on the non-tracking conflict path.
+        """
+        from markdown_vault_mcp.git import (
+            PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS,
+            GitWriteStrategy,
+        )
+
+        # Remote and local edit the SAME file differently → rebase conflict.
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_nt_conflict",
+            file_name="README.md",
+            body="# remote-edited\n",
+        )
+        (git_repo_pair.local_path / "README.md").write_text("# local-edited\n")
+        _run_git(git_repo_pair.local_path, "add", "README.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local edit")
+        _run_git(git_repo_pair.local_path, "branch", "--unset-upstream")
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_pull()
+
+        assert result.applied is True
+        assert result.fast_forward is False
+        assert result.reason == PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS
+        assert result.conflict_files
+        for rel in result.conflict_files:
+            assert (git_repo_pair.local_path / rel).exists(), rel

--- a/tests/test_git_tracking_ref.py
+++ b/tests/test_git_tracking_ref.py
@@ -1,0 +1,134 @@
+"""Tests for tracking-independent remote-ref resolution.
+
+Managed-git sync resolves the remote-tracking ref as ``origin/<branch>``
+(:func:`markdown_vault_mcp.git._run.resolve_tracking_ref`) rather than the
+branch's configured upstream (``@{upstream}``).  A managed clone may be a
+detached or ``git clone --branch`` checkout that never had upstream tracking
+configured; these tests pin the behaviour for the normal, non-tracking,
+detached, and no-remote cases, plus an end-to-end ``force_pull`` on a clone
+whose upstream tracking has been unset.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.git._run import resolve_tracking_ref
+from tests.fixtures.git import _run_git
+from tests.test_git_force_methods import _seed_remote_commit
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.fixtures.git import GitRepoPair
+
+
+class TestResolveTrackingRef:
+    """:func:`resolve_tracking_ref` derives ``origin/<branch>`` locally."""
+
+    def test_normal_clone_returns_origin_branch(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """A clone on ``main`` resolves to ``origin/main``."""
+        assert resolve_tracking_ref(git_repo_pair.local_path) == "origin/main"
+
+    def test_non_tracking_checkout_still_resolves(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """Resolution works even with no ``@{upstream}`` tracking configured.
+
+        This is the core of the fix: unsetting the upstream makes
+        ``@{upstream}`` fail, but ``origin/main`` still exists and is
+        derived from the current branch name.
+        """
+        _run_git(git_repo_pair.local_path, "branch", "--unset-upstream")
+        # Sanity: @{upstream} no longer resolves.
+        import subprocess
+
+        upstream = subprocess.run(
+            ["git", "-C", str(git_repo_pair.local_path), "rev-parse", "@{upstream}"],
+            capture_output=True,
+            text=True,
+        )
+        assert upstream.returncode != 0
+
+        assert resolve_tracking_ref(git_repo_pair.local_path) == "origin/main"
+
+    def test_detached_head_falls_back_to_origin_head(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """A detached HEAD with no current branch falls back to ``origin/HEAD``."""
+        # origin/HEAD is not set by the manual-clone fixture; establish it.
+        _run_git(git_repo_pair.local_path, "remote", "set-head", "origin", "main")
+        head_sha = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+        _run_git(git_repo_pair.local_path, "checkout", head_sha)
+
+        assert resolve_tracking_ref(git_repo_pair.local_path) == "origin/HEAD"
+
+    def test_no_remote_returns_none(self, tmp_path: Path) -> None:
+        """A repo with a commit but no ``origin`` resolves to ``None``."""
+        assert resolve_tracking_ref(_no_remote_repo(tmp_path)) is None
+
+
+def _no_remote_repo(tmp_path: Path) -> Path:
+    """Create a repo with one commit on ``main`` and no ``origin`` remote."""
+    repo = tmp_path / "no_remote"
+    repo.mkdir()
+    _run_git(repo, "init", "--initial-branch=main")
+    _run_git(repo, "config", "user.email", "t@example.com")
+    _run_git(repo, "config", "user.name", "T")
+    (repo / "f.md").write_text("x\n")
+    _run_git(repo, "add", "f.md")
+    _run_git(repo, "commit", "-m", "c")
+    return repo
+
+
+class TestNoRemoteRefGuards:
+    """Sync entry points bail out when no remote-tracking ref resolves."""
+
+    def test_sync_once_skips_without_remote_ref(self, tmp_path: Path) -> None:
+        """:meth:`sync_once` returns ``False`` when ``origin/<branch>`` is absent."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        repo = _no_remote_repo(tmp_path)
+        strategy = GitWriteStrategy(enable_pull=True, enable_push=False, repo_path=repo)
+        assert strategy.sync_once(repo) is False
+
+    def test_start_disables_loop_without_remote_ref(self, tmp_path: Path) -> None:
+        """:meth:`start` does not spin up the pull thread without a remote ref."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        repo = _no_remote_repo(tmp_path)
+        strategy = GitWriteStrategy(enable_pull=True, enable_push=False, repo_path=repo)
+        strategy.start(repo_path=repo, pull_interval_s=600)
+        assert strategy._pull_thread is None
+
+
+class TestForcePullWithoutTracking:
+    """End-to-end: ``force_pull`` works without ``@{upstream}`` configured."""
+
+    def test_force_pull_pulls_on_non_tracking_checkout(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """A clean ff pull succeeds even after the upstream tracking is unset."""
+        from markdown_vault_mcp.git import GitWriteStrategy
+
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_no_track",
+            file_name="new.md",
+            body="from remote\n",
+        )
+        _run_git(git_repo_pair.local_path, "branch", "--unset-upstream")
+
+        strategy = GitWriteStrategy(
+            enable_pull=True,
+            enable_push=False,
+            repo_path=git_repo_pair.local_path,
+        )
+        result = strategy.force_pull()
+
+        assert result.applied is True
+        assert result.fast_forward is True
+        assert result.commits_pulled == 1
+        assert (git_repo_pair.local_path / "new.md").exists()


### PR DESCRIPTION
## Summary

Managed-git sync resolved the remote-tracking branch through `@{upstream}`, coupling it to branch *tracking* being configured on the local clone. A managed clone may be a detached or `git clone --branch` checkout with no upstream set — in which case `@{upstream}` does not resolve and fetch/merge/rebase/push silently degrade (the vault never syncs).

This PR makes ref resolution **tracking-independent**: a single `resolve_tracking_ref()` helper derives `origin/<current-branch>` from `git symbolic-ref --short HEAD`, falling back to `origin/HEAD` only when HEAD is detached (or the branch has no counterpart on `origin`). It stays entirely within the existing "everything is `origin`" invariant — **no new config, no env var, no behavior change for normally-tracking clones**.

## Changes

- `git/_run.py`: new `resolve_tracking_ref(git_root, env)` helper.
- `git/strategy.py`: route `_push_if_unpushed`, `force_pull`, `_force_pull_rebase_fallback`, `force_push`, `sync_once`, and `start` through it; replace the `@{upstream}` / `origin/HEAD` two-step lookups.
- `git/conflict.py`: `restore_upstream_paths` now takes the resolved `ref` for the rebase-abort `checkout <ref> -- <path>`.
- `git/types.py`: `no_remote` / `rebased` reason docstrings updated.
- Docs: `docs/design.md` (git-sync section) + `docs/tools/index.md` (reason tables).
- Tests: new `tests/test_git_tracking_ref.py` (normal / non-tracking / detached / no-remote resolution, no-remote-ref guards, and an end-to-end `force_pull` on a clone with tracking unset); updated the checkout-failure simulation in `test_git_force_methods.py` to match the new ref.

## Gates

- `uv run pytest -x -q` — green
- `uv run ruff check` + `ruff format --check` — clean
- `uv run mypy src/ tests/` — no issues
- Patch coverage 89% (diff-cover vs `main`, gate ≥80%)

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
