### PR TITLE
refactor: modular SPA partials + build_spa.py (#810)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         run: uv sync --all-extras --all-groups
 
 
+      - name: Verify assembled SPA source is up-to-date
+        run: uv run python scripts/build_spa.py --check
+
       - name: Verify vendored SPA is up-to-date
         run: uv run python scripts/vendor_spa.py --check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,13 @@ repos:
         types: [python]
         stages: [pre-push]
 
+      - id: build-spa-check
+        name: assembled SPA source up-to-date
+        language: system
+        entry: uv run python scripts/build_spa.py --check
+        files: ^src/markdown_vault_mcp/static/spa/
+        pass_filenames: false
+
       - id: vendor-spa-check
         name: vendored SPA HTML up-to-date
         language: system

--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -92,6 +92,36 @@ The app integrates with the host client via the ext-apps SDK:
 - **`app.requestDisplayMode()`**: requests fullscreen or inline display
 - **Theme sync**: automatically adapts to the host's light/dark theme and CSS variables
 
+### Source layout and build
+
+The SPA source is authored as small partials under
+`src/markdown_vault_mcp/static/spa/`:
+
+| File | Contents |
+|------|----------|
+| `shell.html` | The HTML document: head, tab bar, view panels, toast |
+| `styles.css` | All styles |
+| `core.js` | App setup, theming, tab navigation, cross-view routing, shared helpers |
+| `views/context.js`, `views/graph.js`, `views/browser.js`, `views/note.js` | One file per view |
+
+Two build steps turn the partials into the served resource:
+
+```text
+spa/*  ->  build_spa.py  ->  app.src.html  ->  vendor_spa.py  ->  app.html
+```
+
+1. `python scripts/build_spa.py` assembles the partials into
+   `static/app.src.html`. Assembly is a recursive `/*@@FILE:path@@*/` include,
+   a valid comment in both CSS and JavaScript, so each partial stays
+   independently readable.
+2. `python scripts/vendor_spa.py` embeds the vendored libraries into the
+   self-contained `static/app.html` that the server serves.
+
+`app.src.html` and `app.html` are both generated, committed artifacts: edit the
+files under `static/spa/`, then run both scripts. Never hand-edit the generated
+files. `build_spa.py --check` and `vendor_spa.py --check` fail the build if
+either artifact is stale; both run in CI and as pre-commit hooks.
+
 ## Client support
 
 MCP Apps views require a client that supports the MCP Apps protocol. Currently supported by Claude on claude.ai. Clients without Apps support receive a text-only fallback from `browse_vault` and `show_context`.

--- a/scripts/build_spa.py
+++ b/scripts/build_spa.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Assemble the modular SPA sources into the single ``static/app.src.html``.
+
+The MCP Apps front-end is authored as small partials under
+``src/<module>/static/spa/`` (a shell, one stylesheet, a core module, and one
+file per view) and assembled here into ``static/app.src.html`` — the single,
+self-contained file that ``scripts/vendor_spa.py`` then vendors into the served
+``static/app.html``.  The full build pipeline is::
+
+    spa/*  ->  build_spa.py  ->  app.src.html  ->  vendor_spa.py  ->  app.html
+
+Assembly is a recursive include: every ``/*@@FILE:relpath@@*/`` marker in a
+partial is replaced by the verbatim bytes of ``spa/relpath``.  The marker is a
+valid comment in both CSS (inside ``<style>``) and JavaScript (inside
+``<script>``), so each partial stays independently parseable — ``core.js`` is
+the whole module with view markers inside its ``try`` block, and each
+``views/*.js`` is a self-contained IIFE.
+
+``static/app.src.html`` is a **generated, committed** artifact: edit the files
+under ``static/spa/`` and regenerate, never hand-edit ``app.src.html``.
+
+Usage::
+
+    python scripts/build_spa.py            # regenerate app.src.html
+    python scripts/build_spa.py --check     # verify app.src.html is up-to-date
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# A ``/*@@FILE:path@@*/`` include marker — valid comment in CSS and JS alike.
+_MARKER = re.compile(r"/\*@@FILE:([^@]+?)@@\*/")
+
+# Guard against a partial including itself (directly or via a cycle).
+_MAX_DEPTH = 64
+
+
+def _find_spa_dir() -> Path:
+    """Locate the single ``src/<module>/static/spa`` directory.
+
+    Discovered at runtime (rather than hard-coding the package name) so this
+    script stays project-agnostic, mirroring ``vendor_spa.py``.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    src_root = repo_root / "src"
+    candidates = sorted(src_root.glob("*/static/spa/shell.html"))
+    if not candidates:
+        raise SystemExit(
+            f"ERROR: no src/*/static/spa/shell.html found under {src_root}"
+        )
+    if len(candidates) > 1:
+        found = ", ".join(str(c) for c in candidates)
+        raise SystemExit(f"ERROR: multiple spa/shell.html found: {found}")
+    return candidates[0].parent
+
+
+def _read_partial(spa_dir: Path, rel: str) -> str:
+    path = (spa_dir / rel).resolve()
+    if not path.is_relative_to(spa_dir.resolve()):
+        raise SystemExit(f"ERROR: include escapes spa/ dir: {rel}")
+    if not path.is_file():
+        raise SystemExit(f"ERROR: included partial not found: {rel}")
+    return path.read_text(encoding="utf-8")
+
+
+def assemble(spa_dir: Path) -> str:
+    """Return the assembled ``app.src.html`` text from ``spa/shell.html``."""
+
+    def expand(text: str, depth: int) -> str:
+        if depth > _MAX_DEPTH:
+            raise SystemExit("ERROR: include recursion too deep (cycle?)")
+        return _MARKER.sub(
+            lambda m: expand(_read_partial(spa_dir, m.group(1).strip()), depth + 1),
+            text,
+        )
+
+    shell = _read_partial(spa_dir, "shell.html")
+    return expand(shell, 0)
+
+
+def main(argv: list[str]) -> int:
+    check = "--check" in argv[1:]
+    spa_dir = _find_spa_dir()
+    out_path = spa_dir.parent / "app.src.html"
+    assembled = assemble(spa_dir)
+
+    if check:
+        current = out_path.read_text(encoding="utf-8") if out_path.exists() else ""
+        if current == assembled:
+            print("OK: app.src.html is up-to-date.")
+            return 0
+        print(
+            "ERROR: app.src.html is out of date — run "
+            "`python scripts/build_spa.py` and commit the result.",
+            file=sys.stderr,
+        )
+        return 1
+
+    out_path.write_text(assembled, encoding="utf-8")
+    print(f"Wrote {out_path.relative_to(spa_dir.parent.parent.parent.parent)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/build_spa.py
+++ b/scripts/build_spa.py
@@ -42,7 +42,8 @@ _MARKER = re.compile(r"/\*@@FILE:([^@]+?)@@\*/")
 _MAX_DEPTH = 64
 
 # The shell must open with this so the injected banner lands *after* the
-# doctype (a comment before the doctype forces the browser into quirks mode).
+# doctype: keeping the DOCTYPE the first line makes document mode unambiguous
+# across parsers (legacy engines treat pre-doctype content as a quirks trigger).
 _DOCTYPE = "<!DOCTYPE html>\n"
 
 # Injected into the generated output at assembly time (kept out of shell.html,

--- a/scripts/build_spa.py
+++ b/scripts/build_spa.py
@@ -129,7 +129,7 @@ def main(argv: list[str]) -> int:
         return 1
 
     out_path.write_text(assembled, encoding="utf-8")
-    print(f"Wrote {out_path.relative_to(spa_dir.parent.parent.parent.parent)}")
+    print(f"Wrote {out_path}")
     return 0
 
 

--- a/scripts/build_spa.py
+++ b/scripts/build_spa.py
@@ -14,10 +14,14 @@ partial is replaced by the verbatim bytes of ``spa/relpath``.  The marker is a
 valid comment in both CSS (inside ``<style>``) and JavaScript (inside
 ``<script>``), so each partial stays independently parseable — ``core.js`` is
 the whole module with view markers inside its ``try`` block, and each
-``views/*.js`` is a self-contained IIFE.
+``views/*.js`` is an IIFE-wrapped view module (its free variables, e.g.
+``app``/``switchTab``, resolve to ``core.js`` scope once assembled).
 
-``static/app.src.html`` is a **generated, committed** artifact: edit the files
-under ``static/spa/`` and regenerate, never hand-edit ``app.src.html``.
+The generated ``static/app.src.html`` carries a "do not edit" banner that this
+script injects at assembly time (it is not stored in ``shell.html``, which is an
+editable source partial). ``static/app.src.html`` is a **generated, committed**
+artifact: edit the files under ``static/spa/`` and regenerate, never hand-edit
+it.
 
 Usage::
 
@@ -36,6 +40,17 @@ _MARKER = re.compile(r"/\*@@FILE:([^@]+?)@@\*/")
 
 # Guard against a partial including itself (directly or via a cycle).
 _MAX_DEPTH = 64
+
+# The shell must open with this so the injected banner lands *after* the
+# doctype (a comment before the doctype forces the browser into quirks mode).
+_DOCTYPE = "<!DOCTYPE html>\n"
+
+# Injected into the generated output at assembly time (kept out of shell.html,
+# which is an editable source partial).
+_GENERATED_BANNER = (
+    "<!-- GENERATED FILE — do not edit. Source lives in static/spa/*; regenerate with\n"
+    "     `python scripts/build_spa.py`, then vendor with `python scripts/vendor_spa.py`. -->\n"
+)
 
 
 def _find_spa_dir() -> Path:
@@ -78,10 +93,23 @@ def assemble(spa_dir: Path) -> str:
         )
 
     shell = _read_partial(spa_dir, "shell.html")
-    return expand(shell, 0)
+    result = expand(shell, 0)
+
+    # A malformed marker (e.g. a missing colon) never matches _MARKER, so it
+    # survives expansion as literal text — fail loudly rather than ship a file
+    # with a partial silently omitted.
+    if "@@FILE" in result:
+        raise SystemExit(
+            "ERROR: an @@FILE include marker survived assembly — check for a "
+            "malformed /*@@FILE:path@@*/ marker in the spa/ partials."
+        )
+    if not result.startswith(_DOCTYPE):
+        raise SystemExit("ERROR: spa/shell.html must begin with '<!DOCTYPE html>'.")
+    return _DOCTYPE + _GENERATED_BANNER + result[len(_DOCTYPE) :]
 
 
 def main(argv: list[str]) -> int:
+    """Entry point. Returns 0 on success, 1 on failure."""
     check = "--check" in argv[1:]
     spa_dir = _find_spa_dir()
     out_path = spa_dir.parent / "app.src.html"

--- a/scripts/vendor_spa.py
+++ b/scripts/vendor_spa.py
@@ -2,11 +2,10 @@
 """Vendor CDN dependencies into static/app.html for offline use.
 
 Downloads pinned library versions and inlines them into the SPA HTML,
-eliminating runtime CDN dependencies.  The source is ``static/app.src.html``
-(with CDN ``<script src>`` tags and an ``ext-apps`` ES-module import); this
-script produces ``static/app.html`` (self-contained, committed).  Projects may
-assemble ``app.src.html`` from smaller sources ahead of this step (see
-``build_spa.py``), so treat it as an input artifact, not a hand-edited file.
+eliminating runtime CDN dependencies.  The source template is
+``static/app.src.html`` (human-editable, with CDN ``<script src>`` tags and
+an ``ext-apps`` ES-module import); this script produces ``static/app.html``
+(self-contained, committed).
 
 This script is template-owned and ships byte-identical to every project, so
 it discovers ``src/<module>/static/app.src.html`` at runtime rather than

--- a/scripts/vendor_spa.py
+++ b/scripts/vendor_spa.py
@@ -2,10 +2,11 @@
 """Vendor CDN dependencies into static/app.html for offline use.
 
 Downloads pinned library versions and inlines them into the SPA HTML,
-eliminating runtime CDN dependencies.  The source template is
-``static/app.src.html`` (human-editable, with CDN ``<script src>`` tags and
-an ``ext-apps`` ES-module import); this script produces ``static/app.html``
-(self-contained, committed).
+eliminating runtime CDN dependencies.  The source is ``static/app.src.html``
+(with CDN ``<script src>`` tags and an ``ext-apps`` ES-module import); this
+script produces ``static/app.html`` (self-contained, committed).  Projects may
+assemble ``app.src.html`` from smaller sources ahead of this step (see
+``build_spa.py``), so treat it as an input artifact, not a hand-edited file.
 
 This script is template-owned and ships byte-identical to every project, so
 it discovers ``src/<module>/static/app.src.html`` at runtime rather than

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<!-- GENERATED FILE — do not edit. Source lives in static/spa/*; regenerate with
+     `python scripts/build_spa.py`, then vendor with `python scripts/vendor_spa.py`. -->
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
@@ -387,7 +389,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
   }
 </style>
-<!-- vendor-spa-source-sha256:44d3a8d9966af461479c0d78b8467c3a6b2735ea3fe80eda0f5ab989295366b2 -->
+<!-- vendor-spa-source-sha256:0038c3bc8599af166c6b394e5650a3d43e668f3b05549cbf83b8543418470346 -->
 </head>
 <body>
 <div class="app-container">
@@ -844,7 +846,6 @@ app.onteardown = () => {
   // Expose for cross-view use
   window.loadContext = loadContext;
 })();
-
 // ── Graph Explorer View ──────────────────────────────────────────────────
 (function() {
   let network = null;
@@ -1128,7 +1129,6 @@ app.onteardown = () => {
 
   window.loadGraph = loadGraph;
 })();
-
 // ── Vault Browser View ──────────────────────────────────────────────────
 (function() {
   function escHtml(s) {
@@ -1347,7 +1347,6 @@ app.onteardown = () => {
   window.loadBrowser = loadRootTree;
   window.loadPreview = loadPreview;
 })();
-
 // ── Connect ──────────────────────────────────────────────────────────────
 await app.connect();
 connected = true;

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -389,7 +389,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
   }
 </style>
-<!-- vendor-spa-source-sha256:0038c3bc8599af166c6b394e5650a3d43e668f3b05549cbf83b8543418470346 -->
+<!-- vendor-spa-source-sha256:80147a610805aa21cfb3bc4c919e680c1dd312a949b54d4b358b98aa27176594 -->
 </head>
 <body>
 <div class="app-container">
@@ -1139,13 +1139,10 @@ app.onteardown = () => {
       .replace(/"/g, '&quot;');
   }
 
-  let currentPreviewPath = null;
-  let currentPreviewData = null;
   let treeDataCache = {};
   let isSearchMode = false;
 
   const treeEl = document.getElementById('browser-tree');
-  const previewEl = document.getElementById('browser-preview');
   const searchInput = document.getElementById('browser-search-input');
   const searchClear = document.getElementById('browser-search-clear');
 
@@ -1199,7 +1196,7 @@ app.onteardown = () => {
       noteDiv.textContent = n.title || n.path;
       noteDiv.title = n.path;
       noteDiv.dataset.path = n.path;
-      noteDiv.addEventListener('click', () => loadPreview(n.path));
+      noteDiv.addEventListener('click', () => window.loadPreview(n.path));
       parentEl.appendChild(noteDiv);
     }
   }
@@ -1210,14 +1207,81 @@ app.onteardown = () => {
     renderTree(data, treeEl);
   }
 
+  // Search
+  let searchTimeout = null;
+  searchInput.addEventListener('input', () => {
+    clearTimeout(searchTimeout);
+    const q = searchInput.value.trim();
+    if (!q) { exitSearch(); return; }
+    searchTimeout = setTimeout(() => doSearch(q), 300);
+  });
+
+  async function doSearch(query) {
+    isSearchMode = true;
+    searchClear.style.display = '';
+    try {
+      const result = await app.callServerTool({
+        name: 'vault___vault_search', arguments: { query, mode: 'hybrid', limit: 20 }
+      });
+      const data = parseToolResult(result) || [];
+      treeEl.innerHTML = '';
+      for (const r of data) {
+        const div = document.createElement('div');
+        div.className = 'search-result';
+        div.innerHTML = '<div class="search-result-title">' + escHtml(r.title || r.path) + '</div>'
+          + '<div class="search-result-snippet">' + escHtml(r.snippet || '') + '</div>';
+        div.addEventListener('click', () => window.loadPreview(r.path));
+        treeEl.appendChild(div);
+      }
+      if (data.length === 0) {
+        treeEl.innerHTML = '<div class="placeholder" style="padding:12px">No results</div>';
+      }
+    } catch (err) {
+      treeEl.innerHTML = '<div class="placeholder" style="padding:12px">Search error</div>';
+    }
+  }
+
+  function exitSearch() {
+    isSearchMode = false;
+    searchClear.style.display = 'none';
+    searchInput.value = '';
+    loadRootTree();
+  }
+
+  searchClear.addEventListener('click', exitSearch);
+
+  // Auto-load when browse tab is selected
+  window.addEventListener('vault-tab-changed', (e) => {
+    if (e.detail.tab === 'browse' && treeEl.children.length === 0 && !isSearchMode) {
+      loadRootTree();
+    }
+  });
+
+  window.loadBrowser = loadRootTree;
+})();
+// ── Note Preview View ────────────────────────────────────────────────────
+(function() {
+  function escHtml(s) {
+    return String(s ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  let currentPreviewPath = null;
+  let currentPreviewData = null;
+
+  const previewEl = document.getElementById('browser-preview');
+
   async function loadPreview(path, { switchToNote = true } = {}) {
     currentPreviewPath = path;
     currentPath = path; // sync shared state
     // Show the Note tab button; switch to it unless caller opts out
     document.getElementById('note-tab-btn').classList.add('visible');
     if (switchToNote) switchTab('note');
-    // Highlight active note in tree
-    treeEl.querySelectorAll('.tree-note').forEach(el => {
+    // Highlight active note in the browser tree
+    document.getElementById('browser-tree')?.querySelectorAll('.tree-note').forEach(el => {
       el.classList.toggle('active', el.dataset.path === path);
     });
 
@@ -1230,11 +1294,11 @@ app.onteardown = () => {
       let html = '<div class="preview-header">';
       html += '<h2>' + escHtml(data.title || path) + '</h2>';
       html += '<div class="preview-actions">';
-      html += '<button class="action-btn action-btn--secondary" id="preview-browse-btn" title="Back to Browse">\u2190 Browse</button>';
-      html += '<button class="action-btn" id="preview-send-btn" title="Send to Claude">\uD83D\uDCAC Send</button>';
-      html += '<button class="action-btn action-btn--secondary" id="preview-ctx-btn" title="Show Context">\uD83D\uDD0D Context</button>';
-      html += '<button class="action-btn action-btn--secondary" id="preview-graph-btn" title="Show in Graph">\uD83D\uDD17 Graph</button>';
-      html += '<button class="edit-btn-disabled" title="Coming soon" disabled>\u270F Edit</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-browse-btn" title="Back to Browse">← Browse</button>';
+      html += '<button class="action-btn" id="preview-send-btn" title="Send to Claude">💬 Send</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-ctx-btn" title="Show Context">🔍 Context</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-graph-btn" title="Show in Graph">🔗 Graph</button>';
+      html += '<button class="edit-btn-disabled" title="Coming soon" disabled>✏ Edit</button>';
       html += '</div></div>';
 
       // Frontmatter
@@ -1285,49 +1349,6 @@ app.onteardown = () => {
     }
   }
 
-  // Search
-  let searchTimeout = null;
-  searchInput.addEventListener('input', () => {
-    clearTimeout(searchTimeout);
-    const q = searchInput.value.trim();
-    if (!q) { exitSearch(); return; }
-    searchTimeout = setTimeout(() => doSearch(q), 300);
-  });
-
-  async function doSearch(query) {
-    isSearchMode = true;
-    searchClear.style.display = '';
-    try {
-      const result = await app.callServerTool({
-        name: 'vault___vault_search', arguments: { query, mode: 'hybrid', limit: 20 }
-      });
-      const data = parseToolResult(result) || [];
-      treeEl.innerHTML = '';
-      for (const r of data) {
-        const div = document.createElement('div');
-        div.className = 'search-result';
-        div.innerHTML = '<div class="search-result-title">' + escHtml(r.title || r.path) + '</div>'
-          + '<div class="search-result-snippet">' + escHtml(r.snippet || '') + '</div>';
-        div.addEventListener('click', () => loadPreview(r.path));
-        treeEl.appendChild(div);
-      }
-      if (data.length === 0) {
-        treeEl.innerHTML = '<div class="placeholder" style="padding:12px">No results</div>';
-      }
-    } catch (err) {
-      treeEl.innerHTML = '<div class="placeholder" style="padding:12px">Search error</div>';
-    }
-  }
-
-  function exitSearch() {
-    isSearchMode = false;
-    searchClear.style.display = 'none';
-    searchInput.value = '';
-    loadRootTree();
-  }
-
-  searchClear.addEventListener('click', exitSearch);
-
   // Listen for navigation events
   window.addEventListener('vault-navigate', (e) => {
     if ((e.detail.view === 'browse' || e.detail.view === 'note') && e.detail.path) {
@@ -1337,14 +1358,6 @@ app.onteardown = () => {
     }
   });
 
-  // Auto-load when browse tab is selected
-  window.addEventListener('vault-tab-changed', (e) => {
-    if (e.detail.tab === 'browse' && treeEl.children.length === 0 && !isSearchMode) {
-      loadRootTree();
-    }
-  });
-
-  window.loadBrowser = loadRootTree;
   window.loadPreview = loadPreview;
 })();
 // ── Connect ──────────────────────────────────────────────────────────────

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<!-- GENERATED FILE — do not edit. Source lives in static/spa/*; regenerate with
+     `python scripts/build_spa.py`, then vendor with `python scripts/vendor_spa.py`. -->
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
@@ -726,7 +728,6 @@ app.onteardown = () => {
   // Expose for cross-view use
   window.loadContext = loadContext;
 })();
-
 // ── Graph Explorer View ──────────────────────────────────────────────────
 (function() {
   let network = null;
@@ -1010,7 +1011,6 @@ app.onteardown = () => {
 
   window.loadGraph = loadGraph;
 })();
-
 // ── Vault Browser View ──────────────────────────────────────────────────
 (function() {
   function escHtml(s) {
@@ -1229,7 +1229,6 @@ app.onteardown = () => {
   window.loadBrowser = loadRootTree;
   window.loadPreview = loadPreview;
 })();
-
 // ── Connect ──────────────────────────────────────────────────────────────
 await app.connect();
 connected = true;

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1021,13 +1021,10 @@ app.onteardown = () => {
       .replace(/"/g, '&quot;');
   }
 
-  let currentPreviewPath = null;
-  let currentPreviewData = null;
   let treeDataCache = {};
   let isSearchMode = false;
 
   const treeEl = document.getElementById('browser-tree');
-  const previewEl = document.getElementById('browser-preview');
   const searchInput = document.getElementById('browser-search-input');
   const searchClear = document.getElementById('browser-search-clear');
 
@@ -1081,7 +1078,7 @@ app.onteardown = () => {
       noteDiv.textContent = n.title || n.path;
       noteDiv.title = n.path;
       noteDiv.dataset.path = n.path;
-      noteDiv.addEventListener('click', () => loadPreview(n.path));
+      noteDiv.addEventListener('click', () => window.loadPreview(n.path));
       parentEl.appendChild(noteDiv);
     }
   }
@@ -1092,14 +1089,81 @@ app.onteardown = () => {
     renderTree(data, treeEl);
   }
 
+  // Search
+  let searchTimeout = null;
+  searchInput.addEventListener('input', () => {
+    clearTimeout(searchTimeout);
+    const q = searchInput.value.trim();
+    if (!q) { exitSearch(); return; }
+    searchTimeout = setTimeout(() => doSearch(q), 300);
+  });
+
+  async function doSearch(query) {
+    isSearchMode = true;
+    searchClear.style.display = '';
+    try {
+      const result = await app.callServerTool({
+        name: 'vault___vault_search', arguments: { query, mode: 'hybrid', limit: 20 }
+      });
+      const data = parseToolResult(result) || [];
+      treeEl.innerHTML = '';
+      for (const r of data) {
+        const div = document.createElement('div');
+        div.className = 'search-result';
+        div.innerHTML = '<div class="search-result-title">' + escHtml(r.title || r.path) + '</div>'
+          + '<div class="search-result-snippet">' + escHtml(r.snippet || '') + '</div>';
+        div.addEventListener('click', () => window.loadPreview(r.path));
+        treeEl.appendChild(div);
+      }
+      if (data.length === 0) {
+        treeEl.innerHTML = '<div class="placeholder" style="padding:12px">No results</div>';
+      }
+    } catch (err) {
+      treeEl.innerHTML = '<div class="placeholder" style="padding:12px">Search error</div>';
+    }
+  }
+
+  function exitSearch() {
+    isSearchMode = false;
+    searchClear.style.display = 'none';
+    searchInput.value = '';
+    loadRootTree();
+  }
+
+  searchClear.addEventListener('click', exitSearch);
+
+  // Auto-load when browse tab is selected
+  window.addEventListener('vault-tab-changed', (e) => {
+    if (e.detail.tab === 'browse' && treeEl.children.length === 0 && !isSearchMode) {
+      loadRootTree();
+    }
+  });
+
+  window.loadBrowser = loadRootTree;
+})();
+// ── Note Preview View ────────────────────────────────────────────────────
+(function() {
+  function escHtml(s) {
+    return String(s ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  let currentPreviewPath = null;
+  let currentPreviewData = null;
+
+  const previewEl = document.getElementById('browser-preview');
+
   async function loadPreview(path, { switchToNote = true } = {}) {
     currentPreviewPath = path;
     currentPath = path; // sync shared state
     // Show the Note tab button; switch to it unless caller opts out
     document.getElementById('note-tab-btn').classList.add('visible');
     if (switchToNote) switchTab('note');
-    // Highlight active note in tree
-    treeEl.querySelectorAll('.tree-note').forEach(el => {
+    // Highlight active note in the browser tree
+    document.getElementById('browser-tree')?.querySelectorAll('.tree-note').forEach(el => {
       el.classList.toggle('active', el.dataset.path === path);
     });
 
@@ -1112,11 +1176,11 @@ app.onteardown = () => {
       let html = '<div class="preview-header">';
       html += '<h2>' + escHtml(data.title || path) + '</h2>';
       html += '<div class="preview-actions">';
-      html += '<button class="action-btn action-btn--secondary" id="preview-browse-btn" title="Back to Browse">\u2190 Browse</button>';
-      html += '<button class="action-btn" id="preview-send-btn" title="Send to Claude">\uD83D\uDCAC Send</button>';
-      html += '<button class="action-btn action-btn--secondary" id="preview-ctx-btn" title="Show Context">\uD83D\uDD0D Context</button>';
-      html += '<button class="action-btn action-btn--secondary" id="preview-graph-btn" title="Show in Graph">\uD83D\uDD17 Graph</button>';
-      html += '<button class="edit-btn-disabled" title="Coming soon" disabled>\u270F Edit</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-browse-btn" title="Back to Browse">← Browse</button>';
+      html += '<button class="action-btn" id="preview-send-btn" title="Send to Claude">💬 Send</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-ctx-btn" title="Show Context">🔍 Context</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-graph-btn" title="Show in Graph">🔗 Graph</button>';
+      html += '<button class="edit-btn-disabled" title="Coming soon" disabled>✏ Edit</button>';
       html += '</div></div>';
 
       // Frontmatter
@@ -1167,49 +1231,6 @@ app.onteardown = () => {
     }
   }
 
-  // Search
-  let searchTimeout = null;
-  searchInput.addEventListener('input', () => {
-    clearTimeout(searchTimeout);
-    const q = searchInput.value.trim();
-    if (!q) { exitSearch(); return; }
-    searchTimeout = setTimeout(() => doSearch(q), 300);
-  });
-
-  async function doSearch(query) {
-    isSearchMode = true;
-    searchClear.style.display = '';
-    try {
-      const result = await app.callServerTool({
-        name: 'vault___vault_search', arguments: { query, mode: 'hybrid', limit: 20 }
-      });
-      const data = parseToolResult(result) || [];
-      treeEl.innerHTML = '';
-      for (const r of data) {
-        const div = document.createElement('div');
-        div.className = 'search-result';
-        div.innerHTML = '<div class="search-result-title">' + escHtml(r.title || r.path) + '</div>'
-          + '<div class="search-result-snippet">' + escHtml(r.snippet || '') + '</div>';
-        div.addEventListener('click', () => loadPreview(r.path));
-        treeEl.appendChild(div);
-      }
-      if (data.length === 0) {
-        treeEl.innerHTML = '<div class="placeholder" style="padding:12px">No results</div>';
-      }
-    } catch (err) {
-      treeEl.innerHTML = '<div class="placeholder" style="padding:12px">Search error</div>';
-    }
-  }
-
-  function exitSearch() {
-    isSearchMode = false;
-    searchClear.style.display = 'none';
-    searchInput.value = '';
-    loadRootTree();
-  }
-
-  searchClear.addEventListener('click', exitSearch);
-
   // Listen for navigation events
   window.addEventListener('vault-navigate', (e) => {
     if ((e.detail.view === 'browse' || e.detail.view === 'note') && e.detail.path) {
@@ -1219,14 +1240,6 @@ app.onteardown = () => {
     }
   });
 
-  // Auto-load when browse tab is selected
-  window.addEventListener('vault-tab-changed', (e) => {
-    if (e.detail.tab === 'browse' && treeEl.children.length === 0 && !isSearchMode) {
-      loadRootTree();
-    }
-  });
-
-  window.loadBrowser = loadRootTree;
   window.loadPreview = loadPreview;
 })();
 // ── Connect ──────────────────────────────────────────────────────────────

--- a/src/markdown_vault_mcp/static/spa/core.js
+++ b/src/markdown_vault_mcp/static/spa/core.js
@@ -191,7 +191,7 @@ app.onteardown = () => {
   return {};
 };
 
-/*@@FILE:views/context.js@@*//*@@FILE:views/graph.js@@*//*@@FILE:views/browser.js@@*/// ── Connect ──────────────────────────────────────────────────────────────
+/*@@FILE:views/context.js@@*//*@@FILE:views/graph.js@@*//*@@FILE:views/browser.js@@*//*@@FILE:views/note.js@@*/// ── Connect ──────────────────────────────────────────────────────────────
 await app.connect();
 connected = true;
 const hostContext = app.getHostContext();

--- a/src/markdown_vault_mcp/static/spa/core.js
+++ b/src/markdown_vault_mcp/static/spa/core.js
@@ -1,0 +1,234 @@
+
+// Static import required for Android webview compatibility (dynamic import()
+// fails there).  SDK is vendored inline via import map (see issue #302).
+import { App, applyDocumentTheme, applyHostStyleVariables, applyHostFonts }
+  from "https://unpkg.com/@modelcontextprotocol/ext-apps@1.3.1/app-with-deps";
+
+try {
+
+// ── Globals ──────────────────────────────────────────────────────────────
+const app = new App(
+  { name: "Vault Explorer", version: "1.0.0" },
+  {},
+  { autoResize: false }
+);
+let currentTab = 'context';
+let isFullscreen = false;
+let currentPath = null; // shared active-note state across views
+
+// ── Utilities ─────────────────────────────────────────────────────────────
+function escHtml(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+/** Extract parsed JSON from a CallToolResult ({content: [{type:'text', text:'...'}]}).
+ *  Returns the parsed object, or null if no text content found.
+ *  Throws Error with descriptive message on malformed JSON. */
+function parseToolResult(result) {
+  if (!result) return null;
+  if (result.content && Array.isArray(result.content)) {
+    const tb = result.content.find(c => c.type === 'text');
+    if (tb) {
+      try { return JSON.parse(tb.text); }
+      catch (e) { throw new Error('Invalid JSON in tool result: ' + e.message); }
+    }
+    return null;
+  }
+  if (typeof result === 'string') {
+    try { return JSON.parse(result); }
+    catch (e) { throw new Error('Invalid JSON in tool result: ' + e.message); }
+  }
+  return null;
+}
+
+// ── Host theming ─────────────────────────────────────────────────────────
+function handleHostContext(ctx) {
+  if (!ctx) return;
+  if (ctx.theme) applyDocumentTheme(ctx.theme);
+  if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
+  if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
+  if (ctx.displayMode !== undefined) {
+    isFullscreen = ctx.displayMode === 'fullscreen';
+    fullscreenBtn.textContent = isFullscreen ? '\u2716 Exit Fullscreen' : '\u26F6 Fullscreen';
+  }
+}
+
+// ── Tab navigation ───────────────────────────────────────────────────────
+function switchTab(tabName) {
+  currentTab = tabName;
+  document.querySelectorAll('.tab-bar button').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.tab === tabName);
+  });
+  document.querySelectorAll('.tab-panel').forEach(panel => {
+    panel.classList.toggle('active', panel.dataset.tab === tabName);
+  });
+  // Emit event for views to react
+  window.dispatchEvent(new CustomEvent('vault-tab-changed', { detail: { tab: tabName } }));
+}
+
+document.getElementById('tabBar').addEventListener('click', (e) => {
+  const btn = e.target.closest('button[data-tab]');
+  if (btn) switchTab(btn.dataset.tab);
+});
+
+// ── Cross-view navigation API ────────────────────────────────────────────
+window.navigateTo = function navigateTo(view, params = {}) {
+  switchTab(view);
+  window.dispatchEvent(new CustomEvent('vault-navigate', {
+    detail: { view, ...params }
+  }));
+};
+
+// ── Display mode (fullscreen toggle) ─────────────────────────────────────
+const fullscreenBtn = document.getElementById('fullscreenBtn');
+
+function updateFullscreenButton(available) {
+  fullscreenBtn.style.display = available ? 'block' : 'none';
+}
+
+fullscreenBtn.addEventListener('click', async () => {
+  try {
+    const mode = isFullscreen ? 'inline' : 'fullscreen';
+    await app.requestDisplayMode({ mode });
+  } catch (err) {
+    console.warn('Display mode change failed:', err);
+  }
+});
+
+// ── Toast helper ─────────────────────────────────────────────────────────
+window.showToast = function showToast(message, durationMs = 2000) {
+  const toast = document.getElementById('toast');
+  toast.textContent = message;
+  toast.classList.add('visible');
+  setTimeout(() => toast.classList.remove('visible'), durationMs);
+};
+
+// ── Shared send-to-LLM helper ───────────────────────────────────────────
+window.sendToLLM = async function sendToLLM(path, content) {
+  const MAX_LEN = 4000;
+  let body = content;
+  if (body.length > MAX_LEN) {
+    body = body.slice(0, MAX_LEN) + "\n... [truncated \u2014 use read('" + path + "') for full content]";
+  }
+  try {
+    await app.sendMessage({
+      role: 'user',
+      content: { type: 'text', text: '[From Vault App] Note: ' + path + '\n\n' + body }
+    });
+    window.showToast('Sent to Claude');
+  } catch (err) {
+    window.showToast('Send failed: ' + (err.message || err));
+  }
+};
+
+// ── Shared ambient context helper ────────────────────────────────────────
+window.updateContext = async function updateContext(viewName, path, title, extras) {
+  const lines = ['User is viewing ' + viewName + ': ' + path];
+  if (title) lines.push('Title: ' + title);
+  if (extras) lines.push(extras);
+  try {
+    await app.updateModelContext({
+      content: [{ type: 'text', text: lines.join('\n') }]
+    });
+  } catch (err) {
+    console.warn('updateModelContext failed:', err);
+  }
+};
+
+// ── Expose app for views ─────────────────────────────────────────────────
+window.vaultApp = app;
+
+// ── Handler registration (before connect) ────────────────────────────────
+let connected = false;
+let pendingToolInput = null;
+
+function processToolInput(args) {
+  const validViews = ['context', 'graph', 'browse', 'note'];
+  const view = (validViews.includes(args.view) ? args.view
+    : (args.path ? 'context' : 'browse'));
+  if (args.path) currentPath = args.path;
+  if (view === 'note') {
+    document.getElementById('note-tab-btn').classList.add('visible');
+  }
+  switchTab(view);
+  if (args.path) {
+    window.dispatchEvent(new CustomEvent('vault-navigate', {
+      detail: { view, path: args.path }
+    }));
+  } else if (view === 'browse') {
+    if (typeof window.loadBrowser === 'function') window.loadBrowser();
+  }
+}
+
+app.ontoolinput = (params) => {
+  const args = params?.arguments || {};
+  if (connected) {
+    processToolInput(args);
+  } else {
+    // Last-wins: only the final pre-connect input is kept. Multiple
+    // ontoolinput calls before connect() are not expected in MCP semantics.
+    pendingToolInput = args;
+  }
+};
+
+app.ontoolresult = (result) => {
+  window.dispatchEvent(new CustomEvent('vault-tool-result', { detail: result }));
+};
+
+app.ontoolcancelled = (params) => {
+  console.info('Tool call cancelled:', params?.reason);
+};
+
+app.onhostcontextchanged = handleHostContext;
+
+app.onerror = (err) => {
+  console.error('MCP App error:', err);
+};
+
+app.onteardown = () => {
+  return {};
+};
+
+/*@@FILE:views/context.js@@*//*@@FILE:views/graph.js@@*//*@@FILE:views/browser.js@@*/// ── Connect ──────────────────────────────────────────────────────────────
+await app.connect();
+connected = true;
+const hostContext = app.getHostContext();
+if (hostContext) handleHostContext(hostContext);
+
+const fullscreenAvailable = hostContext?.availableDisplayModes?.includes('fullscreen') === true;
+updateFullscreenButton(fullscreenAvailable);
+// Auto-expand on first load — complex multi-view app benefits from more space
+if (fullscreenAvailable && !isFullscreen) {
+  app.requestDisplayMode({ mode: 'fullscreen' }).catch(() => {});
+}
+
+// Process any tool input received during connection handshake.
+// If none arrived (host did not send ontoolinput), default to browse view so
+// the app shows data without requiring the LLM to pass explicit arguments.
+if (pendingToolInput) {
+  processToolInput(pendingToolInput);
+  pendingToolInput = null;
+} else {
+  switchTab('browse');
+  if (typeof window.loadBrowser === 'function') window.loadBrowser();
+}
+
+console.log('Vault Explorer connected');
+
+} catch (err) {
+  console.error('Vault Explorer error:', err);
+  const container = document.querySelector('.app-container');
+  const el = document.createElement('div');
+  el.style.cssText = 'padding:24px;text-align:center;color:var(--color-text-secondary);';
+  const h = document.createElement('h2');
+  h.textContent = 'Vault Explorer';
+  const p1 = document.createElement('p');
+  p1.textContent = 'This app requires a compatible MCP client with ext-apps SDK support.';
+  const p2 = document.createElement('p');
+  p2.style.cssText = 'font-size:12px;margin-top:8px;';
+  p2.textContent = 'Error: ' + (err.message || err);
+  el.append(h, p1, p2);
+  (container || document.body).replaceChildren(el);
+}

--- a/src/markdown_vault_mcp/static/spa/shell.html
+++ b/src/markdown_vault_mcp/static/spa/shell.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<!-- GENERATED FILE — do not edit. Source lives in static/spa/*; regenerate with
+     `python scripts/build_spa.py`, then vendor with `python scripts/vendor_spa.py`. -->
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Vault Explorer</title>
+<script src="https://unpkg.com/vis-network@10.0.2/standalone/umd/vis-network.min.js"></script>
+<script src="https://unpkg.com/marked@17.0.5/lib/marked.umd.js"></script>
+<script src="https://unpkg.com/dompurify@3.3.3/dist/purify.min.js"></script>
+<style>/*@@FILE:styles.css@@*/</style>
+</head>
+<body>
+<div class="app-container">
+  <div class="app-header">
+    <button class="fullscreen-btn" id="fullscreenBtn" style="display:none;"
+            title="Toggle fullscreen">&#x26F6; Fullscreen</button>
+  </div>
+  <div class="tab-bar" id="tabBar">
+    <button data-tab="context" class="active">Context</button>
+    <button data-tab="graph">Graph</button>
+    <button data-tab="browse">Browse</button>
+    <button data-tab="note" id="note-tab-btn" class="note-tab-btn">Note</button>
+  </div>
+  <div class="tab-panel active" id="panel-context" data-tab="context">
+    <div class="placeholder" id="context-placeholder">Select a note to view its context</div>
+    <div id="context-card" style="display:none;">
+      <div class="context-header">
+        <div class="context-title-row">
+          <h2 id="ctx-title"></h2>
+          <div class="context-actions">
+            <button class="action-btn action-btn--secondary" id="ctx-graph-btn" title="Show in Graph">&#x1F517; Graph</button>
+            <button class="action-btn action-btn--secondary" id="ctx-browse-btn" title="Open in Browser">&#x1F4C4; Browse</button>
+            <button class="action-btn" id="ctx-send-btn" title="Send to Claude">&#x1F4AC; Send</button>
+          </div>
+        </div>
+        <div class="context-meta">
+          <span id="ctx-path" class="meta-item"></span>
+          <span id="ctx-folder" class="meta-item"></span>
+          <span id="ctx-modified" class="meta-item"></span>
+        </div>
+      </div>
+      <div id="ctx-frontmatter" class="context-section collapsed-section"></div>
+      <div id="ctx-tags" class="context-section collapsed-section"></div>
+      <div id="ctx-backlinks" class="context-section collapsed-section"></div>
+      <div id="ctx-outlinks" class="context-section collapsed-section"></div>
+      <div id="ctx-similar" class="context-section collapsed-section"></div>
+      <div id="ctx-peers" class="context-section collapsed-section"></div>
+    </div>
+  </div>
+  <div class="tab-panel" id="panel-graph" data-tab="graph">
+    <div class="graph-toolbar" id="graph-toolbar">
+      <button class="action-btn" id="graph-send-btn" title="Send graph summary to Claude">&#x1F4AC; Send</button>
+      <button class="action-btn action-btn--secondary" id="graph-semantic-btn" title="Toggle semantic similarity edges">&#x223C; Semantic</button>
+      <button class="action-btn action-btn--secondary" id="graph-fullscreen-btn" title="Request fullscreen for graph">&#x26F6; Expand</button>
+    </div>
+    <div id="graph-container" style="flex:1;position:relative;">
+      <div id="graph-mini-card" class="graph-mini-card" style="display:none;"></div>
+    </div>
+  </div>
+  <div class="tab-panel" id="panel-browse" data-tab="browse">
+    <div class="browser-layout">
+      <div class="browser-sidebar">
+        <div class="browser-search">
+          <input type="text" id="browser-search-input" placeholder="Search vault..." />
+          <button id="browser-search-clear" style="display:none;" title="Clear search">&times;</button>
+        </div>
+        <div id="browser-tree" class="browser-tree"></div>
+      </div>
+    </div>
+  </div>
+  <div class="tab-panel" id="panel-note" data-tab="note">
+    <div class="browser-preview" id="browser-preview">
+      <div class="placeholder">Select a note from Browse to view it</div>
+    </div>
+  </div>
+</div>
+<div class="toast" id="toast"></div>
+
+<script type="module">/*@@FILE:core.js@@*/</script>
+</body>
+</html>

--- a/src/markdown_vault_mcp/static/spa/shell.html
+++ b/src/markdown_vault_mcp/static/spa/shell.html
@@ -1,6 +1,4 @@
 <!DOCTYPE html>
-<!-- GENERATED FILE — do not edit. Source lives in static/spa/*; regenerate with
-     `python scripts/build_spa.py`, then vendor with `python scripts/vendor_spa.py`. -->
 <html lang="en">
 <head>
 <meta charset="utf-8"/>

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -1,0 +1,265 @@
+
+  :root {
+    /* Fallbacks when host does not provide style variables */
+    --color-background-primary: #ffffff;
+    --color-background-secondary: #f5f5f5;
+    --color-text-primary: #1a1a1a;
+    --color-text-secondary: #6b7280;
+    --color-text-inverse: #ffffff;
+    --color-text-info: #6366f1;
+    --color-text-success: #22c55e;
+    --color-text-danger: #ef4444;
+    --color-border-primary: #e0e0e0;
+    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  }
+  [data-theme="dark"] {
+    --color-background-primary: #1a1a1a;
+    --color-background-secondary: #2a2a2a;
+    --color-text-primary: #e5e5e5;
+    --color-text-secondary: #9ca3af;
+    --color-text-inverse: #1a1a1a;
+    --color-text-info: #818cf8;
+    --color-text-success: #4ade80;
+    --color-text-danger: #f87171;
+    --color-border-primary: #404040;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font-sans);
+    background: var(--color-background-primary);
+    color: var(--color-text-primary);
+    line-height: 1.5;
+    overflow: hidden;
+    height: 100vh;
+  }
+  .app-container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+  }
+  /* Tab bar */
+  .tab-bar {
+    display: flex;
+    border-bottom: 1px solid var(--color-border-primary);
+    background: var(--color-background-secondary);
+    flex-shrink: 0;
+  }
+  .tab-bar button {
+    flex: 1;
+    padding: 8px 12px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    font-size: 13px;
+    font-family: inherit;
+    border-bottom: 2px solid transparent;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .tab-bar button:hover {
+    color: var(--color-text-primary);
+  }
+  .tab-bar button.active {
+    color: var(--color-text-info);
+    border-bottom-color: var(--color-text-info);
+    font-weight: 600;
+  }
+  /* Header with fullscreen toggle */
+  .app-header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 4px 8px;
+    flex-shrink: 0;
+  }
+  .fullscreen-btn {
+    background: none;
+    border: 1px solid var(--color-border-primary);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+  }
+  .fullscreen-btn:hover {
+    color: var(--color-text-primary);
+    background: var(--color-background-secondary);
+  }
+  /* Tab panels */
+  .tab-panel {
+    display: none;
+    flex: 1;
+    overflow: auto;
+    padding: 12px;
+    position: relative;
+  }
+  .tab-panel.active { display: flex; flex-direction: column; }
+  .placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: var(--color-text-secondary);
+    font-size: 14px;
+  }
+  /* Toast notifications */
+  .toast {
+    position: fixed;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-text-primary);
+    color: var(--color-background-primary);
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 13px;
+    opacity: 0;
+    transition: opacity 0.3s;
+    pointer-events: none;
+    z-index: 1000;
+  }
+  .toast.visible { opacity: 1; }
+  /* Context card styles */
+  .context-header { margin-bottom: 12px; }
+  .context-title-row {
+    display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  }
+  .context-title-row h2 { font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .context-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; font-size: 12px; color: var(--color-text-secondary); }
+  .meta-item::before { content: ''; }
+  .action-btn {
+    background: var(--color-text-info); color: var(--color-text-inverse); border: none; padding: 4px 10px;
+    border-radius: 4px; cursor: pointer; font-size: 12px; font-family: inherit; white-space: nowrap;
+  }
+  .action-btn:hover { opacity: 0.85; }
+  .action-btn--secondary {
+    background: var(--color-background-secondary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border-primary);
+  }
+  .context-section { margin-bottom: 8px; border: 1px solid var(--color-border-primary); border-radius: 6px; overflow: hidden; }
+  .section-header {
+    display: flex; align-items: center; justify-content: space-between; padding: 8px 12px;
+    background: var(--color-background-secondary); cursor: pointer; font-size: 13px; font-weight: 600;
+    user-select: none;
+  }
+  .section-header .badge { background: var(--color-text-info); color: var(--color-text-inverse); padding: 1px 6px; border-radius: 10px; font-size: 11px; font-weight: 500; }
+  .section-body { padding: 8px 12px; font-size: 13px; display: none; }
+  .context-section:not(.collapsed-section) .section-body { display: block; }
+  .section-header::after { content: '\25B6'; font-size: 10px; transition: transform 0.15s; }
+  .context-section:not(.collapsed-section) .section-header::after { transform: rotate(90deg); }
+  /* Tag pills */
+  .tag-group { margin-bottom: 6px; }
+  .tag-group-label { font-size: 11px; color: var(--color-text-secondary); text-transform: uppercase; margin-bottom: 2px; }
+  .tag-pill {
+    display: inline-block; padding: 2px 8px; margin: 2px 4px 2px 0; border-radius: 12px; font-size: 12px;
+    background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
+  }
+  /* Link lists */
+  .link-item {
+    display: flex; align-items: center; gap: 8px; padding: 4px 0; cursor: pointer;
+    border-bottom: 1px solid var(--color-border-primary);
+  }
+  .link-item:last-child { border-bottom: none; }
+  .link-item:hover { background: var(--color-background-secondary); }
+  .link-path { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--color-text-info); }
+  .link-type-badge {
+    font-size: 10px; padding: 1px 5px; border-radius: 3px;
+    background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
+    color: var(--color-text-secondary);
+  }
+  .link-exists-yes { color: var(--color-text-success); }
+  .link-exists-no { color: var(--color-text-danger); }
+  .link-text { font-size: 11px; color: var(--color-text-secondary); }
+  /* Similar notes */
+  .similar-score {
+    width: 60px; height: 6px; background: var(--color-border-primary); border-radius: 3px; overflow: hidden; flex-shrink: 0;
+  }
+  .similar-score-fill { height: 100%; background: var(--color-text-info); border-radius: 3px; }
+  /* Frontmatter table */
+  .fm-table { width: 100%; border-collapse: collapse; }
+  .fm-table td { padding: 3px 8px; border-bottom: 1px solid var(--color-border-primary); font-size: 12px; vertical-align: top; }
+  .fm-table td:first-child { font-weight: 600; white-space: nowrap; width: 1%; color: var(--color-text-secondary); }
+  /* Graph styles */
+  .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
+  #graph-container { border: 1px solid var(--color-border-primary); border-radius: 6px; min-height: 200px; }
+  .graph-mini-card {
+    position: absolute; bottom: 16px; right: 16px; width: 280px; max-height: 200px; overflow-y: auto;
+    background: var(--color-background-primary); border: 1px solid var(--color-border-primary);
+    border-radius: 8px; padding: 12px; font-size: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); z-index: 10;
+  }
+  .graph-mini-card h4 { margin: 0 0 6px; font-size: 14px; }
+  .graph-mini-card .mini-links { margin: 4px 0; }
+  .graph-mini-card .mini-link { color: var(--color-text-info); cursor: pointer; padding: 1px 0; }
+  .graph-mini-card .mini-link:hover { text-decoration: underline; }
+  .graph-mini-card .mini-actions { margin-top: 8px; display: flex; gap: 6px; }
+  .graph-mini-card .mini-actions button {
+    font-size: 11px; padding: 3px 8px; border-radius: 3px; cursor: pointer;
+    background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
+    color: var(--color-text-primary); font-family: inherit;
+  }
+  .graph-mini-card .mini-actions button:hover { background: var(--color-border-primary); }
+  /* Browser styles */
+  .browser-layout { display: flex; flex-direction: column; flex: 1; min-height: 0; gap: 0; }
+  .browser-sidebar {
+    flex: 1; display: flex; flex-direction: column;
+    overflow: hidden;
+  }
+  .browser-search {
+    display: flex; padding: 6px; gap: 4px; border-bottom: 1px solid var(--color-border-primary); flex-shrink: 0;
+  }
+  .browser-search input {
+    flex: 1; padding: 4px 8px; border: 1px solid var(--color-border-primary); border-radius: 4px;
+    font-size: 12px; font-family: inherit; background: var(--color-background-primary); color: var(--color-text-primary);
+  }
+  .browser-search button {
+    background: none; border: none; cursor: pointer; font-size: 16px; color: var(--color-text-secondary); padding: 0 4px;
+  }
+  .browser-tree { flex: 1; overflow-y: auto; padding: 4px; font-size: 12px; }
+  .tree-folder {
+    cursor: pointer; padding: 3px 4px; display: flex; align-items: center; gap: 4px;
+    font-weight: 600; color: var(--color-text-primary);
+  }
+  .tree-folder:hover { background: var(--color-background-secondary); border-radius: 3px; }
+  .tree-folder .arrow { font-size: 10px; width: 12px; transition: transform 0.15s; display: inline-block; }
+  .tree-folder.expanded .arrow { transform: rotate(90deg); }
+  .tree-children { padding-left: 16px; display: none; }
+  .tree-folder.expanded + .tree-children { display: block; }
+  .tree-note {
+    cursor: pointer; padding: 3px 4px 3px 20px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    color: var(--color-text-primary);
+  }
+  .tree-note:hover { background: var(--color-background-secondary); border-radius: 3px; }
+  .tree-note.active { background: var(--color-text-info); color: var(--color-text-inverse); border-radius: 3px; }
+  .search-result {
+    cursor: pointer; padding: 6px 8px; border-bottom: 1px solid var(--color-border-primary);
+  }
+  .search-result:hover { background: var(--color-background-secondary); }
+  .search-result-title { font-weight: 600; font-size: 13px; }
+  .search-result-snippet { font-size: 11px; color: var(--color-text-secondary); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  /* Note tab styles */
+  .tab-bar .note-tab-btn { display: none; }
+  .tab-bar .note-tab-btn.visible { display: flex; }
+  /* Preview pane (now in Note tab) */
+  .browser-preview { flex: 1; overflow-y: auto; padding: 16px; min-width: 0; }
+  .preview-header {
+    display: flex; align-items: center; justify-content: space-between; gap: 8px;
+    margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--color-border-primary);
+  }
+  .preview-header h1 { font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .preview-actions { display: flex; gap: 6px; flex-shrink: 0; }
+  .preview-fm { margin-bottom: 12px; }
+  .preview-content { font-size: 14px; line-height: 1.6; }
+  .preview-content h1, .preview-content h2, .preview-content h3 { margin-top: 16px; margin-bottom: 8px; }
+  .preview-content p { margin: 8px 0; }
+  .preview-content code { background: var(--color-background-secondary); padding: 1px 4px; border-radius: 3px; font-size: 13px; }
+  .preview-content pre { background: var(--color-background-secondary); padding: 12px; border-radius: 6px; overflow-x: auto; }
+  .preview-content pre code { background: none; padding: 0; }
+  .preview-content blockquote { border-left: 3px solid var(--color-text-info); padding-left: 12px; color: var(--color-text-secondary); margin: 8px 0; }
+  .preview-content a { color: var(--color-text-info); }
+  .edit-btn-disabled {
+    background: var(--color-background-secondary); color: var(--color-text-secondary);
+    border: 1px solid var(--color-border-primary); padding: 4px 10px; border-radius: 4px;
+    font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
+  }

--- a/src/markdown_vault_mcp/static/spa/views/browser.js
+++ b/src/markdown_vault_mcp/static/spa/views/browser.js
@@ -8,13 +8,10 @@
       .replace(/"/g, '&quot;');
   }
 
-  let currentPreviewPath = null;
-  let currentPreviewData = null;
   let treeDataCache = {};
   let isSearchMode = false;
 
   const treeEl = document.getElementById('browser-tree');
-  const previewEl = document.getElementById('browser-preview');
   const searchInput = document.getElementById('browser-search-input');
   const searchClear = document.getElementById('browser-search-clear');
 
@@ -68,7 +65,7 @@
       noteDiv.textContent = n.title || n.path;
       noteDiv.title = n.path;
       noteDiv.dataset.path = n.path;
-      noteDiv.addEventListener('click', () => loadPreview(n.path));
+      noteDiv.addEventListener('click', () => window.loadPreview(n.path));
       parentEl.appendChild(noteDiv);
     }
   }
@@ -77,81 +74,6 @@
     treeDataCache = {};
     const data = await loadFolder(null);
     renderTree(data, treeEl);
-  }
-
-  async function loadPreview(path, { switchToNote = true } = {}) {
-    currentPreviewPath = path;
-    currentPath = path; // sync shared state
-    // Show the Note tab button; switch to it unless caller opts out
-    document.getElementById('note-tab-btn').classList.add('visible');
-    if (switchToNote) switchTab('note');
-    // Highlight active note in tree
-    treeEl.querySelectorAll('.tree-note').forEach(el => {
-      el.classList.toggle('active', el.dataset.path === path);
-    });
-
-    try {
-      const result = await app.callServerTool({ name: 'vault___vault_read', arguments: { path } });
-      const data = parseToolResult(result);
-      if (!data) { previewEl.innerHTML = '<div class="placeholder">Note not found</div>'; return; }
-      currentPreviewData = data;
-
-      let html = '<div class="preview-header">';
-      html += '<h2>' + escHtml(data.title || path) + '</h2>';
-      html += '<div class="preview-actions">';
-      html += '<button class="action-btn action-btn--secondary" id="preview-browse-btn" title="Back to Browse">\u2190 Browse</button>';
-      html += '<button class="action-btn" id="preview-send-btn" title="Send to Claude">\uD83D\uDCAC Send</button>';
-      html += '<button class="action-btn action-btn--secondary" id="preview-ctx-btn" title="Show Context">\uD83D\uDD0D Context</button>';
-      html += '<button class="action-btn action-btn--secondary" id="preview-graph-btn" title="Show in Graph">\uD83D\uDD17 Graph</button>';
-      html += '<button class="edit-btn-disabled" title="Coming soon" disabled>\u270F Edit</button>';
-      html += '</div></div>';
-
-      // Frontmatter
-      if (data.frontmatter && Object.keys(data.frontmatter).length > 0) {
-        html += '<div class="preview-fm"><table class="fm-table">';
-        for (const [k, v] of Object.entries(data.frontmatter)) {
-          const val = typeof v === 'object' ? JSON.stringify(v) : String(v);
-          html += '<tr><td>' + escHtml(k) + '</td><td>' + escHtml(val) + '</td></tr>';
-        }
-        html += '</table></div>';
-      }
-
-      // Rendered markdown
-      let rendered = '';
-      if (typeof marked !== 'undefined' && data.content) {
-        rendered = marked.parse(data.content);
-      } else {
-        rendered = '<pre>' + escHtml(data.content || '') + '</pre>';
-      }
-      if (typeof DOMPurify !== 'undefined') {
-        rendered = DOMPurify.sanitize(rendered);
-      }
-      html += '<div class="preview-content">' + rendered + '</div>';
-
-      previewEl.innerHTML = html;
-
-      // Wire action buttons
-      document.getElementById('preview-browse-btn')?.addEventListener('click', () => {
-        switchTab('browse');
-      });
-      document.getElementById('preview-send-btn')?.addEventListener('click', () => {
-        window.sendToLLM(data.path, data.content || '');
-      });
-      document.getElementById('preview-ctx-btn')?.addEventListener('click', () => {
-        window.navigateTo('context', { path: data.path });
-      });
-      document.getElementById('preview-graph-btn')?.addEventListener('click', () => {
-        window.navigateTo('graph', { path: data.path });
-      });
-
-      window.updateContext('browser', path, data.title);
-    } catch (err) {
-      const errDiv = document.createElement('div');
-      errDiv.className = 'placeholder';
-      errDiv.textContent = 'Error: ' + (err.message || err);
-      previewEl.innerHTML = '';
-      previewEl.appendChild(errDiv);
-    }
   }
 
   // Search
@@ -177,7 +99,7 @@
         div.className = 'search-result';
         div.innerHTML = '<div class="search-result-title">' + escHtml(r.title || r.path) + '</div>'
           + '<div class="search-result-snippet">' + escHtml(r.snippet || '') + '</div>';
-        div.addEventListener('click', () => loadPreview(r.path));
+        div.addEventListener('click', () => window.loadPreview(r.path));
         treeEl.appendChild(div);
       }
       if (data.length === 0) {
@@ -197,15 +119,6 @@
 
   searchClear.addEventListener('click', exitSearch);
 
-  // Listen for navigation events
-  window.addEventListener('vault-navigate', (e) => {
-    if ((e.detail.view === 'browse' || e.detail.view === 'note') && e.detail.path) {
-      // When navigating to browse with a path, load the preview but stay on browse
-      const switchToNote = e.detail.view !== 'browse';
-      loadPreview(e.detail.path, { switchToNote });
-    }
-  });
-
   // Auto-load when browse tab is selected
   window.addEventListener('vault-tab-changed', (e) => {
     if (e.detail.tab === 'browse' && treeEl.children.length === 0 && !isSearchMode) {
@@ -214,5 +127,4 @@
   });
 
   window.loadBrowser = loadRootTree;
-  window.loadPreview = loadPreview;
 })();

--- a/src/markdown_vault_mcp/static/spa/views/browser.js
+++ b/src/markdown_vault_mcp/static/spa/views/browser.js
@@ -1,0 +1,218 @@
+// ── Vault Browser View ──────────────────────────────────────────────────
+(function() {
+  function escHtml(s) {
+    return String(s ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  let currentPreviewPath = null;
+  let currentPreviewData = null;
+  let treeDataCache = {};
+  let isSearchMode = false;
+
+  const treeEl = document.getElementById('browser-tree');
+  const previewEl = document.getElementById('browser-preview');
+  const searchInput = document.getElementById('browser-search-input');
+  const searchClear = document.getElementById('browser-search-clear');
+
+  async function loadFolder(folder) {
+    const key = folder || '__root__';
+    if (treeDataCache[key]) return treeDataCache[key];
+    try {
+      const result = await app.callServerTool({ name: 'vault___vault_list', arguments: { folder: folder || null } });
+      const data = parseToolResult(result);
+      if (!data) return { folders: [], notes: [] };
+      treeDataCache[key] = data;
+      return data;
+    } catch (err) {
+      console.warn('Failed to load folder:', err);
+      return { folders: [], notes: [] };
+    }
+  }
+
+  function renderTree(data, parentEl) {
+    parentEl.innerHTML = '';
+    // Folders
+    for (const f of data.folders) {
+      const name = f.includes('/') ? f.split('/').pop() : f;
+      const folderDiv = document.createElement('div');
+      folderDiv.className = 'tree-folder';
+      folderDiv.innerHTML = '<span class="arrow">\u25B6</span> \uD83D\uDCC1 ' + escHtml(name);
+      folderDiv.dataset.folder = f;
+      parentEl.appendChild(folderDiv);
+
+      const childrenDiv = document.createElement('div');
+      childrenDiv.className = 'tree-children';
+      parentEl.appendChild(childrenDiv);
+
+      folderDiv.addEventListener('click', async () => {
+        const isExpanded = folderDiv.classList.contains('expanded');
+        if (isExpanded) {
+          folderDiv.classList.remove('expanded');
+        } else {
+          folderDiv.classList.add('expanded');
+          if (childrenDiv.children.length === 0) {
+            const subData = await loadFolder(f);
+            renderTree(subData, childrenDiv);
+          }
+        }
+      });
+    }
+    // Notes
+    for (const n of data.notes) {
+      const noteDiv = document.createElement('div');
+      noteDiv.className = 'tree-note';
+      noteDiv.textContent = n.title || n.path;
+      noteDiv.title = n.path;
+      noteDiv.dataset.path = n.path;
+      noteDiv.addEventListener('click', () => loadPreview(n.path));
+      parentEl.appendChild(noteDiv);
+    }
+  }
+
+  async function loadRootTree() {
+    treeDataCache = {};
+    const data = await loadFolder(null);
+    renderTree(data, treeEl);
+  }
+
+  async function loadPreview(path, { switchToNote = true } = {}) {
+    currentPreviewPath = path;
+    currentPath = path; // sync shared state
+    // Show the Note tab button; switch to it unless caller opts out
+    document.getElementById('note-tab-btn').classList.add('visible');
+    if (switchToNote) switchTab('note');
+    // Highlight active note in tree
+    treeEl.querySelectorAll('.tree-note').forEach(el => {
+      el.classList.toggle('active', el.dataset.path === path);
+    });
+
+    try {
+      const result = await app.callServerTool({ name: 'vault___vault_read', arguments: { path } });
+      const data = parseToolResult(result);
+      if (!data) { previewEl.innerHTML = '<div class="placeholder">Note not found</div>'; return; }
+      currentPreviewData = data;
+
+      let html = '<div class="preview-header">';
+      html += '<h2>' + escHtml(data.title || path) + '</h2>';
+      html += '<div class="preview-actions">';
+      html += '<button class="action-btn action-btn--secondary" id="preview-browse-btn" title="Back to Browse">\u2190 Browse</button>';
+      html += '<button class="action-btn" id="preview-send-btn" title="Send to Claude">\uD83D\uDCAC Send</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-ctx-btn" title="Show Context">\uD83D\uDD0D Context</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-graph-btn" title="Show in Graph">\uD83D\uDD17 Graph</button>';
+      html += '<button class="edit-btn-disabled" title="Coming soon" disabled>\u270F Edit</button>';
+      html += '</div></div>';
+
+      // Frontmatter
+      if (data.frontmatter && Object.keys(data.frontmatter).length > 0) {
+        html += '<div class="preview-fm"><table class="fm-table">';
+        for (const [k, v] of Object.entries(data.frontmatter)) {
+          const val = typeof v === 'object' ? JSON.stringify(v) : String(v);
+          html += '<tr><td>' + escHtml(k) + '</td><td>' + escHtml(val) + '</td></tr>';
+        }
+        html += '</table></div>';
+      }
+
+      // Rendered markdown
+      let rendered = '';
+      if (typeof marked !== 'undefined' && data.content) {
+        rendered = marked.parse(data.content);
+      } else {
+        rendered = '<pre>' + escHtml(data.content || '') + '</pre>';
+      }
+      if (typeof DOMPurify !== 'undefined') {
+        rendered = DOMPurify.sanitize(rendered);
+      }
+      html += '<div class="preview-content">' + rendered + '</div>';
+
+      previewEl.innerHTML = html;
+
+      // Wire action buttons
+      document.getElementById('preview-browse-btn')?.addEventListener('click', () => {
+        switchTab('browse');
+      });
+      document.getElementById('preview-send-btn')?.addEventListener('click', () => {
+        window.sendToLLM(data.path, data.content || '');
+      });
+      document.getElementById('preview-ctx-btn')?.addEventListener('click', () => {
+        window.navigateTo('context', { path: data.path });
+      });
+      document.getElementById('preview-graph-btn')?.addEventListener('click', () => {
+        window.navigateTo('graph', { path: data.path });
+      });
+
+      window.updateContext('browser', path, data.title);
+    } catch (err) {
+      const errDiv = document.createElement('div');
+      errDiv.className = 'placeholder';
+      errDiv.textContent = 'Error: ' + (err.message || err);
+      previewEl.innerHTML = '';
+      previewEl.appendChild(errDiv);
+    }
+  }
+
+  // Search
+  let searchTimeout = null;
+  searchInput.addEventListener('input', () => {
+    clearTimeout(searchTimeout);
+    const q = searchInput.value.trim();
+    if (!q) { exitSearch(); return; }
+    searchTimeout = setTimeout(() => doSearch(q), 300);
+  });
+
+  async function doSearch(query) {
+    isSearchMode = true;
+    searchClear.style.display = '';
+    try {
+      const result = await app.callServerTool({
+        name: 'vault___vault_search', arguments: { query, mode: 'hybrid', limit: 20 }
+      });
+      const data = parseToolResult(result) || [];
+      treeEl.innerHTML = '';
+      for (const r of data) {
+        const div = document.createElement('div');
+        div.className = 'search-result';
+        div.innerHTML = '<div class="search-result-title">' + escHtml(r.title || r.path) + '</div>'
+          + '<div class="search-result-snippet">' + escHtml(r.snippet || '') + '</div>';
+        div.addEventListener('click', () => loadPreview(r.path));
+        treeEl.appendChild(div);
+      }
+      if (data.length === 0) {
+        treeEl.innerHTML = '<div class="placeholder" style="padding:12px">No results</div>';
+      }
+    } catch (err) {
+      treeEl.innerHTML = '<div class="placeholder" style="padding:12px">Search error</div>';
+    }
+  }
+
+  function exitSearch() {
+    isSearchMode = false;
+    searchClear.style.display = 'none';
+    searchInput.value = '';
+    loadRootTree();
+  }
+
+  searchClear.addEventListener('click', exitSearch);
+
+  // Listen for navigation events
+  window.addEventListener('vault-navigate', (e) => {
+    if ((e.detail.view === 'browse' || e.detail.view === 'note') && e.detail.path) {
+      // When navigating to browse with a path, load the preview but stay on browse
+      const switchToNote = e.detail.view !== 'browse';
+      loadPreview(e.detail.path, { switchToNote });
+    }
+  });
+
+  // Auto-load when browse tab is selected
+  window.addEventListener('vault-tab-changed', (e) => {
+    if (e.detail.tab === 'browse' && treeEl.children.length === 0 && !isSearchMode) {
+      loadRootTree();
+    }
+  });
+
+  window.loadBrowser = loadRootTree;
+  window.loadPreview = loadPreview;
+})();

--- a/src/markdown_vault_mcp/static/spa/views/context.js
+++ b/src/markdown_vault_mcp/static/spa/views/context.js
@@ -1,0 +1,192 @@
+// ── Context Card View ────────────────────────────────────────────────────
+(function() {
+  let currentContextPath = null;
+  let currentContextData = null;
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function makeSection(id, title, count, bodyHtml) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    if (count === 0 && !bodyHtml) { el.style.display = 'none'; return; }
+    el.style.display = '';
+    el.innerHTML = '<div class="section-header"><span>' + escapeHtml(title) + '</span><span class="badge">' + count + '</span></div>'
+      + '<div class="section-body">' + bodyHtml + '</div>';
+    el.classList.add('collapsed-section');
+    // toggle handled by delegated listener on #panel-context
+  }
+
+  function renderFrontmatter(fm) {
+    if (!fm || Object.keys(fm).length === 0) return '';
+    let rows = '';
+    for (const [k, v] of Object.entries(fm)) {
+      const val = typeof v === 'object' ? JSON.stringify(v) : String(v);
+      rows += '<tr><td>' + escapeHtml(k) + '</td><td>' + escapeHtml(val) + '</td></tr>';
+    }
+    return '<table class="fm-table">' + rows + '</table>';
+  }
+
+  function renderTags(tags) {
+    if (!tags || Object.keys(tags).length === 0) return '';
+    let html = '';
+    for (const [field, values] of Object.entries(tags)) {
+      html += '<div class="tag-group"><div class="tag-group-label">' + escapeHtml(field) + '</div>';
+      for (const v of values) {
+        html += '<span class="tag-pill">' + escapeHtml(v) + '</span>';
+      }
+      html += '</div>';
+    }
+    return html;
+  }
+
+  function renderBacklinks(backlinks) {
+    if (!backlinks || backlinks.length === 0) return '';
+    return backlinks.map(bl =>
+      '<div class="link-item" data-path="' + escapeHtml(bl.source_path) + '">'
+      + '<span class="link-path">' + escapeHtml(bl.source_path) + '</span>'
+      + (bl.link_text ? '<span class="link-text">' + escapeHtml(bl.link_text) + '</span>' : '')
+      + '<span class="link-type-badge">' + escapeHtml(bl.link_type) + '</span>'
+      + '</div>'
+    ).join('');
+  }
+
+  function renderOutlinks(outlinks) {
+    if (!outlinks || outlinks.length === 0) return '';
+    return outlinks.map(ol =>
+      '<div class="link-item" data-path="' + escapeHtml(ol.target_path) + '">'
+      + '<span class="link-path">' + escapeHtml(ol.target_path) + '</span>'
+      + '<span class="' + (ol.exists ? 'link-exists-yes' : 'link-exists-no') + '">' + (ol.exists ? '\u2713' : '\u2717') + '</span>'
+      + '<span class="link-type-badge">' + escapeHtml(ol.link_type) + '</span>'
+      + '</div>'
+    ).join('');
+  }
+
+  function renderSimilar(similar) {
+    if (!similar || similar.length === 0) return '';
+    const maxScore = Math.max(...similar.map(s => s.score), 0.001);
+    return similar.map(s =>
+      '<div class="link-item" data-path="' + escapeHtml(s.path) + '">'
+      + '<span class="link-path">' + escapeHtml(s.title || s.path) + '</span>'
+      + '<div class="similar-score"><div class="similar-score-fill" style="width:' + Math.round((s.score / maxScore) * 100) + '%"></div></div>'
+      + '</div>'
+    ).join('');
+  }
+
+  function renderPeers(peers) {
+    if (!peers || peers.length === 0) return '';
+    return peers.map(p =>
+      '<div class="link-item" data-path="' + escapeHtml(p) + '">'
+      + '<span class="link-path">' + escapeHtml(p) + '</span>'
+      + '</div>'
+    ).join('');
+  }
+
+  async function loadContext(path) {
+    const placeholder = document.getElementById('context-placeholder');
+    const card = document.getElementById('context-card');
+    if (!path) { placeholder.style.display = ''; card.style.display = 'none'; return; }
+    placeholder.style.display = 'none';
+    card.style.display = '';
+
+    try {
+      const result = await app.callServerTool({ name: 'vault___vault_context', arguments: { path } });
+      const data = parseToolResult(result);
+      if (!data) { placeholder.style.display = ''; card.style.display = 'none'; return; }
+      currentContextPath = path;
+      currentContextData = data;
+      currentPath = path; // sync shared state
+
+      document.getElementById('ctx-title').textContent = data.title || path;
+      document.getElementById('ctx-path').textContent = data.path;
+      document.getElementById('ctx-folder').textContent = data.folder ? '\uD83D\uDCC1 ' + data.folder : '';
+      document.getElementById('ctx-modified').textContent = '';
+      if (data.modified_at) {
+        const d = new Date(data.modified_at * 1000);
+        document.getElementById('ctx-modified').textContent = d.toLocaleString();
+      }
+
+      const fmCount = data.frontmatter ? Object.keys(data.frontmatter).length : 0;
+      makeSection('ctx-frontmatter', 'Frontmatter', fmCount, renderFrontmatter(data.frontmatter));
+      const tagCount = data.tags ? Object.values(data.tags).reduce((a, v) => a + v.length, 0) : 0;
+      makeSection('ctx-tags', 'Tags', tagCount, renderTags(data.tags));
+      makeSection('ctx-backlinks', 'Backlinks', (data.backlinks || []).length, renderBacklinks(data.backlinks));
+      makeSection('ctx-outlinks', 'Outlinks', (data.outlinks || []).length, renderOutlinks(data.outlinks));
+      makeSection('ctx-similar', 'Similar', (data.similar || []).length, renderSimilar(data.similar));
+      makeSection('ctx-peers', 'Folder Peers', (data.folder_notes || []).length, renderPeers(data.folder_notes));
+
+      // Auto-expand sections with content
+      for (const id of ['ctx-backlinks', 'ctx-outlinks']) {
+        const el = document.getElementById(id);
+        if (el && el.style.display !== 'none') el.classList.remove('collapsed-section');
+      }
+
+      window.updateContext('context card', path, data.title,
+        'Backlinks: ' + (data.backlinks || []).length + ', Outlinks: ' + (data.outlinks || []).length);
+    } catch (err) {
+      placeholder.style.display = '';
+      placeholder.textContent = 'Error loading context: ' + (err.message || String(err));
+      card.style.display = 'none';
+    }
+  }
+
+  // Delegated handler: link-item navigation + section-header toggle
+  document.getElementById('panel-context').addEventListener('click', (e) => {
+    const header = e.target.closest('.section-header');
+    if (header) { header.closest('.context-section')?.classList.toggle('collapsed-section'); return; }
+    const item = e.target.closest('.link-item[data-path]');
+    if (item) loadContext(item.dataset.path);
+  });
+
+  // Show in Graph
+  document.getElementById('ctx-graph-btn').addEventListener('click', () => {
+    if (currentContextPath) window.navigateTo('graph', { path: currentContextPath });
+  });
+
+  // Open in Browser
+  document.getElementById('ctx-browse-btn').addEventListener('click', () => {
+    if (currentContextPath) window.navigateTo('browse', { path: currentContextPath });
+  });
+
+  // Send to Claude
+  document.getElementById('ctx-send-btn').addEventListener('click', () => {
+    if (!currentContextData) return;
+    const d = currentContextData;
+    const lines = [
+      'Context for: ' + d.title + ' (' + d.path + ')',
+      'Backlinks: ' + (d.backlinks || []).length,
+      'Outlinks: ' + (d.outlinks || []).length,
+      'Similar: ' + (d.similar || []).length,
+    ];
+    if (d.backlinks && d.backlinks.length > 0) {
+      lines.push('Top backlinks: ' + d.backlinks.slice(0, 5).map(b => b.source_path).join(', '));
+    }
+    if (d.similar && d.similar.length > 0) {
+      lines.push('Top similar: ' + d.similar.slice(0, 3).map(s => s.title || s.path).join(', '));
+    }
+    window.sendToLLM(d.path, lines.join('\n'));
+  });
+
+  // Listen for navigation events
+  window.addEventListener('vault-navigate', (e) => {
+    if (e.detail.view === 'context' && e.detail.path) {
+      loadContext(e.detail.path);
+    }
+  });
+
+  // Sync to shared currentPath when switching to this tab
+  window.addEventListener('vault-tab-changed', (e) => {
+    if (e.detail.tab === 'context' && currentPath && currentPath !== currentContextPath) {
+      loadContext(currentPath);
+    }
+  });
+
+  // Expose for cross-view use
+  window.loadContext = loadContext;
+})();

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -1,0 +1,283 @@
+// ── Graph Explorer View ──────────────────────────────────────────────────
+(function() {
+  let network = null;
+  let nodesDS = null;
+  let edgesDS = null;
+  let graphCenterPath = null;
+  let selectedNodeId = null;
+  let semanticEnabled = false;
+
+  // Folder-based node colors — chosen to stand out on both light and dark backgrounds
+  const _FOLDER_COLORS = [
+    '#6366f1', // indigo
+    '#0ea5e9', // sky
+    '#10b981', // emerald
+    '#f59e0b', // amber
+    '#ef4444', // red
+    '#8b5cf6', // violet
+    '#06b6d4', // cyan
+    '#f97316', // orange
+  ];
+  function _folderColor(folder) {
+    if (!folder) return _FOLDER_COLORS[0];
+    let h = 0;
+    for (let i = 0; i < folder.length; i++) h = (h * 31 + folder.charCodeAt(i)) & 0x7fffffff;
+    return _FOLDER_COLORS[h % _FOLDER_COLORS.length];
+  }
+
+  // Color scheme for edges and UI chrome
+  function getColors() {
+    const s = getComputedStyle(document.documentElement);
+    return {
+      fg: s.getPropertyValue('--color-text-primary').trim() || '#1a1a1a',
+      accent: s.getPropertyValue('--color-text-info').trim() || '#6366f1',
+      muted: s.getPropertyValue('--color-text-secondary').trim() || '#6b7280',
+      border: s.getPropertyValue('--color-border-primary').trim() || '#e0e0e0',
+    };
+  }
+
+  const _SEMANTIC_EDGE_COLOR = '#a855f7'; // purple — distinct from folder node colors
+
+  function edgeColorByType(type, c) {
+    if (type === 'semantic') return _SEMANTIC_EDGE_COLOR;
+    if (type === 'wikilink') return c.accent;
+    if (type === 'reference') return c.muted;
+    return c.border; // markdown = default
+  }
+
+  function initNetwork() {
+    if (network) return;
+    const container = document.getElementById('graph-container');
+    if (!container || typeof vis === 'undefined') return;
+    const c = getColors();
+    nodesDS = new vis.DataSet();
+    edgesDS = new vis.DataSet();
+    const options = {
+      physics: { enabled: true, solver: 'forceAtlas2Based', forceAtlas2Based: { gravitationalConstant: -40 } },
+      nodes: {
+        shape: 'dot',
+        scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16 } },
+      },
+      edges: {
+        arrows: { to: { enabled: true, scaleFactor: 0.5 } }, font: { size: 9 }, smooth: { type: 'continuous' },
+      },
+      interaction: { hover: true, tooltipDelay: 200 },
+    };
+    network = new vis.Network(container, { nodes: nodesDS, edges: edgesDS }, options);
+
+    // Click: expand neighbors + center on clicked node
+    network.on('click', async (params) => {
+      if (params.nodes.length > 0) {
+        const nodeId = params.nodes[0];
+        selectedNodeId = nodeId;
+        currentPath = nodeId; // sync shared state
+        await expandNode(nodeId);
+        network.focus(nodeId, { scale: 1.2, animation: { duration: 400, easingFunction: 'easeInOutQuad' } });
+        showMiniCard(nodeId);
+      } else {
+        hideMiniCard();
+        selectedNodeId = null;
+      }
+    });
+
+    // Hover: tooltip is built-in via node.title
+    // Double-click: focus mode — clear graph and reload only this node's neighborhood
+    network.on('doubleClick', (params) => {
+      if (params.nodes.length > 0) {
+        const nodeId = params.nodes[0];
+        currentPath = nodeId;
+        loadGraph(nodeId);
+      }
+    });
+  }
+
+  function addGraphData(data) {
+    if (!nodesDS || !edgesDS) return;
+    const c = getColors();
+    for (const n of data.nodes) {
+      if (!nodesDS.get(n.id)) {
+        const bc = n.backlink_count || 0;
+        const baseColor = n.group === 'orphan' ? '#94a3b8' : _folderColor(n.folder);
+        nodesDS.add({
+          id: n.id, label: n.label,
+          value: Math.max(bc, 1),
+          title: n.label + (n.folder ? ' (' + n.folder + ')' : '') + (bc > 0 ? ' \u2014 ' + bc + ' backlinks' : ''),
+          color: {
+            background: baseColor,
+            border: n.group === 'hub' ? '#ffffff' : baseColor,
+            highlight: { background: baseColor, border: '#ffffff' },
+            hover: { background: baseColor, border: '#ffffff' },
+          },
+          font: { color: '#ffffff', size: 12 },
+          borderWidth: n.group === 'hub' ? 3 : (n.group === 'orphan' ? 1 : 2),
+          borderWidthSelected: 4,
+          shapeProperties: n.group === 'orphan' ? { borderDashes: [5, 5] } : {},
+        });
+      }
+    }
+    for (const e of data.edges) {
+      const isSemantic = e.type === 'semantic';
+      // Semantic edges are undirected — use canonical key to avoid duplicates
+      const edgeId = isSemantic
+        ? 'sem:' + [e.from, e.to].sort().join('<>')
+        : e.from + '->' + e.to;
+      if (!edgesDS.get(edgeId)) {
+        edgesDS.add({
+          id: edgeId, from: e.from, to: e.to,
+          color: { color: edgeColorByType(e.type, c), highlight: _SEMANTIC_EDGE_COLOR },
+          title: e.type,
+          dashes: isSemantic,
+          width: isSemantic ? 1 : 1.5,
+          arrows: isSemantic ? '' : { to: { enabled: true, scaleFactor: 0.5 } },
+        });
+      }
+    }
+  }
+
+  async function expandNode(path) {
+    try {
+      const result = await app.callServerTool({
+        name: 'vault___vault_graph_neighborhood',
+        arguments: { path, depth: 1, include_semantic: semanticEnabled },
+      });
+      const data = parseToolResult(result);
+      if (!data) return;
+      addGraphData(data);
+      const truncSuffix = data.truncated ? ' (truncated — zoom in for more)' : '';
+      window.updateContext('graph explorer', path, nodesDS.get(path)?.label,
+        'Visible: ' + nodesDS.length + ' notes, ' + edgesDS.length + ' links' + truncSuffix);
+    } catch (err) {
+      console.warn('Graph expand failed:', err);
+    }
+  }
+
+  async function loadHubs() {
+    try {
+      const result = await app.callServerTool({ name: 'vault___vault_graph_hubs', arguments: {} });
+      const data = parseToolResult(result);
+      if (!data) return;
+      addGraphData(data);
+      if (data.nodes.length > 0) {
+        window.updateContext('graph explorer', '(hub view)', null,
+          'Showing ' + data.nodes.length + ' most-linked notes');
+      }
+    } catch (err) {
+      console.warn('Graph hubs failed:', err);
+    }
+  }
+
+  async function loadGraph(path) {
+    initNetwork();
+    if (!nodesDS || !edgesDS) return;  // vis CDN failed to load
+    nodesDS.clear();
+    edgesDS.clear();
+    graphCenterPath = path || null;
+    if (path) {
+      await expandNode(path);
+      network.fit({ animation: true });
+    } else {
+      await loadHubs();
+      network.fit({ animation: true });
+    }
+  }
+
+  // Mini context card on single click
+  function showMiniCard(nodeId) {
+    const card = document.getElementById('graph-mini-card');
+    app.callServerTool({ name: 'vault___vault_context', arguments: { path: nodeId } }).then(result => {
+      const data = parseToolResult(result);
+      if (!data) { card.style.display = 'none'; return; }
+      const bl = (data.backlinks || []).slice(0, 3);
+      const ol = (data.outlinks || []).slice(0, 3);
+      let html = '<h4>' + escHtml(data.title || nodeId) + '</h4>';
+      if (data.tags && Object.keys(data.tags).length > 0) {
+        const allTags = Object.values(data.tags).flat().slice(0, 5);
+        html += '<div>' + allTags.map(t => '<span class="tag-pill" style="font-size:10px">' + escHtml(t) + '</span>').join(' ') + '</div>';
+      }
+      if (bl.length > 0) {
+        html += '<div class="mini-links"><strong>Backlinks:</strong>';
+        for (const b of bl) html += '<div class="mini-link" data-path="' + escHtml(b.source_path) + '">' + escHtml(b.source_path) + '</div>';
+        html += '</div>';
+      }
+      if (ol.length > 0) {
+        html += '<div class="mini-links"><strong>Outlinks:</strong>';
+        for (const o of ol) html += '<div class="mini-link" data-path="' + escHtml(o.target_path) + '">' + escHtml(o.target_path) + '</div>';
+        html += '</div>';
+      }
+      html += '<div class="mini-actions">'
+        + '<button id="mini-full-ctx">Full Context</button>'
+        + '<button id="mini-open-browser">Open in Browser</button>'
+        + '</div>';
+      card.innerHTML = html;
+      card.style.display = '';
+
+      card.querySelector('#mini-full-ctx')?.addEventListener('click', () => {
+        window.navigateTo('context', { path: nodeId });
+        hideMiniCard();
+      });
+      card.querySelector('#mini-open-browser')?.addEventListener('click', () => {
+        window.navigateTo('browse', { path: nodeId });
+        hideMiniCard();
+      });
+      card.querySelectorAll('.mini-link').forEach(el => {
+        el.addEventListener('click', () => expandNode(el.dataset.path));
+      });
+    }).catch(() => { card.style.display = 'none'; });
+  }
+
+  function hideMiniCard() {
+    document.getElementById('graph-mini-card').style.display = 'none';
+  }
+
+  // Send graph summary to Claude
+  document.getElementById('graph-send-btn').addEventListener('click', () => {
+    if (!nodesDS || nodesDS.length === 0) return;
+    const center = graphCenterPath || 'hub view';
+    const nodeLabels = nodesDS.get().map(n => n.label).slice(0, 20).join(', ');
+    const summary = 'Graph around ' + center + ': ' + nodesDS.length + ' notes, '
+      + edgesDS.length + ' links\nNotes: ' + nodeLabels;
+    window.sendToLLM(center, summary);
+  });
+
+  // Fullscreen for graph
+  document.getElementById('graph-fullscreen-btn').addEventListener('click', async () => {
+    try { await app.requestDisplayMode({ mode: 'fullscreen' }); } catch (e) { console.warn(e); }
+  });
+
+  // Semantic toggle: reload graph with/without semantic edges
+  document.getElementById('graph-semantic-btn').addEventListener('click', () => {
+    semanticEnabled = !semanticEnabled;
+    const btn = document.getElementById('graph-semantic-btn');
+    if (semanticEnabled) {
+      btn.style.background = _SEMANTIC_EDGE_COLOR;
+      btn.style.color = '#ffffff';
+      btn.style.border = 'none';
+    } else {
+      btn.style.background = 'var(--color-background-secondary)';
+      btn.style.color = 'var(--color-text-primary)';
+      btn.style.border = '1px solid var(--color-border-primary)';
+    }
+    // Reload current graph with updated setting
+    if (graphCenterPath) loadGraph(graphCenterPath);
+  });
+
+  // Listen for navigation events
+  window.addEventListener('vault-navigate', (e) => {
+    if (e.detail.view === 'graph') {
+      loadGraph(e.detail.path || null);
+    }
+  });
+
+  // Sync to shared currentPath when switching to this tab
+  window.addEventListener('vault-tab-changed', (e) => {
+    if (e.detail.tab === 'graph') {
+      if (currentPath && currentPath !== graphCenterPath) {
+        loadGraph(currentPath);
+      } else if (!nodesDS || nodesDS.length === 0) {
+        loadGraph(graphCenterPath);
+      }
+    }
+  });
+
+  window.loadGraph = loadGraph;
+})();

--- a/src/markdown_vault_mcp/static/spa/views/note.js
+++ b/src/markdown_vault_mcp/static/spa/views/note.js
@@ -1,0 +1,101 @@
+// ── Note Preview View ────────────────────────────────────────────────────
+(function() {
+  function escHtml(s) {
+    return String(s ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  let currentPreviewPath = null;
+  let currentPreviewData = null;
+
+  const previewEl = document.getElementById('browser-preview');
+
+  async function loadPreview(path, { switchToNote = true } = {}) {
+    currentPreviewPath = path;
+    currentPath = path; // sync shared state
+    // Show the Note tab button; switch to it unless caller opts out
+    document.getElementById('note-tab-btn').classList.add('visible');
+    if (switchToNote) switchTab('note');
+    // Highlight active note in the browser tree
+    document.getElementById('browser-tree')?.querySelectorAll('.tree-note').forEach(el => {
+      el.classList.toggle('active', el.dataset.path === path);
+    });
+
+    try {
+      const result = await app.callServerTool({ name: 'vault___vault_read', arguments: { path } });
+      const data = parseToolResult(result);
+      if (!data) { previewEl.innerHTML = '<div class="placeholder">Note not found</div>'; return; }
+      currentPreviewData = data;
+
+      let html = '<div class="preview-header">';
+      html += '<h2>' + escHtml(data.title || path) + '</h2>';
+      html += '<div class="preview-actions">';
+      html += '<button class="action-btn action-btn--secondary" id="preview-browse-btn" title="Back to Browse">← Browse</button>';
+      html += '<button class="action-btn" id="preview-send-btn" title="Send to Claude">💬 Send</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-ctx-btn" title="Show Context">🔍 Context</button>';
+      html += '<button class="action-btn action-btn--secondary" id="preview-graph-btn" title="Show in Graph">🔗 Graph</button>';
+      html += '<button class="edit-btn-disabled" title="Coming soon" disabled>✏ Edit</button>';
+      html += '</div></div>';
+
+      // Frontmatter
+      if (data.frontmatter && Object.keys(data.frontmatter).length > 0) {
+        html += '<div class="preview-fm"><table class="fm-table">';
+        for (const [k, v] of Object.entries(data.frontmatter)) {
+          const val = typeof v === 'object' ? JSON.stringify(v) : String(v);
+          html += '<tr><td>' + escHtml(k) + '</td><td>' + escHtml(val) + '</td></tr>';
+        }
+        html += '</table></div>';
+      }
+
+      // Rendered markdown
+      let rendered = '';
+      if (typeof marked !== 'undefined' && data.content) {
+        rendered = marked.parse(data.content);
+      } else {
+        rendered = '<pre>' + escHtml(data.content || '') + '</pre>';
+      }
+      if (typeof DOMPurify !== 'undefined') {
+        rendered = DOMPurify.sanitize(rendered);
+      }
+      html += '<div class="preview-content">' + rendered + '</div>';
+
+      previewEl.innerHTML = html;
+
+      // Wire action buttons
+      document.getElementById('preview-browse-btn')?.addEventListener('click', () => {
+        switchTab('browse');
+      });
+      document.getElementById('preview-send-btn')?.addEventListener('click', () => {
+        window.sendToLLM(data.path, data.content || '');
+      });
+      document.getElementById('preview-ctx-btn')?.addEventListener('click', () => {
+        window.navigateTo('context', { path: data.path });
+      });
+      document.getElementById('preview-graph-btn')?.addEventListener('click', () => {
+        window.navigateTo('graph', { path: data.path });
+      });
+
+      window.updateContext('browser', path, data.title);
+    } catch (err) {
+      const errDiv = document.createElement('div');
+      errDiv.className = 'placeholder';
+      errDiv.textContent = 'Error: ' + (err.message || err);
+      previewEl.innerHTML = '';
+      previewEl.appendChild(errDiv);
+    }
+  }
+
+  // Listen for navigation events
+  window.addEventListener('vault-navigate', (e) => {
+    if ((e.detail.view === 'browse' || e.detail.view === 'note') && e.detail.path) {
+      // When navigating to browse with a path, load the preview but stay on browse
+      const switchToNote = e.detail.view !== 'browse';
+      loadPreview(e.detail.path, { switchToNote });
+    }
+  });
+
+  window.loadPreview = loadPreview;
+})();

--- a/tests/test_apps_vendoring.py
+++ b/tests/test_apps_vendoring.py
@@ -17,18 +17,22 @@ def test_app_html_is_served_with_tools_rewritten() -> None:
     assert "app___" not in html  # every literal rewritten
 
 
-def test_note_view_reaches_served_html() -> None:
-    """The extracted note-preview view (views/note.js) must reach the served
-    app.html.
+def test_all_view_modules_reach_served_html() -> None:
+    """Every view partial's ``/*@@FILE:views/*.js@@*/`` marker must survive
+    assembly into the served app.html.
 
-    Guards against its ``/*@@FILE:views/note.js@@*/`` marker being dropped from
-    core.js — a regression the build/vendor ``--check`` gates would not catch
-    (they compare committed vs freshly assembled, both of which would then lack
-    the view). Asserts on note.js body markers, not the shell's ``data-tab``
-    markup (which survives even if the view module is orphaned)."""
+    A dropped marker is invisible to the build/vendor ``--check`` gates (the
+    committed app.src.html and a fresh assembly would *both* lack the view), so
+    assert a banner string unique to each view module is present. Each phrase
+    below appears only in its own ``views/*.js`` partial."""
     html = apps._SPA_SHELL_HTML
-    assert "loadPreview" in html
-    assert "preview-browse-btn" in html
+    for banner in (
+        "Context Card View",
+        "Graph Explorer View",
+        "Vault Browser View",
+        "Note Preview View",
+    ):
+        assert banner in html, f"view module missing from served HTML: {banner}"
 
 
 def test_build_check_is_clean() -> None:

--- a/tests/test_apps_vendoring.py
+++ b/tests/test_apps_vendoring.py
@@ -49,6 +49,27 @@ def test_build_check_detects_drift() -> None:
         partial.write_text(original, encoding="utf-8")
 
 
+def test_build_rejects_malformed_marker() -> None:
+    """A malformed include marker fails the build loudly instead of silently
+    omitting the partial (residual @@FILE guard)."""
+    repo = Path(__file__).resolve().parent.parent
+    partial = repo / "src" / "markdown_vault_mcp" / "static" / "spa" / "styles.css"
+    original = partial.read_text(encoding="utf-8")
+    try:
+        # Missing colon -> never matches the marker regex -> survives expansion.
+        partial.write_text(original + "\n/*@@FILE styles.css@@*/\n", encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(repo / "scripts" / "build_spa.py"), "--check"],
+            capture_output=True,
+            text=True,
+            cwd=repo,
+        )
+        assert result.returncode != 0
+        assert "@@FILE include marker survived" in result.stderr
+    finally:
+        partial.write_text(original, encoding="utf-8")
+
+
 def test_vendor_check_is_clean() -> None:
     """The committed app.html matches app.src.html (offline --check)."""
     repo = Path(__file__).resolve().parent.parent

