### PR TITLE
chore(copier): adopt the diff-scoped structural-health gate (template v2.10.0)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,10 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.9.1
+_commit: v2.10.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search
 enable_authorization: false
-enable_structural_gate: false
+enable_structural_gate: true
 env_prefix: MARKDOWN_VAULT_MCP
 github_org: pvliesdonk
 human_name: Markdown Vault MCP
@@ -12,3 +12,4 @@ include_mcp_apps_scaffold: true
 project_name: markdown-vault-mcp
 pypi_name: markdown-vault-mcp
 python_module: markdown_vault_mcp
+structural_gate_assert_clean_tree: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,3 +346,51 @@ jobs:
           # don't gate PRs that don't touch them. To enforce repo-wide
           # cleanliness, set this to `nofilter`.
           filter_mode: added
+
+
+  structure:
+    name: Structural Quality (diff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Diff-scoped, so only meaningful on a PR (needs a base branch to compare).
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-${{ runner.os }}
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }} --depth=50
+
+      - name: Structural quality (changed lines only)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Skip when the diff touches no Python — mirrors the diff-cover guard.
+          HAS_PY=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep -c '\.py$' || true)
+          if [ "$HAS_PY" -eq 0 ]; then
+            echo "No Python source changes — skipping structural diff gate"
+            exit 0
+          fi
+          uv run diff-quality --violations=ruff.check \
+            --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
+            --compare-branch="origin/${BASE_REF}" --fail-under=100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
   - repo: local
     hooks:
@@ -23,6 +25,17 @@ repos:
         types: [python]
         pass_filenames: false
         args: [src/, tests/]
+
+      - id: structural-diff-gate
+        name: structural quality (diff vs origin/main)
+        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --compare-branch=origin/main --fail-under=100'
+        language: system
+        pass_filenames: false
+        # Skip the hook when the push has no Python (with pass_filenames: false,
+        # pre-commit still uses `types` to decide whether to run at all). Mirrors
+        # the CI structure job's `HAS_PY` docs-only skip.
+        types: [python]
+        stages: [pre-push]
 
       - id: vendor-spa-check
         name: vendored SPA HTML up-to-date

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,15 @@ Every PR must pass **all** of the following locally before push. These are mecha
 3. **Type-check passes** — `uv run mypy src/ tests/` reports no errors
 4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
 
