### PR TITLE
fix: surface silently-dropped subtrees and a fully-blind watcher

### DIFF
--- a/src/markdown_vault_mcp/_file_watcher.py
+++ b/src/markdown_vault_mcp/_file_watcher.py
@@ -421,6 +421,22 @@ class VaultFileWatcher:
                 )
                 continue
             scheduled.append(root)
+
+        if roots and not scheduled:
+            # Every derived root failed to schedule: the observer will run but
+            # watch nothing, so no edit will ever trigger a reindex. Surface it
+            # above the per-root WARNINGs and the INFO summary so the degraded
+            # state is visible, not buried (#835). Distinct from the legitimate
+            # "no roots at all" case (root_floor off, no children), where roots
+            # is empty and this does not fire.
+            logger.error(
+                "file_watcher: all %d watch root(s) failed to schedule; live "
+                "change detection is disabled — changes are only picked up by "
+                "scans (source_dir=%s)",
+                len(roots),
+                self._source_dir,
+            )
+
         # Assign before start() so stop() can always see and stop it,
         # even if it races into the narrow window between schedule() and start().
         with self._lock:

--- a/src/markdown_vault_mcp/utils/fs.py
+++ b/src/markdown_vault_mcp/utils/fs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from typing import TYPE_CHECKING, Any
@@ -9,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # pathlib's Path.glob / Path.rglob do not recurse into symlinked
 # subdirectories by default — the behavior was unspecified pre-3.13 and an
