### PR TITLE
feat: Paper theming + type system for the SPA shell (#811)

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -204,3 +204,7 @@ workspace
 write_attachment
 Zettelkasten
 Zotero
+
+# --- Fonts / typography ---
+Newsreader
+Plex

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ The two primary tools exposed to MCP Apps clients are:
 
 **Domain configuration:** MCP Apps iframes are sandboxed to a specific Claude app domain. The domain is auto-computed from `MARKDOWN_VAULT_MCP_BASE_URL`. Override with `MARKDOWN_VAULT_MCP_APP_DOMAIN` if your deployment is hosted on a custom domain or behind a proxy that changes the apparent hostname.
 
-Vendored dependencies (bundled at build time, no runtime CDN): vis-network (graph rendering), marked.js (markdown rendering), DOMPurify (XSS sanitization), ext-apps SDK (MCP Apps lifecycle).
+Vendored dependencies (JavaScript libraries bundled at build time, no runtime CDN): vis-network (graph rendering), marked.js (markdown rendering), DOMPurify (XSS sanitization), ext-apps SDK (MCP Apps lifecycle). The one runtime network dependency is web fonts (Newsreader, Public Sans, IBM Plex Mono), loaded from Google Fonts with system-font fallbacks.
 
 ## One-Time Transfer Links
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -2198,6 +2198,12 @@ MCP Apps are browser-based views that MCP clients supporting the protocol can re
 - `DOMPurify`: XSS sanitization for all rendered HTML
 - `@modelcontextprotocol/ext-apps`: MCP Apps SDK lifecycle and theming
 
+**Web fonts** are the one dependency the app does not bundle inline: the "Paper"
+theme's type families (Newsreader, Public Sans, IBM Plex Mono) load at runtime from
+Google Fonts via a `<link>` in the shell, so the served `app.html` keeps a
+single external network dependency. The font stacks declare system fallbacks, so
+a load failure degrades to system fonts with no loss of function.
+
 **Source layout and build**: the SPA is authored as partials under `src/markdown_vault_mcp/static/spa/` (`shell.html`, `styles.css`, `core.js`, and one `views/*.js` per view). `scripts/build_spa.py` assembles them into `static/app.src.html` via recursive `/*@@FILE:path@@*/` include markers, then `scripts/vendor_spa.py` embeds the vendored libraries into the served `static/app.html`. Both `app.src.html` and `app.html` are generated, committed artifacts; edit the partials, not the generated files. Each script has a `--check` mode that gates the build in CI and pre-commit, so a stale artifact fails fast.
 
 **Domain configuration**: MCP Apps iframes are sandboxed to a specific Claude app domain. The server computes it from `MARKDOWN_VAULT_MCP_BASE_URL` via `_compute_claude_app_domain()`. Override with `MARKDOWN_VAULT_MCP_APP_DOMAIN` when `BASE_URL` does not reflect the actual hostname visible to the Claude client (such as behind a proxy, or on a custom domain).

--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -75,7 +75,7 @@ Override `APP_DOMAIN` if your deployment is behind a proxy that changes the appa
 
 ## Architecture
 
-The SPA is a self-contained HTML file with all dependencies vendored at build time (no runtime CDN requests):
+The SPA is a self-contained HTML file with its JavaScript dependencies vendored at build time (no runtime CDN requests for libraries; web fonts are the one exception, see [Visual identity](#visual-identity-paper)):
 
 | Library | Purpose |
 |---------|---------|
@@ -91,6 +91,20 @@ The app integrates with the host client via the ext-apps SDK:
 - **`app.updateModelContext()`**: keeps the LLM aware of which note the user is viewing
 - **`app.requestDisplayMode()`**: requests fullscreen or inline display
 - **Theme sync**: automatically adapts to the host's light/dark theme and CSS variables
+
+### Visual identity ("Paper")
+
+The views use a warm, editorial "Paper" theme (serif headings, a single warm
+accent, light and dark). The Paper palette is expressed as CSS custom properties
+that map onto the host's `--color-*` variables: a host that pushes its own theme
+overrides Paper, otherwise the Paper values show. Three font families load from
+Google Fonts and are exposed as `--font-head` / `--font-body` / `--font-mono`:
+Newsreader styles headings, Public Sans the body and UI, and IBM Plex Mono the
+code, property keys, and tags. (As each view is restyled, these families also
+reach the remaining mono metadata such as paths and scores.) The fonts are the
+one runtime network dependency the app keeps (the vendored libraries are embedded);
+if they fail to load, the app falls back to system fonts with no loss of
+function.
 
 ### Source layout and build
 

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -134,7 +134,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     --color-background-primary: #fbf8f1;
     --color-background-secondary: #f2ecdf;
     --color-text-primary: #2a2620;
-    --color-text-secondary: #928975;
+    --color-text-secondary: #7a7161;
     --color-text-inverse: #ffffff;
     --color-text-info: #b25a35;
     --color-text-success: #22c55e;
@@ -167,7 +167,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     --color-background-primary: #252118;
     --color-background-secondary: #2e281d;
     --color-text-primary: #ece4d4;
-    --color-text-secondary: #8f8571;
+    --color-text-secondary: #978d78;
     --color-text-inverse: #241a12;
     --color-text-info: #d68a5f;
     --color-text-success: #4ade80;
@@ -426,7 +426,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
   }
 </style>
-<!-- vendor-spa-source-sha256:6635f854f1bcaef1e77b8801fdf3a7b8cbc27224d78c6b6d633661822b568bce -->
+<!-- vendor-spa-source-sha256:75d5db348598d5fb364496cb7aa037f89f9a61d6a7380e6ec30aa9a962dd8c09 -->
 </head>
 <body>
 <div class="app-container">

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -162,7 +162,6 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     --font-head: 'Newsreader', Georgia, serif;
     --font-body: 'Public Sans', system-ui, -apple-system, sans-serif;
     --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
-    --font-sans: var(--font-body);
   }
   [data-theme="dark"] {
     --color-background-primary: #252118;
@@ -427,7 +426,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
   }
 </style>
-<!-- vendor-spa-source-sha256:cadf1ea96f77bb6ba9c242584a211c327b4952225837c7314eab35ec6cbb0e18 -->
+<!-- vendor-spa-source-sha256:6635f854f1bcaef1e77b8801fdf3a7b8cbc27224d78c6b6d633661822b568bce -->
 </head>
 <body>
 <div class="app-container">

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -6,6 +6,9 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Vault Explorer</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&amp;family=Public+Sans:wght@400;500;600;700&amp;family=IBM+Plex+Mono:wght@400;500;600&amp;display=swap"/>
 <script>/* vis-network@10.0.2 (vendored) */
 /**
  * vis-network
@@ -125,37 +128,69 @@ if(__exports != exports)module.exports = exports;return module.exports}));
 </script>
 <style>
   :root {
-    /* Fallbacks when host does not provide style variables */
-    --color-background-primary: #ffffff;
-    --color-background-secondary: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #6b7280;
+    /* Host theme vars — the fallback VALUES carry the Paper "light" identity,
+       so a host that pushes its own --color-* overrides Paper; otherwise Paper
+       shows. The Paper semantic tokens below map onto these. */
+    --color-background-primary: #fbf8f1;
+    --color-background-secondary: #f2ecdf;
+    --color-text-primary: #2a2620;
+    --color-text-secondary: #928975;
     --color-text-inverse: #ffffff;
-    --color-text-info: #6366f1;
+    --color-text-info: #b25a35;
     --color-text-success: #22c55e;
-    --color-text-danger: #ef4444;
-    --color-border-primary: #e0e0e0;
-    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --color-text-danger: #b4472c;
+    --color-border-primary: #e4dbc9;
+    /* Paper semantic tokens (map onto host vars so the host can override) */
+    --panel: var(--color-background-primary);
+    --panel-2: var(--color-background-secondary);
+    --ink: var(--color-text-primary);
+    --muted: var(--color-text-secondary);
+    --border: var(--color-border-primary);
+    --accent: var(--color-text-info);
+    --accent-ink: var(--color-text-inverse);
+    /* Paper-only tokens (no host equivalent; flip under [data-theme="dark"]) */
+    --page: #eceae4;
+    --ink-2: #5c5446;
+    --border-2: #efe8d9;
+    --edge: #d3c7ad;
+    --accent-soft: #f3e4d8;
+    --warn: #b4472c;
+    --radius: 11px;
+    --radius-sm: 7px;
+    --pad: 15px;
+    --shadow: 0 1px 2px rgba(70, 48, 24, .05), 0 14px 30px -18px rgba(70, 48, 24, .22);
+    --font-head: 'Newsreader', Georgia, serif;
+    --font-body: 'Public Sans', system-ui, -apple-system, sans-serif;
+    --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
+    --font-sans: var(--font-body);
   }
   [data-theme="dark"] {
-    --color-background-primary: #1a1a1a;
-    --color-background-secondary: #2a2a2a;
-    --color-text-primary: #e5e5e5;
-    --color-text-secondary: #9ca3af;
-    --color-text-inverse: #1a1a1a;
-    --color-text-info: #818cf8;
+    --color-background-primary: #252118;
+    --color-background-secondary: #2e281d;
+    --color-text-primary: #ece4d4;
+    --color-text-secondary: #8f8571;
+    --color-text-inverse: #241a12;
+    --color-text-info: #d68a5f;
     --color-text-success: #4ade80;
-    --color-text-danger: #f87171;
-    --color-border-primary: #404040;
+    --color-text-danger: #e08163;
+    --color-border-primary: #39311f;
+    --page: #111112;
+    --ink-2: #bcb29c;
+    --border-2: #433a26;
+    --edge: #4c4230;
+    --accent-soft: #39291d;
+    --warn: #e08163;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
-    font-family: var(--font-sans);
-    background: var(--color-background-primary);
-    color: var(--color-text-primary);
+    font-family: var(--font-body);
+    background: var(--panel);
+    color: var(--ink);
     line-height: 1.5;
     overflow: hidden;
     height: 100vh;
+    -webkit-font-smoothing: antialiased;
   }
   .app-container {
     display: flex;
@@ -165,29 +200,31 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   /* Tab bar */
   .tab-bar {
     display: flex;
-    border-bottom: 1px solid var(--color-border-primary);
-    background: var(--color-background-secondary);
+    border-bottom: 1px solid var(--border-2);
+    background: var(--panel-2);
     flex-shrink: 0;
+    overflow-x: auto;
   }
   .tab-bar button {
-    flex: 1;
-    padding: 8px 12px;
+    flex: 0 0 auto;
+    padding: 12px 15px;
     border: none;
     background: transparent;
-    color: var(--color-text-secondary);
+    color: var(--muted);
     cursor: pointer;
-    font-size: 13px;
-    font-family: inherit;
-    border-bottom: 2px solid transparent;
-    transition: color 0.15s, border-color 0.15s;
+    font: 600 12px/1 var(--font-body);
+    white-space: nowrap;
+    /* Active underline via inset box-shadow, not a border shorthand+longhand
+       mix (which caused stale styling in prototyping). */
+    box-shadow: none;
+    transition: color 0.15s, box-shadow 0.15s;
   }
   .tab-bar button:hover {
-    color: var(--color-text-primary);
+    color: var(--ink);
   }
   .tab-bar button.active {
-    color: var(--color-text-info);
-    border-bottom-color: var(--color-text-info);
-    font-weight: 600;
+    color: var(--accent);
+    box-shadow: inset 0 -2px 0 var(--accent);
   }
   /* Header with fullscreen toggle */
   .app-header {
@@ -198,18 +235,17 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     flex-shrink: 0;
   }
   .fullscreen-btn {
-    background: none;
-    border: 1px solid var(--color-border-primary);
-    color: var(--color-text-secondary);
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    color: var(--ink-2);
     cursor: pointer;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 12px;
-    font-family: inherit;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    font: 600 11px/1 var(--font-body);
   }
   .fullscreen-btn:hover {
-    color: var(--color-text-primary);
-    background: var(--color-background-secondary);
+    color: var(--ink);
+    border-color: var(--muted);
   }
   /* Tab panels */
   .tab-panel {
@@ -225,8 +261,8 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     align-items: center;
     justify-content: center;
     flex: 1;
-    color: var(--color-text-secondary);
-    font-size: 14px;
+    color: var(--muted);
+    font: 400 14px/1.5 var(--font-body);
   }
   /* Toast notifications */
   .toast {
@@ -234,11 +270,12 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     bottom: 16px;
     left: 50%;
     transform: translateX(-50%);
-    background: var(--color-text-primary);
-    color: var(--color-background-primary);
-    padding: 8px 16px;
-    border-radius: 6px;
-    font-size: 13px;
+    background: var(--ink);
+    color: var(--panel);
+    padding: 9px 16px;
+    border-radius: var(--radius-sm);
+    font: 500 13px/1 var(--font-body);
+    box-shadow: var(--shadow);
     opacity: 0;
     transition: opacity 0.3s;
     pointer-events: none;
@@ -250,7 +287,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   .context-title-row {
     display: flex; align-items: center; justify-content: space-between; gap: 8px;
   }
-  .context-title-row h2 { font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .context-title-row h2 { font-family: var(--font-head); font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .context-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; font-size: 12px; color: var(--color-text-secondary); }
   .meta-item::before { content: ''; }
   .action-btn {
@@ -279,6 +316,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   .tag-group-label { font-size: 11px; color: var(--color-text-secondary); text-transform: uppercase; margin-bottom: 2px; }
   .tag-pill {
     display: inline-block; padding: 2px 8px; margin: 2px 4px 2px 0; border-radius: 12px; font-size: 12px;
+    font-family: var(--font-mono);
     background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
   }
   /* Link lists */
@@ -305,7 +343,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   /* Frontmatter table */
   .fm-table { width: 100%; border-collapse: collapse; }
   .fm-table td { padding: 3px 8px; border-bottom: 1px solid var(--color-border-primary); font-size: 12px; vertical-align: top; }
-  .fm-table td:first-child { font-weight: 600; white-space: nowrap; width: 1%; color: var(--color-text-secondary); }
+  .fm-table td:first-child { font-family: var(--font-mono); font-weight: 600; white-space: nowrap; width: 1%; color: var(--color-text-secondary); }
   /* Graph styles */
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
   #graph-container { border: 1px solid var(--color-border-primary); border-radius: 6px; min-height: 200px; }
@@ -372,14 +410,14 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     display: flex; align-items: center; justify-content: space-between; gap: 8px;
     margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--color-border-primary);
   }
-  .preview-header h1 { font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .preview-header h1 { font-family: var(--font-head); font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .preview-actions { display: flex; gap: 6px; flex-shrink: 0; }
   .preview-fm { margin-bottom: 12px; }
   .preview-content { font-size: 14px; line-height: 1.6; }
-  .preview-content h1, .preview-content h2, .preview-content h3 { margin-top: 16px; margin-bottom: 8px; }
+  .preview-content h1, .preview-content h2, .preview-content h3 { font-family: var(--font-head); margin-top: 16px; margin-bottom: 8px; }
   .preview-content p { margin: 8px 0; }
-  .preview-content code { background: var(--color-background-secondary); padding: 1px 4px; border-radius: 3px; font-size: 13px; }
-  .preview-content pre { background: var(--color-background-secondary); padding: 12px; border-radius: 6px; overflow-x: auto; }
+  .preview-content code { font-family: var(--font-mono); background: var(--color-background-secondary); padding: 1px 4px; border-radius: 3px; font-size: 13px; }
+  .preview-content pre { font-family: var(--font-mono); background: var(--color-background-secondary); padding: 12px; border-radius: 6px; overflow-x: auto; }
   .preview-content pre code { background: none; padding: 0; }
   .preview-content blockquote { border-left: 3px solid var(--color-text-info); padding-left: 12px; color: var(--color-text-secondary); margin: 8px 0; }
   .preview-content a { color: var(--color-text-info); }
@@ -389,7 +427,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
   }
 </style>
-<!-- vendor-spa-source-sha256:80147a610805aa21cfb3bc4c919e680c1dd312a949b54d4b358b98aa27176594 -->
+<!-- vendor-spa-source-sha256:cadf1ea96f77bb6ba9c242584a211c327b4952225837c7314eab35ec6cbb0e18 -->
 </head>
 <body>
 <div class="app-container">

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -6,42 +6,77 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Vault Explorer</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&amp;family=Public+Sans:wght@400;500;600;700&amp;family=IBM+Plex+Mono:wght@400;500;600&amp;display=swap"/>
 <script src="https://unpkg.com/vis-network@10.0.2/standalone/umd/vis-network.min.js"></script>
 <script src="https://unpkg.com/marked@17.0.5/lib/marked.umd.js"></script>
 <script src="https://unpkg.com/dompurify@3.3.3/dist/purify.min.js"></script>
 <style>
   :root {
-    /* Fallbacks when host does not provide style variables */
-    --color-background-primary: #ffffff;
-    --color-background-secondary: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #6b7280;
+    /* Host theme vars — the fallback VALUES carry the Paper "light" identity,
+       so a host that pushes its own --color-* overrides Paper; otherwise Paper
+       shows. The Paper semantic tokens below map onto these. */
+    --color-background-primary: #fbf8f1;
+    --color-background-secondary: #f2ecdf;
+    --color-text-primary: #2a2620;
+    --color-text-secondary: #928975;
     --color-text-inverse: #ffffff;
-    --color-text-info: #6366f1;
+    --color-text-info: #b25a35;
     --color-text-success: #22c55e;
-    --color-text-danger: #ef4444;
-    --color-border-primary: #e0e0e0;
-    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --color-text-danger: #b4472c;
+    --color-border-primary: #e4dbc9;
+    /* Paper semantic tokens (map onto host vars so the host can override) */
+    --panel: var(--color-background-primary);
+    --panel-2: var(--color-background-secondary);
+    --ink: var(--color-text-primary);
+    --muted: var(--color-text-secondary);
+    --border: var(--color-border-primary);
+    --accent: var(--color-text-info);
+    --accent-ink: var(--color-text-inverse);
+    /* Paper-only tokens (no host equivalent; flip under [data-theme="dark"]) */
+    --page: #eceae4;
+    --ink-2: #5c5446;
+    --border-2: #efe8d9;
+    --edge: #d3c7ad;
+    --accent-soft: #f3e4d8;
+    --warn: #b4472c;
+    --radius: 11px;
+    --radius-sm: 7px;
+    --pad: 15px;
+    --shadow: 0 1px 2px rgba(70, 48, 24, .05), 0 14px 30px -18px rgba(70, 48, 24, .22);
+    --font-head: 'Newsreader', Georgia, serif;
+    --font-body: 'Public Sans', system-ui, -apple-system, sans-serif;
+    --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
+    --font-sans: var(--font-body);
   }
   [data-theme="dark"] {
-    --color-background-primary: #1a1a1a;
-    --color-background-secondary: #2a2a2a;
-    --color-text-primary: #e5e5e5;
-    --color-text-secondary: #9ca3af;
-    --color-text-inverse: #1a1a1a;
-    --color-text-info: #818cf8;
+    --color-background-primary: #252118;
+    --color-background-secondary: #2e281d;
+    --color-text-primary: #ece4d4;
+    --color-text-secondary: #8f8571;
+    --color-text-inverse: #241a12;
+    --color-text-info: #d68a5f;
     --color-text-success: #4ade80;
-    --color-text-danger: #f87171;
-    --color-border-primary: #404040;
+    --color-text-danger: #e08163;
+    --color-border-primary: #39311f;
+    --page: #111112;
+    --ink-2: #bcb29c;
+    --border-2: #433a26;
+    --edge: #4c4230;
+    --accent-soft: #39291d;
+    --warn: #e08163;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
-    font-family: var(--font-sans);
-    background: var(--color-background-primary);
-    color: var(--color-text-primary);
+    font-family: var(--font-body);
+    background: var(--panel);
+    color: var(--ink);
     line-height: 1.5;
     overflow: hidden;
     height: 100vh;
+    -webkit-font-smoothing: antialiased;
   }
   .app-container {
     display: flex;
@@ -51,29 +86,31 @@
   /* Tab bar */
   .tab-bar {
     display: flex;
-    border-bottom: 1px solid var(--color-border-primary);
-    background: var(--color-background-secondary);
+    border-bottom: 1px solid var(--border-2);
+    background: var(--panel-2);
     flex-shrink: 0;
+    overflow-x: auto;
   }
   .tab-bar button {
-    flex: 1;
-    padding: 8px 12px;
+    flex: 0 0 auto;
+    padding: 12px 15px;
     border: none;
     background: transparent;
-    color: var(--color-text-secondary);
+    color: var(--muted);
     cursor: pointer;
-    font-size: 13px;
-    font-family: inherit;
-    border-bottom: 2px solid transparent;
-    transition: color 0.15s, border-color 0.15s;
+    font: 600 12px/1 var(--font-body);
+    white-space: nowrap;
+    /* Active underline via inset box-shadow, not a border shorthand+longhand
+       mix (which caused stale styling in prototyping). */
+    box-shadow: none;
+    transition: color 0.15s, box-shadow 0.15s;
   }
   .tab-bar button:hover {
-    color: var(--color-text-primary);
+    color: var(--ink);
   }
   .tab-bar button.active {
-    color: var(--color-text-info);
-    border-bottom-color: var(--color-text-info);
-    font-weight: 600;
+    color: var(--accent);
+    box-shadow: inset 0 -2px 0 var(--accent);
   }
   /* Header with fullscreen toggle */
   .app-header {
@@ -84,18 +121,17 @@
     flex-shrink: 0;
   }
   .fullscreen-btn {
-    background: none;
-    border: 1px solid var(--color-border-primary);
-    color: var(--color-text-secondary);
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    color: var(--ink-2);
     cursor: pointer;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 12px;
-    font-family: inherit;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    font: 600 11px/1 var(--font-body);
   }
   .fullscreen-btn:hover {
-    color: var(--color-text-primary);
-    background: var(--color-background-secondary);
+    color: var(--ink);
+    border-color: var(--muted);
   }
   /* Tab panels */
   .tab-panel {
@@ -111,8 +147,8 @@
     align-items: center;
     justify-content: center;
     flex: 1;
-    color: var(--color-text-secondary);
-    font-size: 14px;
+    color: var(--muted);
+    font: 400 14px/1.5 var(--font-body);
   }
   /* Toast notifications */
   .toast {
@@ -120,11 +156,12 @@
     bottom: 16px;
     left: 50%;
     transform: translateX(-50%);
-    background: var(--color-text-primary);
-    color: var(--color-background-primary);
-    padding: 8px 16px;
-    border-radius: 6px;
-    font-size: 13px;
+    background: var(--ink);
+    color: var(--panel);
+    padding: 9px 16px;
+    border-radius: var(--radius-sm);
+    font: 500 13px/1 var(--font-body);
+    box-shadow: var(--shadow);
     opacity: 0;
     transition: opacity 0.3s;
     pointer-events: none;
@@ -136,7 +173,7 @@
   .context-title-row {
     display: flex; align-items: center; justify-content: space-between; gap: 8px;
   }
-  .context-title-row h2 { font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .context-title-row h2 { font-family: var(--font-head); font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .context-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; font-size: 12px; color: var(--color-text-secondary); }
   .meta-item::before { content: ''; }
   .action-btn {
@@ -165,6 +202,7 @@
   .tag-group-label { font-size: 11px; color: var(--color-text-secondary); text-transform: uppercase; margin-bottom: 2px; }
   .tag-pill {
     display: inline-block; padding: 2px 8px; margin: 2px 4px 2px 0; border-radius: 12px; font-size: 12px;
+    font-family: var(--font-mono);
     background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
   }
   /* Link lists */
@@ -191,7 +229,7 @@
   /* Frontmatter table */
   .fm-table { width: 100%; border-collapse: collapse; }
   .fm-table td { padding: 3px 8px; border-bottom: 1px solid var(--color-border-primary); font-size: 12px; vertical-align: top; }
-  .fm-table td:first-child { font-weight: 600; white-space: nowrap; width: 1%; color: var(--color-text-secondary); }
+  .fm-table td:first-child { font-family: var(--font-mono); font-weight: 600; white-space: nowrap; width: 1%; color: var(--color-text-secondary); }
   /* Graph styles */
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
   #graph-container { border: 1px solid var(--color-border-primary); border-radius: 6px; min-height: 200px; }
@@ -258,14 +296,14 @@
     display: flex; align-items: center; justify-content: space-between; gap: 8px;
     margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--color-border-primary);
   }
-  .preview-header h1 { font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .preview-header h1 { font-family: var(--font-head); font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .preview-actions { display: flex; gap: 6px; flex-shrink: 0; }
   .preview-fm { margin-bottom: 12px; }
   .preview-content { font-size: 14px; line-height: 1.6; }
-  .preview-content h1, .preview-content h2, .preview-content h3 { margin-top: 16px; margin-bottom: 8px; }
+  .preview-content h1, .preview-content h2, .preview-content h3 { font-family: var(--font-head); margin-top: 16px; margin-bottom: 8px; }
   .preview-content p { margin: 8px 0; }
-  .preview-content code { background: var(--color-background-secondary); padding: 1px 4px; border-radius: 3px; font-size: 13px; }
-  .preview-content pre { background: var(--color-background-secondary); padding: 12px; border-radius: 6px; overflow-x: auto; }
+  .preview-content code { font-family: var(--font-mono); background: var(--color-background-secondary); padding: 1px 4px; border-radius: 3px; font-size: 13px; }
+  .preview-content pre { font-family: var(--font-mono); background: var(--color-background-secondary); padding: 12px; border-radius: 6px; overflow-x: auto; }
   .preview-content pre code { background: none; padding: 0; }
   .preview-content blockquote { border-left: 3px solid var(--color-text-info); padding-left: 12px; color: var(--color-text-secondary); margin: 8px 0; }
   .preview-content a { color: var(--color-text-info); }

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -48,7 +48,6 @@
     --font-head: 'Newsreader', Georgia, serif;
     --font-body: 'Public Sans', system-ui, -apple-system, sans-serif;
     --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
-    --font-sans: var(--font-body);
   }
   [data-theme="dark"] {
     --color-background-primary: #252118;

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -20,7 +20,7 @@
     --color-background-primary: #fbf8f1;
     --color-background-secondary: #f2ecdf;
     --color-text-primary: #2a2620;
-    --color-text-secondary: #928975;
+    --color-text-secondary: #7a7161;
     --color-text-inverse: #ffffff;
     --color-text-info: #b25a35;
     --color-text-success: #22c55e;
@@ -53,7 +53,7 @@
     --color-background-primary: #252118;
     --color-background-secondary: #2e281d;
     --color-text-primary: #ece4d4;
-    --color-text-secondary: #8f8571;
+    --color-text-secondary: #978d78;
     --color-text-inverse: #241a12;
     --color-text-info: #d68a5f;
     --color-text-success: #4ade80;

--- a/src/markdown_vault_mcp/static/spa/shell.html
+++ b/src/markdown_vault_mcp/static/spa/shell.html
@@ -4,6 +4,9 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Vault Explorer</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&amp;family=Public+Sans:wght@400;500;600;700&amp;family=IBM+Plex+Mono:wght@400;500;600&amp;display=swap"/>
 <script src="https://unpkg.com/vis-network@10.0.2/standalone/umd/vis-network.min.js"></script>
 <script src="https://unpkg.com/marked@17.0.5/lib/marked.umd.js"></script>
 <script src="https://unpkg.com/dompurify@3.3.3/dist/purify.min.js"></script>

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -34,7 +34,6 @@
     --font-head: 'Newsreader', Georgia, serif;
     --font-body: 'Public Sans', system-ui, -apple-system, sans-serif;
     --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
-    --font-sans: var(--font-body);
   }
   [data-theme="dark"] {
     --color-background-primary: #252118;

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -6,7 +6,7 @@
     --color-background-primary: #fbf8f1;
     --color-background-secondary: #f2ecdf;
     --color-text-primary: #2a2620;
-    --color-text-secondary: #928975;
+    --color-text-secondary: #7a7161;
     --color-text-inverse: #ffffff;
     --color-text-info: #b25a35;
     --color-text-success: #22c55e;
@@ -39,7 +39,7 @@
     --color-background-primary: #252118;
     --color-background-secondary: #2e281d;
     --color-text-primary: #ece4d4;
-    --color-text-secondary: #8f8571;
+    --color-text-secondary: #978d78;
     --color-text-inverse: #241a12;
     --color-text-info: #d68a5f;
     --color-text-success: #4ade80;

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -1,36 +1,68 @@
 
   :root {
-    /* Fallbacks when host does not provide style variables */
-    --color-background-primary: #ffffff;
-    --color-background-secondary: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #6b7280;
+    /* Host theme vars — the fallback VALUES carry the Paper "light" identity,
+       so a host that pushes its own --color-* overrides Paper; otherwise Paper
+       shows. The Paper semantic tokens below map onto these. */
+    --color-background-primary: #fbf8f1;
+    --color-background-secondary: #f2ecdf;
+    --color-text-primary: #2a2620;
+    --color-text-secondary: #928975;
     --color-text-inverse: #ffffff;
-    --color-text-info: #6366f1;
+    --color-text-info: #b25a35;
     --color-text-success: #22c55e;
-    --color-text-danger: #ef4444;
-    --color-border-primary: #e0e0e0;
-    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --color-text-danger: #b4472c;
+    --color-border-primary: #e4dbc9;
+    /* Paper semantic tokens (map onto host vars so the host can override) */
+    --panel: var(--color-background-primary);
+    --panel-2: var(--color-background-secondary);
+    --ink: var(--color-text-primary);
+    --muted: var(--color-text-secondary);
+    --border: var(--color-border-primary);
+    --accent: var(--color-text-info);
+    --accent-ink: var(--color-text-inverse);
+    /* Paper-only tokens (no host equivalent; flip under [data-theme="dark"]) */
+    --page: #eceae4;
+    --ink-2: #5c5446;
+    --border-2: #efe8d9;
+    --edge: #d3c7ad;
+    --accent-soft: #f3e4d8;
+    --warn: #b4472c;
+    --radius: 11px;
+    --radius-sm: 7px;
+    --pad: 15px;
+    --shadow: 0 1px 2px rgba(70, 48, 24, .05), 0 14px 30px -18px rgba(70, 48, 24, .22);
+    --font-head: 'Newsreader', Georgia, serif;
+    --font-body: 'Public Sans', system-ui, -apple-system, sans-serif;
+    --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
+    --font-sans: var(--font-body);
   }
   [data-theme="dark"] {
-    --color-background-primary: #1a1a1a;
-    --color-background-secondary: #2a2a2a;
-    --color-text-primary: #e5e5e5;
-    --color-text-secondary: #9ca3af;
-    --color-text-inverse: #1a1a1a;
-    --color-text-info: #818cf8;
+    --color-background-primary: #252118;
+    --color-background-secondary: #2e281d;
+    --color-text-primary: #ece4d4;
+    --color-text-secondary: #8f8571;
+    --color-text-inverse: #241a12;
+    --color-text-info: #d68a5f;
     --color-text-success: #4ade80;
-    --color-text-danger: #f87171;
-    --color-border-primary: #404040;
+    --color-text-danger: #e08163;
+    --color-border-primary: #39311f;
+    --page: #111112;
+    --ink-2: #bcb29c;
+    --border-2: #433a26;
+    --edge: #4c4230;
+    --accent-soft: #39291d;
+    --warn: #e08163;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
-    font-family: var(--font-sans);
-    background: var(--color-background-primary);
-    color: var(--color-text-primary);
+    font-family: var(--font-body);
+    background: var(--panel);
+    color: var(--ink);
     line-height: 1.5;
     overflow: hidden;
     height: 100vh;
+    -webkit-font-smoothing: antialiased;
   }
   .app-container {
     display: flex;
@@ -40,29 +72,31 @@
   /* Tab bar */
   .tab-bar {
     display: flex;
-    border-bottom: 1px solid var(--color-border-primary);
-    background: var(--color-background-secondary);
+    border-bottom: 1px solid var(--border-2);
+    background: var(--panel-2);
     flex-shrink: 0;
+    overflow-x: auto;
   }
   .tab-bar button {
-    flex: 1;
-    padding: 8px 12px;
+    flex: 0 0 auto;
+    padding: 12px 15px;
     border: none;
     background: transparent;
-    color: var(--color-text-secondary);
+    color: var(--muted);
     cursor: pointer;
-    font-size: 13px;
-    font-family: inherit;
-    border-bottom: 2px solid transparent;
-    transition: color 0.15s, border-color 0.15s;
+    font: 600 12px/1 var(--font-body);
+    white-space: nowrap;
+    /* Active underline via inset box-shadow, not a border shorthand+longhand
+       mix (which caused stale styling in prototyping). */
+    box-shadow: none;
+    transition: color 0.15s, box-shadow 0.15s;
   }
   .tab-bar button:hover {
-    color: var(--color-text-primary);
+    color: var(--ink);
   }
   .tab-bar button.active {
-    color: var(--color-text-info);
-    border-bottom-color: var(--color-text-info);
-    font-weight: 600;
+    color: var(--accent);
+    box-shadow: inset 0 -2px 0 var(--accent);
   }
   /* Header with fullscreen toggle */
   .app-header {
@@ -73,18 +107,17 @@
     flex-shrink: 0;
   }
   .fullscreen-btn {
-    background: none;
-    border: 1px solid var(--color-border-primary);
-    color: var(--color-text-secondary);
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    color: var(--ink-2);
     cursor: pointer;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 12px;
-    font-family: inherit;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    font: 600 11px/1 var(--font-body);
   }
   .fullscreen-btn:hover {
-    color: var(--color-text-primary);
-    background: var(--color-background-secondary);
+    color: var(--ink);
+    border-color: var(--muted);
   }
   /* Tab panels */
   .tab-panel {
@@ -100,8 +133,8 @@
     align-items: center;
     justify-content: center;
     flex: 1;
-    color: var(--color-text-secondary);
-    font-size: 14px;
+    color: var(--muted);
+    font: 400 14px/1.5 var(--font-body);
   }
   /* Toast notifications */
   .toast {
@@ -109,11 +142,12 @@
     bottom: 16px;
     left: 50%;
     transform: translateX(-50%);
-    background: var(--color-text-primary);
-    color: var(--color-background-primary);
-    padding: 8px 16px;
-    border-radius: 6px;
-    font-size: 13px;
+    background: var(--ink);
+    color: var(--panel);
+    padding: 9px 16px;
+    border-radius: var(--radius-sm);
+    font: 500 13px/1 var(--font-body);
+    box-shadow: var(--shadow);
     opacity: 0;
     transition: opacity 0.3s;
     pointer-events: none;
@@ -125,7 +159,7 @@
   .context-title-row {
     display: flex; align-items: center; justify-content: space-between; gap: 8px;
   }
-  .context-title-row h2 { font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .context-title-row h2 { font-family: var(--font-head); font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .context-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; font-size: 12px; color: var(--color-text-secondary); }
   .meta-item::before { content: ''; }
   .action-btn {
@@ -154,6 +188,7 @@
   .tag-group-label { font-size: 11px; color: var(--color-text-secondary); text-transform: uppercase; margin-bottom: 2px; }
   .tag-pill {
     display: inline-block; padding: 2px 8px; margin: 2px 4px 2px 0; border-radius: 12px; font-size: 12px;
+    font-family: var(--font-mono);
     background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
   }
   /* Link lists */
@@ -180,7 +215,7 @@
   /* Frontmatter table */
   .fm-table { width: 100%; border-collapse: collapse; }
   .fm-table td { padding: 3px 8px; border-bottom: 1px solid var(--color-border-primary); font-size: 12px; vertical-align: top; }
-  .fm-table td:first-child { font-weight: 600; white-space: nowrap; width: 1%; color: var(--color-text-secondary); }
+  .fm-table td:first-child { font-family: var(--font-mono); font-weight: 600; white-space: nowrap; width: 1%; color: var(--color-text-secondary); }
   /* Graph styles */
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
   #graph-container { border: 1px solid var(--color-border-primary); border-radius: 6px; min-height: 200px; }
@@ -247,14 +282,14 @@
     display: flex; align-items: center; justify-content: space-between; gap: 8px;
     margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--color-border-primary);
   }
-  .preview-header h1 { font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .preview-header h1 { font-family: var(--font-head); font-size: 18px; margin: 0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .preview-actions { display: flex; gap: 6px; flex-shrink: 0; }
   .preview-fm { margin-bottom: 12px; }
   .preview-content { font-size: 14px; line-height: 1.6; }
-  .preview-content h1, .preview-content h2, .preview-content h3 { margin-top: 16px; margin-bottom: 8px; }
+  .preview-content h1, .preview-content h2, .preview-content h3 { font-family: var(--font-head); margin-top: 16px; margin-bottom: 8px; }
   .preview-content p { margin: 8px 0; }
-  .preview-content code { background: var(--color-background-secondary); padding: 1px 4px; border-radius: 3px; font-size: 13px; }
-  .preview-content pre { background: var(--color-background-secondary); padding: 12px; border-radius: 6px; overflow-x: auto; }
+  .preview-content code { font-family: var(--font-mono); background: var(--color-background-secondary); padding: 1px 4px; border-radius: 3px; font-size: 13px; }
+  .preview-content pre { font-family: var(--font-mono); background: var(--color-background-secondary); padding: 12px; border-radius: 6px; overflow-x: auto; }
   .preview-content pre code { background: none; padding: 0; }
   .preview-content blockquote { border-left: 3px solid var(--color-text-info); padding-left: 12px; color: var(--color-text-secondary); margin: 8px 0; }
   .preview-content a { color: var(--color-text-info); }


### PR DESCRIPTION
## Paper theming + type system for the SPA shell

Closes #811. First visual PR of the Vault Views "Paper" redesign (epic #809) — the shared theming foundation the per-view PRs (#812–#815) build on. **Theming and typography only**; view components/layout/interactions come per-view.

### What
- **Token layer** (`styles.css`): host `--color-*` vars carry Paper's warm light/dark values as fallbacks (a host that pushes its own theme still overrides); Paper semantic tokens (`--panel`/`--ink`/`--accent`/…) map onto them; Paper-only tokens (`--ink-2`/`--border-2`/`--edge`/`--accent-soft`/`--warn`, radii, `--pad`, `--shadow`) flip under `[data-theme="dark"]`.
- **Shell chrome → Paper**: tab strip (`--panel-2`, active tab = `--accent` + inset box-shadow underline), fullscreen button, toast, placeholder, body surface.
- **Type system**: Newsreader on headings, Public Sans on body/UI, IBM Plex Mono on code + frontmatter keys + tag chips. Loaded from Google Fonts via a `<link>` — the one runtime network dependency the app keeps (JS libs stay vendored); degrades to system fonts.
- **Docs**: Paper identity + font dependency documented in `docs/guides/mcp-apps.md`; the runtime-fonts exception recorded in `docs/design.md` and `README.md`, scoping the "no runtime CDN" claim to the JS libraries at every assertion site.

### Verification
Both themes screenshotted locally (warm surface, terracotta accent + tab underline, serif headings, mono metadata, inverted toast). `build`/`vendor --check` clean, apps tests green, Vale clean. Local review passed.

![note] The visible surface is repainted Paper; the individual views keep their current layout until their own PRs restyle the components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
