### PR TITLE
fix: build prompt callables with a synthetic signature instead of exec() (#788)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ variables (`MARKDOWN_VAULT_MCP_TRANSPORT`, `MARKDOWN_VAULT_MCP_HOST`,
 | `MARKDOWN_VAULT_MCP_REQUIRED_FIELDS` | csv | (none) | No | Comma-separated frontmatter fields required on every document; documents missing any are excluded from the index |
 | `MARKDOWN_VAULT_MCP_EXCLUDE` | csv | (none) | No | Comma-separated glob patterns to exclude from scanning (such as `.obsidian/**,.trash/**`) |
 | `MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER` | string | `_templates` | No | Relative folder path used by the `create_from_template` prompt to discover/read template files |
-| `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | path | (none) | No | Path to a directory of `.md` prompt files that extend or override built-in prompts |
+| `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | path | (none) | No | Path to a directory of `.md` prompt files that extend or override built-in prompts. Each declared argument name must be a plain Python identifier (letters, digits, underscore; not a keyword); a prompt with a non-conforming argument name is skipped with a logged warning. |
 
 ## Index Build Timeout
 

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -8,12 +8,16 @@ Call :func:`register_prompts` after constructing the
 from __future__ import annotations
 
 import importlib.resources
+import inspect
 import keyword
 import logging
 import re
 from pathlib import Path, PurePosixPath
 from string import Template
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import frontmatter
 from fastmcp import FastMCP
@@ -27,13 +31,97 @@ _BUILTIN_PROMPTS_DIR = importlib.resources.files("markdown_vault_mcp").joinpath(
 
 logger = logging.getLogger(__name__)
 
-# Only valid Python identifiers are allowed as argument names in user prompts.
-# This prevents exec() injection via malicious frontmatter argument names.
+# Argument names must be plain, non-keyword Python identifiers: they become
+# parameters of a synthetic inspect.Signature (see _build_prompt_fn), so a name
+# that is not a valid identifier cannot form a parameter at all.
 _VALID_IDENT = re.compile(r"^[a-zA-Z_]\w*$")
 
-# Argument names that would shadow variables injected into the exec() namespace,
-# causing silent wrong output (tmpl) or TypeError at invocation (_Template).
-_RESERVED_EXEC_NAMES = frozenset({"tmpl", "_Template"})
+
+def _arg_names_valid(kind: str, name: str, arg_defs: list[dict[str, Any]]) -> bool:
+    """True when every argument name is a plain, non-keyword identifier.
+
+    Logs a warning and returns False on the first offending name so the caller
+    skips the prompt rather than raising when the synthetic signature is built.
+    """
+    for arg in arg_defs:
+        arg_name = arg["name"]
+        if not _VALID_IDENT.match(arg_name):
+            reason = "is not a valid Python identifier"
+        elif keyword.iskeyword(arg_name):
+            reason = "is a reserved Python keyword"
+        else:
+            continue
+        logger.warning(
+            "%s prompt %r argument name %r %s — skipping prompt",
+            kind,
+            name,
+            arg_name,
+            reason,
+        )
+        return False
+    return True
+
+
+def _build_prompt_fn(
+    template: str,
+    arg_defs: list[dict[str, Any]],
+    derive: Callable[[dict[str, Any]], None] | None = None,
+) -> Any:
+    """Build a prompt callable with a synthetic signature (no ``exec``).
+
+    Each argument becomes a ``str`` parameter (optional args default to ``""``)
+    so FastMCP can introspect the prompt's arguments via the attached
+    ``__signature__``. No source string is compiled from the argument names, so
+    a name can only ever be a parameter, never executable code (#788).
+
+    Args:
+        template: The prompt body with ``$name`` / ``${name}`` placeholders.
+        arg_defs: Argument definitions (``name`` + ``required``).
+        derive: Optional hook that adds computed template variables to the
+            bound-argument dict before substitution (e.g. a slug).
+
+    Returns:
+        A callable whose ``__signature__`` exposes the typed arguments.
+
+    Raises:
+        ValueError: If the arguments cannot form a valid signature (e.g. an
+            optional argument precedes a required one).
+    """
+    params = [
+        inspect.Parameter(
+            arg["name"],
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=str,
+            default=inspect.Parameter.empty if arg.get("required", False) else "",
+        )
+        for arg in arg_defs
+    ]
+    signature = inspect.Signature(params, return_annotation=str)
+
+    def prompt_fn(**kwargs: str) -> str:
+        bound = signature.bind_partial(**kwargs)
+        bound.apply_defaults()
+        values: dict[str, Any] = dict(bound.arguments)
+        if derive is not None:
+            derive(values)
+        return Template(template).safe_substitute(**values)
+
+    # FastMCP introspects prompts via BOTH inspect.signature (reads
+    # __signature__) and typing.get_type_hints (reads __annotations__), so set
+    # both to the per-argument view rather than the real ``**kwargs`` one.
+    prompt_fn.__signature__ = signature  # type: ignore[attr-defined]
+    prompt_fn.__annotations__ = {p.name: str for p in params} | {"return": str}
+    return prompt_fn
+
+
+def _research_derive(values: dict[str, Any]) -> None:
+    """Add ``topic_slug`` derived from ``topic`` for the built-in research prompt.
+
+    SYNC: coupled to static/prompts/research.md, which uses ``${topic_slug}``.
+    """
+    values["topic_slug"] = re.sub(r"[^\w\-]", "-", str(values["topic"]).lower()).strip(
+        "-"
+    )
 
 
 def _load_user_prompt_defs(prompts_folder: str | None) -> dict[str, dict[str, Any]]:
@@ -108,8 +196,9 @@ def _load_user_prompt_defs(prompts_folder: str | None) -> dict[str, dict[str, An
 def _register_one_user_prompt(mcp: FastMCP, name: str, defn: dict[str, Any]) -> None:
     """Register a single user-defined prompt on *mcp*.
 
-    Builds a function with the correct signature via :func:`exec` so that
-    FastMCP can introspect the arguments.
+    Builds a callable with a synthetic :class:`inspect.Signature` (see
+    :func:`_build_prompt_fn`) so FastMCP can introspect the arguments without
+    compiling any user-derived source.
 
     Args:
         mcp: The :class:`~fastmcp.FastMCP` instance.
@@ -132,51 +221,23 @@ def _register_one_user_prompt(mcp: FastMCP, name: str, defn: dict[str, Any]) -> 
 
         fn = _make_no_arg(content_template)
     else:
-        # Validate all argument names before building the exec'd function.
-        # Malicious frontmatter could inject arbitrary Python via exec() if
-        # names are not restricted to valid identifiers, or if names happen
-        # to be reserved keywords (which would cause a SyntaxError in exec).
-        for arg in arg_defs:
-            arg_name = arg["name"]
-            if (
-                not _VALID_IDENT.match(arg_name)
-                or keyword.iskeyword(arg_name)
-                or arg_name in _RESERVED_EXEC_NAMES
-            ):
-                logger.warning(
-                    "User prompt %r has invalid or reserved argument name %r — skipping prompt",
-                    name,
-                    arg_name,
-                )
-                return
-
-        # Build a function with the correct typed signature via exec so
-        # FastMCP can introspect argument names and required status.
-        # Template substitution uses string.Template ($var / ${var}) rather
-        # than str.format() to prevent attribute-traversal format-string attacks.
-        param_parts: list[str] = []
-        for arg in arg_defs:
-            if arg.get("required", False):
-                param_parts.append(f"{arg['name']}: str")
-            else:
-                param_parts.append(f'{arg["name"]}: str = ""')
-        params_str = ", ".join(param_parts)
-        sub_args = ", ".join(f"{a['name']}={a['name']}" for a in arg_defs)
-        fn_src = (
-            f"def prompt_fn({params_str}) -> str:\n"
-            f"    return _Template(tmpl).safe_substitute({sub_args})\n"
-        )
-        local_ns: dict[str, Any] = {"tmpl": content_template, "_Template": Template}
+        # Reject non-identifier / keyword names before building the signature.
+        if not _arg_names_valid("User", name, arg_defs):
+            return
+        # Build the callable with a synthetic signature (no exec). Template
+        # substitution uses string.Template ($var / ${var}) rather than
+        # str.format() to prevent attribute-traversal format-string attacks.
         try:
-            exec(fn_src, local_ns)
-        except SyntaxError:
+            fn = _build_prompt_fn(content_template, arg_defs)
+        except ValueError:
             logger.warning(
-                "User prompt %r generated invalid function signature — skipping prompt",
+                "User prompt %r has arguments that cannot form a valid signature "
+                "(e.g. a duplicate name, or an optional argument before a required "
+                "one) — skipping prompt",
                 name,
                 exc_info=True,
             )
             return
-        fn = local_ns["prompt_fn"]
 
     fn.__name__ = name
     fn.__doc__ = description or f"User-defined prompt: {name}"
@@ -251,50 +312,24 @@ def _register_one_builtin_prompt(mcp: FastMCP, name: str, defn: dict[str, Any]) 
     if not arg_defs:
         fn: Any = lambda: content_template  # noqa: E731
     else:
-        # Build a function with correct signature via exec (same pattern as
-        # user-defined prompts) so FastMCP can introspect argument names.
-        param_parts: list[str] = []
-        for arg in arg_defs:
-            if arg.get("required", False):
-                param_parts.append(f"{arg['name']}: str")
-            else:
-                param_parts.append(f'{arg["name"]}: str = ""')
-        params_str = ", ".join(param_parts)
-
-        # Some prompts compute derived variables (e.g. research: topic_slug).
-        # Add a pre-compute block for known derivations.
-        # SYNC: the research block below is coupled to static/prompts/research.md
-        # which uses ${topic_slug}.  If that template drops the variable, remove
-        # the pre-compute and extra arg here as well.
-        pre_compute = ""
-        if name == "research":
-            pre_compute = "    topic_slug = _re_sub(r'[^\\w\\-]', '-', topic.lower()).strip('-')\n"
-
-        all_args = [a["name"] for a in arg_defs]
-        if name == "research":
-            all_args.append("topic_slug")
-        sub_args = ", ".join(f"{a}={a}" for a in all_args)
-
-        fn_src = (
-            f"def prompt_fn({params_str}) -> str:\n"
-            f"{pre_compute}"
-            f"    return _Template(tmpl).safe_substitute({sub_args})\n"
-        )
-        local_ns: dict[str, Any] = {
-            "tmpl": content_template,
-            "_Template": Template,
-            "_re_sub": re.sub,
-        }
+        # Built-in prompt definitions ship in the package (first-party), but
+        # validate their names too so the same synthetic-signature path is used
+        # for both trusted and user prompts and no name is ever exec'd (#788).
+        if not _arg_names_valid("Built-in", name, arg_defs):
+            return
+        # Some prompts compute derived template variables (e.g. research adds
+        # ${topic_slug}); those are computed in the closure via ``derive``.
+        derive = _research_derive if name == "research" else None
         try:
-            exec(fn_src, local_ns)
-        except SyntaxError:
+            fn = _build_prompt_fn(content_template, arg_defs, derive=derive)
+        except ValueError:
             logger.warning(
-                "Built-in prompt %r generated invalid function signature — skipping",
+                "Built-in prompt %r has arguments that cannot form a valid "
+                "signature — skipping",
                 name,
                 exc_info=True,
             )
             return
-        fn = local_ns["prompt_fn"]
 
     fn.__name__ = name
     fn.__doc__ = description

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,7 +10,7 @@ Tests cover:
 
 from __future__ import annotations
 
-from pathlib import Path  # noqa: TC003
+from pathlib import Path
 
 import pytest
 from fastmcp import Client
@@ -234,7 +234,7 @@ class TestRegisterOneUserPromptArgValidation:
             logging.WARNING, logger="markdown_vault_mcp._server_prompts"
         ):
             _register_one_user_prompt(mcp, "bad_prompt", defn)
-        assert "invalid or reserved argument name" in caplog.text
+        assert "is a reserved Python keyword" in caplog.text
 
     def test_skips_prompt_with_non_identifier_arg_name(
         self, caplog: pytest.LogCaptureFixture
@@ -257,12 +257,13 @@ class TestRegisterOneUserPromptArgValidation:
             logging.WARNING, logger="markdown_vault_mcp._server_prompts"
         ):
             _register_one_user_prompt(mcp, "bad_prompt2", defn)
-        assert "invalid or reserved argument name" in caplog.text
+        assert "is not a valid Python identifier" in caplog.text
 
-    def test_skips_prompt_with_reserved_exec_name(
+    def test_formerly_reserved_name_now_allowed(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Arg names 'tmpl'/'_Template' shadow exec closure vars — must be rejected."""
+        """'tmpl' was reserved only to protect the exec() namespace. With exec
+        removed (#788) it is a plain identifier and is no longer rejected."""
         import logging
 
         from fastmcp import FastMCP
@@ -271,7 +272,7 @@ class TestRegisterOneUserPromptArgValidation:
 
         mcp = FastMCP("test")
         defn: dict = {
-            "description": "bad prompt",
+            "description": "ok prompt",
             "arguments": [{"name": "tmpl", "description": "", "required": True}],
             "tags": [],
             "content": "Hello $tmpl",
@@ -279,8 +280,96 @@ class TestRegisterOneUserPromptArgValidation:
         with caplog.at_level(
             logging.WARNING, logger="markdown_vault_mcp._server_prompts"
         ):
-            _register_one_user_prompt(mcp, "bad_exec_name", defn)
-        assert "invalid or reserved argument name" in caplog.text
+            _register_one_user_prompt(mcp, "ok_name", defn)
+        assert "skipping prompt" not in caplog.text
+
+    def test_builtin_prompt_skips_invalid_arg_name(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The built-in registration path also rejects non-identifier names
+        (defense-in-depth for the shared synthetic-signature path, #788)."""
+        import logging
+
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp._server_prompts import _register_one_builtin_prompt
+
+        mcp = FastMCP("test")
+        defn: dict = {
+            "description": "bad builtin",
+            "arguments": [{"name": "bad-name", "description": "", "required": True}],
+            "tags": [],
+            "icons": "",
+            "content": "Hi $x",
+        }
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp._server_prompts"
+        ):
+            _register_one_builtin_prompt(mcp, "bad_builtin", defn)
+        assert "is not a valid Python identifier" in caplog.text
+
+    def test_module_has_no_exec(self) -> None:
+        """The prompt-registration module compiles no source and calls no exec
+        (the S102 sink removed in #788)."""
+        import markdown_vault_mcp._server_prompts as mod
+
+        source = Path(mod.__file__).read_text(encoding="utf-8")
+        assert "exec(" not in source
+
+    def test_user_prompt_skips_invalid_arg_order(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An optional arg before a required one cannot form a valid signature;
+        the prompt is skipped with a warning rather than crashing startup."""
+        import logging
+
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp._server_prompts import _register_one_user_prompt
+
+        mcp = FastMCP("test")
+        defn: dict = {
+            "description": "bad order",
+            "arguments": [
+                {"name": "opt", "description": "", "required": False},
+                {"name": "req", "description": "", "required": True},
+            ],
+            "tags": [],
+            "content": "$opt $req",
+        }
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp._server_prompts"
+        ):
+            _register_one_user_prompt(mcp, "bad_order", defn)
+        assert "cannot form a valid signature" in caplog.text
+
+    def test_builtin_prompt_skips_invalid_arg_order(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The built-in path likewise skips an unformable signature (covers the
+        second except-ValueError handler)."""
+        import logging
+
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp._server_prompts import _register_one_builtin_prompt
+
+        mcp = FastMCP("test")
+        defn: dict = {
+            "description": "bad order builtin",
+            "arguments": [
+                {"name": "opt", "description": "", "required": False},
+                {"name": "req", "description": "", "required": True},
+            ],
+            "tags": [],
+            "icons": "",
+            "content": "$opt $req",
+        }
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp._server_prompts"
+        ):
+            _register_one_builtin_prompt(mcp, "bad_order_builtin", defn)
+        assert "cannot form a valid signature" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -408,6 +497,64 @@ class TestUserPromptWithArgs:
             result = await client.get_prompt("styled", {})
         text = result.messages[0].content.text
         assert "[]" in text  # empty string substituted
+
+    @pytest.mark.usefixtures("_clear_vars")
+    async def test_synthetic_signature_exposes_arguments(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FastMCP introspects the prompt's arguments from the synthetic
+        signature (name + required), so clients see the declared arguments."""
+        prompts_dir = tmp_path / "prompts"
+        prompts_dir.mkdir()
+        content = (
+            "---\n"
+            "arguments:\n"
+            "  - name: path\n"
+            "    required: true\n"
+            "  - name: style\n"
+            "    required: false\n"
+            "---\n"
+            "$path in $style"
+        )
+        (prompts_dir / "twoarg.md").write_text(content, encoding="utf-8")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
+
+        server = make_server()
+        async with Client(server) as client:
+            prompts = await client.list_prompts()
+        prompt = next(p for p in prompts if p.name == "twoarg")
+        args = {a.name: a.required for a in prompt.arguments}
+        assert args == {"path": True, "style": False}
+
+    @pytest.mark.usefixtures("_clear_vars")
+    async def test_formerly_reserved_arg_name_substitutes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A prompt whose arg is named 'tmpl' (formerly exec-reserved) now
+        registers and substitutes end-to-end (#788)."""
+        prompts_dir = tmp_path / "prompts"
+        prompts_dir.mkdir()
+        content = (
+            "---\narguments:\n  - name: tmpl\n    required: true\n---\nHello $tmpl."
+        )
+        (prompts_dir / "greet.md").write_text(content, encoding="utf-8")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.get_prompt("greet", {"tmpl": "World"})
+        assert "Hello World." in result.messages[0].content.text
+
+
+def test_research_derive_slugifies_topic() -> None:
+    """_research_derive turns $topic into a filesystem-safe ${topic_slug}
+    (lowercased; each non-word/dash char → '-'; leading/trailing '-' trimmed) —
+    the one behaviour beyond plain substitution moved out of the exec (#788)."""
+    from markdown_vault_mcp._server_prompts import _research_derive
+
+    values: dict = {"topic": "Horror Fiction!"}
+    _research_derive(values)
+    assert values["topic_slug"] == "horror-fiction"
 
 
 class TestUserPromptOverride:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2351,6 +2351,10 @@ class TestPrompts:
         assert "horror fiction" in text
         assert "`search`" in text
         assert "`write`" in text
+        # The derived ${topic_slug} is substituted end-to-end (#788): no literal
+        # placeholder remains and the slug appears in the target path.
+        assert "Research/horror-fiction.md" in text
+        assert "${topic_slug}" not in text
 
     @pytest.mark.usefixtures("_mcp_env_writable")
     async def test_discuss_prompt(self) -> None:


### PR DESCRIPTION
Closes #788. Refs #799.

## Problem

Both prompt-registration paths in `_server_prompts.py` compiled a **function source string** from each declared argument name and `exec()`'d it (ruff `S102`). The user-prompt path guarded names with an identifier allowlist, but the mechanism itself was an unbounded code-execution sink gated only by "does it parse" — a syntactically-valid but malicious argument name was an injection surface. The built-in path had no name guard at all.

## Fix

Replace `exec` at both sites with a **closure carrying a synthetic `inspect.Signature`** (and matching `__annotations__`). No source string is ever compiled from argument names, so a name can only ever become an `inspect.Parameter` — never executable code. `S102` is now **absent from `src/` entirely** (previously grandfathered by the structural gate).

```python
def prompt_fn(**kwargs: str) -> str:
    bound = signature.bind_partial(**kwargs)
    bound.apply_defaults()          # optional args still default to ""
    values = dict(bound.arguments)
    if derive is not None: derive(values)   # e.g. research's topic_slug
    return Template(template).safe_substitute(**values)
prompt_fn.__signature__ = signature
prompt_fn.__annotations__ = {p.name: str for p in params} | {"return": str}
```

FastMCP introspects prompts via **both** `inspect.signature` (reads `__signature__`) and `typing.get_type_hints` (reads `__annotations__`), so both are set — verified against the FastMCP source.

## Details

- The identifier/keyword validation is **kept and extended to the built-in path**; both now route through one `_arg_names_valid` gate. Its warning now says *why* (non-identifier vs reserved keyword).
- The obsolete `_RESERVED_EXEC_NAMES` guard (`tmpl`/`_Template`, which only protected the exec namespace) is **removed**; its test is rewritten to assert those names now register and substitute.
- `research`'s `topic_slug` derivation moves from an interpolated `exec` pre-compute string into a Python closure hook (`_research_derive`).
- Invalid argument *ordering* (optional before required) and duplicate names now surface as `ValueError` from `inspect.Signature` and are caught + skipped-with-warning (previously `SyntaxError` from `exec`), so one malformed prompt does not crash startup.

## Tests

`_research_derive` slug (unit + end-to-end via the strengthened `test_research_prompt`); both `except ValueError` skip paths (user + built-in); non-identifier and keyword rejection on both paths with the new specific messages; `tmpl` now registers and substitutes; synthetic signature exposes args (name + required) to clients; and `test_module_has_no_exec` as a regression tripwire. Module patch coverage 94%; full suite green.

## Docs

`docs/configuration.md` PROMPTS_FOLDER row notes that argument names must be plain Python identifiers (non-conforming names skip with a warning).

## Out of scope → #799

The `#788` preflight-circus surfaced a **pre-existing** registration-loop robustness gap (a `KeyError` or an `mcp.prompt(...)` failure can abort the whole loop, since the per-prompt helpers lack a loop-level `try/except`), plus a note that first-party built-in defects could be logged louder. That loop structure predates #788; tracked in #799 rather than widening this security-scoped change.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)