### PR TITLE
fix: never watch the vault's own state dir or .git (self-feedback reindex loop)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,12 @@ variables (`MARKDOWN_VAULT_MCP_TRANSPORT`, `MARKDOWN_VAULT_MCP_HOST`,
 | `MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER` | string | `_templates` | No | Relative folder path used by the `create_from_template` prompt to discover/read template files |
 | `MARKDOWN_VAULT_MCP_PROMPTS_FOLDER` | path | (none) | No | Path to a directory of `.md` prompt files that extend or override built-in prompts. Each declared argument name must be a plain Python identifier (letters, digits, underscore; not a keyword); a prompt with a non-conforming argument name is skipped with a logged warning. |
 
+The file watcher never watches the directories that hold `INDEX_PATH`,
+`EMBEDDINGS_PATH`, and `STATE_PATH` (or `.git`), so the writes the server makes
+while indexing do not trigger it again. If you place one of these paths inside a
+content directory, that whole top-level directory stops being watched, so keep
+them at the vault root or outside the vault to keep sibling content watched live.
+
 ## Index Build Timeout
 
 ### `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`

--- a/src/markdown_vault_mcp/_file_watcher.py
+++ b/src/markdown_vault_mcp/_file_watcher.py
@@ -123,20 +123,69 @@ class _WatchRoot:
     recursive: bool
 
 
+def _resolve_internal_dirs(internal_dirs: Sequence[Path]) -> list[Path]:
+    """Resolve *internal_dirs*, dropping any that cannot be resolved.
+
+    Resolving up front lets :func:`_contains_internal_dir` compare against
+    realpaths, so a symlinked state dir still matches its watch-root candidate.
+
+    Args:
+        internal_dirs: Vault-internal directories to protect from watching.
+
+    Returns:
+        The resolvable directories as resolved paths.
+    """
+    resolved: list[Path] = []
+    for d in internal_dirs:
+        try:
+            resolved.append(d.resolve())
+        except OSError:
+            continue
+    return resolved
+
+
+def _contains_internal_dir(child: Path, internal_dirs: frozenset[Path]) -> bool:
+    """Return ``True`` if *child* is, or contains, a vault-internal write dir.
+
+    ``internal_dirs`` must already be resolved. A recursive watch on a directory
+    that is or contains the state / index / embeddings dir (or ``.git``) would
+    deliver the writes ``reindex`` makes into those paths, re-triggering itself;
+    such a directory is skipped entirely so the loop cannot form (#830).
+
+    Args:
+        child: Candidate top-level watch-root directory.
+        internal_dirs: Resolved vault-internal directories to protect.
+
+    Returns:
+        ``True`` when *child* should not be watched.
+    """
+    try:
+        child_resolved = child.resolve()
+    except OSError:
+        return False
+    return any(
+        d == child_resolved or d.is_relative_to(child_resolved) for d in internal_dirs
+    )
+
+
 def _derive_watch_roots(
     source_dir: Path,
     exclude_patterns: Sequence[str] | None,
     *,
     root_floor: bool = True,
+    internal_dirs: Sequence[Path] = (),
 ) -> list[_WatchRoot]:
     """Compute the set of watch roots to schedule for *source_dir*.
 
     Each immediate child directory of ``source_dir`` that the exclude patterns
     do not fully prune becomes a recursive watch root, so events deep inside a
     deliberately-watched dot-root (e.g. ``.claude/projects/x/memory/n.md``) are
-    delivered. When ``root_floor`` is True (default) the ``source_dir`` itself is
-    appended last as a non-recursive floor watch so root-level ``*.md`` changes
-    still trigger.
+    delivered. A child that is, or contains, one of ``internal_dirs`` (the
+    vault's own state / index / embeddings dir or ``.git``) is skipped so the
+    watcher does not observe the writes ``reindex`` makes into them, which would
+    close a self-feedback reindex loop (#830). When ``root_floor`` is True
+    (default) the ``source_dir`` itself is appended last as a non-recursive
+    floor watch so root-level ``*.md`` changes still trigger.
 
     When ``root_floor`` is False the floor is omitted, so no watch is rooted at
     ``source_dir`` (root-level files are then only picked up by scans). This is
@@ -155,6 +204,10 @@ def _derive_watch_roots(
             prune rules. ``None`` or empty prunes nothing.
         root_floor: Whether to append the non-recursive ``source_dir`` floor
             watch. ``False`` omits it on every path, including the fallback.
+        internal_dirs: Vault-internal directories (state / index / embeddings
+            dir, ``.git``) that must never be watched, so the writes ``reindex``
+            makes into them do not re-trigger the watcher. A top-level child
+            that is or contains one of these is skipped entirely.
 
     Returns:
         Watch roots to schedule, the non-recursive ``source_dir`` root last when
@@ -163,6 +216,7 @@ def _derive_watch_roots(
         ``[]`` when it is False.
     """
     anchored, anydepth = _dir_prune_rules(exclude_patterns or ())
