### PR TITLE
fix: derive vector sidecar paths with with_suffix, not string append

### DIFF
--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -10,12 +10,12 @@ routine so the logic lives in a single place.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
+    from pathlib import Path
 
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.vector_index import VectorIndex
@@ -90,7 +90,12 @@ def load_or_self_heal(
             )
             raise
 
-    npy_path = Path(str(embeddings_path) + ".npy")
+    # Derive the sidecar path exactly as VectorIndex.load/save do
+    # (Path.with_suffix), so a base path that already carries an extension
+    # (e.g. EMBEDDINGS_PATH=embeddings.npy) resolves to the same file that was
+    # saved. A string-append would probe embeddings.npy.npy, miss the real
+    # store, cold-build an empty index, and later overwrite the store (#736).
+    npy_path = embeddings_path.with_suffix(".npy")
     if npy_path.exists():
         try:
             set_vectors(VectorIndex.load(embeddings_path, embedding_provider))

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -13,7 +13,6 @@ import logging
 import sqlite3
 import time
 from collections import Counter
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -29,6 +28,7 @@ from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
     from markdown_vault_mcp.fts_index import FTSIndex
     from markdown_vault_mcp.providers import EmbeddingProvider
@@ -898,9 +898,13 @@ class IndexManager:
         if vectors is not None:
             count = vectors.count
         else:
-            npy_path = Path(str(self._embeddings_path) + ".npy")
+            # Derive sidecar paths the way VectorIndex.load/save do
+            # (Path.with_suffix), so an EMBEDDINGS_PATH that carries an
+            # extension resolves to the real files instead of {path}.npy.npy
+            # and misreporting chunk_count=0 (#736).
+            npy_path = self._embeddings_path.with_suffix(".npy")
             if npy_path.exists():
-                json_path = Path(str(self._embeddings_path) + ".json")
+                json_path = self._embeddings_path.with_suffix(".json")
                 if json_path.exists():
                     try:
                         with json_path.open(encoding="utf-8") as fh:

--- a/tests/test_vector_loader.py
+++ b/tests/test_vector_loader.py
@@ -329,6 +329,38 @@ def test_rebuild_that_raises_is_logged_then_propagates(
     )
 
 
+def test_load_finds_store_when_base_path_carries_npy_extension(
+    tmp_path: Path,
+) -> None:
+    """A real store saved at a ``.npy``-suffixed base is loaded, not hidden.
+
+    ``VectorIndex.save``/``load`` derive sidecar paths with
+    ``Path.with_suffix``, so a base of ``embeddings.npy`` writes/reads
+    ``embeddings.npy`` (the extension is replaced, not appended). The loader
+    must derive its existence check the same way; a string-append of ``.npy``
+    would probe ``embeddings.npy.npy``, miss the real store, cold-build an
+    empty index, and later overwrite the store (#736 regression).
+    """
+    provider = MockEmbeddingProvider()
+    base = tmp_path / "embeddings.npy"
+    _populated(provider).save(base)
+    box, get, set_ = _slot()
+    calls: list[int] = []
+
+    result = load_or_self_heal(
+        embeddings_path=base,
+        embedding_provider=provider,
+        get_vectors=get,
+        set_vectors=set_,
+        rebuild=lambda: calls.append(1),
+        logger=_LOG,
+    )
+
+    assert result.count == 1  # found the real store, did not cold-build empty
+    assert calls == []
+    assert box["v"] is result
+
+
 def test_compat_rebuild_that_raises_is_logged_then_propagates(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #819

## Summary

`managers/_vector_loader.py` and `IndexManager.embeddings_status` derived the `.npy`/`.json` sidecar paths by string-appending the suffix to `EMBEDDINGS_PATH`, while `VectorIndex.load`/`save` derive them with `Path.with_suffix`. The two agree only when the configured base path has no extension.

When `EMBEDDINGS_PATH` carries an extension (e.g. `embeddings.npy`), `with_suffix` replaces it, so save writes `embeddings.npy` and load reads `embeddings.npy`; the string-append probes `embeddings.npy.npy` instead. The loader therefore concludes no store exists, cold-builds an empty index, and a later save overwrites the real store, destroying a populated vector index. `embeddings_status` hits the same mismatch and reports `chunk_count=0` for a store that exists.

The fix derives the sidecar paths with `with_suffix` at both call sites so the loader and status read the same files the writer produced, regardless of whether the base path carries an extension.

## Evidence

Field data point from the issue: a 68,796-vector store built by `index --force` was overwritten by a 604-chunk watcher delta on the first `serve` start (log showed "No vector index on disk; created empty VectorIndex" followed by "VectorIndex.save: saved 604 vectors" to the same path the CLI had just written).

## Test plan

Added `test_load_finds_store_when_base_path_carries_npy_extension` in `tests/test_vector_loader.py`. It saves a real populated store at a `.npy`-suffixed base and asserts the loader returns it (`count == 1`) rather than invoking `rebuild` and cold-building an empty index.

- Full suite: 2522 passed, 2 skipped (playwright browser test and an empty domain-wizard placeholder; both environmental).
- `ruff check --fix .`, `ruff format .`, `ruff format --check .`: clean.
- `mypy src/ tests/`: no issues in 154 source files.
- Patch coverage: 100% on the changed lines (diff-cover against `main`; the two `with_suffix` lines in `index.py` and the loader line all exercised).

## Reviewer notes

The inline comments reference `#736`, the issue under which `_vector_loader.py` was extracted as the shared load-or-self-heal routine; that is the module's origin, not the bug issue. The behavioral change is confined to path derivation. `embeddings_status`'s deeper JSON-metadata branch was already uncovered upstream and is unrelated to this diff.
