### PR TITLE
fix: retry transient descriptor-exhaustion when hashing during a scan

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -378,8 +378,13 @@ for built-in names, or pass a custom instance.
   `ReindexResult` instead of `added`; it is re-evaluated (and indexed, if it
   gained valid frontmatter) only when its content hash changes. Transient
   `OSError` skips are deliberately not recorded, so those files retry on
-  every scan. A skipped file deleted from disk is dropped silently; it was
-  never indexed, so it is not counted as `deleted`.
+  every scan. Descriptor-exhaustion errors (`EMFILE`/`ENFILE`) additionally
+  get up to three in-scan retries with a short backoff (0.05 s, 0.1 s,
+  0.2 s) before the file is dropped for that scan, and exhausted retries
+  log at `ERROR` (`hash_read_failed_after_retry`); every other `OSError`
+  keeps the single-attempt `WARNING` path. A skipped file deleted from disk
+  is dropped silently; it was never indexed, so it is not counted as
+  `deleted`.
   The surfaced deterministic skips (parse / encoding / missing-frontmatter /
   internal-error, but not exclude-pattern or transient `OSError`) are also
   recorded with a `{category, detail}` reason in the state file's

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -465,12 +465,16 @@ class ChangeTracker:
             OSError: The last error if a transient failure outlasts every
                 retry, or immediately for any non-transient ``OSError``.
         """
-        for sleep_s in _HASH_RETRY_SLEEPS_S:
+        attempt = 0
+        while True:
             try:
                 return self._compute_hash(path)
             except OSError as exc:
                 if exc.errno not in _TRANSIENT_HASH_ERRNOS:
                     raise
+                if attempt >= len(_HASH_RETRY_SLEEPS_S):
+                    raise
+                sleep_s = _HASH_RETRY_SLEEPS_S[attempt]
                 logger.debug(
                     "hash_read_retry path=%s errno=%s backoff=%ss",
                     path,
@@ -478,7 +482,7 @@ class ChangeTracker:
                     sleep_s,
                 )
                 time.sleep(sleep_s)
-        return self._compute_hash(path)
+                attempt += 1
 
     def _compute_hash(self, path: Path) -> str:
         """Compute the SHA256 hex digest of *path* using chunked reads.

--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import os
 import tempfile
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -22,6 +24,15 @@ logger = logging.getLogger(__name__)
 # Current on-disk state file format version. Version 2 splits the flat
 # path → digest map into separate "indexed" and "skipped" maps (#665).
 _STATE_VERSION = 2
+
+# File-descriptor exhaustion is transient: a scan of a large tree under a busy
+# file watcher opens many files in quick succession, and the next open usually
+# succeeds. Retry the hash read a few times for these errnos before giving up
+# so a momentary spike does not silently drop a brand-new file for the whole
+# scan. Permanent OSErrors (EACCES, ENOENT, …) are not retried — a
+# retry cannot help and would only slow the scan.
+_TRANSIENT_HASH_ERRNOS = frozenset({errno.EMFILE, errno.ENFILE})
+_HASH_RETRY_SLEEPS_S = (0.05, 0.1, 0.2)
 
 
 class ChangeTracker:
@@ -130,9 +141,21 @@ class ChangeTracker:
             if is_path_excluded(rel_str, exclude_patterns):
                 continue
             try:
-                content_hash = self._compute_hash(abs_path)
+                content_hash = self._hash_with_retry(abs_path)
             except OSError as exc:
-                logger.warning("Cannot read %s, skipping: %s", abs_path, exc)
+                if exc.errno in _TRANSIENT_HASH_ERRNOS:
+                    # Retries were exhausted: file-descriptor pressure outlasted
+                    # the retry window. The file is dropped from this scan and
+                    # retried on the next one, but surface it at ERROR so it is
+                    # not lost among a busy watcher's INFO reindex summaries.
+                    logger.error(
+                        "hash_read_failed_after_retry path=%s errno=%s: %s",
+                        abs_path,
+                        exc.errno,
+                        exc,
+                    )
+                else:
+                    logger.warning("Cannot read %s, skipping: %s", abs_path, exc)
                 continue
             disk_state[rel_str] = content_hash
 
@@ -420,6 +443,42 @@ class ChangeTracker:
             len(skip_reasons),
             self._state_path,
         )
