### PR TITLE
feat: restyle the Graph Explorer view to Paper with level-of-detail labels

### DIFF
--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -26,7 +26,7 @@ Interactive force-directed link graph of the vault, powered by vis-network. Two 
 
 Click a node to view that note's context card. Toggle semantic similarity edges when embeddings are available (semantic edges render as dashed accent-colored lines, distinct from the solid wikilink edges).
 
-Node labels follow a level-of-detail rule. The focus note and its direct neighbors keep their labels; farther-out notes render as unlabelled dots. A dot's note name becomes visible on hover or once the view is zoomed in past a threshold (a separate hover text with the note's title and backlink count is always available, regardless of zoom level). A count chip in the top-right corner of the canvas reports how many notes are currently visible, next to zoom-in and zoom-out buttons. A legend below the canvas explains the edge and node styles; on a narrow panel it collapses behind an "ⓘ legend" chip to save space.
+Node labels follow a level-of-detail rule. The focus note, its direct neighbors, and hub notes keep their labels; other farther-out notes render as unlabelled dots (their names appear on hover, or once you zoom in past a threshold). A separate hover text with the note's title and backlink count is always available, regardless of zoom level. A count chip in the top-right corner of the canvas reports how many notes are currently visible, next to zoom-in and zoom-out buttons. A legend below the canvas explains the edge and node styles; on a narrow panel it collapses behind an "ⓘ legend" chip to save space.
 
 ### Vault Browser
 

--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -24,7 +24,9 @@ Interactive force-directed link graph of the vault, powered by vis-network. Two 
 - **Neighborhood**: shows a note and its direct connections (configurable depth, soft-capped at `max_nodes=200` by default; the response carries `truncated=true` when the BFS hit the cap so the SPA can warn the user)
 - **Hubs**: shows the most-linked notes in the vault and their connections
 
-Click a node to view that note's context card. Toggle semantic similarity edges when embeddings are available.
+Click a node to view that note's context card. Toggle semantic similarity edges when embeddings are available (semantic edges render as dashed accent-colored lines, distinct from the solid wikilink edges).
+
+Node labels follow a level-of-detail rule. The focus note and its direct neighbors keep their labels; farther-out notes render as unlabelled dots. A dot's title becomes visible on hover, or once the view is zoomed in past a threshold. A count chip in the top-right corner of the canvas reports how many notes are currently visible, next to zoom-in and zoom-out buttons. A legend in the corner explains the edge and node styles; on a narrow panel it collapses behind an "ⓘ legend" chip to save space.
 
 ### Vault Browser
 

--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -26,7 +26,7 @@ Interactive force-directed link graph of the vault, powered by vis-network. Two 
 
 Click a node to view that note's context card. Toggle semantic similarity edges when embeddings are available (semantic edges render as dashed accent-colored lines, distinct from the solid wikilink edges).
 
-Node labels follow a level-of-detail rule. The focus note and its direct neighbors keep their labels; farther-out notes render as unlabelled dots. A dot's title becomes visible on hover, or once the view is zoomed in past a threshold. A count chip in the top-right corner of the canvas reports how many notes are currently visible, next to zoom-in and zoom-out buttons. A legend in the corner explains the edge and node styles; on a narrow panel it collapses behind an "ⓘ legend" chip to save space.
+Node labels follow a level-of-detail rule. The focus note and its direct neighbors keep their labels; farther-out notes render as unlabelled dots. A dot's note name becomes visible on hover or once the view is zoomed in past a threshold (a separate hover text with the note's title and backlink count is always available, regardless of zoom level). A count chip in the top-right corner of the canvas reports how many notes are currently visible, next to zoom-in and zoom-out buttons. A legend below the canvas explains the edge and node styles; on a narrow panel it collapses behind an "ⓘ legend" chip to save space.
 
 ### Vault Browser
 

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -509,7 +509,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:308a3f139fafaaa707828d68bec0ce83b97c6880cc05e377b95e9e36ad1ed8cf -->
+<!-- vendor-spa-source-sha256:7887fa67aabfb09c1859bd6f34b65e0548d9f7543b75850d7b7893f61ae2951b -->
 </head>
 <body>
 <div class="app-container">
@@ -1216,16 +1216,18 @@ app.onteardown = () => {
               font: { color: c.accentInk, size: 13, face: 'inherit' },
               label: n._label };
       } else if (d === 1 || (n._group === 'hub')) {
-        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
-              color: { background: folder, border: c.border },
-              borderWidth: n._group === 'hub' ? 3 : 1,
-              font: { color: c.ink2, size: 12, face: 'inherit' },
-              shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
-              label: n._label };
-      } else if (_semanticMatch(n.id)) {
-        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
-              color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
-              font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+        if (_semanticMatch(n.id)) {
+          u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
+                color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
+                font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+        } else {
+          u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+                color: { background: folder, border: c.border },
+                borderWidth: n._group === 'hub' ? 3 : 1,
+                font: { color: c.ink2, size: 12, face: 'inherit' },
+                shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
+                label: n._label };
+        }
       } else {
         u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
               color: { background: folder, border: c.edge }, borderWidth: 1.5,

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -509,7 +509,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:c3832bcde5a6089e8cb1dc01f072850fe15e7e668d2d274cc666b9ae647c2ac3 -->
+<!-- vendor-spa-source-sha256:308a3f139fafaaa707828d68bec0ce83b97c6880cc05e377b95e9e36ad1ed8cf -->
 </head>
 <body>
 <div class="app-container">
@@ -1031,6 +1031,8 @@ app.onteardown = () => {
   let semanticEnabled = false;
   let _depths = new Map();
   const LABEL_ZOOM_THRESHOLD = 1.35;
+  let _zoomedIn = false;
+  let _hoveredId = null;
 
   // Folder-based node colors — chosen to stand out on both light and dark backgrounds
   const _FOLDER_COLORS = [
@@ -1090,7 +1092,7 @@ app.onteardown = () => {
       physics: { enabled: true, solver: 'forceAtlas2Based', forceAtlas2Based: { gravitationalConstant: -40 } },
       nodes: {
         shape: 'dot',
-        scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16 } },
+        scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16, drawThreshold: 6 } },
       },
       edges: {
         arrows: { to: { enabled: true, scaleFactor: 0.5 } }, font: { size: 9 }, smooth: { type: 'continuous' },
@@ -1123,6 +1125,13 @@ app.onteardown = () => {
         loadGraph(nodeId);
       }
     });
+
+    network.on('zoom', (params) => {
+      const zoomed = params.scale >= LABEL_ZOOM_THRESHOLD;
+      if (zoomed !== _zoomedIn) { _zoomedIn = zoomed; applyLOD(); }  // only on crossing
+    });
+    network.on('hoverNode', (params) => { _hoveredId = params.node; applyLOD(); });
+    network.on('blurNode', () => { _hoveredId = null; applyLOD(); });
   }
 
   function addGraphData(data) {
@@ -1158,6 +1167,7 @@ app.onteardown = () => {
     _depths = computeDepths();
     styleNodes(_depths);
     styleEdges(_depths);
+    applyLOD();
   }
 
   // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
@@ -1224,6 +1234,22 @@ app.onteardown = () => {
       }
       updates.push(u);
     }
+    nodesDS.update(updates);
+  }
+
+  // Coherence predicate: a node's label shows iff it is near the focus, OR the
+  // graph is zoomed in past the threshold, OR the node is currently hovered.
+  function labelVisible(id) {
+    const d = _depths.has(id) ? _depths.get(id) : Infinity;
+    return d <= 1 || _zoomedIn || id === _hoveredId;
+  }
+
+  // Re-derive every node's label from labelVisible (never toggled ad hoc).
+  function applyLOD() {
+    if (!nodesDS) return;
+    const updates = nodesDS.get().map(n => ({
+      id: n.id, label: labelVisible(n.id) ? n._label : '',
+    }));
     nodesDS.update(updates);
   }
 

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -548,7 +548,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:037398953834ac9c3c3474b29e86755c299387a18eff52f2897df1aa6b6c6b54 -->
+<!-- vendor-spa-source-sha256:46f11e0cdcf072e1550691117cd83a88f680a52a088ceda3862a79e17fb2a452 -->
 </head>
 <body>
 <div class="app-container">
@@ -1251,15 +1251,16 @@ app.onteardown = () => {
     return depths;
   }
 
-  // A node is "semantic-match" if it is reachable from focus only via semantic edges.
+  // A node is "semantic-match" if every edge touching it is a semantic edge.
   function _semanticMatch(id) {
     const touching = edgesDS.get().filter(e => e.from === id || e.to === id);
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Label gate: focus, depth-1,
-  // and semantic-match nodes are labelled here; distant nodes get `label: ''`.
-  // Task 3's applyLOD promotes/demotes by zoom/hover.
+  // Map each node to its Paper role by distance. Focus, depth-1, and hub nodes
+  // are labelled box pills (semantic-match ones get the dashed-pill styling);
+  // all other nodes are dots with `label: ''`. applyLOD then promotes/demotes
+  // labels by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();
@@ -1282,7 +1283,7 @@ app.onteardown = () => {
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
                 color: { background: folder, border: c.border },
                 borderWidth: n._group === 'hub' ? 3 : 1,
-                font: { color: c.ink2, size: 12, face: 'inherit' },
+                font: { color: c.accentInk, size: 12, face: 'inherit' },
                 shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
                 label: n._label };
         }
@@ -1297,18 +1298,19 @@ app.onteardown = () => {
     nodesDS.update(updates);
   }
 
