### PR TITLE
fix: quiet httpx per-request logs at the default level (#792)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1035,9 +1035,12 @@ Follow FastMCP conventions and standard Python logging:
 
 **Log level control:** `FASTMCP_LOG_LEVEL` env var controls FastMCP internals
 (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Default `INFO`. App loggers use `INFO`
-unless overridden by `-v` (sets both app and FastMCP to `DEBUG`). When
-`DEBUG` is active, `httpx` and
-`httpcore` loggers are pinned to `WARNING` to reduce noise.
+unless overridden by `-v` (sets both app and FastMCP to `DEBUG`). The `httpx`
+and `httpcore` loggers are pinned to `WARNING` at the default level so their
+per-request `INFO` line does not flood embedding builds; at `-v` they are reset
+to `NOTSET` so the root `DEBUG` level governs and they become visible. This
+mirrors core's `uvicorn.access` / `mcp.server.lowlevel.server` handling, but
+stays domain-local because `fastmcp-pvl-core` does not own these dependencies.
 
 **Request logging:** `make_server()` wires pvl-core's single
 `RequestLoggingMiddleware` (via `wire_middleware_stack`), which emits

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -46,11 +46,10 @@ def _root(
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
         root.addHandler(handler)
-    if verbose:
-        # httpx/httpcore are noisy at DEBUG; keep them quiet.  Core doesn't
-        # own these deps, so the silencing stays domain-local.
-        logging.getLogger("httpx").setLevel(logging.WARNING)
-        logging.getLogger("httpcore").setLevel(logging.WARNING)
+    # Quiet httpx/httpcore per-request INFO at the default level (#792); -v shows them.
+    _http_level = logging.NOTSET if verbose else logging.WARNING
+    logging.getLogger("httpx").setLevel(_http_level)
+    logging.getLogger("httpcore").setLevel(_http_level)
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,32 @@ def test_no_args_exits_nonzero() -> None:
     assert "serve" in result.output
 
 
+def test_root_keeps_httpx_quiet_at_default_visible_at_debug() -> None:
+    """httpx/httpcore emit a per-request INFO line that floods logs during
+    embedding builds (#792). The root callback pins them to WARNING at the
+    default level (quiet) and to NOTSET at -v (root DEBUG governs, visible)."""
+    import logging
+
+    from markdown_vault_mcp.cli import _root
+
+    root = logging.getLogger()
+    httpx_log = logging.getLogger("httpx")
+    httpcore_log = logging.getLogger("httpcore")
+    saved = (root.level, httpx_log.level, httpcore_log.level)
+    try:
+        _root(verbose=False)
+        assert httpx_log.level == logging.WARNING
+        assert httpcore_log.level == logging.WARNING
+
+        _root(verbose=True)
+        assert httpx_log.level == logging.NOTSET
+        assert httpcore_log.level == logging.NOTSET
+    finally:
+        root.setLevel(saved[0])
+        httpx_log.setLevel(saved[1])
+        httpcore_log.setLevel(saved[2])
+
+
 def test_serve_help_exits_zero() -> None:
     """`serve --help` documents the transport flag."""
     result = runner.invoke(app, ["serve", "--help"])
@@ -746,8 +772,43 @@ def test_verbose_enables_debug_logging(monkeypatch: pytest.MonkeyPatch) -> None:
             os.environ.pop("FASTMCP_LOG_LEVEL", None)
 
 
-def test_verbose_silences_httpx_httpcore(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`-v` sets httpx/httpcore to WARNING to suppress their DEBUG noise."""
+def test_default_level_pins_httpx_httpcore_to_warning(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without -v, the CLI pins httpx/httpcore to WARNING so their per-request
+    INFO lines don't flood normal embedding builds (#792) — the exact production
+    path, exercised through Typer rather than a direct _root call."""
+    import logging
+
+    monkeypatch.setenv(f"{_ENV_PREFIX}_SOURCE_DIR", str(tmp_path))
+    mock_vault = MagicMock()
+    mock_stats = MagicMock()
+    mock_stats.documents_indexed = 0
+    mock_stats.chunks_indexed = 0
+    mock_vault.index.build_index.return_value = mock_stats
+
+    httpx_log = logging.getLogger("httpx")
+    httpcore_log = logging.getLogger("httpcore")
+    saved = (httpx_log.level, httpcore_log.level)
+    # Pre-set the flood-prone state (NOTSET → inherits the root level) so the
+    # assertion proves the default CLI path actively pins WARNING.
+    httpx_log.setLevel(logging.NOTSET)
+    httpcore_log.setLevel(logging.NOTSET)
+    try:
+        with patch("markdown_vault_mcp.cli._build_vault", return_value=mock_vault):
+            runner.invoke(app, ["index"])
+        assert httpx_log.level == logging.WARNING
+        assert httpcore_log.level == logging.WARNING
+    finally:
+        httpx_log.setLevel(saved[0])
+        httpcore_log.setLevel(saved[1])
+
+
+def test_verbose_resets_httpx_httpcore_to_follow_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`-v` resets httpx/httpcore to NOTSET so the root DEBUG level governs and
+    they become visible; it no longer pins them to WARNING (#792)."""
     import logging
 
     monkeypatch.setenv(f"{_ENV_PREFIX}_SOURCE_DIR", "/tmp/vault")
@@ -756,10 +817,22 @@ def test_verbose_silences_httpx_httpcore(monkeypatch: pytest.MonkeyPatch) -> Non
     mock_stats.documents_indexed = 0
     mock_stats.chunks_indexed = 0
     mock_vault.index.build_index.return_value = mock_stats
-    with patch("markdown_vault_mcp.cli._build_vault", return_value=mock_vault):
-        runner.invoke(app, ["-v", "index"])
-    assert logging.getLogger("httpx").level == logging.WARNING
-    assert logging.getLogger("httpcore").level == logging.WARNING
+
+    httpx_log = logging.getLogger("httpx")
+    httpcore_log = logging.getLogger("httpcore")
+    saved = (httpx_log.level, httpcore_log.level)
+    # Pre-set WARNING so the assertion proves -v actively resets it, not that
+    # the logger merely started unset.
+    httpx_log.setLevel(logging.WARNING)
+    httpcore_log.setLevel(logging.WARNING)
+    try:
+        with patch("markdown_vault_mcp.cli._build_vault", return_value=mock_vault):
+            runner.invoke(app, ["-v", "index"])
+        assert httpx_log.level == logging.NOTSET
+        assert httpcore_log.level == logging.NOTSET
+    finally:
+        httpx_log.setLevel(saved[0])
+        httpcore_log.setLevel(saved[1])
 
 
 def test_root_handler_added_when_none_exist(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #792.

## Problem

The Ollama/OpenAI embedding providers use `httpx`, whose logger emits a per-request `INFO` line (`HTTP Request: POST .../api/embed "HTTP/1.1 200 OK"`) for every batch. During an index/embedding build this floods the logs at the **default** level.

The `_root` CLI callback already pinned `httpx`/`httpcore` to `WARNING` — but the code lived **inside the `if verbose:` branch**, so it only ran with `-v`. At the default level the loggers were never touched and their `INFO` lines flowed through. The gating was backwards: it quieted httpx exactly when you asked for *more* logs, and flooded it the rest of the time.

## Fix

Move the level override out of the `if verbose:` branch and pick the level by verbosity:

```python
_http_level = logging.NOTSET if verbose else logging.WARNING
logging.getLogger("httpx").setLevel(_http_level)
logging.getLogger("httpcore").setLevel(_http_level)
```

- **Default level:** `WARNING` — the per-request `INFO` line is suppressed; warnings/errors still surface.
- **`-v` / DEBUG:** `NOTSET` — the loggers defer to the root `DEBUG` level via propagation and become visible.

This is the pattern the issue asked for and the one CLAUDE.md's Logging Standard already prescribes for `uvicorn.access` / `mcp.server.lowlevel.server` (WARNING at default, NOTSET at DEBUG).

## Open question from the issue — resolved

The issue asked whether the suppression belongs upstream in `fastmcp-pvl-core`'s `configure_logging_from_env` or domain-side. **Kept domain-local** (in `cli._root`), matching the pre-existing precedent: `fastmcp-pvl-core` doesn't own `httpx`/`httpcore` (they're pulled in by this project's embedding providers), so the silencing stays with the code that owns the dependency. `docs/design.md`'s logging section now records this rationale.

## Tests

`tests/test_cli.py`:
- `test_root_keeps_httpx_quiet_at_default_visible_at_debug` — direct `_root` calls, both branches (WARNING at default, NOTSET at `-v`).
- `test_default_level_pins_httpx_httpcore_to_warning` — the production path through Typer (`index` with no `-v`), pre-seeds the flood-prone `NOTSET` state then asserts `WARNING`, so it fails if the silencing is ever re-gated inside `if verbose:`.
- `test_verbose_resets_httpx_httpcore_to_follow_root` — verbose CLI path, pre-seeds `WARNING` then asserts `NOTSET` (proves an active reset). Renamed/rewritten from the old `test_verbose_silences_httpx_httpcore`, which asserted the now-wrong behavior.

## Docs

`docs/design.md` logging section corrected (it previously described the old, inverted behavior). No user-facing config knob is added; this is internal log hygiene.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)