### PR TITLE
feat: distinguish internal_error from parse_error in skipped_files (#802)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -359,9 +359,10 @@ for built-in names, or pass a custom instance.
   "skipped": {relative_path: sha256_hash}, "skip_reasons": {relative_path:
   {"category": ..., "detail": ...}}}` as JSON (#665, #775). `skip_reasons`
   is a strict subset of `skipped` covering the surfaced deterministic skips
-  (parse / encoding / missing-frontmatter); a version-2 file without it loads
-  it as `{}`. The legacy flat `{relative_path: sha256_hash}` format still
-  loads (every entry is treated as indexed), so upgrades need no migration.
+  (parse / encoding / missing-frontmatter / internal-error); a version-2 file
+  without it loads it as `{}`. The legacy flat `{relative_path: sha256_hash}`
+  format still loads (every entry is treated as indexed), so upgrades need no
+  migration.
 - **Default path**: `{source_dir}/.markdown_vault_mcp/state.json` (when
   `state_path=None`).
 - On `reindex()`: scan all files, compare hashes to stored state, re-parse and
@@ -379,12 +380,12 @@ for built-in names, or pass a custom instance.
   `OSError` skips are deliberately not recorded, so those files retry on
   every scan. A skipped file deleted from disk is dropped silently; it was
   never indexed, so it is not counted as `deleted`.
-  The surfaced deterministic skips (parse / encoding / missing-frontmatter,
-  but not exclude-pattern or transient `OSError`) are also recorded with a
-  `{category, detail}` reason in the state file's `skip_reasons` map and
-  exposed through `get_index_status`'s `skipped_files` field, so a dropped
-  note is discoverable via the MCP API rather than only the container logs
-  (#775).
+  The surfaced deterministic skips (parse / encoding / missing-frontmatter /
+  internal-error, but not exclude-pattern or transient `OSError`) are also
+  recorded with a `{category, detail}` reason in the state file's
+  `skip_reasons` map and exposed through `get_index_status`'s `skipped_files`
+  field, so a dropped note is discoverable via the MCP API rather than only
+  the container logs (#775).
 
 **Trigger model**: boot reconciliation reindex (submitted by the server
 lifespan behind the initial build job, #665) + explicit `reindex` tool call
@@ -1812,9 +1813,10 @@ format (version 2, #665, #775): `{"version": 2, "indexed": {"Journal/note.md":
 "sha256hex", ...}, "skipped": {"CLAUDE.md": "sha256hex", ...}, "skip_reasons":
 {"CLAUDE.md": {"category": "missing_frontmatter", "detail": "..."}}}` as JSON.
 `skip_reasons` is a strict subset of `skipped` covering the surfaced
-deterministic skips (parse / encoding / missing-frontmatter); a version-2 file
-without it loads it as empty. The legacy flat `{"Journal/note.md":
-"sha256hex", ...}` format loads with every entry treated as indexed.
+deterministic skips (parse / encoding / missing-frontmatter / internal-error);
+a version-2 file without it loads it as empty. The legacy flat
+`{"Journal/note.md": "sha256hex", ...}` format loads with every entry treated
+as indexed.
 
 ### `server.py`: Generic MCP Server
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -227,7 +227,8 @@ build attempt.
   exception message.
 - `skipped_files`: list of files dropped from the index for a surfaced
   deterministic reason. Each entry is `{"path", "category", "detail"}`, with
-  `category` one of `parse_error`, `encoding_error`, or `missing_frontmatter`.
+  `category` one of `parse_error`, `encoding_error`, `missing_frontmatter`, or
+  `internal_error` (an unexpected indexer error rather than a content problem).
   Empty when nothing was skipped. This tells a parse-dropped note apart from
   one that simply has not synced yet, without reading container logs.
   Exclude-pattern matches and transient I/O skips are intentionally omitted.

--- a/src/markdown_vault_mcp/_server_tools/index.py
+++ b/src/markdown_vault_mcp/_server_tools/index.py
@@ -90,8 +90,10 @@ def register(mcp: FastMCP) -> None:
             - skipped_files (list[dict]): Files dropped from the index for a
               surfaced deterministic reason. Each entry is
               ``{"path", "category", "detail"}`` where ``category`` is one of
-              ``"parse_error"``, ``"encoding_error"``, or
-              ``"missing_frontmatter"``. Empty when nothing was skipped.
+              ``"parse_error"``, ``"encoding_error"``,
+              ``"missing_frontmatter"``, or ``"internal_error"`` (an
+              unexpected indexer error, vs a content problem). Empty when
+              nothing was skipped.
               Distinguishes a parse-dropped note from an unsynced one without
               reading container logs. Exclude-pattern and transient-I/O skips
               are intentionally not listed.

--- a/src/markdown_vault_mcp/facets/index.py
+++ b/src/markdown_vault_mcp/facets/index.py
@@ -102,7 +102,8 @@ class IndexFacet:
         ``write_generation`` merged from the writer, and ``skipped_files`` — a
         list of ``{path, category, detail}`` dicts for files dropped from the
         index for a surfaced deterministic reason (parse / encoding /
-        missing-frontmatter), read from tracker state (#775). A captured build
+        missing-frontmatter / internal-error), read from tracker state (#775,
+        #802). A captured build
         error appears in ``error`` as diagnostic context without demoting a
         ``queryable`` status; ``documents_indexed_error`` carries a SQLite read
         failure (``documents_indexed`` stays ``0``) (#583).

--- a/src/markdown_vault_mcp/facets/index.py
+++ b/src/markdown_vault_mcp/facets/index.py
@@ -105,8 +105,8 @@ class IndexFacet:
         missing-frontmatter / internal-error), read from tracker state
         (#775, #802). A captured build error appears in ``error`` as
         diagnostic context without demoting a ``queryable`` status;
-        ``documents_indexed_error`` carries a SQLite read
-        failure (``documents_indexed`` stays ``0``) (#583).
+        ``documents_indexed_error`` carries a SQLite read failure
+        (``documents_indexed`` stays ``0``) (#583).
         """
         status = self._coordinator.get_index_status()
         status["skipped_files"] = [asdict(sf) for sf in self._index_mgr.skipped_files()]

--- a/src/markdown_vault_mcp/facets/index.py
+++ b/src/markdown_vault_mcp/facets/index.py
@@ -102,10 +102,10 @@ class IndexFacet:
         ``write_generation`` merged from the writer, and ``skipped_files`` — a
         list of ``{path, category, detail}`` dicts for files dropped from the
         index for a surfaced deterministic reason (parse / encoding /
-        missing-frontmatter / internal-error), read from tracker state (#775,
-        #802). A captured build
-        error appears in ``error`` as diagnostic context without demoting a
-        ``queryable`` status; ``documents_indexed_error`` carries a SQLite read
+        missing-frontmatter / internal-error), read from tracker state
+        (#775, #802). A captured build error appears in ``error`` as
+        diagnostic context without demoting a ``queryable`` status;
+        ``documents_indexed_error`` carries a SQLite read
         failure (``documents_indexed`` stays ``0``) (#583).
         """
         status = self._coordinator.get_index_status()

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -286,10 +286,19 @@ class IndexManager:
                 skipped_state[rel_str] = compute_file_hash(abs_path)
             except OSError as exc:
                 # Possibly transient — leave unrecorded so the next scan
-                # retries the file.
-                logger.debug(
-                    "build_index_skip_hash_failed path=%s err=%s", rel_str, exc
-                )
+                # retries the file. If the path was an already-surfaced skip,
+                # its reason is clamped away by update_state; warn so the
+                # transient loss is observable rather than silent (#802).
+                if rel_str in skip_reasons:
+                    logger.warning(
+                        "build_index_surfaced_skip_dropped path=%s err=%s",
+                        rel_str,
+                        exc,
+                    )
+                else:
+                    logger.debug(
+                        "build_index_skip_hash_failed path=%s err=%s", rel_str, exc
+                    )
 
         # Update tracker state so reindex() knows the baseline.
         self._tracker.update_state(

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -389,7 +389,7 @@ class IndexManager:
         parsed: list[tuple[str, ParsedNote]] = []
         # Excluded paths are filtered inside detect_changes (before hashing,
         # #257), so they never reach this loop; the only skips recorded here
-        # are parse/decode failures and missing-frontmatter files below.
+        # are parse/decode/unexpected failures and missing-frontmatter below.
         for path in changes.added + changes.modified:
             abs_path = self._source_dir / path
 
@@ -403,14 +403,18 @@ class IndexManager:
                 logger.warning("reindex: skipping %s — %s", path, exc)
                 _record_skip(path, abs_path, "encoding_error", str(exc))
                 continue
+            except yaml.YAMLError as exc:
+                logger.warning("reindex: skipping %s — parse error (%s)", path, exc)
+                _record_skip(path, abs_path, "parse_error", str(exc))
+                continue
             except Exception as exc:
-                logger.warning(
-                    "reindex: skipping %s — parse error (%s)",
+                logger.error(
+                    "reindex: skipping %s — unexpected error (%s)",
                     path,
                     exc,
                     exc_info=True,
                 )
-                _record_skip(path, abs_path, "parse_error", str(exc))
+                _record_skip(path, abs_path, "internal_error", str(exc))
                 continue
 
             if self._required_frontmatter:
@@ -845,8 +849,8 @@ class IndexManager:
         Reads the tracker's persisted ``skip_reasons`` map and returns one
         :class:`~markdown_vault_mcp.types.SkippedFile` per path, sorted by
         path. Covers the deterministic, non-excluded skips (parse / encoding /
-        missing-frontmatter); exclude-pattern and transient-``OSError`` skips
-        are intentionally absent.
+        missing-frontmatter / internal-error); exclude-pattern and
+        transient-``OSError`` skips are intentionally absent.
 
         Returns:
             Path-sorted list of :class:`SkippedFile`. Empty when nothing was

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -1062,10 +1062,10 @@ def scan_directory(
         on_skip: Optional callback invoked once per *surfaced* deterministic
             skip with a :class:`~markdown_vault_mcp.types.SkippedFile`
             (categories ``"encoding_error"``, ``"parse_error"``,
-            ``"missing_frontmatter"``, or ``"internal_error"``). It is **not**
-            called for
-            exclude-pattern matches (intentional) or transient ``OSError``
-            skips (self-healing). ``None`` (default) preserves the historical
+            ``"missing_frontmatter"``, or ``"internal_error"``). It is
+            **not** called for exclude-pattern matches (intentional) or
+            transient ``OSError`` skips (self-healing). ``None`` (default)
+            preserves the historical
             behaviour of silently skipping such files (#775).
 
     Yields:

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -1061,8 +1061,9 @@ def scan_directory(
             Defaults to :class:`HeadingChunker`.
         on_skip: Optional callback invoked once per *surfaced* deterministic
             skip with a :class:`~markdown_vault_mcp.types.SkippedFile`
-            (categories ``"encoding_error"``, ``"parse_error"``, or
-            ``"missing_frontmatter"``). It is **not** called for
+            (categories ``"encoding_error"``, ``"parse_error"``,
+            ``"missing_frontmatter"``, or ``"internal_error"``). It is **not**
+            called for
             exclude-pattern matches (intentional) or transient ``OSError``
             skips (self-healing). ``None`` (default) preserves the historical
             behaviour of silently skipping such files (#775).
@@ -1119,12 +1120,14 @@ def scan_directory(
                 )
             continue
         except Exception as exc:
-            logger.warning(
+            logger.error(
                 "Skipping %s: unexpected error (%s)", abs_path, exc, exc_info=True
             )
             if on_skip is not None:
                 on_skip(
-                    SkippedFile(path=rel_posix, category="parse_error", detail=str(exc))
+                    SkippedFile(
+                        path=rel_posix, category="internal_error", detail=str(exc)
+                    )
                 )
             continue
 

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -1041,9 +1041,11 @@ def scan_directory(
 ) -> Iterator[ParsedNote]:
     """Discover and parse all markdown files under ``source_dir``.
 
-    Yields :class:`~markdown_vault_mcp.types.ParsedNote` objects. Fault-tolerant: a
-    single bad file (UTF-8 decode error, I/O error) is skipped with a
-    ``WARNING`` log entry; the scan continues.
+    Yields :class:`~markdown_vault_mcp.types.ParsedNote` objects. Fault-tolerant:
+    a single bad file (UTF-8 decode error, I/O error, YAML parse error) is
+    skipped and the scan continues, logged at ``WARNING`` — except a genuinely
+    unexpected parse failure (surfaced as ``internal_error``), which is logged
+    at ``ERROR`` with a traceback.
 
     Args:
         source_dir: Root directory to scan.
@@ -1065,8 +1067,8 @@ def scan_directory(
             ``"missing_frontmatter"``, or ``"internal_error"``). It is
             **not** called for exclude-pattern matches (intentional) or
             transient ``OSError`` skips (self-healing). ``None`` (default)
-            preserves the historical
-            behaviour of silently skipping such files (#775).
+            preserves the historical behaviour of silently skipping such
+            files (#775).
 
     Yields:
         Parsed notes in filesystem traversal order.

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -7,12 +7,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-# The three deterministic, non-excluded skip categories surfaced via
+# The four deterministic, non-excluded skip categories surfaced via
 # get_index_status.skipped_files. A plain frozenset (not an enum) keeps the
 # tool payload JSON-trivial; tests/test_types.py pins the legal values and
 # the producer tests assert each category is emitted for the right failure.
+# ``internal_error`` covers a genuinely-unexpected exception from parse_note
+# (a code/chunker bug), as opposed to ``parse_error`` for malformed content.
 SKIP_CATEGORIES: frozenset[str] = frozenset(
-    {"parse_error", "encoding_error", "missing_frontmatter"}
+    {"parse_error", "encoding_error", "missing_frontmatter", "internal_error"}
 )
 
 
@@ -23,7 +25,8 @@ class SkippedFile:
     Attributes:
         path: Source-dir-relative POSIX path of the skipped file.
         category: One of :data:`SKIP_CATEGORIES` — ``"parse_error"``,
-            ``"encoding_error"``, or ``"missing_frontmatter"``.
+            ``"encoding_error"``, ``"missing_frontmatter"``, or
+            ``"internal_error"``.
         detail: Human-readable reason (a YAML/decode error message, or
             ``"missing: [field, ...]"`` for missing frontmatter).
     """

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1318,6 +1318,10 @@ class TestReindexSkipReasons:
         return vault
 
     def test_invalid_yaml_recorded_as_parse_error(self, tmp_path: Path) -> None:
+        # Regression guard for the reindex yaml.YAMLError split (#802): without
+        # the dedicated yaml.YAMLError branch (ahead of the generic Exception
+        # branch, which records internal_error), a malformed-YAML file would be
+        # mislabelled internal_error. Do not remove as "redundant".
         (tmp_path / "seed.md").write_text("---\na: 1\n---\nx", encoding="utf-8")
         vault = self._build(tmp_path)
         try:

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1297,6 +1297,32 @@ class TestReindexSkipReasons:
             vault.close()
         assert by_path["bad.md"].category == "parse_error"
 
+    def test_unexpected_exception_recorded_as_internal_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "seed.md").write_text("---\na: 1\n---\nx", encoding="utf-8")
+        vault = self._build(tmp_path)
+        try:
+            (tmp_path / "boom.md").write_text(
+                "---\ntitle: ok\n---\nbody", encoding="utf-8"
+            )
+            import markdown_vault_mcp.managers.index as index_module
+
+            real_parse = index_module.parse_note
+
+            def maybe_explode(abs_path, source_dir, chunk_strategy):
+                if abs_path.name == "boom.md":
+                    raise RuntimeError("chunker exploded")
+                return real_parse(abs_path, source_dir, chunk_strategy)
+
+            monkeypatch.setattr(index_module, "parse_note", maybe_explode)
+            vault.index.reindex()
+            by_path = {sf.path: sf for sf in vault.index.skipped_files()}
+        finally:
+            vault.close()
+        assert by_path["boom.md"].category == "internal_error"
+        assert "chunker exploded" in by_path["boom.md"].detail
+
     def test_missing_field_recorded_as_missing_frontmatter(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1273,6 +1273,39 @@ class TestBuildIndexSkipReasons:
             vault.close()
         assert by_path["latin.md"].category == "encoding_error"
 
+    def test_pass2_hash_failure_on_surfaced_skip_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        import logging
+
+        from markdown_vault_mcp.vault import Vault
+
+        (tmp_path / "good.md").write_text("---\ntitle: ok\n---\nbody", encoding="utf-8")
+        (tmp_path / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\n", encoding="utf-8"
+        )
+        import markdown_vault_mcp.managers.index as index_module
+
+        def failing_hash(_path):
+            raise OSError("vanished")
+
+        # Only non-indexed files (bad.md) are hashed in build_index's second
+        # pass; good.md is indexed and skipped there. So this forces the
+        # OSError only for the already-surfaced skip.
+        monkeypatch.setattr(index_module, "compute_file_hash", failing_hash)
+        vault = Vault(source_dir=tmp_path)
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="markdown_vault_mcp.managers.index"
+            ):
+                vault.index.build_index()
+        finally:
+            vault.close()
+        assert any(
+            "build_index_surfaced_skip_dropped" in r.message and "bad.md" in r.message
+            for r in caplog.records
+        )
+
 
 class TestReindexSkipReasons:
     """reindex records surfaced skips into tracker skip_reasons (#775)."""

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -825,12 +825,12 @@ class TestScanDirectoryOnSkip:
         _notes, skips = self._collect(tmp_path)
         assert {s.category for s in skips} <= SKIP_CATEGORIES
 
-    def test_reports_unexpected_exception_as_parse_error(
+    def test_reports_unexpected_exception_as_internal_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # A non-YAML/non-decode/non-OSError failure inside parse_note (e.g. a
         # chunker bug raising RuntimeError) hits the generic ``except
-        # Exception`` branch and is surfaced as ``parse_error`` via on_skip.
+        # Exception`` branch and is surfaced as ``internal_error`` via on_skip.
         import markdown_vault_mcp.scanner as scanner_module
         from markdown_vault_mcp.scanner import scan_directory
         from markdown_vault_mcp.types import SkippedFile
@@ -848,6 +848,6 @@ class TestScanDirectoryOnSkip:
             )
         )
         assert notes == []
-        assert [s.category for s in skips] == ["parse_error"]
+        assert [s.category for s in skips] == ["internal_error"]
         assert skips[0].path == "boom.md"
         assert "chunker exploded" in skips[0].detail

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -51,9 +51,10 @@ class TestSkippedFile:
             return
         raise AssertionError("SkippedFile should be frozen")
 
-    def test_skip_categories_are_the_three_legal_values(self) -> None:
+    def test_skip_categories_are_the_legal_values(self) -> None:
         assert {
             "parse_error",
             "encoding_error",
             "missing_frontmatter",
+            "internal_error",
         } == SKIP_CATEGORIES


### PR DESCRIPTION
## Summary

Follow-up to #775 (PR #801) closing the two sub-threshold diagnostic-fidelity gaps its review flagged. Closes #802.

**1. New `internal_error` skip category.** The generic `except Exception` in both build paths previously recorded genuinely-unexpected `parse_note`/chunker failures under `parse_error` — the same category as a user's malformed YAML. An operator reading `get_index_status.skipped_files` could not tell "fix your frontmatter" from "the indexer hit a bug." Those unexpected failures are now surfaced as `internal_error` (logged at `ERROR` with a traceback; content failures stay `WARNING`), while `yaml.YAMLError` stays `parse_error`.

**2. Observability for the `build_index` pass-2 drop.** When a parse-broken file's hash re-read raises `OSError` in build_index's second pass, its already-collected skip reason gets clamped away by `update_state`. That drop was silent (DEBUG); it now logs a `WARNING` (`build_index_surfaced_skip_dropped`). Behaviour is otherwise unchanged — it still self-heals on the next scan.

## What changed

- `SKIP_CATEGORIES` gains a fourth value, `internal_error` (`types.py`).
- `scan_directory` generic branch → `internal_error`/`ERROR` (`scanner.py`); `yaml.YAMLError` branch unchanged.
- `reindex` gains a **dedicated `except yaml.YAMLError` branch** (→ `parse_error`) ahead of its generic branch (→ `internal_error`). Without this, reindex would relabel YAML errors as `internal_error` while build labels them `parse_error` — the pre-existing `test_invalid_yaml_recorded_as_parse_error` is retained (with a comment) as the regression guard that forces the split.
- `build_index` pass-2 `OSError` handler warns on an already-surfaced drop.
- Category enumeration swept across all docstrings, the tool docstring, `docs/tools/index.md`, and `docs/design.md`. Lifecycle unchanged (`internal_error` persists + calcifies like `parse_error`); `_sanitize_skip_reasons` stays shape-only so a persisted `internal_error` round-trips with no migration.

## Test plan

Full suite green; ruff/mypy/vale/structural-diff-gate all clean. New/updated tests: `SKIP_CATEGORIES` four-value set; scanner + reindex each emit `internal_error` for an unexpected exception; reindex still emits `parse_error` for YAML (split guard); and the pass-2 drop WARNING fires (caplog).

## Review

Built via subagent-driven development (2 tasks, per-task spec+quality review), an Opus whole-branch review (0 critical/important), and a 3-round local preflight review circus that converged clean.

**Considered and scoped out (not in this PR):** generalizing the pass-2 warn-on-drop into `ChangeTracker.update_state` itself so any future caller gets it for free. Today `build_index` is the only caller with that pattern (verified), so this is a speculative-future-caller (YAGNI) refinement, not a current gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
