### PR TITLE
feat: folder/subtree table-of-contents + get_toc tool (#773)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `get_outlinks` | Find all links from a document, with existence check |
 | `get_broken_links` | Find all links pointing to non-existent documents |
 | `get_similar` | Find semantically similar notes by document path |
+| `get_toc` | Heading outline for a note or a folder subtree |
 | `get_recent` | Get the most recently modified notes |
 | `get_context` | Get a consolidated context dossier for a note (backlinks, outlinks, similar, folder peers, tags, modified time) |
 | `get_orphan_notes` | Find all notes with no inbound or outbound links |

--- a/docs/design.md
+++ b/docs/design.md
@@ -1812,6 +1812,7 @@ pattern). Each tool is annotated with MCP `ToolAnnotations`:
 | `get_outlinks` | Find links from a document (with exists flag) | `True` | `False` | `True` |
 | `get_broken_links` | Find links to non-existent documents | `True` | `False` | `True` |
 | `get_similar` | Find semantically similar notes by path | `True` | `False` | `True` |
+| `get_toc` | Heading outline for a note or folder subtree | `True` | `False` | `True` |
 | `get_recent` | Get most recently modified notes | `True` | `False` | `True` |
 | `get_context` | Get consolidated context dossier for a note | `True` | `False` | `True` |
 | `get_orphan_notes` | Find notes with no inbound or outbound links | `True` | `False` | `True` |
@@ -1872,10 +1873,17 @@ template functions with no vault dependency.
 | ``tags://vault`` | ``ReaderFacet.list_tags()`` | All tags grouped by indexed field |
 | ``tags://vault/{field}`` | ``ReaderFacet.list_tags(field)`` | Flat list for one field (template) |
 | ``folders://vault`` | ``ReaderFacet.list_folders()`` | Sorted folder path list |
-| ``toc://vault/{path}`` | ``ReaderFacet.get_toc(path)`` | Document headings with synthetic H1 title |
+| ``toc://vault/{path}`` | ``ReaderFacet.get_toc(path)`` | Document headings (note) or per-note heading outline (folder subtree) |
 
 Resources return JSON (``mime_type="application/json"``). The ToC resource
 queries the existing ``sections`` table (no file I/O).
