### PR TITLE
fix: guard each prompt registration so one bad prompt can't abort the rest

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1960,6 +1960,15 @@ built-in, the built-in is skipped and the user's version is registered.
 Domain-specific prompts (such as ``zettelkasten`` or ``para-triage``)
 can live outside the core server and be mounted at deployment time.
 
+**Registration robustness**: ``register_prompts()`` guards each prompt
+registration independently, so one malformed prompt is logged and skipped rather
+than aborting registration of the remaining prompts. Invalid argument names or a
+signature that cannot be built are caught inside the per-prompt helper and logged
+at ``WARNING`` for both built-in and user prompts. A failure that propagates out
+of the helper, such as a missing definition key or a ``mcp.prompt`` rejection, is
+caught by the loop backstop: at ``WARNING`` for a user prompt, and at ``ERROR``
+for a built-in, since a broken first-party prompt is a packaging defect.
+
 ## Configuration
 
 ### Phase 1: Python API Only

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -386,7 +386,19 @@ def register_prompts(
             continue
         defn = _load_builtin_prompt(md_name)
         if defn is not None:
-            _register_one_builtin_prompt(mcp, md_name, defn)
+            # Per-prompt backstop: a malformed built-in (missing def-dict key, or
+            # a mcp.prompt rejection) must not abort registration of its siblings
+            # (#799). A broken first-party built-in is a packaging defect, so log
+            # at ERROR to make it loud in CI/startup.
+            try:
+                _register_one_builtin_prompt(mcp, md_name, defn)
+            except Exception:
+                logger.error(
+                    "Built-in prompt %r failed to register — this is a packaging "
+                    "defect, please file a bug",
+                    md_name,
+                    exc_info=True,
+                )
 
     if "create_from_template" not in user_prompt_defs:
 
@@ -441,4 +453,15 @@ def register_prompts(
 
     # --- Pass 3: register user-defined prompts ---
     for name, defn in user_prompt_defs.items():
-        _register_one_user_prompt(mcp, name, defn)
+        # Per-prompt backstop: one malformed user prompt (missing def-dict key, or
+        # a mcp.prompt rejection) is skipped with a WARNING rather than aborting
+        # registration of the rest (#799). The helpers' own narrow
+        # ``except ValueError`` handlers still fire first for invalid signatures.
+        try:
+            _register_one_user_prompt(mcp, name, defn)
+        except Exception:
+            logger.warning(
+                "User prompt %r failed to register — skipping",
+                name,
+                exc_info=True,
+            )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -718,3 +718,253 @@ class TestProposeLinks:
         assert "7" in text
         assert "$scope" not in text
         assert "$per_note_limit" not in text
+
+
+class TestRegisterPromptsPerPromptGuard:
+    """register_prompts skips a malformed prompt and keeps registering siblings.
+
+    The per-prompt helpers can raise *outside* their narrow ``except ValueError``
+    handlers — a def-dict missing a key (``KeyError``) or a ``mcp.prompt(...)``
+    rejection. The loop backstop in ``register_prompts`` catches these so one bad
+    prompt does not abort registration of the rest (#799).
+    """
+
+    async def test_user_prompt_registration_failure_skips_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A user def missing ``content`` (KeyError in the helper) is skipped with
+        a WARNING naming it; sibling user prompts still register."""
+        import logging
+
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp import _server_prompts
+        from markdown_vault_mcp._server_prompts import register_prompts
+
+        monkeypatch.setattr(
+            _server_prompts,
+            "_load_user_prompt_defs",
+            lambda _folder: {
+                # Missing "content" -> _register_one_user_prompt raises KeyError.
+                "bad": {"description": "b", "arguments": [], "tags": []},
+                "good": {
+                    "description": "g",
+                    "arguments": [],
+                    "tags": [],
+                    "content": "hello",
+                },
+            },
+        )
+        mcp = FastMCP("test")
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp._server_prompts"
+        ):
+            register_prompts(mcp, templates_folder=None, prompts_folder="/whatever")
+
+        assert "User prompt 'bad' failed to register" in caplog.text
+        async with Client(mcp) as client:
+            names = {p.name for p in await client.list_prompts()}
+        assert "good" in names
+        assert "bad" not in names
+
+    async def test_builtin_prompt_registration_failure_skips_and_errors(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A built-in whose defn is missing ``description`` (KeyError in the
+        helper) is skipped at ERROR (packaging defect); other built-ins still
+        register."""
+        import logging
+
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp import _server_prompts
+        from markdown_vault_mcp._server_prompts import register_prompts
+
+        original = _server_prompts._load_builtin_prompt
+
+        def _fake_load(name: str) -> dict[str, object] | None:
+            if name == "summarize":
+                # Missing "description" -> _register_one_builtin_prompt raises.
+                return {"arguments": [], "tags": [], "icons": "", "content": "x"}
+            return original(name)
+
+        monkeypatch.setattr(_server_prompts, "_load_builtin_prompt", _fake_load)
+        mcp = FastMCP("test")
+        with caplog.at_level(
+            logging.ERROR, logger="markdown_vault_mcp._server_prompts"
+        ):
+            register_prompts(mcp, templates_folder=None, prompts_folder=None)
+
+        assert "Built-in prompt 'summarize' failed to register" in caplog.text
+        assert "packaging defect" in caplog.text
+        async with Client(mcp) as client:
+            names = {p.name for p in await client.list_prompts()}
+        assert "summarize" not in names
+        # A sibling built-in loaded normally is still registered.
+        assert "related" in names
+
+    async def test_guard_does_not_mask_helper_valueerror(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The helper's own narrow ``except ValueError`` (invalid signature) still
+        fires its specific WARNING and returns — the loop backstop does not
+        double-log a generic 'failed to register'."""
+        import logging
+
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp import _server_prompts
+        from markdown_vault_mcp._server_prompts import register_prompts
+
+        monkeypatch.setattr(
+            _server_prompts,
+            "_load_user_prompt_defs",
+            lambda _folder: {
+                # Duplicate arg name -> _build_prompt_fn raises ValueError, caught
+                # by the helper's own handler (not the loop backstop).
+                "dupe": {
+                    "description": "d",
+                    "arguments": [
+                        {"name": "x", "required": True},
+                        {"name": "x", "required": True},
+                    ],
+                    "tags": [],
+                    "content": "$x",
+                },
+                "good2": {
+                    "description": "g",
+                    "arguments": [],
+                    "tags": [],
+                    "content": "hello",
+                },
+            },
+        )
+        mcp = FastMCP("test")
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp._server_prompts"
+        ):
+            register_prompts(mcp, templates_folder=None, prompts_folder="/whatever")
+
+        assert "cannot form a valid signature" in caplog.text
+        assert "failed to register" not in caplog.text
+        async with Client(mcp) as client:
+            names = {p.name for p in await client.list_prompts()}
+        assert "good2" in names
+        assert "dupe" not in names
+
+    async def test_user_prompt_mcp_rejection_skips_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A ``mcp.prompt(...)`` rejection at decoration time (raised *outside*
+        the helper's narrow ``except ValueError``) is caught by the loop
+        backstop: the user prompt is skipped with a WARNING; siblings register."""
+        import logging
+
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp import _server_prompts
+        from markdown_vault_mcp._server_prompts import register_prompts
+
+        original_build = _server_prompts._build_prompt_fn
+
+        def _reject_marked(
+            template: str, arg_defs: list, derive: object = None
+        ) -> object:
+            # A prompt whose first argument is named "reject" gets a **kwargs
+            # callable, which FastMCP rejects at mcp.prompt() decoration time.
+            if arg_defs and arg_defs[0].get("name") == "reject":
+
+                def _bad(**_kwargs: object) -> str:
+                    return template
+
+                return _bad
+            return original_build(template, arg_defs, derive)
+
+        monkeypatch.setattr(_server_prompts, "_build_prompt_fn", _reject_marked)
+        # Kill Pass-2 built-in noise so only the user prompts are exercised.
+        monkeypatch.setattr(_server_prompts, "_load_builtin_prompt", lambda _name: None)
+        monkeypatch.setattr(
+            _server_prompts,
+            "_load_user_prompt_defs",
+            lambda _folder: {
+                "bad": {
+                    "description": "b",
+                    "arguments": [{"name": "reject", "required": True}],
+                    "tags": [],
+                    "content": "$reject",
+                },
+                "good": {
+                    "description": "g",
+                    "arguments": [],
+                    "tags": [],
+                    "content": "hello",
+                },
+            },
+        )
+        mcp = FastMCP("test")
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp._server_prompts"
+        ):
+            register_prompts(mcp, templates_folder=None, prompts_folder="/whatever")
+
+        assert "User prompt 'bad' failed to register" in caplog.text
+        async with Client(mcp) as client:
+            names = {p.name for p in await client.list_prompts()}
+        assert "good" in names
+        assert "bad" not in names
+
+    async def test_builtin_prompt_mcp_rejection_skips_and_errors(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A ``mcp.prompt(...)`` rejection for a built-in (raised *outside* the
+        helper's narrow ``except ValueError``) is caught by the loop backstop at
+        ERROR; other built-ins still register."""
+        import logging
+
+        from fastmcp import FastMCP
+
+        from markdown_vault_mcp import _server_prompts
+        from markdown_vault_mcp._server_prompts import register_prompts
+
+        original_build = _server_prompts._build_prompt_fn
+        original_load = _server_prompts._load_builtin_prompt
+
+        def _reject_marked(
+            template: str, arg_defs: list, derive: object = None
+        ) -> object:
+            if arg_defs and arg_defs[0].get("name") == "reject":
+
+                def _bad(**_kwargs: object) -> str:
+                    return template
+
+                return _bad
+            return original_build(template, arg_defs, derive)
+
+        def _load_with_bad_summarize(name: str) -> dict | None:
+            if name == "summarize":
+                return {
+                    "description": "s",
+                    "arguments": [{"name": "reject", "required": True}],
+                    "tags": [],
+                    "icons": "",
+                    "content": "$reject",
+                }
+            return original_load(name)
+
+        monkeypatch.setattr(_server_prompts, "_build_prompt_fn", _reject_marked)
+        monkeypatch.setattr(
+            _server_prompts, "_load_builtin_prompt", _load_with_bad_summarize
+        )
+        mcp = FastMCP("test")
+        with caplog.at_level(
+            logging.ERROR, logger="markdown_vault_mcp._server_prompts"
+        ):
+            register_prompts(mcp, templates_folder=None, prompts_folder=None)
+
+        assert "Built-in prompt 'summarize' failed to register" in caplog.text
+        assert "packaging defect" in caplog.text
+        async with Client(mcp) as client:
+            names = {p.name for p in await client.list_prompts()}
+        assert "summarize" not in names
+        # A sibling built-in (registered via the real _build_prompt_fn) survives.
+        assert "related" in names


### PR DESCRIPTION
Closes #799.

`register_prompts` registered prompts one at a time, but the per-prompt helpers can raise **outside** their narrow `except ValueError` handlers — a def-dict missing a key (`KeyError` on `defn["content"]` / `defn["description"]`) or a `mcp.prompt(...)` decoration-time rejection — so one malformed prompt aborted registration of every subsequent prompt with no per-prompt warning, contradicting the "skip-with-warning, never crash" intent. Latent today (the shipped loaders always populate the keys), but any future loader change or direct call would reintroduce the crash. Surfaced by the #788 preflight-circus (silent-failure-hunter); #788 deliberately scoped itself to the `exec()` removal and left the loop.

## Fix

Wrap each `_register_one_*` call in its loop with a `try/except Exception` backstop that logs and continues:

- **Pass 3 (user prompts)** → `logger.warning(..., exc_info=True)` — a user misconfiguration.
- **Pass 2 (built-ins)** → `logger.error(..., exc_info=True)` — a broken first-party prompt is a packaging defect, kept loud in CI/startup.

The helpers' own narrow `except ValueError` handlers (invalid signatures) are **unchanged** — the backstop only covers the two gaps they don't (`KeyError`, `mcp.prompt` rejection). `except Exception` (not `BaseException`) lets `KeyboardInterrupt`/`SystemExit` propagate.

## Tests

`TestRegisterPromptsPerPromptGuard` covers the full 2×2 matrix (user / built-in × def-dict `KeyError` / decoration-time `mcp.prompt` rejection), each asserting the prompt is skipped at the right level and a sibling still registers, plus a regression pin that the helper's own `ValueError` still fires without the backstop double-logging. Monkeypatches only the def-loading seams; the real loop, helpers, and `FastMCP` client surface are exercised.

## Docs

`docs/design.md` gains a "Registration robustness" paragraph distinguishing helper-caught failures (invalid arg names / signature → WARNING for both) from backstop-caught failures (missing key / `mcp.prompt` rejection → WARNING user, ERROR built-in).

## Scope boundary

Registration-loop robustness + built-in diagnostic severity only. Not the `exec()` removal (#788, done). The inline `create_from_template` prompt is out of the loop and left unguarded (fixed first-party function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)