### PR TITLE
test: restore stripped template smoke coverage, adapted to MVM

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,18 +4,36 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pytest
+from fastmcp import Client
 
 from markdown_vault_mcp.providers import EmbeddingProvider
+from markdown_vault_mcp.server import make_server
 
 # Re-export reusable fixtures so they are auto-discovered by pytest in any
 # test module without requiring a per-file import (which would trip ruff's
 # F811 redefinition check on the parameter shadowing).
 from tests.fixtures.git import git_repo_pair  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip all ``MARKDOWN_VAULT_MCP_*`` env vars before each test (isolation).
+
+    Prevents an env var set by one test (or the ambient shell) from leaking
+    into another. Tests that need configuration set it explicitly afterwards
+    (e.g. via ``_mcp_env`` or ``monkeypatch.setenv``); autouse fixtures run
+    before the requested ones, so those overrides win.
+    """
+    for key in list(os.environ):
+        if key.startswith("MARKDOWN_VAULT_MCP_"):
+            monkeypatch.delenv(key, raising=False)
 
 
 def _parse_tool_data(result: Any) -> Any:
@@ -220,6 +238,22 @@ def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
     for var in _CLEAR_VARS:
         monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+async def client(_mcp_env: None) -> AsyncIterator[Client[Any]]:
+    """In-memory FastMCP client on a server backed by a throwaway tmp vault.
+
+    Adapted from the template's ``client`` fixture: MVM's ``make_server()``
+    calls ``ProjectConfig.from_env()`` which requires ``SOURCE_DIR``, so this
+    depends on ``_mcp_env`` (which sets it from ``vault_path``). Drains the
+    index writer so index-backed resources (e.g. ``config://vault``) are
+    queryable.
+    """
+    server = make_server()
+    async with Client(server) as c:
+        await wait_for_mcp_writer_drain(c)
+        yield c
 
 
 def wait_for_writer_drain(col: object, timeout: float = 5.0) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,11 +27,13 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Strip all ``MARKDOWN_VAULT_MCP_*`` env vars before each test (isolation).
 
     Prevents an env var set by one test (or the ambient shell) from leaking
-    into another.  Because this fixture is ``autouse=True``, pytest resolves it
-    before any fixture or test body that shares the same ``monkeypatch``
-    instance, so these deletions always precede any test-local ``setenv`` — the
-    test's own overrides win.  ``_mcp_env`` declares it as an explicit
-    dependency to make that ordering a hard guarantee.
+    into another.  ``autouse=True`` ensures this runs for every test; pytest
+    always runs fixtures before the test body, so these deletions precede any
+    test-local ``monkeypatch.setenv`` and the test's own overrides win.
+    Ordering relative to *other fixtures* is not implied by ``autouse`` — a
+    fixture that needs a clean env first (e.g. ``_mcp_env``) must declare
+    ``_clear_env: None`` as an explicit parameter; that dependency edge is the
+    only reliable fixture-vs-fixture ordering mechanism.
     """
     for key in list(os.environ):
         if key.startswith("MARKDOWN_VAULT_MCP_"):
@@ -239,9 +241,9 @@ def _mcp_env(
 ) -> None:
     """Set minimal env vars for make_server().
 
-    Only sets ``SOURCE_DIR``: the depended-on ``_clear_env`` already strips every
-    ``MARKDOWN_VAULT_MCP_*`` var (including ``READ_ONLY`` and all ``_CLEAR_VARS``)
-    before this runs, so no per-var clearing is needed here.
+    Only sets ``SOURCE_DIR``; the depended-on ``_clear_env`` (autouse) strips all
+    ``MARKDOWN_VAULT_MCP_*`` vars before this runs, so no per-var clearing is
+    needed here.
     """
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,11 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Strip all ``MARKDOWN_VAULT_MCP_*`` env vars before each test (isolation).
 
     Prevents an env var set by one test (or the ambient shell) from leaking
-    into another. Tests that need configuration set it explicitly afterwards
-    (e.g. via ``_mcp_env`` or ``monkeypatch.setenv``); autouse fixtures run
-    before the requested ones, so those overrides win.
+    into another.  Tests that need configuration set it explicitly afterwards (e.g. via
+    ``_mcp_env``, which depends on this fixture, or via ``monkeypatch.setenv``).
+    ``monkeypatch`` applies env mutations sequentially within each test, so the
+    strips here are always visible before any test-local ``setenv`` — the
+    test's own overrides win.
     """
     for key in list(os.environ):
         if key.startswith("MARKDOWN_VAULT_MCP_"):
@@ -232,7 +234,9 @@ _CLEAR_VARS = (
 
 
 @pytest.fixture
-def _mcp_env(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _mcp_env(
+    _clear_env: None, vault_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Set minimal env vars for make_server()."""
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
     monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
@@ -247,8 +251,14 @@ async def client(_mcp_env: None) -> AsyncIterator[Client[Any]]:
     Adapted from the template's ``client`` fixture: MVM's ``make_server()``
     calls ``ProjectConfig.from_env()`` which requires ``SOURCE_DIR``, so this
     depends on ``_mcp_env`` (which sets it from ``vault_path``). Drains the
-    index writer so index-backed resources (e.g. ``config://vault``) are
-    queryable.
+    index writer so FTS-backed resources/tools (e.g. ``stats://vault``,
+    ``search``) return populated results rather than empty cold-start state.
+
+    Args:
+        _mcp_env: Fixture that sets ``SOURCE_DIR`` (injected by pytest).
+
+    Yields:
+        An in-process FastMCP ``Client`` with the index writer drained.
     """
     server = make_server()
     async with Client(server) as c:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,11 +27,11 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Strip all ``MARKDOWN_VAULT_MCP_*`` env vars before each test (isolation).
 
     Prevents an env var set by one test (or the ambient shell) from leaking
-    into another.  Tests that need configuration set it explicitly afterwards (e.g. via
-    ``_mcp_env``, which depends on this fixture, or via ``monkeypatch.setenv``).
-    ``monkeypatch`` applies env mutations sequentially within each test, so the
-    strips here are always visible before any test-local ``setenv`` — the
-    test's own overrides win.
+    into another.  Because this fixture is ``autouse=True``, pytest resolves it
+    before any fixture or test body that shares the same ``monkeypatch``
+    instance, so these deletions always precede any test-local ``setenv`` — the
+    test's own overrides win.  ``_mcp_env`` declares it as an explicit
+    dependency to make that ordering a hard guarantee.
     """
     for key in list(os.environ):
         if key.startswith("MARKDOWN_VAULT_MCP_"):
@@ -237,11 +237,13 @@ _CLEAR_VARS = (
 def _mcp_env(
     _clear_env: None, vault_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Set minimal env vars for make_server()."""
+    """Set minimal env vars for make_server().
+
+    Only sets ``SOURCE_DIR``: the depended-on ``_clear_env`` already strips every
+    ``MARKDOWN_VAULT_MCP_*`` var (including ``READ_ONLY`` and all ``_CLEAR_VARS``)
+    before this runs, so no per-var clearing is needed here.
+    """
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
-    monkeypatch.delenv("MARKDOWN_VAULT_MCP_READ_ONLY", raising=False)
-    for var in _CLEAR_VARS:
-        monkeypatch.delenv(var, raising=False)
 
 
 @pytest.fixture
@@ -250,12 +252,15 @@ async def client(_mcp_env: None) -> AsyncIterator[Client[Any]]:
 
     Adapted from the template's ``client`` fixture: MVM's ``make_server()``
     calls ``ProjectConfig.from_env()`` which requires ``SOURCE_DIR``, so this
-    depends on ``_mcp_env`` (which sets it from ``vault_path``). Drains the
-    index writer so FTS-backed resources/tools (e.g. ``stats://vault``,
-    ``search``) return populated results rather than empty cold-start state.
+    depends on ``_mcp_env`` (which sets it from ``vault_path``). The server's
+    vault is therefore populated from ``vault_path`` (a copy of the markdown
+    fixtures), not an empty directory. Drains the index writer so FTS-backed
+    resources/tools (e.g. ``stats://vault``, ``search``) return populated
+    results rather than empty cold-start state.
 
     Args:
-        _mcp_env: Fixture that sets ``SOURCE_DIR`` (injected by pytest).
+        _mcp_env: Fixture that sets ``SOURCE_DIR`` from ``vault_path``
+            (injected by pytest; transitively pulls in ``vault_path``).
 
     Yields:
         An in-process FastMCP ``Client`` with the index writer drained.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -82,7 +82,12 @@ def test_server_name_env_override(
 async def test_server_name_override_reaches_server_info(
     monkeypatch: pytest.MonkeyPatch, vault_path: Path
 ) -> None:
-    """The overridden name also flows through to ``get_server_info``."""
+    """The overridden name also flows through to ``get_server_info``.
+
+    Uses an inline ``Client`` rather than the shared ``client`` fixture because
+    it needs a custom ``SERVER_NAME`` set before ``make_server()``; the autouse
+    ``_clear_env`` still isolates the env (it runs before this test body).
+    """
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SERVER_NAME", "renamed-instance")
     async with Client(make_server()) as c:
@@ -118,7 +123,9 @@ def test_blank_overrides_fall_back_to_defaults(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_INSTRUCTIONS", "   ")
     server = make_server()
     assert server.name == "markdown-vault-mcp"
-    assert server.instructions  # non-empty default, not "   "
+    # the built default, not the whitespace that was set (which would leak if
+    # the strip-blank-to-default logic regressed)
+    assert server.instructions and server.instructions != "   "
 
 
 async def test_no_file_exchange_scaffolding(
@@ -128,9 +135,10 @@ async def test_no_file_exchange_scaffolding(
 
     Two guards: no tool name carries the removed file-exchange scaffolding
     substrings (``file_exchange`` / ``upload_file``), and the real transfer
-    tools (``create_upload_link`` / ``create_download_link``) — which are
-    registered only on HTTP/SSE transport — are absent on the in-process stdio
-    transport used here.
+    tools (``create_upload_link`` / ``create_download_link``) are absent. The
+    transfer tools register only when ``make_server()`` runs with a non-stdio
+    transport; here it uses its default ``transport="stdio"`` argument (the
+    in-memory ``Client`` channel is unrelated to that gating).
     """
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     async with Client(make_server()) as c:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,6 @@
 """Smoke tests for Markdown Vault MCP.
 
-This file diverges from the template's scaffold because MV's
+This file diverges from the template's scaffold because MVM's
 ``make_server`` calls ``ProjectConfig.from_env`` which requires a non-empty
 ``MARKDOWN_VAULT_MCP_SOURCE_DIR``.  The template's bare
 ``server = make_server(); assert server`` would raise before the
@@ -11,7 +11,10 @@ test to any real vault.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, Any
+
+from fastmcp import Client
 
 from markdown_vault_mcp.server import make_server
 
@@ -26,5 +29,114 @@ def test_make_server_constructs(
 ) -> None:
     """make_server() returns a FastMCP instance without raising."""
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    assert make_server() is not None
+
+
+async def test_config_resource_round_trips(client: Client[Any]) -> None:
+    """A real MVM resource is reachable via the client and returns valid JSON.
+
+    Adapts the template's ``status://`` example to MVM's surface (MVM has no
+    ``status://``): ``config://vault`` round-trips the server's config.
+    """
+    result = await client.read_resource("config://vault")
+    data = json.loads(result[0].text)
+    assert "source_dir" in data
+    assert isinstance(data["read_only"], bool)
+
+
+async def test_get_server_info_tool_registered(client: Client[Any]) -> None:
+    """``get_server_info`` is wired by default and returns wrapper info."""
+    tools = {t.name for t in await client.list_tools()}
+    assert "get_server_info" in tools
+    result = await client.call_tool("get_server_info", {})
+    assert result.data  # non-empty server-info payload
+
+
+async def test_summarize_prompt_round_trips_path(client: Client[Any]) -> None:
+    """MVM's built-in ``summarize`` prompt round-trips its ``path`` argument.
+
+    Adapts the template's ``summarize``-``context`` example: MVM's summarize is
+    a built-in markdown prompt taking ``path`` (required); its body substitutes
+    ``$path``.
+    """
+    result = await client.get_prompt("summarize", {"path": "notes/intro.md"})
+    rendered = " ".join(m.content.text for m in result.messages)
+    assert "notes/intro.md" in rendered
+
+
+def test_server_name_env_override(
+    monkeypatch: pytest.MonkeyPatch, vault_path: Path
+) -> None:
+    """``MARKDOWN_VAULT_MCP_SERVER_NAME`` overrides the FastMCP server name."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SERVER_NAME", "renamed-instance")
+    assert make_server().name == "renamed-instance"
+
+
+async def test_server_name_override_reaches_server_info(
+    monkeypatch: pytest.MonkeyPatch, vault_path: Path
+) -> None:
+    """The overridden name also flows through to ``get_server_info``."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SERVER_NAME", "renamed-instance")
+    async with Client(make_server()) as c:
+        result = await c.call_tool("get_server_info", {})
+    assert "renamed-instance" in json.dumps(result.data)
+
+
+def test_instructions_env_override(
+    monkeypatch: pytest.MonkeyPatch, vault_path: Path
+) -> None:
+    """``MARKDOWN_VAULT_MCP_INSTRUCTIONS`` replaces the built-in instructions."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INSTRUCTIONS", "Custom operator text.")
+    assert make_server().instructions == "Custom operator text."
+
+
+def test_instructions_default_is_built(
+    monkeypatch: pytest.MonkeyPatch, vault_path: Path
+) -> None:
+    """With no override, instructions fall back to the built default."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+    monkeypatch.delenv("MARKDOWN_VAULT_MCP_INSTRUCTIONS", raising=False)
+    assert make_server().instructions  # non-empty default
+
+
+def test_blank_overrides_fall_back_to_defaults(
+    monkeypatch: pytest.MonkeyPatch, vault_path: Path
+) -> None:
+    """Blank SERVER_NAME / INSTRUCTIONS are treated as unset (env strips)."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SERVER_NAME", "   ")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_INSTRUCTIONS", "   ")
     server = make_server()
-    assert server is not None
+    assert server.name == "markdown-vault-mcp"
+    assert server.instructions  # non-empty default, not "   "
+
+
+async def test_no_file_exchange_scaffolding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """make_server() registers no file-exchange tools (removed scaffolding)."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    async with Client(make_server()) as c:
+        tools = {t.name for t in await c.list_tools()}
+    assert not any("file_exchange" in t or "upload_file" in t for t in tools)
+
+
+def test_register_apps_logs_configured_domain(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    vault_path: Path,
+) -> None:
+    """register_apps logs the configured app domain.
+
+    Adapted from the template: MVM's ``register_apps`` is real (not a no-op), so
+    we construct a server with APP_DOMAIN set and assert the structured log,
+    rather than re-calling register_apps on an already-registered server.
+    """
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_APP_DOMAIN", "example.com")
+    with caplog.at_level("INFO", logger="markdown_vault_mcp._server_apps"):
+        make_server()
+    assert any(r.args == ("example.com",) for r in caplog.records)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -88,7 +88,7 @@ async def test_server_name_override_reaches_server_info(
     async with Client(make_server()) as c:
         await wait_for_mcp_writer_drain(c)
         result = await c.call_tool("get_server_info", {})
-    assert "renamed-instance" in json.dumps(result.data)
+    assert result.data.get("server_name") == "renamed-instance"
 
 
 def test_instructions_env_override(
@@ -124,18 +124,21 @@ def test_blank_overrides_fall_back_to_defaults(
 async def test_no_file_exchange_scaffolding(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """make_server() registers no file-exchange tools.
+    """make_server() on stdio registers no file-exchange or transfer tools.
 
-    Transfer replacements (create_upload_link / create_download_link) are
-    registered only on HTTP/SSE transport, not on the in-process stdio
-    transport used here — but they must not silently become file-exchange
-    tools under any name.
+    Two guards: no tool name carries the removed file-exchange scaffolding
+    substrings (``file_exchange`` / ``upload_file``), and the real transfer
+    tools (``create_upload_link`` / ``create_download_link``) — which are
+    registered only on HTTP/SSE transport — are absent on the in-process stdio
+    transport used here.
     """
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     async with Client(make_server()) as c:
         await wait_for_mcp_writer_drain(c)
         tools = {t.name for t in await c.list_tools()}
     assert not any("file_exchange" in t or "upload_file" in t for t in tools)
+    assert "create_upload_link" not in tools
+    assert "create_download_link" not in tools
 
 
 def test_register_apps_logs_configured_domain(
@@ -146,11 +149,15 @@ def test_register_apps_logs_configured_domain(
     """register_apps logs the configured app domain.
 
     Adapted from the template: MVM's ``register_apps`` is real (not a no-op), so
-    we construct a server with APP_DOMAIN set and assert the log record args contain the domain,
-    rather than re-calling register_apps on an already-registered server.
+    we construct a server with APP_DOMAIN set and assert the log record (from
+    the _server_apps logger, args carrying the domain) rather than re-calling
+    register_apps on an already-registered server.
     """
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_APP_DOMAIN", "example.com")
     with caplog.at_level("INFO", logger="markdown_vault_mcp._server_apps"):
         make_server()
-    assert any(r.args == ("example.com",) for r in caplog.records)
+    assert any(
+        r.name == "markdown_vault_mcp._server_apps" and r.args == ("example.com",)
+        for r in caplog.records
+    )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 from fastmcp import Client
 
 from markdown_vault_mcp.server import make_server
+from tests.conftest import wait_for_mcp_writer_drain
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -32,15 +33,18 @@ def test_make_server_constructs(
     assert make_server() is not None
 
 
-async def test_config_resource_round_trips(client: Client[Any]) -> None:
-    """A real MVM resource is reachable via the client and returns valid JSON.
+async def test_config_resource_round_trips(
+    client: Client[Any], vault_path: Path
+) -> None:
+    """``config://vault`` exposes the server config as JSON with the expected fields.
 
     Adapts the template's ``status://`` example to MVM's surface (MVM has no
-    ``status://``): ``config://vault`` round-trips the server's config.
+    ``status://``): the config resource is reachable via the client and carries
+    the wired ``source_dir`` plus a typed ``read_only`` flag.
     """
     result = await client.read_resource("config://vault")
     data = json.loads(result[0].text)
-    assert "source_dir" in data
+    assert data["source_dir"] == str(vault_path)
     assert isinstance(data["read_only"], bool)
 
 
@@ -49,18 +53,20 @@ async def test_get_server_info_tool_registered(client: Client[Any]) -> None:
     tools = {t.name for t in await client.list_tools()}
     assert "get_server_info" in tools
     result = await client.call_tool("get_server_info", {})
-    assert result.data  # non-empty server-info payload
+    assert result.data.get("server_name") == "markdown-vault-mcp"
+    assert result.data.get("server_version")  # non-empty version string
+    assert result.data.get("core_version")  # non-empty
 
 
 async def test_summarize_prompt_round_trips_path(client: Client[Any]) -> None:
-    """MVM's built-in ``summarize`` prompt round-trips its ``path`` argument.
+    """MVM's built-in ``summarize`` prompt requires a ``path`` arg and its
+    rendered output includes the supplied path value.
 
     Adapts the template's ``summarize``-``context`` example: MVM's summarize is
-    a built-in markdown prompt taking ``path`` (required); its body substitutes
-    ``$path``.
+    a built-in markdown prompt taking ``path`` (required).
     """
     result = await client.get_prompt("summarize", {"path": "notes/intro.md"})
-    rendered = " ".join(m.content.text for m in result.messages)
+    rendered = result.messages[0].content.text
     assert "notes/intro.md" in rendered
 
 
@@ -80,6 +86,7 @@ async def test_server_name_override_reaches_server_info(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SERVER_NAME", "renamed-instance")
     async with Client(make_server()) as c:
+        await wait_for_mcp_writer_drain(c)
         result = await c.call_tool("get_server_info", {})
     assert "renamed-instance" in json.dumps(result.data)
 
@@ -117,9 +124,16 @@ def test_blank_overrides_fall_back_to_defaults(
 async def test_no_file_exchange_scaffolding(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """make_server() registers no file-exchange tools (removed scaffolding)."""
+    """make_server() registers no file-exchange tools.
+
+    Transfer replacements (create_upload_link / create_download_link) are
+    registered only on HTTP/SSE transport, not on the in-process stdio
+    transport used here — but they must not silently become file-exchange
+    tools under any name.
+    """
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
     async with Client(make_server()) as c:
+        await wait_for_mcp_writer_drain(c)
         tools = {t.name for t in await c.list_tools()}
     assert not any("file_exchange" in t or "upload_file" in t for t in tools)
 
@@ -132,7 +146,7 @@ def test_register_apps_logs_configured_domain(
     """register_apps logs the configured app domain.
 
     Adapted from the template: MVM's ``register_apps`` is real (not a no-op), so
-    we construct a server with APP_DOMAIN set and assert the structured log,
+    we construct a server with APP_DOMAIN set and assert the log record args contain the domain,
     rather than re-calling register_apps on an already-registered server.
     """
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))


### PR DESCRIPTION
Closes #769. Child of epic #766 (template re-convergence).

## What

Restores the test scaffolding MVM stripped from the template, **adapted to MVM's real surface** (not the scaffold examples verbatim):

- **`tests/conftest.py`** — re-adds the autouse `_clear_env` fixture (strips all `MARKDOWN_VAULT_MCP_*` before each test for isolation) and an async `client` fixture (in-memory `Client(make_server())`). `client` is adapted for MVM: it depends on `_mcp_env` (MVM's `make_server()` requires `SOURCE_DIR`) and drains the index writer so FTS-backed resources/tools are queryable. `_mcp_env` now declares `_clear_env` as an explicit dependency (hard ordering) and only sets `SOURCE_DIR` (the autouse strip subsumes its old per-var clears).
- **`tests/test_smoke.py`** — grows from 1 to 11 smoke tests. Ported cleanly: `get_server_info` registration + field assertions, the SERVER_NAME/INSTRUCTIONS override suite (incl. blank→default), `no_file_exchange`, `register_apps` domain log. **Adapted** to MVM's surface: the template's `status://` resource round-trip → a real MVM resource (`config://vault`, asserting `source_dir == vault_path`); the `summarize`-`context` prompt → MVM's built-in `summarize` prompt with its real `path` argument.

These two files are in the template's `_skip_if_exists` list, so copier never re-adds the fixtures — this is the manual reconciliation #769 exists for, and #771's copier update will not touch them.

No `src/` changes — test scaffolding only. `tests/test_cli.py` untouched (converged in #768).

## Review

A full local **preflight circus (8 lenses) was run three times** — each round's findings fixed before the next, until convergence:
- **R1** (10 fixes): restored 2 fixtures + adapted suite; caught the index-readiness wiring, the `summarize` `path` adaptation, and 3 assertion-strengthenings.
- **R2** (6 fixes): made `no_file_exchange` non-tautological (assert the real stdio-gated transfer tools absent), field-level `server_name` assertion, pinned the `register_apps` logger name, simplified `_mcp_env`.
- **R3** (5 fixes): docstring accuracy (`_clear_env` ordering is the explicit-dependency edge, not autouse; the `no_file_exchange` "stdio" wording) + a blank-default assertion. **Zero new bugs** — convergence reached.

Full suite **2378 passed**, 3 skipped; `mypy src/ tests/` clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