+    protected = frozenset(_resolve_internal_dirs(internal_dirs))
     roots: list[_WatchRoot] = []
     try:
         children = sorted(source_dir.iterdir())
@@ -180,6 +234,8 @@ def _derive_watch_roots(
         if not child.is_dir():
             continue
         if _should_prune_dir(child.name, anchored, anydepth):
+            continue
+        if _contains_internal_dir(child, protected):
             continue
         roots.append(_WatchRoot(child, recursive=True))
 
@@ -249,9 +305,11 @@ class VaultFileWatcher:
     """Watch a vault directory for external file changes and call *on_change*.
 
     Debounces rapid bursts of filesystem events into a single callback.
-    Changes inside hidden directories (e.g. ``.git/``, ``.markdown_vault_mcp/``)
-    are silently ignored so git operations and state-file writes do not
-    trigger spurious reindexes.
+    The vault's own internal write dirs (state / index / embeddings dir and
+    ``.git``, passed as ``internal_dirs``) are never watched, so git operations
+    and the state-file write ``reindex`` makes on every run do not trigger a
+    self-feedback reindex loop.  User dot-roots (e.g. ``.claude/``) are still
+    watched recursively.
 
     A ``_stopped`` flag prevents watchdog events delivered *during* ``stop()``
     from resurrecting the debounce timer or invoking ``on_change`` after the
@@ -271,6 +329,10 @@ class VaultFileWatcher:
             watch (default ``True``).  ``False`` omits it, so no watch is rooted
             at ``source_dir`` and root-level files rely on scans (see
             :func:`_derive_watch_roots`).
+        internal_dirs: Vault-internal directories (state / index / embeddings
+            dir, ``.git``) that must never be watched, so ``reindex``'s writes
+            into them do not re-trigger the watcher (see
+            :func:`_derive_watch_roots`).
     """
 
     def __init__(
@@ -280,12 +342,14 @@ class VaultFileWatcher:
         debounce_s: float = 2.0,
         exclude_patterns: Sequence[str] | None = None,
         root_floor: bool = True,
+        internal_dirs: Sequence[Path] = (),
     ) -> None:
         self._source_dir = source_dir
         self._on_change = on_change
         self._debounce_s = debounce_s
         self._exclude_patterns = exclude_patterns
         self._root_floor = root_floor
+        self._internal_dirs = tuple(internal_dirs)
         self._observer: Any = None
         self._timer: threading.Timer | None = None
         self._lock = threading.Lock()
@@ -333,7 +397,10 @@ class VaultFileWatcher:
             self._stopped = False
 
         roots = _derive_watch_roots(
-            self._source_dir, self._exclude_patterns, root_floor=self._root_floor
+            self._source_dir,
+            self._exclude_patterns,
+            root_floor=self._root_floor,
+            internal_dirs=self._internal_dirs,
         )
         observer = Observer()
         scheduled: list[_WatchRoot] = []

--- a/src/markdown_vault_mcp/_server_deps.py
+++ b/src/markdown_vault_mcp/_server_deps.py
@@ -163,12 +163,32 @@ def make_vault_lifespan(config: ProjectConfig) -> Any:
                 except Exception:
                     logger.error("file_watcher: reindex failed", exc_info=True)
 
+            # Never watch the vault's own write targets: reindex() rewrites the
+            # state file on every run, and a watch on its dir would re-trigger
+            # the watcher into a self-feedback loop (#830). .git is protected
+            # too so local git-write commits don't storm reindexes.
+            from markdown_vault_mcp.vault import _DEFAULT_STATE_SUBDIR
+
+            state_dir = (
+                config.indexing.state_path.parent
+                if config.indexing.state_path is not None
+                else config.source_dir / _DEFAULT_STATE_SUBDIR
+            )
+            internal_dirs = [config.source_dir / ".git", state_dir]
+            for extra in (
+                config.indexing.index_path,
+                config.indexing.embeddings_path,
+            ):
+                if extra is not None:
+                    internal_dirs.append(extra.parent)
+
             file_watcher = VaultFileWatcher(
                 config.source_dir,
                 _on_file_change,
                 debounce_s=config.sync.file_watcher_debounce_s,
                 exclude_patterns=config.indexing.exclude_patterns,
                 root_floor=config.sync.file_watcher_root_floor,
+                internal_dirs=internal_dirs,
             )
             file_watcher.start()
         elif not config.sync.file_watcher_enabled:

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -524,6 +524,63 @@ def test_lifespan_starts_and_stops_watcher_when_no_git(tmp_path: Path) -> None:
     asyncio.run(_run())
 
 
+def test_lifespan_passes_configured_internal_dirs_to_watcher(tmp_path: Path) -> None:
+    """Explicit state/index/embeddings paths flow into the watcher's internal_dirs.
+
+    Covers the non-``None`` branches of the ``internal_dirs`` construction in
+    ``make_vault_lifespan`` (custom ``state_path`` fallback plus the
+    ``index_path``/``embeddings_path`` parent-append loop, #830): each configured
+    directory, and ``.git``, must be protected from watching so the watcher can
+    never observe the writes reindex makes into them.
+    """
+    import asyncio
+
+    from markdown_vault_mcp.config import ProjectConfig
+    from markdown_vault_mcp.config_sections import IndexingConfig
+
+    (tmp_path / "note.md").write_text("# note\n\nbody", encoding="utf-8")
+    state_dir = tmp_path / "state_area"
+    index_dir = tmp_path / "index_area"
+    emb_dir = tmp_path / "emb_area"
+    for d in (state_dir, index_dir, emb_dir):
+        d.mkdir()
+
+    config = ProjectConfig(
+        source_dir=tmp_path,
+        read_only=False,
+        indexing=IndexingConfig(
+            state_path=state_dir / "state.json",
+            index_path=index_dir / "index.db",
+            embeddings_path=emb_dir / "embeddings",
+        ),
+    )
+    lifespan_fn = make_vault_lifespan(config)
+
+    captured: dict[str, object] = {}
+    real_init = VaultFileWatcher.__init__
+
+    def spy_init(self: VaultFileWatcher, *args: object, **kwargs: object) -> None:
+        captured["internal_dirs"] = kwargs.get("internal_dirs")
+        real_init(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    async def _run() -> None:
+        with (
+            patch.object(VaultFileWatcher, "__init__", spy_init),
+            patch.object(VaultFileWatcher, "start"),
+            patch.object(VaultFileWatcher, "stop"),
+        ):
+            async with lifespan_fn(None):  # type: ignore[arg-type]
+                pass
+
+    asyncio.run(_run())
+
+    internal = set(captured["internal_dirs"])  # type: ignore[arg-type]
+    assert state_dir in internal
+    assert index_dir in internal
+    assert emb_dir in internal
+    assert tmp_path / ".git" in internal
+
+
 def test_lifespan_skips_watcher_when_git_pull_active(tmp_path: Path) -> None:
     """The lifespan does not start the watcher when the git pull loop is active.
 

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -622,6 +622,86 @@ def test_derive_watch_roots_falls_back_on_enumeration_error(tmp_path: Path) -> N
     assert roots == [_WatchRoot(missing, recursive=False)]
 
 
+def test_derive_watch_roots_skips_internal_state_and_git_dirs(tmp_path: Path) -> None:
+    """The vault's own state dir and ``.git`` are never watch roots (#830).
+
+    With no ``exclude_patterns`` the scoped-watch change would otherwise promote
+    every top-level dir — including the default state dir ``.markdown_vault_mcp``
+    (which ``reindex`` writes ``state.json`` into on every run) and ``.git`` — to
+    a recursive watch root, closing a self-feedback reindex loop. A deliberately
+    watched *user* dot-root like ``.claude`` must still be watched; only the
+    vault's internal write targets are skipped.
+    """
+    (tmp_path / ".markdown_vault_mcp").mkdir()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".claude").mkdir()
+    roots = _derive_watch_roots(
+        tmp_path,
+        None,
+        internal_dirs=[tmp_path / ".markdown_vault_mcp", tmp_path / ".git"],
+    )
+    names = _root_names(roots)
+    assert ".markdown_vault_mcp" not in names, "state dir must not be a watch root"
+    assert ".git" not in names, ".git must not be a watch root"
+    assert ".claude" in names, "a user dot-root must still be watched"
+
+
+def test_derive_watch_roots_skips_top_level_dir_containing_internal_dir(
+    tmp_path: Path,
+) -> None:
+    """A top-level dir that *contains* an internal write dir is not watched.
+
+    Guards against reintroducing the loop when the state dir is configured
+    beneath a top-level directory: watching that directory recursively would
+    still deliver the state-file writes. The whole subtree is skipped so the
+    loop can never form (a limitation documented for nested state paths).
+    """
+    state_dir = tmp_path / "data" / "state"
+    state_dir.mkdir(parents=True)
+    roots = _derive_watch_roots(tmp_path, None, internal_dirs=[state_dir])
+    assert "data" not in _root_names(roots)
+
+
+def test_start_does_not_schedule_watch_on_internal_state_dir(tmp_path: Path) -> None:
+    """``start()`` forwards ``internal_dirs`` so the state dir is never scheduled.
+
+    Exercises the wiring, not just ``_derive_watch_roots``: a pre-existing state
+    dir (present before the watcher starts, as at lifespan startup) must not get
+    a recursive watch, while a sibling content dir must (#830).
+    """
+    (tmp_path / ".markdown_vault_mcp").mkdir()
+    (tmp_path / "notes").mkdir()
+
+    class _RecordingObserver:
+        def __init__(self) -> None:
+            self.scheduled: list[str] = []
+
+        def schedule(self, _handler: object, path: str, **_kwargs: object) -> None:
+            self.scheduled.append(path)
+
+        def start(self) -> None:
+            pass
+
+        def stop(self) -> None:
+            pass
+
+        def join(self, timeout: float | None = None) -> None:
+            pass
+
+    fake = _RecordingObserver()
+    watcher = VaultFileWatcher(
+        tmp_path,
+        lambda: None,  # type: ignore[arg-type]
+        internal_dirs=[tmp_path / ".markdown_vault_mcp"],
+    )
+    with patch("markdown_vault_mcp._file_watcher.Observer", lambda: fake):
+        watcher.start()
+        watcher.stop()
+
+    assert str(tmp_path / ".markdown_vault_mcp") not in fake.scheduled
+    assert str(tmp_path / "notes") in fake.scheduled
+
+
 def test_derive_watch_roots_root_floor_false_omits_non_recursive_root(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #830.

## Problem

#828's scoped-watch change (`_derive_watch_roots`) promotes every non-pruned immediate child of `source_dir` to a **recursive** watch root, pruned only by `exclude_patterns` (which defaults to `None`), and `_VaultEventHandler` now judges hiddenness **relative to the delivering watch root**. So the default state dir `.markdown_vault_mcp/` and `.git/` each became their own recursive watch root, and a write to `.markdown_vault_mcp/state.json` — which `reindex()` performs **unconditionally** on every run — was no longer seen as hidden.

That closes a self-feedback reindex loop (a regression of the #720/#721 fix), reachable in a default configuration, plus reindex storms on `.git` activity (e.g. the local-git-write auto-commit path).

Verified in-process: `_derive_watch_roots(vault, None)` returned recursive roots including `.git` and `.markdown_vault_mcp`, and `_is_hidden_relative_to_root(".../.markdown_vault_mcp/state.json", ".../.markdown_vault_mcp")` returned `False`.

## Fix

`_derive_watch_roots` gains an `internal_dirs` parameter and skips any top-level child that **is or contains** one of them; `_server_deps` passes the vault's state / index / embeddings dirs and `.git`. User dot-roots (`.claude/`) are still watched recursively, preserving the #558/#828 behavior. Skipping a subtree that *contains* an internal dir (rather than only an exact match) guarantees the loop can never form even if the state dir is configured beneath a top-level directory.

## Tests

- `test_derive_watch_roots_skips_internal_state_and_git_dirs` — state dir + `.git` excluded, `.claude` retained.
- `test_derive_watch_roots_skips_top_level_dir_containing_internal_dir` — a dir containing a nested state dir is skipped.
- `test_start_does_not_schedule_watch_on_internal_state_dir` — exercises the `start()` wiring with a recording observer.

Full `tests/test_file_watcher.py` (61) green; ruff + mypy clean.

## Provenance

Surfaced by a local multi-lens review of the merged #824/#826/#827/#828 range; two independent lenses (git-history + general code review) reached this with the repro above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._