-  // Coherence predicate: a node's label shows iff it is near the focus, OR the
-  // graph is zoomed in past the threshold, OR the node is currently hovered.
-  function labelVisible(id) {
-    const d = _depths.has(id) ? _depths.get(id) : Infinity;
-    return d <= 1 || _zoomedIn || id === _hoveredId;
+  // Coherence predicate: a node's label shows iff it is near the focus, OR it
+  // is a hub node, OR the graph is zoomed in past the threshold, OR the node
+  // is currently hovered.
+  function labelVisible(n) {
+    const d = _depths.has(n.id) ? _depths.get(n.id) : Infinity;
+    return d <= 1 || n._group === 'hub' || _zoomedIn || n.id === _hoveredId;
   }
 
   // Re-derive every node's label from labelVisible (never toggled ad hoc).
   function applyLOD() {
     if (!nodesDS) return;
     const updates = nodesDS.get().map(n => ({
-      id: n.id, label: labelVisible(n.id) ? n._label : '',
+      id: n.id, label: labelVisible(n) ? n._label : '',
     }));
     nodesDS.update(updates);
   }

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -356,7 +356,12 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   .fm-table td:first-child { font-family: var(--font-mono); font-size: 11px; white-space: nowrap; width: 66px; padding-right: 12px; color: var(--muted); }
   /* Graph styles */
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
-  #graph-container { border: 1px solid var(--color-border-primary); border-radius: 6px; min-height: 200px; }
+  #graph-container {
+    border: 1px solid var(--border-2); border-radius: var(--radius); min-height: 200px;
+    background-color: var(--panel);
+    background-image: radial-gradient(var(--edge) 1px, transparent 1px);
+    background-size: 21px 21px; background-position: -0.5px -0.5px;
+  }
   .graph-mini-card {
     position: absolute; bottom: 16px; right: 16px; width: 280px; max-height: 200px; overflow-y: auto;
     background: var(--color-background-primary); border: 1px solid var(--color-border-primary);
@@ -504,7 +509,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:7bbde69c611deeceb877201db41afdcf6382244844392d5a50bc5458c769d751 -->
+<!-- vendor-spa-source-sha256:46d424cb3bc2b57a7b0dd06ab083ef744eca2559c182be9b609a4b3927dc7f53 -->
 </head>
 <body>
 <div class="app-container">
@@ -1043,24 +1048,33 @@ app.onteardown = () => {
     return _FOLDER_COLORS[h % _FOLDER_COLORS.length];
   }
 
-  // Color scheme for edges and UI chrome
+  // Paper palette for edges and canvas chrome, read from CSS vars so the graph
+  // re-themes when the host flips theme (see refreshColors / vault-theme-changed).
   function getColors() {
     const s = getComputedStyle(document.documentElement);
+    const v = (name, fallback) => s.getPropertyValue(name).trim() || fallback;
     return {
-      fg: s.getPropertyValue('--color-text-primary').trim() || '#1a1a1a',
-      accent: s.getPropertyValue('--color-text-info').trim() || '#6366f1',
-      muted: s.getPropertyValue('--color-text-secondary').trim() || '#6b7280',
-      border: s.getPropertyValue('--color-border-primary').trim() || '#e0e0e0',
+      panel:      v('--panel', '#fbf8f1'),
+      panel2:     v('--panel-2', '#f2ecdf'),
+      ink:        v('--ink', '#2a2620'),
+      ink2:       v('--ink-2', '#5c5446'),
+      muted:      v('--muted', '#928975'),
+      edge:       v('--edge', '#d3c7ad'),
+      accent:     v('--accent', '#b25a35'),
+      accentInk:  v('--accent-ink', '#ffffff'),
+      accentSoft: v('--accent-soft', '#f3e4d8'),
+      border:     v('--border', '#e4dbc9'),
     };
   }
 
-  const _SEMANTIC_EDGE_COLOR = '#a855f7'; // purple — distinct from folder node colors
-
-  function edgeColorByType(type, c) {
-    if (type === 'semantic') return _SEMANTIC_EDGE_COLOR;
-    if (type === 'wikilink') return c.accent;
-    if (type === 'reference') return c.muted;
-    return c.border; // markdown = default
+  // Edge styling: solid --edge for link edges (thinner + lower opacity when the
+  // farthest endpoint is distant), dashed --accent for semantic similarity.
+  function edgeStyle(type, depthMax, c) {
+    if (type === 'semantic') {
+      return { color: { color: c.accent, opacity: 0.75 }, dashes: [5, 4], width: 1 };
+    }
+    const far = depthMax >= 2;
+    return { color: { color: c.edge, opacity: far ? 0.5 : 1 }, dashes: false, width: far ? 1 : 1.6 };
   }
 
   function initNetwork() {
@@ -1140,12 +1154,10 @@ app.onteardown = () => {
         ? 'sem:' + [e.from, e.to].sort().join('<>')
         : e.from + '->' + e.to;
       if (!edgesDS.get(edgeId)) {
+        const es = edgeStyle(e.type, 0, c);
         edgesDS.add({
           id: edgeId, from: e.from, to: e.to,
-          color: { color: edgeColorByType(e.type, c), highlight: _SEMANTIC_EDGE_COLOR },
-          title: e.type,
-          dashes: isSemantic,
-          width: isSemantic ? 1 : 1.5,
+          color: es.color, title: e.type, dashes: es.dashes, width: es.width,
           arrows: isSemantic ? '' : { to: { enabled: true, scaleFactor: 0.5 } },
         });
       }
@@ -1267,13 +1279,13 @@ app.onteardown = () => {
     semanticEnabled = !semanticEnabled;
     const btn = document.getElementById('graph-semantic-btn');
     if (semanticEnabled) {
-      btn.style.background = _SEMANTIC_EDGE_COLOR;
-      btn.style.color = '#ffffff';
+      btn.style.background = 'var(--accent)';
+      btn.style.color = 'var(--accent-ink)';
       btn.style.border = 'none';
     } else {
-      btn.style.background = 'var(--color-background-secondary)';
-      btn.style.color = 'var(--color-text-primary)';
-      btn.style.border = '1px solid var(--color-border-primary)';
+      btn.style.background = 'var(--panel-2)';
+      btn.style.color = 'var(--ink)';
+      btn.style.border = '1px solid var(--border)';
     }
     // Reload current graph with updated setting
     if (graphCenterPath) loadGraph(graphCenterPath);

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -548,7 +548,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:46f11e0cdcf072e1550691117cd83a88f680a52a088ceda3862a79e17fb2a452 -->
+<!-- vendor-spa-source-sha256:0bd5ce1dbea6fba032bfe6b96518c9c4da39269094fae955e19d21a2b6380e1d -->
 </head>
 <body>
 <div class="app-container">
@@ -1272,18 +1272,18 @@ app.onteardown = () => {
       if (d === 0) {
         u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
               color: { background: c.accent, border: c.accent }, borderWidth: 2,
-              font: { color: c.accentInk, size: 13, face: 'inherit' },
+              font: { color: c.accentInk, size: 13 },
               label: n._label };
       } else if (d === 1 || (n._group === 'hub')) {
         if (_semanticMatch(n.id)) {
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
                 color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
-                font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+                font: { color: c.ink2, size: 12 }, label: n._label };
         } else {
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
-                color: { background: folder, border: c.border },
-                borderWidth: n._group === 'hub' ? 3 : 1,
-                font: { color: c.accentInk, size: 12, face: 'inherit' },
+                color: { background: c.panel, border: folder },
+                borderWidth: n._group === 'hub' ? 3 : 1.5,
+                font: { color: c.ink2, size: 12 },
                 shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
                 label: n._label };
         }

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -548,7 +548,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:f79cbf22485c272ae241ab7e88712b7616485e955c76e41281620200b0282c03 -->
+<!-- vendor-spa-source-sha256:3f9964b5117296cedcca02e89fd372e5c29852daaccf2940b32c62be3bc9c8ec -->
 </head>
 <body>
 <div class="app-container">
@@ -1258,10 +1258,10 @@ app.onteardown = () => {
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Focus, depth-1, and hub nodes
-  // are labelled box pills (semantic-match ones get the dashed-pill styling);
-  // all other nodes are dots with `label: ''`. applyLOD then promotes/demotes
-  // labels by zoom/hover.
+  // Map each node to its Paper role by distance. Focus is the accent pill;
+  // depth-1 and hub nodes are box pills, and among those the semantic-match ones
+  // (every touching edge semantic) get the dashed-pill styling; all other nodes
+  // are dots with `label: ''`. applyLOD then promotes/demotes labels by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -548,7 +548,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:3f9964b5117296cedcca02e89fd372e5c29852daaccf2940b32c62be3bc9c8ec -->
+<!-- vendor-spa-source-sha256:179472c7e40373f35e097a280f1198551e125281df24ef92ab43a074c2e1276f -->
 </head>
 <body>
 <div class="app-container">
@@ -1142,7 +1142,6 @@ app.onteardown = () => {
     if (network) return;
     const container = document.getElementById('graph-container');
     if (!container || typeof vis === 'undefined') return;
-    const c = getColors();
     nodesDS = new vis.DataSet();
     edgesDS = new vis.DataSet();
     const options = {

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -548,7 +548,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:0bd5ce1dbea6fba032bfe6b96518c9c4da39269094fae955e19d21a2b6380e1d -->
+<!-- vendor-spa-source-sha256:f79cbf22485c272ae241ab7e88712b7616485e955c76e41281620200b0282c03 -->
 </head>
 <body>
 <div class="app-container">
@@ -1228,7 +1228,8 @@ app.onteardown = () => {
     updateCountChip();
   }
 
-  // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
+  // BFS distance-from-focus over the accumulated edge set. Unreachable nodes are
+  // absent from the returned map; callers treat a missing entry as Infinity.
   function computeDepths() {
     const depths = new Map();
     if (!nodesDS || !graphCenterPath || !nodesDS.get(graphCenterPath)) return depths;
@@ -1291,6 +1292,7 @@ app.onteardown = () => {
         u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
               color: { background: folder, border: c.edge }, borderWidth: 1.5,
               shapeProperties: n._group === 'orphan' ? { borderDashes: [5, 5] } : {},
+              font: { color: c.ink2 },
               label: '' };
       }
       updates.push(u);

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -302,6 +302,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     color: var(--color-text-primary);
     border: 1px solid var(--color-border-primary);
   }
+  .action-btn.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
   /* Context card */
   .context-header { margin-bottom: 6px; }
   .context-title-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
@@ -365,20 +366,19 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   }
   .graph-mini-card {
     position: absolute; bottom: 16px; right: 16px; width: 280px; max-height: 200px; overflow-y: auto;
-    background: var(--color-background-primary); border: 1px solid var(--color-border-primary);
-    border-radius: 8px; padding: 12px; font-size: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); z-index: 10;
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: var(--pad); font-size: 12px; box-shadow: var(--shadow); z-index: 10;
   }
-  .graph-mini-card h4 { margin: 0 0 6px; font-size: 14px; }
+  .graph-mini-card h4 { margin: 0 0 6px; font-family: var(--font-head, inherit); font-size: 14px; color: var(--ink); }
   .graph-mini-card .mini-links { margin: 4px 0; }
-  .graph-mini-card .mini-link { color: var(--color-text-info); cursor: pointer; padding: 1px 0; }
+  .graph-mini-card .mini-link { color: var(--accent); cursor: pointer; padding: 1px 0; }
   .graph-mini-card .mini-link:hover { text-decoration: underline; }
   .graph-mini-card .mini-actions { margin-top: 8px; display: flex; gap: 6px; }
   .graph-mini-card .mini-actions button {
-    font-size: 11px; padding: 3px 8px; border-radius: 3px; cursor: pointer;
-    background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
-    color: var(--color-text-primary); font-family: inherit;
+    font: 600 11px/1 var(--font-body); padding: 5px 9px; border-radius: var(--radius-sm); cursor: pointer;
+    background: var(--panel-2); border: 1px solid var(--border); color: var(--ink-2);
   }
-  .graph-mini-card .mini-actions button:hover { background: var(--color-border-primary); }
+  .graph-mini-card .mini-actions button:hover { color: var(--ink); border-color: var(--muted); }
   .graph-overlay {
     position: absolute; top: 10px; right: 10px; z-index: 10;
     display: flex; align-items: center; gap: 8px;
@@ -548,7 +548,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:76d3d01c7faf33559047a5fd0ffe1ee79fb964f00140c41e17ede02675c120c1 -->
+<!-- vendor-spa-source-sha256:037398953834ac9c3c3474b29e86755c299387a18eff52f2897df1aa6b6c6b54 -->
 </head>
 <body>
 <div class="app-container">
@@ -693,7 +693,10 @@ function parseToolResult(result) {
 // ── Host theming ─────────────────────────────────────────────────────────
 function handleHostContext(ctx) {
   if (!ctx) return;
-  if (ctx.theme) applyDocumentTheme(ctx.theme);
+  if (ctx.theme) {
+    applyDocumentTheme(ctx.theme);
+    window.dispatchEvent(new CustomEvent('vault-theme-changed', { detail: { theme: ctx.theme } }));
+  }
   if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
   if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
   if (ctx.displayMode !== undefined) {
@@ -1321,6 +1324,16 @@ app.onteardown = () => {
     edgesDS.update(updates);
   }
 
+  // Re-read Paper vars and restyle everything (a canvas doesn't inherit CSS-var
+  // changes, so the graph must re-read on host theme flips).
+  function refreshColors() {
+    if (!nodesDS) return;
+    styleNodes(_depths);
+    styleEdges(_depths);
+    applyLOD();
+  }
+  window.addEventListener('vault-theme-changed', refreshColors);
+
   async function expandNode(path) {
     try {
       const result = await app.callServerTool({
@@ -1451,15 +1464,7 @@ app.onteardown = () => {
   document.getElementById('graph-semantic-btn').addEventListener('click', () => {
     semanticEnabled = !semanticEnabled;
     const btn = document.getElementById('graph-semantic-btn');
-    if (semanticEnabled) {
-      btn.style.background = 'var(--accent)';
-      btn.style.color = 'var(--accent-ink)';
-      btn.style.border = 'none';
-    } else {
-      btn.style.background = 'var(--panel-2)';
-      btn.style.color = 'var(--ink)';
-      btn.style.border = '1px solid var(--border)';
-    }
+    btn.classList.toggle('active', semanticEnabled);
     // Reload current graph with updated setting
     if (graphCenterPath) loadGraph(graphCenterPath);
   });

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -378,6 +378,22 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     color: var(--color-text-primary); font-family: inherit;
   }
   .graph-mini-card .mini-actions button:hover { background: var(--color-border-primary); }
+  .graph-overlay {
+    position: absolute; top: 10px; right: 10px; z-index: 10;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .graph-count {
+    font: 600 11px/1 var(--font-mono); color: var(--muted);
+    background: var(--panel); border: 1px solid var(--border);
+    padding: 5px 9px; border-radius: var(--radius-sm);
+  }
+  .graph-zoom { display: flex; background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius-sm); overflow: hidden; }
+  .graph-zoom button {
+    background: none; border: none; cursor: pointer; color: var(--ink-2);
+    font: 600 15px/1 var(--font-body); padding: 4px 10px;
+  }
+  .graph-zoom button:hover { background: var(--panel-2); color: var(--ink); }
+  .graph-zoom button + button { border-left: 1px solid var(--border); }
   /* Browser styles */
   .browser-layout { display: flex; flex-direction: column; flex: 1; min-height: 0; gap: 0; }
   .browser-sidebar {
@@ -509,7 +525,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:7887fa67aabfb09c1859bd6f34b65e0548d9f7543b75850d7b7893f61ae2951b -->
+<!-- vendor-spa-source-sha256:09fc2f471865ce0a7a1e05d73caf327f5521ed97c58c8931d2e2f684552bb95e -->
 </head>
 <body>
 <div class="app-container">
@@ -563,6 +579,13 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     </div>
     <div id="graph-container" style="flex:1;position:relative;">
       <div id="graph-mini-card" class="graph-mini-card" style="display:none;"></div>
+      <div class="graph-overlay" id="graph-overlay">
+        <span class="graph-count" id="graph-count">0 notes</span>
+        <div class="graph-zoom">
+          <button id="graph-zoom-out" title="Zoom out">&#8722;</button>
+          <button id="graph-zoom-in" title="Zoom in">&#43;</button>
+        </div>
+      </div>
     </div>
   </div>
   <div class="tab-panel" id="panel-browse" data-tab="browse">
@@ -1168,6 +1191,7 @@ app.onteardown = () => {
     styleNodes(_depths);
     styleEdges(_depths);
     applyLOD();
+    updateCountChip();
   }
 
   // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
@@ -1360,6 +1384,17 @@ app.onteardown = () => {
   function hideMiniCard() {
     document.getElementById('graph-mini-card').style.display = 'none';
   }
+
+  function updateCountChip() {
+    const chip = document.getElementById('graph-count');
+    if (chip && nodesDS) chip.textContent = nodesDS.length + (nodesDS.length === 1 ? ' note' : ' notes');
+  }
+  document.getElementById('graph-zoom-in')?.addEventListener('click', () => {
+    if (network) network.moveTo({ scale: network.getScale() * 1.3 });
+  });
+  document.getElementById('graph-zoom-out')?.addEventListener('click', () => {
+    if (network) network.moveTo({ scale: network.getScale() / 1.3 });
+  });
 
   // Send graph summary to Claude
   document.getElementById('graph-send-btn').addEventListener('click', () => {

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -355,6 +355,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   .fm-table tr:last-child td { border-bottom: none; }
   .fm-table td:first-child { font-family: var(--font-mono); font-size: 11px; white-space: nowrap; width: 66px; padding-right: 12px; color: var(--muted); }
   /* Graph styles */
+  #panel-graph { container-type: inline-size; }
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
   #graph-container {
     border: 1px solid var(--border-2); border-radius: var(--radius); min-height: 200px;
@@ -394,6 +395,28 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   }
   .graph-zoom button:hover { background: var(--panel-2); color: var(--ink); }
   .graph-zoom button + button { border-left: 1px solid var(--border); }
+  .graph-legend {
+    display: flex; flex-wrap: wrap; gap: 12px; padding: 8px 10px; flex-shrink: 0;
+    font: 500 11px/1 var(--font-body); color: var(--muted);
+  }
+  .graph-legend .lg-item { display: inline-flex; align-items: center; gap: 6px; }
+  .lg-line { width: 16px; height: 0; border-top: 1.6px solid var(--edge); }
+  .lg-dashed { border-top: 1.6px dashed var(--accent); }
+  .lg-pill { width: 14px; height: 9px; border-radius: 999px; }
+  .lg-focus { background: var(--accent); }
+  .lg-linked { background: var(--panel); border: 1px solid var(--border); }
+  .lg-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--panel); border: 1.5px solid var(--edge); }
+  .graph-legend-chip {
+    display: none; align-self: flex-start; margin: 6px 10px;
+    background: var(--panel-2); border: 1px solid var(--border); color: var(--ink-2);
+    font: 600 11px/1 var(--font-body); padding: 6px 10px; border-radius: var(--radius-sm); cursor: pointer;
+  }
+  /* Content-first shedding: on a narrow panel the legend collapses to the chip. */
+  @container (max-width: 420px) {
+    .graph-legend { display: none; }
+    .graph-legend.open { display: flex; }
+    .graph-legend-chip { display: inline-block; }
+  }
   /* Browser styles */
   .browser-layout { display: flex; flex-direction: column; flex: 1; min-height: 0; gap: 0; }
   .browser-sidebar {
@@ -525,7 +548,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:09fc2f471865ce0a7a1e05d73caf327f5521ed97c58c8931d2e2f684552bb95e -->
+<!-- vendor-spa-source-sha256:76d3d01c7faf33559047a5fd0ffe1ee79fb964f00140c41e17ede02675c120c1 -->
 </head>
 <body>
 <div class="app-container">
@@ -586,6 +609,14 @@ if(__exports != exports)module.exports = exports;return module.exports}));
           <button id="graph-zoom-in" title="Zoom in">&#43;</button>
         </div>
       </div>
+    </div>
+    <button class="graph-legend-chip" id="graph-legend-chip" title="Show legend">&#9432; legend</button>
+    <div class="graph-legend" id="graph-legend">
+      <span class="lg-item"><span class="lg-line lg-solid"></span>wikilink</span>
+      <span class="lg-item"><span class="lg-line lg-dashed"></span>semantic</span>
+      <span class="lg-item"><span class="lg-pill lg-focus"></span>focus note</span>
+      <span class="lg-item"><span class="lg-pill lg-linked"></span>linked note</span>
+      <span class="lg-item"><span class="lg-dot"></span>more (hover)</span>
     </div>
   </div>
   <div class="tab-panel" id="panel-browse" data-tab="browse">
@@ -1394,6 +1425,11 @@ app.onteardown = () => {
   });
   document.getElementById('graph-zoom-out')?.addEventListener('click', () => {
     if (network) network.moveTo({ scale: network.getScale() / 1.3 });
+  });
+
+  // Narrow-panel legend collapse chip
+  document.getElementById('graph-legend-chip')?.addEventListener('click', () => {
+    document.getElementById('graph-legend')?.classList.toggle('open');
   });
 
   // Send graph summary to Claude

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -509,7 +509,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:46d424cb3bc2b57a7b0dd06ab083ef744eca2559c182be9b609a4b3927dc7f53 -->
+<!-- vendor-spa-source-sha256:1d9c8ccc84775e1ad93e205308b4e85c447cfe9b542ab93dfc5532704ee9b4b7 -->
 </head>
 <body>
 <div class="app-container">
@@ -1029,6 +1029,8 @@ app.onteardown = () => {
   let graphCenterPath = null;
   let selectedNodeId = null;
   let semanticEnabled = false;
+  let _depths = new Map();
+  const LABEL_ZOOM_THRESHOLD = 1.35;
 
   // Folder-based node colors — chosen to stand out on both light and dark backgrounds
   const _FOLDER_COLORS = [
@@ -1129,21 +1131,12 @@ app.onteardown = () => {
     for (const n of data.nodes) {
       if (!nodesDS.get(n.id)) {
         const bc = n.backlink_count || 0;
-        const baseColor = n.group === 'orphan' ? '#94a3b8' : _folderColor(n.folder);
         nodesDS.add({
           id: n.id, label: n.label,
-          value: Math.max(bc, 1),
           title: n.label + (n.folder ? ' (' + n.folder + ')' : '') + (bc > 0 ? ' \u2014 ' + bc + ' backlinks' : ''),
-          color: {
-            background: baseColor,
-            border: n.group === 'hub' ? '#ffffff' : baseColor,
-            highlight: { background: baseColor, border: '#ffffff' },
-            hover: { background: baseColor, border: '#ffffff' },
-          },
-          font: { color: '#ffffff', size: 12 },
-          borderWidth: n.group === 'hub' ? 3 : (n.group === 'orphan' ? 1 : 2),
-          borderWidthSelected: 4,
-          shapeProperties: n.group === 'orphan' ? { borderDashes: [5, 5] } : {},
+          _label: n.label, _folder: n.folder, _group: n.group,
+          _folderColor: n.group === 'orphan' ? '#94a3b8' : _folderColor(n.folder),
+          _backlinks: bc,
         });
       }
     }
@@ -1162,6 +1155,86 @@ app.onteardown = () => {
         });
       }
     }
+    _depths = computeDepths();
+    styleNodes(_depths);
+    styleEdges(_depths);
+  }
+
+  // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
+  function computeDepths() {
+    const depths = new Map();
+    if (!nodesDS || !graphCenterPath || !nodesDS.get(graphCenterPath)) return depths;
+    const adj = new Map();
+    for (const e of edgesDS.get()) {
+      if (!adj.has(e.from)) adj.set(e.from, []);
+      if (!adj.has(e.to)) adj.set(e.to, []);
+      adj.get(e.from).push(e.to);
+      adj.get(e.to).push(e.from);
+    }
+    const queue = [graphCenterPath];
+    depths.set(graphCenterPath, 0);
+    while (queue.length) {
+      const id = queue.shift();
+      const d = depths.get(id);
+      for (const nb of adj.get(id) || []) {
+        if (!depths.has(nb)) { depths.set(nb, d + 1); queue.push(nb); }
+      }
+    }
+    return depths;
+  }
+
+  // A node is "semantic-match" if it is reachable from focus only via semantic edges.
+  function _semanticMatch(id) {
+    const touching = edgesDS.get().filter(e => e.from === id || e.to === id);
+    return touching.length > 0 && touching.every(e => e.title === 'semantic');
+  }
+
+  // Map each node to its Paper role by distance. Label gate: only distance ≤ 1
+  // is labelled here; Task 3's applyLOD promotes/demotes the rest by zoom/hover.
+  function styleNodes(depths) {
+    if (!nodesDS) return;
+    const c = getColors();
+    const updates = [];
+    for (const n of nodesDS.get()) {
+      const d = depths.has(n.id) ? depths.get(n.id) : Infinity;
+      const folder = n._folderColor || _folderColor(n._folder);
+      let u;
+      if (d === 0) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+              color: { background: c.accent, border: c.accent }, borderWidth: 2,
+              font: { color: c.accentInk, size: 13, face: 'inherit' },
+              label: n._label };
+      } else if (d === 1 || (n._group === 'hub')) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+              color: { background: folder, border: c.border },
+              borderWidth: n._group === 'hub' ? 3 : 1,
+              font: { color: c.ink2, size: 12, face: 'inherit' },
+              shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
+              label: n._label };
+      } else if (_semanticMatch(n.id)) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
+              color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
+              font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+      } else {
+        u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
+              color: { background: folder, border: c.edge }, borderWidth: 1.5,
+              shapeProperties: n._group === 'orphan' ? { borderDashes: [5, 5] } : {},
+              label: '' };
+      }
+      updates.push(u);
+    }
+    nodesDS.update(updates);
+  }
+
+  function styleEdges(depths) {
+    if (!edgesDS) return;
+    const c = getColors();
+    const updates = edgesDS.get().map(e => {
+      const dm = Math.max(depths.get(e.from) ?? 0, depths.get(e.to) ?? 0);
+      const es = edgeStyle(e.title, dm, c);
+      return { id: e.id, color: es.color, dashes: es.dashes, width: es.width };
+    });
+    edgesDS.update(updates);
   }
 
   async function expandNode(path) {

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -509,7 +509,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:1d9c8ccc84775e1ad93e205308b4e85c447cfe9b542ab93dfc5532704ee9b4b7 -->
+<!-- vendor-spa-source-sha256:c3832bcde5a6089e8cb1dc01f072850fe15e7e668d2d274cc666b9ae647c2ac3 -->
 </head>
 <body>
 <div class="app-container">
@@ -1189,8 +1189,9 @@ app.onteardown = () => {
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Label gate: only distance ≤ 1
-  // is labelled here; Task 3's applyLOD promotes/demotes the rest by zoom/hover.
+  // Map each node to its Paper role by distance. Label gate: focus, depth-1,
+  // and semantic-match nodes are labelled here; distant nodes get `label: ''`.
+  // Task 3's applyLOD promotes/demotes by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();
@@ -1230,7 +1231,7 @@ app.onteardown = () => {
     if (!edgesDS) return;
     const c = getColors();
     const updates = edgesDS.get().map(e => {
-      const dm = Math.max(depths.get(e.from) ?? 0, depths.get(e.to) ?? 0);
+      const dm = Math.max(depths.get(e.from) ?? Infinity, depths.get(e.to) ?? Infinity);
       const es = edgeStyle(e.title, dm, c);
       return { id: e.id, color: es.color, dashes: es.dashes, width: es.width };
     });

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1024,7 +1024,6 @@ app.onteardown = () => {
     if (network) return;
     const container = document.getElementById('graph-container');
     if (!container || typeof vis === 'undefined') return;
-    const c = getColors();
     nodesDS = new vis.DataSet();
     edgesDS = new vis.DataSet();
     const options = {

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1133,15 +1133,16 @@ app.onteardown = () => {
     return depths;
   }
 
-  // A node is "semantic-match" if it is reachable from focus only via semantic edges.
+  // A node is "semantic-match" if every edge touching it is a semantic edge.
   function _semanticMatch(id) {
     const touching = edgesDS.get().filter(e => e.from === id || e.to === id);
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Label gate: focus, depth-1,
-  // and semantic-match nodes are labelled here; distant nodes get `label: ''`.
-  // Task 3's applyLOD promotes/demotes by zoom/hover.
+  // Map each node to its Paper role by distance. Focus, depth-1, and hub nodes
+  // are labelled box pills (semantic-match ones get the dashed-pill styling);
+  // all other nodes are dots with `label: ''`. applyLOD then promotes/demotes
+  // labels by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();
@@ -1164,7 +1165,7 @@ app.onteardown = () => {
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
                 color: { background: folder, border: c.border },
                 borderWidth: n._group === 'hub' ? 3 : 1,
-                font: { color: c.ink2, size: 12, face: 'inherit' },
+                font: { color: c.accentInk, size: 12, face: 'inherit' },
                 shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
                 label: n._label };
         }
@@ -1179,18 +1180,19 @@ app.onteardown = () => {
     nodesDS.update(updates);
   }
 
-  // Coherence predicate: a node's label shows iff it is near the focus, OR the
-  // graph is zoomed in past the threshold, OR the node is currently hovered.
-  function labelVisible(id) {
-    const d = _depths.has(id) ? _depths.get(id) : Infinity;
-    return d <= 1 || _zoomedIn || id === _hoveredId;
+  // Coherence predicate: a node's label shows iff it is near the focus, OR it
+  // is a hub node, OR the graph is zoomed in past the threshold, OR the node
+  // is currently hovered.
+  function labelVisible(n) {
+    const d = _depths.has(n.id) ? _depths.get(n.id) : Infinity;
+    return d <= 1 || n._group === 'hub' || _zoomedIn || n.id === _hoveredId;
   }
 
   // Re-derive every node's label from labelVisible (never toggled ad hoc).
   function applyLOD() {
     if (!nodesDS) return;
     const updates = nodesDS.get().map(n => ({
-      id: n.id, label: labelVisible(n.id) ? n._label : '',
+      id: n.id, label: labelVisible(n) ? n._label : '',
     }));
     nodesDS.update(updates);
   }

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -913,6 +913,8 @@ app.onteardown = () => {
   let semanticEnabled = false;
   let _depths = new Map();
   const LABEL_ZOOM_THRESHOLD = 1.35;
+  let _zoomedIn = false;
+  let _hoveredId = null;
 
   // Folder-based node colors — chosen to stand out on both light and dark backgrounds
   const _FOLDER_COLORS = [
@@ -972,7 +974,7 @@ app.onteardown = () => {
       physics: { enabled: true, solver: 'forceAtlas2Based', forceAtlas2Based: { gravitationalConstant: -40 } },
       nodes: {
         shape: 'dot',
-        scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16 } },
+        scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16, drawThreshold: 6 } },
       },
       edges: {
         arrows: { to: { enabled: true, scaleFactor: 0.5 } }, font: { size: 9 }, smooth: { type: 'continuous' },
@@ -1005,6 +1007,13 @@ app.onteardown = () => {
         loadGraph(nodeId);
       }
     });
+
+    network.on('zoom', (params) => {
+      const zoomed = params.scale >= LABEL_ZOOM_THRESHOLD;
+      if (zoomed !== _zoomedIn) { _zoomedIn = zoomed; applyLOD(); }  // only on crossing
+    });
+    network.on('hoverNode', (params) => { _hoveredId = params.node; applyLOD(); });
+    network.on('blurNode', () => { _hoveredId = null; applyLOD(); });
   }
 
   function addGraphData(data) {
@@ -1040,6 +1049,7 @@ app.onteardown = () => {
     _depths = computeDepths();
     styleNodes(_depths);
     styleEdges(_depths);
+    applyLOD();
   }
 
   // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
@@ -1106,6 +1116,22 @@ app.onteardown = () => {
       }
       updates.push(u);
     }
+    nodesDS.update(updates);
+  }
+
+  // Coherence predicate: a node's label shows iff it is near the focus, OR the
+  // graph is zoomed in past the threshold, OR the node is currently hovered.
+  function labelVisible(id) {
+    const d = _depths.has(id) ? _depths.get(id) : Infinity;
+    return d <= 1 || _zoomedIn || id === _hoveredId;
+  }
+
+  // Re-derive every node's label from labelVisible (never toggled ad hoc).
+  function applyLOD() {
+    if (!nodesDS) return;
+    const updates = nodesDS.get().map(n => ({
+      id: n.id, label: labelVisible(n.id) ? n._label : '',
+    }));
     nodesDS.update(updates);
   }
 

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -264,6 +264,22 @@
     color: var(--color-text-primary); font-family: inherit;
   }
   .graph-mini-card .mini-actions button:hover { background: var(--color-border-primary); }
+  .graph-overlay {
+    position: absolute; top: 10px; right: 10px; z-index: 10;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .graph-count {
+    font: 600 11px/1 var(--font-mono); color: var(--muted);
+    background: var(--panel); border: 1px solid var(--border);
+    padding: 5px 9px; border-radius: var(--radius-sm);
+  }
+  .graph-zoom { display: flex; background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius-sm); overflow: hidden; }
+  .graph-zoom button {
+    background: none; border: none; cursor: pointer; color: var(--ink-2);
+    font: 600 15px/1 var(--font-body); padding: 4px 10px;
+  }
+  .graph-zoom button:hover { background: var(--panel-2); color: var(--ink); }
+  .graph-zoom button + button { border-left: 1px solid var(--border); }
   /* Browser styles */
   .browser-layout { display: flex; flex-direction: column; flex: 1; min-height: 0; gap: 0; }
   .browser-sidebar {
@@ -448,6 +464,13 @@
     </div>
     <div id="graph-container" style="flex:1;position:relative;">
       <div id="graph-mini-card" class="graph-mini-card" style="display:none;"></div>
+      <div class="graph-overlay" id="graph-overlay">
+        <span class="graph-count" id="graph-count">0 notes</span>
+        <div class="graph-zoom">
+          <button id="graph-zoom-out" title="Zoom out">&#8722;</button>
+          <button id="graph-zoom-in" title="Zoom in">&#43;</button>
+        </div>
+      </div>
     </div>
   </div>
   <div class="tab-panel" id="panel-browse" data-tab="browse">
@@ -1050,6 +1073,7 @@ app.onteardown = () => {
     styleNodes(_depths);
     styleEdges(_depths);
     applyLOD();
+    updateCountChip();
   }
 
   // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
@@ -1242,6 +1266,17 @@ app.onteardown = () => {
   function hideMiniCard() {
     document.getElementById('graph-mini-card').style.display = 'none';
   }
+
+  function updateCountChip() {
+    const chip = document.getElementById('graph-count');
+    if (chip && nodesDS) chip.textContent = nodesDS.length + (nodesDS.length === 1 ? ' note' : ' notes');
+  }
+  document.getElementById('graph-zoom-in')?.addEventListener('click', () => {
+    if (network) network.moveTo({ scale: network.getScale() * 1.3 });
+  });
+  document.getElementById('graph-zoom-out')?.addEventListener('click', () => {
+    if (network) network.moveTo({ scale: network.getScale() / 1.3 });
+  });
 
   // Send graph summary to Claude
   document.getElementById('graph-send-btn').addEventListener('click', () => {

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -242,7 +242,12 @@
   .fm-table td:first-child { font-family: var(--font-mono); font-size: 11px; white-space: nowrap; width: 66px; padding-right: 12px; color: var(--muted); }
   /* Graph styles */
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
-  #graph-container { border: 1px solid var(--color-border-primary); border-radius: 6px; min-height: 200px; }
+  #graph-container {
+    border: 1px solid var(--border-2); border-radius: var(--radius); min-height: 200px;
+    background-color: var(--panel);
+    background-image: radial-gradient(var(--edge) 1px, transparent 1px);
+    background-size: 21px 21px; background-position: -0.5px -0.5px;
+  }
   .graph-mini-card {
     position: absolute; bottom: 16px; right: 16px; width: 280px; max-height: 200px; overflow-y: auto;
     background: var(--color-background-primary); border: 1px solid var(--color-border-primary);
@@ -925,24 +930,33 @@ app.onteardown = () => {
     return _FOLDER_COLORS[h % _FOLDER_COLORS.length];
   }
 
-  // Color scheme for edges and UI chrome
+  // Paper palette for edges and canvas chrome, read from CSS vars so the graph
+  // re-themes when the host flips theme (see refreshColors / vault-theme-changed).
   function getColors() {
     const s = getComputedStyle(document.documentElement);
+    const v = (name, fallback) => s.getPropertyValue(name).trim() || fallback;
     return {
-      fg: s.getPropertyValue('--color-text-primary').trim() || '#1a1a1a',
-      accent: s.getPropertyValue('--color-text-info').trim() || '#6366f1',
-      muted: s.getPropertyValue('--color-text-secondary').trim() || '#6b7280',
-      border: s.getPropertyValue('--color-border-primary').trim() || '#e0e0e0',
+      panel:      v('--panel', '#fbf8f1'),
+      panel2:     v('--panel-2', '#f2ecdf'),
+      ink:        v('--ink', '#2a2620'),
+      ink2:       v('--ink-2', '#5c5446'),
+      muted:      v('--muted', '#928975'),
+      edge:       v('--edge', '#d3c7ad'),
+      accent:     v('--accent', '#b25a35'),
+      accentInk:  v('--accent-ink', '#ffffff'),
+      accentSoft: v('--accent-soft', '#f3e4d8'),
+      border:     v('--border', '#e4dbc9'),
     };
   }
 
-  const _SEMANTIC_EDGE_COLOR = '#a855f7'; // purple — distinct from folder node colors
-
-  function edgeColorByType(type, c) {
-    if (type === 'semantic') return _SEMANTIC_EDGE_COLOR;
-    if (type === 'wikilink') return c.accent;
-    if (type === 'reference') return c.muted;
-    return c.border; // markdown = default
+  // Edge styling: solid --edge for link edges (thinner + lower opacity when the
+  // farthest endpoint is distant), dashed --accent for semantic similarity.
+  function edgeStyle(type, depthMax, c) {
+    if (type === 'semantic') {
+      return { color: { color: c.accent, opacity: 0.75 }, dashes: [5, 4], width: 1 };
+    }
+    const far = depthMax >= 2;
+    return { color: { color: c.edge, opacity: far ? 0.5 : 1 }, dashes: false, width: far ? 1 : 1.6 };
   }
 
   function initNetwork() {
@@ -1022,12 +1036,10 @@ app.onteardown = () => {
         ? 'sem:' + [e.from, e.to].sort().join('<>')
         : e.from + '->' + e.to;
       if (!edgesDS.get(edgeId)) {
+        const es = edgeStyle(e.type, 0, c);
         edgesDS.add({
           id: edgeId, from: e.from, to: e.to,
-          color: { color: edgeColorByType(e.type, c), highlight: _SEMANTIC_EDGE_COLOR },
-          title: e.type,
-          dashes: isSemantic,
-          width: isSemantic ? 1 : 1.5,
+          color: es.color, title: e.type, dashes: es.dashes, width: es.width,
           arrows: isSemantic ? '' : { to: { enabled: true, scaleFactor: 0.5 } },
         });
       }
@@ -1149,13 +1161,13 @@ app.onteardown = () => {
     semanticEnabled = !semanticEnabled;
     const btn = document.getElementById('graph-semantic-btn');
     if (semanticEnabled) {
-      btn.style.background = _SEMANTIC_EDGE_COLOR;
-      btn.style.color = '#ffffff';
+      btn.style.background = 'var(--accent)';
+      btn.style.color = 'var(--accent-ink)';
       btn.style.border = 'none';
     } else {
-      btn.style.background = 'var(--color-background-secondary)';
-      btn.style.color = 'var(--color-text-primary)';
-      btn.style.border = '1px solid var(--color-border-primary)';
+      btn.style.background = 'var(--panel-2)';
+      btn.style.color = 'var(--ink)';
+      btn.style.border = '1px solid var(--border)';
     }
     // Reload current graph with updated setting
     if (graphCenterPath) loadGraph(graphCenterPath);

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1098,16 +1098,18 @@ app.onteardown = () => {
               font: { color: c.accentInk, size: 13, face: 'inherit' },
               label: n._label };
       } else if (d === 1 || (n._group === 'hub')) {
-        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
-              color: { background: folder, border: c.border },
-              borderWidth: n._group === 'hub' ? 3 : 1,
-              font: { color: c.ink2, size: 12, face: 'inherit' },
-              shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
-              label: n._label };
-      } else if (_semanticMatch(n.id)) {
-        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
-              color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
-              font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+        if (_semanticMatch(n.id)) {
+          u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
+                color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
+                font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+        } else {
+          u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+                color: { background: folder, border: c.border },
+                borderWidth: n._group === 'hub' ? 3 : 1,
+                font: { color: c.ink2, size: 12, face: 'inherit' },
+                shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
+                label: n._label };
+        }
       } else {
         u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
               color: { background: folder, border: c.edge }, borderWidth: 1.5,

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1154,18 +1154,18 @@ app.onteardown = () => {
       if (d === 0) {
         u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
               color: { background: c.accent, border: c.accent }, borderWidth: 2,
-              font: { color: c.accentInk, size: 13, face: 'inherit' },
+              font: { color: c.accentInk, size: 13 },
               label: n._label };
       } else if (d === 1 || (n._group === 'hub')) {
         if (_semanticMatch(n.id)) {
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
                 color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
-                font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+                font: { color: c.ink2, size: 12 }, label: n._label };
         } else {
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
-                color: { background: folder, border: c.border },
-                borderWidth: n._group === 'hub' ? 3 : 1,
-                font: { color: c.accentInk, size: 12, face: 'inherit' },
+                color: { background: c.panel, border: folder },
+                borderWidth: n._group === 'hub' ? 3 : 1.5,
+                font: { color: c.ink2, size: 12 },
                 shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
                 label: n._label };
         }

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1071,8 +1071,9 @@ app.onteardown = () => {
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Label gate: only distance ≤ 1
-  // is labelled here; Task 3's applyLOD promotes/demotes the rest by zoom/hover.
+  // Map each node to its Paper role by distance. Label gate: focus, depth-1,
+  // and semantic-match nodes are labelled here; distant nodes get `label: ''`.
+  // Task 3's applyLOD promotes/demotes by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();
@@ -1112,7 +1113,7 @@ app.onteardown = () => {
     if (!edgesDS) return;
     const c = getColors();
     const updates = edgesDS.get().map(e => {
-      const dm = Math.max(depths.get(e.from) ?? 0, depths.get(e.to) ?? 0);
+      const dm = Math.max(depths.get(e.from) ?? Infinity, depths.get(e.to) ?? Infinity);
       const es = edgeStyle(e.title, dm, c);
       return { id: e.id, color: es.color, dashes: es.dashes, width: es.width };
     });

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1140,10 +1140,10 @@ app.onteardown = () => {
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Focus, depth-1, and hub nodes
-  // are labelled box pills (semantic-match ones get the dashed-pill styling);
-  // all other nodes are dots with `label: ''`. applyLOD then promotes/demotes
-  // labels by zoom/hover.
+  // Map each node to its Paper role by distance. Focus is the accent pill;
+  // depth-1 and hub nodes are box pills, and among those the semantic-match ones
+  // (every touching edge semantic) get the dashed-pill styling; all other nodes
+  // are dots with `label: ''`. applyLOD then promotes/demotes labels by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -1110,7 +1110,8 @@ app.onteardown = () => {
     updateCountChip();
   }
 
-  // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
+  // BFS distance-from-focus over the accumulated edge set. Unreachable nodes are
+  // absent from the returned map; callers treat a missing entry as Infinity.
   function computeDepths() {
     const depths = new Map();
     if (!nodesDS || !graphCenterPath || !nodesDS.get(graphCenterPath)) return depths;
@@ -1173,6 +1174,7 @@ app.onteardown = () => {
         u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
               color: { background: folder, border: c.edge }, borderWidth: 1.5,
               shapeProperties: n._group === 'orphan' ? { borderDashes: [5, 5] } : {},
+              font: { color: c.ink2 },
               label: '' };
       }
       updates.push(u);

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -911,6 +911,8 @@ app.onteardown = () => {
   let graphCenterPath = null;
   let selectedNodeId = null;
   let semanticEnabled = false;
+  let _depths = new Map();
+  const LABEL_ZOOM_THRESHOLD = 1.35;
 
   // Folder-based node colors — chosen to stand out on both light and dark backgrounds
   const _FOLDER_COLORS = [
@@ -1011,21 +1013,12 @@ app.onteardown = () => {
     for (const n of data.nodes) {
       if (!nodesDS.get(n.id)) {
         const bc = n.backlink_count || 0;
-        const baseColor = n.group === 'orphan' ? '#94a3b8' : _folderColor(n.folder);
         nodesDS.add({
           id: n.id, label: n.label,
-          value: Math.max(bc, 1),
           title: n.label + (n.folder ? ' (' + n.folder + ')' : '') + (bc > 0 ? ' \u2014 ' + bc + ' backlinks' : ''),
-          color: {
-            background: baseColor,
-            border: n.group === 'hub' ? '#ffffff' : baseColor,
-            highlight: { background: baseColor, border: '#ffffff' },
-            hover: { background: baseColor, border: '#ffffff' },
-          },
-          font: { color: '#ffffff', size: 12 },
-          borderWidth: n.group === 'hub' ? 3 : (n.group === 'orphan' ? 1 : 2),
-          borderWidthSelected: 4,
-          shapeProperties: n.group === 'orphan' ? { borderDashes: [5, 5] } : {},
+          _label: n.label, _folder: n.folder, _group: n.group,
+          _folderColor: n.group === 'orphan' ? '#94a3b8' : _folderColor(n.folder),
+          _backlinks: bc,
         });
       }
     }
@@ -1044,6 +1037,86 @@ app.onteardown = () => {
         });
       }
     }
+    _depths = computeDepths();
+    styleNodes(_depths);
+    styleEdges(_depths);
+  }
+
+  // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
+  function computeDepths() {
+    const depths = new Map();
+    if (!nodesDS || !graphCenterPath || !nodesDS.get(graphCenterPath)) return depths;
+    const adj = new Map();
+    for (const e of edgesDS.get()) {
+      if (!adj.has(e.from)) adj.set(e.from, []);
+      if (!adj.has(e.to)) adj.set(e.to, []);
+      adj.get(e.from).push(e.to);
+      adj.get(e.to).push(e.from);
+    }
+    const queue = [graphCenterPath];
+    depths.set(graphCenterPath, 0);
+    while (queue.length) {
+      const id = queue.shift();
+      const d = depths.get(id);
+      for (const nb of adj.get(id) || []) {
+        if (!depths.has(nb)) { depths.set(nb, d + 1); queue.push(nb); }
+      }
+    }
+    return depths;
+  }
+
+  // A node is "semantic-match" if it is reachable from focus only via semantic edges.
+  function _semanticMatch(id) {
+    const touching = edgesDS.get().filter(e => e.from === id || e.to === id);
+    return touching.length > 0 && touching.every(e => e.title === 'semantic');
+  }
+
+  // Map each node to its Paper role by distance. Label gate: only distance ≤ 1
+  // is labelled here; Task 3's applyLOD promotes/demotes the rest by zoom/hover.
+  function styleNodes(depths) {
+    if (!nodesDS) return;
+    const c = getColors();
+    const updates = [];
+    for (const n of nodesDS.get()) {
+      const d = depths.has(n.id) ? depths.get(n.id) : Infinity;
+      const folder = n._folderColor || _folderColor(n._folder);
+      let u;
+      if (d === 0) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+              color: { background: c.accent, border: c.accent }, borderWidth: 2,
+              font: { color: c.accentInk, size: 13, face: 'inherit' },
+              label: n._label };
+      } else if (d === 1 || (n._group === 'hub')) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+              color: { background: folder, border: c.border },
+              borderWidth: n._group === 'hub' ? 3 : 1,
+              font: { color: c.ink2, size: 12, face: 'inherit' },
+              shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
+              label: n._label };
+      } else if (_semanticMatch(n.id)) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
+              color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
+              font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+      } else {
+        u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
+              color: { background: folder, border: c.edge }, borderWidth: 1.5,
+              shapeProperties: n._group === 'orphan' ? { borderDashes: [5, 5] } : {},
+              label: '' };
+      }
+      updates.push(u);
+    }
+    nodesDS.update(updates);
+  }
+
+  function styleEdges(depths) {
+    if (!edgesDS) return;
+    const c = getColors();
+    const updates = edgesDS.get().map(e => {
+      const dm = Math.max(depths.get(e.from) ?? 0, depths.get(e.to) ?? 0);
+      const es = edgeStyle(e.title, dm, c);
+      return { id: e.id, color: es.color, dashes: es.dashes, width: es.width };
+    });
+    edgesDS.update(updates);
   }
 
   async function expandNode(path) {

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -241,6 +241,7 @@
   .fm-table tr:last-child td { border-bottom: none; }
   .fm-table td:first-child { font-family: var(--font-mono); font-size: 11px; white-space: nowrap; width: 66px; padding-right: 12px; color: var(--muted); }
   /* Graph styles */
+  #panel-graph { container-type: inline-size; }
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
   #graph-container {
     border: 1px solid var(--border-2); border-radius: var(--radius); min-height: 200px;
@@ -280,6 +281,28 @@
   }
   .graph-zoom button:hover { background: var(--panel-2); color: var(--ink); }
   .graph-zoom button + button { border-left: 1px solid var(--border); }
+  .graph-legend {
+    display: flex; flex-wrap: wrap; gap: 12px; padding: 8px 10px; flex-shrink: 0;
+    font: 500 11px/1 var(--font-body); color: var(--muted);
+  }
+  .graph-legend .lg-item { display: inline-flex; align-items: center; gap: 6px; }
+  .lg-line { width: 16px; height: 0; border-top: 1.6px solid var(--edge); }
+  .lg-dashed { border-top: 1.6px dashed var(--accent); }
+  .lg-pill { width: 14px; height: 9px; border-radius: 999px; }
+  .lg-focus { background: var(--accent); }
+  .lg-linked { background: var(--panel); border: 1px solid var(--border); }
+  .lg-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--panel); border: 1.5px solid var(--edge); }
+  .graph-legend-chip {
+    display: none; align-self: flex-start; margin: 6px 10px;
+    background: var(--panel-2); border: 1px solid var(--border); color: var(--ink-2);
+    font: 600 11px/1 var(--font-body); padding: 6px 10px; border-radius: var(--radius-sm); cursor: pointer;
+  }
+  /* Content-first shedding: on a narrow panel the legend collapses to the chip. */
+  @container (max-width: 420px) {
+    .graph-legend { display: none; }
+    .graph-legend.open { display: flex; }
+    .graph-legend-chip { display: inline-block; }
+  }
   /* Browser styles */
   .browser-layout { display: flex; flex-direction: column; flex: 1; min-height: 0; gap: 0; }
   .browser-sidebar {
@@ -471,6 +494,14 @@
           <button id="graph-zoom-in" title="Zoom in">&#43;</button>
         </div>
       </div>
+    </div>
+    <button class="graph-legend-chip" id="graph-legend-chip" title="Show legend">&#9432; legend</button>
+    <div class="graph-legend" id="graph-legend">
+      <span class="lg-item"><span class="lg-line lg-solid"></span>wikilink</span>
+      <span class="lg-item"><span class="lg-line lg-dashed"></span>semantic</span>
+      <span class="lg-item"><span class="lg-pill lg-focus"></span>focus note</span>
+      <span class="lg-item"><span class="lg-pill lg-linked"></span>linked note</span>
+      <span class="lg-item"><span class="lg-dot"></span>more (hover)</span>
     </div>
   </div>
   <div class="tab-panel" id="panel-browse" data-tab="browse">
@@ -1276,6 +1307,11 @@ app.onteardown = () => {
   });
   document.getElementById('graph-zoom-out')?.addEventListener('click', () => {
     if (network) network.moveTo({ scale: network.getScale() / 1.3 });
+  });
+
+  // Narrow-panel legend collapse chip
+  document.getElementById('graph-legend-chip')?.addEventListener('click', () => {
+    document.getElementById('graph-legend')?.classList.toggle('open');
   });
 
   // Send graph summary to Claude

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -188,6 +188,7 @@
     color: var(--color-text-primary);
     border: 1px solid var(--color-border-primary);
   }
+  .action-btn.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
   /* Context card */
   .context-header { margin-bottom: 6px; }
   .context-title-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
@@ -251,20 +252,19 @@
   }
   .graph-mini-card {
     position: absolute; bottom: 16px; right: 16px; width: 280px; max-height: 200px; overflow-y: auto;
-    background: var(--color-background-primary); border: 1px solid var(--color-border-primary);
-    border-radius: 8px; padding: 12px; font-size: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); z-index: 10;
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: var(--pad); font-size: 12px; box-shadow: var(--shadow); z-index: 10;
   }
