### PR TITLE
chore: conform gitleaks/codeql/pre-commit infra to the template (#770)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,15 @@
 name: "CodeQL config"
 
-query-filters:
-  - exclude:
-      id: py/clear-text-storage-of-sensitive-information
-      paths:
-        - src/markdown_vault_mcp/git.py
+# Add project-specific CodeQL tuning here, e.g. `paths-ignore:` to skip
+# generated/vendored code, or a `query-filters:` block to suppress a
+# specific alert on a specific path once you've reviewed it.  Example:
+#
+#   query-filters:
+#     - exclude:
+#         id: py/clear-text-storage-of-sensitive-information
+#         paths:
+#           - src/markdown_vault_mcp/some_module.py
+#
+# This scaffold ships no filters: suppress an alert only after you've
+# confirmed it's a false positive for a path that actually exists, so a
+# real finding is never silently hidden.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,9 +1,8 @@
-# Gitleaks configuration
-# https://github.com/gitleaks/gitleaks
-
 [allowlist]
-  # Example placeholder tokens in documentation are not real secrets
-  paths = [
-    '''docs/guides/.*\.md''',
-    '''examples/.*\.env''',
-  ]
+description = "Allow test/example tokens"
+regexes = [
+    # Test bearer tokens in test files and examples
+    '''my-secret-token''',
+    '''test-secret''',
+    '''your-generated-token''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,10 @@ repos:
         name: mypy
         language: system
         entry: uv run mypy
-        files: ^src/
+        files: ^(src|tests)/
+        types: [python]
         pass_filenames: false
-        args: [src/]
+        args: [src/, tests/]
 
       - id: vendor-spa-check
         name: vendored SPA HTML up-to-date
@@ -38,6 +39,11 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
       - id: check-json
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
 
   # Vale prose lint for docs/**. Requires Vale on PATH (`brew install vale`,
   # `apt install vale`, or download from https://vale.sh/docs/install).


### PR DESCRIPTION
Closes #770. Child of epic #766 (template re-convergence), sequence 4 of 5.

## What

Conforms four drifted, template-owned infra settings to the canonical template (v2.9.0) so #771's copier update applies cleanly. Infra/config only — no `src/`, no tests, no domain logic.

1. **`.gitleaks.toml`** — replace MVM's path-based allowlist with the template's token-`regexes` form (byte-identical to the v2.9.0 render). The path form was drift, not a domain choice.
2. **`.github/codeql/codeql-config.yml`** — drop the dead `py/clear-text-storage` filter on `src/markdown_vault_mcp/git.py` (now the `git/` *package* — the path no longer exists, so the filter was a dead no-op); converge to the template's no-filters commented-example form.
3. **`.pre-commit-config.yaml` (gitleaks)** — restore the template's `gitleaks/gitleaks@v8.30.1` hook (local secret-scan parity; makes CLAUDE.md:81's "pre-commit … runs gitleaks" claim accurate).
4. **`.pre-commit-config.yaml` (mypy)** — widen the mypy hook from `src/` to `src/` + `tests/` (`files: ^(src|tests)/`, `args: [src/, tests/]`, `types: [python]`), matching the template, CI Gate #3, and CLAUDE.md:81 ("mypy on `src/` and `tests/`"). The `src/`-only scope was drift.

**Deferred to #771** (auto-reconverge): `ci.yml` action pins (codecov v6→v7, gitleaks-action v2→v3). **Out of scope** (sanctioned domain): `vendor-spa-check`, the 3-manifest bump.

## Verification / pre-empting review concerns

A full local preflight review was run (6 lenses, twice). The genuinely-actionable finding (the `src/`-only mypy drift) is fixed above. The recurring "narrowing" concerns are **verified safe**, with evidence:

- **gitleaks path→regex narrowing:** `gitleaks detect --config <new> --source .` over all 1606 commits, and per-directory scans of `examples/` and `docs/guides/`, all report **"no leaks found."** The example/doc placeholders (`ghp_your_token_here`, `change-me-to-a-random-secret`, `your-client-secret-here`, etc.) don't match gitleaks' built-in rules (the `ghp_` placeholder is 15 non-alphanumeric chars, not the 36-char github-pat pattern). The narrow regex form is the template's deliberate, *safer* design — path-allowlisting whole directories risks hiding a real secret accidentally committed there.
- **codeql filter removal:** the repo's only `py/clear-text-storage` alert is in state **`fixed`** (zero open alerts), so nothing fires on the `git/` package today; the credential code uses `GIT_ASKPASS` (a standard pattern, not clear-text storage). The filter has pointed at the gone `git.py` since #577, so it has been a dead no-op regardless.
- **mypy hook + `tests.*` override:** `pyproject.toml` has `[[tool.mypy.overrides]] module=["tests.*"] ignore_errors=true` (documented "Typing the full test suite is tracked separately"). That override applies equally to the existing `uv run mypy src/ tests/` gate command — widening the hook makes it *match* the gate, and it auto-enforces if/when that override is removed.
- **gitleaks `rev: v8.30.1`:** byte-identical to the template's hook (verified). Pre-commit hooks idiomatically pin to version tags and run locally (not in CI with secret access); SHA-pinning would re-introduce drift from the template.

`uv run pre-commit run --all-files` is green (incl. the new gitleaks hook and the widened mypy hook); the two template-rendered files diff clean against a pristine v2.9.0 render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