+
+    def _hash_with_retry(self, path: Path) -> str:
+        """Hash *path*, retrying briefly on transient file-descriptor exhaustion.
+
+        A busy file watcher rescans the whole tree on every event, opening many
+        files in quick succession; a momentary ``EMFILE``/``ENFILE`` should not
+        drop a file for the entire scan when the next open would succeed (#558).
+        Retries only the transient errnos in :data:`_TRANSIENT_HASH_ERRNOS`;
+        every other ``OSError`` (``EACCES``, ``ENOENT``, …) propagates on the
+        first failure, mirroring :func:`_retry_on_sqlite_locked`'s
+        discriminate-then-retry idiom.
+
+        Args:
+            path: Absolute path to the file to hash.
+
+        Returns:
+            Lowercase hex-encoded SHA256 digest.
+
+        Raises:
+            OSError: The last error if a transient failure outlasts every
+                retry, or immediately for any non-transient ``OSError``.
+        """
+        for sleep_s in _HASH_RETRY_SLEEPS_S:
+            try:
+                return self._compute_hash(path)
+            except OSError as exc:
+                if exc.errno not in _TRANSIENT_HASH_ERRNOS:
+                    raise
+                logger.debug(
+                    "hash_read_retry path=%s errno=%s backoff=%ss",
+                    path,
+                    exc.errno,
+                    sleep_s,
+                )
+                time.sleep(sleep_s)
+        return self._compute_hash(path)
 
     def _compute_hash(self, path: Path) -> str:
         """Compute the SHA256 hex digest of *path* using chunked reads.

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -527,6 +527,74 @@ class TestUnreadableFiles:
         assert changes.added == []
         assert any("File outside source_dir" in r.message for r in caplog.records)
 
+    def test_transient_fd_exhaustion_is_retried_within_the_scan(
+        self, tmp_path: Path
+    ) -> None:
+        """A momentary EMFILE while hashing does not drop the file for the scan.
+
+        File-descriptor exhaustion (errno EMFILE) is transient: the very next
+        open often succeeds. A single scan must retry rather than silently drop
+        a brand-new file — otherwise it is reported as neither added nor
+        unchanged and never reaches the index until a later scan happens to
+        hash it cleanly (the file-watcher reindex symptom).
+        """
+        import errno
+        from unittest.mock import patch as mock_patch
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "new.md", "brand new\n")
+
+        real = ChangeTracker._compute_hash
+        calls: list[int] = []
+
+        def flaky(self: ChangeTracker, path: Path) -> str:
+            calls.append(1)
+            if len(calls) == 1:
+                raise OSError(errno.EMFILE, "Too many open files")
+            return real(self, path)
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        with mock_patch.object(ChangeTracker, "_compute_hash", flaky):
+            changes = tracker.detect_changes(vault)
+
+        assert changes.added == ["new.md"]  # recovered on retry, not dropped
+        assert len(calls) >= 2  # the first EMFILE was retried
+
+    def test_persistent_fd_exhaustion_is_dropped_and_logged_at_error(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A persistent EMFILE that survives the retries is surfaced at ERROR.
+
+        The file is still dropped for this scan (nothing can be done without a
+        successful read) and retried on the next scan, but the failure must be
+        visible at ERROR rather than lost among the many INFO reindex-summary
+        lines a busy watcher emits.
+        """
+        import errno
+        import logging
+        from unittest.mock import patch as mock_patch
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "stuck.md", "cannot read\n")
+
+        def always_emfile(_self: ChangeTracker, _path: Path) -> str:
+            raise OSError(errno.EMFILE, "Too many open files")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        with (
+            mock_patch.object(ChangeTracker, "_compute_hash", always_emfile),
+            caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.tracker"),
+        ):
+            changes = tracker.detect_changes(vault)
+
+        assert changes.added == []  # dropped this scan; retried next scan
+        assert any(
+            r.levelno == logging.ERROR and "stuck.md" in r.getMessage()
+            for r in caplog.records
+        )
+
 
 class TestLegacyStateFormat:
     def test_legacy_flat_state_loads_as_indexed(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #821

## Summary

Framing: hardening, not a field-observed bug. The drop path is demonstrated under fault injection only, not observed in the wild on my deployment (descriptor pressure never materialized there). Filing because the drop path is plainly reachable and unobservable at the default log level.

`tracker.py` `detect_changes` hashes every discovered file and, on any `OSError`, logs a WARNING and drops the path from the disk snapshot. A brand-new file that fails to hash is then reported as neither added, modified, unchanged, nor deleted; it never reaches the FTS upsert and the reindex summary logs a self-consistent "0 added, 0 modified, 0 deleted, N unchanged", so the drop is invisible at INFO.

The fix retries the hash read a few times with a short backoff, but only for the transient descriptor-exhaustion errnos (`EMFILE`/`ENFILE`), so a momentary spike no longer drops the file for the whole scan. Every other `OSError` (`EACCES`, `ENOENT`, ...) still propagates on the first failure and is dropped with the existing warning, preserving the documented "transient skips are not recorded, retry next scan" contract. When retries are exhausted the failure is logged at ERROR with a distinct event name so a persistently unreadable file is visible instead of lost among a busy watcher's INFO summaries. This mirrors the existing `_retry_on_sqlite_locked` discriminate-then-retry idiom.

## Evidence

Demonstrated end to end with an injected-EMFILE shim against a live http server: the watcher's reindex silently omitted the new file while logging a clean summary at INFO. Retries: three attempts with backoffs of 0.05s, 0.1s, 0.2s.

## Test plan

Added two tests in `tests/test_tracker.py`:

- `test_transient_fd_exhaustion_is_retried_within_the_scan`: a single EMFILE on the first hash attempt recovers on retry, and the file is reported as added rather than dropped.
- `test_persistent_fd_exhaustion_is_dropped_and_logged_at_error`: a persistent EMFILE that outlasts every retry is dropped for the scan (nothing can be read) and surfaced at ERROR with the file name.

Both assert on the returned `ChangeSet` and on log records rather than internal state.

- Full suite: 2523 passed, 2 skipped (playwright browser test and an empty domain-wizard placeholder; both environmental).
- `ruff check --fix .`, `ruff format .`, `ruff format --check .`: clean.
- `mypy src/ tests/`: no issues in 154 source files.
- Patch coverage: 100% on the changed lines (diff-cover against `main`).

## Reviewer notes

Deliberately kept out of scope: a per-scan "unreadable" counter on `ReindexResult`. It would complement this and align with the skipped-files-visibility direction of #775/#802, but it changes a public schema, so it belongs in its own change. The retry is bounded (three short sleeps) so a persistently unreadable file adds at most ~0.35s before being dropped and logged.
