### PR TITLE
fix: make excluded files invisible in build_index (file-shaped patterns) + test gaps

### DIFF
--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -134,8 +134,7 @@ class IndexManager:
         still needs the per-file check. Excluded files are therefore invisible
         everywhere — neither skip-counted nor recorded in ``skipped_state``
         (#257/#832) — matching ``detect_changes``. Non-files (such as broken
-        symlinks) and paths resolving outside ``source_dir`` are dropped with a
-        warning.
+        symlinks) are dropped.
 
         Returns:
             ``(absolute_path, relative_posix_path)`` pairs for non-excluded
@@ -145,12 +144,9 @@ class IndexManager:
         for abs_path in iter_markdown_files(self._source_dir, self._exclude_patterns):
             if not abs_path.is_file():
                 continue
-            try:
-                rel_str = abs_path.relative_to(self._source_dir).as_posix()
-            except ValueError:
-                # Symlink target outside the vault — mirror detect_changes.
-                logger.warning("File outside source_dir, skipping: %s", abs_path)
-                continue
+            # iter_markdown_files yields paths built as source_dir / rel, so
+            # relative_to always succeeds (no outside-source_dir guard needed).
+            rel_str = abs_path.relative_to(self._source_dir).as_posix()
             if self._is_path_excluded(rel_str):
                 continue
             candidates.append((abs_path, rel_str))

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -125,6 +125,37 @@ class IndexManager:
         """
         return is_path_excluded(path, self._exclude_patterns)
 
+    def _discover_indexable_candidates(self) -> list[tuple[Path, str]]:
+        """Discover markdown files eligible for indexing, with relative paths.
+
+        Applies the per-file :meth:`_is_path_excluded` filter as the correctness
+        layer: ``iter_markdown_files`` prunes only directory-shaped exclude
+        patterns, so a file-shaped exclude (such as ``notes/*`` or ``*.draft.md``)
+        still needs the per-file check. Excluded files are therefore invisible
+        everywhere — neither skip-counted nor recorded in ``skipped_state``
+        (#257/#832) — matching ``detect_changes``. Non-files (such as broken
+        symlinks) and paths resolving outside ``source_dir`` are dropped with a
+        warning.
+
+        Returns:
+            ``(absolute_path, relative_posix_path)`` pairs for non-excluded
+            files, in discovery order.
+        """
+        candidates: list[tuple[Path, str]] = []
+        for abs_path in iter_markdown_files(self._source_dir, self._exclude_patterns):
+            if not abs_path.is_file():
+                continue
+            try:
+                rel_str = abs_path.relative_to(self._source_dir).as_posix()
+            except ValueError:
+                # Symlink target outside the vault — mirror detect_changes.
+                logger.warning("File outside source_dir, skipping: %s", abs_path)
+                continue
+            if self._is_path_excluded(rel_str):
+                continue
+            candidates.append((abs_path, rel_str))
+        return candidates
+
     def _require_vectors(self) -> None:
         """Raise :class:`EmbeddingsNotConfiguredError` if embeddings are unconfigured."""
         if self._embedding_provider is None or self._embeddings_path is None:
@@ -260,13 +291,14 @@ class IndexManager:
             if should_optimize(purged, len(rows)):
                 self._fts.optimize()
 
-        # Count how many files were skipped due to required_frontmatter.
-        # Prune excluded subtrees during discovery (the same walk scan_directory
-        # used for `notes`) so excluded files are never walked, hashed into
-        # skipped_state, or skip-counted. This matches detect_changes and the
-        # "excluded files are invisible" contract (#257).
-        all_files = list(iter_markdown_files(self._source_dir, self._exclude_patterns))
-        skipped = len(all_files) - len(notes)
+        # Count how many files were skipped (e.g. for required_frontmatter).
+        # Discovery prunes excluded *subtrees* and then drops any remaining
+        # excluded file via the per-file filter, so excluded files are invisible
+        # everywhere — never skip-counted or recorded in skipped_state — matching
+        # detect_changes and the "excluded files are invisible" contract
+        # (#257/#832).
+        candidates = self._discover_indexable_candidates()
+        skipped = len(candidates) - len(notes)
 
         # Resolve vault-wide wikilinks now that all documents are indexed.
         self._fts.resolve_vault_wikilinks()
@@ -276,15 +308,7 @@ class IndexManager:
         # reconciliation pass after a cold build (#665) — does not re-report
         # them as added and re-log every skip.
         skipped_state: dict[str, str] = {}
-        for abs_path in all_files:
-            if not abs_path.is_file():
-                continue
-            try:
-                rel_str = abs_path.relative_to(self._source_dir).as_posix()
-            except ValueError:
-                # Symlink target outside the vault — mirror detect_changes.
-                logger.warning("File outside source_dir, skipping: %s", abs_path)
-                continue
+        for abs_path, rel_str in candidates:
             if rel_str in indexed_paths:
                 continue
             try:

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -167,6 +167,29 @@ class TestBuildIndex:
         assert "beta.md" in paths
         assert not any(p.startswith("notes/") for p in paths)
 
+    def test_excluded_files_invisible_for_non_prunable_pattern(
+        self, index_vault: Path, tmp_path: Path
+    ):
+        """Excluded files under a file-shaped pattern are not skip-counted or
+        recorded in skipped_state (the invisible-excluded contract, #257/#832).
+
+        ``notes/*`` is not a directory-prunable shape, so ``iter_markdown_files``
+        still descends ``notes/`` and yields its files; without the per-file
+        ``is_path_excluded`` filter they leak into ``IndexStats.skipped`` and the
+        tracker's skipped map, contradicting the contract and the comment.
+        """
+        mgr, _fts, _ = _make_index_mgr(
+            index_vault, tmp_path, exclude_patterns=["notes/*"]
+        )
+        result = mgr.build_index()
+
+        # Two indexable roots (alpha, beta); the two notes/ files are excluded.
+        assert result.skipped == 0
+        _indexed, skipped_state, _reasons = mgr._tracker._load_state()
+        assert not any(p.startswith("notes/") for p in skipped_state), (
+            "excluded files must not enter the tracker's skipped state"
+        )
+
     def test_continues_on_upsert_error(self, index_vault: Path, tmp_path: Path):
         """If one document fails to upsert, others still get indexed."""
         fts = FTSIndex(db_path=":memory:")
@@ -1040,6 +1063,48 @@ class TestEmbeddingsStatus:
         assert status["available"] is True
         assert status["provider"] == "MockEmbeddingProvider"
         assert status["path"] == str(embeddings_path)
+
+    def test_chunk_count_from_disk_sidecar_with_npy_extension(
+        self, index_vault: Path, tmp_path: Path
+    ):
+        """The disk-read branch reports the real count for a `.npy`-suffixed base.
+
+        With vectors unloaded, ``embeddings_status`` reads the sidecar count from
+        disk. This exercises the second copy of the #819 ``with_suffix`` fix (in
+        ``embeddings_status`` itself): a base carrying a ``.npy`` extension must
+        resolve to the real files, not ``{base}.npy.npy`` (which would misreport
+        0). Guards the previously-untested extension-carrying disk path (#836).
+        """
+        from markdown_vault_mcp.vector_index import VectorIndex
+        from tests.conftest import MockEmbeddingProvider
+
+        provider = MockEmbeddingProvider()
+        base = tmp_path / "embeddings.npy"
+        vi = VectorIndex(provider)
+        vi.add(
+            ["hello world"],
+            [
+                {
+                    "path": "a.md",
+                    "title": "A",
+                    "folder": "",
+                    "heading": None,
+                    "content": "hello world",
+                }
+            ],
+        )
+        vi.save(base)
+
+        # get_vectors defaults to None (unbuilt), forcing the disk-read branch.
+        mgr, _, holder = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=base,
+            embedding_provider=provider,
+        )
+        assert holder["vectors"] is None
+        status = mgr.embeddings_status()
+        assert status["chunk_count"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -190,6 +190,26 @@ class TestBuildIndex:
             "excluded files must not enter the tracker's skipped state"
         )
 
+    def test_broken_symlink_md_is_skipped_not_hashed(
+        self, index_vault: Path, tmp_path: Path
+    ):
+        """A broken symlink named ``*.md`` is discovered but skipped, not hashed.
+
+        ``_discover_indexable_candidates`` drops non-files via ``is_file()`` so a
+        dangling link does not reach ``compute_file_hash``; the build must not
+        crash and the link must not be indexed.
+        """
+        dangling = index_vault / "dangling.md"
+        try:
+            dangling.symlink_to(index_vault / "does-not-exist-target.md")
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation not supported here: {exc}")
+
+        mgr, fts, _ = _make_index_mgr(index_vault, tmp_path)
+        mgr.build_index()  # must not raise on the broken link
+        paths = {n["path"] for n in fts.list_notes()}
+        assert "dangling.md" not in paths
+
     def test_continues_on_upsert_error(self, index_vault: Path, tmp_path: Path):
         """If one document fails to upsert, others still get indexed."""
         fts = FTSIndex(db_path=":memory:")

--- a/tests/test_utils_fs.py
+++ b/tests/test_utils_fs.py
@@ -93,6 +93,24 @@ class TestIterMarkdownFiles:
         _touch(tmp_path, ".claude/plugins/cache/x.md")
         assert _rels(tmp_path, LIVE_EXCLUDES) == {".claude/keep.md"}
 
+    def test_anchored_prefix_does_not_prune_prefix_colliding_sibling(
+        self, tmp_path: Path
+    ) -> None:
+        # ``go/**`` prunes ``go/`` but must NOT prune a sibling ``google/`` that
+        # merely shares the prefix. The boundary guard in _should_prune_dir
+        # (``rel == prefix or rel.startswith(prefix + "/")``) is load-bearing: a
+        # bare ``startswith`` would prune ``google/`` and silently drop
+        # ``google/keep.md`` (#836).
+        _touch(tmp_path, "go/pkg/x.md")
+        _touch(tmp_path, "google/keep.md")
+        discovered = _rels(tmp_path, ["go/**"])
+        assert "google/keep.md" in discovered
+        assert "go/pkg/x.md" not in discovered
+
+        anchored, anydepth = _dir_prune_rules(["go/**"])
+        assert _should_prune_dir("go", anchored, anydepth) is True
+        assert _should_prune_dir("google", anchored, anydepth) is False
+
     def test_top_level_anydepth_dir_not_pruned(self, tmp_path: Path) -> None:
         # ``**/node_modules/**`` needs a slash before the segment, so a
         # top-level ``node_modules`` is NOT excluded and must be discovered;


### PR DESCRIPTION
Closes #832, closes #836.

## #832 — build_index leaked excluded files into the skip count / skipped_state

`build_index` discovered files via `iter_markdown_files` (which prunes only **directory-shaped** exclude patterns) and then hashed every non-indexed file into `skipped_state` and skip-counted it. A **file-shaped** exclude such as `notes/*` or `*.draft.md` is not directory-prunable, so its files still descended into discovery and leaked into `IndexStats.skipped` and the tracker's `skipped` map — contradicting the "excluded files are invisible" contract (#257) and the code's own comment, which claimed excluded files are "never … hashed into skipped_state, or skip-counted."

**Fix:** extract `_discover_indexable_candidates()`, which applies the per-file `is_path_excluded` filter as the correctness layer (matching `detect_changes`), and drive both the skip count and `skipped_state` from it. Corrected the overstating comment.

## #836 — test-coverage gaps

- `test_excluded_files_invisible_for_non_prunable_pattern` — `build_index` with `notes/*` yields `skipped == 0` and no `notes/` entry in the tracker's skipped state (fails on `main`: `skipped == 2`).
- `test_chunk_count_from_disk_sidecar_with_npy_extension` — `embeddings_status` reads the real `chunk_count` from a `.npy`-suffixed disk sidecar, exercising the second copy of the #819 `with_suffix` fix (previously only the extensionless / in-memory path was tested).
- `test_anchored_prefix_does_not_prune_prefix_colliding_sibling` — `go/**` prunes `go/` but not a prefix-colliding `google/`; guards the `_should_prune_dir` boundary (`rel == prefix or rel.startswith(prefix + "/")`) whose regression would silently drop `google/keep.md`.

_(The third #836 item — a non-transient-errno no-retry assertion — already shipped with #840.)_

Full affected-module sweep (index/utils_fs/tracker/scanner/vault) green (454); ruff + mypy clean; structural-diff gate 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._