--- a/tests/test_apps_vendoring.py
+++ b/tests/test_apps_vendoring.py
@@ -43,47 +43,6 @@ def test_build_check_is_clean() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_build_check_detects_drift() -> None:
-    """Mutating a spa/ partial makes build --check fail (anti-drift gate works)."""
-    repo = Path(__file__).resolve().parent.parent
-    partial = (
-        repo / "src" / "markdown_vault_mcp" / "static" / "spa" / "views" / "context.js"
-    )
-    original = partial.read_text(encoding="utf-8")
-    try:
-        partial.write_text(original + "\n// drift\n", encoding="utf-8")
-        result = subprocess.run(
-            [sys.executable, str(repo / "scripts" / "build_spa.py"), "--check"],
-            capture_output=True,
-            text=True,
-            cwd=repo,
-        )
-        assert result.returncode == 1
-    finally:
-        partial.write_text(original, encoding="utf-8")
-
-
-def test_build_rejects_malformed_marker() -> None:
-    """A malformed include marker fails the build loudly instead of silently
-    omitting the partial (residual @@FILE guard)."""
-    repo = Path(__file__).resolve().parent.parent
-    partial = repo / "src" / "markdown_vault_mcp" / "static" / "spa" / "styles.css"
-    original = partial.read_text(encoding="utf-8")
-    try:
-        # Missing colon -> never matches the marker regex -> survives expansion.
-        partial.write_text(original + "\n/*@@FILE styles.css@@*/\n", encoding="utf-8")
-        result = subprocess.run(
-            [sys.executable, str(repo / "scripts" / "build_spa.py"), "--check"],
-            capture_output=True,
-            text=True,
-            cwd=repo,
-        )
-        assert result.returncode != 0
-        assert "@@FILE include marker survived" in result.stderr
-    finally:
-        partial.write_text(original, encoding="utf-8")
-
-
 def test_vendor_check_is_clean() -> None:
     """The committed app.html matches app.src.html (offline --check)."""
     repo = Path(__file__).resolve().parent.parent

