### PR TITLE
docs: SPA build note in design.md + _find_spa_dir branch tests (#817)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -2198,6 +2198,8 @@ MCP Apps are browser-based views that MCP clients supporting the protocol can re
 - `DOMPurify`: XSS sanitization for all rendered HTML
 - `@modelcontextprotocol/ext-apps`: MCP Apps SDK lifecycle and theming
 
+**Source layout and build**: the SPA is authored as partials under `src/markdown_vault_mcp/static/spa/` (`shell.html`, `styles.css`, `core.js`, and one `views/*.js` per view). `scripts/build_spa.py` assembles them into `static/app.src.html` via recursive `/*@@FILE:path@@*/` include markers, then `scripts/vendor_spa.py` embeds the vendored libraries into the served `static/app.html`. Both `app.src.html` and `app.html` are generated, committed artifacts; edit the partials, not the generated files. Each script has a `--check` mode that gates the build in CI and pre-commit, so a stale artifact fails fast.
+
 **Domain configuration**: MCP Apps iframes are sandboxed to a specific Claude app domain. The server computes it from `MARKDOWN_VAULT_MCP_BASE_URL` via `_compute_claude_app_domain()`. Override with `MARKDOWN_VAULT_MCP_APP_DOMAIN` when `BASE_URL` does not reflect the actual hostname visible to the Claude client (such as behind a proxy, or on a custom domain).
 
 | Variable | Default | Description |

--- a/tests/test_build_spa.py
+++ b/tests/test_build_spa.py
@@ -130,3 +130,33 @@ def test_check_reports_stale(
     (tmp_path / "app.src.html").write_text("<!DOCTYPE html>\nstale\n", encoding="utf-8")
     monkeypatch.setattr(build_spa, "_find_spa_dir", lambda: spa_copy)
     assert build_spa.main(["build_spa.py", "--check"]) == 1
+
+
+def _point_discovery_at(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Relocate the module ``__file__`` so ``_find_spa_dir`` globs under ``tmp_path/src``."""
+    monkeypatch.setattr(
+        build_spa, "__file__", str(tmp_path / "scripts" / "build_spa.py")
+    )
+
+
+def test_find_spa_dir_errors_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ``src/*/static/spa/shell.html`` under the repo → loud SystemExit."""
+    _point_discovery_at(tmp_path, monkeypatch)
+    (tmp_path / "src").mkdir()
+    with pytest.raises(SystemExit, match=r"no .*shell\.html found under"):
+        build_spa._find_spa_dir()
+
+
+def test_find_spa_dir_errors_when_multiple(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """More than one ``spa/shell.html`` under the repo → loud SystemExit."""
+    _point_discovery_at(tmp_path, monkeypatch)
+    for pkg in ("a", "b"):
+        d = tmp_path / "src" / pkg / "static" / "spa"
+        d.mkdir(parents=True)
+        (d / "shell.html").write_text("<!DOCTYPE html>\n", encoding="utf-8")
+    with pytest.raises(SystemExit, match=r"multiple .*shell\.html found"):
+        build_spa._find_spa_dir()


### PR DESCRIPTION
## Follow-ups from the #816 code review

Closes #817. Two minor, non-blocking items the claude-review bot flagged on #816 (#810):

1. **`docs/design.md`** — add a "Source layout and build" note to the MCP Apps section documenting the `static/spa/` partial layout and the two-stage `build_spa.py` → `vendor_spa.py` pipeline (both artifacts generated + `--check`-gated), mirroring the `docs/guides/mcp-apps.md` section added in #816. The authoritative spec now reflects the architectural change (Documentation Discipline).
2. **`tests/test_build_spa.py`** — cover `_find_spa_dir()`'s two `SystemExit` branches (no `shell.html` found / multiple found) by relocating the module `__file__` to a `tmp_path` with zero, then two, matches.

Gates green: pytest, ruff, mypy, structural 100%, vale, build/vendor `--check`. Local preflight-circus clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
