### PR TITLE
fix: floor the semantic candidate pool so recall does not depend on limit

### DIFF
--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -56,6 +56,13 @@ logger = logging.getLogger(__name__)
 # RRF constant — standard value recommended in the original paper.
 _RRF_K = 60
 
+# Floor for the vector-search candidate pool, applied by both the semantic and
+# the hybrid path. Vector search does a full linear scan and sort regardless of
+# limit (see VectorIndex.search), so a wide floor only costs the final slice,
+# not extra distance work. It keeps recall of the best-scoring documents from
+# depending on how large a limit the caller passed.
+_SEMANTIC_CANDIDATE_FLOOR = 1000
+
 # Regex for extracting query tokens (alphanumeric sequences).
 _QUERY_TOKEN_RE = _re.compile(r"[A-Za-z0-9]+")
 
@@ -712,15 +719,7 @@ class SearchManager:
         snippet_words: int,
     ) -> list[GroupedResult]:
         vectors = self._load_vectors()
-        # Floor the candidate pool well above the caller's limit so recall of
-        # the best-scoring documents does not depend on how large a limit was
-        # passed. A small limit with a low floor lets many chunks from a few
-        # large documents crowd out a smaller document whose best chunk ranks
-        # just past the floor, hiding it from the grouped results entirely.
-        # vector search does a full linear scan and sort regardless (see
-        # VectorIndex.search), so a wider pool only costs the slice, not extra
-        # distance computations.
-        candidate_limit = max(limit * (chunks_per_file + 4), 1000)
+        candidate_limit = max(limit * (chunks_per_file + 4), _SEMANTIC_CANDIDATE_FLOOR)
         raw = vectors.search(query, limit=candidate_limit)
 
         filtered: list[dict[str, Any]] = []
@@ -793,11 +792,20 @@ class SearchManager:
         snippet_words: int,
     ) -> list[GroupedResult]:
         """RRF merge of keyword and semantic results, then field-collapse."""
-        candidate_limit = max(limit * (chunks_per_file + 4), 50)
+        # The two channels size their candidate pools independently. FTS keeps a
+        # floor of 50 (a BM25 query does real work per candidate). The vector
+        # channel uses the same full-scan floor as _semantic_search, since it
+        # goes through the identical VectorIndex.search and the same recall cap
+        # applies: a floor-50 pool drops a document whose best chunk ranks just
+        # past 50 from the RRF merge at small limits.
+        fts_candidate_limit = max(limit * (chunks_per_file + 4), 50)
+        vec_candidate_limit = max(
+            limit * (chunks_per_file + 4), _SEMANTIC_CANDIDATE_FLOOR
+        )
 
         fts_raw: list[FTSResult] = self._fts.search(
             query,
-            limit=candidate_limit,
+            limit=fts_candidate_limit,
             filters=filters,
             folder=folder,
             snippet_words=None,
@@ -807,7 +815,7 @@ class SearchManager:
         )
 
         vectors = self._load_vectors()
-        vec_raw = vectors.search(query, limit=candidate_limit)
+        vec_raw = vectors.search(query, limit=vec_candidate_limit)
         vec_filtered: list[dict[str, Any]] = []
         for r in vec_raw:
             if folder is not None:
@@ -923,7 +931,7 @@ class SearchManager:
                 snippet_words=snippet_words,
                 folder=folder,
                 filters=filters,
-                candidate_limit=candidate_limit,
+                candidate_limit=fts_candidate_limit,
             )
 
         out: list[GroupedResult] = []

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -712,7 +712,15 @@ class SearchManager:
         snippet_words: int,
     ) -> list[GroupedResult]:
         vectors = self._load_vectors()