--- a/tests/test_apps_vendoring.py
+++ b/tests/test_apps_vendoring.py
@@ -17,6 +17,20 @@ def test_app_html_is_served_with_tools_rewritten() -> None:
     assert "app___" not in html  # every literal rewritten
 
 
+def test_note_view_reaches_served_html() -> None:
+    """The extracted note-preview view (views/note.js) must reach the served
+    app.html.
+
+    Guards against its ``/*@@FILE:views/note.js@@*/`` marker being dropped from
+    core.js — a regression the build/vendor ``--check`` gates would not catch
+    (they compare committed vs freshly assembled, both of which would then lack
+    the view). Asserts on note.js body markers, not the shell's ``data-tab``
+    markup (which survives even if the view module is orphaned)."""
+    html = apps._SPA_SHELL_HTML
+    assert "loadPreview" in html
+    assert "preview-browse-btn" in html
+
+
 def test_build_check_is_clean() -> None:
     """The committed app.src.html matches the spa/ partials (offline --check)."""
     repo = Path(__file__).resolve().parent.parent

--- a/tests/test_apps_vendoring.py
+++ b/tests/test_apps_vendoring.py
@@ -17,6 +17,38 @@ def test_app_html_is_served_with_tools_rewritten() -> None:
     assert "app___" not in html  # every literal rewritten
 
 