-  .graph-mini-card h4 { margin: 0 0 6px; font-size: 14px; }
+  .graph-mini-card h4 { margin: 0 0 6px; font-family: var(--font-head, inherit); font-size: 14px; color: var(--ink); }
   .graph-mini-card .mini-links { margin: 4px 0; }
-  .graph-mini-card .mini-link { color: var(--color-text-info); cursor: pointer; padding: 1px 0; }
+  .graph-mini-card .mini-link { color: var(--accent); cursor: pointer; padding: 1px 0; }
   .graph-mini-card .mini-link:hover { text-decoration: underline; }
   .graph-mini-card .mini-actions { margin-top: 8px; display: flex; gap: 6px; }
   .graph-mini-card .mini-actions button {
-    font-size: 11px; padding: 3px 8px; border-radius: 3px; cursor: pointer;
-    background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
-    color: var(--color-text-primary); font-family: inherit;
+    font: 600 11px/1 var(--font-body); padding: 5px 9px; border-radius: var(--radius-sm); cursor: pointer;
+    background: var(--panel-2); border: 1px solid var(--border); color: var(--ink-2);
   }
-  .graph-mini-card .mini-actions button:hover { background: var(--color-border-primary); }
+  .graph-mini-card .mini-actions button:hover { color: var(--ink); border-color: var(--muted); }
   .graph-overlay {
     position: absolute; top: 10px; right: 10px; z-index: 10;
     display: flex; align-items: center; gap: 8px;
@@ -575,7 +575,10 @@ function parseToolResult(result) {
 // ── Host theming ─────────────────────────────────────────────────────────
 function handleHostContext(ctx) {
   if (!ctx) return;
-  if (ctx.theme) applyDocumentTheme(ctx.theme);
+  if (ctx.theme) {
+    applyDocumentTheme(ctx.theme);
+    window.dispatchEvent(new CustomEvent('vault-theme-changed', { detail: { theme: ctx.theme } }));
+  }
   if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
   if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
   if (ctx.displayMode !== undefined) {
@@ -1203,6 +1206,16 @@ app.onteardown = () => {
     edgesDS.update(updates);
   }
 
+  // Re-read Paper vars and restyle everything (a canvas doesn't inherit CSS-var
+  // changes, so the graph must re-read on host theme flips).
+  function refreshColors() {
+    if (!nodesDS) return;
+    styleNodes(_depths);
+    styleEdges(_depths);
+    applyLOD();
+  }
+  window.addEventListener('vault-theme-changed', refreshColors);
+
   async function expandNode(path) {
     try {
       const result = await app.callServerTool({
@@ -1333,15 +1346,7 @@ app.onteardown = () => {
   document.getElementById('graph-semantic-btn').addEventListener('click', () => {
     semanticEnabled = !semanticEnabled;
     const btn = document.getElementById('graph-semantic-btn');
-    if (semanticEnabled) {
-      btn.style.background = 'var(--accent)';
-      btn.style.color = 'var(--accent-ink)';
-      btn.style.border = 'none';
-    } else {
-      btn.style.background = 'var(--panel-2)';
-      btn.style.color = 'var(--ink)';
-      btn.style.border = '1px solid var(--border)';
-    }
+    btn.classList.toggle('active', semanticEnabled);
     // Reload current graph with updated setting
     if (graphCenterPath) loadGraph(graphCenterPath);
   });

--- a/src/markdown_vault_mcp/static/spa/core.js
+++ b/src/markdown_vault_mcp/static/spa/core.js
@@ -46,7 +46,10 @@ function parseToolResult(result) {
 // ── Host theming ─────────────────────────────────────────────────────────
 function handleHostContext(ctx) {
   if (!ctx) return;
-  if (ctx.theme) applyDocumentTheme(ctx.theme);
+  if (ctx.theme) {
+    applyDocumentTheme(ctx.theme);
+    window.dispatchEvent(new CustomEvent('vault-theme-changed', { detail: { theme: ctx.theme } }));
+  }
   if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
   if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
   if (ctx.displayMode !== undefined) {

--- a/src/markdown_vault_mcp/static/spa/shell.html
+++ b/src/markdown_vault_mcp/static/spa/shell.html
@@ -64,6 +64,13 @@
     </div>
     <div id="graph-container" style="flex:1;position:relative;">
       <div id="graph-mini-card" class="graph-mini-card" style="display:none;"></div>
+      <div class="graph-overlay" id="graph-overlay">
+        <span class="graph-count" id="graph-count">0 notes</span>
+        <div class="graph-zoom">
+          <button id="graph-zoom-out" title="Zoom out">&#8722;</button>
+          <button id="graph-zoom-in" title="Zoom in">&#43;</button>
+        </div>
+      </div>
     </div>
   </div>
   <div class="tab-panel" id="panel-browse" data-tab="browse">

--- a/src/markdown_vault_mcp/static/spa/shell.html
+++ b/src/markdown_vault_mcp/static/spa/shell.html
@@ -72,6 +72,14 @@
         </div>
       </div>
     </div>
+    <button class="graph-legend-chip" id="graph-legend-chip" title="Show legend">&#9432; legend</button>
+    <div class="graph-legend" id="graph-legend">
+      <span class="lg-item"><span class="lg-line lg-solid"></span>wikilink</span>
+      <span class="lg-item"><span class="lg-line lg-dashed"></span>semantic</span>
+      <span class="lg-item"><span class="lg-pill lg-focus"></span>focus note</span>
+      <span class="lg-item"><span class="lg-pill lg-linked"></span>linked note</span>
+      <span class="lg-item"><span class="lg-dot"></span>more (hover)</span>
+    </div>
   </div>
   <div class="tab-panel" id="panel-browse" data-tab="browse">
     <div class="browser-layout">

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -228,7 +228,12 @@
   .fm-table td:first-child { font-family: var(--font-mono); font-size: 11px; white-space: nowrap; width: 66px; padding-right: 12px; color: var(--muted); }
   /* Graph styles */
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
-  #graph-container { border: 1px solid var(--color-border-primary); border-radius: 6px; min-height: 200px; }
+  #graph-container {
+    border: 1px solid var(--border-2); border-radius: var(--radius); min-height: 200px;
+    background-color: var(--panel);
+    background-image: radial-gradient(var(--edge) 1px, transparent 1px);
+    background-size: 21px 21px; background-position: -0.5px -0.5px;
+  }
   .graph-mini-card {
     position: absolute; bottom: 16px; right: 16px; width: 280px; max-height: 200px; overflow-y: auto;
     background: var(--color-background-primary); border: 1px solid var(--color-border-primary);

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -250,6 +250,22 @@
     color: var(--color-text-primary); font-family: inherit;
   }
   .graph-mini-card .mini-actions button:hover { background: var(--color-border-primary); }
+  .graph-overlay {
+    position: absolute; top: 10px; right: 10px; z-index: 10;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .graph-count {
+    font: 600 11px/1 var(--font-mono); color: var(--muted);
+    background: var(--panel); border: 1px solid var(--border);
+    padding: 5px 9px; border-radius: var(--radius-sm);
+  }
+  .graph-zoom { display: flex; background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius-sm); overflow: hidden; }
+  .graph-zoom button {
+    background: none; border: none; cursor: pointer; color: var(--ink-2);
+    font: 600 15px/1 var(--font-body); padding: 4px 10px;
+  }
+  .graph-zoom button:hover { background: var(--panel-2); color: var(--ink); }
+  .graph-zoom button + button { border-left: 1px solid var(--border); }
   /* Browser styles */
   .browser-layout { display: flex; flex-direction: column; flex: 1; min-height: 0; gap: 0; }
   .browser-sidebar {

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -174,6 +174,7 @@
     color: var(--color-text-primary);
     border: 1px solid var(--color-border-primary);
   }
+  .action-btn.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
   /* Context card */
   .context-header { margin-bottom: 6px; }
   .context-title-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
@@ -237,20 +238,19 @@
   }
   .graph-mini-card {
     position: absolute; bottom: 16px; right: 16px; width: 280px; max-height: 200px; overflow-y: auto;
-    background: var(--color-background-primary); border: 1px solid var(--color-border-primary);
-    border-radius: 8px; padding: 12px; font-size: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); z-index: 10;
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: var(--pad); font-size: 12px; box-shadow: var(--shadow); z-index: 10;
   }
-  .graph-mini-card h4 { margin: 0 0 6px; font-size: 14px; }
+  .graph-mini-card h4 { margin: 0 0 6px; font-family: var(--font-head, inherit); font-size: 14px; color: var(--ink); }
   .graph-mini-card .mini-links { margin: 4px 0; }
-  .graph-mini-card .mini-link { color: var(--color-text-info); cursor: pointer; padding: 1px 0; }
+  .graph-mini-card .mini-link { color: var(--accent); cursor: pointer; padding: 1px 0; }
   .graph-mini-card .mini-link:hover { text-decoration: underline; }
   .graph-mini-card .mini-actions { margin-top: 8px; display: flex; gap: 6px; }
   .graph-mini-card .mini-actions button {
-    font-size: 11px; padding: 3px 8px; border-radius: 3px; cursor: pointer;
-    background: var(--color-background-secondary); border: 1px solid var(--color-border-primary);
-    color: var(--color-text-primary); font-family: inherit;
+    font: 600 11px/1 var(--font-body); padding: 5px 9px; border-radius: var(--radius-sm); cursor: pointer;
+    background: var(--panel-2); border: 1px solid var(--border); color: var(--ink-2);
   }
-  .graph-mini-card .mini-actions button:hover { background: var(--color-border-primary); }
+  .graph-mini-card .mini-actions button:hover { color: var(--ink); border-color: var(--muted); }
   .graph-overlay {
     position: absolute; top: 10px; right: 10px; z-index: 10;
     display: flex; align-items: center; gap: 8px;

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -227,6 +227,7 @@
   .fm-table tr:last-child td { border-bottom: none; }
   .fm-table td:first-child { font-family: var(--font-mono); font-size: 11px; white-space: nowrap; width: 66px; padding-right: 12px; color: var(--muted); }
   /* Graph styles */
+  #panel-graph { container-type: inline-size; }
   .graph-toolbar { display: flex; gap: 8px; padding: 4px 0; flex-shrink: 0; }
   #graph-container {
     border: 1px solid var(--border-2); border-radius: var(--radius); min-height: 200px;
@@ -266,6 +267,28 @@
   }
   .graph-zoom button:hover { background: var(--panel-2); color: var(--ink); }
   .graph-zoom button + button { border-left: 1px solid var(--border); }
+  .graph-legend {
+    display: flex; flex-wrap: wrap; gap: 12px; padding: 8px 10px; flex-shrink: 0;
+    font: 500 11px/1 var(--font-body); color: var(--muted);
+  }
+  .graph-legend .lg-item { display: inline-flex; align-items: center; gap: 6px; }
+  .lg-line { width: 16px; height: 0; border-top: 1.6px solid var(--edge); }
+  .lg-dashed { border-top: 1.6px dashed var(--accent); }
+  .lg-pill { width: 14px; height: 9px; border-radius: 999px; }
+  .lg-focus { background: var(--accent); }
+  .lg-linked { background: var(--panel); border: 1px solid var(--border); }
+  .lg-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--panel); border: 1.5px solid var(--edge); }
+  .graph-legend-chip {
+    display: none; align-self: flex-start; margin: 6px 10px;
+    background: var(--panel-2); border: 1px solid var(--border); color: var(--ink-2);
+    font: 600 11px/1 var(--font-body); padding: 6px 10px; border-radius: var(--radius-sm); cursor: pointer;
+  }
+  /* Content-first shedding: on a narrow panel the legend collapses to the chip. */
+  @container (max-width: 420px) {
+    .graph-legend { display: none; }
+    .graph-legend.open { display: flex; }
+    .graph-legend-chip { display: inline-block; }
+  }
   /* Browser styles */
   .browser-layout { display: flex; flex-direction: column; flex: 1; min-height: 0; gap: 0; }
   .browser-sidebar {

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -6,6 +6,8 @@
   let graphCenterPath = null;
   let selectedNodeId = null;
   let semanticEnabled = false;
+  let _depths = new Map();
+  const LABEL_ZOOM_THRESHOLD = 1.35;
 
   // Folder-based node colors — chosen to stand out on both light and dark backgrounds
   const _FOLDER_COLORS = [
@@ -106,21 +108,12 @@
     for (const n of data.nodes) {
       if (!nodesDS.get(n.id)) {
         const bc = n.backlink_count || 0;
-        const baseColor = n.group === 'orphan' ? '#94a3b8' : _folderColor(n.folder);
         nodesDS.add({
           id: n.id, label: n.label,
-          value: Math.max(bc, 1),
           title: n.label + (n.folder ? ' (' + n.folder + ')' : '') + (bc > 0 ? ' \u2014 ' + bc + ' backlinks' : ''),
-          color: {
-            background: baseColor,
-            border: n.group === 'hub' ? '#ffffff' : baseColor,
-            highlight: { background: baseColor, border: '#ffffff' },
-            hover: { background: baseColor, border: '#ffffff' },
-          },
-          font: { color: '#ffffff', size: 12 },
-          borderWidth: n.group === 'hub' ? 3 : (n.group === 'orphan' ? 1 : 2),
-          borderWidthSelected: 4,
-          shapeProperties: n.group === 'orphan' ? { borderDashes: [5, 5] } : {},
+          _label: n.label, _folder: n.folder, _group: n.group,
+          _folderColor: n.group === 'orphan' ? '#94a3b8' : _folderColor(n.folder),
+          _backlinks: bc,
         });
       }
     }
@@ -139,6 +132,86 @@
         });
       }
     }
+    _depths = computeDepths();
+    styleNodes(_depths);
+    styleEdges(_depths);
+  }
+
+  // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
+  function computeDepths() {
+    const depths = new Map();
+    if (!nodesDS || !graphCenterPath || !nodesDS.get(graphCenterPath)) return depths;
+    const adj = new Map();
+    for (const e of edgesDS.get()) {
+      if (!adj.has(e.from)) adj.set(e.from, []);
+      if (!adj.has(e.to)) adj.set(e.to, []);
+      adj.get(e.from).push(e.to);
+      adj.get(e.to).push(e.from);
+    }
+    const queue = [graphCenterPath];
+    depths.set(graphCenterPath, 0);
+    while (queue.length) {
+      const id = queue.shift();
+      const d = depths.get(id);
+      for (const nb of adj.get(id) || []) {
+        if (!depths.has(nb)) { depths.set(nb, d + 1); queue.push(nb); }
+      }
+    }
+    return depths;
+  }
+
+  // A node is "semantic-match" if it is reachable from focus only via semantic edges.
+  function _semanticMatch(id) {
+    const touching = edgesDS.get().filter(e => e.from === id || e.to === id);
+    return touching.length > 0 && touching.every(e => e.title === 'semantic');
+  }
+
+  // Map each node to its Paper role by distance. Label gate: only distance ≤ 1
+  // is labelled here; Task 3's applyLOD promotes/demotes the rest by zoom/hover.
+  function styleNodes(depths) {
+    if (!nodesDS) return;
+    const c = getColors();
+    const updates = [];
+    for (const n of nodesDS.get()) {
+      const d = depths.has(n.id) ? depths.get(n.id) : Infinity;
+      const folder = n._folderColor || _folderColor(n._folder);
+      let u;
+      if (d === 0) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+              color: { background: c.accent, border: c.accent }, borderWidth: 2,
+              font: { color: c.accentInk, size: 13, face: 'inherit' },
+              label: n._label };
+      } else if (d === 1 || (n._group === 'hub')) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+              color: { background: folder, border: c.border },
+              borderWidth: n._group === 'hub' ? 3 : 1,
+              font: { color: c.ink2, size: 12, face: 'inherit' },
+              shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
+              label: n._label };
+      } else if (_semanticMatch(n.id)) {
+        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
+              color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
+              font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+      } else {
+        u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
+              color: { background: folder, border: c.edge }, borderWidth: 1.5,
+              shapeProperties: n._group === 'orphan' ? { borderDashes: [5, 5] } : {},
+              label: '' };
+      }
+      updates.push(u);
+    }
+    nodesDS.update(updates);
+  }
+
+  function styleEdges(depths) {
+    if (!edgesDS) return;
+    const c = getColors();
+    const updates = edgesDS.get().map(e => {
+      const dm = Math.max(depths.get(e.from) ?? 0, depths.get(e.to) ?? 0);
+      const es = edgeStyle(e.title, dm, c);
+      return { id: e.id, color: es.color, dashes: es.dashes, width: es.width };
+    });
+    edgesDS.update(updates);
   }
 
   async function expandNode(path) {

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -25,24 +25,33 @@
     return _FOLDER_COLORS[h % _FOLDER_COLORS.length];
   }
 
