### PR TITLE
chore(copier): update to v2.6.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.5.3
+_commit: v2.6.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,37 @@
+name: Bootstrap repo
+
+# Seeds repository labels that checked-in config references but that GitHub
+# does not create on its own.  `.github/dependabot.yml` applies the
+# `dependencies` label to the PRs it opens; a freshly generated repo has no
+# such label, so without this those PRs would land unlabelled (Dependabot
+# silently drops labels that don't exist).
+#
+# Idempotent: `gh label create --force` creates the label or updates it in
+# place, so every run is a no-op once the label exists.  The first push to the
+# default branch seeds it; `workflow_dispatch` lets you re-seed on demand.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/bootstrap.yml
+      - .github/dependabot.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  labels:
+    name: Ensure repository labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create dependencies label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh label create dependencies \
+            --color 0366d6 \
+            --description "Pull requests that update a dependency" \
+            --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -54,7 +54,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -100,7 +100,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           # `uv python install` writes to UV_PYTHON_INSTALL_DIR, which is
           # separate from the uv package cache and not covered by setup-uv's
@@ -222,7 +222,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-${{ runner.os }}
@@ -259,7 +259,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -286,7 +286,7 @@ jobs:
         # Pack list mirrors the Packages = line in .vale.ini; if you add or
         # remove a pack, update both. Bump the v1- prefix to evict all cached
         # packs if Vale changes pack format backward-incompatibly.
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             .vale/styles/Google

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,16 @@ Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain
 
 Env var prefix is `MARKDOWN_VAULT_MCP_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 
+### Config wizard
+
+`docs/javascripts/config-wizard/wizard-spec.json` drives the guided-setup page. It is **domain-owned and write-once** (`_skip_if_exists`): the runtime (`wizard.js`, `generators.js`, `wizard-spec-schema.json`, the generic tests) is template-owned and re-rendered, but the spec itself is never re-rendered, so it does **not** auto-update when you add config or when the template grows new questions. Reconcile it by hand.
+
+Two rules keep the spec honest:
+
+- **Cover the `ServerConfig` surface.** The seed covers the full `ServerConfig` surface plus logging; the drift test enforces completeness, so no explicit field list needs hand-maintaining here. When you add a domain setting that an operator would plausibly configure, add a question for it. When you adopt a new upstream setting, surface it too.
+- **Coverage is CI-enforced:** `tests/test_config_wizard_drift.py` fails if the wizard offers a var no read site consumes (orphan) or omits a setting the server reads: both `ServerConfig` (via `server_config_env_suffixes()`) and your `ProjectConfig.from_env`. Offer every setting; hide niche ones with `advancedGroup`, never by omission. For the coverage check, the only escape is `_COVERED_BY_INFERENCE`, for settings with no dedicated control by design (for example, `AUTH_MODE`, inferred from which auth vars are set). For the orphan check, `FASTMCP_*` vars are exempt: their prefix never matches `MARKDOWN_VAULT_MCP_`, so they sit outside the coverage check by construction, and they are read by FastMCP itself rather than by project code.
+- **Only offer vars the server actually consumes.** Every `var` must resolve to a real read site (`ServerConfig.from_env`, your `ProjectConfig.from_env`, the CLI, or a native `FASTMCP_*` var) — *advertised but unread* env vars (e.g. a hint that mentions `MARKDOWN_VAULT_MCP_SERVER_NAME` while the scaffold hardcodes the name) must not appear. List secret-bearing vars in `secretKeys` so the wizard masks them and keeps them out of the shareable link. A question may legitimately have **no `var`** when it is a wizard-internal routing key — the seed's `auth` select drives `showIf` but maps to no single env var (auth mode is inferred by `ServerConfig` from which vars are set), so it is not an orphan. Gate `showIf`/`guards` on the questions that are actually visible, and make every `showIf` self-contained: because the runtime checks raw answers with no cascade, a question gated on `auth` must *also* gate on `deployment=server` (the gate on `auth` itself), or it leaks — and emits its var — when `auth` is hidden but its stale answer lingers.
+
 ### Tool icons
 
 Drop SVG / PNG / ICO / JPEG files into `src/markdown_vault_mcp/static/icons/` and bulk-attach them to registered tools via `fastmcp_pvl_core.register_tool_icons(mcp, {"tool_name": "filename.svg"}, static_dir=...)` at the end of `register_tools()` — or attach at decoration time with `@mcp.tool(icons=[make_icon(STATIC / "x.svg")])` (where `STATIC = Path(__file__).parent / "static" / "icons"` is a shorthand you define at module level). The scaffold ships an empty `static/icons/` directory; commented-out wiring lives in `tools.py`.
@@ -192,6 +202,17 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 - `# DOCKERFILE-UV-EXTRAS-START` / `-END` — `--extra <name>` flags added to both `uv sync` invocations (deps cache layer + project install — adding only to one breaks the cache layer)
 - `# DOCKERFILE-STATE-DIRS-START` / `-END` — state subdirectories created under `/data` (chowned to the runtime user)
 - `# DOCKERFILE-VOLUMES-START` / `-END` — `VOLUME` declarations on the final image
