### PR TITLE
feat: move_folder folder-level move with vault-wide link rewrite

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -47,6 +47,7 @@ traceback
 accessors
 affordances
 allowlist
+allowlisted
 ANDed
 APIs
 async
@@ -167,6 +168,7 @@ stderr
 streamable
 subprocess
 subqueries
+subtree
 svg
 syscalls
 teardown

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 > **Upgrading.** As of this release, `search` returns query-relevant snippets in the `content` field by default (approximately 200 words). Pass `snippet_words=0` to recover the prior full-chunk behaviour, or use `read(path, section=heading)` to fetch the full section after seeing a snippet. Documents are also re-chunked on next `reindex` to honour the adaptive `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` threshold (default 400).
 - **Frontmatter-aware** — indexes YAML frontmatter fields, supports required field enforcement
 - **Incremental reindexing** — hash-based change detection, only re-processes modified files; an automatic boot-time reconciliation pass picks up changes made while no server was running, and the vector index converges to the reconciled chunk set (embedding exactly the delta)
-- **Write operations** — create, edit, delete, rename documents with automatic index updates
+- **Write operations** — create, edit, delete, rename documents, and move entire folder subtrees with automatic index updates
 - **Attachment support** — read, write, delete, and list non-markdown files (PDFs, images, etc.)
 - **Git integration** — optional auto-commit and push on every write via `GIT_ASKPASS`
 - **OIDC authentication** — optional token-based auth for HTTP deployments (Authelia, Keycloak, etc.)
-- **MCP tools** — 31 LLM-visible tools including search, read, write, edit, delete, rename, git history, manual git sync, one-time transfer links, and admin operations; plus 6 app-only tools for MCP Apps clients
+- **MCP tools** — 32 LLM-visible tools including search, read, write, edit, delete, rename, move_folder, git history, manual git sync, one-time transfer links, and admin operations; plus 6 app-only tools for MCP Apps clients
 - **MCP resources** — 9 resources exposing vault configuration, statistics, tags, folders, document outlines, similar notes, recent notes, and an interactive SPA
 - **MCP prompts** — 7 prompt templates including template-driven note creation
 <!-- DOMAIN-END -->
@@ -383,6 +383,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `edit` | Replace text in a document — exact match, line-range, or scoped match with normalized fallback |
 | `delete` | Delete a document or attachment and its index entries |
 | `rename` | Rename/move a document or attachment, updating all index entries; pass `update_links=true` to also rewrite backlinks in other notes |
+| `move_folder` | Move an entire folder subtree to a new prefix, rewriting all vault links that point into the moved subtree in one call |
 | `list_documents` | List indexed documents; pass `include_attachments=true` to also list non-markdown files |
 | `list_folders` | List all folder paths in the vault |
 | `list_tags` | List all unique frontmatter tag values |
@@ -409,7 +410,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `browse_vault` | Open the vault explorer SPA in a supporting MCP Apps client |
 | `show_context` | Open the Context Card for a specific note in a supporting MCP Apps client |
 
-Write tools (`write`, `edit`, `delete`, `rename`, `fetch`, `git_sync`, `create_upload_link`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`. `git_sync` additionally requires managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` set).
+Write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, `create_upload_link`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`. `git_sync` additionally requires managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` set).
 
 `browse_vault` and `show_context` are LLM-visible in all clients; when called in an MCP Apps-capable client they open the interactive SPA. Six additional internal tools (`vault_context`, `vault_list`, `vault_read`, `vault_search`, `vault_graph_neighborhood`, `vault_graph_hubs`) use `visibility="app"` and are used by the SPA only — they are never visible to the LLM.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1606,7 +1606,10 @@ destination file list is computed. If ANY destination path already exists the
 call raises immediately and nothing is moved. Merging into a pre-existing
 target directory is allowed as long as no individual file would collide. The
 gate is atomic (all-or-nothing) but there is **no rollback of link rewrites**
-once the move phase begins.
+once the move phase begins. The move phase itself is not OS-failure-atomic: an
+OS error during file moves (permission error, full disk, concurrent removal)
+can leave the subtree partially moved with the index unchanged; a subsequent
+`reindex` reconciles the index with the on-disk state.
 
 *File move policy*: all files in the subtree are moved (`.md` notes,
 allowlisted attachments, and any other files). Only `.md` files are

--- a/docs/design.md
+++ b/docs/design.md
@@ -1597,6 +1597,43 @@ source-directory-relative links (such as `../notes/target.md`) are rewritten
 with the correct new relative path from the source file's directory.
 `update_links` is silently ignored for attachments (non-`.md` files).
 