-5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
-6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
+5. **Structural quality (diff) passes** — new/changed code must introduce no new structural violations (complexity, too-many-*, security). Enforced on the diff only, so pre-existing code is never blocked. Run before pushing:
+   ```bash
+   uv run diff-quality --violations=ruff.check \
+     --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
+     --compare-branch=origin/main --fail-under=100
+   ```
+   `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.
+6. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
+7. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
 
 
 ## Pre-commit Hooks
@@ -85,9 +92,43 @@ This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), 
 
 - **Install once per clone:** `uv run pre-commit install`.
 - **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
+
+- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs the command above automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — same command, same range, as long as your PR targets `main` (the hook hardcodes `origin/main`; CI compares against the PR's actual base branch).
+
 - **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
 
 The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, yamllint, project-specific linters, additional file checks) on top of the shipped defaults survive `copier update`.
+
+
+## Structural health
+
+The structural gate stops *new* debt; these practices and the advisory audit keep existing debt visible.
+
+**Local-shape rules (checkable while you write):**
+
+- Keep functions short and single-purpose; if a function needs a comment to explain a *section*, that section is a function.
+- Nesting beyond ~3 levels is a smell — extract or invert/early-return.
+- Five parameters is the ceiling; past it, pass an object or split the function.
+- A new responsibility is a **new collaborator, not a longer class**. When a class grows a second reason to change, that reason belongs in its own unit.
+
+**Advisory audit (on demand — run before substantial work in an unfamiliar area, or when about to touch a flagged module):**
+
+```bash
+uv run --with radon python -m radon cc -s -n C src/    # complexity hotspots (grade C+)
+uv run --with radon python -m radon mi -s src/         # maintainability index
+uv run --with vulture vulture src/                     # dead-code candidates
+```
+
+Each analyzer is optional and degrades gracefully if absent. `vulture` over-reports on importable/decorated/framework-registered code — **confirm before deleting** and keep a whitelist.
+
+**When you notice decay outside the current change's scope** — a god class forming, a dead branch, a leaking abstraction, a name that no longer matches behaviour, or an audit hotspot — do **not** fix it inline (scope creep) and do **not** pass over it silently. **Open an issue** using this template:
+
+> **What:** the structural problem in one sentence.
+> **Where:** file/symbol and the metric or observation that flagged it.
+> **Why it compounds:** what gets harder or riskier if it's left.
+> **Suggested direction:** a starting point, not a prescribed refactor.
+
+Constrain issues to **decay that will compound**, not anything imperfect. The diff-gate blocks new debt; these issues are the refactor-later backlog for pre-existing debt — neither blocks the current PR.
 
 
 ## PR Discipline

--- a/tests/test_structural_gate.py
+++ b/tests/test_structural_gate.py
@@ -1,0 +1,214 @@
+"""Structural-health gate: behavioural, wiring, and anti-drift tests.
+
+These run inside the rendered project's suite (and any downstream's suite that
+keeps the structural gate enabled), continuously verifying that this project's
+own rendered gate artifacts (pre-commit hook, CI job, pyproject, CLAUDE.md) are
+wired correctly. Only rendered when ``enable_structural_gate`` is true.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Canonical structural ruff selection — MUST stay byte-identical to the string
+# in .pre-commit-config.yaml, .github/workflows/ci.yml, and CLAUDE.md. The
+# anti-drift test in this module enforces that.
+STRUCTURAL = "C901,PLR0911,PLR0912,PLR0913,PLR0915,S"
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A function whose cyclomatic complexity exceeds the mccabe default (10): a
+# long if/elif chain. Written to a temp file and linted via subprocess so this
+# test module itself stays simple (and never trips the gate it is testing).
+OVER_COMPLEX = """
+def tangled(n):
+    if n == 1:
+        return 1
+    elif n == 2:
+        return 2
+    elif n == 3:
+        return 3
+    elif n == 4:
+        return 4
+    elif n == 5:
+        return 5
+    elif n == 6:
+        return 6
+    elif n == 7:
+        return 7
+    elif n == 8:
+        return 8
+    elif n == 9:
+        return 9
+    elif n == 10:
+        return 10
+    elif n == 11:
+        return 11
+    return 0
+"""
+
+
+def _ruff(args: list[str], target: Path) -> subprocess.CompletedProcess[str]:
+    # --config pins THIS project's pyproject.toml. ruff otherwise discovers
+    # config from the target file's directory (tmp_path here), which would test
+    # ruff's defaults instead of the project's `select` — the base-config
+    # assertion below must reflect the project's real selection.
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            "--config",
+            str(REPO_ROOT / "pyproject.toml"),
+            "--output-format",
+            "concise",
+            *args,
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_structural_rule_fires_only_as_overlay(tmp_path: Path) -> None:
+    """C901 fires under --extend-select but NOT under the base project config.
+
+    Guards the core invariant: strict-on-diff, lenient-on-repo. If someone
+    promotes these rules into the whole-repo `select`, the base run starts
+    reporting C901 and this test fails.
+    """
+    target = tmp_path / "snippet.py"
+    target.write_text(OVER_COMPLEX)
+
+    overlay = _ruff([f"--extend-select={STRUCTURAL}"], target)
+    base = _ruff([], target)
+
+    assert "C901" in overlay.stdout, f"overlay should flag C901:\n{overlay.stdout}"
+    assert "C901" not in base.stdout, f"base config must NOT flag C901:\n{base.stdout}"
+
+
+def test_security_rules_are_overlay_only(tmp_path: Path) -> None:
+    """The `S` (security) family fires under --extend-select but NOT under the
+    base config — the same strict-on-diff/lenient-on-repo invariant as C901, for
+    the other high-stakes cluster. If `S` were promoted into the whole-repo
+    `select`, the tests/** per-file-ignores would silently become load-bearing
+    for the entire repo lint, not just the gate; this test fails first.
+    """
+    target = tmp_path / "insecure.py"
+    # `assert` trips S101; the snippet lives outside tests/, so the tests/**
+    # per-file-ignores do not apply and the overlay's `S` is free to fire.
+    target.write_text("def check(x):\n    assert x\n    return x\n")
+
+    overlay = _ruff([f"--extend-select={STRUCTURAL}"], target)
+    base = _ruff([], target)
+
+    assert "S101" in overlay.stdout, f"overlay should flag S101:\n{overlay.stdout}"
+    assert "S101" not in base.stdout, f"base config must NOT flag S101:\n{base.stdout}"
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _diff_quality(repo: Path, extend: bool) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "diff_cover.diff_quality_tool",
+        "--violations=ruff.check",
+        "--compare-branch=main",
+        "--fail-under=100",
+    ]
+    if extend:
+        # EXACTLY the argv element a shell produces from the hook's
+        # --options="--extend-select=..." — this is the splitting under test.
+        cmd.append(f"--options=--extend-select={STRUCTURAL}")
+    return subprocess.run(cmd, cwd=repo, capture_output=True, text=True)
+
+
+def test_options_reach_ruff_and_gate_is_diff_scoped(tmp_path: Path) -> None:
+    """A new over-complex function fails the gate ONLY with the structural
+    overlay passed through diff-quality --options; a clean base run passes.
+
+    Proves three things at once: (1) --options actually reaches ruff,
+    (2) the diff scoping works, (3) without the overlay the same diff passes.
+    """
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(["init", "-b", "main"], repo)
+    (repo / "base.py").write_text("x = 1\n")
+    _git(["add", "."], repo)
+    _git(["commit", "-m", "base"], repo)
+
+    _git(["checkout", "-b", "feature"], repo)
+    (repo / "tangled.py").write_text(OVER_COMPLEX)
+    _git(["add", "."], repo)
+    _git(["commit", "-m", "add tangled"], repo)
+
+    with_overlay = _diff_quality(repo, extend=True)
+    without_overlay = _diff_quality(repo, extend=False)
+
+    assert with_overlay.returncode != 0, (
+        "structural overlay must fail the diff gate:\n"
+        f"{with_overlay.stdout}\n{with_overlay.stderr}"
+    )
+    assert without_overlay.returncode == 0, (
+        "base ruff (no structural overlay) must pass the same diff:\n"
+        f"{without_overlay.stdout}\n{without_overlay.stderr}"
+    )
+
+
+def test_precommit_config_wires_pre_push_hook() -> None:
+    text = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    assert "default_install_hook_types: [pre-commit, pre-push]" in text
+    assert "id: structural-diff-gate" in text
+    assert "stages: [pre-push]" in text
+    assert "language: system" in text
+    # Mirrors the CI HAS_PY skip: no Python in the push → hook does not run.
+    assert "types: [python]" in text
+    # The `entry: bash -c` wrapper is load-bearing: it makes the shell (not
+    # pre-commit's arg splitter) own the --options quoting verified by the
+    # end-to-end test. Assert it so a refactor to a direct `uv run` entry —
+    # which would break that quoting — can't pass silently.
+    assert "entry: bash -c " in text
+    assert f"--extend-select={STRUCTURAL}" in text
+
+
+def test_ci_has_structure_job() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    assert "structure:" in text
+    assert "diff-quality" in text
+    assert f"--extend-select={STRUCTURAL}" in text
+    # PR-only, like the diff-cover patch-coverage steps.
+    assert "github.event_name == 'pull_request'" in text
+
+
+def test_claudemd_documents_the_gate_command() -> None:
+    text = (REPO_ROOT / "CLAUDE.md").read_text()
+    assert "diff-quality" in text
+    assert f"--extend-select={STRUCTURAL}" in text
+    # Advisory audit + eyes content present.
+    assert "radon" in text and "vulture" in text
+    assert "Why it compounds" in text  # decay-issue template marker
+
+
+def test_structural_select_string_is_identical_across_surfaces() -> None:
+    """The select string lives in three rendered files; drift between them is a
+    silent gate weakening. Assert all three carry the canonical string verbatim.
+    """
+    needle = f"--extend-select={STRUCTURAL}"
+    precommit = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    claudemd = (REPO_ROOT / "CLAUDE.md").read_text()
+    for name, text in [("pre-commit", precommit), ("ci", ci), ("CLAUDE.md", claudemd)]:
+        assert needle in text, f"{name} missing canonical structural select"


### PR DESCRIPTION
## Summary

Adopts the template's **diff-scoped structural-health gate** (copier update `v2.9.1` → `v2.10.0`), resolving the deferral tracked in #783.

The gate is enabled with the **brownfield opt-out** shipped upstream in [fastmcp-server-template#231](https://github.com/pvliesdonk/fastmcp-server-template/pull/231) (released in template `v2.10.0`):

- `enable_structural_gate=true`, `structural_gate_assert_clean_tree=false`.
- The diff-scoped gate (pre-push hook + CI `structure` job) holds **new/changed** code to the bar (`C901,PLR0911,PLR0912,PLR0913,PLR0915,S` on the diff only); **pre-existing complexity debt is grandfathered** — the whole-tree clean assertion is dropped via the opt-out.

Closes #783.

## What changed

- **`.copier-answers.yml`** — pin `v2.9.1`→`v2.10.0`; `enable_structural_gate` false→true; new `structural_gate_assert_clean_tree: false`.
- **`.github/workflows/ci.yml`** — template-rendered `structure:` job (PR-only, diff-quality on changed lines).
- **`.pre-commit-config.yaml`** — hand-wired `default_install_hook_types: [pre-commit, pre-push]` + the `structural-diff-gate` pre-push hook. This file is `_skip_if_exists`, so copier can't render the hook itself; the block is transplanted verbatim from a pristine `v2.10.0` render.
- **`CLAUDE.md`** — template-rendered structural-gate acceptance item (#5) + "Structural health" guidance.
- **`tests/test_structural_gate.py`** — the template's anti-drift / behavioural gate suite (7 tests; the whole-tree `test_shipped_code_passes_…` is intentionally absent under the opt-out).

## Pre-existing debt is *not* suppressed here

The gate is the **contrapart** to the cluster-A refactor backlog, kept independent of it. Existing complexity hotspots (`managers/`, `git/query.py`, `scanner.py`, `_server_apps.py`, …) stay as honest, diff-grandfathered debt — to be paid down separately under #759–763, not blanket-`noqa`'d here. The gate's only job is to stop *new* debt.

## Verification

- Full suite: **2432 passed, 3 skipped**. `tests/test_structural_gate.py`: **7/7**.
- `ruff check` / `ruff format --check` / `mypy src/ tests/`: clean.
- The new diff-scoped gate passes on this PR's own diff (0 violations).
- Conflict resolution (the two answer-flip conflicts in `ci.yml`/`CLAUDE.md`) took the template's new gate content; no MVM content lost; CLAUDE.md gates renumbered 1–7 cleanly.
- Local five-lens + supplementary pre-push review: clean in one round.

## Follow-ups (separate, out of scope here)

- The `S102 exec` observation in `_server_prompts.py` surfaced during the #783 investigation is filed as #788 (the gate grandfathers it; it warrants its own fix).
- After merge, run `uv run pre-commit install` once per clone to activate the pre-push stage.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