@@ -139,9 +142,10 @@ def iter_markdown_files(
     directory's own path is not otherwise filtered here.
 
     Symlink handling matches :data:`GLOB_SYMLINK_KWARGS`: symlinked
-    subdirectories are followed only on Python 3.13+. ``os.walk`` swallows
-    ``OSError`` from unreadable directories (permission denied, broken links)
-    by default, mirroring ``glob``'s suppression of the same.
+    subdirectories are followed only on Python 3.13+. An unreadable directory
+    (permission denied, broken link) is skipped rather than aborting the walk,
+    but — unlike ``glob``'s silent suppression — it is logged at WARNING so a
+    dropped subtree is observable instead of vanishing without a trace (#835).
 
     Yields paths in ``os.walk`` order (arbitrary within a directory); callers
     that need a stable order must sort, exactly as they did around the glob.
@@ -159,8 +163,15 @@ def iter_markdown_files(
     """
     anchored, anydepth = _dir_prune_rules(exclude_patterns or ())
     source_str = os.fspath(source_dir)
+
+    def _on_walk_error(exc: OSError) -> None:
+        # os.walk drops the offending directory and continues; surface it so a
+        # permission-denied or broken-link subtree does not silently disappear
+        # from discovery/indexing (#835).
+        logger.warning("markdown_walk_dir_unreadable path=%s: %s", exc.filename, exc)
+
     for dirpath, dirnames, filenames in os.walk(
-        source_str, followlinks=_WALK_FOLLOWLINKS
+        source_str, onerror=_on_walk_error, followlinks=_WALK_FOLLOWLINKS
     ):
         rel_dir = os.path.relpath(dirpath, source_str)
         rel_prefix = "" if rel_dir == "." else rel_dir.replace(os.sep, "/")

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -271,6 +271,50 @@ def test_start_skips_root_whose_schedule_raises(
     assert len(fake.scheduled) == 2
 
 
+def test_start_logs_error_when_all_roots_fail_to_schedule(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A watcher that ends up watching nothing is surfaced at ERROR (#835).
+
+    If every derived root fails to schedule, the observer runs but watches
+    nothing, so no edit ever triggers a reindex. That degraded state must be
+    visible above the per-root WARNINGs and the INFO summary — distinct from the
+    legitimate "no roots at all" case.
+    """
+    import logging
+
+    (tmp_path / "childA").mkdir()
+
+    class _AllFailObserver:
+        def schedule(self, _handler: object, _path: str, **_kwargs: object) -> None:
+            raise OSError("cannot watch anything")
+
+        def start(self) -> None:
+            pass
+
+        def stop(self) -> None:
+            pass
+
+        def join(self, timeout: float | None = None) -> None:
+            pass
+
+    fake = _AllFailObserver()
+    watcher = _make_watcher(tmp_path, lambda: None)
+    with (
+        patch("markdown_vault_mcp._file_watcher.Observer", lambda: fake),
+        caplog.at_level(logging.ERROR, logger="markdown_vault_mcp._file_watcher"),
+    ):
+        watcher.start()  # must not raise
+        watcher.stop()
+
+    assert any(
+        r.levelno == logging.ERROR
+        and "live" in r.getMessage()
+        and "change detection is disabled" in r.getMessage()
+        for r in caplog.records
+    ), "a fully-blind watcher must be surfaced at ERROR"
+
+
 # ---------------------------------------------------------------------------
 # Hidden directory filtering
 # ---------------------------------------------------------------------------

--- a/tests/test_utils_fs.py
+++ b/tests/test_utils_fs.py
@@ -143,19 +143,38 @@ class TestIterMarkdownFiles:
         (tmp_path / "README.txt").write_text("text", encoding="utf-8")
         assert _rels(tmp_path, LIVE_EXCLUDES) == {"note.md"}
 
-    def test_permission_error_dir_suppressed(self, tmp_path: Path) -> None:
-        # os.walk swallows OSError from unreadable dirs, matching glob. The
-        # readable sibling is still discovered; the scan does not crash.
+    def test_permission_error_dir_logged_and_skipped(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # An unreadable dir is skipped (the walk does not crash and the readable
+        # sibling is still discovered), but it is now logged at WARNING so the
+        # dropped subtree is observable instead of vanishing silently (#835).
+        import logging
+
         _touch(tmp_path, "readable/ok.md")
         locked = tmp_path / "locked"
         locked.mkdir()
         _touch(tmp_path, "locked/hidden.md")
         locked.chmod(0o000)
         try:
-            discovered = _rels(tmp_path, LIVE_EXCLUDES)
+            # Root bypasses permission bits, so chmod 0o000 does not block the
+            # read there — only assert the WARNING when the dir is truly locked.
+            try:
+                list(locked.iterdir())
+                unreadable = False
+            except OSError:
+                unreadable = True
+            with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.utils.fs"):
+                discovered = _rels(tmp_path, LIVE_EXCLUDES)
         finally:
             locked.chmod(0o755)
         assert "readable/ok.md" in discovered
+        if unreadable:
+            assert any(
+                "markdown_walk_dir_unreadable" in r.getMessage()
+                and "locked" in r.getMessage()
+                for r in caplog.records
+            ), "an unreadable subtree must be surfaced at WARNING"
 
     @pytest.mark.skipif(
         sys.version_info < (3, 13),


### PR DESCRIPTION
Closes #835.

Two degradation paths from the #822/#828 discovery/watch work were handled but invisible below WARNING/ERROR. Surfaced by the multi-lens review of the #824–#828 range (silent-failure lens).

## `iter_markdown_files` silently dropped unreadable subtrees
`os.walk` was called with the default `onerror=None`, so an `OSError` on a subdirectory (permission denied, broken followed link on 3.13+) discarded the directory and **every `.md` beneath it** with no log at any level. Now passes an `onerror` callback that logs at WARNING (`markdown_walk_dir_unreadable`) and continues — the walk stays resilient, but a dropped subtree is observable.

## Watcher could start fully blind at INFO
`VaultFileWatcher.start()` logged its terminal summary at INFO even when **every** derived root failed to schedule (`scheduled` empty, `roots` non-empty). The observer runs but watches nothing, so no edit ever triggers a reindex. Now logs that state at ERROR — distinct from the legitimate "no roots at all" case (empty `roots`).

## Tests
- The permission-error walk test now asserts the WARNING (guarded: root bypasses `chmod 0o000`, so it only asserts when the dir is genuinely unreadable).
- A new `start()` test asserts the ERROR fires when all roots fail to schedule.

Affected-module sweep (file_watcher/utils_fs/scanner/tracker/managers_index) green (242); ruff + mypy clean; structural-diff gate 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._