### PR TITLE
fix: keep an already-indexed file that fails to re-hash instead of purging it

### DIFF
--- a/src/markdown_vault_mcp/tracker.py
+++ b/src/markdown_vault_mcp/tracker.py
@@ -152,11 +152,30 @@ class ChangeTracker:
             try:
                 content_hash = self._hash_with_retry(abs_path)
             except OSError as exc:
+                prior = indexed_state.get(rel_str)
+                if prior is not None:
+                    # Already indexed: a failed re-hash must NOT drop it, or the
+                    # file would be absent from disk_state and look "deleted"
+                    # below, purging a live document from FTS and its embedding
+                    # on a merely-unreadable-right-now file (transient EMFILE, or
+                    # a still-present EACCES). Carry the prior hash forward so it
+                    # counts as unchanged this scan and is re-hashed next scan
+                    # (#831). A genuinely deleted file is absent from discovery
+                    # on the next scan and reported deleted then.
+                    disk_state[rel_str] = prior
+                    logger.warning(
+                        "hash_read_failed_keeping_indexed path=%s errno=%s: %s",
+                        abs_path,
+                        exc.errno,
+                        exc,
+                    )
+                    continue
                 if exc.errno in _TRANSIENT_HASH_ERRNOS:
-                    # Retries were exhausted: file-descriptor pressure outlasted
-                    # the retry window. The file is dropped from this scan and
-                    # retried on the next one, but surface it at ERROR so it is
-                    # not lost among a busy watcher's INFO reindex summaries.
+                    # A brand-new (unindexed) file that failed even after
+                    # retries: nothing to carry forward, so it is dropped from
+                    # this scan and retried on the next one. Surface it at ERROR
+                    # so it is not lost among a busy watcher's INFO reindex
+                    # summaries.
                     logger.error(
                         "hash_read_failed_after_retry path=%s errno=%s: %s",
                         abs_path,

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -616,6 +616,69 @@ class TestUnreadableFiles:
             for r in caplog.records
         )
 
+    def test_indexed_file_failing_to_hash_is_kept_not_deleted(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An already-indexed file that fails to re-hash is retained, not purged.
+
+        Dropping it from the disk snapshot would route it into ``deleted``,
+        purging a live document from FTS and its embedding on a transient (or
+        even a permanent-but-still-present, e.g. EACCES) read failure (#831).
+        The prior hash is carried forward so the file counts as unchanged this
+        scan and is re-hashed on the next one.
+        """
+        import errno
+        import hashlib
+        import logging
+        from unittest.mock import patch as mock_patch
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        md = _write_md(vault, "keep.md", "content\n")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        tracker.detect_changes(vault)
+        note = _make_note("keep.md", hashlib.sha256(md.read_bytes()).hexdigest())
+        tracker.update_state([note])
+
+        def eacces(_self: ChangeTracker, _path: Path) -> str:
+            raise OSError(errno.EACCES, "Permission denied")
+
+        with (
+            mock_patch.object(ChangeTracker, "_compute_hash", eacces),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.tracker"),
+        ):
+            changes = tracker.detect_changes(vault)
+
+        assert changes.deleted == [], "an unreadable indexed file must not be purged"
+        assert "keep.md" not in changes.modified
+        assert changes.unchanged == 1  # carried forward as unchanged
+
+    def test_non_transient_errno_is_not_retried(self, tmp_path: Path) -> None:
+        """A non-transient OSError (EACCES) fails on the first attempt, no retry.
+
+        Guards the discriminate-then-retry contract: only EMFILE/ENFILE retry;
+        if EACCES were added to the transient set, the EMFILE tests would still
+        pass (just slower), so this asserts the call count directly (#836).
+        """
+        import errno
+        from unittest.mock import patch as mock_patch
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_md(vault, "new.md", "x\n")
+        calls: list[int] = []
+
+        def eacces(_self: ChangeTracker, _path: Path) -> str:
+            calls.append(1)
+            raise OSError(errno.EACCES, "Permission denied")
+
+        tracker = ChangeTracker(tmp_path / "state.json")
+        with mock_patch.object(ChangeTracker, "_compute_hash", eacces):
+            tracker.detect_changes(vault)
+
+        assert len(calls) == 1, "a non-transient errno must be attempted exactly once"
+
 
 class TestLegacyStateFormat:
     def test_legacy_flat_state_loads_as_indexed(self, tmp_path: Path) -> None:

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -653,6 +653,12 @@ class TestUnreadableFiles:
         assert changes.deleted == [], "an unreadable indexed file must not be purged"
         assert "keep.md" not in changes.modified
         assert changes.unchanged == 1  # carried forward as unchanged
+        assert any(
+            r.levelno == logging.WARNING
+            and "hash_read_failed_keeping_indexed" in r.getMessage()
+            and "keep.md" in r.getMessage()
+            for r in caplog.records
+        ), "the carry-forward must be visible in the log for operators"
 
     def test_non_transient_errno_is_not_retried(self, tmp_path: Path) -> None:
         """A non-transient OSError (EACCES) fails on the first attempt, no retry.


### PR DESCRIPTION
Closes #831.

## Problem

`ChangeTracker.detect_changes` dropped **any** file that failed to hash from the disk snapshot. For a file already in the indexed state, that routed it into the `deleted` list, and the downstream reindex purged the live document from FTS and its embedding — on a merely transient (`EMFILE`) or a still-present-but-unreadable (`EACCES`) read error. #827's retry lowered the probability for `EMFILE`, but the exhaustion branch and every non-transient `OSError` kept the wrong outcome. Surfaced by the multi-lens review of the #824–#828 range (silent-failure lens).

## Fix

When hashing fails for a path already in `indexed_state`, carry its prior hash forward into `disk_state` so it counts as **unchanged** for that scan and is re-hashed on the next one. Only a newly discovered (unindexed) file that fails to hash is dropped (unchanged behavior). A genuinely deleted file is absent from discovery on the next scan and reported `deleted` then.

## Tests

- `test_indexed_file_failing_to_hash_is_kept_not_deleted` — an indexed file that raises `EACCES` on re-hash is not in `deleted`, not `modified`, counted `unchanged` (fails on `main`: the file is purged).
- `test_non_transient_errno_is_not_retried` — asserts a non-transient errno is attempted exactly once, locking in the discriminate-then-retry contract (part of #836).

Full `tests/test_tracker.py` (41) green; ruff + mypy clean; structural-diff gate 100%.

**Note:** the matching `docs/design.md` contract update rides with the design.md-relocation PR (design.md currently fails the local Vale hook on pre-existing content and is being moved under `docs/design/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._