+def test_build_check_is_clean() -> None:
+    """The committed app.src.html matches the spa/ partials (offline --check)."""
+    repo = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        [sys.executable, str(repo / "scripts" / "build_spa.py"), "--check"],
+        capture_output=True,
+        text=True,
+        cwd=repo,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_build_check_detects_drift() -> None:
+    """Mutating a spa/ partial makes build --check fail (anti-drift gate works)."""
+    repo = Path(__file__).resolve().parent.parent
+    partial = (
+        repo / "src" / "markdown_vault_mcp" / "static" / "spa" / "views" / "context.js"
+    )
+    original = partial.read_text(encoding="utf-8")
+    try:
+        partial.write_text(original + "\n// drift\n", encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(repo / "scripts" / "build_spa.py"), "--check"],
+            capture_output=True,
+            text=True,
+            cwd=repo,
+        )
+        assert result.returncode == 1
+    finally:
+        partial.write_text(original, encoding="utf-8")
+
+
 def test_vendor_check_is_clean() -> None:
     """The committed app.html matches app.src.html (offline --check)."""
     repo = Path(__file__).resolve().parent.parent

--- a/tests/test_build_spa.py
+++ b/tests/test_build_spa.py
@@ -102,6 +102,16 @@ def test_assemble_rejects_missing_partial(spa_copy: Path) -> None:
         build_spa.assemble(spa_copy)
 
 
