### PR TITLE
fix: resolve watch roots to realpath so FSEvents events are not dropped

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -711,7 +711,13 @@ symlinked ancestor (`/var` resolving to `/private/var`) and symlink-farm
 vaults whose top-level children are symlinks to real directories from being
 watched but blind (edits seen only by scans). Prune rules still match the
 child's vault-visible name inside `source_dir`, not the resolved target's
-basename, so exclude patterns keep working across the link.
+basename, so exclude patterns keep working across the link. `Path.resolve`
+(`strict=False`) resolves best-effort and does not raise on a broken symlink or
+a missing component, so this is not about missing targets; when it does fail on
+a genuinely unresolvable path — a symlink loop raises `RuntimeError` on Python <
+3.13, and a pathological path raises `OSError` — the root is kept unresolved
+with a WARNING rather than dropped, degrading to the pre-resolution behavior
+(correct on inotify / ReadDirectoryChangesW) instead of crashing `start()`.
 
 **Per-document write semantics.** `write()`, `edit()`, `delete()`,
 `rename()`, and `write_attachment()` perform the file mutation under a

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -700,7 +700,18 @@ its directory would re-trigger the watcher into a self-feedback loop.
 Consequences: a top-level directory created after startup needs a restart
 to be watched, and a state/index/embeddings path configured beneath a
 content directory un-watches that whole top-level directory (keep those
-paths at the vault root or outside the vault).
+paths at the vault root or outside the vault). Every derived watch root
+(`source_dir`, its floor, and each kept child) is resolved to its realpath
+at derive time (#849), because watchdog's macOS FSEvents emitter resolves
+the scheduled path with `os.path.realpath` and delivers events whose
+`src_path` carries that realpath, so scheduling and the root-relative
+filter must agree on the resolved form or `relative_to` raises and every
+event is silently dropped; this keeps a `source_dir` reached through a
+symlinked ancestor (`/var` resolving to `/private/var`) and symlink-farm
+vaults whose top-level children are symlinks to real directories from being
+watched but blind (edits seen only by scans). Prune rules still match the
+child's vault-visible name inside `source_dir`, not the resolved target's
+basename, so exclude patterns keep working across the link.
 
 **Per-document write semantics.** `write()`, `edit()`, `delete()`,
 `rename()`, and `write_attachment()` perform the file mutation under a

--- a/src/markdown_vault_mcp/_file_watcher.py
+++ b/src/markdown_vault_mcp/_file_watcher.py
@@ -194,6 +194,19 @@ def _derive_watch_roots(
     zero-``source_dir``-rooted-FSEvents guarantee exactly where the caller cannot
     observe it. The WARNING still logs.
 
+    Every returned root is resolved with :meth:`Path.resolve`. watchdog's
+    FSEvents emitter (macOS) resolves the scheduled watch path with
+    ``os.path.realpath`` and delivers events with realpath-prefixed
+    ``src_path``s, so a watch scheduled on a symlinked child (farm layouts) or
+    on a ``source_dir`` under a symlinked prefix (``/var`` vs ``/private/var``)
+    would filter every event against a root that is never a prefix of the
+    delivered paths — ``relative_to`` raises and each event is silently
+    dropped. Scheduling and filtering on the resolved root keeps the two in
+    agreement on every platform: inotify and ReadDirectoryChangesW deliver
+    events prefixed with the path as scheduled, which is then the resolved
+    path too. Prune rules still match the child's name *inside* ``source_dir``
+    (the vault-visible name), not its resolved target's basename.
+
     Reuses :func:`~markdown_vault_mcp.utils.fs._dir_prune_rules` and
     :func:`~markdown_vault_mcp.utils.fs._should_prune_dir` as the single source
     of truth for prune rules, matching ``iter_markdown_files``.
@@ -210,13 +223,15 @@ def _derive_watch_roots(
             that is or contains one of these is skipped entirely.
 
     Returns:
-        Watch roots to schedule, the non-recursive ``source_dir`` root last when
-        ``root_floor`` is True. On an unreadable or vanished ``source_dir``, the
-        single non-recursive ``source_dir`` root when ``root_floor`` is True, or
-        ``[]`` when it is False.
+        Resolved watch roots to schedule, the non-recursive resolved
+        ``source_dir`` root last when ``root_floor`` is True. On an unreadable
+        or vanished ``source_dir``, the single non-recursive resolved
+        ``source_dir`` root when ``root_floor`` is True, or ``[]`` when it is
+        False.
     """
     anchored, anydepth = _dir_prune_rules(exclude_patterns or ())
     protected = frozenset(_resolve_internal_dirs(internal_dirs))
+    source_dir = source_dir.resolve()
     roots: list[_WatchRoot] = []
     try:
         children = sorted(source_dir.iterdir())
@@ -239,7 +254,7 @@ def _derive_watch_roots(
             continue
         if _contains_internal_dir(child, protected):
             continue
-        roots.append(_WatchRoot(child, recursive=True))
+        roots.append(_WatchRoot(child.resolve(), recursive=True))
 
     if root_floor:
         roots.append(_WatchRoot(source_dir, recursive=False))

--- a/src/markdown_vault_mcp/_file_watcher.py
+++ b/src/markdown_vault_mcp/_file_watcher.py
@@ -139,7 +139,16 @@ def _resolve_internal_dirs(internal_dirs: Sequence[Path]) -> list[Path]:
     for d in internal_dirs:
         try:
             resolved.append(d.resolve())
-        except OSError:
+        except (OSError, RuntimeError):
+            # Unresolvable dir (see _resolve_or_original for the two cases).
+            # Dropping a protected dir fails open on the #830 guard — its child
+            # could then be watched — so warn rather than drop silently.
+            logger.warning(
+                "file_watcher: could not resolve internal dir=%s; it will not "
+                "be protected from watching",
+                d,
+                exc_info=True,
+            )
             continue
     return resolved
 
@@ -157,15 +166,60 @@ def _contains_internal_dir(child: Path, internal_dirs: frozenset[Path]) -> bool:
         internal_dirs: Resolved vault-internal directories to protect.
 
     Returns:
-        ``True`` when *child* should not be watched.
+        ``True`` when *child* should not be watched. An unresolvable *child*
+        returns ``False`` (a symlink-loop child is already screened out earlier
+        by the caller's ``is_dir`` check).
     """
     try:
         child_resolved = child.resolve()
-    except OSError:
+    except (OSError, RuntimeError):
+        # Unresolvable child (see _resolve_or_original for the two cases); it
+        # cannot be matched against the resolved internal dirs, so classify it as
+        # non-internal. A symlink-loop child is screened by is_dir() upstream, so
+        # the realistic trigger here is OSError; log so it is not silent.
+        logger.debug(
+            "file_watcher: could not resolve child=%s; treating as non-internal",
+            child,
+            exc_info=True,
+        )
         return False
     return any(
         d == child_resolved or d.is_relative_to(child_resolved) for d in internal_dirs
     )
+
+
+def _resolve_or_original(path: Path) -> Path:
+    """Resolve *path* to its realpath, falling back to *path* on ``OSError`` /
+    ``RuntimeError``.
+
+    A watch root must be scheduled on its resolved form so it matches watchdog's
+    realpath-prefixed FSEvents delivery (see :func:`_derive_watch_roots`).
+    ``Path.resolve`` (``strict=False``) resolves best-effort and does *not* raise
+    on a broken symlink or a missing / unreadable intermediate component — it
+    returns the partially-resolved path. Two failure modes remain, and this guard
+    catches both: a **symlink loop** raises ``RuntimeError`` on Python < 3.13
+    (3.13+ returns the partially-resolved path instead), and a pathological path
+    can raise ``OSError`` on some platforms / filesystems.
+    On either we keep the unresolved path — the pre-resolution behavior, correct on
+    inotify / ReadDirectoryChangesW — rather than dropping the watch or crashing
+    ``start()``, and log at WARNING so the degraded case is visible.
+
+    Args:
+        path: Watch path (``source_dir`` or a top-level child) to resolve.
+
+    Returns:
+        The resolved path, or *path* unchanged when resolution raises
+        ``OSError`` / ``RuntimeError``.
+    """
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        logger.warning(
+            "file_watcher: could not resolve watch path=%s; using it unresolved",
+            path,
+            exc_info=True,
+        )
+        return path
 
 
 def _derive_watch_roots(
@@ -194,7 +248,11 @@ def _derive_watch_roots(
     zero-``source_dir``-rooted-FSEvents guarantee exactly where the caller cannot
     observe it. The WARNING still logs.
 
-    Every returned root is resolved with :meth:`Path.resolve`. watchdog's
+    Every returned root is resolved with :meth:`Path.resolve` where it can be
+    (a root whose path cannot be resolved — a symlink loop, or a rare
+    ``OSError`` — is kept unresolved with a WARNING via
+    :func:`_resolve_or_original` rather than dropped, degrading to the
+    pre-resolution behavior). watchdog's
     FSEvents emitter (macOS) resolves the scheduled watch path with
     ``os.path.realpath`` and delivers events with realpath-prefixed
     ``src_path``s, so a watch scheduled on a symlinked child (farm layouts) or
@@ -231,7 +289,7 @@ def _derive_watch_roots(
     """
     anchored, anydepth = _dir_prune_rules(exclude_patterns or ())
     protected = frozenset(_resolve_internal_dirs(internal_dirs))
-    source_dir = source_dir.resolve()
+    source_dir = _resolve_or_original(source_dir)
     roots: list[_WatchRoot] = []
     try:
         children = sorted(source_dir.iterdir())
@@ -254,7 +312,7 @@ def _derive_watch_roots(
             continue
         if _contains_internal_dir(child, protected):
             continue
-        roots.append(_WatchRoot(child.resolve(), recursive=True))
+        roots.append(_WatchRoot(_resolve_or_original(child), recursive=True))
 
     if root_floor:
         roots.append(_WatchRoot(source_dir, recursive=False))

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -35,9 +35,12 @@ from watchdog.events import (
 
 from markdown_vault_mcp._file_watcher import (
     VaultFileWatcher,
+    _contains_internal_dir,
     _derive_watch_roots,
     _has_hidden_component,
     _is_hidden_relative_to_root,
+    _resolve_internal_dirs,
+    _resolve_or_original,
     _VaultEventHandler,
     _WatchRoot,
     should_start_file_watcher,
@@ -703,7 +706,7 @@ def test_derive_watch_roots_always_appends_non_recursive_source_dir(
     """The non-recursive ``source_dir`` root is always present and last."""
     (tmp_path / "notes").mkdir()
     roots = _derive_watch_roots(tmp_path, ["go/**"])
-    assert roots[-1] == _WatchRoot(tmp_path, recursive=False)
+    assert roots[-1] == _WatchRoot(tmp_path.resolve(), recursive=False)
     assert sum(1 for r in roots if not r.recursive) == 1
 
 
@@ -720,7 +723,7 @@ def test_derive_watch_roots_falls_back_on_enumeration_error(tmp_path: Path) -> N
     """An unreadable/vanished source_dir yields just the non-recursive root."""
     missing = tmp_path / "gone"
     roots = _derive_watch_roots(missing, None)
-    assert roots == [_WatchRoot(missing, recursive=False)]
+    assert roots == [_WatchRoot(missing.resolve(), recursive=False)]
 
 
 def test_derive_watch_roots_skips_internal_state_and_git_dirs(tmp_path: Path) -> None:
@@ -958,7 +961,9 @@ def test_symlink_farm_layout_does_not_crash(tmp_path: Path) -> None:
 
     # is_dir() follows the links, so each becomes a candidate recursive root.
     roots = _derive_watch_roots(farm, None)
-    assert _WatchRoot(farm, recursive=False) in roots, "floor watch must be present"
+    assert _WatchRoot(farm.resolve(), recursive=False) in roots, (
+        "floor watch must be present"
+    )
 
     watcher = _make_watcher(farm, lambda: None)
     watcher.start()  # must not raise even if a symlinked-child schedule fails
@@ -968,6 +973,108 @@ def test_symlink_farm_layout_does_not_crash(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Symlinked watch roots resolve to their realpath (FSEvents realpath delivery)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("exc", [OSError("boom"), RuntimeError("Symlink loop")])
+def test_resolve_or_original_falls_back_and_warns(
+    caplog: pytest.LogCaptureFixture, exc: Exception
+) -> None:
+    """A path whose ``resolve()`` raises is returned unresolved, with a WARNING.
+
+    Guards the degradation contract for both real failure modes: ``Path.resolve``
+    raises ``OSError`` on a pathological path and ``RuntimeError`` on a symlink
+    loop (Python < 3.13). Neither may drop the watch or crash ``start()``; both
+    fall back to the unresolved path (correct on inotify / ReadDirectoryChangesW).
+    """
+    import logging
+
+    p = Path("/some/watch/root")
+    with (
+        patch.object(Path, "resolve", side_effect=exc),
+        caplog.at_level(logging.WARNING),
+    ):
+        result = _resolve_or_original(p)
+    assert result == p
+    assert "could not resolve watch path" in caplog.text
+
+
+def test_derive_watch_roots_survives_symlink_loop_source_dir(tmp_path: Path) -> None:
+    """A ``source_dir`` that is a symlink loop degrades instead of crashing.
+
+    On Python < 3.13 ``resolve()`` raises ``RuntimeError`` on the loop, which the
+    ``_resolve_or_original`` guard keeps from propagating out of ``start()``; on
+    3.13+ ``resolve`` returns and the loop is caught by the ``iterdir`` fallback
+    instead. Either way ``_derive_watch_roots`` must return exactly the
+    non-recursive floor watch and never raise. Uses a real on-disk loop rather
+    than a mock, so it exercises whichever path the running interpreter takes.
+    """
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    roots = _derive_watch_roots(a, None)  # must not raise on the loop
+
+    assert len(roots) == 1
+    assert roots[0].recursive is False
+
+
+def test_resolve_internal_dirs_skips_on_resolve_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An internal dir whose ``resolve()`` raises is dropped with a WARNING.
+
+    ``resolve()`` raises ``RuntimeError`` on a symlink loop (Python < 3.13); the
+    guard must drop the unresolvable dir rather than crash startup, and warn
+    because dropping a protected dir fails open on the #830 guard. Forced via
+    mock so the ``RuntimeError`` branch is covered on every interpreter.
+    """
+    import logging
+
+    with (
+        patch.object(Path, "resolve", side_effect=RuntimeError("Symlink loop")),
+        caplog.at_level(logging.WARNING),
+    ):
+        assert _resolve_internal_dirs([Path("/x")]) == []
+    assert "will not be protected from watching" in caplog.text
+
+
+def test_contains_internal_dir_false_on_resolve_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unresolvable child returns ``False`` (non-internal), not raised, + DEBUG.
+
+    Branch coverage for the widened ``except (OSError, RuntimeError)``. In
+    production the realistic trigger is ``OSError`` — a symlink-loop child is
+    screened by ``is_dir()`` before this is reached — so ``RuntimeError`` is
+    mocked purely to exercise the branch on every interpreter.
+    """
+    import logging
+
+    with (
+        patch.object(Path, "resolve", side_effect=RuntimeError("Symlink loop")),
+        caplog.at_level(logging.DEBUG),
+    ):
+        assert _contains_internal_dir(Path("/x"), frozenset()) is False
+    assert "treating as non-internal" in caplog.text
+
+
+def test_derive_watch_roots_survives_symlink_loop_internal_dir(tmp_path: Path) -> None:
+    """A symlink-loop configured ``internal_dir`` does not crash derivation.
+
+    The internal-dir resolution runs at the top of ``_derive_watch_roots``; a
+    loop there (``RuntimeError`` on < 3.13) must degrade, not propagate. Wired
+    end-to-end through ``_derive_watch_roots`` per the #830 protection path.
+    """
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+    (tmp_path / "notes").mkdir()
+
+    roots = _derive_watch_roots(tmp_path, None, internal_dirs=[a])  # must not raise
+
+    assert "notes" in _root_names(roots)
 
 
 def test_derive_watch_roots_resolves_symlinked_child_root(tmp_path: Path) -> None:
@@ -984,8 +1091,38 @@ def test_derive_watch_roots_resolves_symlinked_child_root(tmp_path: Path) -> Non
     (farm / "alpha").symlink_to(real, target_is_directory=True)
 
     roots = _derive_watch_roots(farm, None)
-    assert _WatchRoot(real, recursive=True) in roots
+    assert _WatchRoot(real.resolve(), recursive=True) in roots
     assert _WatchRoot(farm / "alpha", recursive=True) not in roots
+
+
+def test_derive_watch_roots_prunes_by_link_name_not_resolved_basename(
+    tmp_path: Path,
+) -> None:
+    """Prune matches the vault-visible child name, not the resolved target base.
+
+    Locks the ordering invariant the docstring promises: ``_should_prune_dir``
+    runs on ``child.name`` (the symlink's own name) *before* the child is
+    resolved, so a link named ``drop`` pointing at target ``keep`` is pruned by
+    ``drop/**`` and untouched by ``keep/**``. A regression that resolved before
+    pruning would match on the target basename and invert both assertions; the
+    same-name fixtures elsewhere in this file cannot catch that.
+    """
+    target = tmp_path / "targets" / "keep"
+    target.mkdir(parents=True)
+    farm = tmp_path / "farm"
+    farm.mkdir()
+    (farm / "drop").symlink_to(target, target_is_directory=True)
+
+    # Excluding the resolved target's basename must NOT prune the link.
+    kept = _derive_watch_roots(farm, ["keep/**"])
+    assert _WatchRoot(target.resolve(), recursive=True) in kept, (
+        "prune must match link name 'drop', not resolved basename 'keep'"
+    )
+
+    # Excluding the vault-visible link name DOES prune it.
+    pruned = _derive_watch_roots(farm, ["drop/**"])
+    assert _WatchRoot(target.resolve(), recursive=True) not in pruned
+    assert "drop" not in _root_names(pruned)
 
 
 def test_derive_watch_roots_resolves_source_dir_under_symlinked_prefix(
@@ -1003,8 +1140,10 @@ def test_derive_watch_roots_resolves_source_dir_under_symlinked_prefix(
     link_parent.symlink_to(real_parent, target_is_directory=True)
 
     roots = _derive_watch_roots(link_parent / "vault", None)
-    assert roots[-1] == _WatchRoot(real_parent / "vault", recursive=False)
-    assert _WatchRoot(real_parent / "vault" / "notes", recursive=True) in roots
+    assert roots[-1] == _WatchRoot((real_parent / "vault").resolve(), recursive=False)
+    assert (
+        _WatchRoot((real_parent / "vault" / "notes").resolve(), recursive=True) in roots
+    )
 
 
 def test_derive_watch_roots_fallback_resolves_source_dir(tmp_path: Path) -> None:
@@ -1015,16 +1154,61 @@ def test_derive_watch_roots_fallback_resolves_source_dir(tmp_path: Path) -> None
     link_parent.symlink_to(real_parent, target_is_directory=True)
 
     roots = _derive_watch_roots(link_parent / "gone", None)
-    assert roots == [_WatchRoot(real_parent / "gone", recursive=False)]
+    assert roots == [_WatchRoot((real_parent / "gone").resolve(), recursive=False)]
+
+
+def test_resolved_root_admits_realpath_prefixed_event(tmp_path: Path) -> None:
+    """A handler on the resolved root admits a realpath-prefixed event; one on
+    the unresolved symlink root drops it.
+
+    Characterizes *why* ``_derive_watch_roots`` resolves its roots, at the filter
+    boundary: watchdog's FSEvents emitter delivers ``src_path`` prefixed with the
+    resolved watch path, so the handler's ``relative_to`` check matches only when
+    the scheduled root is itself resolved. It drives the filter directly and does
+    not call ``_derive_watch_roots``, so it is not itself the end-to-end
+    regression guard — those are the derive-level resolution tests above and
+    ``test_symlinked_watch_root_delivers_link_and_target_writes`` (which fails
+    pre-fix on Linux). This one is platform-independent.
+    """
+    real = tmp_path / "targets" / "alpha"
+    real.mkdir(parents=True)
+    link = tmp_path / "alpha"
+    link.symlink_to(real, target_is_directory=True)
+    assert link.resolve() == real.resolve()  # the symlink's realpath is the target
+
+    # FSEvents delivers events prefixed with the resolved (realpath) watch path.
+    event = FileModifiedEvent(str(real / "note.md"))
+
+    calls = 0
+
+    def _schedule() -> None:
+        nonlocal calls
+        calls += 1
+
+    # Resolved root (what _derive_watch_roots now schedules): event admitted.
+    _VaultEventHandler(_schedule, real).on_any_event(event)
+    assert calls == 1, "realpath-prefixed event must pass under the resolved root"
+
+    # Unresolved symlink root (the pre-fix state): the same event is dropped.
+    calls = 0
+    _VaultEventHandler(_schedule, link).on_any_event(event)
+    assert calls == 0, "realpath-prefixed event is dropped by an unresolved root"
 
 
 def test_symlinked_watch_root_delivers_link_and_target_writes(tmp_path: Path) -> None:
-    """A recursive watch root that is a symlink delivers events for writes made
-    both through the link and directly via the target.
+    """End-to-end: a symlinked recursive watch root delivers events for writes
+    made both through the link and directly via the target.
 
-    Regression: FSEvents delivered target-prefixed src_paths for a watch
-    scheduled on the symlink path, so ``relative_to`` against the unresolved
-    root raised and ``on_change`` never fired.
+    A genuine regression guard on Linux too, not only macOS: without the
+    resolved-root fix a recursive watch scheduled on the unresolved symlinked
+    child does not deliver the writes made under it, so ``on_change`` never fires
+    (verified: fails deterministically here pre-fix). The exact internal reason
+    differs by platform — macOS FSEvents delivers realpath-prefixed ``src_path``s
+    that miss the unresolved root's ``relative_to`` filter, while Linux inotify
+    yields no events for that watch — but resolving the root fixes both. The
+    sibling ``test_source_dir_under_symlinked_prefix_delivers_events`` is the
+    Linux-agnostic case; ``test_resolved_root_admits_realpath_prefixed_event``
+    is the platform-independent filter-level proof.
     """
     real = tmp_path / "targets" / "alpha"
     real.mkdir(parents=True)
@@ -1047,11 +1231,15 @@ def test_symlinked_watch_root_delivers_link_and_target_writes(tmp_path: Path) ->
 
 
 def test_source_dir_under_symlinked_prefix_delivers_events(tmp_path: Path) -> None:
-    """A source_dir reached through a symlinked ancestor still delivers events.
+    """End-to-end: a source_dir reached through a symlinked ancestor still
+    delivers events.
 
-    Regression: with source_dir given as e.g. ``/var/...`` on macOS, the floor
-    watch filtered realpath-prefixed events against the unresolved root and
-    dropped them all.
+    Reproduces the macOS ``/var`` → ``/private/var`` FSEvents case (#849).
+    Unlike ``test_symlinked_watch_root_delivers_link_and_target_writes`` (which
+    fails on Linux without the fix), the inotify watch here is scheduled on the
+    symlinked-ancestor path and still delivers, so this passes on Linux with or
+    without the fix; the platform-independent filter-level check is
+    ``test_resolved_root_admits_realpath_prefixed_event``.
     """
     real_parent = tmp_path / "real"
     (real_parent / "vault").mkdir(parents=True)

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -965,6 +965,110 @@ def test_symlink_farm_layout_does_not_crash(tmp_path: Path) -> None:
     watcher.stop()
 
 
+# ---------------------------------------------------------------------------
+# Symlinked watch roots resolve to their realpath (FSEvents realpath delivery)
+# ---------------------------------------------------------------------------
+
+
+def test_derive_watch_roots_resolves_symlinked_child_root(tmp_path: Path) -> None:
+    """A symlinked child becomes a recursive root on its resolved target.
+
+    macOS FSEvents resolves the scheduled watch path with realpath and delivers
+    events with target-prefixed src_paths; scheduling and filtering on the
+    symlink path makes ``relative_to`` raise and silently drop every event.
+    """
+    real = tmp_path / "targets" / "alpha"
+    real.mkdir(parents=True)
+    farm = tmp_path / "farm"
+    farm.mkdir()
+    (farm / "alpha").symlink_to(real, target_is_directory=True)
+
+    roots = _derive_watch_roots(farm, None)
+    assert _WatchRoot(real, recursive=True) in roots
+    assert _WatchRoot(farm / "alpha", recursive=True) not in roots
+
+
+def test_derive_watch_roots_resolves_source_dir_under_symlinked_prefix(
+    tmp_path: Path,
+) -> None:
+    """A source_dir given through a symlinked prefix resolves floor and children.
+
+    Mirrors a macOS source_dir given as ``/var/...`` (a symlink to
+    ``/private/var/...``): scans work through the link, but FSEvents delivers
+    realpath-prefixed events.
+    """
+    real_parent = tmp_path / "real"
+    (real_parent / "vault" / "notes").mkdir(parents=True)
+    link_parent = tmp_path / "link"
+    link_parent.symlink_to(real_parent, target_is_directory=True)
+
+    roots = _derive_watch_roots(link_parent / "vault", None)
+    assert roots[-1] == _WatchRoot(real_parent / "vault", recursive=False)
+    assert _WatchRoot(real_parent / "vault" / "notes", recursive=True) in roots
+
+
+def test_derive_watch_roots_fallback_resolves_source_dir(tmp_path: Path) -> None:
+    """The enumeration-error fallback floor is also resolved."""
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    link_parent = tmp_path / "link"
+    link_parent.symlink_to(real_parent, target_is_directory=True)
+
+    roots = _derive_watch_roots(link_parent / "gone", None)
+    assert roots == [_WatchRoot(real_parent / "gone", recursive=False)]
+
+
+def test_symlinked_watch_root_delivers_link_and_target_writes(tmp_path: Path) -> None:
+    """A recursive watch root that is a symlink delivers events for writes made
+    both through the link and directly via the target.
+
+    Regression: FSEvents delivered target-prefixed src_paths for a watch
+    scheduled on the symlink path, so ``relative_to`` against the unresolved
+    root raised and ``on_change`` never fired.
+    """
+    real = tmp_path / "targets" / "alpha"
+    real.mkdir(parents=True)
+    farm = tmp_path / "farm"
+    farm.mkdir()
+    link = farm / "alpha"
+    link.symlink_to(real, target_is_directory=True)
+
+    called = threading.Event()
+    watcher = _make_watcher(farm, lambda: called.set())
+    watcher.start()
+    try:
+        (link / "through_link.md").write_text("via link")
+        assert called.wait(timeout=2.0), "write through the symlink not delivered"
+        called.clear()
+        (real / "via_target.md").write_text("via target")
+        assert called.wait(timeout=2.0), "write via the link target not delivered"
+    finally:
+        watcher.stop()
+
+
+def test_source_dir_under_symlinked_prefix_delivers_events(tmp_path: Path) -> None:
+    """A source_dir reached through a symlinked ancestor still delivers events.
+
+    Regression: with source_dir given as e.g. ``/var/...`` on macOS, the floor
+    watch filtered realpath-prefixed events against the unresolved root and
+    dropped them all.
+    """
+    real_parent = tmp_path / "real"
+    (real_parent / "vault").mkdir(parents=True)
+    link_parent = tmp_path / "link"
+    link_parent.symlink_to(real_parent, target_is_directory=True)
+    source_dir = link_parent / "vault"
+
+    called = threading.Event()
+    watcher = _make_watcher(source_dir, lambda: called.set())
+    watcher.start()
+    try:
+        (source_dir / "note.md").write_text("hello")
+        assert called.wait(timeout=2.0), "write under symlinked prefix not delivered"
+    finally:
+        watcher.stop()
+
+
 def test_lifespan_skips_watcher_when_webhook_active(tmp_path: Path) -> None:
     """The lifespan does not start the watcher when a webhook secret is configured."""
     import asyncio


### PR DESCRIPTION
Closes #849

## Summary

watchdog's FSEvents emitter (macOS) resolves each scheduled watch path with `os.path.realpath` and delivers events with realpath-prefixed `src_path`s. The watcher's root-relative filter compares those against the path *as scheduled*, so when a watch root is (or sits under) a symlink, `relative_to(watch_root)` raises for every delivered event and each one is silently dropped. Scheduling still succeeds, so the all-roots-failed ERROR from #845 never fires — the watcher is live but effectively blind for that root, and changes are only picked up by scans.

Affected layouts: a symlinked `SOURCE_DIR` (`/var/...` resolving to `/private/var/...`), symlinked top-level children of the vault root, and symlink-farm vaults (the #508 family — glob discovery follows the links since #508 was fixed, but live events for them die at the filter).

The fix resolves `source_dir` and each derived child root with `Path.resolve()` at derive time in `_derive_watch_roots`, so scheduling and filtering agree on every platform (inotify and ReadDirectoryChangesW deliver events prefixed with the scheduled path, which is then the resolved path too). Prune rules still match the child's vault-visible name inside `source_dir`, not the resolved target's basename, so exclude patterns keep working across the link.

The watcher-scoping section of `docs/design/design.md` is updated to document the derive-time realpath resolution, why scheduling and filtering must agree on the resolved form, and the symlinked-`source_dir` / symlink-farm consequence.

## Evidence

Verified with a raw-handler probe on macOS (watchdog 6.0.0): a watch scheduled on a symlink path receives events for writes made **both through the link and via the target**, every `src_path` realpath-prefixed. The shipped filter (`_is_hidden_relative_to_root` → `Path(src_path).relative_to(watch_root)`) drops them all, because the unresolved `watch_root` is never a prefix of the realpath-prefixed `src_path`. Scheduling on the resolved root makes the prefix match and the events flow through to the debounce scheduler.

## Test plan

Five regression tests added to `tests/test_file_watcher.py`:

- `test_derive_watch_roots_resolves_symlinked_child_root` — a symlinked child becomes a recursive root on its resolved target, not the link path.
- `test_derive_watch_roots_resolves_source_dir_under_symlinked_prefix` — floor and children resolve when `source_dir` is given through a symlinked ancestor.
- `test_derive_watch_roots_fallback_resolves_source_dir` — the enumeration-error fallback floor is resolved too.
- `test_symlinked_watch_root_delivers_link_and_target_writes` — live watcher: a symlinked recursive root delivers events for writes made both through the link and via the target.
- `test_source_dir_under_symlinked_prefix_delivers_events` — live watcher: a `source_dir` reached through a symlinked ancestor still delivers events.

Gates (fresh venv, `uv sync --extra all --group dev`, macOS, Python 3.13.5, watchdog 6.0.0):

- `pytest tests/test_file_watcher.py`: 68 passed.
- Patch coverage on `_file_watcher.py` (`--cov=markdown_vault_mcp._file_watcher`): **89.71%** (gate 80%).
- Full suite: 2592 passed, 2 skipped, 1 failed. The failure is pre-existing and unrelated — `tests/test_structural_gate.py::test_options_reach_ruff_and_gate_is_diff_scoped` fails identically on clean `upstream/main` (baseline before this change: 1 failed, 2587 passed, 2 skipped) with `Failure: 'ruff.check is not installed'`, a `diff-quality`/ruff-plugin discovery issue in the fresh local venv. This PR adds exactly the 5 new tests (2587 + 5 = 2592).
- `ruff check src/ tests/`: passed. `ruff format --check`: 155 files already formatted. `mypy src/ tests/`: no issues.

## Reviewer notes

This branch was rebuilt on current `main` and conflicted with recent work in `_derive_watch_roots`. Resolutions:

- **vs #838 (never watch state dir / `.git`).** #838 added `protected = frozenset(_resolve_internal_dirs(internal_dirs))` and a `_contains_internal_dir(child, protected)` guard. Both are kept; my `source_dir = source_dir.resolve()` line was placed immediately after the `protected` assignment, and the child append became `_WatchRoot(child.resolve(), recursive=True)` after (not instead of) the internal-dir guard.
- **Composition with #838's exclusion-path convention (the coherence check).** #838's exclusion is already resolved-vs-resolved: `_resolve_internal_dirs` resolves every `internal_dir`, and `_contains_internal_dir` resolves `child` internally (`child.resolve()`) before comparing `d == child_resolved or d.is_relative_to(child_resolved)`. Because the guard resolves `child` with the same `Path.resolve()` I use to build the appended root, the directory the guard evaluates is exactly the directory that gets scheduled — the exclusion stays correct after roots become resolved, and no comparison-side fix was required. (Had #838 left its exclusion paths unresolved while roots became resolved, a symlinked state dir could have slipped past the guard; it does not, because #838 already resolves both sides.)
- **vs #845 (surface a fully-blind watcher).** #845's per-root scheduling loop, the `if roots and not scheduled:` all-roots-failed ERROR, and the scheduled/recursive-count tracking in `start()` are untouched — this change only affects which paths `_derive_watch_roots` returns, upstream of that loop. The resolved roots make the previously-silent blind-watcher case (#849) actually deliver events, which is complementary to #845's louder logging of the genuinely-unschedulable case.
- **vs #839 (comment rewording).** The `is_dir()` follows-symlinks comment #839 reworded was kept as-is; my change adds lines below it and does not touch its wording.
- **Prune-rule ordering.** `_should_prune_dir(child.name, ...)` still runs on the vault-visible `child.name` before resolution, so exclude patterns match the name inside `source_dir`, not the resolved target's basename.
- **`tmp_path` and resolution.** pytest's `tmp_path` fixture is already realpath-resolved (`/private/var/...`), so `source_dir.resolve()` is a no-op for the floor and non-symlinked children — existing assertions like `test_symlink_farm_layout_does_not_crash`'s `_WatchRoot(farm, recursive=False) in roots` still hold. Only the deliberately-symlinked test fixtures resolve to their targets.
