### PR TITLE
docs: correct stale comments from #824/#827/#828

### DIFF
--- a/src/markdown_vault_mcp/_file_watcher.py
+++ b/src/markdown_vault_mcp/_file_watcher.py
@@ -87,9 +87,9 @@ def _is_hidden_relative_to_root(abs_path: str, watch_root: Path) -> bool:
     under*, not relative to ``source_dir``. A deliberately-watched dot-root such
     as ``.claude`` delivers its non-dot descendants (the remainder carries no dot
     component), while genuinely hidden noise below any root (``.git``,
-    ``.markdown_vault_mcp``, editor swap dirs) is still dropped, and the
-    ``DirModifiedEvent`` watchdog fires on the watched dir itself (empty
-    remainder) is dropped.
+    ``.markdown_vault_mcp``, editor swap dirs) is still dropped, as is the
+    ``DirModifiedEvent`` the watchdog fires on the watched dir itself (empty
+    remainder).
 
     When there is a single non-dot watch root equal to ``source_dir`` this
     reduces to the old ``rel = path.relative_to(source_dir)`` behavior exactly.
@@ -175,8 +175,10 @@ def _derive_watch_roots(
         return [_WatchRoot(source_dir, recursive=False)] if root_floor else []
 
     for child in children:
-        # is_dir() follows symlinks, matching the 3.13+ followlinks semantics
-        # iter_markdown_files uses so watched roots and indexed files agree.
+        # is_dir() follows symlinks on all versions; iter_markdown_files walks
+        # with followlinks only on 3.13+. So watched roots and indexed files
+        # agree on 3.13+; on 3.11/3.12 a symlinked top-level dir may be watched
+        # though its files are not indexed (harmless: an extra watch).
         if not child.is_dir():
             continue
         if _should_prune_dir(child.name, anchored, anydepth):

--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -33,7 +33,9 @@ def load_or_self_heal(
     """Load the vector sidecar into the caller's slot, self-healing corruption.
 
     Returns the cached index if ``get_vectors()`` is already populated.
-    Otherwise deserialises it from ``{embeddings_path}.npy``/``.json``; on an
+    Otherwise deserialises it from the ``.npy``/``.json`` sidecars derived via
+    ``Path.with_suffix`` (a base that already carries an extension has it
+    replaced, not doubled); on an
     incompatible, corrupt, or incomplete sidecar
     (``VectorIndexCompatibilityError``, ``VectorIndexCorruptError``,
     ``json.JSONDecodeError``/``ValueError``, ``EOFError``,
@@ -42,8 +44,9 @@ def load_or_self_heal(
     (e.g. ``PermissionError``) are not caught and propagate.
 
     Args:
-        embeddings_path: Base path for the sidecar files (``.npy``/``.json``
-            are appended).
+        embeddings_path: Base path for the sidecar files; the ``.npy``/``.json``
+            sidecar paths are derived with ``Path.with_suffix`` (a base that
+            already carries an extension has it replaced, not doubled).
         embedding_provider: Provider attached to a freshly-built index.
         get_vectors: Reads the caller's cached index slot (``None`` if empty).
         set_vectors: Writes a loaded/empty index into the caller's slot.
@@ -94,7 +97,7 @@ def load_or_self_heal(
     # (Path.with_suffix), so a base path that already carries an extension
     # (e.g. EMBEDDINGS_PATH=embeddings.npy) resolves to the same file that was
     # saved. A string-append would probe embeddings.npy.npy, miss the real
-    # store, cold-build an empty index, and later overwrite the store (#736).
+    # store, cold-build an empty index, and later overwrite the store (#819).
     npy_path = embeddings_path.with_suffix(".npy")
     if npy_path.exists():
         try:

--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -45,8 +45,7 @@ def load_or_self_heal(
 
     Args:
         embeddings_path: Base path for the sidecar files; the ``.npy``/``.json``
-            sidecar paths are derived with ``Path.with_suffix`` (a base that
-            already carries an extension has it replaced, not doubled).
+            paths are derived with ``Path.with_suffix`` as described above.
         embedding_provider: Provider attached to a freshly-built index.
         get_vectors: Reads the caller's cached index slot (``None`` if empty).
         set_vectors: Writes a loaded/empty index into the caller's slot.

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -905,7 +905,7 @@ class IndexManager:
             # Derive sidecar paths the way VectorIndex.load/save do
             # (Path.with_suffix), so an EMBEDDINGS_PATH that carries an
             # extension resolves to the real files instead of {path}.npy.npy
-            # and misreporting chunk_count=0 (#736).
+            # and misreporting chunk_count=0 (#819).
             npy_path = self._embeddings_path.with_suffix(".npy")
             if npy_path.exists():
                 json_path = self._embeddings_path.with_suffix(".json")


### PR DESCRIPTION
Closes #833.

Comment/docstring accuracy only — **no behavior change**. Surfaced by the multi-lens review of the merged #824/#826/#827/#828 range.

- `_vector_loader.py`: `load_or_self_heal` docstring said the `.npy`/`.json` sidecars are "appended"; #824 changed the derivation to `Path.with_suffix` (which *replaces* an existing extension). Reworded the summary and the `embeddings_path` arg doc.
- `_vector_loader.py:97` and `index.py:908`: the behavior-describing comments cited `(#736)` — an unrelated `_load_vectors` unification — for the data-loss bug actually fixed under **#819**. Repointed both to `#819`. The correct module-level `(#736)` docstring is untouched.
- `_file_watcher.py`: qualified the `is_dir()`/`followlinks` comment (they only agree on 3.13+); fixed a garbled sentence in `_is_hidden_relative_to_root`'s docstring.

_(The pre-commit Vale-exclude realignment that was originally bundled here now rides with the design.md relocation PR #841, which needs it; #837 is closed there.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._