### PR TITLE
feat: surface skipped files via get_index_status (#775)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -356,9 +356,12 @@ for built-in names, or pass a custom instance.
 
 - **State file** (the JSON persistence layer for hash-based change detection):
   versioned format `{"version": 2, "indexed": {relative_path: sha256_hash},
-  "skipped": {relative_path: sha256_hash}}` as JSON (#665). The legacy flat
-  `{relative_path: sha256_hash}` format still loads (every entry is treated
-  as indexed), so upgrades need no migration step.
+  "skipped": {relative_path: sha256_hash}, "skip_reasons": {relative_path:
+  {"category": ..., "detail": ...}}}` as JSON (#665, #775). `skip_reasons`
+  is a strict subset of `skipped` covering the surfaced deterministic skips
+  (parse / encoding / missing-frontmatter); a version-2 file without it loads
+  it as `{}`. The legacy flat `{relative_path: sha256_hash}` format still
+  loads (every entry is treated as indexed), so upgrades need no migration.
 - **Default path**: `{source_dir}/.markdown_vault_mcp/state.json` (when
   `state_path=None`).
 - On `reindex()`: scan all files, compare hashes to stored state, re-parse and

--- a/docs/design.md
+++ b/docs/design.md
@@ -1801,15 +1801,20 @@ class ChangeTracker:
     def detect_changes(self, source_dir: Path,
                        glob_pattern: str = "**/*.md") -> ChangeSet: ...
     def update_state(self, notes: list[ParsedNote],
-                     skipped: dict[str, str] | None = None) -> None: ...
+                     skipped: dict[str, str] | None = None,
+                     skip_reasons: dict[str, dict[str, str]] | None = None) -> None: ...
+    def skip_reasons(self) -> dict[str, dict[str, str]]: ...
     def reset(self) -> None: ...
 ```
 
 `tracker.py` is entirely new code (no ifcraftcorpus equivalent). State file
-format (version 2, #665): `{"version": 2, "indexed": {"Journal/note.md":
-"sha256hex", ...}, "skipped": {"CLAUDE.md": "sha256hex", ...}}` as JSON.
-The legacy flat `{"Journal/note.md": "sha256hex", ...}` format loads with
-every entry treated as indexed.
+format (version 2, #665, #775): `{"version": 2, "indexed": {"Journal/note.md":
+"sha256hex", ...}, "skipped": {"CLAUDE.md": "sha256hex", ...}, "skip_reasons":
+{"CLAUDE.md": {"category": "missing_frontmatter", "detail": "..."}}}` as JSON.
+`skip_reasons` is a strict subset of `skipped` covering the surfaced
+deterministic skips (parse / encoding / missing-frontmatter); a version-2 file
+without it loads it as empty. The legacy flat `{"Journal/note.md":
+"sha256hex", ...}` format loads with every entry treated as indexed.
 
 ### `server.py`: Generic MCP Server
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -379,6 +379,12 @@ for built-in names, or pass a custom instance.
   `OSError` skips are deliberately not recorded, so those files retry on
   every scan. A skipped file deleted from disk is dropped silently; it was
   never indexed, so it is not counted as `deleted`.
+  The surfaced deterministic skips (parse / encoding / missing-frontmatter,
+  but not exclude-pattern or transient `OSError`) are also recorded with a
+  `{category, detail}` reason in the state file's `skip_reasons` map and
+  exposed through `get_index_status`'s `skipped_files` field, so a dropped
+  note is discoverable via the MCP API rather than only the container logs
+  (#775).
 
 **Trigger model**: boot reconciliation reindex (submitted by the server
 lifespan behind the initial build job, #665) + explicit `reindex` tool call

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -225,6 +225,12 @@ build attempt.
   closed database), in which case `documents_indexed` is `0`.
 - `error`: `null` unless the background build raised; otherwise the
   exception message.
+- `skipped_files`: list of files dropped from the index for a surfaced
+  deterministic reason. Each entry is `{"path", "category", "detail"}`, with
+  `category` one of `parse_error`, `encoding_error`, or `missing_frontmatter`.
+  Empty when nothing was skipped. This tells a parse-dropped note apart from
+  one that simply has not synced yet, without reading container logs.
+  Exclude-pattern matches and transient I/O skips are intentionally omitted.
 
 **Tags:** read-only.
 

--- a/src/markdown_vault_mcp/_server_tools/index.py
+++ b/src/markdown_vault_mcp/_server_tools/index.py
@@ -87,6 +87,14 @@ def register(mcp: FastMCP) -> None:
               which case ``documents_indexed`` is ``0``.
             - error (str | None): ``None`` unless the background build
               raised.
+            - skipped_files (list[dict]): Files dropped from the index for a
+              surfaced deterministic reason. Each entry is
+              ``{"path", "category", "detail"}`` where ``category`` is one of
+              ``"parse_error"``, ``"encoding_error"``, or
+              ``"missing_frontmatter"``. Empty when nothing was skipped.
+              Distinguishes a parse-dropped note from an unsynced one without
+              reading container logs. Exclude-pattern and transient-I/O skips
+              are intentionally not listed.
         """
         return await asyncio.to_thread(vault.index.get_index_status)
 

--- a/src/markdown_vault_mcp/facets/index.py
+++ b/src/markdown_vault_mcp/facets/index.py
@@ -4,7 +4,8 @@ A thin view over the
 :class:`~markdown_vault_mcp.indexing.IndexWriteCoordinator` (build / reindex /
 embeddings sync + async, plus the readiness and writer-status queries) and
 :class:`~markdown_vault_mcp.managers.index.IndexManager`
-(:meth:`IndexFacet.embeddings_status`). It deliberately does NOT expose the coordinator's
+(:meth:`IndexFacet.embeddings_status`, :meth:`IndexFacet.skipped_files`). It
+deliberately does NOT expose the coordinator's
 internal surface (``close``, ``writer``, ``require_built``,
 ``mark_paths_dirty``, ``rebuild_embeddings``), which the root owns. Part of the
 ``vault.py`` facade decomposition (#576).
@@ -12,15 +13,15 @@ internal surface (``close``, ``writer``, ``require_built``,
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from concurrent.futures import Future
-    from typing import Any
 
     from markdown_vault_mcp.indexing import IndexWriteCoordinator
     from markdown_vault_mcp.managers.index import IndexManager
-    from markdown_vault_mcp.types import IndexStats, ReindexResult
+    from markdown_vault_mcp.types import IndexStats, ReindexResult, SkippedFile
 
 
 class IndexFacet:
@@ -92,18 +93,23 @@ class IndexFacet:
         return self._coordinator.wait_for_drain(timeout)
 
     def get_index_status(self) -> dict[str, Any]:
-        """Return a non-blocking eleven-key snapshot of build + writer state.
+        """Return a non-blocking twelve-key snapshot of build + writer state.
 
         Keys: ``status`` (``"queryable"`` | ``"building"`` | ``"failed"``),
         ``documents_indexed``, ``documents_indexed_error``, ``error``,
         ``last_reindex_error``, ``last_build_embeddings_error``, plus
         ``queue_depth``, ``in_flight``, ``dirty_paths``, ``dirty_embeddings``,
-        ``write_generation`` merged from the writer. A captured build error
-        appears in ``error`` as diagnostic context without demoting a
-        ``queryable`` status; ``documents_indexed_error`` carries a SQLite
-        read failure (``documents_indexed`` stays ``0``) (#583).
+        ``write_generation`` merged from the writer, and ``skipped_files`` — a
+        list of ``{path, category, detail}`` dicts for files dropped from the
+        index for a surfaced deterministic reason (parse / encoding /
+        missing-frontmatter), read from tracker state (#775). A captured build
+        error appears in ``error`` as diagnostic context without demoting a
+        ``queryable`` status; ``documents_indexed_error`` carries a SQLite read
+        failure (``documents_indexed`` stays ``0``) (#583).
         """
-        return self._coordinator.get_index_status()
+        status = self._coordinator.get_index_status()
+        status["skipped_files"] = [asdict(sf) for sf in self._index_mgr.skipped_files()]
+        return status
 
     def wait_until_queryable(self, timeout: float | None = None) -> None:
         """Block until the FTS index is queryable, or raise.
@@ -200,3 +206,15 @@ class IndexFacet:
             ``available``.
         """
         return self._index_mgr.embeddings_status()
+
+    def skipped_files(self) -> list[SkippedFile]:
+        """Return files dropped from the index for a surfaced reason (#775).
+
+        Delegates to :meth:`IndexManager.skipped_files`; also merged, as
+        plain dicts, into :meth:`IndexFacet.get_index_status`'s
+        ``skipped_files`` key.
+
+        Returns:
+            Path-sorted list of :class:`~markdown_vault_mcp.types.SkippedFile`.
+        """
+        return self._index_mgr.skipped_files()

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -839,6 +839,29 @@ class IndexManager:
         )
         return added
 
+    def skipped_files(self) -> list[SkippedFile]:
+        """Return files dropped from the index for a surfaced reason (#775).
+
+        Reads the tracker's persisted ``skip_reasons`` map and returns one
+        :class:`~markdown_vault_mcp.types.SkippedFile` per path, sorted by
+        path. Covers the deterministic, non-excluded skips (parse / encoding /
+        missing-frontmatter); exclude-pattern and transient-``OSError`` skips
+        are intentionally absent.
+
+        Returns:
+            Path-sorted list of :class:`SkippedFile`. Empty when nothing was
+            skipped for a surfaced reason.
+        """
+        reasons = self._tracker.skip_reasons()
+        return [
+            SkippedFile(
+                path=path,
+                category=reason.get("category", ""),
+                detail=reason.get("detail", ""),
+            )
+            for path, reason in sorted(reasons.items())
+        ]
+
     def embeddings_status(self) -> dict[str, Any]:
         """Return status information about the vector index.
 

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -370,13 +370,20 @@ class IndexManager:
         # scan; it is only re-evaluated when its content changes.  Transient
         # I/O errors are NOT recorded, so those files retry on every scan.
         newly_skipped: dict[str, str] = {}
+        newly_skip_reasons: dict[str, dict[str, str]] = {}
 
-        def _record_skip(rel_path: str, abs_file: Path) -> None:
-            """Record a deterministically skipped file's current hash."""
+        def _record_skip(
+            rel_path: str, abs_file: Path, category: str, detail: str
+        ) -> None:
+            """Record a deterministically skipped file's hash and reason (#775)."""
             try:
                 newly_skipped[rel_path] = compute_file_hash(abs_file)
             except OSError as exc:
+                # File vanished/unreadable since parse — treat as transient:
+                # record neither the hash nor the reason so it retries.
                 logger.debug("reindex_skip_hash_failed path=%s err=%s", rel_path, exc)
+                return
+            newly_skip_reasons[rel_path] = {"category": category, "detail": detail}
 
         # Pre-parse notes outside the lock to minimise lock hold time.
         parsed: list[tuple[str, ParsedNote]] = []
@@ -394,7 +401,7 @@ class IndexManager:
                 continue
             except UnicodeDecodeError as exc:
                 logger.warning("reindex: skipping %s — %s", path, exc)
-                _record_skip(path, abs_path)
+                _record_skip(path, abs_path, "encoding_error", str(exc))
                 continue
             except Exception as exc:
                 logger.warning(
@@ -403,7 +410,7 @@ class IndexManager:
                     exc,
                     exc_info=True,
                 )
-                _record_skip(path, abs_path)
+                _record_skip(path, abs_path, "parse_error", str(exc))
                 continue
 
             if self._required_frontmatter:
@@ -417,6 +424,10 @@ class IndexManager:
                         missing,
                     )
                     newly_skipped[path] = note.content_hash
+                    newly_skip_reasons[path] = {
+                        "category": "missing_frontmatter",
+                        "detail": f"missing: {missing}",
+                    }
                     continue
 
             parsed.append((path, note))
@@ -527,7 +538,9 @@ class IndexManager:
             )
             for r in self._fts.list_notes()
         ]
-        self._tracker.update_state(state_notes, skipped=newly_skipped)
+        self._tracker.update_state(
+            state_notes, skipped=newly_skipped, skip_reasons=newly_skip_reasons
+        )
 
         return ReindexResult(
             added=indexed_added,

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -22,7 +22,7 @@ from markdown_vault_mcp.fts_index import _derive_folder, should_optimize
 from markdown_vault_mcp.hashing import compute_file_hash
 from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
 from markdown_vault_mcp.scanner import parse_note, scan_directory
-from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult
+from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult, SkippedFile
 from markdown_vault_mcp.utils import is_path_excluded
 from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS
 
@@ -191,12 +191,18 @@ class IndexManager:
 
         logger.info("build_index: scanning %s", self._source_dir)
 
+        skip_reasons: dict[str, dict[str, str]] = {}
+
+        def _collect_skip(sf: SkippedFile) -> None:
+            skip_reasons[sf.path] = {"category": sf.category, "detail": sf.detail}
+
         notes = list(
             scan_directory(
                 self._source_dir,
                 required_frontmatter=self._required_frontmatter,
                 chunk_strategy=self._chunk_strategy,
                 exclude_patterns=self._exclude_patterns,
+                on_skip=_collect_skip,
             )
         )
 
@@ -286,7 +292,9 @@ class IndexManager:
                 )
 
         # Update tracker state so reindex() knows the baseline.
-        self._tracker.update_state(notes, skipped=skipped_state)
+        self._tracker.update_state(
+            notes, skipped=skipped_state, skip_reasons=skip_reasons
+        )
 
         if errored:
             logger.warning(

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -12,12 +12,12 @@ import frontmatter
 import yaml
 
 from markdown_vault_mcp.hashing import compute_etag
-from markdown_vault_mcp.types import Chunk, LinkInfo, ParsedNote
+from markdown_vault_mcp.types import Chunk, LinkInfo, ParsedNote, SkippedFile
 from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS
 from markdown_vault_mcp.utils.text import decode_utf8
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -1037,6 +1037,7 @@ def scan_directory(
     exclude_patterns: list[str] | None = None,
     required_frontmatter: list[str] | None = None,
     chunk_strategy: ChunkStrategy | None = None,
+    on_skip: Callable[[SkippedFile], None] | None = None,
 ) -> Iterator[ParsedNote]:
     """Discover and parse all markdown files under ``source_dir``.
 
@@ -1058,6 +1059,13 @@ def scan_directory(
             skipped documents is logged at ``INFO`` level after the scan.
         chunk_strategy: Chunking strategy to pass to :func:`parse_note`.
             Defaults to :class:`HeadingChunker`.
+        on_skip: Optional callback invoked once per *surfaced* deterministic
+            skip with a :class:`~markdown_vault_mcp.types.SkippedFile`
+            (categories ``"encoding_error"``, ``"parse_error"``, or
+            ``"missing_frontmatter"``). It is **not** called for
+            exclude-pattern matches (intentional) or transient ``OSError``
+            skips (self-healing). ``None`` (default) preserves the historical
+            behaviour of silently skipping such files (#775).
 
     Yields:
         Parsed notes in filesystem traversal order.
@@ -1088,21 +1096,36 @@ def scan_directory(
         # Parse the file; skip on decode / I/O / YAML errors.
         try:
             note = parse_note(abs_path, source_dir, chunk_strategy)
-        except UnicodeDecodeError:
+        except UnicodeDecodeError as exc:
             logger.warning(
                 "Skipping %s: cannot decode as UTF-8", abs_path, exc_info=False
             )
+            if on_skip is not None:
+                on_skip(
+                    SkippedFile(
+                        path=rel_posix, category="encoding_error", detail=str(exc)
+                    )
+                )
             continue
         except OSError as exc:
+            # Possibly transient (I/O error) — do not surface; retry next scan.
             logger.warning("Skipping %s: I/O error (%s)", abs_path, exc)
             continue
         except yaml.YAMLError as exc:
             logger.warning("Skipping %s: parse error (%s)", abs_path, exc)
+            if on_skip is not None:
+                on_skip(
+                    SkippedFile(path=rel_posix, category="parse_error", detail=str(exc))
+                )
             continue
         except Exception as exc:
             logger.warning(
                 "Skipping %s: unexpected error (%s)", abs_path, exc, exc_info=True
             )
+            if on_skip is not None:
+                on_skip(
+                    SkippedFile(path=rel_posix, category="parse_error", detail=str(exc))
+                )
             continue
 
         # Apply required_frontmatter filter.
@@ -1117,6 +1140,14 @@ def scan_directory(
                     missing,
                 )
                 skipped_required += 1
+                if on_skip is not None:
+                    on_skip(
+                        SkippedFile(
+                            path=rel_posix,
+                            category="missing_frontmatter",
+                            detail=f"missing: {missing}",
+                        )
+                    )
                 continue
 
         yield note

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -331,7 +331,7 @@ class ChangeTracker:
                         self._state_path,
                     )
                     return {}, {}, {}
-                return indexed, skipped, skip_reasons
+                return indexed, skipped, self._sanitize_skip_reasons(skip_reasons)
             # Legacy flat format: every entry is an indexed path → digest.
             return state, {}, {}
         except (OSError, json.JSONDecodeError) as exc:
@@ -341,6 +341,43 @@ class ChangeTracker:
                 exc,
             )
             return {}, {}, {}
+
+    @staticmethod
+    def _sanitize_skip_reasons(
+        raw: dict[str, object],
+    ) -> dict[str, dict[str, str]]:
+        """Drop malformed skip-reason entries, keeping only well-formed ones.
+
+        A well-formed entry maps a path to a ``{"category": str, "detail":
+        str}`` dict. Entries whose value is not such a dict — from
+        format-version skew, a manual edit, or corruption — are dropped with a
+        ``WARNING`` so a single bad entry cannot raise out of the
+        never-blocking ``get_index_status`` read path (#775).
+
+        Args:
+            raw: The ``skip_reasons`` map as loaded from the state file; its
+                values are untrusted.
+
+        Returns:
+            A map containing only entries with a valid ``{category, detail}``
+            string dict.
+        """
+        clean: dict[str, dict[str, str]] = {}
+        for path, reason in raw.items():
+            if (
+                isinstance(reason, dict)
+                and isinstance(reason.get("category"), str)
+                and isinstance(reason.get("detail"), str)
+            ):
+                clean[path] = {
+                    "category": reason["category"],
+                    "detail": reason["detail"],
+                }
+            else:
+                logger.warning(
+                    "skip_reason_malformed path=%s reason=%r; dropping", path, reason
+                )
+        return clean
 
     def _save_state(
         self,

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -55,6 +55,10 @@ class ChangeTracker:
         # Skipped entries from the last detect_changes() that are still on
         # disk with unchanged content; carried forward by update_state().
         self._skipped_carry: dict[str, str] = {}
+        # Reasons for the carried-forward unchanged skips (parallel to
+        # _skipped_carry); loaded from state so a surfaced skip keeps its
+        # reason across scans that do not re-observe the failure (#775).
+        self._skip_reasons_carry: dict[str, dict[str, str]] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -109,7 +113,7 @@ class ChangeTracker:
         Returns:
             A :class:`~markdown_vault_mcp.types.ChangeSet` describing the delta.
         """
-        indexed_state, skipped_state = self._load_state()
+        indexed_state, skipped_state, skip_reasons_state = self._load_state()
 
         # Build a mapping of relative path → sha256 for current disk contents.
         disk_state: dict[str, str] = {}
@@ -137,6 +141,7 @@ class ChangeTracker:
         unchanged: int = 0
         skipped_unchanged: int = 0
         self._skipped_carry = {}
+        self._skip_reasons_carry = {}
 
         for rel_path, current_hash in disk_state.items():
             if rel_path in indexed_state:
@@ -151,6 +156,10 @@ class ChangeTracker:
                 else:
                     skipped_unchanged += 1
                     self._skipped_carry[rel_path] = current_hash
+                    if rel_path in skip_reasons_state:
+                        self._skip_reasons_carry[rel_path] = skip_reasons_state[
+                            rel_path
+                        ]
             else:
                 added.append(rel_path)
 
@@ -189,14 +198,17 @@ class ChangeTracker:
         self,
         notes: list[ParsedNote],
         skipped: dict[str, str] | None = None,
+        skip_reasons: dict[str, dict[str, str]] | None = None,
     ) -> None:
         """Persist the current hash state derived from *notes*.
 
         Overwrites the entire state file. The indexed map comes from *notes*;
         the skipped map merges the unchanged skipped entries observed by the
-        preceding :meth:`detect_changes` call with *skipped*. Call this after
-        successfully (re)indexing a set of documents to record their current
-        content hashes.
+        preceding :meth:`detect_changes` call with *skipped*. The
+        ``skip_reasons`` map is maintained in lockstep: it merges the carried
+        reasons with *skip_reasons* and is then restricted to exactly the keys
+        of the new skipped map, so a path that indexes successfully or leaves
+        the skipped set also loses its reason (#775).
 
         Args:
             notes: Parsed notes whose ``path`` and ``content_hash`` attributes
@@ -205,8 +217,11 @@ class ChangeTracker:
             skipped: Mapping of relative path to SHA256 hex digest for files
                 seen during this scan but deliberately not indexed (missing
                 required frontmatter, excluded, unparseable). Indexed paths
-                always win: any path also present in *notes* is dropped from
-                the skipped map.
+                always win: any path also present in *notes* is dropped.
+            skip_reasons: Mapping of relative path to a ``{"category",
+                "detail"}`` dict for the surfaced deterministic skips observed
+                this scan. Merged with the carried reasons and clamped to the
+                new skipped key set. ``None`` records no new reasons.
         """
         new_indexed = {note.path: note.content_hash for note in notes}
         new_skipped = {
@@ -217,15 +232,26 @@ class ChangeTracker:
             }.items()
             if path not in new_indexed
         }
-        self._save_state(new_indexed, new_skipped)
-        # The carry is consumed by exactly one update_state call; clearing it
-        # keeps a later call without a fresh detect_changes (e.g. a full
-        # build_index) from merging stale skipped entries into its snapshot.
+        merged_reasons = {
+            **self._skip_reasons_carry,
+            **(skip_reasons or {}),
+        }
+        new_skip_reasons = {
+            path: reason
+            for path, reason in merged_reasons.items()
+            if path in new_skipped
+        }
+        self._save_state(new_indexed, new_skipped, new_skip_reasons)
+        # The carries are consumed by exactly one update_state call; clearing
+        # them keeps a later call without a fresh detect_changes (e.g. a full
+        # build_index) from merging stale entries into its snapshot.
         self._skipped_carry = {}
+        self._skip_reasons_carry = {}
         logger.debug(
-            "update_state: wrote state for %d indexed, %d skipped document(s)",
+            "update_state: wrote state for %d indexed, %d skipped, %d skip-reason(s)",
             len(new_indexed),
             len(new_skipped),
+            len(new_skip_reasons),
         )
 
     def reset(self) -> None:
@@ -234,34 +260,54 @@ class ChangeTracker:
         If the state file does not exist, this is a no-op.
         """
         self._skipped_carry = {}
+        self._skip_reasons_carry = {}
         if self._state_path.exists():
             self._state_path.unlink()
             logger.debug("reset: deleted state file %s", self._state_path)
         else:
             logger.debug("reset: state file does not exist, nothing to delete")
 
+    def skip_reasons(self) -> dict[str, dict[str, str]]:
+        """Return the persisted surfaced-skip reasons (path → category/detail).
+
+        Reads the state file fresh on each call (best-effort, non-blocking:
+        a missing or malformed file yields ``{}``), so callers see the reasons
+        recorded by the most recent build/reindex even after a restart (#775).
+
+        Returns:
+            Mapping of relative POSIX path to a ``{"category", "detail"}`` dict.
+            Empty when nothing was skipped for a surfaced reason.
+        """
+        _indexed, _skipped, skip_reasons = self._load_state()
+        return skip_reasons
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _load_state(self) -> tuple[dict[str, str], dict[str, str]]:
+    def _load_state(
+        self,
+    ) -> tuple[dict[str, str], dict[str, str], dict[str, dict[str, str]]]:
         """Load the persisted state from disk.
 
         Supports two formats: the current versioned object
-        (``{"version": 2, "indexed": {...}, "skipped": {...}}``) and the
-        legacy flat mapping of path to digest, which is loaded with every
-        entry treated as indexed.
+        (``{"version": 2, "indexed": {...}, "skipped": {...},
+        "skip_reasons": {...}}``) and the legacy flat mapping of path to
+        digest, which is loaded with every entry treated as indexed.
 
         Returns:
-            Tuple of ``(indexed, skipped)`` maps of relative document path to
-            SHA256 hex digest. Both are empty when the state file does not
-            exist or is malformed.
+            Tuple of ``(indexed, skipped, skip_reasons)``. ``indexed`` and
+            ``skipped`` map relative document path to SHA256 hex digest;
+            ``skip_reasons`` maps relative path to a ``{"category", "detail"}``
+            dict for the surfaced deterministic skips (#775). All three are
+            empty when the state file does not exist or is malformed; a
+            version-2 file lacking ``skip_reasons`` loads it as ``{}``.
         """
         if not self._state_path.exists():
             logger.debug(
                 "No state file at %s; treating all files as added", self._state_path
             )
-            return {}, {}
+            return {}, {}, {}
         try:
             with self._state_path.open(encoding="utf-8") as fh:
                 state = json.load(fh)
@@ -270,29 +316,39 @@ class ChangeTracker:
                     "State file %s is malformed (expected object); resetting",
                     self._state_path,
                 )
-                return {}, {}
+                return {}, {}, {}
             if state.get("version") == _STATE_VERSION:
                 indexed = state.get("indexed", {})
                 skipped = state.get("skipped", {})
-                if not isinstance(indexed, dict) or not isinstance(skipped, dict):
+                skip_reasons = state.get("skip_reasons", {})
+                if (
+                    not isinstance(indexed, dict)
+                    or not isinstance(skipped, dict)
+                    or not isinstance(skip_reasons, dict)
+                ):
                     logger.warning(
                         "State file %s is malformed (expected object maps); resetting",
                         self._state_path,
                     )
-                    return {}, {}
-                return indexed, skipped
+                    return {}, {}, {}
+                return indexed, skipped, skip_reasons
             # Legacy flat format: every entry is an indexed path → digest.
-            return state, {}
+            return state, {}, {}
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning(
                 "Cannot read state file %s (%s); treating all files as added",
                 self._state_path,
                 exc,
             )
-            return {}, {}
+            return {}, {}, {}
 
-    def _save_state(self, indexed: dict[str, str], skipped: dict[str, str]) -> None:
-        """Write the indexed and skipped maps to the state file as JSON.
+    def _save_state(
+        self,
+        indexed: dict[str, str],
+        skipped: dict[str, str],
+        skip_reasons: dict[str, dict[str, str]],
+    ) -> None:
+        """Write the indexed, skipped, and skip_reasons maps to state as JSON.
 
         Creates parent directories if they do not exist.
 
@@ -301,8 +357,16 @@ class ChangeTracker:
                 for documents present in the index.
             skipped: Mapping of relative document path to SHA256 hex digest
                 for files seen on disk but deliberately not indexed.
+            skip_reasons: Mapping of relative document path to a
+                ``{"category", "detail"}`` dict for the surfaced deterministic
+                skips (#775). A strict subset of ``skipped``.
         """
-        state = {"version": _STATE_VERSION, "indexed": indexed, "skipped": skipped}
+        state = {
+            "version": _STATE_VERSION,
+            "indexed": indexed,
+            "skipped": skipped,
+            "skip_reasons": skip_reasons,
+        }
         self._state_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_path = tempfile.mkstemp(dir=self._state_path.parent, suffix=".tmp")
         try:
@@ -313,9 +377,10 @@ class ChangeTracker:
             Path(tmp_path).unlink(missing_ok=True)
             raise
         logger.debug(
-            "Saved state for %d indexed, %d skipped path(s) to %s",
+            "Saved state for %d indexed, %d skipped, %d skip-reason path(s) to %s",
             len(indexed),
             len(skipped),
+            len(skip_reasons),
             self._state_path,
         )
 

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -7,6 +7,31 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+# The three deterministic, non-excluded skip categories surfaced via
+# get_index_status.skipped_files. A plain frozenset (not an enum) keeps the
+# tool payload JSON-trivial; tests/test_types.py pins the legal values and
+# the producer tests assert each category is emitted for the right failure.
+SKIP_CATEGORIES: frozenset[str] = frozenset(
+    {"parse_error", "encoding_error", "missing_frontmatter"}
+)
+
+
+@dataclass(frozen=True)
+class SkippedFile:
+    """A file deliberately dropped from the index for a surfaced reason.
+
+    Attributes:
+        path: Source-dir-relative POSIX path of the skipped file.
+        category: One of :data:`SKIP_CATEGORIES` — ``"parse_error"``,
+            ``"encoding_error"``, or ``"missing_frontmatter"``.
+        detail: Human-readable reason (a YAML/decode error message, or
+            ``"missing: [field, ...]"`` for missing frontmatter).
+    """
+
+    path: str
+    category: str
+    detail: str
+
 
 @dataclass
 class Chunk:

--- a/tests/test_facet_index.py
+++ b/tests/test_facet_index.py
@@ -57,3 +57,34 @@ class TestIndexFacetEncapsulation:
             "rebuild_embeddings",
         ):
             assert not hasattr(built.index, internal), internal
+
+
+class TestIndexFacetSkippedFiles:
+    """get_index_status surfaces skipped_files (#775)."""
+
+    def test_clean_vault_has_empty_skipped_files(self, tmp_path: Path) -> None:
+        # A fresh tmp_path (not the shared `built` fixture, which
+        # deliberately includes malformed_yaml.md) has nothing to skip.
+        (tmp_path / "good.md").write_text("---\ntitle: ok\n---\nbody", encoding="utf-8")
+        col = Vault(source_dir=tmp_path)
+        try:
+            col.index.build_index()
+            status = col.index.get_index_status()
+        finally:
+            col.close()
+        assert status["skipped_files"] == []
+
+    def test_reports_parse_skip(self, vault_path: Path) -> None:
+        col = Vault(source_dir=vault_path)
+        try:
+            col.index.build_index()
+            (vault_path / "bad.md").write_text(
+                "---\ntitle: [unclosed\n---\n", encoding="utf-8"
+            )
+            col.index.reindex()
+            status = col.index.get_index_status()
+        finally:
+            col.close()
+        entries = {e["path"]: e for e in status["skipped_files"]}
+        assert entries["bad.md"]["category"] == "parse_error"
+        assert set(entries["bad.md"]) == {"path", "category", "detail"}

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1246,6 +1246,33 @@ class TestBuildIndexSkipReasons:
         assert by_path["bad.md"].category == "parse_error"
         assert "good.md" not in by_path
 
+    def test_missing_frontmatter_appears_in_skip_reasons(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.vault import Vault
+
+        (tmp_path / "good.md").write_text("---\ntitle: ok\n---\nbody", encoding="utf-8")
+        (tmp_path / "nomatter.md").write_text("no frontmatter", encoding="utf-8")
+        vault = Vault(source_dir=tmp_path, required_frontmatter=["title"])
+        try:
+            vault.index.build_index()
+            by_path = {sf.path: sf for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()
+        assert by_path["nomatter.md"].category == "missing_frontmatter"
+        assert "title" in by_path["nomatter.md"].detail
+
+    def test_encoding_error_appears_in_skip_reasons(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.vault import Vault
+
+        (tmp_path / "good.md").write_text("---\ntitle: ok\n---\nbody", encoding="utf-8")
+        (tmp_path / "latin.md").write_bytes(b"\xff\xfe not utf-8")
+        vault = Vault(source_dir=tmp_path)
+        try:
+            vault.index.build_index()
+            by_path = {sf.path: sf for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()
+        assert by_path["latin.md"].category == "encoding_error"
+
 
 class TestReindexSkipReasons:
     """reindex records surfaced skips into tracker skip_reasons (#775)."""
@@ -1327,5 +1354,27 @@ class TestReindexSkipReasons:
             bad.write_text("---\ntitle: fixed\n---\nbody", encoding="utf-8")
             vault.index.reindex()
             assert "bad.md" not in {sf.path for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()
+
+    def test_reason_carried_forward_through_unchanged_reindex(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "seed.md").write_text("---\na: 1\n---\nx", encoding="utf-8")
+        (tmp_path / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\n", encoding="utf-8"
+        )
+        vault = self._build(tmp_path)
+        try:
+            vault.index.reindex()
+            first = {sf.path: sf for sf in vault.index.skipped_files()}
+            assert first["bad.md"].category == "parse_error"
+            # Second reindex with bad.md unchanged: it lands in
+            # skipped_unchanged and is never re-parsed, so the reason must
+            # survive via the tracker's carry-forward wired through reindex.
+            vault.index.reindex()
+            second = {sf.path: sf for sf in vault.index.skipped_files()}
+            assert second["bad.md"].category == "parse_error"
+            assert second["bad.md"].detail == first["bad.md"].detail
         finally:
             vault.close()

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1223,3 +1223,109 @@ def test_index_manager_no_longer_schedules_timer():
     # mark_dirty / remove_from_dirty also gone
     assert "def mark_dirty" not in source
     assert "def remove_from_dirty" not in source
+
+
+class TestBuildIndexSkipReasons:
+    """build_index records surfaced skips into tracker skip_reasons (#775)."""
+
+    def test_invalid_yaml_file_appears_in_skip_reasons(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.vault import Vault
+
+        (tmp_path / "good.md").write_text("---\ntitle: ok\n---\nbody", encoding="utf-8")
+        (tmp_path / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
+        )
+        vault = Vault(source_dir=tmp_path)
+        try:
+            vault.index.build_index()
+            reasons = vault.index.skipped_files()
+        finally:
+            vault.close()
+        by_path = {sf.path: sf for sf in reasons}
+        assert "bad.md" in by_path
+        assert by_path["bad.md"].category == "parse_error"
+        assert "good.md" not in by_path
+
+
+class TestReindexSkipReasons:
+    """reindex records surfaced skips into tracker skip_reasons (#775)."""
+
+    def _build(self, tmp_path: Path):
+        from markdown_vault_mcp.vault import Vault
+
+        vault = Vault(source_dir=tmp_path)
+        vault.index.build_index()
+        return vault
+
+    def test_invalid_yaml_recorded_as_parse_error(self, tmp_path: Path) -> None:
+        (tmp_path / "seed.md").write_text("---\na: 1\n---\nx", encoding="utf-8")
+        vault = self._build(tmp_path)
+        try:
+            (tmp_path / "bad.md").write_text(
+                "---\ntitle: [unclosed\n---\n", encoding="utf-8"
+            )
+            vault.index.reindex()
+            by_path = {sf.path: sf for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()
+        assert by_path["bad.md"].category == "parse_error"
+
+    def test_missing_field_recorded_as_missing_frontmatter(
+        self, tmp_path: Path
+    ) -> None:
+        from markdown_vault_mcp.vault import Vault
+
+        (tmp_path / "seed.md").write_text("---\ntitle: ok\n---\nx", encoding="utf-8")
+        vault = Vault(source_dir=tmp_path, required_frontmatter=["title"])
+        try:
+            vault.index.build_index()
+            (tmp_path / "nomatter.md").write_text("no fm", encoding="utf-8")
+            vault.index.reindex()
+            by_path = {sf.path: sf for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()
+        assert by_path["nomatter.md"].category == "missing_frontmatter"
+        assert "title" in by_path["nomatter.md"].detail
+
+    def test_non_utf8_recorded_as_encoding_error(self, tmp_path: Path) -> None:
+        (tmp_path / "seed.md").write_text("---\na: 1\n---\nx", encoding="utf-8")
+        vault = self._build(tmp_path)
+        try:
+            (tmp_path / "latin.md").write_bytes(b"\xff\xfe bad bytes")
+            vault.index.reindex()
+            by_path = {sf.path: sf for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()
+        assert by_path["latin.md"].category == "encoding_error"
+
+    def test_excluded_file_not_recorded(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.vault import Vault
+
+        (tmp_path / "seed.md").write_text("---\na: 1\n---\nx", encoding="utf-8")
+        (tmp_path / "excluded").mkdir()
+        vault = Vault(source_dir=tmp_path, exclude_patterns=["excluded/**"])
+        try:
+            vault.index.build_index()
+            (tmp_path / "excluded" / "bad.md").write_text(
+                "---\ntitle: [unclosed\n---\n", encoding="utf-8"
+            )
+            vault.index.reindex()
+            paths = {sf.path for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()
+        assert "excluded/bad.md" not in paths
+
+    def test_fixed_file_removed_from_skip_reasons(self, tmp_path: Path) -> None:
+        (tmp_path / "seed.md").write_text("---\na: 1\n---\nx", encoding="utf-8")
+        bad = tmp_path / "bad.md"
+        bad.write_text("---\ntitle: [unclosed\n---\n", encoding="utf-8")
+        vault = self._build(tmp_path)
+        try:
+            vault.index.reindex()
+            assert "bad.md" in {sf.path for sf in vault.index.skipped_files()}
+            # Fix the YAML; the next reindex indexes it and clears the reason.
+            bad.write_text("---\ntitle: fixed\n---\nbody", encoding="utf-8")
+            vault.index.reindex()
+            assert "bad.md" not in {sf.path for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -824,3 +824,30 @@ class TestScanDirectoryOnSkip:
         (tmp_path / "nomatter.md").write_text("plain", encoding="utf-8")
         _notes, skips = self._collect(tmp_path)
         assert {s.category for s in skips} <= SKIP_CATEGORIES
+
+    def test_reports_unexpected_exception_as_parse_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A non-YAML/non-decode/non-OSError failure inside parse_note (e.g. a
+        # chunker bug raising RuntimeError) hits the generic ``except
+        # Exception`` branch and is surfaced as ``parse_error`` via on_skip.
+        import markdown_vault_mcp.scanner as scanner_module
+        from markdown_vault_mcp.scanner import scan_directory
+        from markdown_vault_mcp.types import SkippedFile
+
+        (tmp_path / "boom.md").write_text("---\ntitle: ok\n---\nbody", encoding="utf-8")
+
+        def exploding_parse(abs_path, source_dir, chunk_strategy):  # noqa: ARG001
+            raise RuntimeError("chunker exploded")
+
+        monkeypatch.setattr(scanner_module, "parse_note", exploding_parse)
+        skips: list[SkippedFile] = []
+        notes = list(
+            scan_directory(
+                tmp_path, required_frontmatter=["title"], on_skip=skips.append
+            )
+        )
+        assert notes == []
+        assert [s.category for s in skips] == ["parse_error"]
+        assert skips[0].path == "boom.md"
+        assert "chunker exploded" in skips[0].detail

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -754,3 +754,73 @@ class TestListSectionHeadings:
 def test_normalize_heading_collapses_whitespace() -> None:
     assert normalize_heading("1.3.   Reducing   deps  ") == "1.3. Reducing deps"
     assert normalize_heading("\tA\nB\t") == "A B"
+
+
+class TestScanDirectoryOnSkip:
+    """scan_directory reports surfaced skips through on_skip (#775)."""
+
+    def _collect(self, source_dir: Path) -> tuple[list, list]:
+        from markdown_vault_mcp.scanner import scan_directory
+        from markdown_vault_mcp.types import SkippedFile
+
+        skips: list[SkippedFile] = []
+        notes = list(
+            scan_directory(
+                source_dir,
+                required_frontmatter=["title"],
+                exclude_patterns=["excluded/**"],
+                on_skip=skips.append,
+            )
+        )
+        return notes, skips
+
+    def test_reports_parse_error(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
+        )
+        _notes, skips = self._collect(tmp_path)
+        assert [s.category for s in skips] == ["parse_error"]
+        assert skips[0].path == "bad.md"
+        assert skips[0].detail
+
+    def test_reports_encoding_error(self, tmp_path: Path) -> None:
+        (tmp_path / "latin.md").write_bytes(b"\xff\xfe not utf-8")
+        _notes, skips = self._collect(tmp_path)
+        assert [s.category for s in skips] == ["encoding_error"]
+        assert skips[0].path == "latin.md"
+
+    def test_reports_missing_frontmatter(self, tmp_path: Path) -> None:
+        (tmp_path / "nomatter.md").write_text("no frontmatter here", encoding="utf-8")
+        _notes, skips = self._collect(tmp_path)
+        assert [s.category for s in skips] == ["missing_frontmatter"]
+        assert skips[0].path == "nomatter.md"
+        assert "title" in skips[0].detail
+
+    def test_not_called_for_excluded(self, tmp_path: Path) -> None:
+        (tmp_path / "excluded").mkdir()
+        (tmp_path / "excluded" / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\n", encoding="utf-8"
+        )
+        _notes, skips = self._collect(tmp_path)
+        assert skips == []
+
+    def test_omitting_on_skip_preserves_behavior(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.scanner import scan_directory
+
+        (tmp_path / "good.md").write_text("---\ntitle: ok\n---\nbody", encoding="utf-8")
+        (tmp_path / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\n", encoding="utf-8"
+        )
+        notes = list(scan_directory(tmp_path, required_frontmatter=["title"]))
+        assert [n.path for n in notes] == ["good.md"]
+
+    def test_every_reported_category_is_legal(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.types import SKIP_CATEGORIES
+
+        (tmp_path / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\n", encoding="utf-8"
+        )
+        (tmp_path / "latin.md").write_bytes(b"\xff\xfe")
+        (tmp_path / "nomatter.md").write_text("plain", encoding="utf-8")
+        _notes, skips = self._collect(tmp_path)
+        assert {s.category for s in skips} <= SKIP_CATEGORIES

--- a/tests/test_tools_index.py
+++ b/tests/test_tools_index.py
@@ -1,0 +1,63 @@
+"""End-to-end tests for the get_index_status tool skipped_files field (#775)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastmcp import Client
+
+from markdown_vault_mcp.server import make_server
+from tests.conftest import wait_for_mcp_writer_drain
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+# Mirrors tests/test_server.py's _CLEAR_VARS: env vars that must not leak
+# from the shell/CI environment into a test that sets up its own minimal
+# env via monkeypatch.
+_CLEAR_VARS = (
+    "MARKDOWN_VAULT_MCP_INDEX_PATH",
+    "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH",
+    "MARKDOWN_VAULT_MCP_STATE_PATH",
+    "MARKDOWN_VAULT_MCP_INDEXED_FIELDS",
+    "MARKDOWN_VAULT_MCP_REQUIRED_FIELDS",
+    "MARKDOWN_VAULT_MCP_EXCLUDE",
+    "MARKDOWN_VAULT_MCP_GIT_TOKEN",
+    "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
+    "MARKDOWN_VAULT_MCP_SERVER_NAME",
+    "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
+    # Auth vars — ensure non-auth tests run unauthenticated
+    "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
+    "MARKDOWN_VAULT_MCP_AUTH_MODE",
+    "MARKDOWN_VAULT_MCP_BASE_URL",
+    "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL",
+    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID",
+    "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
+    "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY",
+    "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE",
+    "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES",
+)
+
+
+async def test_get_index_status_exposes_skipped_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "good.md").write_text("---\ntitle: ok\n---\nbody", encoding="utf-8")
+    (tmp_path / "bad.md").write_text("---\ntitle: [unclosed\n---\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
+    server = make_server()
+    async with Client(server) as client:
+        # reindex submits an async job to the writer; wait for it to drain
+        # so the skip is guaranteed recorded before get_index_status reads it.
+        await client.call_tool("reindex", {})
+        await wait_for_mcp_writer_drain(client)
+        result = await client.call_tool("get_index_status", {})
+    data = result.data
+    paths = {e["path"]: e for e in data["skipped_files"]}
+    assert "bad.md" in paths
+    assert paths["bad.md"]["category"] == "parse_error"

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -313,7 +313,7 @@ class TestMalformedStateFile:
             # Restore permissions so pytest can clean up tmp_path.
             state_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
-        assert result == ({}, {})
+        assert result == ({}, {}, {})
         assert any("Cannot read state file" in r.message for r in caplog.records)
 
 
@@ -328,7 +328,7 @@ class TestSaveStateFailure:
             patch("json.dump", side_effect=RuntimeError("disk full")),
             pytest.raises(RuntimeError, match="disk full"),
         ):
-            tracker._save_state({"a.md": "abc123"}, {})
+            tracker._save_state({"a.md": "abc123"}, {}, {})
 
         # No leftover .tmp files.
         leftover = list(tmp_path.glob("*.tmp"))
@@ -647,3 +647,87 @@ class TestExcludePatterns:
         assert ".claude/old.md" not in changes.deleted
         assert ".claude/old.md" not in changes.added
         assert ".claude/old.md" not in changes.modified
+
+
+class TestSkipReasons:
+    """skip_reasons map is persisted in lockstep with the skipped map (#775)."""
+
+    def _hash_of(self, path: Path) -> str:
+        from markdown_vault_mcp.hashing import compute_file_hash
+
+        return compute_file_hash(path)
+
+    def test_round_trips_through_state_file(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.json"
+        md = tmp_path / "skip.md"
+        md.write_text("bad", encoding="utf-8")
+        tracker = ChangeTracker(state_path)
+        tracker.update_state(
+            [],
+            skipped={"skip.md": self._hash_of(md)},
+            skip_reasons={"skip.md": {"category": "parse_error", "detail": "boom"}},
+        )
+        reloaded = ChangeTracker(state_path)
+        assert reloaded.skip_reasons() == {
+            "skip.md": {"category": "parse_error", "detail": "boom"},
+        }
+
+    def test_missing_key_loads_as_empty(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.json"
+        # A version-2 state file with no skip_reasons key (older format).
+        state_path.write_text(
+            '{"version": 2, "indexed": {}, "skipped": {"skip.md": "abc"}}',
+            encoding="utf-8",
+        )
+        tracker = ChangeTracker(state_path)
+        assert tracker.skip_reasons() == {}
+
+    def test_reason_dropped_when_path_leaves_skipped_set(self, tmp_path: Path) -> None:
+        # A skipped file that later indexes successfully loses its reason.
+        state_path = tmp_path / "state.json"
+        md = tmp_path / "skip.md"
+        md.write_text("---\ntitle: x\n---\nbody", encoding="utf-8")
+        tracker = ChangeTracker(state_path)
+        tracker.update_state(
+            [],
+            skipped={"skip.md": self._hash_of(md)},
+            skip_reasons={
+                "skip.md": {
+                    "category": "missing_frontmatter",
+                    "detail": "missing: ['title']",
+                }
+            },
+        )
+        # Now the same path indexes successfully (present in notes).
+        from markdown_vault_mcp.types import ParsedNote
+
+        note = ParsedNote(
+            path="skip.md",
+            frontmatter={"title": "x"},
+            title="x",
+            chunks=[],
+            content_hash=self._hash_of(md),
+            modified_at=0.0,
+        )
+        tracker.update_state([note])
+        assert tracker.skip_reasons() == {}
+
+    def test_reason_carried_forward_for_unchanged_skip(self, tmp_path: Path) -> None:
+        # An unchanged skipped file keeps its reason across a reindex cycle
+        # even though update_state is not re-passed the reason.
+        state_path = tmp_path / "state.json"
+        md = tmp_path / "skip.md"
+        md.write_text("bad yaml", encoding="utf-8")
+        tracker = ChangeTracker(state_path)
+        tracker.update_state(
+            [],
+            skipped={"skip.md": self._hash_of(md)},
+            skip_reasons={"skip.md": {"category": "parse_error", "detail": "boom"}},
+        )
+        # A fresh scan sees the file unchanged -> carry -> next update_state
+        # (with no skip_reasons passed) must preserve the reason.
+        tracker.detect_changes(tmp_path)
+        tracker.update_state([])
+        assert tracker.skip_reasons() == {
+            "skip.md": {"category": "parse_error", "detail": "boom"},
+        }

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -731,3 +731,46 @@ class TestSkipReasons:
         assert tracker.skip_reasons() == {
             "skip.md": {"category": "parse_error", "detail": "boom"},
         }
+
+
+class TestSkipReasonsSanitization:
+    """Malformed persisted skip_reasons entries are dropped, never raise (#775)."""
+
+    def test_non_dict_value_is_dropped(self, tmp_path: Path, caplog) -> None:
+        import logging
+
+        state_path = tmp_path / "state.json"
+        # A version-2 state file whose skip_reasons value is a bare string,
+        # e.g. from format-version skew or a manual edit.
+        state_path.write_text(
+            '{"version": 2, "indexed": {}, "skipped": {"bad.md": "abc"}, '
+            '"skip_reasons": {"bad.md": "not-a-dict"}}',
+            encoding="utf-8",
+        )
+        tracker = ChangeTracker(state_path)
+        with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.tracker"):
+            result = tracker.skip_reasons()
+        assert result == {}
+        assert any("skip_reason_malformed" in r.message for r in caplog.records)
+
+    def test_dict_missing_detail_key_is_dropped(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            '{"version": 2, "indexed": {}, "skipped": {"bad.md": "abc"}, '
+            '"skip_reasons": {"bad.md": {"category": "parse_error"}}}',
+            encoding="utf-8",
+        )
+        tracker = ChangeTracker(state_path)
+        assert tracker.skip_reasons() == {}
+
+    def test_wellformed_entry_survives_sanitization(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            '{"version": 2, "indexed": {}, "skipped": {"bad.md": "abc"}, '
+            '"skip_reasons": {"bad.md": {"category": "parse_error", "detail": "boom"}}}',
+            encoding="utf-8",
+        )
+        tracker = ChangeTracker(state_path)
+        assert tracker.skip_reasons() == {
+            "bad.md": {"category": "parse_error", "detail": "boom"},
+        }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,8 +1,11 @@
 """Tests for data types."""
 
-import dataclasses
+from __future__ import annotations
 
-from markdown_vault_mcp.types import MoveFolderResult
+import dataclasses
+from dataclasses import asdict
+
+from markdown_vault_mcp.types import SKIP_CATEGORIES, MoveFolderResult, SkippedFile
 
 
 def test_move_folder_result_fields():
@@ -25,3 +28,32 @@ def test_move_folder_result_failed_links_defaults_empty():
     assert r.failed_links == []
     # asdict works (the MCP tool serializes via dataclasses.asdict)
     assert dataclasses.asdict(r)["failed_links"] == []
+
+
+class TestSkippedFile:
+    def test_serializes_to_plain_dict(self) -> None:
+        sf = SkippedFile(
+            path="notes/bad.md",
+            category="parse_error",
+            detail="while scanning a simple key",
+        )
+        assert asdict(sf) == {
+            "path": "notes/bad.md",
+            "category": "parse_error",
+            "detail": "while scanning a simple key",
+        }
+
+    def test_is_frozen(self) -> None:
+        sf = SkippedFile(path="a.md", category="parse_error", detail="x")
+        try:
+            sf.path = "b.md"  # type: ignore[misc]
+        except AttributeError:
+            return
+        raise AssertionError("SkippedFile should be frozen")
+
+    def test_skip_categories_are_the_three_legal_values(self) -> None:
+        assert {
+            "parse_error",
+            "encoding_error",
+            "missing_frontmatter",
+        } == SKIP_CATEGORIES


### PR DESCRIPTION
## Summary

Makes deterministic, non-excluded index skips **discoverable through `get_index_status`**, so a note dropped from the index (invalid YAML, non-UTF-8, or missing a required frontmatter field) can be told apart from one that simply hasn't synced yet — without reading container logs.

Previously such a skip was only a container-log `WARNING`: `get_index_status` reported `queryable`/`dirty_paths: 0`, and `read` on the path raised `ValueError: document is not indexed`. Now the reason is recorded in tracker state and surfaced via a new `skipped_files` field.

Closes #775.

## What changed

- **New `SkippedFile` type + `SKIP_CATEGORIES`** (`types.py`) — frozen dataclass `{path, category, detail}`; the three legal categories (`parse_error`, `encoding_error`, `missing_frontmatter`) are pinned in one place and test-enforced.
- **`skip_reasons` map in the tracker state file** (`tracker.py`) — path → `{category, detail}`, maintained in lockstep as a strict subset of the existing `skipped` hash map (carried forward for unchanged skips, cleared when a path indexes or leaves disk). Back-compatible: a v2 `state.json` without the key loads as `{}`, no migration. Malformed persisted entries are dropped with a `WARNING` so the non-blocking `get_index_status` read never raises.
- **Both index-build paths feed it** — `build_index` via a new `on_skip` callback on `scan_directory`; `reindex` inline via `_record_skip`. Exclude-pattern matches and transient `OSError` skips are intentionally **not** surfaced (the latter self-heals on the next scan).
- **Surfaced via `get_index_status.skipped_files`** — `IndexManager.skipped_files()` reads the map; the facet merges it (as `asdict` dicts) into the status response. Tool docstring, `docs/tools/index.md`, and `docs/design.md` updated.

## Test plan

- Full suite green (2479+ passing); ruff + mypy clean; patch coverage ≥ 80% (the four touched modules at ~100%); structural diff-gate 100%.
- New coverage: `SkippedFile` serialization + category enforcement; tracker `skip_reasons` round-trip / carry-forward / drop-on-index / malformed-value sanitization / back-compat; `scan_directory` `on_skip` per category (incl. the generic-exception branch) and not-for-excluded; both build paths across all three categories; carry-forward through `IndexManager.reindex`; and an end-to-end FastMCP `Client` test asserting `get_index_status.skipped_files`.

## Review

Built via subagent-driven development (5 tasks, per-task spec+quality review) plus an Opus whole-branch review (0 critical/important) and a 3-round local preflight review circus that converged clean.

**Known sub-threshold follow-ups (non-blocking, tracked separately):** a distinct category for genuinely-unexpected `parse_note` exceptions (vs. reusing `parse_error`), and a `WARNING` log when a `build_index` pass-2 hash re-read races a vanishing file and drops an already-surfaced reason (rare, self-healing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
