### PR TITLE
chore: bump fastmcp-pvl-core to >=4.1.0 for get_server_info title (#754)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "fastmcp-pvl-core>=4.0.0,<5",
+    "fastmcp-pvl-core>=4.1.0,<5",
     "typer>=0.12",
 
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -330,7 +330,9 @@ class TestToolAnnotations:
         disabled-by-default tools (``git_sync``, the HTTP-only transfer tools)
         are asserted too. ``get_server_info`` is not in this set: it is added
         only by ``make_server`` via ``fastmcp-pvl-core``'s
-        ``register_server_info_tool``, which sets no title.
+        ``register_server_info_tool``, not the ``register_*`` functions; its
+        title (``"Server Info"`` on the >=4.1.0 core floor) is asserted
+        separately by ``test_get_server_info_has_title``.
         """
         from fastmcp import FastMCP
 
@@ -355,6 +357,19 @@ class TestToolAnnotations:
         titles = [t.annotations.title for t in tools if t.annotations]
         dupes = sorted({t for t in titles if titles.count(t) > 1})
         assert not dupes, f"duplicate tool titles: {dupes}"
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_get_server_info_has_title(self) -> None:
+        """get_server_info is core-owned; its title comes from the
+        fastmcp-pvl-core >=4.1.0 floor (register_server_info_tool's title
+        param, default "Server Info"). It is registered by make_server, not
+        the register_* functions, so it sits outside the registry sweep above
+        and gets its own integration assertion (#754).
+        """
+        server = make_server()
+        tool = await server.get_tool("get_server_info")
+        assert tool.annotations is not None
+        assert tool.annotations.title == "Server Info"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -739,15 +739,15 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "4.0.1"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/05/7e3410fd62a35ed178544744e0c89b08228035a66e543864cab27a426ef8/fastmcp_pvl_core-4.0.1.tar.gz", hash = "sha256:2321481c93d559c4a272b90b81627965a0e0c78873533ba4ed53650a3b2f04be", size = 353049, upload-time = "2026-06-20T11:33:10.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/c7/b98a1c76eba4bf7443122bb7dce4240625ce7ae34a50658bf29270e9e2fd/fastmcp_pvl_core-4.1.0.tar.gz", hash = "sha256:e21a2d9d284d6252dd1cdfe332d36798b0f8b99a9154a6dfbc52cc2996eb83ce", size = 353304, upload-time = "2026-06-27T14:27:09.205Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/de/e6491b2a9cc5e72f20c6e073a4fc8ff45869a40e33938fc57b8868745c27/fastmcp_pvl_core-4.0.1-py3-none-any.whl", hash = "sha256:8228ca4a88b49855c5c8b0ef50cdd5479a62e1f06564960fc046867ecc200cfe", size = 52208, upload-time = "2026-06-20T11:33:09.203Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/f36aa3e95b8cb991159060143cbcc998615eea54dee93955f9ffab5a348a/fastmcp_pvl_core-4.1.0-py3-none-any.whl", hash = "sha256:63fbe679f51f079ef2c54a8ac0be81f705c3e97a334e62b3353c7e57a0d4acd6", size = 52328, upload-time = "2026-06-27T14:27:08.042Z" },
 ]
 
 [package.optional-dependencies]
@@ -1391,7 +1391,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.3" },
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "fastmcp-pvl-core", specifier = ">=4.0.0,<5" },
+    { name = "fastmcp-pvl-core", specifier = ">=4.1.0,<5" },
     { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25" },
     { name = "httpx", marker = "extra == 'embeddings-api'", specifier = ">=0.25" },


### PR DESCRIPTION
## Summary
Completes the `get_server_info` half of the #751 tool-title work. Core [v4.1.0](https://github.com/pvliesdonk/fastmcp-pvl-core/releases/tag/v4.1.0) added a `title` parameter (default `"Server Info"`) to `register_server_info_tool` (pvliesdonk/fastmcp-pvl-core#198). Raising the dependency floor makes `get_server_info` ship a human-readable title to title-aware clients (VS Code) — the one tool #751 could not title locally because it is core-owned.

## Changes
- `pyproject.toml`: `fastmcp-pvl-core` floor `>=4.0.0,<5` → `>=4.1.0,<5`; `uv.lock` re-locked to 4.1.0.
- New integration test `TestToolAnnotations::test_get_server_info_has_title`: builds a server via `make_server()` and asserts `get_server_info` exposes `annotations.title == "Server Info"`. It goes through the real composition root (not the `register_*` registry sweep, which doesn't include `get_server_info`), so it would fail against a too-old core.
- Updated the sibling `test_every_registered_tool_has_title` docstring: its old "`register_server_info_tool` sets no title" note was true under the 4.0.x floor but stale as of 4.1.0; it now points at the new dedicated test.

## Notes
- Manifest version-lockstep gate (#6) not triggered — this is a dependency-floor bump, not a project version change; `server.json` / `plugin.json` / `.mcp.json` stay at 3.0.4.

## Testing
- `uv run pytest -q` — 2369 passed, 2 skipped (against core 4.1.0).
- `uv run ruff check . && uv run ruff format --check .` — clean.
- `uv run mypy src/ tests/` — clean.

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._