-  // Color scheme for edges and UI chrome
+  // Paper palette for edges and canvas chrome, read from CSS vars so the graph
+  // re-themes when the host flips theme (see refreshColors / vault-theme-changed).
   function getColors() {
     const s = getComputedStyle(document.documentElement);
+    const v = (name, fallback) => s.getPropertyValue(name).trim() || fallback;
     return {
-      fg: s.getPropertyValue('--color-text-primary').trim() || '#1a1a1a',
-      accent: s.getPropertyValue('--color-text-info').trim() || '#6366f1',
-      muted: s.getPropertyValue('--color-text-secondary').trim() || '#6b7280',
-      border: s.getPropertyValue('--color-border-primary').trim() || '#e0e0e0',
+      panel:      v('--panel', '#fbf8f1'),
+      panel2:     v('--panel-2', '#f2ecdf'),
+      ink:        v('--ink', '#2a2620'),
+      ink2:       v('--ink-2', '#5c5446'),
+      muted:      v('--muted', '#928975'),
+      edge:       v('--edge', '#d3c7ad'),
+      accent:     v('--accent', '#b25a35'),
+      accentInk:  v('--accent-ink', '#ffffff'),
+      accentSoft: v('--accent-soft', '#f3e4d8'),
+      border:     v('--border', '#e4dbc9'),
     };
   }
 