+
+## Tool Registration Checklist
+
+Every MCP tool you register must carry the full set of metadata below — not just the behaviour. A tool that works but lacks a title, hints, or docs is incomplete. When adding or changing a tool, verify each item:
+
+- **Title** — a human-readable `annotations.title` (e.g. `"Search Vault"`). Title-aware clients (notably VS Code, which honours only `title` and `readOnlyHint` among annotations) render this as the tool's label; without it they fall back to the raw machine name. Set it inline in the tool's `annotations={...}` dict.
+- **Behavioural hints** — `readOnlyHint`, and where they apply `destructiveHint` / `idempotentHint`, in the same `annotations` dict. These describe side effects accurately (a destructive tool must set `destructiveHint=True`).
+- **Icon** — an entry wired via `register_tool_icons(...)` or `@mcp.tool(icons=[...])` (see [Tool icons](#tool-icons)).
+- **Docstring** — a Google-style docstring; FastMCP surfaces it as the tool description and per-parameter docs.
+- **Docs entry** — a row in your published tools reference (e.g. `docs/tools/index.md`) so the tool is documented for users (per [Documentation Discipline](#documentation-discipline)).
+- **Enforcement test** — keep a test that enumerates the registered tools and asserts each carries the metadata above (at minimum a non-empty `annotations.title`). Enumerate the *full* registry, not just the client-facing listing, so app-only / hidden tools cannot slip past. Such a test turns this checklist into a CI gate: a future tool added without a title fails loudly rather than silently shipping its machine name.
 
 ## Server Info Tool (`get_server_info`)
 

--- a/FORKING.md
+++ b/FORKING.md
@@ -52,15 +52,28 @@ the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
 ```bash
 # -i.bak + rm keeps this portable across GNU sed (Linux) and BSD sed (macOS),
 # which disagree on the in-place flag's syntax.
-sed -i.bak '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md && rm -f CLAUDE.md.bak
+sed -i.bak \
+  -e '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' \
+  -e '/<!-- ===== TEMPLATE-OWNED SECTIONS BELOW/d' \
+  -e '/<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->/d' \
+  -e 's/ Kept across copier update\.//' \
+  -e 's/ on top of the shipped defaults survive `copier update`\./ on top of the shipped defaults are yours to maintain./' \
+  -e 's/ are preserved across `copier update`\./ are domain-owned./' \
+  -e 's/The block is preserved across `copier update`\./The block is domain-owned./' \
+  CLAUDE.md && rm -f CLAUDE.md.bak
 ```
 
 This deletes the template-coupled sections — the bot-reviewer merge-gate
-paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** —
-while keeping the fork-neutral contributor guidance (Conventions, the PR
-acceptance gates, the Logging Standard, the config contract, GitHub Review
-Types). If your fork added its own `.claude/CLAUDE.md`, apply the same scrub
-there.
+paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** — and
+strips the copier-update wording that no longer describes a detached fork: the
+`TEMPLATE-OWNED SECTIONS` banner fences (a fork owns every section, so the
+template/domain split is moot), the "Kept across copier update" notes on the
+DOMAIN blocks, and the remaining "preserved/survive across copier update" notes
+(the pre-commit defaults, the `Dockerfile` sentinels, and the upstream sentinel).
+The fork-neutral contributor guidance
+(Conventions, the PR acceptance gates, the Logging Standard, the config
+contract, GitHub Review Types) is kept. If your fork added its own
+`.claude/CLAUDE.md`, apply the same scrub there.
 
 ## Step 4 — README cleanup (optional)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "fastmcp-pvl-core>=4.1.0,<5",
+    "fastmcp-pvl-core>=4.2.0,<5",
     "typer>=0.12",
 
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -162,6 +162,16 @@ def make_server(transport: str = "stdio", config: VaultConfig | None = None) -> 
     else:
         instructions = _build_default_instructions(read_only=is_read_only)
 
+    # Operator overrides: SERVER_NAME renames this instance; INSTRUCTIONS
+    # replaces the default instructions text (the latter is the override that
+    # build_instructions' hint advertises). Both fall back when unset/empty.
+    server_name = env(_ENV_PREFIX, "SERVER_NAME", "markdown-vault-mcp")
+    instructions = env(_ENV_PREFIX, "INSTRUCTIONS") or build_instructions(
+        read_only=True,
+        env_prefix=_ENV_PREFIX,
+        domain_line="Generic markdown vault MCP server with FTS5 + semantic search",
+    )
+
     auth = build_auth(config.server)
     # build_auth returns None only for mode="none" or precondition-miss inside an
     # OIDC builder (missing required fields).  pvl-core 2.0 raises ConfigurationError

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -25,6 +25,7 @@ from fastmcp_pvl_core import (
     build_auth,
     build_kv_store,  # noqa: F401  — re-exported for downstream projects' convenience
     configure_logging_from_env,  # noqa: F401  — re-exported for downstream projects' convenience
+    env,
     register_server_info_tool,
     resolve_auth_mode,
     wire_middleware_stack,

--- a/tests/test_config_wizard_drift.py
+++ b/tests/test_config_wizard_drift.py
@@ -1,0 +1,264 @@
+"""Drift guards between the config-wizard spec and the env surface it mirrors.
+
+Two directions, both fail CI:
+
+* Orphan — a wizard ``var`` (or option ``emit`` key) that no read site consumes.
+* Coverage — a core (``ServerConfig``) or domain (``ProjectConfig``) env setting
+  with no wizard ``var``/``emit``.
+
+Runs in the main lane. On the scaffold the domain surface is empty (every
+``ProjectConfig.from_env`` domain read is a commented example), so this reduces
+to "the seed covers core"; downstream it checks core + the project's domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import re
+import textwrap
+from pathlib import Path
+from typing import Any, cast
+
+from fastmcp_pvl_core import server_config_env_suffixes
+
+from markdown_vault_mcp.config import ProjectConfig
+
+_ENV_PREFIX = "MARKDOWN_VAULT_MCP"
+_WIZARD_SPEC = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "javascripts"
+    / "config-wizard"
+    / "wizard-spec.json"
+)
+
+# Core ServerConfig suffixes with no dedicated wizard control by design.
+# AUTH_MODE: ServerConfig infers the auth mode from which auth vars are set (the
+# ``auth`` select is a no-var routing key — see the Config wizard section of
+# CLAUDE.md), so there is no AUTH_MODE control to offer.
+_COVERED_BY_INFERENCE = frozenset({"AUTH_MODE"})
+
+
+def _spec() -> dict[str, Any]:
+    return cast("dict[str, Any]", json.loads(_WIZARD_SPEC.read_text(encoding="utf-8")))
+
+
+def _wizard_emitted_vars(spec: dict[str, Any]) -> set[str]:
+    """Every env var the wizard can emit: question ``var``s + option ``emit`` keys."""
+    out: set[str] = set()
+    for q in spec["questions"]:
+        if q.get("var"):
+            out.add(q["var"])
+        for opt in q.get("options", []):
+            out.update((opt.get("emit") or {}).keys())
+    return out
+
+
+def _suffix(var: str) -> str | None:
+    """The part after ``{PREFIX}_``, or None if ``var`` is not prefixed."""
+    prefix = _ENV_PREFIX + "_"
+    return var[len(prefix) :] if var.startswith(prefix) else None
+
+
+def _suffixes_in_source(src: str) -> set[str]:
+    """Literal suffixes read by ``env``/``env_int``/``env_float`` calls in ``src``.
+
+    Only string-literal second positional args are seen; a suffix built from a
+    variable, passed by keyword, or read through a non-``env`` helper is
+    invisible — keep reads in the ``env(_ENV_PREFIX, "LITERAL")`` form.
+    """
+    funcs = {"env", "env_int", "env_float"}
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(textwrap.dedent(src))):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in funcs
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            found.add(node.args[1].value)
+    return found
+
+
+def _domain_suffixes() -> set[str]:
+    """Suffixes ``ProjectConfig.from_env`` reads beyond ``ServerConfig``.
+
+    The ``server=ServerConfig.from_env(_ENV_PREFIX)`` call passes no suffix
+    literal, so it contributes nothing. Vacuous on the scaffold (domain reads
+    are commented examples), live downstream.
+    """
+    return _suffixes_in_source(inspect.getsource(ProjectConfig.from_env))
+
+
+def _surface() -> set[str]:
+    """The config surface the wizard must COVER: core (ServerConfig) + domain.
+
+    This is the coverage target. The orphan check uses a broader read set (it
+    also accepts scaffold-direct reads — see ``_src_text``), because the wizard
+    may legitimately offer a var the scaffold reads outside ServerConfig (e.g.
+    ``HTTP_PATH`` is read in ``cli.py``).
+    """
+    return set(server_config_env_suffixes()) | _domain_suffixes()
+
+
+def _src_text() -> str:
+    """Concatenated text of the project's ``src/**/*.py``.
+
+    Used by :func:`_read_in_src` to accept wizard vars read directly in the
+    scaffold (e.g. ``HTTP_PATH`` in ``cli.py``) that are not
+    ``ServerConfig``/``ProjectConfig`` fields and would otherwise be flagged as
+    orphans.
+    """
+    src = Path(__file__).resolve().parent.parent / "src"
+    return "\n".join(p.read_text(encoding="utf-8") for p in sorted(src.rglob("*.py")))
+
+
+def _read_in_src(suffix: str, src_text: str) -> bool:
+    """True if ``suffix`` appears as an env-read *token* in src, not a bare match.
+
+    Matches the two scaffold read idioms: ``env(_ENV_PREFIX, "SUFFIX")`` (the
+    quoted literal ``"SUFFIX"``) and ``os.environ.get(f"{_ENV_PREFIX}_SUFFIX")``
+    (the ``_SUFFIX`` fragment). The fragment arm anchors a trailing
+    word-boundary so a short suffix does not match inside a longer fragment
+    (``_HOST`` must not clear via ``_HOSTNAME``). Requiring one of these — rather
+    than a bare ``suffix in src_text`` substring — avoids clearing a real orphan
+    just because its suffix happens to appear in an unrelated comment or
+    identifier.
+    """
+    return (
+        f'"{suffix}"' in src_text
+        or re.search(rf"_{re.escape(suffix)}(?![A-Z0-9_])", src_text) is not None
+    )
+
+
+def _orphan_vars(spec: dict[str, Any]) -> list[str]:
+    """Wizard vars/emits that resolve to no read site (excluding FASTMCP_* natives)."""
+    core_domain = _surface()
+    src_text = _src_text()
+    out: list[str] = []
+    for var in sorted(_wizard_emitted_vars(spec)):
+        if var.startswith("FASTMCP_"):
+            continue  # native, read by FastMCP / configure_logging_from_env
+        suffix = _suffix(var)
+        if suffix is None:
+            out.append(f"{var} (not {_ENV_PREFIX}_-prefixed and not FASTMCP_*)")
+        elif suffix not in core_domain and not _read_in_src(suffix, src_text):
+            out.append(f"{var} (no read site consumes {suffix})")
+    return out
+
+
+def test_no_orphan_wizard_vars() -> None:
+    """Every wizard var/emit resolves to a read site (or is a FASTMCP_* native)."""
+    orphans = _orphan_vars(_spec())
+    assert not orphans, "wizard offers vars nothing reads: " + "; ".join(orphans)
+
+
+def test_orphan_guard_flags_unread_var() -> None:
+    """A wizard var whose suffix no read site consumes is reported."""
+    spec: dict[str, Any] = {
+        "questions": [{"id": "x", "var": f"{_ENV_PREFIX}_NONSENSE_XYZ"}]
+    }
+    orphans = _orphan_vars(spec)
+    assert any("NONSENSE_XYZ" in o for o in orphans)
+
+
+def test_domain_scan_extracts_literal_env_reads() -> None:
+    """The domain scan picks literal env*-read suffixes and ignores the rest."""
+    src = textwrap.dedent(
+        """
+        @classmethod
+        def from_env(cls):
+            other = some_var
+            return cls(
+                server=ServerConfig.from_env(_ENV_PREFIX),
+                vault_path=env(_ENV_PREFIX, "VAULT_PATH", "/data/vault"),
+                max_n=env_int(_ENV_PREFIX, "MAX_N", 5),
+                skip=env(_ENV_PREFIX, other),
+            )
+        """
+    )
+    assert _suffixes_in_source(src) == {"VAULT_PATH", "MAX_N"}
+
+
+def _missing_suffixes(surface: set[str], emitted_suffixes: set[str]) -> list[str]:
+    """Surface suffixes not covered by a wizard var/emit and not inference-excepted."""
+    return sorted(
+        s
+        for s in surface
+        if s not in emitted_suffixes and s not in _COVERED_BY_INFERENCE
+    )
+
+
+def test_wizard_covers_full_env_surface() -> None:
+    """Every core/domain setting is covered by a wizard var/emit (advanced ok).
+
+    Hiding a setting is done with ``advancedGroup``, never by omission. A
+    setting with no dedicated control by design goes in ``_COVERED_BY_INFERENCE``.
+    """
+    emitted_suffixes = {
+        s for v in _wizard_emitted_vars(_spec()) if (s := _suffix(v)) is not None
+    }
+    missing = _missing_suffixes(_surface(), emitted_suffixes)
+    assert not missing, (
+        "env settings the server reads but the wizard does not offer "
+        "(add a question/emit, or _COVERED_BY_INFERENCE if inferred by design): "
+        + ", ".join(missing)
+    )
+
+
+def test_coverage_guard_flags_missing_suffix() -> None:
+    """A surface suffix with no wizard var/emit is reported as missing."""
+    assert _missing_suffixes({"VAULT_PATH"}, set()) == ["VAULT_PATH"]
+
+
+def test_inference_exception_suppresses_auth_mode() -> None:
+    """AUTH_MODE is in the surface and not emitted, yet not reported missing
+    (the _COVERED_BY_INFERENCE exception, not coincidence, keeps it green)."""
+    assert "AUTH_MODE" in _surface()
+    emitted = {
+        s for v in _wizard_emitted_vars(_spec()) if (s := _suffix(v)) is not None
+    }
+    assert "AUTH_MODE" not in emitted
+    assert "AUTH_MODE" not in _missing_suffixes(_surface(), emitted)
+
+
+def test_transport_covered_via_option_emit() -> None:
+    """TRANSPORT is covered through the deployment option `emit`, not a question var."""
+    emitted = _wizard_emitted_vars(_spec())
+    assert f"{_ENV_PREFIX}_TRANSPORT" in emitted
+    emitted_suffixes = {s for v in emitted if (s := _suffix(v)) is not None}
+    assert "TRANSPORT" not in _missing_suffixes(_surface(), emitted_suffixes)
+
+
+def test_orphan_guard_exempts_fastmcp_native() -> None:
+    """A FASTMCP_* wizard var is exempt from the orphan check (read by FastMCP)."""
+    assert _orphan_vars({"questions": [{"id": "x", "var": "FASTMCP_LOG_LEVEL"}]}) == []
+
+
+def test_orphan_guard_accepts_scaffold_direct_read() -> None:
+    """A wizard var read directly in src (not a ServerConfig/domain field) is not
+    an orphan. HTTP_PATH is the case: read in cli.py, absent from the core/domain
+    surface, cleared only by the ``_read_in_src`` token match.
+    """
+    assert "HTTP_PATH" not in _surface()
+    assert _read_in_src("HTTP_PATH", _src_text())
+    # The token match does not clear a suffix that is merely a coincidental
+    # substring (no ``"ZZZNONSENSE"`` literal or ``_ZZZNONSENSE`` fragment).
+    assert not _read_in_src("ZZZNONSENSE", _src_text())
+
+
+def test_read_in_src_quoted_literal_arm() -> None:
+    """The quoted-literal arm matches an ``env(prefix, "SUFFIX")`` read."""
+    assert _read_in_src("WIDGET", 'x = env(_ENV_PREFIX, "WIDGET")\n')
+    assert not _read_in_src("WIDGET", "x = widget_count  # WIDGET in a comment\n")
+
+
+def test_read_in_src_fragment_arm_anchors_word_boundary() -> None:
+    """The ``_SUFFIX`` arm matches an f-string read but not a longer fragment."""
+    assert _read_in_src("HOST", 'os.environ.get(f"{_ENV_PREFIX}_HOST")\n')
+    # ``_HOST`` inside ``_HOSTNAME`` must NOT clear HOST as read.
+    assert not _read_in_src("HOST", 'os.environ.get(f"{_ENV_PREFIX}_HOSTNAME")\n')

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -334,3 +334,62 @@ def test_compose_quotes_yaml_typed_env_values(page: Page) -> None:
     assert 'DEMO_FLAG: "true"' in result
     assert "DEMO_FLAG: true\n" not in result
     assert 'DEMO_PORT: "8080"' in result
+
+
+# A two-level showIf chain (child gates on `auth`, `auth` gates on `deployment`)
+# mirrors the auth/OIDC structure every shipped spec uses. These two tests pin
+# the runtime behaviour the spec-level cascade test (in
+# test_config_wizard_spec_schema.py) is a static proxy for: isVisible does NOT
+# cascade, so buildEnvMap emits a child's var whenever the child's own showIf is
+# satisfied by the raw answers — even if the gating question is itself hidden by
+# a stale answer. A self-contained child showIf is what closes the leak.
+def _cascade_spec(child_showif: str) -> str:
+    return (
+        "{ version: 1,"
+        " meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },"
+        " secretKeys: [],"
+        " questions: ["
+        "   { id: 'deployment', label: 'D', type: 'select',"
+        "     options: [{ value: 'local', label: 'L' }, { value: 'server', label: 'S' }] },"
+        "   { id: 'auth', label: 'A', type: 'select', showIf: { deployment: ['server'] },"
+        "     options: [{ value: 'none', label: 'N' }, { value: 'oidc', label: 'O' }] },"
+        "   { id: 'oidc_url', label: 'U', type: 'text', var: 'DEMO_OIDC_CONFIG_URL',"
+        "     showIf: " + child_showif + " },"
+        " ],"
+        " guards: [] }"
+    )
+
+
+# Stale state from configuring OIDC under deployment='server' (the auth answer
+# AND a filled-in oidc_url value), then flipping deployment back to 'local'.
+_STALE = "{ deployment: 'local', auth: 'oidc', oidc_url: 'https://auth.example.com' }"
+
+
+def test_buildenvmap_leaks_without_self_contained_showif(page: Page) -> None:
+    # Child gated ONLY on auth (the pre-fix shape). The stale auth answer keeps
+    # the child visible, so its filled-in value is still emitted after deployment
+    # flips back to 'local'. This documents the leak the cascade gate prevents.
+    result = _eval_generators(
+        page,
+        "(g) => {"
+        "  const spec = " + _cascade_spec("{ auth: ['oidc'] }") + ";"
+        "  return g.buildEnvMap(spec, " + _STALE + ");"
+        "}",
+    )
+    assert result.get("DEMO_OIDC_CONFIG_URL") == "https://auth.example.com"
+
+
+def test_buildenvmap_self_contained_showif_blocks_stale_answer(page: Page) -> None:
+    # Child gated on BOTH deployment and auth (the fixed shape). The same stale
+    # state no longer leaks because deployment='local' fails the child's own
+    # deployment gate, so isVisible is false and the var is not emitted.
+    result = _eval_generators(
+        page,
+        "(g) => {"
+        "  const spec = "
+        + _cascade_spec("{ deployment: ['server'], auth: ['oidc'] }")
+        + ";"
+        "  return g.buildEnvMap(spec, " + _STALE + ");"
+        "}",
+    )
+    assert "DEMO_OIDC_CONFIG_URL" not in result

--- a/tests/test_config_wizard_spec_schema.py
+++ b/tests/test_config_wizard_spec_schema.py
@@ -80,6 +80,93 @@ def test_showif_references_existing_ids(spec: dict[str, Any]) -> None:
             assert key in ids, f"showIf references unknown question id: {key}"
 
 
+def _assert_gates_self_contained(
+    gates: dict[str, Any], by_id: dict[str, Any], owner: str
+) -> None:
+    """Assert a ``showIf``/``when`` map carries its referenced questions' gates.
+
+    Both ``isVisible`` and the guard evaluator (generators.js / wizard.js) check
+    raw ``answers[k]`` with no cascade. So if ``gates`` references question B and
+    B is itself gated on C, ``gates`` must also gate on C — with a value set no
+    wider than B's — or it stays active when B is hidden but B's stale answer
+    lingers.
+    """
+    for parent_id in gates:
+        parent_gates = by_id.get(parent_id, {}).get("showIf") or {}
+        for grand_id, grand_allowed in parent_gates.items():
+            assert grand_id in gates, (
+                f"{owner} gates on {parent_id!r} but not on {parent_id!r}'s own "
+                f"gate {grand_id!r}; it stays active when {parent_id!r} is hidden"
+            )
+            assert set(gates[grand_id]) <= set(grand_allowed), (
+                f"{owner} allows {grand_id!r} values {gates[grand_id]} wider than "
+                f"{parent_id!r}'s {grand_allowed}; it can be active when "
+                f"{parent_id!r} is not"
+            )
+
+
+def test_showif_and_guard_gates_cascade(spec: dict[str, Any]) -> None:
+    """Question ``showIf`` and guard ``when`` must stay self-contained.
+
+    Neither ``isVisible`` (which gates ``buildEnvMap``'s var emission) nor the
+    guard evaluator cascades — each checks raw ``answers[k]`` only. A question
+    gated only on ``auth`` keeps emitting its ``var`` after the user flips
+    ``deployment`` back to a value that hides the ``auth`` control, because the
+    stale ``auth`` answer persists; a guard gated only on ``auth`` fires its
+    warning the same way. So whenever a ``showIf``/``when`` gates on B and B
+    itself gates on C, it must also gate on C (values no wider than B's). This
+    asserts that transitive closure for every question and every guard.
+    """
+    by_id = {q["id"]: q for q in spec["questions"]}
+    for q in spec["questions"]:
+        _assert_gates_self_contained(
+            q.get("showIf") or {}, by_id, f"question {q['id']!r}"
+        )
+    for i, guard in enumerate(spec.get("guards", [])):
+        _assert_gates_self_contained(guard.get("when") or {}, by_id, f"guard[{i}]")
+
+
+def _chain_spec(questions: list[dict[str, Any]]) -> dict[str, Any]:
+    base = _minimal_valid_spec()
+    base["questions"] = questions
+    return base
+
+
+def _sel(qid: str, show_if: dict[str, Any] | None = None) -> dict[str, Any]:
+    q: dict[str, Any] = {
+        "id": qid,
+        "label": qid.upper(),
+        "type": "select",
+        "options": [{"value": "on", "label": "On"}, {"value": "off", "label": "Off"}],
+    }
+    if show_if is not None:
+        q["showIf"] = show_if
+    return q
+
+
+def test_cascade_check_enforces_full_transitive_closure() -> None:
+    """The one-level-per-question check composes to full transitive closure.
+
+    A 3-level chain d <- c <- b <- a: `a` correctly carries b and c but omits
+    d's gate. The check must still reject it, because `a` gates on c and c gates
+    on d, so c's gate (d) is re-checked against `a`. This pins the docstring's
+    "transitive closure" claim — the single-level check is not merely a
+    one-hop guard.
+    """
+    chain = [
+        _sel("d"),
+        _sel("c", {"d": ["on"]}),
+        _sel("b", {"c": ["on"], "d": ["on"]}),
+    ]
+    # Fully closed: a carries every ancestor gate -> passes.
+    good = _chain_spec([*chain, _sel("a", {"b": ["on"], "c": ["on"], "d": ["on"]})])
+    test_showif_and_guard_gates_cascade(good)
+    # a omits the transitive gate d -> must be rejected.
+    bad = _chain_spec([*chain, _sel("a", {"b": ["on"], "c": ["on"]})])
+    with pytest.raises(AssertionError):
+        test_showif_and_guard_gates_cascade(bad)
+
+
 def test_guard_when_references_existing_ids(spec: dict[str, Any]) -> None:
     ids = {q["id"] for q in spec["questions"]}
     for guard in spec.get("guards", []):


### PR DESCRIPTION
## Template update: `v2.5.3` → `v2.6.0`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v2.5.3...v2.6.0)

<details><summary>Release notes (v2.6.0)</summary>

- #207 feat(scaffold): CI-enforced config-wizard env-surface coverage
- #206 feat(scaffold): honor {PREFIX}_SERVER_NAME and {PREFIX}_INSTRUCTIONS
- #205 feat(wizard): seed the upstream ServerConfig questions; document coverage
- #204 docs(claude-md): add Tool Registration Checklist section

</details>

<details><summary>Files changed (10)</summary>

```
 .copier-answers.yml                     |   2 +-
 .github/workflows/bootstrap.yml         |  37 +++++
 .github/workflows/ci.yml                |  12 +-
 CLAUDE.md                               |  21 +++
 FORKING.md                              |  25 ++-
 pyproject.toml                          |   2 +-
 src/markdown_vault_mcp/server.py        |  11 ++
 tests/test_config_wizard_drift.py       | 264 ++++++++++++++++++++++++++++++++
 tests/test_config_wizard_smoke.py       |  59 +++++++
 tests/test_config_wizard_spec_schema.py |  87 +++++++++++
 10 files changed, 506 insertions(+), 14 deletions(-)
```

</details>

### ⚠️ 6 file(s) with unresolved conflict markers

The `<<<<<<< before updating` markers **are committed to this branch** — resolve them before merging:

- `.github/workflows/ci.yml`
- `README.md`
- `docs/configuration.md`
- `pyproject.toml`
- `src/markdown_vault_mcp/cli.py`
- `src/markdown_vault_mcp/server.py`

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

---

## Agent analysis

### 🔧 Conflict resolutions

**Auto-committed by claude-code** — VERIFY before merging:

- `.github/workflows/ci.yml` (commit 56dc6922df65ea6c9e6d67cef29afb9c22235c90): _Resolved the gitleaks-action comment-spacing conflict (one space → two spaces before # pin comment) and staged all accompanying non-conflict template changes: six `actions/cache@v5` → `actions/cache@v6` bumps that copier merged automatically without markers._
- `pyproject.toml` (commit 56dc6922df65ea6c9e6d67cef29afb9c22235c90): _Template bumped the fastmcp-pvl-core lower bound from >=4.1.0 to >=4.2.0; accepted the template's version constraint bump._
- `src/markdown_vault_mcp/server.py` (commit 51375853f4360dced859ec6d7703d750da131ef0): _Merged both sides: kept the downstream's `# noqa: F401` re-export annotation on `configure_logging_from_env` and added the `env` import from the template — required because copier's 3-way merge had already applied the `env()` call sites at lines 173–174 without conflict, leaving the file unrunnable without the import._

**Needs review** — conflict markers remain, operator must resolve:

- `README.md`: Two independent changes are bundled in the 'after updating' side: (1) the template inserts a second `<!-- mcp-name: io.github.pvliesdonk/markdown-vault-mcp -->` comment (the downstream already placed this manually at line 1 before the heading, so accepting 'after updating' would create a duplicate); (2) the badge URL changes from `https://pvliesdonk.github.io/markdown-vault-mcp/latest/llms.txt` to the non-versioned path `https://pvliesdonk.github.io/markdown-vault-mcp/llms.txt`. The downstream uses mike for versioned docs, so `latest/llms.txt` is intentional and the URL change would break the versioned llms.txt link. README.md is `_skip_if_exists` (downstream-owned), so both changes require operator judgment.
  Recommended approach: Keep the downstream's badge line with the `latest/llms.txt` URL (the downstream uses mike versioned docs, so `latest/llms.txt` is intentional and the template's bare `/llms.txt` would break the versioned link). Remove the duplicate `<!-- mcp-name -->` comment from the 'after updating' side — it already exists at line 1 of the file. The final result is just the original badges line, unchanged from the 'before updating' side.
- `docs/configuration.md`: The template's 'after updating' side inserts a new `## Server identity` section documenting `MARKDOWN_VAULT_MCP_SERVER_NAME` and `MARKDOWN_VAULT_MCP_INSTRUCTIONS`; the downstream already has a comprehensive `## Server Identity` table for those variables inside the `DOMAIN-CONFIG-VARS` block at L76–89, making the template section a near-duplicate. Accepting 'after updating' verbatim discards the useful admonition blocks (config generator tip and startup validation note) that the downstream added and that are absent from the template.
  Recommended approach: Keep the downstream's admonition blocks from 'before updating' (the guided-setup tip and startup-validation note). If the new template section adds documentation value that is not already covered by the `## Server Identity` table at L76–89 inside the DOMAIN block, insert the template's `## Server identity` prose (12 lines) immediately before `<!-- DOMAIN-CONFIG-VARS-START -->`; otherwise discard it to avoid the near-duplicate.
- `src/markdown_vault_mcp/cli.py`: The downstream intentionally restructured `cli.py` into a thin shim (documented in the module docstring: 'This module is intentionally tiny so the template-owned cli.py patches have no shared context lines to apply against'). Accepting 'after updating' verbatim would reintroduce the fat monolithic `cli.py` the downstream explicitly moved to `_cli_impl.py`, causing a `def main():` redefinition conflict with the existing `from markdown_vault_mcp._cli_impl import main` import at the top of the file. The only substantive behavioral delta between v2.5.3 and v2.6.0 templates is `host`/`port` defaulting to `None` with config-based fallbacks instead of hardcoded `'0.0.0.0'`/`8000`.
  Recommended approach: Keep the downstream's thin-shim approach ('before updating': `__all__ = ['main']`). Separately port the two behavioral changes introduced in template v2.6.0 into `src/markdown_vault_mcp/_cli_impl.py`: (1) change `host: str = typer.Option('0.0.0.0', ...)` to `host: str | None = typer.Option(None, ...)`, and (2) change `port: int = typer.Option(8000, ...)` to `port: int | None = typer.Option(None, ...)`, adding `host if host is not None else config.server.host` and `port if port is not None else config.server.port` fallbacks in the `uvicorn.run()` call.
- `src/markdown_vault_mcp/server.py`: The template simplified the log format to 4 params, removing the 3 domain-specific diagnostic fields (vault mode, source directory, embeddings state). Accepting 'after updating' as-is would create a format/argument count mismatch (4 `%s` slots with 7 positional args still in the surrounding code), which Python logging silently truncates — a latent correctness bug. The extra fields are domain-owned and operationally useful for troubleshooting deployments.
  Recommended approach: Keep the 'before updating' format string with 7 `%s` slots (`'Server config: version=%s name=%s transport=%s auth=%s mode=%s vault=%s embeddings=%s'`) together with all 7 positional arguments (`pkg_ver`, `server_name`, `transport`, `auth_mode`, `'read-only' if is_read_only else 'read-write'`, `config.source_dir`, `'enabled' if config.indexing.embeddings_path else 'disabled'`).
- `src/markdown_vault_mcp/server.py`: Three distinct changes are bundled: (1) positional `server_name` → keyword `name=server_name` (safe FastMCP API update); (2) `icons=_SERVER_ICON` is a downstream addition for server icon display, absent from the template; (3) `lifespan=server_lifespan` (template's generic stub from `_server_deps`) conflicts with `lifespan=make_vault_lifespan(config)` (downstream's domain-specific lifespan factory) — using `server_lifespan` verbatim would be a `NameError` at runtime since the downstream's `_server_deps` exports `make_vault_lifespan`, not `server_lifespan`. Additionally, copier auto-merged the template's `env()`-based `server_name`/`instructions` assignments at lines 173–178 without conflict, leaving both a config-based block (163–168) and an env-based block (173–178) that both write to the same variables — the later block silently overrides the earlier one.
  Recommended approach: Merge: accept the template's `name=server_name` keyword argument (FastMCP API update from positional to keyword), keep the downstream's `icons=_SERVER_ICON` parameter, and keep `lifespan=make_vault_lifespan(config)` — not `lifespan=server_lifespan` which is undefined in the downstream. Resulting call: `FastMCP(name=server_name, instructions=instructions, icons=_SERVER_ICON, lifespan=make_vault_lifespan(config), auth=auth)`. Also decide whether to keep the auto-merged env-override block at lines 163–178 (two consecutive assignments to `server_name`/`instructions`): keep only one — either the config-based block at 163–168 (removing 173–178 and adding `# noqa: F401` to the `env` import) or the env-based block at 173–178 (removing 163–168).

### ✨ New features in this update

**Needs your attention** (action-required):

- #205 feat(wizard): seed the upstream ServerConfig questions; document coverage — needs opt-in.
  Enriches the wizard-spec.json seed with the full upstream ServerConfig surface: an auth select (none/bearer/oidc/both), the OIDC suite (ISSUER, AUDIENCE, JWKS_URI, CLIENT_ID, CLIENT_SECRET), BASE_URL, HTTP_PATH, and KV_STORE_URL — plus a cascade-invariant fix ensuring OIDC questions gate on both auth=oidc AND deployment=server so stale answers don't leak vars. The CLAUDE.md 'Config wizard' subsection (write-once nature, two coverage rules, _COVERED_BY_INFERENCE escape hatch, orphan-exempt FASTMCP_* vars) and the cascade-invariant test in test_config_wizard_spec_schema.py ship automatically; test_config_wizard_smoke.py gains new cascade-invariant coverage that also ships automatically. However, wizard-spec.json itself is in _skip_if_exists and is NOT overwritten — downstream keeps its existing spec unchanged. To benefit, manually reconcile your wizard-spec.json against the enriched template seed (auth select, OIDC suite, BASE_URL, HTTP_PATH, KV_STORE_URL questions). The drift test from #207 will flag any missing ServerConfig coverage once it lands.
- #207 feat(scaffold): CI-enforced config-wizard env-surface coverage — needs opt-in.
  Adds tests/test_config_wizard_drift.py — a new CI-gate test (not in _skip_if_exists, so it ships automatically) that fails in two directions: (1) orphan — wizard advertises a var no read site in ServerConfig or ProjectConfig.from_env consumes; (2) missing — a ServerConfig or ProjectConfig.from_env setting has no wizard var/emit. The orphan check uses env-read tokens ('SUFFIX' or _SUFFIX) with word-boundary anchoring to avoid false clears; AUTH_MODE is the documented exception via _COVERED_BY_INFERENCE. Also ships automatically: a floor bump of fastmcp-pvl-core to >=4.2.0 (required for server_config_env_suffixes()), a fix to cli.py so {PREFIX}_HOST and {PREFIX}_PORT are actually read from config (overridable by the CLI flag), and the CLAUDE.md coverage-rules update. Does NOT ship automatically: the wizard-spec.json seed additions for HOST, PORT, BEARER_TOKENS_FILE, BEARER_DEFAULT_SUBJECT, EVENT_STORE_URL, and APP_DOMAIN (wizard-spec.json is in _skip_if_exists), and the test_cli.py test updates (also in _skip_if_exists). Action required: the new drift test will immediately fail CI because your existing wizard-spec.json does not cover the ServerConfig vars now enumerated by server_config_env_suffixes(). You must update wizard-spec.json to add questions (or _COVERED_BY_INFERENCE entries) for each missing suffix, then verify the drift test passes locally with `uv run pytest tests/test_config_wizard_drift.py -v` before pushing.

**Ships through automatically** (informational):

- #204 docs(claude-md): add Tool Registration Checklist section — applied this run
- #206 feat(scaffold): honor {PREFIX}_SERVER_NAME and {PREFIX}_INSTRUCTIONS — applied this run