+def test_main_writes_assembled_source(
+    spa_copy: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-check ``main()`` writes the assembled app.src.html next to ``spa/``."""
+    monkeypatch.setattr(build_spa, "_find_spa_dir", lambda: spa_copy)
+    assert build_spa.main(["build_spa.py"]) == 0
+    written = (tmp_path / "app.src.html").read_text(encoding="utf-8")
+    assert written == build_spa.assemble(spa_copy)
+
+
 def test_check_reports_up_to_date(
     spa_copy: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_build_spa.py
+++ b/tests/test_build_spa.py
@@ -1,0 +1,122 @@
+"""Unit tests for the modular-SPA assembler (``scripts/build_spa.py``).
+
+These exercise the assembler and its guards against **temporary copies** of the
+real ``static/spa/`` partials, so no committed file is ever mutated (unlike a
+subprocess-against-the-tree approach).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_REPO = Path(__file__).resolve().parent.parent
+_REAL_SPA = _REPO / "src" / "markdown_vault_mcp" / "static" / "spa"
+_COMMITTED_SRC = _REAL_SPA.parent / "app.src.html"
+
+
+def _load_build_spa() -> ModuleType:
+    """Import scripts/build_spa.py (not an installed package) by file path."""
+    spec = importlib.util.spec_from_file_location(
+        "build_spa", _REPO / "scripts" / "build_spa.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+build_spa = _load_build_spa()
+
+
+@pytest.fixture
+def spa_copy(tmp_path: Path) -> Path:
+    """A writable copy of the real ``spa/`` partials under ``tmp_path``."""
+    dest = tmp_path / "spa"
+    shutil.copytree(_REAL_SPA, dest)
+    return dest
+
+
+def _patch_shell(spa_dir: Path, old: str, new: str, count: int = 1) -> None:
+    shell = spa_dir / "shell.html"
+    shell.write_text(shell.read_text().replace(old, new, count), encoding="utf-8")
+
+
+def test_assemble_reproduces_committed_source(spa_copy: Path) -> None:
+    """Assembling the real partials reproduces the committed app.src.html."""
+    assert build_spa.assemble(spa_copy) == _COMMITTED_SRC.read_text(encoding="utf-8")
+
+
+def test_assemble_injects_banner_after_doctype(spa_copy: Path) -> None:
+    """The generated banner is injected right after the doctype (not before,
+    which would risk quirks mode; not stored in shell.html)."""
+    out = build_spa.assemble(spa_copy)
+    assert out.startswith("<!DOCTYPE html>\n<!-- GENERATED FILE")
+    assert "GENERATED FILE" not in (spa_copy / "shell.html").read_text()
+
+
+def test_assemble_rejects_malformed_marker(spa_copy: Path) -> None:
+    """A colon-less marker never matches the regex, survives as literal text,
+    and is caught by the residual-@@FILE guard rather than silently dropped."""
+    css = spa_copy / "styles.css"
+    css.write_text(css.read_text() + "\n/*@@FILE styles.css@@*/\n", encoding="utf-8")
+    with pytest.raises(SystemExit, match="@@FILE include marker survived"):
+        build_spa.assemble(spa_copy)
+
+
+def test_assemble_rejects_include_cycle(spa_copy: Path) -> None:
+    """A partial that includes itself trips the recursion-depth guard (a loud
+    SystemExit rather than a bare RecursionError)."""
+    (spa_copy / "loop.js").write_text("/*@@FILE:loop.js@@*/", encoding="utf-8")
+    _patch_shell(spa_copy, "/*@@FILE:core.js@@*/", "/*@@FILE:loop.js@@*/")
+    with pytest.raises(SystemExit, match="recursion too deep"):
+        build_spa.assemble(spa_copy)
+
+
+def test_assemble_rejects_missing_doctype(spa_copy: Path) -> None:
+    """A shell that does not open with the doctype is rejected (the banner
+    splice depends on the doctype being the first line)."""
+    _patch_shell(spa_copy, "<!DOCTYPE html>\n", "")
+    with pytest.raises(SystemExit, match="must begin with"):
+        build_spa.assemble(spa_copy)
+
+
+def test_assemble_rejects_path_escape(spa_copy: Path) -> None:
+    """An include marker resolving outside spa/ is rejected."""
+    _patch_shell(spa_copy, "/*@@FILE:core.js@@*/", "/*@@FILE:../escape.js@@*/")
+    with pytest.raises(SystemExit, match="escapes spa/ dir"):
+        build_spa.assemble(spa_copy)
+
+
+def test_assemble_rejects_missing_partial(spa_copy: Path) -> None:
+    """A well-formed marker pointing at a nonexistent partial is rejected."""
+    _patch_shell(spa_copy, "/*@@FILE:core.js@@*/", "/*@@FILE:nope.js@@*/")
+    with pytest.raises(SystemExit, match="not found"):
+        build_spa.assemble(spa_copy)
+
+
+def test_check_reports_up_to_date(
+    spa_copy: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--check`` returns 0 when the sibling app.src.html matches the partials."""
+    (tmp_path / "app.src.html").write_text(
+        build_spa.assemble(spa_copy), encoding="utf-8"
+    )
+    monkeypatch.setattr(build_spa, "_find_spa_dir", lambda: spa_copy)
+    assert build_spa.main(["build_spa.py", "--check"]) == 0
+
+
+def test_check_reports_stale(
+    spa_copy: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--check`` returns 1 when the sibling app.src.html is stale."""
+    (tmp_path / "app.src.html").write_text("<!DOCTYPE html>\nstale\n", encoding="utf-8")
+    monkeypatch.setattr(build_spa, "_find_spa_dir", lambda: spa_copy)
+    assert build_spa.main(["build_spa.py", "--check"]) == 1


### PR DESCRIPTION
## Restructure the MCP-apps SPA into modular partials + `build_spa.py`

Closes #810. Part of the Vault Views "Paper" redesign epic (#809) — the
foundational refactor that makes the single ~52 KB `static/app.src.html`
maintainable before the redesign lands on top.

### What

Author the SPA as small partials under `src/markdown_vault_mcp/static/spa/`
and assemble them into the single `app.src.html` the (template-owned)
`vendor_spa.py` requires:

| File | Contents |
|------|----------|
| `shell.html` | HTML document: head, tab bar, view panels, toast |
| `styles.css` | all styles |
| `core.js` | app setup, theming, tab nav, cross-view routing, shared helpers |
| `views/{context,graph,browser,note}.js` | one file per view |

A new project-owned `scripts/build_spa.py` assembles them via recursive
`/*@@FILE:path@@*/` include markers (a valid comment in both CSS and JS, so each
partial stays independently parseable), injecting a "generated — do not edit"
banner. Build pipeline:

```
spa/*  ->  build_spa.py  ->  app.src.html  ->  vendor_spa.py  ->  app.html
```

Note-preview logic — previously sharing the Vault Browser IIFE's closure — is
extracted into its own `views/note.js` via the existing `window.loadPreview`
seam, so the redesign's Browser (#813) and Note Preview (#814) work will touch
separate files.

### Behavior-preserving

This is a pure structural move. The vendored `app.html` is unchanged apart from
a generated-file banner, blank lines between view sections, and the vendor
source-hash marker; the note extraction was verified by a line-level diff to be
only the relocation + the `window.loadPreview` seam + a tree-lookup rewrite — no
logic changed. All existing `test_mcp_apps_*` tests stay green.

### Gates

- New `build_spa.py --check` wired into `ci.yml` + `.pre-commit-config.yaml`
  (before the vendor check), mirroring `vendor_spa --check`.
- `tests/test_build_spa.py`: a `tmp_path`-based unit suite (no committed-file
  mutation) covering the assemble round-trip, banner injection, and every guard
  — malformed marker, include cycle, missing doctype, path escape, missing
  partial — plus `main()`'s `--check` and write paths.
- `tests/test_apps_vendoring.py`: `test_all_view_modules_reach_served_html`
  guards every view against a dropped include marker (a regression `--check`
  alone cannot catch).
- `docs/guides/mcp-apps.md` documents the source layout and two-stage build.

### Review

Ran the local preflight-circus (five core lenses + code-reviewer,
silent-failure-hunter, pr-test-analyzer, comment-analyzer) to convergence.

### Follow-up (not in this PR)

`scripts/vendor_spa.py` is **template-owned** and its docstring still calls
`app.src.html` "human-editable", which is stale once `build_spa.py` generates
it. The durable fix belongs upstream in `fastmcp-server-template` (a local edit
would break the file's byte-identity and be overwritten by copier), so it is
left untouched here — `build_spa.py`'s own docstring + `docs/` state the
generated-artifact contract authoritatively. Tracked separately for upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