-  const _SEMANTIC_EDGE_COLOR = '#a855f7'; // purple — distinct from folder node colors
-
-  function edgeColorByType(type, c) {
-    if (type === 'semantic') return _SEMANTIC_EDGE_COLOR;
-    if (type === 'wikilink') return c.accent;
-    if (type === 'reference') return c.muted;
-    return c.border; // markdown = default
+  // Edge styling: solid --edge for link edges (thinner + lower opacity when the
+  // farthest endpoint is distant), dashed --accent for semantic similarity.
+  function edgeStyle(type, depthMax, c) {
+    if (type === 'semantic') {
+      return { color: { color: c.accent, opacity: 0.75 }, dashes: [5, 4], width: 1 };
+    }
+    const far = depthMax >= 2;
+    return { color: { color: c.edge, opacity: far ? 0.5 : 1 }, dashes: false, width: far ? 1 : 1.6 };
   }
 
   function initNetwork() {
@@ -122,12 +131,10 @@
         ? 'sem:' + [e.from, e.to].sort().join('<>')
         : e.from + '->' + e.to;
       if (!edgesDS.get(edgeId)) {
+        const es = edgeStyle(e.type, 0, c);
         edgesDS.add({
           id: edgeId, from: e.from, to: e.to,
-          color: { color: edgeColorByType(e.type, c), highlight: _SEMANTIC_EDGE_COLOR },
-          title: e.type,
-          dashes: isSemantic,
-          width: isSemantic ? 1 : 1.5,
+          color: es.color, title: e.type, dashes: es.dashes, width: es.width,
           arrows: isSemantic ? '' : { to: { enabled: true, scaleFactor: 0.5 } },
         });
       }
@@ -249,13 +256,13 @@
     semanticEnabled = !semanticEnabled;
     const btn = document.getElementById('graph-semantic-btn');
     if (semanticEnabled) {
-      btn.style.background = _SEMANTIC_EDGE_COLOR;
-      btn.style.color = '#ffffff';
+      btn.style.background = 'var(--accent)';
+      btn.style.color = 'var(--accent-ink)';
       btn.style.border = 'none';
     } else {
-      btn.style.background = 'var(--color-background-secondary)';
-      btn.style.color = 'var(--color-text-primary)';
-      btn.style.border = '1px solid var(--color-border-primary)';
+      btn.style.background = 'var(--panel-2)';
+      btn.style.color = 'var(--ink)';
+      btn.style.border = '1px solid var(--border)';
     }
     // Reload current graph with updated setting
     if (graphCenterPath) loadGraph(graphCenterPath);

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -192,18 +192,18 @@
       if (d === 0) {
         u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
               color: { background: c.accent, border: c.accent }, borderWidth: 2,
-              font: { color: c.accentInk, size: 13, face: 'inherit' },
+              font: { color: c.accentInk, size: 13 },
               label: n._label };
       } else if (d === 1 || (n._group === 'hub')) {
         if (_semanticMatch(n.id)) {
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
                 color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
-                font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+                font: { color: c.ink2, size: 12 }, label: n._label };
         } else {
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
-                color: { background: folder, border: c.border },
-                borderWidth: n._group === 'hub' ? 3 : 1,
-                font: { color: c.accentInk, size: 12, face: 'inherit' },
+                color: { background: c.panel, border: folder },
+                borderWidth: n._group === 'hub' ? 3 : 1.5,
+                font: { color: c.ink2, size: 12 },
                 shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
                 label: n._label };
         }

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -178,10 +178,10 @@
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Focus, depth-1, and hub nodes
-  // are labelled box pills (semantic-match ones get the dashed-pill styling);
-  // all other nodes are dots with `label: ''`. applyLOD then promotes/demotes
-  // labels by zoom/hover.
+  // Map each node to its Paper role by distance. Focus is the accent pill;
+  // depth-1 and hub nodes are box pills, and among those the semantic-match ones
+  // (every touching edge semantic) get the dashed-pill styling; all other nodes
+  // are dots with `label: ''`. applyLOD then promotes/demotes labels by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -145,6 +145,7 @@
     styleNodes(_depths);
     styleEdges(_depths);
     applyLOD();
