### PR TITLE
feat: add human-readable title annotations to all tools (#751)

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -9,39 +9,39 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 
 ## Quick Reference
 
-| Tool | Category | Description |
-|------|----------|-------------|
-| [`search`](#search) | Read | Hybrid full-text + semantic search with optional frontmatter filters |
-| [`read`](#read) | Read | Read a document or attachment by relative path |
-| [`list_documents`](#list_documents) | Read | List indexed documents and optionally attachments |
-| [`list_folders`](#list_folders) | Read | List all folder paths in the vault |
-| [`list_tags`](#list_tags) | Read | List all unique frontmatter tag values |
-| [`stats`](#stats) | Read | Get vault statistics and capabilities |
-| [`embeddings_status`](#embeddings_status) | Read | Check embedding provider and vector index status |
-| [`get_index_status`](#get_index_status) | Read | Check background FTS build state (queryable / building / failed) |
-| [`get_backlinks`](#get_backlinks) | Read | Find all documents that link to a given document |
-| [`get_outlinks`](#get_outlinks) | Read | Find all links from a document, with existence check |
-| [`get_broken_links`](#get_broken_links) | Read | Find all links pointing to non-existent documents |
-| [`get_similar`](#get_similar) | Read | Find semantically similar notes by document path |
-| [`get_recent`](#get_recent) | Read | Get the most recently modified notes |
-| [`get_context`](#get_context) | Read | Get a consolidated context dossier for a note |
-| [`get_orphan_notes`](#get_orphan_notes) | Read | Find notes with no inbound or outbound links |
-| [`get_most_linked`](#get_most_linked) | Read | Find the most-linked-to notes ranked by backlink count |
-| [`get_connection_path`](#get_connection_path) | Read | Find the shortest path between two notes via link graph |
-| [`get_history`](#get_history) | Read (git) | List commits that touched a note, attachment, or the whole vault |
-| [`get_diff`](#get_diff) | Read (git) | Return a diff of a note or attachment between two points in history |
-| [`reindex`](#reindex) | Admin | Force a full reindex of the vault |
-| [`build_embeddings`](#build_embeddings) | Admin | Build or rebuild vector embeddings |
-| [`write`](#write) | Write | Create or overwrite a document or attachment |
-| [`edit`](#edit) | Write | Replace a unique text span in a document |
-| [`delete`](#delete) | Write | Delete a document or attachment |
-| [`rename`](#rename) | Write | Rename/move a document or attachment |
-| [`fetch`](#fetch) | Write | Download from URL and save to vault |
-| [`git_sync`](#git_sync) | Write (git) | Force an immediate git pull / push / both, bypassing the periodic loops |
-| [`create_download_link`](#create_download_link) | Transfer | Mint a one-time capability URL to download a vault file (HTTP/SSE only) |
-| [`create_upload_link`](#create_upload_link) | Transfer | Mint a one-time capability URL to upload bytes to a fixed vault path (HTTP/SSE only) |
-| [`browse_vault`](#browse_vault) | Apps | Open the vault explorer SPA |
-| [`show_context`](#show_context) | Apps | Open the Context Card for a note |
+| Tool | Title | Category | Description |
+|------|-------|----------|-------------|
+| [`search`](#search) | Search Vault | Read | Hybrid full-text + semantic search with optional frontmatter filters |
+| [`read`](#read) | Read Note | Read | Read a document or attachment by relative path |
+| [`list_documents`](#list_documents) | List Documents | Read | List indexed documents and optionally attachments |
+| [`list_folders`](#list_folders) | List Folders | Read | List all folder paths in the vault |
+| [`list_tags`](#list_tags) | List Tags | Read | List all unique frontmatter tag values |
+| [`stats`](#stats) | Vault Stats | Read | Get vault statistics and capabilities |
+| [`embeddings_status`](#embeddings_status) | Embeddings Status | Read | Check embedding provider and vector index status |
+| [`get_index_status`](#get_index_status) | Index Status | Read | Check background FTS build state (queryable / building / failed) |
+| [`get_backlinks`](#get_backlinks) | Backlinks | Read | Find all documents that link to a given document |
+| [`get_outlinks`](#get_outlinks) | Outlinks | Read | Find all links from a document, with existence check |
+| [`get_broken_links`](#get_broken_links) | Broken Links | Read | Find all links pointing to non-existent documents |
+| [`get_similar`](#get_similar) | Similar Notes | Read | Find semantically similar notes by document path |
+| [`get_recent`](#get_recent) | Recent Notes | Read | Get the most recently modified notes |
+| [`get_context`](#get_context) | Note Context | Read | Get a consolidated context dossier for a note |
+| [`get_orphan_notes`](#get_orphan_notes) | Orphan Notes | Read | Find notes with no inbound or outbound links |
+| [`get_most_linked`](#get_most_linked) | Most-Linked Notes | Read | Find the most-linked-to notes ranked by backlink count |
+| [`get_connection_path`](#get_connection_path) | Connection Path | Read | Find the shortest path between two notes via link graph |
+| [`get_history`](#get_history) | Note History | Read (git) | List commits that touched a note, attachment, or the whole vault |
+| [`get_diff`](#get_diff) | Note Diff | Read (git) | Return a diff of a note or attachment between two points in history |
+| [`reindex`](#reindex) | Reindex Vault | Admin | Force a full reindex of the vault |
+| [`build_embeddings`](#build_embeddings) | Build Embeddings | Admin | Build or rebuild vector embeddings |
+| [`write`](#write) | Write Note | Write | Create or overwrite a document or attachment |
+| [`edit`](#edit) | Edit Note | Write | Replace a unique text span in a document |
+| [`delete`](#delete) | Delete Note | Write | Delete a document or attachment |
+| [`rename`](#rename) | Rename Note | Write | Rename/move a document or attachment |
+| [`fetch`](#fetch) | Fetch to Vault | Write | Download from URL and save to vault |
+| [`git_sync`](#git_sync) | Sync with Git | Write (git) | Force an immediate git pull / push / both, bypassing the periodic loops |
+| [`create_download_link`](#create_download_link) | Download Link | Transfer | Mint a one-time capability URL to download a vault file (HTTP/SSE only) |
+| [`create_upload_link`](#create_upload_link) | Upload Link | Transfer | Mint a one-time capability URL to upload bytes to a fixed vault path (HTTP/SSE only) |
+| [`browse_vault`](#browse_vault) | Browse Vault | Apps | Open the vault explorer SPA |
+| [`show_context`](#show_context) | Context Card | Apps | Open the Context Card for a note |
 
 ---
 

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -241,6 +241,7 @@ def register_apps(mcp: FastMCP) -> None:
         tags={"apps-ui"},
         icons=_TOOL_ICONS["browse_vault"],
         annotations={
+            "title": "Browse Vault",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -307,6 +308,7 @@ def register_apps(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["vault_context"],
         annotations={
+            "title": "Vault Context",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -342,6 +344,7 @@ def register_apps(mcp: FastMCP) -> None:
         tags={"apps-ui"},
         icons=_TOOL_ICONS["show_context"],
         annotations={
+            "title": "Context Card",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -399,6 +402,7 @@ def register_apps(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["vault_graph_neighborhood"],
         annotations={
+            "title": "Graph Neighborhood",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -593,6 +597,7 @@ def register_apps(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["vault_graph_hubs"],
         annotations={
+            "title": "Graph Hubs",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -706,6 +711,7 @@ def register_apps(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["vault_list"],
         annotations={
+            "title": "Vault List",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -772,6 +778,7 @@ def register_apps(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["vault_read"],
         annotations={
+            "title": "Vault Read",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -810,6 +817,7 @@ def register_apps(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["vault_search"],
         annotations={
+            "title": "Vault Search",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,

--- a/src/markdown_vault_mcp/_server_tools/git.py
+++ b/src/markdown_vault_mcp/_server_tools/git.py
@@ -200,6 +200,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_history"],
         annotations={
+            "title": "Note History",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -270,6 +271,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_diff"],
         annotations={
+            "title": "Note Diff",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -359,6 +361,7 @@ def register(mcp: FastMCP) -> None:
         tags={"write", "git-managed"},
         icons=_TOOL_ICONS["git_sync"],
         annotations={
+            "title": "Sync with Git",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": False,

--- a/src/markdown_vault_mcp/_server_tools/graph.py
+++ b/src/markdown_vault_mcp/_server_tools/graph.py
@@ -21,6 +21,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_backlinks"],
         annotations={
+            "title": "Backlinks",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -100,6 +101,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_outlinks"],
         annotations={
+            "title": "Outlinks",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -177,6 +179,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_broken_links"],
         annotations={
+            "title": "Broken Links",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -244,6 +247,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_orphan_notes"],
         annotations={
+            "title": "Orphan Notes",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -307,6 +311,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_most_linked"],
         annotations={
+            "title": "Most-Linked Notes",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -363,6 +368,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_connection_path"],
         annotations={
+            "title": "Connection Path",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,

--- a/src/markdown_vault_mcp/_server_tools/index.py
+++ b/src/markdown_vault_mcp/_server_tools/index.py
@@ -19,6 +19,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["embeddings_status"],
         annotations={
+            "title": "Embeddings Status",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -49,6 +50,7 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool(
         annotations={
+            "title": "Index Status",
             "readOnlyHint": True,
             "openWorldHint": False,
         },
@@ -91,6 +93,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["reindex"],
         annotations={
+            "title": "Reindex Vault",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -128,6 +131,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["build_embeddings"],
         annotations={
+            "title": "Build Embeddings",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": True,

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -21,6 +21,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["search"],
         annotations={
+            "title": "Search Vault",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -137,6 +138,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["read"],
         annotations={
+            "title": "Read Note",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -220,6 +222,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["list_documents"],
         annotations={
+            "title": "List Documents",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -292,6 +295,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["list_folders"],
         annotations={
+            "title": "List Folders",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -343,6 +347,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["list_tags"],
         annotations={
+            "title": "List Tags",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -399,6 +404,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["stats"],
         annotations={
+            "title": "Vault Stats",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -462,6 +468,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_similar"],
         annotations={
+            "title": "Similar Notes",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -553,6 +560,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_recent"],
         annotations={
+            "title": "Recent Notes",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -614,6 +622,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["get_context"],
         annotations={
+            "title": "Note Context",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -124,6 +124,7 @@ def register(mcp: FastMCP) -> None:
         tags={"write"},
         icons=_TOOL_ICONS["write"],
         annotations={
+            "title": "Write Note",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -217,6 +218,7 @@ def register(mcp: FastMCP) -> None:
         tags={"write"},
         icons=_TOOL_ICONS["edit"],
         annotations={
+            "title": "Edit Note",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": False,
@@ -306,6 +308,7 @@ def register(mcp: FastMCP) -> None:
         tags={"write"},
         icons=_TOOL_ICONS["delete"],
         annotations={
+            "title": "Delete Note",
             "readOnlyHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
@@ -349,6 +352,7 @@ def register(mcp: FastMCP) -> None:
         tags={"write"},
         icons=_TOOL_ICONS["rename"],
         annotations={
+            "title": "Rename Note",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": False,
@@ -409,6 +413,7 @@ def register(mcp: FastMCP) -> None:
         tags={"write"},
         icons=_TOOL_ICONS["fetch"],
         annotations={
+            "title": "Fetch to Vault",
             "readOnlyHint": False,
             "destructiveHint": False,
             # Treat like write — calling twice with the same inputs is safe

--- a/src/markdown_vault_mcp/_server_transfer.py
+++ b/src/markdown_vault_mcp/_server_transfer.py
@@ -258,6 +258,7 @@ def register_transfer(mcp: FastMCP, config: VaultConfig) -> None:
     @mcp.tool(
         icons=_TOOL_ICONS["create_download_link"],
         annotations={
+            "title": "Download Link",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": False,
@@ -293,6 +294,7 @@ def register_transfer(mcp: FastMCP, config: VaultConfig) -> None:
         tags={"write"},
         icons=_TOOL_ICONS["create_upload_link"],
         annotations={
+            "title": "Upload Link",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": False,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -314,6 +314,48 @@ class TestToolAnnotations:
         assert ann.readOnlyHint is False
         assert ann.destructiveHint is True
 
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_every_registered_tool_has_title(self) -> None:
+        """Every registered tool exposes a non-empty annotations.title (#751).
+
+        Title-aware clients (notably VS Code's MCP client, which honours only
+        ``title`` and ``readOnlyHint`` among annotations) render the title as
+        the tool's label; without it they fall back to the raw machine name.
+
+        Enumerates the *full* tool registry via ``_list_tools()``, not the
+        client-facing ``list_tools()``: the latter filters out app-only tools
+        (``visibility=["app"]``), which would let a titleless app tool slip
+        past this guard. Builds the surface via the ``register_*`` functions
+        directly — bypassing ``make_server``'s tag-based disable passes — so
+        disabled-by-default tools (``git_sync``, the HTTP-only transfer tools)
+        are asserted too. ``get_server_info`` is not in this set: it is added
+        only by ``make_server`` via ``fastmcp-pvl-core``'s
+        ``register_server_info_tool``, which sets no title.
+        """
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp._server_apps import register_apps
+        from markdown_vault_mcp._server_tools import register_tools
+        from markdown_vault_mcp._server_transfer import register_transfer
+        from markdown_vault_mcp.config import VaultConfig
+
+        mcp = FastMCP("title-test")
+        register_tools(mcp)
+        register_apps(mcp)
+        register_transfer(mcp, VaultConfig.from_env())
+
+        tools = await mcp._list_tools()
+        missing = sorted(
+            t.name for t in tools if t.annotations is None or not t.annotations.title
+        )
+        assert not missing, f"tools missing annotations.title: {missing}"
+
+        # Titles are bulk-authored, so guard against a copy-paste collision
+        # (two tools sharing one label is as useless to the user as none).
+        titles = [t.annotations.title for t in tools if t.annotations]
+        dupes = sorted({t for t in titles if titles.count(t) > 1})
+        assert not dupes, f"duplicate tool titles: {dupes}"
+
 
 # ---------------------------------------------------------------------------
 # Read-only tools

--- a/uv.lock
+++ b/uv.lock
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "3.0.2"
+version = "3.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary
Registered MCP tools carried behavioural hints and icons but no `title` annotation. VS Code's MCP client honours only `title` and `readOnlyHint` among annotations, so tools surfaced under their raw machine names (`get_backlinks`, `git_sync`) instead of friendly labels.

This adds a descriptive `annotations.title` to **all 37 registered tools**:
- the 31 client-visible reader/writer/graph/index/git/transfer/apps tools, and
- the 6 app-only (`visibility=["app"]`) SPA tools.

## Changes
- **Titles** on every `@mcp.tool` across `_server_tools/{reader,writer,graph,index,git}.py`, `_server_apps.py`, `_server_transfer.py`.
- **Enforcement test** (`TestToolAnnotations::test_every_registered_tool_has_title`): builds the full tool surface via the `register_*` functions directly (bypassing `make_server`'s tag-disable passes so `git_sync` and the HTTP-only transfer tools are covered) and enumerates the **full registry** via `_list_tools()` — not the client-facing `list_tools()`, which filters out app-only tools and would let a titleless app tool slip past. Asserts every registered tool has a non-empty title, and that titles are unique (guards against a copy-paste collision). A future tool registered without a title fails CI.
- **Docs**: a `Title` column added to the Quick Reference table in `docs/tools/index.md`.

## Out of scope (tracked separately)
- `get_server_info` is registered by `fastmcp-pvl-core`'s `register_server_info_tool`, which sets no title and exposes no hook for one. Tracked upstream at pvliesdonk/fastmcp-pvl-core#197; it is correctly excluded from the enforcement test (not built by the `register_*` functions).
- The systemic gap — no shared "tool registration checklist" so per-tool concerns get missed — is tracked at pvliesdonk/fastmcp-server-template#200.

## Note
`uv.lock` carries a one-line self-version correction (3.0.2 → 3.0.4): `main`'s lock lagged `pyproject.toml`, and pre-commit's `uv` regenerates it. Included to keep the hook green.

## Testing
- `uv run pytest -q` — 2368 passed, 2 skipped.
- `uv run ruff check . && uv run ruff format --check .` — clean.
- `uv run mypy src/ tests/` — clean.

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._