### PR TITLE
chore: address deferred cli.py/test_cli.py review nits

### DIFF
--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -47,9 +47,9 @@ def _root(
         handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
         root.addHandler(handler)
     # Quiet httpx/httpcore per-request INFO at the default level (#792); -v shows them.
-    _http_level = logging.NOTSET if verbose else logging.WARNING
-    logging.getLogger("httpx").setLevel(_http_level)
-    logging.getLogger("httpcore").setLevel(_http_level)
+    http_level = logging.NOTSET if verbose else logging.WARNING
+    logging.getLogger("httpx").setLevel(http_level)
+    logging.getLogger("httpcore").setLevel(http_level)
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,6 +51,7 @@ def test_root_keeps_httpx_quiet_at_default_visible_at_debug() -> None:
     httpx_log = logging.getLogger("httpx")
     httpcore_log = logging.getLogger("httpcore")
     saved = (root.level, httpx_log.level, httpcore_log.level)
+    original_handlers = root.handlers[:]
     try:
         _root(verbose=False)
         assert httpx_log.level == logging.WARNING
@@ -63,6 +64,7 @@ def test_root_keeps_httpx_quiet_at_default_visible_at_debug() -> None:
         root.setLevel(saved[0])
         httpx_log.setLevel(saved[1])
         httpcore_log.setLevel(saved[2])
+        root.handlers[:] = original_handlers
 
 
 def test_serve_help_exits_zero() -> None:


### PR DESCRIPTION
Closes #798.

Two non-blocking `claude-review` nits from PR #795 (issue #792), intentionally deferred at that merge to avoid a CI re-run for cosmetic changes, now bundled per the issue's guidance.

## Changes

1. **`cli.py` `_root()`** — rename local `_http_level` → `http_level` (leading underscore is conventionally module/class-private, not function-local). Pure rename, all three occurrences; no behavior change.
2. **`tests/test_cli.py`** — in `test_root_keeps_httpx_quiet_at_default_visible_at_debug`, save/restore `root.handlers` in the `finally` (capture `original_handlers = root.handlers[:]` before the try, `root.handlers[:] = original_handlers` after). `_root()` attaches a `StreamHandler` when root has none, so a direct call in an isolated run could leak a handler into later tests. Mirrors the established `test_root_handler_added_when_none_exist` save/restore idiom.

## Testing

No behavior change, so no new test. Verified:
- `grep _http_level src/ tests/` → gone.
- `uv run pytest tests/test_cli.py -q` → 46 passed (and the httpx test passes in isolation).
- ruff / mypy clean.

## Scope boundary

Only these two nits (per the issue) — no broader logging or test-hygiene sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)