+
+**TOC surface** (``get_toc`` tool and ``toc://vault/{path}`` resource): dispatch is by suffix. Paths ending in ``.md`` are note mode; all other paths are folder-prefix mode.
+
+- **Note mode** returns a flat ordered ``list[{heading, level}]``. The document title is included as a synthetic H1 entry.
+- **Folder mode** returns ``{path, notes, truncated}`` where ``notes`` is an ordered ``list[{path, title, headings}]`` aggregating every note under the subtree (sorted by path). ``max_notes`` (default 200) caps the note count; when more notes match, the first ``max_notes`` by path are returned and ``truncated`` is ``True``.
+- **``max_level``** (tool only, default ``None``) filters out headings deeper than the given level. The synthetic H1 title always survives regardless of ``max_level``.
+- The resource (``toc://vault/{path}``) exposes no ``max_level`` or ``max_notes`` controls; use the ``get_toc`` tool when those controls are needed.
 
 **Prompts**: 6 built-in prompt templates, plus optional user-defined prompts:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -14,7 +14,7 @@ MCP resources expose vault metadata that clients can read directly without invok
 | [`tags://vault`](#tagsvault) | All tags grouped by indexed field |
 | [`tags://vault/{field}`](#tagsvaultfield) | Tags for a specific field |
 | [`folders://vault`](#foldersvault) | All folder paths |
-| [`toc://vault/{path}`](#tocvaultpath) | Table of contents for a document |
+| [`toc://vault/{path}`](#tocvaultpath) | Table of contents for a note or folder subtree |
 | [`similar://vault/{path}`](#similarvaultpath) | Semantically similar notes for a document |
 | [`recent://vault`](#recentvault) | Most recently modified notes |
 | [`ui://vault/app.html`](#uivaultapphtml) | Interactive vault explorer SPA (MCP Apps) |
@@ -95,10 +95,12 @@ The empty string `""` represents the root folder (top-level documents).
 
 ## `toc://vault/{path}`
 
-Table of contents (heading outline) for a specific document. This is a URI template: replace `{path}` with the document's relative path.
+Table of contents (heading outline) for a note or a folder subtree. This is a URI template: replace `{path}` with a document path (ending in `.md`) or a folder path.
 
 !!! note "Cold-start blocking"
     Calls during a cold-start background FTS build block via the tool-layer `needs_queryable` decorator and may surface `IndexUnavailableError(reason="build_failed")` if a scheduled background build ran and failed (the captured error message is available via `get_index_status`'s `error` field), or `IndexUnavailableError(reason="timeout")` if the decorator's bounded wait elapsed first. The decorator also remaps a SQLite `OperationalError` from the resource handler to `IndexUnavailableError(reason="broken")` (corruption / I/O failure / unknown codes) or `reason="busy"` (SQLITE_BUSY/LOCKED, lock contention); inspect the exception's `__cause__` for the underlying SQLite error. Poll `get_index_status` to observe build state without blocking.
+
+**Note path** (ending in `.md`): returns a flat ordered list of `{heading, level}` entries. The title is added as a synthetic H1 and deduplicated if the first real heading matches it.
 
 **Example:** `toc://vault/Journal/note.md`
 
@@ -106,15 +108,36 @@ Table of contents (heading outline) for a specific document. This is a URI templ
 
 ```json
 [
-  {"level": 1, "title": "My Note"},
-  {"level": 2, "title": "Introduction"},
-  {"level": 2, "title": "Main Points"},
-  {"level": 3, "title": "First Point"},
-  {"level": 2, "title": "Conclusion"}
+  {"level": 1, "heading": "My Note"},
+  {"level": 2, "heading": "Introduction"},
+  {"level": 2, "heading": "Main Points"},
+  {"level": 3, "heading": "First Point"},
+  {"level": 2, "heading": "Conclusion"}
 ]
 ```
 
-The TOC prepends a synthetic H1 from the document title and deduplicates if the first real heading matches the title.
+**Folder path**: returns a nested-per-note object aggregating the subtree (capped at 200 notes by default). Use the `get_toc` tool for the same data with `max_level` / `max_notes` controls.
+
+**Example:** `toc://vault/Journal`
+
+**Response:**
+
+```json
+{
+  "path": "Journal",
+  "notes": [
+    {
+      "path": "Journal/note.md",
+      "title": "My Note",
+      "headings": [
+        {"level": 1, "heading": "My Note"},
+        {"level": 2, "heading": "Introduction"}
+      ]
+    }
+  ],
+  "truncated": false
+}
+```
 
 ## `similar://vault/{path}`
 

--- a/docs/superpowers/plans/2026-06-29-subtree-toc.md
+++ b/docs/superpowers/plans/2026-06-29-subtree-toc.md
@@ -1,0 +1,757 @@
+# Folder/subtree TOC + per-note TOC tool — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a folder/subtree table-of-contents and expose the TOC as a tool (not just a resource), via one path-dispatched facet method (#773).
+
+**Architecture:** A single `get_toc(path, *, max_level, max_notes)` method dispatches on the `.md` suffix: note paths keep today's flat `[{heading, level}]` output; folder paths return a nested-per-note object aggregated from the FTS `sections` table. The method is exposed through the existing `toc://vault/{path}` resource (defaults) and a new `get_toc` MCP tool (both knobs).
+
+**Tech Stack:** Python 3.11+, SQLite FTS5, FastMCP, pytest, `uv`, `ruff`, `mypy`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-29-subtree-toc-design.md` (authoritative).
+- Per-note shape is `{heading, level}` — **no** `text`/`anchor` fields are added.
+- Folder match is on a path boundary via the precomputed `documents.folder`
+  column: `folder = ? OR folder LIKE ? ESCAPE '\'` with `_escape_like(prefix)`,
+  mirroring `FTSIndex.search` (`fts_index.py:1124-1129`). `Project` must never
+  match `Projects/...`.
+- Folder mode default `max_notes=200`; `max_level` default `None` (all levels).
+- Empty/nonexistent folder → `{"path": ..., "notes": [], "truncated": False}`
+  (no raise). Missing **note** → `ValueError` (unchanged).
+- Gates (run before every commit that touches `src/`): `uv run ruff check --fix .`
+  then `uv run ruff format .`, `uv run mypy src/ tests/`, `uv run pytest -x -q`.
+- Docs ship in the same commit as the user-facing change (CLAUDE.md gate #5).
+- Conventional commits.
+
+---
+
+### Task 1: FTS layer — `max_level` on `get_toc` + new `get_subtree_toc`
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/fts_index.py` (`get_toc` ~line 1382; add `get_subtree_toc` adjacent to it)
+- Test: `tests/test_fts_subtree_toc.py` (create)
+
+**Interfaces:**
+- Produces:
+  - `FTSIndex.get_toc(self, path: str, *, max_level: int | None = None) -> list[dict[str, str | int]]`
+  - `FTSIndex.get_subtree_toc(self, prefix: str, *, max_level: int | None = None, max_notes: int = 200) -> tuple[list[dict[str, Any]], bool]`
+    where each list item is `{"path": str, "title": str, "headings": list[{"heading": str, "level": int}]}` (raw section headings, **no** synthetic H1), and the bool is `truncated`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_fts_subtree_toc.py`:
+
+```python
+"""FTS-layer tests for subtree TOC aggregation and max_level filtering (#773)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.scanner import HeadingChunker, scan_directory
+
+
+def _build_fts(root: Path) -> FTSIndex:
+    fts = FTSIndex(db_path=":memory:")
+    for note in scan_directory(root):
+        fts.upsert_note(note)
+    fts.resolve_vault_wikilinks()
+    return fts
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    (tmp_path / "Projects").mkdir()
+    (tmp_path / "Projects" / "alpha.md").write_text(
+        "---\ntitle: Alpha\n---\n# Alpha\n\n## Goals\n\nx\n\n### Detail\n\ny\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "Projects" / "beta.md").write_text(
+        "---\ntitle: Beta\n---\n# Beta\n\n## Plan\n\nz\n",
+        encoding="utf-8",
+    )
+    sub = tmp_path / "Projects" / "sub"
+    sub.mkdir()
+    (sub / "gamma.md").write_text(
+        "---\ntitle: Gamma\n---\n# Gamma\n\n## Nested\n\nq\n",
+        encoding="utf-8",
+    )
+    # A sibling folder whose prefix shares a leading substring with "Projects".
+    (tmp_path / "Projectile.md").write_text(
+        "---\ntitle: Projectile\n---\n# Projectile\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_subtree_toc_is_recursive_and_path_ordered(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, truncated = fts.get_subtree_toc("Projects")
+    assert truncated is False
+    assert [n["path"] for n in notes] == [
+        "Projects/alpha.md",
+        "Projects/beta.md",
+        "Projects/sub/gamma.md",
+    ]
+    alpha = notes[0]
+    assert alpha["title"] == "Alpha"
+    # Raw section headings only — no synthetic H1 prepended at this layer.
+    assert {"heading": "Goals", "level": 2} in alpha["headings"]
+    assert {"heading": "Detail", "level": 3} in alpha["headings"]
+
+
+def test_subtree_prefix_is_boundary_matched(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, _ = fts.get_subtree_toc("Project")
+    assert notes == []  # neither "Projects/..." nor "Projectile.md" match
+
+
+def test_subtree_max_level_filters_headings(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, _ = fts.get_subtree_toc("Projects", max_level=2)
+    alpha = next(n for n in notes if n["path"] == "Projects/alpha.md")
+    levels = {h["level"] for h in alpha["headings"]}
+    assert levels <= {1, 2}  # H3 "Detail" dropped
+
+
+def test_subtree_max_notes_truncates(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, truncated = fts.get_subtree_toc("Projects", max_notes=2)
+    assert truncated is True
+    assert len(notes) == 2
+    assert [n["path"] for n in notes] == ["Projects/alpha.md", "Projects/beta.md"]
+
+
+def test_get_toc_max_level_filter(vault: Path) -> None:
+    fts = _build_fts(vault)
+    toc = fts.get_toc("Projects/alpha.md", max_level=2)
+    assert all(h["level"] <= 2 for h in toc)
+    assert {"heading": "Detail", "level": 3} not in toc
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_fts_subtree_toc.py -q`
+Expected: FAIL — `get_subtree_toc` missing / `get_toc()` got unexpected keyword `max_level`.
+
+- [ ] **Step 3: Add `max_level` to `get_toc`**
+
+In `fts_index.py`, change the `get_toc` signature and SQL. Current method:
+
+```python
+    def get_toc(self, path: str) -> list[dict[str, str | int]]:
+```
+
+Replace the signature line and inject the level predicate:
+
+```python
+    def get_toc(
+        self, path: str, *, max_level: int | None = None
+    ) -> list[dict[str, str | int]]:
+```
+
+In its SQL, after `AND heading IS NOT NULL`, add the optional clause. Replace the
+`execute(...)` call body so it reads:
+
+```python
+        level_clause = "" if max_level is None else "AND heading_level <= ?"
+        params: list[object] = [path]
+        if max_level is not None:
+            params.append(max_level)
+        cur = self._conn().execute(
+            f"""
+            SELECT heading, heading_level
+            FROM sections
+            WHERE document_id = (SELECT id FROM documents WHERE path = ?)
+              AND heading IS NOT NULL
+              {level_clause}
+            GROUP BY heading, heading_level
+            ORDER BY MIN(rowid)
+            """,
+            params,
+        )
+```
+
+- [ ] **Step 4: Add `get_subtree_toc`**
+
+Immediately after `get_toc`, add (carry the same `@_retry_on_locked` decorator
+that the surrounding read methods use):
+
+```python
+    @_retry_on_locked
+    def get_subtree_toc(
+        self,
+        prefix: str,
+        *,
+        max_level: int | None = None,
+        max_notes: int = 200,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Return per-note headings for every document under a folder prefix.
+
+        Matches documents whose ``folder`` equals *prefix* or is a descendant
+        of it (boundary match, so ``"Project"`` never matches ``"Projects"``).
+
+        Args:
+            prefix: Folder path with no trailing slash (e.g. ``"Projects"``).
+            max_level: If set, drop headings with ``level`` greater than this.
+            max_notes: Cap on distinct notes returned (default 200).
+
+        Returns:
+            ``(notes, truncated)`` where *notes* is a list of
+            ``{"path", "title", "headings": [{"heading", "level"}]}`` ordered
+            by path, *headings* are raw section headings (no synthetic H1),
+            and *truncated* is True when more than ``max_notes`` notes matched.
+        """
+        escaped = _escape_like(prefix)
+        doc_rows = self._conn().execute(
+            """
+            SELECT id, path, title
+            FROM documents
+            WHERE (folder = ? OR folder LIKE ? ESCAPE '\\')
+            ORDER BY path ASC
+            LIMIT ?
+            """,
+            (prefix, escaped + "/%", max_notes + 1),
+        ).fetchall()
+        truncated = len(doc_rows) > max_notes
+        doc_rows = doc_rows[:max_notes]
+        if not doc_rows:
+            return [], truncated
+
+        ids = [row["id"] for row in doc_rows]
+        placeholders = ",".join("?" * len(ids))
+        level_clause = "" if max_level is None else "AND heading_level <= ?"
+        params: list[object] = [*ids]
+        if max_level is not None:
+            params.append(max_level)
+        section_rows = self._conn().execute(
+            f"""
+            SELECT document_id, heading, heading_level
+            FROM sections
+            WHERE document_id IN ({placeholders})
+              AND heading IS NOT NULL
+              {level_clause}
+            GROUP BY document_id, heading, heading_level
+            ORDER BY document_id, MIN(rowid)
+            """,
+            params,
+        ).fetchall()
+
+        by_doc: dict[int, list[dict[str, Any]]] = {}
+        for row in section_rows:
+            by_doc.setdefault(row["document_id"], []).append(
+                {"heading": row["heading"], "level": row["heading_level"]}
+            )
+
+        notes = [
+            {
+                "path": row["path"],
+                "title": row["title"],
+                "headings": by_doc.get(row["id"], []),
+            }
+            for row in doc_rows
+        ]
+        return notes, truncated
+```
+
+Confirm `Any` is imported in `fts_index.py` (it is — `get_backlinks` uses it).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_fts_subtree_toc.py -q`
+Expected: PASS (5 tests). Then regression: `uv run pytest tests/test_fts_index_retry.py tests/test_managers_document.py -q` → PASS.
+
+- [ ] **Step 6: Lint + typecheck + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/
+git add src/markdown_vault_mcp/fts_index.py tests/test_fts_subtree_toc.py
+git commit -m "feat: FTS get_subtree_toc + max_level filter on get_toc (#773)"
+```
+
+---
+
+### Task 2: Library dispatch — `DocumentManager.get_toc` + `ReaderFacet.get_toc`
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/managers/document.py` (`get_toc` ~line 495)
+- Modify: `src/markdown_vault_mcp/facets/reader.py` (`get_toc` ~line 175)
+- Test: `tests/test_managers_document.py` (extend `TestGetToc`), `tests/test_facet_reader.py`
+
+**Interfaces:**
+- Consumes: `FTSIndex.get_toc(path, *, max_level)`, `FTSIndex.get_subtree_toc(prefix, *, max_level, max_notes)` (Task 1); existing `self._validate_dir_path` (`document.py`).
+- Produces:
+  - `DocumentManager.get_toc(self, path: str, *, max_level: int | None = None, max_notes: int = 200) -> list[dict[str, Any]] | dict[str, Any]`
+  - `ReaderFacet.get_toc(self, path: str, *, max_level: int | None = None, max_notes: int = 200) -> list[dict[str, Any]] | dict[str, Any]`
+  - Folder-mode dict shape: `{"path": str, "notes": [{"path", "title", "headings": [{"heading", "level"}]}], "truncated": bool}`. Each note's `headings` has the title prepended as a synthetic H1 (deduped against an existing leading H1 equal to the title) — structurally identical to note mode.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_managers_document.py`, extend `class TestGetToc` (the `doc_vault`
+fixture has `alpha.md`, `beta.md`, `sub/gamma.md` with `# Gamma` / `## Section One`):
+
+```python
+    def test_get_toc_max_level_note_mode(self, doc_mgr: DocumentManager) -> None:
+        toc = doc_mgr.get_toc("sub/gamma.md", max_level=1)
+        # Only the synthetic H1 title survives an H1-only cap.
+        assert toc == [{"heading": "Gamma", "level": 1}]
+
+    def test_get_toc_folder_mode_nested(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.get_toc("sub")
+        assert isinstance(result, dict)
+        assert result["path"] == "sub"
+        assert result["truncated"] is False
+        paths = [n["path"] for n in result["notes"]]
+        assert paths == ["sub/gamma.md"]
+        gamma = result["notes"][0]
+        assert gamma["title"] == "Gamma"
+        # Synthetic H1 prepended, body headings follow.
+        assert gamma["headings"][0] == {"heading": "Gamma", "level": 1}
+        assert {"heading": "Section One", "level": 2} in gamma["headings"]
+
+    def test_get_toc_folder_trailing_slash(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.get_toc("sub/")
+        assert result["path"] == "sub"
+        assert [n["path"] for n in result["notes"]] == ["sub/gamma.md"]
+
+    def test_get_toc_empty_folder_returns_empty(
+        self, doc_mgr: DocumentManager
+    ) -> None:
+        result = doc_mgr.get_toc("does-not-exist")
+        assert result == {"path": "does-not-exist", "notes": [], "truncated": False}
+
+    def test_get_toc_folder_max_level(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.get_toc("sub", max_level=1)
+        gamma = result["notes"][0]
+        assert gamma["headings"] == [{"heading": "Gamma", "level": 1}]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_managers_document.py::TestGetToc -q`
+Expected: FAIL — folder mode not implemented / unexpected keyword `max_level`.
+
+- [ ] **Step 3: Implement dispatch in `DocumentManager.get_toc`**
+
+Replace the existing `get_toc` body in `managers/document.py` with:
+
+```python
+    def get_toc(
+        self,
+        path: str,
+        *,
+        max_level: int | None = None,
+        max_notes: int = 200,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Return a table of contents for a note or a folder subtree.
+
+        When *path* ends in ``.md`` the result is a single note's flat
+        outline: a list of ``{"heading", "level"}`` with the document title
+        prepended as a synthetic H1. Otherwise *path* is treated as a folder
+        prefix and the result is a nested-per-note object aggregating the
+        subtree.
+
+        Args:
+            path: Note path (``"a/b.md"``) or folder prefix (``"a/b"``).
+            max_level: If set, drop headings with ``level`` above this. The
+                synthetic H1 title always survives ``max_level >= 1``.
+            max_notes: Folder mode only — cap on distinct notes (default 200).
+
+        Returns:
+            Note mode: ``list[{"heading", "level"}]``.
+            Folder mode: ``{"path", "notes": [...], "truncated": bool}`` where
+            each note is ``{"path", "title", "headings": [...]}``.
+
+        Raises:
+            ValueError: Note mode, if no document exists at *path*; or if a
+                folder *path* is empty/root or escapes the vault.
+        """
+        if path.endswith(".md"):
+            return self._note_toc(path, max_level=max_level)
+        return self._subtree_toc(path, max_level=max_level, max_notes=max_notes)
+
+    def _note_toc(
+        self, path: str, *, max_level: int | None
+    ) -> list[dict[str, Any]]:
+        self._validate_path(path)
+        row = self._fts.get_note(path)
+        if row is None:
+            raise ValueError(f"Document not found: {path}")
+        title: str = row["title"]
+        headings = self._fts.get_toc(path, max_level=max_level)
+        toc: list[dict[str, Any]] = [{"heading": title, "level": 1}]
+        toc.extend(
+            h for h in headings if not (h["level"] == 1 and h["heading"] == title)
+        )
+        return toc
+
+    def _subtree_toc(
+        self, path: str, *, max_level: int | None, max_notes: int
+    ) -> dict[str, Any]:
+        prefix = path.rstrip("/")
+        self._validate_dir_path(prefix)
+        notes_raw, truncated = self._fts.get_subtree_toc(
+            prefix, max_level=max_level, max_notes=max_notes
+        )
+        notes: list[dict[str, Any]] = []
+        for note in notes_raw:
+            title = note["title"]
+            headings: list[dict[str, Any]] = [{"heading": title, "level": 1}]
+            headings.extend(
+                h
+                for h in note["headings"]
+                if not (h["level"] == 1 and h["heading"] == title)
+            )
+            notes.append(
+                {"path": note["path"], "title": title, "headings": headings}
+            )
+        return {"path": prefix, "notes": notes, "truncated": truncated}
+```
+
+Note: `_note_toc` keeps the synthetic H1 (level 1) regardless of `max_level`
+because it is prepended *after* the FTS filter — matching the spec rule that the
+title survives `max_level >= 1`.
+
+- [ ] **Step 4: Forward kwargs in `ReaderFacet.get_toc`**
+
+In `facets/reader.py`, replace the `get_toc` method:
+
+```python
+    def get_toc(
+        self,
+        path: str,
+        *,
+        max_level: int | None = None,
+        max_notes: int = 200,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Return a table of contents for a note or a folder subtree.
+
+        Note paths (ending in ``.md``) return a flat ``[{"heading", "level"}]``
+        outline with the title as a synthetic H1. Folder paths return a
+        nested-per-note object ``{"path", "notes", "truncated"}``. The result
+        depends on the FTS index, so cold-start callers must build the index
+        first (bucket 3).
+
+        Args:
+            path: Note path or folder prefix.
+            max_level: Drop headings with ``level`` above this (both modes).
+            max_notes: Folder mode cap on distinct notes (default 200).
+
+        Returns:
+            ``list`` for a note path, ``dict`` for a folder path.
+
+        Raises:
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
+            ValueError: Note path with no document; invalid folder path.
+        """
+        self._require_built()
+        return self._doc_mgr.get_toc(path, max_level=max_level, max_notes=max_notes)
+```
+
+- [ ] **Step 5: Add a facet-level folder test**
+
+In `tests/test_facet_reader.py`, near `test_get_toc_returns_list`:
+
+```python
+    def test_get_toc_folder_returns_dict(self, built: Vault) -> None:
+        result = built.reader.get_toc("subfolder")
+        assert isinstance(result, dict)
+        assert "notes" in result and "truncated" in result
+```
+
+(The `built` vault indexes `tests/fixtures/`, which contains
+`subfolder/nested.md` and `subfolder/deep/doc.md`.)
+
+- [ ] **Step 6: Run tests + gates + commit**
+
+Run: `uv run pytest tests/test_managers_document.py tests/test_facet_reader.py -q`
+Expected: PASS.
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/
+git add src/markdown_vault_mcp/managers/document.py src/markdown_vault_mcp/facets/reader.py tests/test_managers_document.py tests/test_facet_reader.py
+git commit -m "feat: path-dispatched get_toc (note + folder subtree) in library (#773)"
+```
+
+---
+
+### Task 3: MCP resource extension + docstring fix + docs
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/_server_resources.py` (`vault_toc` ~line 180-194)
+- Modify: `docs/resources.md`
+- Test: `tests/test_server.py` — class `TestResources` (~line 2201; existing `test_toc_resource` at ~2267)
+
+**Interfaces:**
+- Consumes: `ReaderFacet.get_toc(path)` (Task 2), now returning list **or** dict.
+- The resource passes only defaults (no knobs).
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_server.py`, add to class `TestResources` (next to the existing
+`test_toc_resource`, which uses `Client(make_server())` and `json` — both already
+imported in this file). `tests/fixtures/` ships `subfolder/` with two notes:
+
+```python
+    async def test_toc_resource_folder_returns_nested(self) -> None:
+        async with Client(make_server()) as client:
+            result = await client.read_resource("toc://vault/subfolder")
+            data = json.loads(result[0].text)
+            assert isinstance(data, dict)
+            assert "notes" in data and data["path"] == "subfolder"
+```
+
+(Match the `usefixtures` / decorators on the neighboring `TestResources` tests.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_server.py -q -k toc`
+Expected: FAIL — folder path currently raises (note-only `get_toc`).
+
+- [ ] **Step 3: Fix the resource docstring (no behavior change needed in body)**
+
+The body already calls `vault.reader.get_toc(path)` and JSON-dumps the result,
+so list-or-dict passes through unchanged. Only correct the inaccurate docstring.
+Replace the `vault_toc` docstring:
+
+```python
+        """Table of contents for a note or a folder subtree.
+
+        A note path (ending in ``.md``) returns a flat ordered list of
+        ``{heading, level}`` headings (the title as a synthetic H1). A folder
+        path returns a nested-per-note object
+        ``{path, notes: [{path, title, headings}], truncated}`` aggregating the
+        subtree (default cap 200 notes). Useful for navigating structure
+        without reading full content. See the ``get_toc`` tool for the same
+        data with ``max_level`` / ``max_notes`` controls.
+
+        Index freshness is reported in _meta.index_stale.
+        """
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_server.py -q -k toc`
+Expected: PASS (folder + existing note cases).
+
+- [ ] **Step 5: Update `docs/resources.md`**
+
+Update the `toc://vault/{path}` entry to document both shapes (note → list;
+folder → nested `{path, notes, truncated}` object) and cross-reference the new
+`get_toc` tool. Match the surrounding entry format in that file.
+
+- [ ] **Step 6: Gates + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/
+git add src/markdown_vault_mcp/_server_resources.py docs/resources.md tests/test_server.py
+git commit -m "feat: extend toc:// resource to folder subtree; fix docstring (#773)"
+```
+
+---
+
+### Task 4: New `get_toc` MCP tool + registry tests + docs
+
+**Files:**
+- Modify: `src/markdown_vault_mcp/_server_tools/reader.py` (add tool after `get_similar`, ~line 558)
+- Modify: `tests/test_server.py` (manifest list ~line 254; add tool behavior tests)
+- Modify: `docs/tools/index.md`, `README.md`, `docs/design.md`
+- Modify: `src/markdown_vault_mcp/_icons.py` only if a `get_toc` icon key is desired (optional — reuse `_TOOL_ICONS["read"]`)
+
+**Interfaces:**
+- Consumes: `ReaderFacet.get_toc(path, *, max_level, max_notes)` (Task 2); `_maybe_wait_for_drain`, `_staleness_result`, `needs_queryable`, `_TOOL_ICONS` (already imported in `reader.py`).
+- Produces: MCP tool `get_toc(path, max_level=None, max_notes=200, wait_for_pending_writes=False)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_server.py`, add `"get_toc"` to the expected manifest list in
+`test_register_tools_registers_exact_manifest` (alphabetical: after
+`"get_similar"`, before `"git_sync"`):
+
+```python
+            "get_similar",
+            "get_toc",
+            "git_sync",
+```
+
+Then add a behavior test class (mirror the existing `Client(make_server())`
+style used elsewhere in the file):
+
+```python
+class TestGetTocTool:
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_get_toc_tool_note(self) -> None:
+        async with Client(make_server()) as client:
+            result = await client.call_tool("get_toc", {"path": "simple.md"})
+            assert isinstance(result.data, list)
+            assert result.data[0]["level"] == 1
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_get_toc_tool_folder(self) -> None:
+        async with Client(make_server()) as client:
+            result = await client.call_tool("get_toc", {"path": "subfolder"})
+            assert isinstance(result.data, dict)
+            assert "notes" in result.data and "truncated" in result.data
+```
+
+(Use the same `make_server` import / fixtures the other tool tests in this file
+use. `tests/fixtures/` ships `simple.md` and `subfolder/`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_server.py -q -k "manifest or GetTocTool"`
+Expected: FAIL — manifest mismatch / unknown tool `get_toc`.
+
+- [ ] **Step 3: Implement the tool**
+
+In `_server_tools/reader.py`, add after the `get_similar` tool block:
+
+```python
+    @mcp.tool(
+        icons=_TOOL_ICONS["read"],
+        annotations={
+            "title": "Table of Contents",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    @needs_queryable()
+    async def get_toc(
+        path: str,
+        max_level: int | None = None,
+        max_notes: int = 200,
+        wait_for_pending_writes: bool = False,
+        vault: Vault = Depends(get_vault),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Heading outline for a single note or a whole folder subtree.
+
+        If 'path' ends in '.md' it is a note: returns a flat ordered list of
+        {heading, level} (the title as a synthetic H1). Otherwise 'path' is a
+        folder: returns {path, notes, truncated} where 'notes' is an ordered
+        list of {path, title, headings} aggregating every note under the
+        subtree. Mirrors the 'toc://vault/{path}' resource, adding the
+        max_level / max_notes controls below.
+
+        Args:
+            path: Note path ("a/b.md") or folder prefix ("a/b").
+            max_level: Drop headings deeper than this level (e.g. 2 keeps
+                H1-H2). The synthetic H1 title always survives. Default None
+                returns all levels.
+            max_notes: Folder mode only — cap on distinct notes (default 200).
+                When more notes match, the first max_notes (by path) are
+                returned and 'truncated' is True.
+            wait_for_pending_writes: When True, wait until recent
+                write/edit/delete/rename operations are applied to the index
+                before answering. Default False answers from the current
+                index; inspect '_meta.index_stale' to tell whether a write was
+                still in flight. Bounded by a server timeout (default 60s).
+
+        Returns:
+            Note mode: list of {heading (str), level (int)}.
+            Folder mode: {path (str), notes (list[{path, title, headings}]),
+            truncated (bool)}. Empty/nonexistent folder → empty 'notes'.
+
+            Index freshness is reported out-of-band in '_meta.index_stale'.
+
+        Raises:
+            ValueError: Note path with no document; invalid folder path.
+        """
+        drained = await _maybe_wait_for_drain(
+            vault, wait_for_pending_writes, "get_toc"
+        )
+        gen_before = vault.index.write_generation()
+        data = await asyncio.to_thread(
+            vault.reader.get_toc,
+            path,
+            max_level=max_level,
+            max_notes=max_notes,
+        )
+        return _staleness_result(
+            vault,
+            data,
+            drained_on_request=drained,
+            gen_before=gen_before,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_server.py -q -k "manifest or title or GetTocTool"`
+Expected: PASS — manifest matches, `get_toc` has the unique title
+"Table of Contents", both behavior tests pass.
+
+- [ ] **Step 5: Update docs**
+
+- `docs/tools/index.md`: add a `get_toc` entry (params `path`, `max_level`,
+  `max_notes`, `wait_for_pending_writes`; both return shapes; cross-ref the
+  `toc://vault/{path}` resource). Match the surrounding entry format.
+- `README.md`: add `get_toc` to the tools list.
+- `docs/design.md`: document the TOC surface (note + subtree), the path-dispatch
+  rule, and the `max_notes` bound, in the reader/TOC section.
+
+- [ ] **Step 6: Full gate run + commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .
+uv run mypy src/ tests/
+uv run pytest -x -q
+git add -A
+git commit -m "feat: add get_toc MCP tool for note + subtree TOC (#773)"
+```
+
+---
+
+### Task 5: Final verification + PR prep
+
+- [ ] **Step 1: Patch-coverage check**
+
+Run: `uv run pytest --cov=markdown_vault_mcp.fts_index --cov=markdown_vault_mcp.managers.document --cov=markdown_vault_mcp.facets.reader --cov=markdown_vault_mcp._server_tools.reader --cov-report=term-missing -q`
+Expected: new lines exercised; patch coverage ≥ 80%. Add tests for any uncovered
+branch (notably folder-with-headings-filtered and the truncation path).
+
+- [ ] **Step 2: Pre-commit + preflight**
+
+Run: `uv run pre-commit run --all-files` → green.
+Then invoke the `preflight-circus` skill against `origin/main..HEAD` before pushing.
+
+- [ ] **Step 3: Push + open PR**
+
+```bash
+git push -u origin feat/773-subtree-toc
+```
+Open PR with `Closes #773`, a summary of the new tool + extended resource, the
+two return shapes, and the bounds. End the PR body with the required generation
+trailer and the agent-attribution signature line.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Path dispatch (`.md` → note, else folder) — Tasks 1-2. ✓
+- Note mode `{heading, level}` + `max_level` — Tasks 1-2. ✓
+- Folder nested-per-note `{path, notes, truncated}`, recursive, path-ordered — Tasks 1-2. ✓
+- Boundary prefix match (`Project` ≠ `Projects`) — Task 1 test. ✓
+- Trailing slash normalized — Task 2 test. ✓
+- `max_notes` cap + truncation flag — Tasks 1-2 tests. ✓
+- Empty/nonexistent folder → empty, no raise — Task 2 test. ✓
+- Resource extended + docstring fix — Task 3. ✓
+- New `get_toc` tool, `needs_queryable`, staleness — Task 4. ✓
+- Registry title + exact-manifest enforcement — Task 4. ✓
+- Docs (resources, tools, README, design) — Tasks 3-4. ✓
+
+**Placeholder scan:** No TBD/TODO; all code steps carry full code. Two
+deliberate "match the surrounding file's style" instructions (resource test
+import names, docs entry format) point at a single concrete file each — resolve
+by reading that file, not by judgment.
+
+**Type consistency:** `get_toc(path, *, max_level=None, max_notes=200)` and the
+`list | dict` return are identical across FTS-helper boundary (Task 1 returns the
+raw `(notes, truncated)` tuple; manager assembles the dict), manager, facet, and
+tool. Folder dict keys (`path`, `notes`, `truncated`) and note dict keys
+(`path`, `title`, `headings`) are used identically everywhere.

--- a/docs/superpowers/specs/2026-06-29-subtree-toc-design.md
+++ b/docs/superpowers/specs/2026-06-29-subtree-toc-design.md
@@ -1,0 +1,204 @@
+# Folder/subtree TOC + per-note TOC tool — Design (#773)
+
+**Issue:** [#773](https://github.com/pvliesdonk/markdown-vault-mcp/issues/773)
+**Date:** 2026-06-29
+**Status:** Approved (brainstorm)
+
+## Problem
+
+There is no way to get a heading-level table of contents for a **folder/subtree**
+of the vault — only for a single note. Separately, the per-note TOC is exposed
+**only as an MCP resource** (`toc://vault/{path}`), so tool-only clients cannot
+retrieve even a single note's outline.
+
+## Goals
+
+1. Extend the existing `toc://vault/{path}` **resource** so that when `path`
+   names a folder it returns an aggregated subtree TOC; when it names a note it
+   keeps today's behavior unchanged.
+2. Add a **tool** `get_toc` with the same path-dispatch behavior, exposing the
+   two bounding knobs the resource cannot take as parameters.
+
+Non-goals (YAGNI): anchors, pagination/cursors, heading-hierarchy merging,
+full-content retrieval (that is `read`).
+
+## What exists today (verified)
+
+- `FTSIndex.get_toc(path)` → `list[{heading, level}]` for one note, from the
+  `sections` table (`document_id`, `heading`, `heading_level`), ordered by first
+  appearance.
+- `DocumentManager.get_toc(path)` validates the path, looks up the note (raises
+  `ValueError` if missing), prepends the document **title** as a synthetic H1,
+  and de-dups a leading H1 that already equals the title.
+- `ReaderFacet.get_toc(path)` forwards to the manager.
+- `toc://vault/{path}` resource (`_server_resources.py:vault_toc`) JSON-dumps the
+  manager output and wraps it via `_stale_resource` for `_meta.index_stale`.
+  **There is no TOC tool.**
+- The per-note shape is `{heading, level}`. The resource docstring claiming
+  `{level, text, anchor}` is **inaccurate** and will be corrected as part of this
+  work (no `text`/`anchor` fields exist or are being added).
+
+## Contract
+
+### Path dispatch
+
+A single rule, used identically by the resource and the tool:
+
+- `path` **ends in `.md`** → **note mode** (existing behavior).
+- otherwise → **folder mode** (new subtree behavior). A trailing `/` on the
+  input is stripped. The subtree match is on a path **boundary**
+  (`<folder> + "/"`), so `Project` never matches `Projects/...`.
+
+### Note mode
+
+Returns the existing flat list, now subject to the `max_level` filter:
+
+```json
+[ {"heading": "Title", "level": 1}, {"heading": "Intro", "level": 2}, ... ]
+```
+
+- Missing note → `ValueError` (unchanged).
+- `max_level` (if set) drops entries with `level > max_level`. The synthetic H1
+  title is always level 1, so it survives any `max_level >= 1`.
+- `max_notes` is ignored in note mode.
+
+### Folder mode
+
+Returns a **nested-per-note** object:
+
+```json
+{
+  "path": "Projects",
+  "notes": [
+    {
+      "path": "Projects/alpha.md",
+      "title": "Alpha",
+      "headings": [ {"heading": "Goals", "level": 2}, ... ]
+    },
+    ...
+  ],
+  "truncated": false
+}
+```
+
+- **Recursive** over the whole subtree (all descendants, not just direct
+  children).
+- Notes ordered by `path` ascending.
+- Per-note `headings` use the same `{heading, level}` shape as note mode, with
+  the synthetic H1 title prepended (the `title` is *also* carried on the note
+  object for convenience; the synthetic H1 keeps note-mode and folder-mode
+  per-note blocks structurally identical).
+- `max_level` (optional, default `None` = all levels): drops headings with
+  `level > max_level` within every note.
+- `max_notes` (default `200`): caps the number of distinct notes. When more
+  notes match than the cap, return the first `max_notes` (by path order) and set
+  `truncated: true`. Detected by selecting `LIMIT max_notes + 1` and checking for
+  overflow.
+- Empty or nonexistent folder → `{"path": ..., "notes": [], "truncated": false}`
+  (**not** an error — folders are not first-class entities; raising would punish
+  legitimately empty folders). *(User-confirmed.)*
+
+## Components & changes
+
+All changes live in this repo (domain code), none in template-owned files.
+
+### 1. `fts_index.py` — new subtree query
+
+`FTSIndex.get_subtree_toc(prefix, *, max_level=None, max_notes=200)`:
+
+1. Select documents whose `path` starts with `prefix + "/"`, ordered by `path`,
+   `LIMIT max_notes + 1`. Capture `(id, path, title)`. Overflow of the `+1`
+   row ⇒ `truncated = True`; drop the extra row.
+2. For the selected document ids, select `heading, heading_level` from `sections`
+   where `heading IS NOT NULL` (and `heading_level <= max_level` when set),
+   grouped/ordered as in `get_toc`, keyed by `document_id`.
+3. Return the per-note rows + `truncated` flag in a plain structure for the
+   manager to assemble. (Two queries; both bounded by `max_notes`.)
+
+`FTSIndex.get_toc` gains an optional `max_level` filter (push the predicate into
+SQL, or filter in Python — implementation detail settled under TDD).
+
+### 2. `managers/document.py` — dispatch + assembly
+
+`DocumentManager.get_toc(path, *, max_level=None, max_notes=200)`:
+
+- Note mode (`path.endswith(".md")`): current logic + `max_level` filter applied
+  after the synthetic-H1 prepend.
+- Folder mode: normalize prefix (strip trailing `/`), call `get_subtree_toc`,
+  prepend each note's synthetic H1 title to its headings (reusing the same
+  de-dup rule as note mode), assemble the nested object.
+- `_validate_path` still guards traversal for both modes.
+
+### 3. `facets/reader.py` — forward kwargs
+
+`ReaderFacet.get_toc(path, *, max_level=None, max_notes=200)` forwards to the
+manager. Return type widens to `list[...] | dict[str, Any]`.
+
+### 4. `_server_resources.py` — extend the resource
+
+`vault_toc` calls `vault.reader.get_toc(path)` (defaults). Note path → bare list
+(unchanged); folder path → nested object. JSON-dump + `_stale_resource` as today.
+Fix the inaccurate `{level, text, anchor}` docstring to describe both shapes.
+
+### 5. `_server_tools/reader.py` — new tool
+
+`get_toc(path, max_level=None, max_notes=200, vault=Depends(get_vault))`:
+
+- `@mcp.tool(...)` with `readOnlyHint=True`, `idempotentHint=True`,
+  `destructiveHint=False`, title e.g. `"Table of Contents"`, plus a tool icon.
+- `@needs_queryable()` — requires a built index (bucket 3), like the resource.
+- `asyncio.to_thread(vault.reader.get_toc, path, max_level=..., max_notes=...)`,
+  wrapped with the standard staleness helper so `_meta.index_stale` is reported.
+- Docstring documents both return shapes and cross-references the
+  `toc://vault/{path}` resource.
+
+## Error handling
+
+| Case | Behavior |
+|------|----------|
+| Note path, missing note | `ValueError` (unchanged) |
+| Note path, no headings | `[{title, 1}]` (synthetic H1 only) |
+| Folder path, no matching notes | `{path, notes: [], truncated: false}` |
+| Folder path, > `max_notes` notes | first `max_notes`, `truncated: true` |
+| `max_level` filters out all body headings | note still carries its synthetic H1 |
+| Path traversal attempt | `_validate_path` raises (unchanged) |
+| Index not built | `needs_queryable` / resource gating (unchanged) |
+
+## Testing (failure modes to cover)
+
+Library level (`tests/` against `FTSIndex` / `DocumentManager` / `ReaderFacet`):
+
+- Note mode unchanged: existing per-note tests stay green.
+- `max_level` in note mode drops deep headings, keeps synthetic H1.
+- Folder mode: nested shape, notes path-ordered, recursive across nested
+  subfolders.
+- Folder prefix boundary: `Project` does **not** match `Projects/...`.
+- Trailing-slash input normalized.
+- `max_notes` truncation: exactly-at-cap (no truncation) vs over-cap
+  (`truncated: true`, count == cap).
+- `max_level` in folder mode filters within every note.
+- Empty/nonexistent folder → empty `notes`, no raise.
+- Note with no body headings inside a folder → synthetic-H1-only block.
+
+MCP level (`async with Client(server)`):
+
+- New `get_toc` tool: note path and folder path return the two shapes; knobs
+  honored; `_meta.index_stale` present.
+- Resource `toc://vault/{path}`: note path bare list (unchanged), folder path
+  nested object.
+- `get_toc` registered in the full tool registry with a title (registry
+  enforcement test).
+- Bucket-3 gating: tool/resource on a cold (unbuilt) index behaves like peers.
+
+## Documentation impact
+
+- `docs/tools/index.md` — new `get_toc` tool.
+- `docs/resources.md` — extended `toc://vault/{path}` (both shapes) + cross-ref
+  to the tool.
+- `README.md` — tool/resource list update.
+- `docs/design.md` — TOC surface (note + subtree) and bounds.
+
+## Out of scope
+
+Anchors, pagination/continuation cursors, heading-hierarchy nesting, full-content
+retrieval. Each can be a follow-up issue if a real need appears.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -3,7 +3,7 @@
 markdown-vault-mcp exposes MCP tools across several categories. Write tools are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`.
 
 !!! note "Index freshness on read tools (`wait_for_pending_writes` + `_meta.index_stale`)"
-    Every read tool that queries the FTS index (`search`, `list_documents`, `list_folders`, `list_tags`, `stats`, `get_recent`, `get_backlinks`, `get_outlinks`, `get_broken_links`, `get_similar`, `get_context`, `get_orphan_notes`, `get_most_linked`, and `get_connection_path`) accepts an optional **`wait_for_pending_writes`** (`bool`, default `false`) parameter and reports index freshness **out-of-band in the MCP response's `_meta.index_stale` field** rather than wrapping the payload in a `{stale, data}` envelope. The data payload is a **bare list/dict, identical whether the index is fresh or stale**; clients that do not care about drift ignore `_meta` entirely. Clients that need a fresh-read guarantee either inspect `result._meta.index_stale`, or pass `wait_for_pending_writes=true` to block until the writer drains (bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S`, default 60&nbsp;s; on timeout it answers from the current index rather than raising). `index_stale` is `true` when the IndexWriter had pending or in-flight work. The relevant conditions are: the optional `wait_for_pending_writes` timed out; a write completed inside the read window; the writer was non-idle at response time. The same `_meta.index_stale` field rides on the index-querying MCP **resources** (`config://`, `stats://`, `folders://`, `tags://`, `recent://`, `toc://`, `similar://`), readable via the resource read's `_meta` (resources carry no `wait_for_pending_writes` parameter; they signal only).
+    Every read tool that queries the FTS index (`search`, `list_documents`, `list_folders`, `list_tags`, `stats`, `get_recent`, `get_backlinks`, `get_outlinks`, `get_broken_links`, `get_similar`, `get_toc`, `get_context`, `get_orphan_notes`, `get_most_linked`, and `get_connection_path`) accepts an optional **`wait_for_pending_writes`** (`bool`, default `false`) parameter and reports index freshness **out-of-band in the MCP response's `_meta.index_stale` field** rather than wrapping the payload in a `{stale, data}` envelope. The data payload is a **bare list/dict, identical whether the index is fresh or stale**; clients that do not care about drift ignore `_meta` entirely. Clients that need a fresh-read guarantee either inspect `result._meta.index_stale`, or pass `wait_for_pending_writes=true` to block until the writer drains (bounded by `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S`, default 60&nbsp;s; on timeout it answers from the current index rather than raising). `index_stale` is `true` when the IndexWriter had pending or in-flight work. The relevant conditions are: the optional `wait_for_pending_writes` timed out; a write completed inside the read window; the writer was non-idle at response time. The same `_meta.index_stale` field rides on the index-querying MCP **resources** (`config://`, `stats://`, `folders://`, `tags://`, `recent://`, `toc://`, `similar://`), readable via the resource read's `_meta` (resources carry no `wait_for_pending_writes` parameter; they signal only).
 
 <!-- DOMAIN-TOOLS-LIST-START -->
 
@@ -23,6 +23,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`get_outlinks`](#get_outlinks) | Outlinks | Read | Find all links from a document, with existence check |
 | [`get_broken_links`](#get_broken_links) | Broken Links | Read | Find all links pointing to non-existent documents |
 | [`get_similar`](#get_similar) | Similar Notes | Read | Find semantically similar notes by document path |
+| [`get_toc`](#get_toc) | Table of Contents | Read | Heading outline for a note or a folder subtree |
 | [`get_recent`](#get_recent) | Recent Notes | Read | Get the most recently modified notes |
 | [`get_context`](#get_context) | Note Context | Read | Get a consolidated context dossier for a note |
 | [`get_orphan_notes`](#get_orphan_notes) | Orphan Notes | Read | Find notes with no inbound or outbound links |
@@ -620,6 +621,26 @@ Find semantically similar notes by document path. Requires embeddings to be buil
 
 !!! note "Grouped result shape"
     Returns one entry per file with up to `chunks_per_file` best-matching sections. Default is 2 sections per file; pass `chunks_per_file=1` for compact dossiers.
+
+### `get_toc`
+
+Heading outline for a single note or an entire folder subtree. Mirrors the [`toc://vault/{path}`](../resources.md#tocvaultpath) resource, adding `max_level` and `max_notes` controls. Dispatch is by suffix: paths ending in `.md` are treated as notes; all other paths are treated as folder prefixes.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | string | required | Note path (such as `"a/b.md"`) or folder prefix (such as `"a/b"`) |
+| `max_level` | int | `null` | Drop headings deeper than this level (such as `2` to keep H1 and H2). The synthetic H1 title always survives. `null` returns all levels. |
+| `max_notes` | int | `200` | Folder mode only. Cap on distinct notes. When more notes match, the first `max_notes` (sorted by path) are returned and `truncated` is `true`. |
+| `wait_for_pending_writes` | bool | `false` | Block until the IndexWriter drains before answering, then report freshness via `_meta.index_stale` (see the *Index freshness on read tools* note at the top of this page). |
+
+**Returns:**
+
+- **Note mode** (`path` ends in `.md`): flat ordered `list` of `{heading (str), level (int)}`. The document title is included as a synthetic H1 entry.
+- **Folder mode** (`path` is a folder prefix): `{path (str), notes (list), truncated (bool)}` where each entry in `notes` is `{path, title, headings}` and `headings` is a list of `{heading, level}` for that note. An empty or nonexistent folder returns an empty `notes` list with `truncated: false`.
+
+Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).
 
 ### `get_recent`
 

--- a/src/markdown_vault_mcp/_icons.py
+++ b/src/markdown_vault_mcp/_icons.py
@@ -69,6 +69,9 @@ _TOOL_ICONS: dict[str, list[Icon]] = {
 # Status tools reuse existing icons rather than introducing new SVG files.
 _TOOL_ICONS["get_index_status"] = _TOOL_ICONS["embeddings_status"]
 
+# get_toc reuses the read icon.
+_TOOL_ICONS["get_toc"] = _TOOL_ICONS["read"]
+
 # App-only tools reuse existing icons rather than introducing new SVG files.
 _TOOL_ICONS["vault_context"] = _TOOL_ICONS["get_context"]
 _TOOL_ICONS["vault_list"] = _TOOL_ICONS["list_documents"]

--- a/src/markdown_vault_mcp/_server_resources.py
+++ b/src/markdown_vault_mcp/_server_resources.py
@@ -185,7 +185,15 @@ def register_resources(mcp: FastMCP) -> None:
         path: str,
         vault: Vault = Depends(get_vault),
     ) -> ResourceResult:
-        """Table of contents — ordered list of {level, text, anchor} headings. Useful for navigating long notes without reading full content.
+        """Table of contents for a note or a folder subtree.
+
+        A note path (ending in ``.md``) returns a flat ordered list of
+        ``{heading, level}`` headings (the title as a synthetic H1). A folder
+        path returns a nested-per-note object
+        ``{path, notes: [{path, title, headings}], truncated}`` aggregating the
+        subtree (default cap 200 notes). Useful for navigating structure
+        without reading full content. See the ``get_toc`` tool for the same
+        data with ``max_level`` / ``max_notes`` controls.
 
         Index freshness is reported in _meta.index_stale.
         """

--- a/src/markdown_vault_mcp/_server_tools/_common.py
+++ b/src/markdown_vault_mcp/_server_tools/_common.py
@@ -63,6 +63,7 @@ def _staleness_result(
     *,
     drained_on_request: bool,
     gen_before: int,
+    force_result_wrap: bool = False,
 ) -> _T:
     """Wrap a read tool's payload with index-freshness metadata.
 
@@ -90,13 +91,21 @@ def _staleness_result(
     accepts ``Any`` serializable value and converts it to a JSON ``TextContent``
     block, which is the documented path for non-content-block payloads (it is
     not the ``# type: ignore`` target — that is solely the ``-> _T`` bridge).
+
+    ``force_result_wrap``: pass ``True`` for union-return tools (e.g.
+    ``list | dict``) whose output schema requires the ``{"result": ...}``
+    envelope for every branch, overriding the default dict-passthrough.
     """
     index_stale = (
         (not drained_on_request)
         or (vault.index.write_generation() != gen_before)
         or (not vault.index.is_drained())
     )
-    structured = data if isinstance(data, dict) else {"result": data}
+    structured = (
+        {"result": data}
+        if force_result_wrap
+        else (data if isinstance(data, dict) else {"result": data})
+    )
     return ToolResult(  # type: ignore[return-value]
         content=data,
         structured_content=structured,

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -586,11 +586,11 @@ def register(mcp: FastMCP) -> None:
         Args:
             path: Note path ("a/b.md") or folder prefix ("a/b").
             max_level: Drop headings deeper than this level (e.g. 2 keeps
-                H1-H2). The synthetic H1 title always survives. Default None
-                returns all levels.
-            max_notes: Folder mode only — cap on distinct notes (default 200).
-                When more notes match, the first max_notes (by path) are
-                returned and 'truncated' is True.
+                H1-H2); must be >= 1. The synthetic H1 title always survives.
+                Default None returns all levels.
+            max_notes: Folder mode only — cap on distinct notes (default 200,
+                must be >= 1). When more notes match, the first max_notes (by
+                path) are returned and 'truncated' is True.
             wait_for_pending_writes: When True, wait until recent
                 write/edit/delete/rename operations are applied to the index
                 before answering. Default False answers from the current

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -559,7 +559,7 @@ def register(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(
-        icons=_TOOL_ICONS["read"],
+        icons=_TOOL_ICONS["get_toc"],
         annotations={
             "title": "Table of Contents",
             "readOnlyHint": True,

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -6,7 +6,6 @@ from typing import Any, Literal
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
-from fastmcp.tools import ToolResult
 
 from markdown_vault_mcp.vault import Vault
 
@@ -616,19 +615,12 @@ def register(mcp: FastMCP) -> None:
             max_level=max_level,
             max_notes=max_notes,
         )
-        index_stale = (
-            (not drained)
-            or (vault.index.write_generation() != gen_before)
-            or (not vault.index.is_drained())
-        )
-        # The union return type (list | dict) causes FastMCP to generate an
-        # output schema that wraps both branches in {"result": <payload>}.
-        # Construct ToolResult directly to ensure structured_content always
-        # uses the {"result": ...} envelope that the schema requires.
-        return ToolResult(  # type: ignore[return-value]
-            content=data,
-            structured_content={"result": data},
-            meta={"index_stale": index_stale},
+        return _staleness_result(
+            vault,
+            data,
+            drained_on_request=drained,
+            gen_before=gen_before,
+            force_result_wrap=True,
         )
 
     @mcp.tool(

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
+from fastmcp.tools import ToolResult
 
 from markdown_vault_mcp.vault import Vault
 
@@ -555,6 +556,79 @@ def register(mcp: FastMCP) -> None:
             [asdict(r) for r in results],
             drained_on_request=drained,
             gen_before=gen_before,
+        )
+
+    @mcp.tool(
+        icons=_TOOL_ICONS["read"],
+        annotations={
+            "title": "Table of Contents",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    @needs_queryable()
+    async def get_toc(
+        path: str,
+        max_level: int | None = None,
+        max_notes: int = 200,
+        wait_for_pending_writes: bool = False,
+        vault: Vault = Depends(get_vault),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Heading outline for a single note or a whole folder subtree.
+
+        If 'path' ends in '.md' it is a note: returns a flat ordered list of
+        {heading, level} (the title as a synthetic H1). Otherwise 'path' is a
+        folder: returns {path, notes, truncated} where 'notes' is an ordered
+        list of {path, title, headings} aggregating every note under the
+        subtree. Mirrors the 'toc://vault/{path}' resource, adding the
+        max_level / max_notes controls below.
+
+        Args:
+            path: Note path ("a/b.md") or folder prefix ("a/b").
+            max_level: Drop headings deeper than this level (e.g. 2 keeps
+                H1-H2). The synthetic H1 title always survives. Default None
+                returns all levels.
+            max_notes: Folder mode only — cap on distinct notes (default 200).
+                When more notes match, the first max_notes (by path) are
+                returned and 'truncated' is True.
+            wait_for_pending_writes: When True, wait until recent
+                write/edit/delete/rename operations are applied to the index
+                before answering. Default False answers from the current
+                index; inspect '_meta.index_stale' to tell whether a write was
+                still in flight. Bounded by a server timeout (default 60s).
+
+        Returns:
+            Note mode: list of {heading (str), level (int)}.
+            Folder mode: {path (str), notes (list[{path, title, headings}]),
+            truncated (bool)}. Empty/nonexistent folder → empty 'notes'.
+
+            Index freshness is reported out-of-band in '_meta.index_stale'.
+
+        Raises:
+            ValueError: Note path with no document; invalid folder path.
+        """
+        drained = await _maybe_wait_for_drain(vault, wait_for_pending_writes, "get_toc")
+        gen_before = vault.index.write_generation()
+        data = await asyncio.to_thread(
+            vault.reader.get_toc,
+            path,
+            max_level=max_level,
+            max_notes=max_notes,
+        )
+        index_stale = (
+            (not drained)
+            or (vault.index.write_generation() != gen_before)
+            or (not vault.index.is_drained())
+        )
+        # The union return type (list | dict) causes FastMCP to generate an
+        # output schema that wraps both branches in {"result": <payload>}.
+        # Construct ToolResult directly to ensure structured_content always
+        # uses the {"result": ...} envelope that the schema requires.
+        return ToolResult(  # type: ignore[return-value]
+            content=data,
+            structured_content={"result": data},
+            meta={"index_stale": index_stale},
         )
 
     @mcp.tool(

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -172,26 +172,35 @@ class ReaderFacet:
         """
         return self._search_mgr.list_tags(field)
 
-    def get_toc(self, path: str) -> list[dict[str, Any]]:
-        """Return table of contents for a document.
+    def get_toc(
+        self,
+        path: str,
+        *,
+        max_level: int | None = None,
+        max_notes: int = 200,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Return a table of contents for a note or a folder subtree.
 
-        Queries the FTS sections table for headings and prepends the document
-        title as a synthetic H1 entry. The result depends on the FTS index, so
-        cold-start callers must build the index first (bucket 3).
+        Note paths (ending in ``.md``) return a flat ``[{"heading", "level"}]``
+        outline with the title as a synthetic H1. Folder paths return a
+        nested-per-note object ``{"path", "notes", "truncated"}``. The result
+        depends on the FTS index, so cold-start callers must build the index
+        first (bucket 3).
 
         Args:
-            path: Relative path to the document (e.g. ``"notes/intro.md"``).
+            path: Note path or folder prefix.
+            max_level: Drop headings with ``level`` above this (both modes).
+            max_notes: Folder mode cap on distinct notes (default 200).
 
         Returns:
-            List of ``{"heading": str, "level": int}`` dicts ordered by
-            position, with the document title prepended as level 1.
+            ``list`` for a note path, ``dict`` for a folder path.
 
         Raises:
             IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.
-            ValueError: If no document exists at the given path.
+            ValueError: Note path with no document; invalid folder path.
         """
         self._require_built()
-        return self._doc_mgr.get_toc(path)
+        return self._doc_mgr.get_toc(path, max_level=max_level, max_notes=max_notes)
 
     def get_recent(
         self, *, limit: int = 20, folder: str | None = None

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -193,7 +193,11 @@ class ReaderFacet:
             max_notes: Folder mode cap on distinct notes (default 200).
 
         Returns:
-            ``list`` for a note path, ``dict`` for a folder path.
+            Note path → ``list[{"heading": str, "level": int}]`` with the
+            document title prepended as a synthetic H1.
+            Folder path → ``{"path": str, "notes": list[{"path": str,
+            "title": str, "headings": list[{"heading": str, "level": int}]}],
+            "truncated": bool}``.
 
         Raises:
             IndexUnavailableError: If :meth:`IndexFacet.build_index` has not been called.

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -1438,8 +1438,10 @@ class FTSIndex:
         Returns:
             ``(notes, truncated)`` where *notes* is a list of
             ``{"path", "title", "headings": [{"heading", "level"}]}`` ordered
-            by path, *headings* are raw section headings (no synthetic H1),
-            and *truncated* is True when more than ``max_notes`` notes matched.
+            by path, *headings* are raw section headings (no synthetic H1 —
+            the manager layer prepends the synthetic H1 before exposing them
+            to consumers), and *truncated* is True when more than ``max_notes``
+            notes matched.
         """
         escaped = _escape_like(prefix)
         doc_rows = (

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -1379,7 +1379,9 @@ class FTSIndex:
         return [dict(row) for row in cur.fetchall()]
 
     @_retry_on_locked
-    def get_toc(self, path: str) -> list[dict[str, str | int]]:
+    def get_toc(
+        self, path: str, *, max_level: int | None = None
+    ) -> list[dict[str, str | int]]:
         """Return headings for a document, ordered by position.
 
         Queries the sections table for distinct non-NULL headings, ordered by
@@ -1387,27 +1389,116 @@ class FTSIndex:
 
         Args:
             path: Relative document path (e.g. ``"Journal/note.md"``).
+            max_level: If set, drop headings with ``level`` greater than this.
 
         Returns:
             List of ``{"heading": str, "level": int}`` dicts ordered by
             first appearance.  Empty list if the document is not found or
             has no headings.
         """
+        level_clause = "" if max_level is None else "AND heading_level <= ?"
+        params: list[object] = [path]
+        if max_level is not None:
+            params.append(max_level)
         cur = self._conn().execute(
-            """
+            f"""
             SELECT heading, heading_level
             FROM sections
             WHERE document_id = (SELECT id FROM documents WHERE path = ?)
               AND heading IS NOT NULL
+              {level_clause}
             GROUP BY heading, heading_level
             ORDER BY MIN(rowid)
             """,
-            (path,),
+            params,
         )
         return [
             {"heading": row["heading"], "level": row["heading_level"]}
             for row in cur.fetchall()
         ]
+
+    @_retry_on_locked
+    def get_subtree_toc(
+        self,
+        prefix: str,
+        *,
+        max_level: int | None = None,
+        max_notes: int = 200,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Return per-note headings for every document under a folder prefix.
+
+        Matches documents whose ``folder`` equals *prefix* or is a descendant
+        of it (boundary match, so ``"Project"`` never matches ``"Projects"``).
+
+        Args:
+            prefix: Folder path with no trailing slash (e.g. ``"Projects"``).
+            max_level: If set, drop headings with ``level`` greater than this.
+            max_notes: Cap on distinct notes returned (default 200).
+
+        Returns:
+            ``(notes, truncated)`` where *notes* is a list of
+            ``{"path", "title", "headings": [{"heading", "level"}]}`` ordered
+            by path, *headings* are raw section headings (no synthetic H1),
+            and *truncated* is True when more than ``max_notes`` notes matched.
+        """
+        escaped = _escape_like(prefix)
+        doc_rows = (
+            self._conn()
+            .execute(
+                """
+            SELECT id, path, title
+            FROM documents
+            WHERE (folder = ? OR folder LIKE ? ESCAPE '\\')
+            ORDER BY path ASC
+            LIMIT ?
+            """,
+                (prefix, escaped + "/%", max_notes + 1),
+            )
+            .fetchall()
+        )
+        truncated = len(doc_rows) > max_notes
+        doc_rows = doc_rows[:max_notes]
+        if not doc_rows:
+            return [], truncated
+
+        ids = [row["id"] for row in doc_rows]
+        placeholders = ",".join("?" * len(ids))
+        level_clause = "" if max_level is None else "AND heading_level <= ?"
+        params: list[object] = [*ids]
+        if max_level is not None:
+            params.append(max_level)
+        section_rows = (
+            self._conn()
+            .execute(
+                f"""
+            SELECT document_id, heading, heading_level
+            FROM sections
+            WHERE document_id IN ({placeholders})
+              AND heading IS NOT NULL
+              {level_clause}
+            GROUP BY document_id, heading, heading_level
+            ORDER BY document_id, MIN(rowid)
+            """,
+                params,
+            )
+            .fetchall()
+        )
+
+        by_doc: dict[int, list[dict[str, Any]]] = {}
+        for row in section_rows:
+            by_doc.setdefault(row["document_id"], []).append(
+                {"heading": row["heading"], "level": row["heading_level"]}
+            )
+
+        notes = [
+            {
+                "path": row["path"],
+                "title": row["title"],
+                "headings": by_doc.get(row["id"], []),
+            }
+            for row in doc_rows
+        ]
+        return notes, truncated
 
     @_retry_on_locked
     def get_backlinks(

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -233,7 +233,8 @@ class DocumentManager:
         """Resolve a relative folder path and validate it is inside the vault.
 
         Unlike :meth:`_validate_path`, this does not require a ``.md`` suffix —
-        it is for directory prefixes used by :meth:`move_folder`.
+        it is for directory prefixes used by :meth:`move_folder` and
+        :meth:`_subtree_toc`.
 
         Args:
             path: Relative folder path (e.g. ``"drafts"`` or ``"a/b"``).
@@ -521,8 +522,8 @@ class DocumentManager:
 
         Raises:
             ValueError: Note mode, if no document exists at *path* or if the
-                path escapes the vault; folder mode, if *path* is empty/root or
-                escapes the vault.
+                path escapes the vault; folder mode, if *path* is empty, the
+                vault root (```.```/```/```), or escaping the vault.
         """
         if path.endswith(".md"):
             return self._note_toc(path, max_level=max_level)

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -510,10 +510,11 @@ class DocumentManager:
 
         Args:
             path: Note path (``"a/b.md"``) or folder prefix (``"a/b"``).
-            max_level: If set, drop headings with ``level`` above this.
-                The synthetic H1 title is always present regardless of
+            max_level: If set, drop headings with ``level`` above this; must be
+                ``>= 1``. The synthetic H1 title is always present regardless of
                 ``max_level`` (it is prepended after the level filter).
-            max_notes: Folder mode only — cap on distinct notes (default 200).
+            max_notes: Folder mode only — cap on distinct notes (default 200);
+                must be ``>= 1``.
 
         Returns:
             Note mode: ``list[{"heading", "level"}]``.
@@ -521,10 +522,15 @@ class DocumentManager:
             each note is ``{"path", "title", "headings": [...]}``.
 
         Raises:
-            ValueError: Note mode, if no document exists at *path* or if the
-                path escapes the vault; folder mode, if *path* is empty, the
-                vault root (```.```/```/```), or escaping the vault.
+            ValueError: If ``max_notes < 1`` or ``max_level < 1``; note mode, if
+                no document exists at *path* or if the path escapes the vault;
+                folder mode, if *path* is empty, the vault root
+                (```.```/```/```), or escaping the vault.
         """
+        if max_notes < 1:
+            raise ValueError(f"max_notes must be >= 1, got {max_notes!r}")
+        if max_level is not None and max_level < 1:
+            raise ValueError(f"max_level must be >= 1, got {max_level!r}")
         if path.endswith(".md"):
             return self._note_toc(path, max_level=max_level)
         return self._subtree_toc(path, max_level=max_level, max_notes=max_notes)

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -526,6 +526,17 @@ class DocumentManager:
             return self._note_toc(path, max_level=max_level)
         return self._subtree_toc(path, max_level=max_level, max_notes=max_notes)
 
+    @staticmethod
+    def _prepend_title_h1(
+        title: str, headings: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Prepend the document title as a synthetic H1, deduping a leading H1 equal to it."""
+        toc: list[dict[str, Any]] = [{"heading": title, "level": 1}]
+        toc.extend(
+            h for h in headings if not (h["level"] == 1 and h["heading"] == title)
+        )
+        return toc
+
     def _note_toc(self, path: str, *, max_level: int | None) -> list[dict[str, Any]]:
         self._validate_path(path)
         row = self._fts.get_note(path)
@@ -533,11 +544,7 @@ class DocumentManager:
             raise ValueError(f"Document not found: {path}")
         title: str = row["title"]
         headings = self._fts.get_toc(path, max_level=max_level)
-        toc: list[dict[str, Any]] = [{"heading": title, "level": 1}]
-        toc.extend(
-            h for h in headings if not (h["level"] == 1 and h["heading"] == title)
-        )
-        return toc
+        return self._prepend_title_h1(title, headings)
 
     def _subtree_toc(
         self, path: str, *, max_level: int | None, max_notes: int
@@ -550,12 +557,7 @@ class DocumentManager:
         notes: list[dict[str, Any]] = []
         for note in notes_raw:
             title = note["title"]
-            headings: list[dict[str, Any]] = [{"heading": title, "level": 1}]
-            headings.extend(
-                h
-                for h in note["headings"]
-                if not (h["level"] == 1 and h["heading"] == title)
-            )
+            headings = self._prepend_title_h1(title, note["headings"])
             notes.append({"path": note["path"], "title": title, "headings": headings})
         return {"path": prefix, "notes": notes, "truncated": truncated}
 

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -492,36 +492,72 @@ class DocumentManager:
             etag=etag,
         )
 
-    def get_toc(self, path: str) -> list[dict[str, Any]]:
-        """Return table of contents for a document.
+    def get_toc(
+        self,
+        path: str,
+        *,
+        max_level: int | None = None,
+        max_notes: int = 200,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Return a table of contents for a note or a folder subtree.
 
-        Queries the FTS sections table for headings and prepends the document
-        title as a synthetic H1 entry.
+        When *path* ends in ``.md`` the result is a single note's flat
+        outline: a list of ``{"heading", "level"}`` with the document title
+        prepended as a synthetic H1. Otherwise *path* is treated as a folder
+        prefix and the result is a nested-per-note object aggregating the
+        subtree.
 
         Args:
-            path: Relative path to the document (e.g. ``"notes/intro.md"``).
+            path: Note path (``"a/b.md"``) or folder prefix (``"a/b"``).
+            max_level: If set, drop headings with ``level`` above this. The
+                synthetic H1 title always survives ``max_level >= 1``.
+            max_notes: Folder mode only — cap on distinct notes (default 200).
 
         Returns:
-            List of ``{"heading": str, "level": int}`` dicts ordered by
-            position, with the document title prepended as level 1.
+            Note mode: ``list[{"heading", "level"}]``.
+            Folder mode: ``{"path", "notes": [...], "truncated": bool}`` where
+            each note is ``{"path", "title", "headings": [...]}``.
 
         Raises:
-            ValueError: If no document exists at the given path.
+            ValueError: Note mode, if no document exists at *path*; or if a
+                folder *path* is empty/root or escapes the vault.
         """
-        self._validate_path(path)
+        if path.endswith(".md"):
+            return self._note_toc(path, max_level=max_level)
+        return self._subtree_toc(path, max_level=max_level, max_notes=max_notes)
 
+    def _note_toc(self, path: str, *, max_level: int | None) -> list[dict[str, Any]]:
+        self._validate_path(path)
         row = self._fts.get_note(path)
         if row is None:
             raise ValueError(f"Document not found: {path}")
-
         title: str = row["title"]
-        headings = self._fts.get_toc(path)
-
+        headings = self._fts.get_toc(path, max_level=max_level)
         toc: list[dict[str, Any]] = [{"heading": title, "level": 1}]
         toc.extend(
             h for h in headings if not (h["level"] == 1 and h["heading"] == title)
         )
         return toc
+
+    def _subtree_toc(
+        self, path: str, *, max_level: int | None, max_notes: int
+    ) -> dict[str, Any]:
+        prefix = path.rstrip("/")
+        self._validate_dir_path(prefix)
+        notes_raw, truncated = self._fts.get_subtree_toc(
+            prefix, max_level=max_level, max_notes=max_notes
+        )
+        notes: list[dict[str, Any]] = []
+        for note in notes_raw:
+            title = note["title"]
+            headings: list[dict[str, Any]] = [{"heading": title, "level": 1}]
+            headings.extend(
+                h
+                for h in note["headings"]
+                if not (h["level"] == 1 and h["heading"] == title)
+            )
+            notes.append({"path": note["path"], "title": title, "headings": headings})
+        return {"path": prefix, "notes": notes, "truncated": truncated}
 
     # ------------------------------------------------------------------
     # Write operations

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -509,8 +509,9 @@ class DocumentManager:
 
         Args:
             path: Note path (``"a/b.md"``) or folder prefix (``"a/b"``).
-            max_level: If set, drop headings with ``level`` above this. The
-                synthetic H1 title always survives ``max_level >= 1``.
+            max_level: If set, drop headings with ``level`` above this.
+                The synthetic H1 title is always present regardless of
+                ``max_level`` (it is prepended after the level filter).
             max_notes: Folder mode only — cap on distinct notes (default 200).
 
         Returns:
@@ -519,8 +520,9 @@ class DocumentManager:
             each note is ``{"path", "title", "headings": [...]}``.
 
         Raises:
-            ValueError: Note mode, if no document exists at *path*; or if a
-                folder *path* is empty/root or escapes the vault.
+            ValueError: Note mode, if no document exists at *path* or if the
+                path escapes the vault; folder mode, if *path* is empty/root or
+                escapes the vault.
         """
         if path.endswith(".md"):
             return self._note_toc(path, max_level=max_level)
@@ -530,7 +532,7 @@ class DocumentManager:
     def _prepend_title_h1(
         title: str, headings: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Prepend the document title as a synthetic H1, deduping a leading H1 equal to it."""
+        """Prepend the document title as a synthetic H1, dropping any real H1 whose text matches the title."""
         toc: list[dict[str, Any]] = [{"heading": title, "level": 1}]
         toc.extend(
             h for h in headings if not (h["level"] == 1 and h["heading"] == title)
@@ -538,6 +540,7 @@ class DocumentManager:
         return toc
 
     def _note_toc(self, path: str, *, max_level: int | None) -> list[dict[str, Any]]:
+        """Return a single note's flat outline, title prepended as a synthetic H1."""
         self._validate_path(path)
         row = self._fts.get_note(path)
         if row is None:
@@ -549,6 +552,7 @@ class DocumentManager:
     def _subtree_toc(
         self, path: str, *, max_level: int | None, max_notes: int
     ) -> dict[str, Any]:
+        """Return the nested-per-note TOC for every note under a folder prefix."""
         prefix = path.rstrip("/")
         self._validate_dir_path(prefix)
         notes_raw, truncated = self._fts.get_subtree_toc(

--- a/tests/test_facet_reader.py
+++ b/tests/test_facet_reader.py
@@ -50,6 +50,11 @@ class TestReaderFacetBehaviour:
     def test_get_toc_returns_list(self, built: Vault) -> None:
         assert isinstance(built.reader.get_toc("full_frontmatter.md"), list)
 
+    def test_get_toc_folder_returns_dict(self, built: Vault) -> None:
+        result = built.reader.get_toc("subfolder")
+        assert isinstance(result, dict)
+        assert "notes" in result and "truncated" in result
+
     def test_get_similar_empty_without_embeddings(self, built: Vault) -> None:
         # No embedding provider configured -> semantic similarity degrades to [].
         assert built.reader.get_similar("full_frontmatter.md") == []

--- a/tests/test_fts_subtree_toc.py
+++ b/tests/test_fts_subtree_toc.py
@@ -39,9 +39,17 @@ def vault(tmp_path: Path) -> Path:
         "---\ntitle: Gamma\n---\n# Gamma\n\n## Nested\n\nq\n",
         encoding="utf-8",
     )
-    # A sibling folder whose prefix shares a leading substring with "Projects".
+    # A root-level file whose name starts with "Project" (not a folder).
     (tmp_path / "Projectile.md").write_text(
         "---\ntitle: Projectile\n---\n# Projectile\n",
+        encoding="utf-8",
+    )
+    # A sibling *folder* whose name starts with "Project" — exercises the /
+    # boundary in the LIKE pattern so "Projects/" does not match "Projectile/".
+    pjl = tmp_path / "Projectile"
+    pjl.mkdir()
+    (pjl / "note.md").write_text(
+        "---\ntitle: Projectile Note\n---\n# Projectile Note\n\n## Misc\n\nm\n",
         encoding="utf-8",
     )
     return tmp_path
@@ -67,6 +75,9 @@ def test_subtree_prefix_is_boundary_matched(vault: Path) -> None:
     fts = _build_fts(vault)
     notes, _ = fts.get_subtree_toc("Project")
     assert notes == []  # neither "Projects/..." nor "Projectile.md" match
+    # Also verify "Projects/" prefix does not bleed into "Projectile/" folder.
+    notes_all, _ = fts.get_subtree_toc("Projects")
+    assert all(not n["path"].startswith("Projectile/") for n in notes_all)
 
 
 def test_subtree_max_level_filters_headings(vault: Path) -> None:

--- a/tests/test_fts_subtree_toc.py
+++ b/tests/test_fts_subtree_toc.py
@@ -96,6 +96,13 @@ def test_subtree_max_notes_truncates(vault: Path) -> None:
     assert [n["path"] for n in notes] == ["Projects/alpha.md", "Projects/beta.md"]
 
 
+def test_subtree_max_notes_at_cap_not_truncated(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, truncated = fts.get_subtree_toc("Projects", max_notes=3)
+    assert truncated is False
+    assert len(notes) == 3
+
+
 def test_get_toc_max_level_filter(vault: Path) -> None:
     fts = _build_fts(vault)
     toc = fts.get_toc("Projects/alpha.md", max_level=2)

--- a/tests/test_fts_subtree_toc.py
+++ b/tests/test_fts_subtree_toc.py
@@ -69,6 +69,9 @@ def test_subtree_toc_is_recursive_and_path_ordered(vault: Path) -> None:
     # Raw section headings only — no synthetic H1 prepended at this layer.
     assert {"heading": "Goals", "level": 2} in alpha["headings"]
     assert {"heading": "Detail", "level": 3} in alpha["headings"]
+    assert alpha["headings"].index({"heading": "Goals", "level": 2}) < alpha[
+        "headings"
+    ].index({"heading": "Detail", "level": 3})
 
 
 def test_subtree_prefix_is_boundary_matched(vault: Path) -> None:
@@ -108,3 +111,18 @@ def test_get_toc_max_level_filter(vault: Path) -> None:
     toc = fts.get_toc("Projects/alpha.md", max_level=2)
     assert all(h["level"] <= 2 for h in toc)
     assert {"heading": "Detail", "level": 3} not in toc
+
+
+def test_subtree_escapes_like_wildcards(tmp_path: Path) -> None:
+    (tmp_path / "notes_2026").mkdir()
+    (tmp_path / "notes_2026" / "a.md").write_text(
+        "---\ntitle: A\n---\n# A\n\n## Sec\n\nx\n", encoding="utf-8"
+    )
+    (tmp_path / "notesX2026").mkdir()
+    (tmp_path / "notesX2026" / "b.md").write_text(
+        "---\ntitle: B\n---\n# B\n\n## Sec\n\ny\n", encoding="utf-8"
+    )
+    fts = _build_fts(tmp_path)
+    notes, _ = fts.get_subtree_toc("notes_2026")
+    paths = [n["path"] for n in notes]
+    assert paths == ["notes_2026/a.md"]

--- a/tests/test_fts_subtree_toc.py
+++ b/tests/test_fts_subtree_toc.py
@@ -1,0 +1,92 @@
+"""FTS-layer tests for subtree TOC aggregation and max_level filtering (#773)."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+
+import pytest
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.scanner import HeadingChunker, scan_directory
+
+
+def _build_fts(root: Path) -> FTSIndex:
+    # short_doc_lines=0 disables the short-doc bypass so heading-boundary
+    # splitting fires even on small test fixtures.  max_chunk_words=1 forces
+    # adaptive re-splitting at H3+ so all heading levels appear in sections.
+    chunker = HeadingChunker(short_doc_lines=0, max_chunk_words=1)
+    fts = FTSIndex(db_path=":memory:")
+    for note in scan_directory(root, chunk_strategy=chunker):
+        fts.upsert_note(note)
+    fts.resolve_vault_wikilinks()
+    return fts
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    (tmp_path / "Projects").mkdir()
+    (tmp_path / "Projects" / "alpha.md").write_text(
+        "---\ntitle: Alpha\n---\n# Alpha\n\n## Goals\n\nx\n\n### Detail\n\ny\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "Projects" / "beta.md").write_text(
+        "---\ntitle: Beta\n---\n# Beta\n\n## Plan\n\nz\n",
+        encoding="utf-8",
+    )
+    sub = tmp_path / "Projects" / "sub"
+    sub.mkdir()
+    (sub / "gamma.md").write_text(
+        "---\ntitle: Gamma\n---\n# Gamma\n\n## Nested\n\nq\n",
+        encoding="utf-8",
+    )
+    # A sibling folder whose prefix shares a leading substring with "Projects".
+    (tmp_path / "Projectile.md").write_text(
+        "---\ntitle: Projectile\n---\n# Projectile\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_subtree_toc_is_recursive_and_path_ordered(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, truncated = fts.get_subtree_toc("Projects")
+    assert truncated is False
+    assert [n["path"] for n in notes] == [
+        "Projects/alpha.md",
+        "Projects/beta.md",
+        "Projects/sub/gamma.md",
+    ]
+    alpha = notes[0]
+    assert alpha["title"] == "Alpha"
+    # Raw section headings only — no synthetic H1 prepended at this layer.
+    assert {"heading": "Goals", "level": 2} in alpha["headings"]
+    assert {"heading": "Detail", "level": 3} in alpha["headings"]
+
+
+def test_subtree_prefix_is_boundary_matched(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, _ = fts.get_subtree_toc("Project")
+    assert notes == []  # neither "Projects/..." nor "Projectile.md" match
+
+
+def test_subtree_max_level_filters_headings(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, _ = fts.get_subtree_toc("Projects", max_level=2)
+    alpha = next(n for n in notes if n["path"] == "Projects/alpha.md")
+    levels = {h["level"] for h in alpha["headings"]}
+    assert levels <= {1, 2}  # H3 "Detail" dropped
+
+
+def test_subtree_max_notes_truncates(vault: Path) -> None:
+    fts = _build_fts(vault)
+    notes, truncated = fts.get_subtree_toc("Projects", max_notes=2)
+    assert truncated is True
+    assert len(notes) == 2
+    assert [n["path"] for n in notes] == ["Projects/alpha.md", "Projects/beta.md"]
+
+
+def test_get_toc_max_level_filter(vault: Path) -> None:
+    fts = _build_fts(vault)
+    toc = fts.get_toc("Projects/alpha.md", max_level=2)
+    assert all(h["level"] <= 2 for h in toc)
+    assert {"heading": "Detail", "level": 3} not in toc

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -496,6 +496,14 @@ class TestValidation:
         assert doc_mgr._is_attachment("image.png") is True
         assert doc_mgr._is_attachment("note.md") is False
 
+    def test_get_toc_folder_traversal_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="Path traversal"):
+            doc_mgr.get_toc("../../etc")
+
+    def test_get_toc_folder_root_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="Invalid folder path"):
+            doc_mgr.get_toc(".")
+
     def test_is_path_excluded(self, doc_vault: Path) -> None:
         fts = FTSIndex(db_path=":memory:")
         mgr = DocumentManager(

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -445,15 +445,18 @@ class TestGetToc:
 
     def test_get_toc_folder_trailing_slash(self, doc_mgr: DocumentManager) -> None:
         result = doc_mgr.get_toc("sub/")
+        assert isinstance(result, dict)
         assert result["path"] == "sub"
         assert [n["path"] for n in result["notes"]] == ["sub/gamma.md"]
 
     def test_get_toc_empty_folder_returns_empty(self, doc_mgr: DocumentManager) -> None:
         result = doc_mgr.get_toc("does-not-exist")
+        assert isinstance(result, dict)
         assert result == {"path": "does-not-exist", "notes": [], "truncated": False}
 
     def test_get_toc_folder_max_level(self, doc_mgr: DocumentManager) -> None:
         result = doc_mgr.get_toc("sub", max_level=1)
+        assert isinstance(result, dict)
         gamma = result["notes"][0]
         assert gamma["headings"] == [{"heading": "Gamma", "level": 1}]
 

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -465,6 +465,18 @@ class TestGetToc:
         h1s = [e for e in toc if e == {"heading": "Gamma", "level": 1}]
         assert len(h1s) == 1
 
+    def test_get_toc_rejects_max_notes_below_one(
+        self, doc_mgr: DocumentManager
+    ) -> None:
+        with pytest.raises(ValueError, match="max_notes must be >= 1"):
+            doc_mgr.get_toc("sub", max_notes=0)
+
+    def test_get_toc_rejects_max_level_below_one(
+        self, doc_mgr: DocumentManager
+    ) -> None:
+        with pytest.raises(ValueError, match="max_level must be >= 1"):
+            doc_mgr.get_toc("sub/gamma.md", max_level=0)
+
 
 # ---------------------------------------------------------------------------
 # Validation tests

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -460,6 +460,11 @@ class TestGetToc:
         gamma = result["notes"][0]
         assert gamma["headings"] == [{"heading": "Gamma", "level": 1}]
 
+    def test_get_toc_dedups_title_matching_h1(self, doc_mgr: DocumentManager) -> None:
+        toc = doc_mgr.get_toc("sub/gamma.md")
+        h1s = [e for e in toc if e == {"heading": "Gamma", "level": 1}]
+        assert len(h1s) == 1
+
 
 # ---------------------------------------------------------------------------
 # Validation tests

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -67,8 +67,11 @@ def doc_mgr(doc_vault: Path) -> DocumentManager:
     """
     from markdown_vault_mcp.scanner import parse_note as _parse_note
 
+    # short_doc_lines=0 disables the short-doc bypass; max_chunk_words=1 forces
+    # heading-boundary splitting so all heading levels appear in sections.
+    _chunker = HeadingChunker(short_doc_lines=0, max_chunk_words=1)
     fts = FTSIndex(db_path=":memory:")
-    for note in scan_directory(doc_vault):
+    for note in scan_directory(doc_vault, chunk_strategy=_chunker):
         fts.upsert_note(note)
     fts.resolve_vault_wikilinks()
 
@@ -421,6 +424,38 @@ class TestGetToc:
     def test_get_toc_not_found(self, doc_mgr: DocumentManager) -> None:
         with pytest.raises(ValueError, match="Document not found"):
             doc_mgr.get_toc("missing.md")
+
+    def test_get_toc_max_level_note_mode(self, doc_mgr: DocumentManager) -> None:
+        toc = doc_mgr.get_toc("sub/gamma.md", max_level=1)
+        # Only the synthetic H1 title survives an H1-only cap.
+        assert toc == [{"heading": "Gamma", "level": 1}]
+
+    def test_get_toc_folder_mode_nested(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.get_toc("sub")
+        assert isinstance(result, dict)
+        assert result["path"] == "sub"
+        assert result["truncated"] is False
+        paths = [n["path"] for n in result["notes"]]
+        assert paths == ["sub/gamma.md"]
+        gamma = result["notes"][0]
+        assert gamma["title"] == "Gamma"
+        # Synthetic H1 prepended, body headings follow.
+        assert gamma["headings"][0] == {"heading": "Gamma", "level": 1}
+        assert {"heading": "Section One", "level": 2} in gamma["headings"]
+
+    def test_get_toc_folder_trailing_slash(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.get_toc("sub/")
+        assert result["path"] == "sub"
+        assert [n["path"] for n in result["notes"]] == ["sub/gamma.md"]
+
+    def test_get_toc_empty_folder_returns_empty(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.get_toc("does-not-exist")
+        assert result == {"path": "does-not-exist", "notes": [], "truncated": False}
+
+    def test_get_toc_folder_max_level(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.get_toc("sub", max_level=1)
+        gamma = result["notes"][0]
+        assert gamma["headings"] == [{"heading": "Gamma", "level": 1}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2020,6 +2020,8 @@ class TestGetTocTool:
         assert isinstance(data, dict)
         assert "notes" in data and "truncated" in data
         assert isinstance(data["notes"], list)
+        assert result.structured_content is not None
+        assert result.structured_content == {"result": data}
 
 
 class TestRecentTool:
@@ -3703,6 +3705,8 @@ class TestIndexStaleSignal:
                 {"source": "notes/topic.md", "target": "index.md"},
                 dict,
             ),
+            ("get_toc", {"path": "notes/topic.md"}, list),
+            ("get_toc", {"path": "notes"}, dict),
         ],
     )
     async def test_index_stale_true_uniform_across_index_tools(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2019,6 +2019,7 @@ class TestGetTocTool:
         data = _parse_tool_data(result)
         assert isinstance(data, dict)
         assert "notes" in data and "truncated" in data
+        assert isinstance(data["notes"], list)
 
 
 class TestRecentTool:
@@ -2311,6 +2312,7 @@ class TestResources:
             data = json.loads(result[0].text)
             assert isinstance(data, dict)
             assert "notes" in data and data["path"] == "subfolder"
+            assert isinstance(data["notes"], list)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -252,6 +252,7 @@ class TestToolManifest:
             "get_outlinks",
             "get_recent",
             "get_similar",
+            "get_toc",
             "git_sync",
             "list_documents",
             "list_folders",
@@ -1998,6 +1999,26 @@ class TestSimilarTool:
             )
         assert _meta_stale(result) is False
         assert isinstance(_parse_tool_data(result), list)
+
+
+class TestGetTocTool:
+    """Integration tests for get_toc tool."""
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_get_toc_tool_note(self) -> None:
+        async with Client(make_server()) as client:
+            result = await client.call_tool("get_toc", {"path": "simple.md"})
+        data = _parse_tool_data(result)
+        assert isinstance(data, list)
+        assert data[0]["level"] == 1
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_get_toc_tool_folder(self) -> None:
+        async with Client(make_server()) as client:
+            result = await client.call_tool("get_toc", {"path": "subfolder"})
+        data = _parse_tool_data(result)
+        assert isinstance(data, dict)
+        assert "notes" in data and "truncated" in data
 
 
 class TestRecentTool:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2283,6 +2283,14 @@ class TestResources:
             with pytest.raises(McpError, match="Document not found"):
                 await client.read_resource("toc://vault/does_not_exist.md")
 
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_toc_resource_folder_returns_nested(self) -> None:
+        async with Client(make_server()) as client:
+            result = await client.read_resource("toc://vault/subfolder")
+            data = json.loads(result[0].text)
+            assert isinstance(data, dict)
+            assert "notes" in data and data["path"] == "subfolder"
+
 
 # ---------------------------------------------------------------------------
 # Prompts

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -291,6 +291,7 @@ class TestToolAnnotations:
             "get_broken_links",
             "get_similar",
             "get_recent",
+            "get_toc",
         ):
             ann = by_name[name].annotations
             assert ann is not None, f"{name} missing annotations"
@@ -2011,6 +2012,7 @@ class TestGetTocTool:
         data = _parse_tool_data(result)
         assert isinstance(data, list)
         assert data[0]["level"] == 1
+        assert result.structured_content == {"result": data}
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_get_toc_tool_folder(self) -> None:
@@ -2306,6 +2308,12 @@ class TestResources:
         async with Client(server) as client:
             with pytest.raises(McpError, match="Document not found"):
                 await client.read_resource("toc://vault/does_not_exist.md")
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_toc_resource_folder_traversal_raises(self) -> None:
+        async with Client(make_server()) as client:
+            with pytest.raises(McpError):
+                await client.read_resource("toc://vault/..%2Fetc")
 
     @pytest.mark.usefixtures("_mcp_env")
     async def test_toc_resource_folder_returns_nested(self) -> None:


### PR DESCRIPTION
Closes #773.

## What this adds

A heading-level **table of contents for a folder/subtree**, and exposes the per-note TOC as a **tool** (it was resource-only). Both go through one path-dispatched library method.

`get_toc(path, *, max_level=None, max_notes=200)` dispatches on the `.md` suffix:

- **Note path** (`a/b.md`) → flat `list[{heading, level}]` with the title as a synthetic H1 (unchanged shape; now also honors `max_level`).
- **Folder path** (`a/b`) → nested-per-note `{path, notes: [{path, title, headings}], truncated}`, recursive over the subtree, ordered by path, capped at `max_notes` (default 200) with a `truncated` flag.

Exposed two ways with identical behavior:

- **Extended resource** `toc://vault/{path}` — now dispatches to folders too (defaults only). The pre-existing inaccurate `{level, text, anchor}` docstring is corrected to the real `{heading, level}` shape.
- **New tool** `get_toc` — same dispatch plus the `max_level` / `max_notes` / `wait_for_pending_writes` controls; `needs_queryable` (bucket 3), `_meta.index_stale` reported out-of-band.

## Design notes

- **Boundary match.** Folder matching reuses the precomputed `documents.folder` column with `folder = ? OR folder LIKE ? ESCAPE '\'` (via the existing `_escape_like`), so `Project` never matches `Projects/…` or a sibling `Projectile/`.
- **Bounds.** Truncation is detected with `LIMIT max_notes + 1`; `max_level` is pushed into SQL; the synthetic H1 is prepended *after* the filter, so it always survives.
- **Union return + staleness.** The tool's `list | dict` return makes FastMCP's output schema require a `{"result": …}` envelope on every branch. This is handled by the shared `_staleness_result` helper via a new `force_result_wrap=True` flag — keeping the out-of-band `index_stale` contract in one place (no inlined duplicate, no `# type: ignore`). `result.data` is still the bare list/dict for clients.
- **No schema migration; backward compatible.** Note-mode output is byte-identical to before; the resource extension is purely additive.

## Out of scope

Anchors, pagination, heading-hierarchy nesting. Tightening the TOC payload types (`dict[str, Any]` → `TypedDict`/dataclass) is tracked separately in #779 — deliberately deferred since `get_toc` already returned dicts pre-PR and the JSON wire shape is unchanged.

## Testing

- Full suite green (2404 passed); `ruff`, `ruff format --check`, and `mypy src/ tests/` all clean.
- **100% patch coverage** on all changed source files (diff-cover).
- New tests cover: path dispatch; both shapes; `max_notes` at-cap vs over-cap; boundary prefix (`Project`/`Projects`/`Projectile/`); `_escape_like` wildcard folder names; trailing-slash normalization; empty/nonexistent folder → empty (no raise); missing note → `ValueError`; folder traversal/root → `ValueError` (manager) and `McpError` through the MCP stack (resource); `max_level` in both modes with the synthetic H1 surviving; heading order within a note; `_prepend_title_h1` dedup; the tool's `_meta.index_stale` signal (added to the uniform-stale parametrized test) and the `{"result": …}` envelope on both branches; the `readOnly`/`destructive` annotations; and full-registry title/manifest enforcement.

## Docs

`docs/design.md`, `docs/resources.md`, `docs/tools/index.md`, and `README.md` updated in-PR for the new tool and extended resource (both shapes, the bounds, and the resource↔tool cross-reference).

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