+    updateCountChip();
   }
 
   // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
@@ -337,6 +338,17 @@
   function hideMiniCard() {
     document.getElementById('graph-mini-card').style.display = 'none';
   }
+
+  function updateCountChip() {
+    const chip = document.getElementById('graph-count');
+    if (chip && nodesDS) chip.textContent = nodesDS.length + (nodesDS.length === 1 ? ' note' : ' notes');
+  }
+  document.getElementById('graph-zoom-in')?.addEventListener('click', () => {
+    if (network) network.moveTo({ scale: network.getScale() * 1.3 });
+  });
+  document.getElementById('graph-zoom-out')?.addEventListener('click', () => {
+    if (network) network.moveTo({ scale: network.getScale() / 1.3 });
+  });
 
   // Send graph summary to Claude
   document.getElementById('graph-send-btn').addEventListener('click', () => {

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -8,6 +8,8 @@
   let semanticEnabled = false;
   let _depths = new Map();
   const LABEL_ZOOM_THRESHOLD = 1.35;
+  let _zoomedIn = false;
+  let _hoveredId = null;
 
   // Folder-based node colors — chosen to stand out on both light and dark backgrounds
   const _FOLDER_COLORS = [
@@ -67,7 +69,7 @@
       physics: { enabled: true, solver: 'forceAtlas2Based', forceAtlas2Based: { gravitationalConstant: -40 } },
       nodes: {
         shape: 'dot',
-        scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16 } },
+        scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16, drawThreshold: 6 } },
       },
       edges: {
         arrows: { to: { enabled: true, scaleFactor: 0.5 } }, font: { size: 9 }, smooth: { type: 'continuous' },
@@ -100,6 +102,13 @@
         loadGraph(nodeId);
       }
     });
