### PR TITLE
docs: watcher scoping + root_floor + tracker carry-forward (design.md, .env)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@
 # File watcher — detects external file changes for non-git vaults (requires watchdog extra)
 # MARKDOWN_VAULT_MCP_FILE_WATCHER=true
 # MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S=2.0
+# Watch source_dir itself (non-recursively) as a floor for root-level files.
+# Set false to remove every source_dir-rooted watch (root-level files then rely on scans).
+# MARKDOWN_VAULT_MCP_FILE_WATCHER_ROOT_FLOOR=true
 
 # HTTP transport extras
 # MARKDOWN_VAULT_MCP_EVENT_STORE_URL=file:///data/state/events

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -684,7 +684,7 @@ ends the worker loop.
 
 **File watcher scoping (#823/#828/#830).** When the file watcher is
 active (neither git pull nor a webhook is configured), it does not place a
-single recursive watch on `source_dir`. On a home-directory vault that
+single recursive watch on `source_dir`, which on a home-directory vault
 would register an OS-level recursive stream over every unrelated subtree
 (and, on macOS, trigger repeated TCC consent prompts). Instead it derives
 its watch roots: each non-excluded immediate child directory of

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -382,9 +382,13 @@ for built-in names, or pass a custom instance.
   get up to three in-scan retries with a short backoff (0.05 s, 0.1 s,
   0.2 s) before the file is dropped for that scan, and exhausted retries
   log at `ERROR` (`hash_read_failed_after_retry`); every other `OSError`
-  keeps the single-attempt `WARNING` path. A skipped file deleted from disk
-  is dropped silently; it was never indexed, so it is not counted as
-  `deleted`.
+  keeps the single-attempt `WARNING` path. A file that is already indexed and
+  fails to hash is not dropped: its previous hash is carried forward so it
+  counts as unchanged for that scan and is re-hashed on the next one, so a
+  read error that leaves the file in place never purges a live document. Only
+  a newly discovered file that fails to hash is dropped for the scan. A
+  skipped file deleted from disk is dropped silently; it was never indexed, so
+  it is not counted as `deleted`.
   The surfaced deterministic skips (parse / encoding / missing-frontmatter /
   internal-error, but not exclude-pattern or transient `OSError`) are also
   recorded with a `{category, detail}` reason in the state file's
@@ -677,6 +681,26 @@ reconciled; no extra staleness bookkeeping is needed. Follow-up submissions issu
 itself succeed even during shutdown drain, so `ProcessDirtyPaths` can
 chain into `FlushDirtyEmbeddings` and both flush before the sentinel
 ends the worker loop.
+
+**File watcher scoping (#823/#828/#830).** When the file watcher is
+active (neither git pull nor a webhook is configured), it does not place a
+single recursive watch on `source_dir`. On a home-directory vault that
+would register an OS-level recursive stream over every unrelated subtree
+(and, on macOS, trigger repeated TCC consent prompts). Instead it derives
+its watch roots: each non-excluded immediate child directory of
+`source_dir` is watched recursively — so events deep inside a deliberately
+watched dot-root such as `.claude/` are delivered — and `source_dir`
+itself is watched non-recursively as a floor for root-level files. The
+floor is gated by `MARKDOWN_VAULT_MCP_FILE_WATCHER_ROOT_FLOOR` (default
+on); setting it false removes every `source_dir`-rooted registration, at
+the cost of root-level files being picked up only by scans. The vault's
+own state / index / embeddings directories and `.git` are never watched
+(#830): `reindex()` rewrites the state file on every run, so a watch on
+its directory would re-trigger the watcher into a self-feedback loop.
+Consequences: a top-level directory created after startup needs a restart
+to be watched, and a state/index/embeddings path configured beneath a
+content directory un-watches that whole top-level directory (keep those
+paths at the vault root or outside the vault).
 
 **Per-document write semantics.** `write()`, `edit()`, `delete()`,
 `rename()`, and `write_attachment()` perform the file mutation under a


### PR DESCRIPTION
Closes #834, closes #843.

Documentation only — now unblocked because #841 relocated `docs/design.md` under the Vale-excluded `docs/design/` subtree.

## #834 — scoped-watch behavior + env var
- `docs/design/design.md`: new **File watcher scoping** note covering the #823/#828 change (per-child recursive watch roots instead of one recursive watch on `source_dir`; the `FILE_WATCHER_ROOT_FLOOR` floor) and the #830 rule that the vault's own state/index/embeddings dirs and `.git` are never watched — with the two operator-visible consequences (a top-level dir created after startup needs a restart; a state path nested under a content dir un-watches that whole directory).
- `.env.example`: document `MARKDOWN_VAULT_MCP_FILE_WATCHER_ROOT_FLOOR` beside its `FILE_WATCHER` siblings.

## #843 — tracker carry-forward contract
- `docs/design/design.md`: add the #831 already-indexed carry-forward paragraph to the tracker OSError-handling contract (a file already indexed that fails to hash carries its prior hash forward and is never purged; only a newly discovered file is dropped). Deferred here from #840/#841 per both reviewers' notes, until the relocation unblocked editing the spec.

No code change. design.md is excluded from the site build and from Vale by convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._