-        candidate_limit = max(limit * (chunks_per_file + 4), 50)
+        # Floor the candidate pool well above the caller's limit so recall of
+        # the best-scoring documents does not depend on how large a limit was
+        # passed. A small limit with a low floor lets many chunks from a few
+        # large documents crowd out a smaller document whose best chunk ranks
+        # just past the floor, hiding it from the grouped results entirely.
+        # vector search does a full linear scan and sort regardless (see
+        # VectorIndex.search), so a wider pool only costs the slice, not extra
+        # distance computations.
+        candidate_limit = max(limit * (chunks_per_file + 4), 1000)
         raw = vectors.search(query, limit=candidate_limit)
 
         filtered: list[dict[str, Any]] = []

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -738,6 +738,25 @@ def test_semantic_recall_of_best_document_is_independent_of_limit(
     assert "TARGET.md" in paths
 
 
+def test_hybrid_recall_of_best_document_is_independent_of_limit(
+    tmp_path: Path,
+) -> None:
+    """Hybrid's vector channel floors its candidate pool like semantic does.
+
+    The store has an empty FTS index, so the keyword channel contributes
+    nothing and TARGET (no keyword overlap) is reachable only through the
+    vector channel. TARGET's only chunk sits at global cosine rank 51. If the
+    vector channel inherits the keyword channel's floor-50 candidate limit, the
+    pool fills with the two large documents' chunks and TARGET never enters the
+    RRF merge at a small limit. The vector-side floor must be sized like the
+    semantic path so recall does not depend on the caller's limit.
+    """
+    mgr = _semantic_mgr_with_ranked_chunks(tmp_path / "embeddings")
+    results = mgr.search("q", mode="hybrid", limit=5, chunks_per_file=2)
+    paths = [r.path for r in results]
+    assert "TARGET.md" in paths
+
+
 def test_hybrid_search_caps_per_file_after_rrf(
     search_mgr_with_embeddings: SearchManager,
 ) -> None:

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -642,6 +642,102 @@ def test_semantic_search_applies_chunks_per_file_cap_and_snippet(
             assert len(s.content.split()) <= 10
 
 
+class _FixedQueryProvider:
+    """Embeds every query to the same unit vector along the first axis.
+
+    The stored document vectors are written directly onto the index, so the
+    cosine of each chunk against the query is just that chunk's first
+    coordinate. This gives a test exact control over chunk ranks.
+    """
+
+    provider_name = "fixed"
+    model_name = "fixed-model"
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0] for _ in texts]
+
+
+def _semantic_mgr_with_ranked_chunks(base: Path) -> SearchManager:
+    """SearchManager over a store where a small TARGET doc's only chunk sits
+    at global cosine rank 51, behind 50 chunks from two large documents.
+
+    Only three documents exist, so a caller asking for as few as three results
+    wants TARGET among them. It is reachable only if the semantic candidate
+    pool extends past rank 51.
+    """
+    import numpy as np
+
+    from markdown_vault_mcp.vector_index import VectorIndex
+
+    provider = _FixedQueryProvider()
+    vi = VectorIndex(provider)
+    texts: list[str] = []
+    meta: list[dict[str, object]] = []
+    vecs: list[np.ndarray] = []
+
+    def unit(cos: float) -> np.ndarray:
+        v = np.array([cos, np.sqrt(max(0.0, 1 - cos * cos))], dtype=np.float32)
+        return v / np.linalg.norm(v)
+
+    cos = 0.7500
+    for doc in ("giantA", "giantB"):
+        for j in range(25):
+            texts.append(f"{doc} chunk {j}")
+            meta.append(
+                {
+                    "path": f"{doc}.md",
+                    "title": doc,
+                    "folder": "",
+                    "heading": f"h{j}",
+                    "content": f"{doc} chunk {j}",
+                }
+            )
+            vecs.append(unit(cos))
+            cos += 0.0005
+    texts.append("target unique answer")
+    meta.append(
+        {
+            "path": "TARGET.md",
+            "title": "Target",
+            "folder": "",
+            "heading": None,
+            "content": "target unique answer",
+        }
+    )
+    vecs.append(unit(0.7499))  # just below every giant chunk -> global rank 51
+
+    vi.add(texts, meta)
+    vi._embeddings = np.vstack(vecs).astype(np.float32)
+    vi.save(base)
+
+    fts = FTSIndex(db_path=":memory:")
+    mgr = SearchManager(
+        fts=fts,
+        source_dir=base.parent,
+        embeddings_path=base,
+        embedding_provider=provider,
+        indexed_frontmatter_fields=[],
+    )
+    mgr._vectors = vi
+    return mgr
+
+
+def test_semantic_recall_of_best_document_is_independent_of_limit(
+    tmp_path: Path,
+) -> None:
+    """The true-best document is returned at a small limit, not only a large one.
+
+    With three documents total and TARGET's only chunk at global cosine rank
+    51, a floor-50 candidate pool fills entirely with the two large documents'
+    chunks and drops TARGET at any small limit. Recall of a real document must
+    not depend on how large a limit the caller happened to pass.
+    """
+    mgr = _semantic_mgr_with_ranked_chunks(tmp_path / "embeddings")
+    results = mgr.search("q", mode="semantic", limit=5, chunks_per_file=2)
+    paths = [r.path for r in results]
+    assert "TARGET.md" in paths
+
+
 def test_hybrid_search_caps_per_file_after_rrf(
     search_mgr_with_embeddings: SearchManager,
 ) -> None:


### PR DESCRIPTION
Closes #820

## Summary

`managers/search.py` `_semantic_search` sizes its vector candidate pool as `max(limit * (chunks_per_file + 4), 50)` and then groups the returned chunks into documents. `VectorIndex.search` does a full linear scan and sort over every stored vector regardless, slicing to the requested limit afterwards, so the floor is a pure recall cap rather than a cost control.

At a small limit the floor of 50 chunks can be consumed entirely by many chunks from a few large documents, so a smaller document whose best chunk ranks just past the floor never enters the pool and is absent from the grouped results, even when it is the best-scoring document for the query. The same query at a larger limit widens the pool and the document reappears, so recall depends on the caller's `limit` rather than on relevance. Scores are also not comparable across limits, since the pool changes what gets grouped.

The fix raises the floor to 1000 so the best-scoring documents are reachable at any limit in practice. Because the underlying search already scans and sorts every vector, the wider pool costs only the slice, not additional distance computations.

## Evidence

From the issue, observed on a real 6,916-chunk vault: for one query the true best document (cosine 0.685) was absent at `limit` 3 through 12 while the returned top-1 scored 0.495; it appeared only at `limit >= 13` (pool 78).

## Test plan

Added `test_semantic_recall_of_best_document_is_independent_of_limit` in `tests/test_managers_search.py`. It builds a three-document store where a small TARGET document's only chunk sits at global cosine rank 51, behind 50 chunks from two large documents, and asserts TARGET is returned at `limit=5`. The test drives chunk ranks exactly by writing document vectors onto the index and embedding every query to a fixed unit vector, so the cosine of each chunk is its own first coordinate.

- Full suite: 2522 passed, 2 skipped (playwright browser test and an empty domain-wizard placeholder; both environmental).
- `ruff check --fix .`, `ruff format .`, `ruff format --check .`: clean.
- `mypy src/ tests/`: no issues in 154 source files.
- Patch coverage: 100% on the changed line (diff-cover against `main`).

## Reviewer notes

The change is scoped to `_semantic_search` only. The floor-50 pools in `_keyword_search`, `_hybrid_search`, the snippet re-query, and the attachment path are intentionally left unchanged; the recall pathology and the "scan is already full" argument are specific to the semantic vector path. The test reaches into `VectorIndex._embeddings` and `SearchManager._vectors` to fix ranks precisely, matching the existing pattern in this test module, and asserts on returned paths rather than internal calls.