+**`move_folder()` behavior**: a dedicated tool (not an overload of `rename`)
+that moves an entire folder subtree to a new prefix in one call. It is the
+folder-level analogue of `rename`.
+
+*Collision gate (atomic pre-check)*: before any file is moved, the full
+destination file list is computed. If ANY destination path already exists the
+call raises immediately and nothing is moved. Merging into a pre-existing
+target directory is allowed as long as no individual file would collide. The
+gate is atomic (all-or-nothing) but there is **no rollback of link rewrites**
+once the move phase begins.
+
+*File move policy*: all files in the subtree are moved (`.md` notes,
+allowlisted attachments, and any other files). Only `.md` files are
+re-indexed; non-markdown files are moved on disk without index updates.
+
+*Link rewrite*: after all files are moved, a single pass over the vault
+rewrites every outbound link (markdown links and wikilinks) whose target falls
+under the old prefix. This covers links between documents inside the moved
+subtree (intra-subtree) and backlinks from outside documents that pointed into
+the subtree. The rewrite applies a prefix-shift: `old_dir/…` to `new_dir/…`.
+Rewriting is **best-effort**: a source document that cannot be rewritten is
+logged at `WARNING` and its path is appended to `failed_links` in the result;
+this does not abort the move. A single `mark_paths_dirty` batch
+drives one `resolve_vault_wikilinks()` pass so the index is consistent after
+the call.
+
+*Empty-source-dir cleanup*: after the move the (now-empty) source directory is
+removed from disk.
+
+*Read-only vaults*: the call raises `ReadOnlyError` immediately.
+
+*Result fields*: `old_dir` (str), `new_dir` (str), `files_moved` (int),
+`updated_links` (int), `failed_links` (list[str]).
+
+*Out of scope*: transactional rollback of link rewrites, dry-run/preview, and
+cross-vault moves.
+
 **`list_documents()` pattern parameter**: if provided, `pattern` is a Unix glob
 matched against the relative path using `fnmatch.fnmatch()`. Example:
 `pattern="Journal/*.md"` returns only documents in the Journal folder.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -36,6 +36,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`edit`](#edit) | Edit Note | Write | Replace a unique text span in a document |
 | [`delete`](#delete) | Delete Note | Write | Delete a document or attachment |
 | [`rename`](#rename) | Rename Note | Write | Rename/move a document or attachment |
+| [`move_folder`](#move_folder) | Move Folder | Write | Move an entire folder subtree and rewrite vault links |
 | [`fetch`](#fetch) | Fetch to Vault | Write | Download from URL and save to vault |
 | [`git_sync`](#git_sync) | Sync with Git | Write (git) | Force an immediate git pull / push / both, bypassing the periodic loops |
 | [`create_download_link`](#create_download_link) | Download Link | Transfer | Mint a one-time capability URL to download a vault file (HTTP/SSE only) |
@@ -349,6 +350,36 @@ Rename a document or attachment, or move it to a different folder. Parent direct
 | `new_path` | string | Target relative path. Fails if `new_path` already exists |
 
 **Returns:** `{"old_path": "drafts/idea.md", "new_path": "projects/idea.md"}`
+
+### `move_folder`
+
+Move an entire folder subtree to a new prefix and rewrite all vault links that point into the moved subtree. This is the folder-level analogue of `rename`.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `old_dir` | string | Current folder path (relative, no trailing slash, such as `"drafts/2024"`) |
+| `new_dir` | string | Target folder path (relative, such as `"archive/2024"`) |
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `old_dir` | string | Source folder path (echoed back) |
+| `new_dir` | string | Destination folder path (echoed back) |
+| `files_moved` | integer | Number of files moved on disk |
+| `updated_links` | integer | Number of source documents whose links were rewritten |
+| `failed_links` | array of strings | Paths of documents whose link rewrite failed (best-effort) |
+
+**Atomicity:** before any file is moved, every destination path is checked. If any single destination file already exists the call raises and **nothing is moved**. Merging into a pre-existing target directory is allowed as long as no per-file collision exists.
+
+**Link rewrites:** after the move, all vault links pointing into the subtree (markdown links and wikilinks, including links between documents inside the moved subtree and backlinks from outside) are rewritten in a single pass. Rewriting is best-effort; a document that cannot be rewritten is listed in `failed_links` and does not abort the move.
+
+**Index:** updated immediately after the call; no `reindex` needed.
+
+!!! warning
+    Link rewrites are not rolled back if the process is interrupted after the move phase begins. Use `rename` for single-file moves where full atomicity is required.
 
 ### `fetch`
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -379,7 +379,7 @@ Move an entire folder subtree to a new prefix and rewrite all vault links that p
 **Index:** updated immediately after the call; no `reindex` needed.
 
 !!! warning
-    Link rewrites are not rolled back if the process is interrupted after the move phase begins. Use `rename` for single-file moves where full atomicity is required.
+    Link rewrites are not rolled back if the process is interrupted after the move phase begins. The move phase itself is not OS-failure-atomic: an OS error during file moves (permission error, full disk, concurrent removal) can leave the subtree partially moved with the index unchanged; run `reindex` to recover. Use `rename` for single-file moves where full atomicity is required.
 
 ### `fetch`
 

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -437,7 +437,10 @@ def register(mcp: FastMCP) -> None:
         The move is atomic at the gate: if any destination file already exists,
         the call fails before moving anything. Link rewrites are best-effort —
         a source that cannot be rewritten is reported in failed_links rather
-        than aborting the move.
+        than aborting the move. Note: an OS error during the move phase itself
+        (permission error, full disk, concurrent file removal) can leave the
+        subtree partially moved with the index unchanged; call 'reindex' to
+        reconcile the index with the on-disk state.
 
         Args:
             old_dir: Relative source folder prefix (e.g. "drafts").

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -415,7 +415,10 @@ def register(mcp: FastMCP) -> None:
         annotations={
             "title": "Move Folder",
             "readOnlyHint": False,
-            "destructiveHint": False,
+            # Removes the source directory tree (shutil.rmtree) and can leave a
+            # partial state on a mid-move OS error — materially larger blast
+            # radius than single-file rename, so flag it destructive.
+            "destructiveHint": True,
             "idempotentHint": False,
         },
     )

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -411,6 +411,55 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool(
         tags={"write"},
+        icons=_TOOL_ICONS["rename"],
+        annotations={
+            "title": "Move Folder",
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": False,
+        },
+    )
+    async def move_folder(
+        old_dir: str,
+        new_dir: str,
+        vault: Vault = Depends(get_vault),
+    ) -> dict[str, Any]:
+        """Move an entire folder subtree to a new location in one call,
+        rewriting every link across the vault that points into the moved
+        subtree — the folder-level analogue of 'rename'.
+
+        Moves all files under old_dir (.md notes, attachments, and any other
+        files) to the matching path under new_dir, preserving structure. Links
+        between documents inside the subtree and backlinks from outside are all
+        rewritten. The search index is updated immediately — do not call
+        'reindex' afterward.
+
+        The move is atomic at the gate: if any destination file already exists,
+        the call fails before moving anything. Link rewrites are best-effort —
+        a source that cannot be rewritten is reported in failed_links rather
+        than aborting the move.
+
+        Args:
+            old_dir: Relative source folder prefix (e.g. "drafts").
+            new_dir: Relative target folder prefix (e.g. "archive/2026").
+                May be an existing folder — files merge in; a per-file name
+                clash aborts the whole move.
+
+        Returns:
+            Dict with old_dir (str), new_dir (str), files_moved (int),
+            updated_links (int), and failed_links (list[str]).
+
+        Raises:
+            DocumentNotFoundError: If old_dir is missing, not a folder, or empty.
+            DocumentExistsError: If any destination file already exists.
+            ValueError: If a path fails traversal validation or the two paths
+                are nested.
+        """
+        result = await asyncio.to_thread(vault.writer.move_folder, old_dir, new_dir)
+        return asdict(result)
+
+    @mcp.tool(
+        tags={"write"},
         icons=_TOOL_ICONS["fetch"],
         annotations={
             "title": "Fetch to Vault",

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -203,6 +203,10 @@ class WriterFacet:
             DocumentExistsError: If any destination file already exists.
             ValueError: If either path escapes the vault or the two paths are
                 nested.
+            OSError: If the OS raises during the move phase (e.g. a permission
+                error or full disk). The collision gate prevents pre-existing
+                destination clashes, but a mid-move OS error leaves the subtree
+                partially moved with the index unchanged; reindex recovers.
         """
         return self._doc_mgr.move_folder(old_dir, new_dir)
 

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from markdown_vault_mcp.types import (
         DeleteResult,
         EditResult,
+        MoveFolderResult,
         RenameResult,
         WriteResult,
     )
@@ -176,6 +177,34 @@ class WriterFacet:
             if_match=if_match,
             update_links=update_links,
         )
+
+    def move_folder(self, old_dir: str, new_dir: str) -> MoveFolderResult:
+        """Move a folder subtree to a new prefix, rewriting links vault-wide.
+
+        Moves every file under *old_dir* (notes, attachments, and other
+        files) to the matching path under *new_dir* and rewrites all links
+        across the vault that point into the moved subtree, including links
+        between documents inside it.
+
+        The move is atomic at the gate (a destination-file collision aborts
+        before anything moves); link rewrites are best-effort.
+
+        Args:
+            old_dir: Relative source folder prefix (e.g. ``"drafts"``).
+            new_dir: Relative target folder prefix (e.g. ``"archive/2026"``).
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.MoveFolderResult`.
+
+        Raises:
+            ReadOnlyError: If the vault is read-only.
+            DocumentNotFoundError: If *old_dir* is missing, not a directory,
+                or empty.
+            DocumentExistsError: If any destination file already exists.
+            ValueError: If either path escapes the vault or the two paths are
+                nested.
+        """
+        return self._doc_mgr.move_folder(old_dir, new_dir)
 
     def write_attachment(
         self,

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -1062,6 +1062,58 @@ class DocumentManager:
             updated_links=updated_links,
         )
 
+    def _rewrite_one_source(
+        self,
+        source_abs: Path,
+        rewrites: list[tuple[str, str, str | None, str, str]],
+        source_path: str,
+    ) -> str:
+        """Rewrite all link targets in a single source file in one pass.
+
+        Reads *source_abs*, applies every ``(link_type, raw_target, fragment,
+        target_old, target_new)`` rewrite using the source's *current* vault
+        path (which, for a moved source, is its new path), and writes the
+        result back atomically.
+
+        Args:
+            source_abs: Absolute path of the source file to rewrite (its
+                current on-disk location).
+            rewrites: One tuple per link to rewrite:
+                ``(link_type, raw_target, fragment, target_old, target_new)``.
+            source_path: Vault-relative path of the source at its current
+                location — used for correct relative-path computation.
+
+        Returns:
+            The rewritten file content.
+        """
+        content = _read_text_utf8(source_abs)
+        for link_type, raw_target, fragment, target_old, target_new in rewrites:
+            new_raw = _compute_new_raw_target(
+                link_type,
+                raw_target,
+                fragment,
+                target_new,
+                source_path=source_path,
+                old_path=target_old,
+            )
+            content = _apply_link_replacement(content, link_type, raw_target, new_raw)
+        with tempfile.NamedTemporaryFile(
+            dir=source_abs.parent,
+            mode="w",
+            encoding="utf-8",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp.write(content)
+            tmp_name = tmp.name
+        shutil.copymode(source_abs, tmp_name)
+        try:
+            Path(tmp_name).replace(source_abs)
+        except Exception:
+            Path(tmp_name).unlink(missing_ok=True)
+            raise
+        return content
+
     def _update_backlinks(
         self,
         old_path: str,
@@ -1115,37 +1167,17 @@ class DocumentManager:
                         source_path,
                     )
                     continue
-                content = _read_text_utf8(source_abs)
-                for row in rows:
-                    new_raw = _compute_new_raw_target(
+                rewrites = [
+                    (
                         row["link_type"],
                         row["raw_target"],
                         row["fragment"],
+                        old_path,
                         new_path,
-                        source_path=source_path,
-                        old_path=old_path,
                     )
-                    content = _apply_link_replacement(
-                        content,
-                        row["link_type"],
-                        row["raw_target"],
-                        new_raw,
-                    )
-                with tempfile.NamedTemporaryFile(
-                    dir=source_abs.parent,
-                    mode="w",
-                    encoding="utf-8",
-                    suffix=".tmp",
-                    delete=False,
-                ) as tmp:
-                    tmp.write(content)
-                    tmp_name = tmp.name
-                shutil.copymode(source_abs, tmp_name)
-                try:
-                    Path(tmp_name).replace(source_abs)
-                except Exception:
-                    Path(tmp_name).unlink(missing_ok=True)
-                    raise
+                    for row in rows
+                ]
+                content = self._rewrite_one_source(source_abs, rewrites, source_path)
                 pending_callbacks.append((source_abs, content))
                 dirty_paths.append(source_path)
             except (

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -1252,6 +1252,12 @@ class DocumentManager:
             DocumentExistsError: If any destination file already exists.
             ValueError: If either path escapes the vault, is the vault root,
                 or one path is nested inside the other.
+            OSError: If the OS raises during the move phase (e.g. a permission
+                error, full disk, or concurrent file removal). The pre-move
+                collision gate prevents destination clashes, but an OS error
+                mid-move can leave the subtree partially moved with the index
+                unchanged; a subsequent reindex reconciles the index with the
+                on-disk state.
         """
         self._check_writable()
 

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -37,6 +37,7 @@ from markdown_vault_mcp.types import (
     AttachmentContent,
     DeleteResult,
     EditResult,
+    MoveFolderResult,
     NoteContent,
     RenameResult,
     WriteOperation,
@@ -225,6 +226,29 @@ class DocumentManager:
             )
         abs_path = (self._source_dir / path).resolve()
         if not abs_path.is_relative_to(self._source_dir.resolve()):
+            raise ValueError(f"Path traversal detected: {path}")
+        return abs_path
+
+    def _validate_dir_path(self, path: str) -> Path:
+        """Resolve a relative folder path and validate it is inside the vault.
+
+        Unlike :meth:`_validate_path`, this does not require a ``.md`` suffix —
+        it is for directory prefixes used by :meth:`move_folder`.
+
+        Args:
+            path: Relative folder path (e.g. ``"drafts"`` or ``"a/b"``).
+
+        Returns:
+            The resolved absolute path.
+
+        Raises:
+            ValueError: If the path is empty or escapes the source directory.
+        """
+        if not path or path in (".", "/"):
+            raise ValueError(f"Invalid folder path: {path!r}")
+        abs_path = (self._source_dir / path).resolve()
+        source_root = self._source_dir.resolve()
+        if abs_path == source_root or not abs_path.is_relative_to(source_root):
             raise ValueError(f"Path traversal detected: {path}")
         return abs_path
 
@@ -1199,3 +1223,177 @@ class DocumentManager:
                     exc_info=True,
                 )
         return pending_callbacks, dirty_paths
+
+    def move_folder(self, old_dir: str, new_dir: str) -> MoveFolderResult:
+        """Move an entire folder subtree to a new prefix, rewriting links.
+
+        Moves every file under *old_dir* (``.md`` notes, allowlisted
+        attachments, and any other files) to the matching path under
+        *new_dir*, preserving relative structure. All links across the vault
+        that point into the moved subtree — including links *between*
+        documents inside it — are rewritten in a single pass.
+
+        The move is atomic at the gate: if any destination file path already
+        exists, the operation raises before moving anything. Link rewrites are
+        best-effort: a source that cannot be rewritten is logged and reported
+        in :attr:`MoveFolderResult.failed_links` without aborting the move.
+
+        Args:
+            old_dir: Relative source folder prefix (e.g. ``"drafts"``).
+            new_dir: Relative target folder prefix (e.g. ``"archive/2026"``).
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.MoveFolderResult`.
+
+        Raises:
+            ReadOnlyError: If the vault is read-only.
+            DocumentNotFoundError: If *old_dir* is missing, not a directory,
+                or empty.
+            DocumentExistsError: If any destination file already exists.
+            ValueError: If either path escapes the vault, is the vault root,
+                or one path is nested inside the other.
+        """
+        self._check_writable()
+
+        with self._file_write_lock:
+            old_abs = self._validate_dir_path(old_dir)
+            new_abs = self._validate_dir_path(new_dir)
+
+            if not old_abs.is_dir():
+                raise DocumentNotFoundError(f"Folder not found: {old_dir}")
+
+            # Reject nesting in either direction (would corrupt the prefix map).
+            if old_abs == new_abs:
+                raise ValueError("old_dir and new_dir are the same folder")
+            if new_abs.is_relative_to(old_abs) or old_abs.is_relative_to(new_abs):
+                raise ValueError("move_folder: old_dir and new_dir must not be nested")
+
+            # 1. Enumerate the subtree (filesystem, not the index — attachments
+            #    and other files are not indexed). Build the old->new path map.
+            old_rel = old_dir.strip("/")
+            new_rel = new_dir.strip("/")
+            attachment_exts = self._effective_attachment_extensions()
+
+            moves: list[tuple[Path, Path]] = []  # (src_abs, dst_abs)
+            md_map: dict[str, str] = {}  # old_rel_path -> new_rel_path (.md only)
+            attachment_moves: list[tuple[Path, str]] = []  # (dst_abs, new_rel)
+            for src_abs in sorted(old_abs.rglob("*")):
+                if not src_abs.is_file():
+                    continue
+                rel_within = src_abs.relative_to(old_abs).as_posix()
+                old_path = f"{old_rel}/{rel_within}"
+                new_path = f"{new_rel}/{rel_within}"
+                dst_abs = (self._source_dir / new_path).resolve()
+                moves.append((src_abs, dst_abs))
+                if old_path.endswith(".md"):
+                    md_map[old_path] = new_path
+                else:
+                    suffix = src_abs.suffix.lstrip(".").lower()
+                    if "*" in attachment_exts or suffix in attachment_exts:
+                        attachment_moves.append((dst_abs, new_path))
+
+            if not moves:
+                raise DocumentNotFoundError(f"Folder is empty: {old_dir}")
+
+            # 2. Atomic collision gate — fail before moving anything.
+            for _src_abs, dst_abs in moves:
+                if dst_abs.exists():
+                    rel = dst_abs.relative_to(self._source_dir.resolve()).as_posix()
+                    raise DocumentExistsError(f"Target already exists: {rel}")
+
+            # 3. Capture backlinks for every moved note BEFORE the move, while
+            #    the index still reflects old paths. Annotate each row with its
+            #    target's old/new path so a multi-target rewrite is possible.
+            annotated: list[tuple[str, dict[str, Any]]] = []  # (target_old, row)
+            for target_old in md_map:
+                for row in self._fts.get_backlinks(target_old):
+                    annotated.append((target_old, row))
+
+            # 4. Move every file.
+            for src_abs, dst_abs in moves:
+                dst_abs.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src_abs), str(dst_abs))
+
+            # 5. Single-pass link rewrite. Group annotated rows by source,
+            #    remapping a source that moved to its new path so it is read at
+            #    its new on-disk location.
+            by_source: dict[str, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
+            for target_old, row in annotated:
+                src_old = row["source_path"]
+                src_new = md_map.get(src_old, src_old)  # remap if inside subtree
+                by_source[src_new].append((target_old, row))
+
+            pending_callbacks: list[tuple[Path, str]] = []
+            dirty_paths: list[str] = []
+            failed_links: list[str] = []
+            for source_path, items in by_source.items():
+                try:
+                    source_abs = self._validate_path(source_path)
+                    if not source_abs.is_file():
+                        logger.warning(
+                            "move_folder: skipping %s — file not found",
+                            source_path,
+                        )
+                        failed_links.append(source_path)
+                        continue
+                    rewrites = [
+                        (
+                            row["link_type"],
+                            row["raw_target"],
+                            row["fragment"],
+                            target_old,
+                            md_map[target_old],
+                        )
+                        for target_old, row in items
+                    ]
+                    content = self._rewrite_one_source(
+                        source_abs, rewrites, source_path
+                    )
+                    pending_callbacks.append((source_abs, content))
+                    dirty_paths.append(source_path)
+                except (OSError, UnicodeDecodeError, ValueError, sqlite3.Error) as exc:
+                    logger.warning(
+                        "move_folder: failed to update %s: %s", source_path, exc
+                    )
+                    failed_links.append(source_path)
+                except Exception as exc:
+                    logger.warning(
+                        "move_folder: unexpected error updating %s: %s",
+                        source_path,
+                        exc,
+                        exc_info=True,
+                    )
+                    failed_links.append(source_path)
+
+            # 6. Index: purge old note paths, reparse new note paths, plus the
+            #    rewritten sources. A single mark_paths_dirty batch makes the
+            #    writer run resolve_vault_wikilinks() once.
+            if self._mark_paths_dirty is not None:
+                dirty: list[str] = []
+                dirty.extend(md_map.keys())  # old paths -> purged
+                dirty.extend(md_map.values())  # new paths -> reparsed
+                dirty.extend(dirty_paths)  # rewritten sources
+                self._mark_paths_dirty(dirty)
+
+            # 7. Callbacks: rename for every moved note + allowlisted attachment,
+            #    edit for every rewritten source.
+            for _old_path, new_path in md_map.items():
+                new_note_abs = (self._source_dir / new_path).resolve()
+                self._on_write_callback(
+                    new_note_abs, _read_text_utf8(new_note_abs), "rename"
+                )
+            for dst_abs, _new_rel in attachment_moves:
+                self._on_write_callback(dst_abs, "", "rename")
+            for src_abs, src_content in pending_callbacks:
+                self._on_write_callback(src_abs, src_content, "edit")
+
+            # 8. Remove the now-empty source tree.
+            shutil.rmtree(old_abs, ignore_errors=True)
+
+        return MoveFolderResult(
+            old_dir=old_dir,
+            new_dir=new_dir,
+            files_moved=len(moves),
+            updated_links=len(pending_callbacks),
+            failed_links=failed_links,
+        )

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -1382,7 +1382,11 @@ class DocumentManager:
                 self._mark_paths_dirty(dirty)
 
             # 7. Callbacks: rename for every moved note + allowlisted attachment,
-            #    edit for every rewritten source.
+            #    edit for every rewritten source. A source inside the moved
+            #    subtree already gets a "rename" callback (it is in md_map), so
+            #    skip its redundant "edit" to avoid a duplicate git commit.
+            moved_note_paths = set(md_map.values())
+            source_root = self._source_dir.resolve()
             for _old_path, new_path in md_map.items():
                 new_note_abs = (self._source_dir / new_path).resolve()
                 self._on_write_callback(
@@ -1391,10 +1395,21 @@ class DocumentManager:
             for dst_abs, _new_rel in attachment_moves:
                 self._on_write_callback(dst_abs, "", "rename")
             for src_abs, src_content in pending_callbacks:
+                src_rel = src_abs.relative_to(source_root).as_posix()
+                if src_rel in moved_note_paths:
+                    continue
                 self._on_write_callback(src_abs, src_content, "edit")
 
-            # 8. Remove the now-empty source tree.
-            shutil.rmtree(old_abs, ignore_errors=True)
+            # 8. Remove the now-empty source tree. A leftover file (e.g. from a
+            #    concurrent write) is logged rather than silently swallowed.
+            try:
+                shutil.rmtree(old_abs)
+            except OSError as exc:
+                logger.warning(
+                    "move_folder: failed to remove source tree %s: %s",
+                    old_dir,
+                    exc,
+                )
 
         return MoveFolderResult(
             old_dir=old_dir,

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -99,7 +99,9 @@ def _build_default_instructions(*, read_only: bool) -> str:
         else (
             " Write tools: use 'write' to create, 'edit' for targeted changes "
             "(read first), 'rename' to move (pass update_links=True to fix links "
-            "in other notes), 'delete' to remove. All write operations update the "
+            "in other notes), 'delete' to remove. Use 'move_folder(old_dir, new_dir)' "
+            "to move an entire folder subtree and rewrite all vault links in one call. "
+            "All write operations update the "
             "search index immediately — never call 'reindex' after write, edit, "
             "delete, or rename."
         )

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -278,6 +278,28 @@ class RenameResult:
     updated_links: int = 0
 
 
+@dataclass(frozen=True)
+class MoveFolderResult:
+    """Result of a folder-level move operation.
+
+    Attributes:
+        old_dir: Original relative folder prefix that was moved.
+        new_dir: New relative folder prefix after the move.
+        files_moved: Total number of files moved (notes + attachments +
+            other files).
+        updated_links: Number of source documents whose links were
+            successfully rewritten to point into the new prefix.
+        failed_links: Relative paths of source documents whose link rewrite
+            failed (best-effort; logged and skipped, not aborted).
+    """
+
+    old_dir: str
+    new_dir: str
+    files_moved: int
+    updated_links: int = 0
+    failed_links: list[str] = field(default_factory=list)
+
+
 @dataclass
 class IndexStats:
     """Statistics from :meth:`~markdown_vault_mcp.facets.index.IndexFacet.build_index`.

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -278,9 +278,14 @@ class RenameResult:
     updated_links: int = 0
 
 
-@dataclass(frozen=True)
+@dataclass
 class MoveFolderResult:
     """Result of a folder-level move operation.
+
+    Not frozen — ``failed_links`` is a mutable list (matching the other
+    result dataclasses such as :class:`RenameResult` and :class:`IndexStats`),
+    and a frozen dataclass holding a list neither prevents in-place mutation
+    nor stays hashable.
 
     Attributes:
         old_dir: Original relative folder prefix that was moved.

--- a/tests/test_move_folder.py
+++ b/tests/test_move_folder.py
@@ -257,6 +257,58 @@ def test_move_folder_preserves_nested_structure(vault: Vault, source_dir: Path) 
     assert result.files_moved == 2
 
 
+def test_move_folder_mid_move_oserror_leaves_subtree_partial(
+    vault: Vault, source_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OSError on the 2nd shutil.move call leaves the subtree partially moved.
+
+    Asserts the documented partial-failure contract:
+    - move_folder raises OSError.
+    - The first file reached its new path; the second file is still at the old path.
+    - The index was NOT updated: searching a unique token from the first (moved)
+      file does NOT return the new path, confirming mark_paths_dirty never ran.
+    """
+    _write(vault, "drafts/alpha.md", "unique_alpha_token_qzx\n")
+    _write(vault, "drafts/beta.md", "unique_beta_token_qzx\n")
+    _write(vault, "backlinker.md", "Links to [alpha](drafts/alpha.md).\n")
+
+    import shutil as _shutil_real
+
+    call_count = 0
+    real_move = _shutil_real.move
+
+    def flaky_move(src: str, dst: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise OSError("injected mid-move failure")
+        real_move(src, dst)
+
+    import markdown_vault_mcp.managers.document as _doc_mod
+
+    monkeypatch.setattr(_doc_mod.shutil, "move", flaky_move)
+
+    with pytest.raises(OSError, match="injected mid-move failure"):
+        vault.writer.move_folder("drafts", "moved")
+
+    wait_for_writer_drain(vault)
+
+    # Subtree is partially moved: the first file succeeded, the second did not.
+    # (shutil.move processes moves in sorted order via rglob+sorted; alpha < beta.)
+    assert (source_dir / "moved/alpha.md").is_file(), "first file should have moved"
+    assert (source_dir / "drafts/beta.md").is_file(), (
+        "second file should still be at old path"
+    )
+
+    # Index was NOT updated by the failed operation: mark_paths_dirty never ran,
+    # so searching the unique token from the moved file returns NO new-path hit.
+    hits = vault.reader.search("unique_alpha_token_qzx")
+    new_paths = [h.path for h in hits]
+    assert "moved/alpha.md" not in new_paths, (
+        "index should not have been updated after mid-move OSError"
+    )
+
+
 def test_move_folder_best_effort_generic_exception(
     vault: Vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_move_folder.py
+++ b/tests/test_move_folder.py
@@ -1,0 +1,275 @@
+"""Tests for DocumentManager.move_folder (#511).
+
+Exercised through the public ``vault.writer.move_folder`` facet surface,
+mirroring the established writable-Vault test pattern in
+``tests/test_vault.py`` (the ``writable`` fixture + ``wait_for_writer_drain``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.exceptions import (
+    DocumentExistsError,
+    DocumentNotFoundError,
+    ReadOnlyError,
+)
+from markdown_vault_mcp.types import MoveFolderResult
+from markdown_vault_mcp.vault import Vault
+from tests.conftest import wait_for_writer_drain
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def source_dir(tmp_path: Path) -> Path:
+    """Empty vault root the tests seed via ``vault.writer.write``."""
+    root = tmp_path / "vault"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def vault(source_dir: Path) -> Iterator[Vault]:
+    """Writable Vault with an allowlist that permits ``.png`` attachments.
+
+    ``png`` is allowlisted (so the attachment-carry test gets a rename
+    callback) while ``.DS_Store`` is *not* (so the non-allowlisted-carry
+    test exercises the silent-move branch).
+    """
+    col = Vault(
+        source_dir=source_dir,
+        read_only=False,
+        attachment_extensions=["png"],
+    )
+    try:
+        col.index.build_index()
+        yield col
+    finally:
+        col.close()
+
+
+@pytest.fixture
+def read_only_vault(source_dir: Path) -> Iterator[Vault]:
+    """Read-only Vault for the rejection test."""
+    col = Vault(source_dir=source_dir, read_only=True)
+    try:
+        col.index.build_index()
+        yield col
+    finally:
+        col.close()
+
+
+def _write(vault: Vault, path: str, body: str) -> None:
+    """Seed a note and wait for the async writer to index it."""
+    vault.writer.write(path, body)
+    wait_for_writer_drain(vault)
+
+
+def test_move_folder_moves_notes_and_rewrites_inter_subtree_links(
+    vault: Vault, source_dir: Path
+) -> None:
+    _write(vault, "drafts/a.md", "See [b](./b.md) and [[c]].\n")
+    _write(vault, "drafts/b.md", "I am b.\n")
+    _write(vault, "drafts/c.md", "I am c.\n")
+
+    result = vault.writer.move_folder("drafts", "archive/2026")
+    wait_for_writer_drain(vault)
+
+    assert isinstance(result, MoveFolderResult)
+    assert result.files_moved == 3
+    # Files landed at the new prefix.
+    assert (source_dir / "archive/2026/a.md").is_file()
+    assert (source_dir / "archive/2026/b.md").is_file()
+    assert (source_dir / "archive/2026/c.md").is_file()
+    # Old prefix is gone.
+    assert not (source_dir / "drafts").exists()
+    # The relative link a->b still resolves to b in the same (moved) directory.
+    # Both moved by the same prefix shift, so the link target is recomputed by
+    # the rewrite machinery to a normalised same-dir relative path ("b.md" /
+    # "./b.md") — never the cross-prefix "archive/2026/b.md".
+    a_text = (source_dir / "archive/2026/a.md").read_text()
+    assert "(b.md)" in a_text or "(./b.md)" in a_text
+    assert "archive/2026/b.md" not in a_text
+
+
+def test_move_folder_rewrites_external_backlinks(
+    vault: Vault, source_dir: Path
+) -> None:
+    _write(vault, "drafts/a.md", "content\n")
+    _write(vault, "index.md", "Link to [A](drafts/a.md).\n")
+
+    result = vault.writer.move_folder("drafts", "archive")
+    wait_for_writer_drain(vault)
+
+    assert result.updated_links >= 1
+    index_text = (source_dir / "index.md").read_text()
+    assert "archive/a.md" in index_text
+    assert "drafts/a.md" not in index_text
+
+
+def test_move_folder_carries_allowlisted_attachment(
+    vault: Vault, source_dir: Path
+) -> None:
+    _write(vault, "drafts/note.md", "![img](./pic.png)\n")
+    (source_dir / "drafts" / "pic.png").write_bytes(b"\x89PNG\r\n")
+
+    result = vault.writer.move_folder("drafts", "media")
+    wait_for_writer_drain(vault)
+
+    assert (source_dir / "media/pic.png").is_file()
+    assert not (source_dir / "drafts").exists()
+    assert result.files_moved == 2
+
+
+def test_move_folder_target_collision_aborts_nothing_moved(
+    vault: Vault, source_dir: Path
+) -> None:
+    _write(vault, "drafts/a.md", "a\n")
+    _write(vault, "archive/a.md", "pre-existing\n")  # destination clash
+
+    with pytest.raises(DocumentExistsError):
+        vault.writer.move_folder("drafts", "archive")
+
+    # Nothing moved: source intact, pre-existing target untouched.
+    assert (source_dir / "drafts/a.md").is_file()
+    assert (source_dir / "archive/a.md").read_text() == "pre-existing\n"
+
+
+def test_move_folder_merges_into_existing_target(
+    vault: Vault, source_dir: Path
+) -> None:
+    _write(vault, "drafts/a.md", "a\n")
+    _write(vault, "archive/existing.md", "keep me\n")
+
+    result = vault.writer.move_folder("drafts", "archive")
+    wait_for_writer_drain(vault)
+
+    assert (source_dir / "archive/a.md").is_file()
+    assert (source_dir / "archive/existing.md").read_text() == "keep me\n"
+    assert result.files_moved == 1
+
+
+def test_move_folder_best_effort_skips_unwritable_source(
+    vault: Vault, source_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(vault, "drafts/a.md", "content\n")
+    _write(vault, "ext1.md", "[A](drafts/a.md)\n")
+    _write(vault, "ext2.md", "[A](drafts/a.md)\n")
+
+    # Make exactly one source rewrite fail.
+    real = vault.writer._doc_mgr._rewrite_one_source
+
+    def flaky(source_abs, rewrites, source_path):  # type: ignore[no-untyped-def]
+        if source_abs.name == "ext1.md":
+            raise OSError("boom")
+        return real(source_abs, rewrites, source_path)
+
+    monkeypatch.setattr(vault.writer._doc_mgr, "_rewrite_one_source", flaky)
+
+    result = vault.writer.move_folder("drafts", "archive")
+    wait_for_writer_drain(vault)
+
+    assert "ext1.md" in result.failed_links
+    assert result.updated_links >= 1
+    assert "archive/a.md" in (source_dir / "ext2.md").read_text()
+
+
+def test_move_folder_read_only_rejected(read_only_vault: Vault) -> None:
+    with pytest.raises(ReadOnlyError):
+        read_only_vault.writer.move_folder("drafts", "archive")
+
+
+def test_move_folder_missing_source_raises(vault: Vault) -> None:
+    with pytest.raises(DocumentNotFoundError):
+        vault.writer.move_folder("nope", "archive")
+
+
+def test_move_folder_index_consistency(vault: Vault) -> None:
+    _write(vault, "drafts/findme.md", "unique_token_zzz\n")
+    vault.writer.move_folder("drafts", "archive")
+    wait_for_writer_drain(vault)
+
+    hits = vault.reader.search("unique_token_zzz")
+    paths = [h.path for h in hits]
+    assert "archive/findme.md" in paths
+    assert "drafts/findme.md" not in paths
+
+
+def test_move_folder_carries_non_allowlisted_file(
+    vault: Vault, source_dir: Path
+) -> None:
+    _write(vault, "drafts/a.md", "a\n")
+    (source_dir / "drafts" / ".DS_Store").write_bytes(b"junk")
+
+    result = vault.writer.move_folder("drafts", "archive")
+    wait_for_writer_drain(vault)
+
+    assert (source_dir / "archive/.DS_Store").is_file()
+    assert not (source_dir / "drafts").exists()
+    assert result.files_moved == 2
+
+
+def test_move_folder_rejects_nested_target(vault: Vault) -> None:
+    _write(vault, "drafts/a.md", "a\n")
+    with pytest.raises(ValueError):
+        vault.writer.move_folder("drafts", "drafts/sub")
+
+
+def test_move_folder_rejects_same_folder(vault: Vault) -> None:
+    _write(vault, "drafts/a.md", "a\n")
+    with pytest.raises(ValueError):
+        vault.writer.move_folder("drafts", "drafts")
+
+
+def test_move_folder_rejects_vault_root(vault: Vault) -> None:
+    _write(vault, "drafts/a.md", "a\n")
+    with pytest.raises(ValueError):
+        vault.writer.move_folder(".", "archive")
+
+
+def test_move_folder_rejects_path_traversal(vault: Vault) -> None:
+    _write(vault, "drafts/a.md", "a\n")
+    with pytest.raises(ValueError):
+        vault.writer.move_folder("../escape", "archive")
+
+
+def test_move_folder_empty_folder_raises(vault: Vault, source_dir: Path) -> None:
+    (source_dir / "empty").mkdir()
+    with pytest.raises(DocumentNotFoundError):
+        vault.writer.move_folder("empty", "archive")
+
+
+def test_move_folder_preserves_nested_structure(vault: Vault, source_dir: Path) -> None:
+    _write(vault, "drafts/a.md", "top\n")
+    _write(vault, "drafts/sub/deep.md", "deep\n")
+
+    result = vault.writer.move_folder("drafts", "archive")
+    wait_for_writer_drain(vault)
+
+    assert (source_dir / "archive/a.md").is_file()
+    assert (source_dir / "archive/sub/deep.md").is_file()
+    assert not (source_dir / "drafts").exists()
+    assert result.files_moved == 2
+
+
+def test_move_folder_best_effort_generic_exception(
+    vault: Vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(vault, "drafts/a.md", "content\n")
+    _write(vault, "ext.md", "[A](drafts/a.md)\n")
+
+    def boom(_source_abs, _rewrites, _source_path):  # type: ignore[no-untyped-def]
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(vault.writer._doc_mgr, "_rewrite_one_source", boom)
+
+    result = vault.writer.move_folder("drafts", "archive")
+    wait_for_writer_drain(vault)
+
+    assert "ext.md" in result.failed_links
+    assert result.updated_links == 0

--- a/tests/test_move_folder.py
+++ b/tests/test_move_folder.py
@@ -325,3 +325,50 @@ def test_move_folder_best_effort_generic_exception(
 
     assert "ext.md" in result.failed_links
     assert result.updated_links == 0
+
+
+def test_move_folder_no_double_callback_for_intra_subtree_source(
+    tmp_path: Path,
+) -> None:
+    """A moved note that is also link-rewritten gets ONE callback, not two.
+
+    Such a note appears in both the moved set (a ``"rename"`` callback) and
+    the rewritten-sources set (an ``"edit"`` callback). Firing both would emit
+    a redundant git commit for the same file, so the ``"edit"`` is suppressed.
+    """
+    import threading
+
+    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.managers.document import DocumentManager
+    from markdown_vault_mcp.scanner import HeadingChunker, scan_directory
+
+    vault_dir = tmp_path / "v"
+    (vault_dir / "drafts").mkdir(parents=True)
+    # a.md links to its sibling b.md — both move together.
+    (vault_dir / "drafts" / "a.md").write_text("Link to [b](./b.md).\n")
+    (vault_dir / "drafts" / "b.md").write_text("I am b.\n")
+
+    fts = FTSIndex(db_path=":memory:")
+    for note in scan_directory(vault_dir):
+        fts.upsert_note(note)
+    fts.resolve_vault_wikilinks()
+
+    calls: list[tuple[str, str]] = []
+    mgr = DocumentManager(
+        fts=fts,
+        source_dir=vault_dir,
+        write_lock=threading.RLock(),
+        chunk_strategy=HeadingChunker(),
+        read_only=False,
+        on_write_callback=lambda p, _c, op: calls.append((p.as_posix(), op)),
+        mark_paths_dirty=lambda _paths: None,
+    )
+
+    mgr.move_folder("drafts", "archive")
+
+    # archive/a.md was moved AND link-rewritten -> exactly one "rename".
+    a_ops = [op for path, op in calls if path.endswith("archive/a.md")]
+    assert a_ops == ["rename"], a_ops
+    # archive/b.md only moved -> one "rename".
+    b_ops = [op for path, op in calls if path.endswith("archive/b.md")]
+    assert b_ops == ["rename"], b_ops

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -309,11 +309,13 @@ class TestToolAnnotations:
             assert ann.readOnlyHint is False, f"{name} readOnlyHint"
             assert ann.destructiveHint is False, f"{name} destructiveHint"
 
-        # Delete is destructive
-        ann = by_name["delete"].annotations
-        assert ann is not None
-        assert ann.readOnlyHint is False
-        assert ann.destructiveHint is True
+        # Delete and move_folder are destructive (move_folder removes the
+        # source directory tree and can leave a partial state on OS failure)
+        for name in ("delete", "move_folder"):
+            ann = by_name[name].annotations
+            assert ann is not None
+            assert ann.readOnlyHint is False, f"{name} readOnlyHint"
+            assert ann.destructiveHint is True, f"{name} destructiveHint"
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_every_registered_tool_has_title(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -256,6 +256,7 @@ class TestToolManifest:
             "list_documents",
             "list_folders",
             "list_tags",
+            "move_folder",
             "read",
             "reindex",
             "rename",
@@ -814,6 +815,76 @@ class TestRenameTool:
             result = await client.call_tool_mcp(
                 "rename",
                 {"old_path": "simple.md", "new_path": "simple.md"},
+            )
+        assert result.isError is True
+
+
+# ---------------------------------------------------------------------------
+# move_folder tool
+# ---------------------------------------------------------------------------
+
+
+class TestMoveFolderTool:
+    """Test the move_folder MCP tool."""
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_move_folder_tool_moves_and_reports(self, vault_path: Path) -> None:
+        """move_folder tool moves files and returns the expected result dict."""
+        # Seed two notes inside a 'drafts' subfolder.
+        (vault_path / "drafts").mkdir(exist_ok=True)
+        (vault_path / "drafts" / "a.md").write_text(
+            "# A\n\nSee [b](./b.md).\n", encoding="utf-8"
+        )
+        (vault_path / "drafts" / "b.md").write_text(
+            "# B\n\nContent.\n", encoding="utf-8"
+        )
+        # External backlink from the vault root so updated_links is exercised.
+        (vault_path / "index.md").write_text(
+            "# Index\n\nSee [A](drafts/a.md).\n", encoding="utf-8"
+        )
+
+        server = make_server()
+        async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "move_folder", {"old_dir": "drafts", "new_dir": "archive"}
+            )
+
+        data = result.data
+        assert data["old_dir"] == "drafts"
+        assert data["new_dir"] == "archive"
+        assert data["files_moved"] >= 2
+        assert "updated_links" in data
+        assert "failed_links" in data
+        # Files landed at new location.
+        assert (vault_path / "archive" / "a.md").is_file()
+        assert (vault_path / "archive" / "b.md").is_file()
+        # Old folder is gone.
+        assert not (vault_path / "drafts").exists()
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_move_folder_tool_missing_source_returns_error(self) -> None:
+        """move_folder tool returns an error when old_dir does not exist."""
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool_mcp(
+                "move_folder", {"old_dir": "nonexistent", "new_dir": "archive"}
+            )
+        assert result.isError is True
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_move_folder_tool_nested_target_returns_error(
+        self, vault_path: Path
+    ) -> None:
+        """move_folder tool returns an error when new_dir is nested under old_dir."""
+        (vault_path / "drafts").mkdir(exist_ok=True)
+        (vault_path / "drafts" / "a.md").write_text("# A\n", encoding="utf-8")
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool_mcp(
+                "move_folder",
+                {"old_dir": "drafts", "new_dir": "drafts/sub"},
             )
         assert result.isError is True
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,27 @@
+"""Tests for data types."""
+
+import dataclasses
+
+from markdown_vault_mcp.types import MoveFolderResult
+
+
+def test_move_folder_result_fields():
+    r = MoveFolderResult(
+        old_dir="drafts",
+        new_dir="archive/2026",
+        files_moved=3,
+        updated_links=2,
+        failed_links=["notes/bad.md"],
+    )
+    assert r.old_dir == "drafts"
+    assert r.new_dir == "archive/2026"
+    assert r.files_moved == 3
+    assert r.updated_links == 2
+    assert r.failed_links == ["notes/bad.md"]
+
+
+def test_move_folder_result_failed_links_defaults_empty():
+    r = MoveFolderResult(old_dir="a", new_dir="b", files_moved=0, updated_links=0)
+    assert r.failed_links == []
+    # asdict works (the MCP tool serializes via dataclasses.asdict)
+    assert dataclasses.asdict(r)["failed_links"] == []


### PR DESCRIPTION
Closes #511.

## Summary

Adds a `move_folder(old_dir, new_dir)` MCP tool — the folder-level analogue of single-file `rename`. It moves an entire folder subtree (`.md` notes, allowlisted attachments, and any other files) to a new prefix in one call and rewrites every link across the vault that points into the moved subtree (markdown links **and** wikilinks), including links *between* documents inside the subtree as well as external backlinks.

## Design decisions (locked in the spec)

- **Dedicated tool**, not a `rename` overload — a subtree has no meaningful `if_match` etag or single-file result shape.
- **Atomic at the gate**: a pre-existing destination-file clash aborts before anything moves. Merging into an existing target dir is allowed; only per-file name clashes abort.
- **Move all files, index/link only `.md` + allowlisted attachments** — a faithful folder move so the source dir ends up empty and removable.
- **`update_links` always on** — a folder move that left links dangling would be useless.
- **Single-pass link rewrite** over an old→new path map; a source inside the subtree is read at its new location so relative targets compute correctly (prefix-shift-idempotent for intra-subtree links).
- **Best-effort link rewrites** reported in `failed_links`; no transaction/rollback machinery (matches existing `_update_backlinks`).
- Single batched `mark_paths_dirty` drives one `resolve_vault_wikilinks()`; empty source dir removed after a successful move.

## Result shape

`MoveFolderResult(old_dir, new_dir, files_moved, updated_links, failed_links)`.

## Implementation (5 commits, TDD)

1. `MoveFolderResult` dataclass.
2. Behavior-preserving refactor: extract `_rewrite_one_source` from `_update_backlinks` (shared by single-file rename and folder move; 91/91 rename regression parity).
3. `DocumentManager.move_folder` + `WriterFacet.move_folder` + 18 tests.
4. `move_folder` MCP tool (`title: "Move Folder"`; exact-manifest + title-enforcement tests updated).
5. Docs: `docs/design.md`, `docs/tools/index.md`, `README.md`, server `instructions`.

A final whole-branch review surfaced one honest gap — a mid-*move* OS error (permissions/disk-full/concurrent deletion) can leave the subtree partially moved with the index unchanged. Per the locked "no rollback machinery" decision, this is now **documented across all surfaces and pinned by a test** (`test_move_folder_mid_move_oserror_leaves_subtree_partial`); a `reindex` reconciles.

## Gates

- `uv run pytest -x -q` → **2392 passed, 2 skipped**
- `uv run ruff check` / `ruff format --check` → clean
- `uv run mypy src/ tests/` → clean
- New-code patch coverage ~96.6%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._