### PR TITLE
feat: restyle the Vault Browser view to Paper (#813)

### DIFF
--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -380,38 +380,48 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     flex: 1; display: flex; flex-direction: column;
     overflow: hidden;
   }
-  .browser-search {
-    display: flex; padding: 6px; gap: 4px; border-bottom: 1px solid var(--color-border-primary); flex-shrink: 0;
+  .browser-search { padding: var(--pad); border-bottom: 1px solid var(--border-2); flex-shrink: 0; }
+  .search-field {
+    display: flex; align-items: center; gap: 8px;
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 9px 11px;
   }
+  .search-ico { color: var(--muted); flex: none; }
   .browser-search input {
-    flex: 1; padding: 4px 8px; border: 1px solid var(--color-border-primary); border-radius: 4px;
-    font-size: 12px; font-family: inherit; background: var(--color-background-primary); color: var(--color-text-primary);
+    flex: 1; min-width: 0; border: none; background: transparent; padding: 0;
+    font: 500 13px/1 var(--font-body); color: var(--ink);
   }
-  .browser-search button {
-    background: none; border: none; cursor: pointer; font-size: 16px; color: var(--color-text-secondary); padding: 0 4px;
+  .browser-search input:focus { outline: none; }
+  .browser-search input::placeholder { color: var(--muted); }
+  #browser-search-clear {
+    background: none; border: none; cursor: pointer; font-size: 15px; line-height: 1; color: var(--muted); padding: 0 2px; flex: none;
   }
-  .browser-tree { flex: 1; overflow-y: auto; padding: 4px; font-size: 12px; }
+  .hybrid-badge {
+    flex: none; font: 600 10px/1 var(--font-mono); text-transform: uppercase; letter-spacing: .05em;
+    color: var(--accent); background: var(--accent-soft); padding: 4px 7px; border-radius: 5px;
+  }
+  .browser-tree { flex: 1; overflow-y: auto; padding: 9px 10px 12px; }
   .tree-folder {
-    cursor: pointer; padding: 3px 4px; display: flex; align-items: center; gap: 4px;
-    font-weight: 600; color: var(--color-text-primary);
+    cursor: pointer; padding: 6px; display: flex; align-items: center; gap: 7px; border-radius: var(--radius-sm);
   }
-  .tree-folder:hover { background: var(--color-background-secondary); border-radius: 3px; }
-  .tree-folder .arrow { font-size: 10px; width: 12px; transition: transform 0.15s; display: inline-block; }
-  .tree-folder.expanded .arrow { transform: rotate(90deg); }
-  .tree-children { padding-left: 16px; display: none; }
+  .tree-folder .tree-label { font: 600 12.5px/1 var(--font-body); color: var(--ink); }
+  .tree-chevron { color: var(--muted); flex: none; transition: transform 0.15s; }
+  .tree-folder.expanded .tree-chevron { transform: rotate(90deg); }
+  .tree-children { padding-left: 14px; display: none; }
   .tree-folder.expanded + .tree-children { display: block; }
   .tree-note {
-    cursor: pointer; padding: 3px 4px 3px 20px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    color: var(--color-text-primary);
+    cursor: pointer; padding: 5px 6px 5px 26px; display: flex; align-items: center; gap: 8px; border-radius: var(--radius-sm);
   }
-  .tree-note:hover { background: var(--color-background-secondary); border-radius: 3px; }
-  .tree-note.active { background: var(--color-text-info); color: var(--color-text-inverse); border-radius: 3px; }
-  .search-result {
-    cursor: pointer; padding: 6px 8px; border-bottom: 1px solid var(--color-border-primary);
-  }
-  .search-result:hover { background: var(--color-background-secondary); }
-  .search-result-title { font-weight: 600; font-size: 13px; }
-  .search-result-snippet { font-size: 11px; color: var(--color-text-secondary); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tree-ico { color: var(--muted); flex: none; }
+  .tree-note .tree-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 500 12.5px/1 var(--font-body); color: var(--ink-2); }
+  .tree-folder:hover, .tree-note:hover { background: var(--panel-2); }
+  .tree-note.active { background: var(--accent-soft); box-shadow: inset 2px 0 0 var(--accent); }
+  .tree-note.active .tree-ico, .tree-note.active .tree-label { color: var(--accent); }
+  .tree-note.active .tree-label { font-weight: 600; }
+  .search-result { cursor: pointer; padding: 8px; border-radius: var(--radius-sm); border-bottom: 1px solid var(--border-2); }
+  .search-result:last-child { border-bottom: none; }
+  .search-result:hover { background: var(--panel-2); }
+  .search-result-title { font: 600 13px/1.3 var(--font-body); color: var(--ink); }
+  .search-result-snippet { font: 400 11px/1.4 var(--font-body); color: var(--muted); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   /* Note tab styles */
   .tab-bar .note-tab-btn { display: none; }
   .tab-bar .note-tab-btn.visible { display: flex; }
@@ -438,7 +448,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font-size: 12px; cursor: not-allowed; opacity: 0.6; font-family: inherit;
   }
 </style>
-<!-- vendor-spa-source-sha256:3aeae3c7fdf3007502d0a1161625b8eabe815b457a36bb2b0ca0d336df382b02 -->
+<!-- vendor-spa-source-sha256:eb2c4602c691df7d71812ca9e12b2f9542df999fce6660cc0cb38554f1a219d3 -->
 </head>
 <body>
 <div class="app-container">
@@ -498,8 +508,12 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     <div class="browser-layout">
       <div class="browser-sidebar">
         <div class="browser-search">
-          <input type="text" id="browser-search-input" placeholder="Search vault..." />
-          <button id="browser-search-clear" style="display:none;" title="Clear search">&times;</button>
+          <div class="search-field">
+            <svg class="search-ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+            <input type="text" id="browser-search-input" placeholder="Search vault&#8230;" />
+            <button id="browser-search-clear" style="display:none;" title="Clear search">&times;</button>
+            <span class="hybrid-badge">hybrid</span>
+          </div>
         </div>
         <div id="browser-tree" class="browser-tree"></div>
       </div>
@@ -1239,6 +1253,10 @@ app.onteardown = () => {
       .replace(/"/g, '&quot;');
   }
 
+  const ICON_CHEVRON = '<svg class="tree-chevron" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>';
+  const ICON_FILE = '<svg class="tree-ico" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M6 3h8l4 4v14H6z"/><path d="M14 3v4h4"/></svg>';
+  const ICON_IMAGE = '<svg class="tree-ico" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="4" y="5" width="16" height="14" rx="2"/><circle cx="9" cy="10" r="1.6"/><path d="M5 17l5-4 4 3 3-2 2 2"/></svg>';
+
   let treeDataCache = {};
   let isSearchMode = false;
 
@@ -1268,7 +1286,7 @@ app.onteardown = () => {
       const name = f.includes('/') ? f.split('/').pop() : f;
       const folderDiv = document.createElement('div');
       folderDiv.className = 'tree-folder';
-      folderDiv.innerHTML = '<span class="arrow">\u25B6</span> \uD83D\uDCC1 ' + escHtml(name);
+      folderDiv.innerHTML = ICON_CHEVRON + '<span class="tree-label">' + escHtml(name) + '</span>';
       folderDiv.dataset.folder = f;
       parentEl.appendChild(folderDiv);
 
@@ -1293,7 +1311,8 @@ app.onteardown = () => {
     for (const n of data.notes) {
       const noteDiv = document.createElement('div');
       noteDiv.className = 'tree-note';
-      noteDiv.textContent = n.title || n.path;
+      const icon = n.kind === 'attachment' ? ICON_IMAGE : ICON_FILE;
+      noteDiv.innerHTML = icon + '<span class="tree-label">' + escHtml(n.title || n.path) + '</span>';
       noteDiv.title = n.path;
       noteDiv.dataset.path = n.path;
       noteDiv.addEventListener('click', () => window.loadPreview(n.path));

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -266,38 +266,48 @@
     flex: 1; display: flex; flex-direction: column;
     overflow: hidden;
   }
-  .browser-search {
-    display: flex; padding: 6px; gap: 4px; border-bottom: 1px solid var(--color-border-primary); flex-shrink: 0;
+  .browser-search { padding: var(--pad); border-bottom: 1px solid var(--border-2); flex-shrink: 0; }
+  .search-field {
+    display: flex; align-items: center; gap: 8px;
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 9px 11px;
   }
+  .search-ico { color: var(--muted); flex: none; }
   .browser-search input {
-    flex: 1; padding: 4px 8px; border: 1px solid var(--color-border-primary); border-radius: 4px;
-    font-size: 12px; font-family: inherit; background: var(--color-background-primary); color: var(--color-text-primary);
+    flex: 1; min-width: 0; border: none; background: transparent; padding: 0;
+    font: 500 13px/1 var(--font-body); color: var(--ink);
   }
-  .browser-search button {
-    background: none; border: none; cursor: pointer; font-size: 16px; color: var(--color-text-secondary); padding: 0 4px;
+  .browser-search input:focus { outline: none; }
+  .browser-search input::placeholder { color: var(--muted); }
+  #browser-search-clear {
+    background: none; border: none; cursor: pointer; font-size: 15px; line-height: 1; color: var(--muted); padding: 0 2px; flex: none;
   }
-  .browser-tree { flex: 1; overflow-y: auto; padding: 4px; font-size: 12px; }
+  .hybrid-badge {
+    flex: none; font: 600 10px/1 var(--font-mono); text-transform: uppercase; letter-spacing: .05em;
+    color: var(--accent); background: var(--accent-soft); padding: 4px 7px; border-radius: 5px;
+  }
+  .browser-tree { flex: 1; overflow-y: auto; padding: 9px 10px 12px; }
   .tree-folder {
-    cursor: pointer; padding: 3px 4px; display: flex; align-items: center; gap: 4px;
-    font-weight: 600; color: var(--color-text-primary);
+    cursor: pointer; padding: 6px; display: flex; align-items: center; gap: 7px; border-radius: var(--radius-sm);
   }
-  .tree-folder:hover { background: var(--color-background-secondary); border-radius: 3px; }
-  .tree-folder .arrow { font-size: 10px; width: 12px; transition: transform 0.15s; display: inline-block; }
-  .tree-folder.expanded .arrow { transform: rotate(90deg); }
-  .tree-children { padding-left: 16px; display: none; }
+  .tree-folder .tree-label { font: 600 12.5px/1 var(--font-body); color: var(--ink); }
+  .tree-chevron { color: var(--muted); flex: none; transition: transform 0.15s; }
+  .tree-folder.expanded .tree-chevron { transform: rotate(90deg); }
+  .tree-children { padding-left: 14px; display: none; }
   .tree-folder.expanded + .tree-children { display: block; }
   .tree-note {
-    cursor: pointer; padding: 3px 4px 3px 20px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    color: var(--color-text-primary);
+    cursor: pointer; padding: 5px 6px 5px 26px; display: flex; align-items: center; gap: 8px; border-radius: var(--radius-sm);
   }
-  .tree-note:hover { background: var(--color-background-secondary); border-radius: 3px; }
-  .tree-note.active { background: var(--color-text-info); color: var(--color-text-inverse); border-radius: 3px; }
-  .search-result {
-    cursor: pointer; padding: 6px 8px; border-bottom: 1px solid var(--color-border-primary);
-  }
-  .search-result:hover { background: var(--color-background-secondary); }
-  .search-result-title { font-weight: 600; font-size: 13px; }
-  .search-result-snippet { font-size: 11px; color: var(--color-text-secondary); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tree-ico { color: var(--muted); flex: none; }
+  .tree-note .tree-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 500 12.5px/1 var(--font-body); color: var(--ink-2); }
+  .tree-folder:hover, .tree-note:hover { background: var(--panel-2); }
+  .tree-note.active { background: var(--accent-soft); box-shadow: inset 2px 0 0 var(--accent); }
+  .tree-note.active .tree-ico, .tree-note.active .tree-label { color: var(--accent); }
+  .tree-note.active .tree-label { font-weight: 600; }
+  .search-result { cursor: pointer; padding: 8px; border-radius: var(--radius-sm); border-bottom: 1px solid var(--border-2); }
+  .search-result:last-child { border-bottom: none; }
+  .search-result:hover { background: var(--panel-2); }
+  .search-result-title { font: 600 13px/1.3 var(--font-body); color: var(--ink); }
+  .search-result-snippet { font: 400 11px/1.4 var(--font-body); color: var(--muted); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   /* Note tab styles */
   .tab-bar .note-tab-btn { display: none; }
   .tab-bar .note-tab-btn.visible { display: flex; }
@@ -383,8 +393,12 @@
     <div class="browser-layout">
       <div class="browser-sidebar">
         <div class="browser-search">
-          <input type="text" id="browser-search-input" placeholder="Search vault..." />
-          <button id="browser-search-clear" style="display:none;" title="Clear search">&times;</button>
+          <div class="search-field">
+            <svg class="search-ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+            <input type="text" id="browser-search-input" placeholder="Search vault&#8230;" />
+            <button id="browser-search-clear" style="display:none;" title="Clear search">&times;</button>
+            <span class="hybrid-badge">hybrid</span>
+          </div>
         </div>
         <div id="browser-tree" class="browser-tree"></div>
       </div>
@@ -1121,6 +1135,10 @@ app.onteardown = () => {
       .replace(/"/g, '&quot;');
   }
 
+  const ICON_CHEVRON = '<svg class="tree-chevron" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>';
+  const ICON_FILE = '<svg class="tree-ico" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M6 3h8l4 4v14H6z"/><path d="M14 3v4h4"/></svg>';
+  const ICON_IMAGE = '<svg class="tree-ico" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="4" y="5" width="16" height="14" rx="2"/><circle cx="9" cy="10" r="1.6"/><path d="M5 17l5-4 4 3 3-2 2 2"/></svg>';
+
   let treeDataCache = {};
   let isSearchMode = false;
 
@@ -1150,7 +1168,7 @@ app.onteardown = () => {
       const name = f.includes('/') ? f.split('/').pop() : f;
       const folderDiv = document.createElement('div');
       folderDiv.className = 'tree-folder';
-      folderDiv.innerHTML = '<span class="arrow">\u25B6</span> \uD83D\uDCC1 ' + escHtml(name);
+      folderDiv.innerHTML = ICON_CHEVRON + '<span class="tree-label">' + escHtml(name) + '</span>';
       folderDiv.dataset.folder = f;
       parentEl.appendChild(folderDiv);
 
@@ -1175,7 +1193,8 @@ app.onteardown = () => {
     for (const n of data.notes) {
       const noteDiv = document.createElement('div');
       noteDiv.className = 'tree-note';
-      noteDiv.textContent = n.title || n.path;
+      const icon = n.kind === 'attachment' ? ICON_IMAGE : ICON_FILE;
+      noteDiv.innerHTML = icon + '<span class="tree-label">' + escHtml(n.title || n.path) + '</span>';
       noteDiv.title = n.path;
       noteDiv.dataset.path = n.path;
       noteDiv.addEventListener('click', () => window.loadPreview(n.path));

--- a/src/markdown_vault_mcp/static/spa/shell.html
+++ b/src/markdown_vault_mcp/static/spa/shell.html
@@ -70,8 +70,12 @@
     <div class="browser-layout">
       <div class="browser-sidebar">
         <div class="browser-search">
-          <input type="text" id="browser-search-input" placeholder="Search vault..." />
-          <button id="browser-search-clear" style="display:none;" title="Clear search">&times;</button>
+          <div class="search-field">
+            <svg class="search-ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+            <input type="text" id="browser-search-input" placeholder="Search vault&#8230;" />
+            <button id="browser-search-clear" style="display:none;" title="Clear search">&times;</button>
+            <span class="hybrid-badge">hybrid</span>
+          </div>
         </div>
         <div id="browser-tree" class="browser-tree"></div>
       </div>

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -252,38 +252,48 @@
     flex: 1; display: flex; flex-direction: column;
     overflow: hidden;
   }
-  .browser-search {
-    display: flex; padding: 6px; gap: 4px; border-bottom: 1px solid var(--color-border-primary); flex-shrink: 0;
+  .browser-search { padding: var(--pad); border-bottom: 1px solid var(--border-2); flex-shrink: 0; }
+  .search-field {
+    display: flex; align-items: center; gap: 8px;
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 9px 11px;
   }
+  .search-ico { color: var(--muted); flex: none; }
   .browser-search input {
-    flex: 1; padding: 4px 8px; border: 1px solid var(--color-border-primary); border-radius: 4px;
-    font-size: 12px; font-family: inherit; background: var(--color-background-primary); color: var(--color-text-primary);
+    flex: 1; min-width: 0; border: none; background: transparent; padding: 0;
+    font: 500 13px/1 var(--font-body); color: var(--ink);
   }
-  .browser-search button {
-    background: none; border: none; cursor: pointer; font-size: 16px; color: var(--color-text-secondary); padding: 0 4px;
+  .browser-search input:focus { outline: none; }
+  .browser-search input::placeholder { color: var(--muted); }
+  #browser-search-clear {
+    background: none; border: none; cursor: pointer; font-size: 15px; line-height: 1; color: var(--muted); padding: 0 2px; flex: none;
   }
-  .browser-tree { flex: 1; overflow-y: auto; padding: 4px; font-size: 12px; }
+  .hybrid-badge {
+    flex: none; font: 600 10px/1 var(--font-mono); text-transform: uppercase; letter-spacing: .05em;
+    color: var(--accent); background: var(--accent-soft); padding: 4px 7px; border-radius: 5px;
+  }
+  .browser-tree { flex: 1; overflow-y: auto; padding: 9px 10px 12px; }
   .tree-folder {
-    cursor: pointer; padding: 3px 4px; display: flex; align-items: center; gap: 4px;
-    font-weight: 600; color: var(--color-text-primary);
+    cursor: pointer; padding: 6px; display: flex; align-items: center; gap: 7px; border-radius: var(--radius-sm);
   }
-  .tree-folder:hover { background: var(--color-background-secondary); border-radius: 3px; }
-  .tree-folder .arrow { font-size: 10px; width: 12px; transition: transform 0.15s; display: inline-block; }
-  .tree-folder.expanded .arrow { transform: rotate(90deg); }
-  .tree-children { padding-left: 16px; display: none; }
+  .tree-folder .tree-label { font: 600 12.5px/1 var(--font-body); color: var(--ink); }
+  .tree-chevron { color: var(--muted); flex: none; transition: transform 0.15s; }
+  .tree-folder.expanded .tree-chevron { transform: rotate(90deg); }
+  .tree-children { padding-left: 14px; display: none; }
   .tree-folder.expanded + .tree-children { display: block; }
   .tree-note {
-    cursor: pointer; padding: 3px 4px 3px 20px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    color: var(--color-text-primary);
+    cursor: pointer; padding: 5px 6px 5px 26px; display: flex; align-items: center; gap: 8px; border-radius: var(--radius-sm);
   }
-  .tree-note:hover { background: var(--color-background-secondary); border-radius: 3px; }
-  .tree-note.active { background: var(--color-text-info); color: var(--color-text-inverse); border-radius: 3px; }
-  .search-result {
-    cursor: pointer; padding: 6px 8px; border-bottom: 1px solid var(--color-border-primary);
-  }
-  .search-result:hover { background: var(--color-background-secondary); }
-  .search-result-title { font-weight: 600; font-size: 13px; }
-  .search-result-snippet { font-size: 11px; color: var(--color-text-secondary); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tree-ico { color: var(--muted); flex: none; }
+  .tree-note .tree-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 500 12.5px/1 var(--font-body); color: var(--ink-2); }
+  .tree-folder:hover, .tree-note:hover { background: var(--panel-2); }
+  .tree-note.active { background: var(--accent-soft); box-shadow: inset 2px 0 0 var(--accent); }
+  .tree-note.active .tree-ico, .tree-note.active .tree-label { color: var(--accent); }
+  .tree-note.active .tree-label { font-weight: 600; }
+  .search-result { cursor: pointer; padding: 8px; border-radius: var(--radius-sm); border-bottom: 1px solid var(--border-2); }
+  .search-result:last-child { border-bottom: none; }
+  .search-result:hover { background: var(--panel-2); }
+  .search-result-title { font: 600 13px/1.3 var(--font-body); color: var(--ink); }
+  .search-result-snippet { font: 400 11px/1.4 var(--font-body); color: var(--muted); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   /* Note tab styles */
   .tab-bar .note-tab-btn { display: none; }
   .tab-bar .note-tab-btn.visible { display: flex; }

--- a/src/markdown_vault_mcp/static/spa/views/browser.js
+++ b/src/markdown_vault_mcp/static/spa/views/browser.js
@@ -8,6 +8,10 @@
       .replace(/"/g, '&quot;');
   }
 
+  const ICON_CHEVRON = '<svg class="tree-chevron" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>';
+  const ICON_FILE = '<svg class="tree-ico" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M6 3h8l4 4v14H6z"/><path d="M14 3v4h4"/></svg>';
+  const ICON_IMAGE = '<svg class="tree-ico" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="4" y="5" width="16" height="14" rx="2"/><circle cx="9" cy="10" r="1.6"/><path d="M5 17l5-4 4 3 3-2 2 2"/></svg>';
+
   let treeDataCache = {};
   let isSearchMode = false;
 
@@ -37,7 +41,7 @@
       const name = f.includes('/') ? f.split('/').pop() : f;
       const folderDiv = document.createElement('div');
       folderDiv.className = 'tree-folder';
-      folderDiv.innerHTML = '<span class="arrow">\u25B6</span> \uD83D\uDCC1 ' + escHtml(name);
+      folderDiv.innerHTML = ICON_CHEVRON + '<span class="tree-label">' + escHtml(name) + '</span>';
       folderDiv.dataset.folder = f;
       parentEl.appendChild(folderDiv);
 
@@ -62,7 +66,8 @@
     for (const n of data.notes) {
       const noteDiv = document.createElement('div');
       noteDiv.className = 'tree-note';
-      noteDiv.textContent = n.title || n.path;
+      const icon = n.kind === 'attachment' ? ICON_IMAGE : ICON_FILE;
+      noteDiv.innerHTML = icon + '<span class="tree-label">' + escHtml(n.title || n.path) + '</span>';
       noteDiv.title = n.path;
       noteDiv.dataset.path = n.path;
       noteDiv.addEventListener('click', () => window.loadPreview(n.path));

--- a/tests/test_mcp_apps_browser.py
+++ b/tests/test_mcp_apps_browser.py
@@ -66,6 +66,20 @@ class TestBrowserHTML:
         html = await get_app_html()
         assert 'id="browser-search-clear"' in html
 
+    async def test_search_field_paper(self) -> None:
+        html = await get_app_html()
+        # Paper search field: a container with a magnifier icon and a hybrid badge.
+        assert "search-field" in html
+        assert "search-ico" in html
+        assert "hybrid-badge" in html
+
+    async def test_tree_row_icons(self) -> None:
+        html = await get_app_html()
+        # Folders carry a rotatable chevron; files/attachments carry a leading icon.
+        assert "tree-chevron" in html
+        assert "tree-ico" in html
+        assert "tree-label" in html
+
     async def test_preview_panel(self) -> None:
         html = await get_app_html()
         assert 'id="browser-preview"' in html
@@ -92,9 +106,13 @@ class TestBrowserHTML:
         html = await get_app_html()
         assert "marked.parse" in html
 
-    async def test_host_font_inheritance(self) -> None:
+    async def test_paper_font_variables(self) -> None:
         html = await get_app_html()
-        assert "font-family: inherit" in html or "--font-sans" in html
+        # The Browser (and the wider SPA) applies the Paper type system via CSS
+        # font variables; the search input reads --font-body.
+        assert "var(--font-body)" in html
+        assert "--font-head" in html
+        assert "--font-mono" in html
 
     async def test_update_model_context(self) -> None:
         html = await get_app_html()


### PR DESCRIPTION
## Restyle the Vault Browser view to Paper

Closes #813. Third view of the Vault Views "Paper" redesign (epic #809), branched off main (#811 theming + #812 shared classes are merged). **Presentation only** — lazy folder loading, hybrid search, and `window.loadPreview` navigation are preserved.

### What
- **Search field** → Paper: a `--panel-2` field with a magnifier icon, "Search vault…" placeholder, and an uppercase `hybrid` badge (accent on accent-soft) marking the search mode; the clear (×) stays.
- **Tree rows** → Paper: folders get a rotatable chevron + bold label; files a file icon + label; attachments (`kind="attachment"`) an image glyph; nesting indents via the existing `.tree-children`. The active note (highlighted by `note.js` on open) gets `--accent-soft` + an inset accent left-bar + accent label.
- **Search results** → Paper (title + muted snippet).
- Per-folder counts / file sizes are intentionally **omitted** — `vault_list` doesn't return them (content-first shedding drops them first anyway).
- Tests: added search-field / tree-icon presence tests; replaced the now-obsolete `host-font-inheritance` assertion (the SPA uses Paper font variables since #811) with a `--font-body`/`--font-head`/`--font-mono` check.

### Verification
Both light and dark themes screenshotted against a representative tree (folders, files, an attachment, the active note) — matches the mockup. `build`/`vendor --check` clean, apps tests green. Local 5-lens review passed (all clean; the one "dead `.tree-note.active`" flag was a false positive — that class is produced by `note.js`'s `loadPreview`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