+
+    network.on('zoom', (params) => {
+      const zoomed = params.scale >= LABEL_ZOOM_THRESHOLD;
+      if (zoomed !== _zoomedIn) { _zoomedIn = zoomed; applyLOD(); }  // only on crossing
+    });
+    network.on('hoverNode', (params) => { _hoveredId = params.node; applyLOD(); });
+    network.on('blurNode', () => { _hoveredId = null; applyLOD(); });
   }
 
   function addGraphData(data) {
@@ -135,6 +144,7 @@
     _depths = computeDepths();
     styleNodes(_depths);
     styleEdges(_depths);
+    applyLOD();
   }
 
   // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
@@ -201,6 +211,22 @@
       }
       updates.push(u);
     }
+    nodesDS.update(updates);
+  }
+
+  // Coherence predicate: a node's label shows iff it is near the focus, OR the
+  // graph is zoomed in past the threshold, OR the node is currently hovered.
+  function labelVisible(id) {
+    const d = _depths.has(id) ? _depths.get(id) : Infinity;
+    return d <= 1 || _zoomedIn || id === _hoveredId;
+  }
+
+  // Re-derive every node's label from labelVisible (never toggled ad hoc).
+  function applyLOD() {
+    if (!nodesDS) return;
+    const updates = nodesDS.get().map(n => ({
+      id: n.id, label: labelVisible(n.id) ? n._label : '',
+    }));
     nodesDS.update(updates);
   }
 

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -171,15 +171,16 @@
     return depths;
   }
 
-  // A node is "semantic-match" if it is reachable from focus only via semantic edges.
+  // A node is "semantic-match" if every edge touching it is a semantic edge.
   function _semanticMatch(id) {
     const touching = edgesDS.get().filter(e => e.from === id || e.to === id);
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Label gate: focus, depth-1,
-  // and semantic-match nodes are labelled here; distant nodes get `label: ''`.
-  // Task 3's applyLOD promotes/demotes by zoom/hover.
+  // Map each node to its Paper role by distance. Focus, depth-1, and hub nodes
+  // are labelled box pills (semantic-match ones get the dashed-pill styling);
+  // all other nodes are dots with `label: ''`. applyLOD then promotes/demotes
+  // labels by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();
@@ -202,7 +203,7 @@
           u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
                 color: { background: folder, border: c.border },
                 borderWidth: n._group === 'hub' ? 3 : 1,
-                font: { color: c.ink2, size: 12, face: 'inherit' },
+                font: { color: c.accentInk, size: 12, face: 'inherit' },
                 shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
                 label: n._label };
         }
@@ -217,18 +218,19 @@
     nodesDS.update(updates);
   }
 
-  // Coherence predicate: a node's label shows iff it is near the focus, OR the
-  // graph is zoomed in past the threshold, OR the node is currently hovered.
-  function labelVisible(id) {
-    const d = _depths.has(id) ? _depths.get(id) : Infinity;
-    return d <= 1 || _zoomedIn || id === _hoveredId;
+  // Coherence predicate: a node's label shows iff it is near the focus, OR it
+  // is a hub node, OR the graph is zoomed in past the threshold, OR the node
+  // is currently hovered.
+  function labelVisible(n) {
+    const d = _depths.has(n.id) ? _depths.get(n.id) : Infinity;
+    return d <= 1 || n._group === 'hub' || _zoomedIn || n.id === _hoveredId;
   }
 
   // Re-derive every node's label from labelVisible (never toggled ad hoc).
   function applyLOD() {
     if (!nodesDS) return;
     const updates = nodesDS.get().map(n => ({
-      id: n.id, label: labelVisible(n.id) ? n._label : '',
+      id: n.id, label: labelVisible(n) ? n._label : '',
     }));
     nodesDS.update(updates);
   }

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -244,6 +244,16 @@
     edgesDS.update(updates);
   }
 
