### PR TITLE
fix: surface internal semantic-search failures in get_context (#804)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -614,7 +614,7 @@ Two-layer model:
 | `EditConflictError` | `edit()` | `old_text` not found or appears more than once. Includes optional diagnostic fields: `closest_match_line`, `first_diff_char`, `expected_snippet`, `found_snippet` |
 | `DocumentExistsError` | `rename()` | `new_path` already exists |
 | `ConcurrentModificationError` | `write()`, `edit()`, `delete()`, `rename()`, `write_attachment()` | `if_match` provided and current file hash does not match |
-| `EmbeddingsNotConfiguredError` | `build_embeddings()` | No `embedding_provider` or `embeddings_path` configured (a `ValueError` subclass, so `except ValueError` still catches it) |
+| `EmbeddingsNotConfiguredError` | `build_embeddings()`, `search()` (semantic/hybrid mode) | No `embedding_provider` or `embeddings_path` configured (a `ValueError` subclass, so `except ValueError` still catches it) |
 | `None` return | `read()` | Path escapes `source_dir` (traversal attempt) or file does not exist on disk |
 | `ValueError` | `edit()` | `old_text` is empty string |
 

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -114,8 +114,8 @@ def register(mcp: FastMCP) -> None:
         creating a near-duplicate.
 
         Raises:
-            ValueError: If mode is "semantic" or "hybrid" and no embedding
-                provider is configured.
+            EmbeddingsNotConfiguredError: If mode is "semantic" or "hybrid" and
+                no embedding provider is configured (a ``ValueError`` subclass).
         """
         drained = await _maybe_wait_for_drain(vault, wait_for_pending_writes, "search")
         gen_before = vault.index.write_generation()

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -1329,8 +1329,15 @@ class SearchManager:
                 similar_grouped = self.get_similar(
                     path, limit=similar_limit, chunks_per_file=1
                 )
-            except ValueError:
-                logger.debug("get_context: get_similar raised for %s, similar=[]", path)
+            except EmbeddingsNotConfiguredError:
+                # Guarded above, but stay quiet if embeddings go unconfigured mid-call.
+                logger.debug(
+                    "get_context: embeddings not configured for %s, similar=[]", path
+                )
+            except ValueError as exc:
+                # A genuine internal failure (e.g. corrupt vector sidecar) — surface
+                # it instead of silently reducing the dossier to similar=[] (#804).
+                logger.warning("get_context: get_similar failed for %s — %s", path, exc)
 
         # Folder peers — other notes in the same folder, capped.
         folder = row["folder"]

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -21,6 +21,7 @@ from dataclasses import replace as _dc_replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 
+from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
 from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
 from markdown_vault_mcp.types import (
     AttachmentInfo,
@@ -366,9 +367,9 @@ class SearchManager:
         validate_path(path, self._source_dir)
 
     def _require_vectors(self) -> None:
-        """Raise ValueError if semantic search is not configured."""
+        """Raise :class:`EmbeddingsNotConfiguredError` if semantic search is unconfigured."""
         if self._embedding_provider is None or self._embeddings_path is None:
-            raise ValueError(
+            raise EmbeddingsNotConfiguredError(
                 "Semantic search requires both 'embedding_provider' and "
                 "'embeddings_path' to be configured."
             )
@@ -525,8 +526,9 @@ class SearchManager:
             by descending file score (max of section scores).
 
         Raises:
-            ValueError: If *mode* is ``"semantic"`` or ``"hybrid"`` but no
-                embedding provider or embeddings path is configured.
+            EmbeddingsNotConfiguredError: If *mode* is ``"semantic"`` or
+                ``"hybrid"`` but no embedding provider or embeddings path is
+                configured (a ``ValueError`` subclass).
         """
         eff_cap = (
             chunks_per_file if chunks_per_file is not None else self._chunks_per_file

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -1329,14 +1329,12 @@ class SearchManager:
                 similar_grouped = self.get_similar(
                     path, limit=similar_limit, chunks_per_file=1
                 )
-            except EmbeddingsNotConfiguredError:
-                # Guarded above, but stay quiet if embeddings go unconfigured mid-call.
-                logger.debug(
-                    "get_context: embeddings not configured for %s, similar=[]", path
-                )
             except ValueError as exc:
-                # A genuine internal failure (e.g. corrupt vector sidecar) — surface
-                # it instead of silently reducing the dossier to similar=[] (#804).
+                # The outer guard + get_similar's own not-configured check mean
+                # this only fires on a genuine internal failure (e.g. a corrupt
+                # vector sidecar surfaced by _load_vectors()) — surface it at
+                # WARNING instead of silently reducing the dossier to similar=[]
+                # (#804). Not broadened to Exception: unexpected types propagate.
                 logger.warning("get_context: get_similar failed for %s — %s", path, exc)
 
         # Folder peers — other notes in the same folder, capped.

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -148,6 +148,19 @@ class TestSemanticSearch:
             search_mgr.search("hello", mode="hybrid")
 
 
+class TestSearchRequiresEmbeddings:
+    def test_semantic_search_unconfigured_raises_embeddings_not_configured(
+        self, search_mgr: SearchManager
+    ) -> None:
+        from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
+
+        with pytest.raises(EmbeddingsNotConfiguredError):
+            search_mgr.search("alpha", mode="semantic")
+        # Subclass of ValueError → historical contract preserved.
+        with pytest.raises(ValueError):
+            search_mgr.search("alpha", mode="hybrid")
+
+
 # ---------------------------------------------------------------------------
 # list
 # ---------------------------------------------------------------------------

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -1027,3 +1027,44 @@ class TestSearchLoadVectorsSelfHeal:
         with pytest.raises(PermissionError, match="read denied"):
             mgr._load_vectors()
         assert rebuild_calls == []  # no rebuild attempted
+
+
+class TestGetContextSurfacesInternalFailure:
+    def test_get_context_warns_on_internal_get_similar_failure(
+        self,
+        search_mgr_with_embeddings: SearchManager,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog,
+    ) -> None:
+        import logging
+
+        def boom(*_args: object, **_kwargs: object) -> list[GroupedResult]:
+            # A genuine internal failure, NOT the not-configured case.
+            raise ValueError("Failed to load vector index after _load_vectors()")
+
+        monkeypatch.setattr(search_mgr_with_embeddings, "get_similar", boom)
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.search"
+        ):
+            result = search_mgr_with_embeddings.get_context("alpha.md")
+        # Degraded, not failed: dossier returns with an empty similar list.
+        assert result.similar == []
+        # And the internal failure is visible at WARNING, not swallowed at DEBUG.
+        assert any(
+            "get_context: get_similar failed" in r.message
+            and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+    def test_get_context_unconfigured_is_quiet(
+        self, search_mgr: SearchManager, caplog
+    ) -> None:
+        import logging
+
+        # No embeddings configured: the guard skips get_similar; no WARNING, no raise.
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.search"
+        ):
+            result = search_mgr.get_context("alpha.md")
+        assert result.similar == []
+        assert not any("get_similar failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Follow-up to #774/#805, applying the same silent-failure fix to the read/semantic-search path. Closes #804.

`SearchManager.get_context()` previously wrapped its `get_similar()` call in `except ValueError: logger.debug(...)`, which silently degraded the dossier's `similar` list to `[]` and logged only at DEBUG — invisible at the default level. Because the call is already guarded by a not-configured check, the only `ValueError` reaching that catch is a **genuine internal failure** (a corrupt vector sidecar surfaced by `_load_vectors()`'s self-heal) — exactly the kind of failure that should be visible.

## What changed

- **`SearchManager._require_vectors()` raises `EmbeddingsNotConfiguredError`** (the `ValueError` subclass from #774) instead of a plain `ValueError`, so "embeddings not configured" is typed consistently across `IndexManager` and `SearchManager`. Back-compatible (subclass), so `except ValueError` callers still catch it. Three docstring assertion sites swept (`_require_vectors`, `search()` `Raises:`, the `search` MCP tool), plus the `docs/design.md` exception table (now lists `search()` alongside `build_embeddings()`).
- **`get_context()` logs the internal failure at `WARNING`** (was DEBUG) while still degrading to `similar=[]` — consistent with the sibling backlinks/outlinks handlers in the same method, which already log-and-degrade at WARNING. The catch stays a broad `except ValueError` (not narrowed to `EmbeddingsNotConfiguredError`, and not broadened to `Exception`): `get_similar` never raises the subclass (it returns `[]` when unconfigured), so the internal `ValueError` from a corrupt sidecar is what must surface.

Internal/unrelated `ValueError`s (`_load_vectors` self-heal, `chunks_per_file`, document-not-found) are deliberately left as plain `ValueError`.

## Test plan

Full suite green; ruff/mypy/vale/structural-diff-gate clean. New tests: semantic/hybrid search on an unconfigured manager raises `EmbeddingsNotConfiguredError` (and is still catchable as `ValueError`); `get_context` where `get_similar` raises an internal `ValueError` → logs `WARNING` and returns `similar=[]` (degraded, non-vacuous — fails against the old DEBUG-swallow); `get_context` unconfigured stays quiet (guard-path regression).

## Review

Built via subagent-driven development (2 tasks, per-task spec+quality review), an Opus whole-branch review (0 critical/important), and a 3-round preflight review circus that converged clean. During review the circus caught (and I removed) an unreachable `except EmbeddingsNotConfiguredError` branch my initial design had included — `get_similar` can't raise that type, so the broad `except ValueError` is the correct catch. The #804 issue's verification note was corrected to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