+  // Re-read Paper vars and restyle everything (a canvas doesn't inherit CSS-var
+  // changes, so the graph must re-read on host theme flips).
+  function refreshColors() {
+    if (!nodesDS) return;
+    styleNodes(_depths);
+    styleEdges(_depths);
+    applyLOD();
+  }
+  window.addEventListener('vault-theme-changed', refreshColors);
+
   async function expandNode(path) {
     try {
       const result = await app.callServerTool({
@@ -374,15 +384,7 @@
   document.getElementById('graph-semantic-btn').addEventListener('click', () => {
     semanticEnabled = !semanticEnabled;
     const btn = document.getElementById('graph-semantic-btn');
-    if (semanticEnabled) {
-      btn.style.background = 'var(--accent)';
-      btn.style.color = 'var(--accent-ink)';
-      btn.style.border = 'none';
-    } else {
-      btn.style.background = 'var(--panel-2)';
-      btn.style.color = 'var(--ink)';
-      btn.style.border = '1px solid var(--border)';
-    }
+    btn.classList.toggle('active', semanticEnabled);
     // Reload current graph with updated setting
     if (graphCenterPath) loadGraph(graphCenterPath);
   });

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -148,7 +148,8 @@
     updateCountChip();
   }
 
-  // BFS distance-from-focus over the accumulated edge set. Unreachable → Infinity.
+  // BFS distance-from-focus over the accumulated edge set. Unreachable nodes are
+  // absent from the returned map; callers treat a missing entry as Infinity.
   function computeDepths() {
     const depths = new Map();
     if (!nodesDS || !graphCenterPath || !nodesDS.get(graphCenterPath)) return depths;
@@ -211,6 +212,7 @@
         u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
               color: { background: folder, border: c.edge }, borderWidth: 1.5,
               shapeProperties: n._group === 'orphan' ? { borderDashes: [5, 5] } : {},
+              font: { color: c.ink2 },
               label: '' };
       }
       updates.push(u);

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -166,8 +166,9 @@
     return touching.length > 0 && touching.every(e => e.title === 'semantic');
   }
 
-  // Map each node to its Paper role by distance. Label gate: only distance ≤ 1
-  // is labelled here; Task 3's applyLOD promotes/demotes the rest by zoom/hover.
+  // Map each node to its Paper role by distance. Label gate: focus, depth-1,
+  // and semantic-match nodes are labelled here; distant nodes get `label: ''`.
+  // Task 3's applyLOD promotes/demotes by zoom/hover.
   function styleNodes(depths) {
     if (!nodesDS) return;
     const c = getColors();
@@ -207,7 +208,7 @@
     if (!edgesDS) return;
     const c = getColors();
     const updates = edgesDS.get().map(e => {
-      const dm = Math.max(depths.get(e.from) ?? 0, depths.get(e.to) ?? 0);
+      const dm = Math.max(depths.get(e.from) ?? Infinity, depths.get(e.to) ?? Infinity);
       const es = edgeStyle(e.title, dm, c);
       return { id: e.id, color: es.color, dashes: es.dashes, width: es.width };
     });

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -62,7 +62,6 @@
     if (network) return;
     const container = document.getElementById('graph-container');
     if (!container || typeof vis === 'undefined') return;
-    const c = getColors();
     nodesDS = new vis.DataSet();
     edgesDS = new vis.DataSet();
     const options = {

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -350,6 +350,11 @@
     if (network) network.moveTo({ scale: network.getScale() / 1.3 });
   });
 
+  // Narrow-panel legend collapse chip
+  document.getElementById('graph-legend-chip')?.addEventListener('click', () => {
+    document.getElementById('graph-legend')?.classList.toggle('open');
+  });
+
   // Send graph summary to Claude
   document.getElementById('graph-send-btn').addEventListener('click', () => {
     if (!nodesDS || nodesDS.length === 0) return;

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -193,16 +193,18 @@
               font: { color: c.accentInk, size: 13, face: 'inherit' },
               label: n._label };
       } else if (d === 1 || (n._group === 'hub')) {
-        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
-              color: { background: folder, border: c.border },
-              borderWidth: n._group === 'hub' ? 3 : 1,
-              font: { color: c.ink2, size: 12, face: 'inherit' },
-              shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
-              label: n._label };
-      } else if (_semanticMatch(n.id)) {
-        u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
-              color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
-              font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+        if (_semanticMatch(n.id)) {
+          u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20, borderDashes: [4, 3] },
+                color: { background: c.accentSoft, border: c.accent }, borderWidth: 1.5,
+                font: { color: c.ink2, size: 12, face: 'inherit' }, label: n._label };
+        } else {
+          u = { id: n.id, shape: 'box', shapeProperties: { borderRadius: 20 },
+                color: { background: folder, border: c.border },
+                borderWidth: n._group === 'hub' ? 3 : 1,
+                font: { color: c.ink2, size: 12, face: 'inherit' },
+                shadow: { enabled: true, size: 6, x: 0, y: 1, color: 'rgba(0,0,0,0.12)' },
+                label: n._label };
+        }
       } else {
         u = { id: n.id, shape: 'dot', value: Math.max(n._backlinks, 1),
               color: { background: folder, border: c.edge }, borderWidth: 1.5,

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -105,6 +105,23 @@ class TestGraphExplorerHTML:
         # Label gate: distant nodes get an empty label.
         assert "label: ''" in html or "label:''" in html
 
+    async def test_lod_zoom_reveal(self) -> None:
+        html = await get_app_html()
+        assert "network.on('zoom'" in html
+        assert "LABEL_ZOOM_THRESHOLD" in html
+        assert "1.35" in html
+
+    async def test_lod_hover_reveal(self) -> None:
+        html = await get_app_html()
+        assert "hoverNode" in html
+        assert "blurNode" in html
+        assert "applyLOD" in html
+
+    async def test_lod_graceful_font_floor(self) -> None:
+        html = await get_app_html()
+        # scaling.label acts as a graceful adjunct, not the mechanism.
+        assert "drawThreshold" in html
+
     async def test_send_to_claude_button(self) -> None:
         html = await get_app_html()
         assert 'id="graph-send-btn"' in html

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -174,6 +174,27 @@ class TestGraphExplorerHTML:
         assert 'id="graph-count"' in html
         assert "updateCountChip" in html
 
+    async def test_graph_legend_matches_drawing(self) -> None:
+        html = await get_app_html()
+        assert 'id="graph-legend"' in html
+        # "semantic" and "more" also occur elsewhere in the bundle (Paper
+        # semantic tokens, "N more properties"), so pin the exact legend
+        # entry markup rather than the bare words.
+        for entry_markup in (
+            '<span class="lg-line lg-solid"></span>wikilink',
+            '<span class="lg-line lg-dashed"></span>semantic',
+            '<span class="lg-pill lg-focus"></span>focus note',
+            '<span class="lg-pill lg-linked"></span>linked note',
+            '<span class="lg-dot"></span>more (hover)',
+        ):
+            assert entry_markup in html
+
+    async def test_graph_legend_collapse_chip(self) -> None:
+        html = await get_app_html()
+        assert 'id="graph-legend-chip"' in html
+        assert "graph-legend-chip" in html
+        assert "legend" in html
+
 
 # ---------------------------------------------------------------------------
 # Graph data tools

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -154,9 +154,24 @@ class TestGraphExplorerHTML:
     async def test_graph_reads_paper_tokens(self) -> None:
         html = await get_app_html()
         assert "getColors" in html
-        # getColors reads Paper semantic tokens for the canvas chrome.
-        assert "--accent" in html
-        assert "--edge" in html
+        # Pin the actual getColors read sites, not the shared CSS tokens.
+        assert "v('--accent'" in html
+        assert "v('--edge'" in html
+
+    async def test_graph_semantic_match_labelled(self) -> None:
+        html = await get_app_html()
+        # _semanticMatch drives the dashed-pill styling in styleNodes.
+        assert "_semanticMatch" in html
+
+    async def test_graph_edge_lod_fade(self) -> None:
+        html = await get_app_html()
+        # edgeStyle fades link edges once the farthest endpoint is >= depth 2.
+        assert "depthMax >= 2" in html
+
+    async def test_graph_hub_labels_always_visible(self) -> None:
+        html = await get_app_html()
+        # labelVisible must treat hub nodes as always-labelled (Fix for #815).
+        assert "n._group === 'hub'" in html
 
     async def test_graph_dotted_grid_surface(self) -> None:
         html = await get_app_html()

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -163,6 +163,17 @@ class TestGraphExplorerHTML:
         assert "radial-gradient" in html
         assert "#graph-container" in html
 
+    async def test_zoom_control_overlay(self) -> None:
+        html = await get_app_html()
+        assert 'id="graph-zoom-in"' in html
+        assert 'id="graph-zoom-out"' in html
+        assert "network.moveTo" in html
+
+    async def test_node_count_chip(self) -> None:
+        html = await get_app_html()
+        assert 'id="graph-count"' in html
+        assert "updateCountChip" in html
+
 
 # ---------------------------------------------------------------------------
 # Graph data tools

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -423,13 +423,18 @@ class TestSemanticGraphHTML:
 
     async def test_graph_refreshes_on_theme_change(self) -> None:
         html = await get_app_html()
-        assert "vault-theme-changed" in html
-        assert "refreshColors" in html
+        # Pins the actual event binding, not just the vocabulary (which
+        # pre-existed in a forward-reference comment).
+        assert "window.addEventListener('vault-theme-changed', refreshColors)" in html
+        # Pins core.js's dispatch specifically, not only graph.js's listener.
+        assert "new CustomEvent('vault-theme-changed'" in html
 
     async def test_semantic_toggle_active_is_accent(self) -> None:
         html = await get_app_html()
-        # Active semantic toggle uses accent-soft/accent, not the old purple.
-        assert "accent-soft" in html
+        # Pins the toggle wiring + the CSS rule (accent-soft alone is a
+        # shared token used by other components).
+        assert "classList.toggle('active', semanticEnabled)" in html
+        assert ".action-btn.active {" in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -105,6 +105,10 @@ class TestGraphExplorerHTML:
         # Label gate: distant nodes get an empty label.
         assert "label: ''" in html or "label:''" in html
 
+    async def test_focus_node_accent_pill(self) -> None:
+        html = await get_app_html()
+        assert "background: c.accent, border: c.accent" in html
+
     async def test_lod_zoom_reveal(self) -> None:
         html = await get_app_html()
         assert "network.on('zoom'" in html
@@ -432,6 +436,10 @@ class TestSemanticGraphHTML:
         assert "_SEMANTIC_EDGE_COLOR" not in html
         assert "isSemantic" in html
         assert "dashes" in html
+
+    async def test_semantic_edge_accent_color(self) -> None:
+        html = await get_app_html()
+        assert "color: c.accent, opacity: 0.75" in html
 
     async def test_semantic_edge_dashed(self) -> None:
         html = await get_app_html()

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -473,8 +473,8 @@ class TestSemanticGraphHTML:
 
     async def test_graph_refreshes_on_theme_change(self) -> None:
         html = await get_app_html()
-        # Pins the actual event binding, not just the vocabulary (which
-        # pre-existed in a forward-reference comment).
+        # Pin the actual event binding (listener + dispatch), not just the
+        # string, so a stub can't satisfy the test.
         assert "window.addEventListener('vault-theme-changed', refreshColors)" in html
         # Pins core.js's dispatch specifically, not only graph.js's listener.
         assert "new CustomEvent('vault-theme-changed'" in html

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -81,8 +81,8 @@ class TestGraphExplorerHTML:
         html = await get_app_html()
         # Node size proportional to backlink_count via value
         assert "backlink_count" in html
-        # Edge color by type
-        assert "edgeColorByType" in html
+        # Edge color/style by type
+        assert "edgeStyle" in html
         # Orphan dashed border
         assert "borderDashes" in html
 
@@ -113,7 +113,18 @@ class TestGraphExplorerHTML:
     async def test_host_css_variables_in_graph(self) -> None:
         html = await get_app_html()
         assert "getColors" in html
-        assert "--color-text-info" in html
+
+    async def test_graph_reads_paper_tokens(self) -> None:
+        html = await get_app_html()
+        assert "getColors" in html
+        # getColors reads Paper semantic tokens for the canvas chrome.
+        assert "--accent" in html
+        assert "--edge" in html
+
+    async def test_graph_dotted_grid_surface(self) -> None:
+        html = await get_app_html()
+        assert "radial-gradient" in html
+        assert "#graph-container" in html
 
 
 # ---------------------------------------------------------------------------
@@ -318,9 +329,13 @@ class TestSemanticGraphHTML:
         assert "include_semantic" in html
         assert "semanticEnabled" in html
 
-    async def test_semantic_edge_color_constant(self) -> None:
+    async def test_semantic_edge_is_dashed_accent_not_purple(self) -> None:
         html = await get_app_html()
-        assert "_SEMANTIC_EDGE_COLOR" in html
+        # The old purple semantic constant is gone; semantic reads as dashed accent.
+        assert "#a855f7" not in html
+        assert "_SEMANTIC_EDGE_COLOR" not in html
+        assert "isSemantic" in html
+        assert "dashes" in html
 
     async def test_semantic_edge_dashed(self) -> None:
         html = await get_app_html()

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -170,8 +170,20 @@ class TestGraphExplorerHTML:
 
     async def test_graph_hub_labels_always_visible(self) -> None:
         html = await get_app_html()
-        # labelVisible must treat hub nodes as always-labelled (Fix for #815).
+        # labelVisible must treat hub nodes as always-labelled.
         assert "n._group === 'hub'" in html
+
+    async def test_lod_predicate_pinned(self) -> None:
+        html = await get_app_html()
+        # Pin the whole label-visibility decision so it can't be gutted silently.
+        assert (
+            "return d <= 1 || n._group === 'hub' || _zoomedIn || n.id === _hoveredId"
+            in html
+        )
+
+    async def test_legend_chip_toggle_wired(self) -> None:
+        html = await get_app_html()
+        assert "classList.toggle('open')" in html
 
     async def test_graph_dotted_grid_surface(self) -> None:
         html = await get_app_html()

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -113,14 +113,15 @@ class TestGraphExplorerHTML:
 
     async def test_lod_hover_reveal(self) -> None:
         html = await get_app_html()
-        assert "hoverNode" in html
-        assert "blurNode" in html
+        assert "network.on('hoverNode'" in html
+        assert "network.on('blurNode'" in html
+        assert "_hoveredId = params.node" in html
         assert "applyLOD" in html
 
     async def test_lod_graceful_font_floor(self) -> None:
         html = await get_app_html()
         # scaling.label acts as a graceful adjunct, not the mechanism.
-        assert "drawThreshold" in html
+        assert "drawThreshold: 6" in html
 
     async def test_send_to_claude_button(self) -> None:
         html = await get_app_html()

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -185,6 +185,21 @@ class TestGraphExplorerHTML:
             in html
         )
 
+    async def test_edge_lod_fade_outcome(self) -> None:
+        html = await get_app_html()
+        # Pin the fade itself, not just the `depthMax >= 2` threshold.
+        assert "opacity: far ? 0.5 : 1" in html
+        assert "width: far ? 1 : 1.6" in html
+
+    async def test_semantic_match_dashed_pill_styling(self) -> None:
+        html = await get_app_html()
+        assert "borderDashes: [4, 3]" in html
+        assert "background: c.accentSoft, border: c.accent" in html
+
+    async def test_zoom_crossing_triggers_relabel(self) -> None:
+        html = await get_app_html()
+        assert "if (zoomed !== _zoomedIn) { _zoomedIn = zoomed; applyLOD(); }" in html
+
     async def test_legend_chip_toggle_wired(self) -> None:
         html = await get_app_html()
         assert "classList.toggle('open')" in html

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -421,6 +421,16 @@ class TestSemanticGraphHTML:
         html = await get_app_html()
         assert "currentPath" in html
 
+    async def test_graph_refreshes_on_theme_change(self) -> None:
+        html = await get_app_html()
+        assert "vault-theme-changed" in html
+        assert "refreshColors" in html
+
+    async def test_semantic_toggle_active_is_accent(self) -> None:
+        html = await get_app_html()
+        # Active semantic toggle uses accent-soft/accent, not the old purple.
+        assert "accent-soft" in html
+
 
 # ---------------------------------------------------------------------------
 # Semantic edges with embeddings enabled

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -85,6 +85,25 @@ class TestGraphExplorerHTML:
         assert "edgeStyle" in html
         # Orphan dashed border
         assert "borderDashes" in html
+        # Edge styling applied via styleEdges
+        assert "styleEdges" in html
+
+    async def test_bfs_distance_computed(self) -> None:
+        html = await get_app_html()
+        assert "computeDepths" in html
+        # BFS from the center over the current edge set.
+        assert "graphCenterPath" in html
+
+    async def test_node_roles_pills_and_dots(self) -> None:
+        html = await get_app_html()
+        assert "styleNodes" in html
+        # Focus/neighbor nodes are box pills; distant nodes are dots.
+        assert "'box'" in html
+        assert "shapeProperties" in html
+        # Folder colors preserved for node fills.
+        assert "_folderColor" in html
+        # Label gate: distant nodes get an empty label.
+        assert "label: ''" in html or "label:''" in html
 
     async def test_send_to_claude_button(self) -> None:
         html = await get_app_html()


### PR DESCRIPTION
## Summary

Restyles the **Graph Explorer** MCP App view to the "Paper" design and adds **level-of-detail (LOD) labels** so labels never overlap regardless of zoom or graph size. This is the last child of the Vault Views "Paper" epic (#809), after #829 (Context Card), #842 (Vault Browser), and #847 (Note Preview).

Closes #815.

### What changed (presentation + view-logic only — no server change)

- **Level-of-detail labels** — BFS distance-from-focus (`computeDepths`); a node's label shows **iff** `distance ≤ 1` **or** it is a hub **or** the graph is zoomed past `~1.35` **or** it is hovered (single `labelVisible` predicate, one `applyLOD` pass). Distant nodes render as unlabeled dots whose name appears on hover or once zoomed in. Replaces the old "all labels always shown / collide" behavior.
- **Paper node roles** — focus = accent-filled pill; depth-1 / hub = `--panel`-filled pill with a folder-colored border and `--ink-2` label (legible on both themes, matches the legend); semantic-match = dashed-accent pill; distant = folder-colored dot. The existing hashed folder-color scheme and `backlink_count` sizing are preserved.
- **Edges** — solid `--edge` links (thinner + lower opacity when distant); `semantic` = dashed `--accent`. The old purple `#a855f7` is gone.
- **Chrome** — dotted-grid surface; a top-right `− / +` zoom control + node-count chip; a legend that exactly matches what is drawn, collapsing to an `ⓘ legend` chip on a narrow panel.
- **Theme re-read** — a `<canvas>` doesn't inherit CSS-var changes, so `core.js` dispatches a new `vault-theme-changed` event on host theme flips and the graph re-reads its colors (`refreshColors`). This is the one shared-file touch.
- Preserved behaviors (mini-card, single/double click, semantic toggle, Send, fullscreen) restyled to Paper, wiring intact.

### Engine decision (why not a renderer swap)

Stayed on **vis-network**. A library evaluation and the design team's own **live Cytoscape.js LOD prototype** both concluded the same: the distance-from-focus logic is manual in every engine, and Cytoscape/Sigma are full rewrites + a new vendored dependency for no LOD win below ~1–2k on-canvas nodes (a ~1000-note vault renders a neighborhood ≤ `max_nodes=200`). Details in `docs/superpowers/specs/2026-07-03-graph-lod-design.md`.

### Testing

- `tests/test_mcp_apps_graph.py` — assertions anchored to graph-specific strings (the LOD predicate, edge fade, semantic-match pill, zoom-crossing body, theme-refresh binding, legend markup, etc.), deliberately avoiding the vendored-bundle / shared-token false-pass traps.
- A **runtime vis-network harness** verified the legibility acceptance (labels never overlap at default zoom; zoom/hover reveals distant labels) in light + dark — the one thing the static-string tests can't check.
- Full suite green; `build_spa.py --check` / `vendor_spa.py --check`, ruff, mypy, and diff-quality (100%) all pass.

### Docs

`docs/guides/mcp-apps.md` — Graph section updated (LOD labels, zoom control + count chip, legend + collapse, dashed-accent semantic edges).

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
