### PR TITLE
fix: resolve graph canvas colors via probe so Desktop nodes aren't black

### DIFF
--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -548,7 +548,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:179472c7e40373f35e097a280f1198551e125281df24ef92ab43a074c2e1276f -->
+<!-- vendor-spa-source-sha256:bd6655ec90c154dbaed0b5eaee39de7a65e7c35beb383b75deea2f31836e15cb -->
 </head>
 <body>
 <div class="app-container">
@@ -1112,9 +1112,23 @@ app.onteardown = () => {
   // Paper palette for edges and canvas chrome, read from CSS vars so the graph
   // re-themes when the host flips theme (see refreshColors / vault-theme-changed).
   function getColors() {
-    const s = getComputedStyle(document.documentElement);
-    const v = (name, fallback) => s.getPropertyValue(name).trim() || fallback;
-    return {
+    // Resolve each token to a concrete rgb() string via a probe element.
+    // getComputedStyle(documentElement).getPropertyValue('--panel') can return
+    // the literal "var(--color-background-primary)" when a Paper token is an
+    // indirection (styles.css maps --panel/--ink/--accent/... onto --color-*).
+    // Modern Chromium resolves that, but older Chromium (Claude Desktop's
+    // Electron) returns the unresolved string, which canvas fillStyle can't
+    // parse -> vis-network paints black. Assigning `var(...)` to a real
+    // property (color) forces full var() substitution in every engine and
+    // still honors host overrides + theme flips.
+    const probe = document.createElement('span');
+    probe.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none';
+    document.body.appendChild(probe);
+    const v = (name, fallback) => {
+      probe.style.color = `var(${name}, ${fallback})`;
+      return getComputedStyle(probe).color; // always a resolved rgb(...)
+    };
+    const c = {
       panel:      v('--panel', '#fbf8f1'),
       panel2:     v('--panel-2', '#f2ecdf'),
       ink:        v('--ink', '#2a2620'),
@@ -1126,6 +1140,8 @@ app.onteardown = () => {
       accentSoft: v('--accent-soft', '#f3e4d8'),
       border:     v('--border', '#e4dbc9'),
     };
+    probe.remove();
+    return c;
   }
 
   // Edge styling: solid --edge for link edges (thinner + lower opacity when the
@@ -1148,6 +1164,7 @@ app.onteardown = () => {
       physics: { enabled: true, solver: 'forceAtlas2Based', forceAtlas2Based: { gravitationalConstant: -40 } },
       nodes: {
         shape: 'dot',
+        widthConstraint: { maximum: 180 }, // wrap long titles -> compact pills, not full-width bars
         scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16, drawThreshold: 6 } },
       },
       edges: {

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -994,9 +994,23 @@ app.onteardown = () => {
   // Paper palette for edges and canvas chrome, read from CSS vars so the graph
   // re-themes when the host flips theme (see refreshColors / vault-theme-changed).
   function getColors() {
-    const s = getComputedStyle(document.documentElement);
-    const v = (name, fallback) => s.getPropertyValue(name).trim() || fallback;
-    return {
+    // Resolve each token to a concrete rgb() string via a probe element.
+    // getComputedStyle(documentElement).getPropertyValue('--panel') can return
+    // the literal "var(--color-background-primary)" when a Paper token is an
+    // indirection (styles.css maps --panel/--ink/--accent/... onto --color-*).
+    // Modern Chromium resolves that, but older Chromium (Claude Desktop's
+    // Electron) returns the unresolved string, which canvas fillStyle can't
+    // parse -> vis-network paints black. Assigning `var(...)` to a real
+    // property (color) forces full var() substitution in every engine and
+    // still honors host overrides + theme flips.
+    const probe = document.createElement('span');
+    probe.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none';
+    document.body.appendChild(probe);
+    const v = (name, fallback) => {
+      probe.style.color = `var(${name}, ${fallback})`;
+      return getComputedStyle(probe).color; // always a resolved rgb(...)
+    };
+    const c = {
       panel:      v('--panel', '#fbf8f1'),
       panel2:     v('--panel-2', '#f2ecdf'),
       ink:        v('--ink', '#2a2620'),
@@ -1008,6 +1022,8 @@ app.onteardown = () => {
       accentSoft: v('--accent-soft', '#f3e4d8'),
       border:     v('--border', '#e4dbc9'),
     };
+    probe.remove();
+    return c;
   }
 
   // Edge styling: solid --edge for link edges (thinner + lower opacity when the
@@ -1030,6 +1046,7 @@ app.onteardown = () => {
       physics: { enabled: true, solver: 'forceAtlas2Based', forceAtlas2Based: { gravitationalConstant: -40 } },
       nodes: {
         shape: 'dot',
+        widthConstraint: { maximum: 180 }, // wrap long titles -> compact pills, not full-width bars
         scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16, drawThreshold: 6 } },
       },
       edges: {

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -32,9 +32,23 @@
   // Paper palette for edges and canvas chrome, read from CSS vars so the graph
   // re-themes when the host flips theme (see refreshColors / vault-theme-changed).
   function getColors() {
-    const s = getComputedStyle(document.documentElement);
-    const v = (name, fallback) => s.getPropertyValue(name).trim() || fallback;
-    return {
+    // Resolve each token to a concrete rgb() string via a probe element.
+    // getComputedStyle(documentElement).getPropertyValue('--panel') can return
+    // the literal "var(--color-background-primary)" when a Paper token is an
+    // indirection (styles.css maps --panel/--ink/--accent/... onto --color-*).
+    // Modern Chromium resolves that, but older Chromium (Claude Desktop's
+    // Electron) returns the unresolved string, which canvas fillStyle can't
+    // parse -> vis-network paints black. Assigning `var(...)` to a real
+    // property (color) forces full var() substitution in every engine and
+    // still honors host overrides + theme flips.
+    const probe = document.createElement('span');
+    probe.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none';
+    document.body.appendChild(probe);
+    const v = (name, fallback) => {
+      probe.style.color = `var(${name}, ${fallback})`;
+      return getComputedStyle(probe).color; // always a resolved rgb(...)
+    };
+    const c = {
       panel:      v('--panel', '#fbf8f1'),
       panel2:     v('--panel-2', '#f2ecdf'),
       ink:        v('--ink', '#2a2620'),
@@ -46,6 +60,8 @@
       accentSoft: v('--accent-soft', '#f3e4d8'),
       border:     v('--border', '#e4dbc9'),
     };
+    probe.remove();
+    return c;
   }
 
   // Edge styling: solid --edge for link edges (thinner + lower opacity when the
@@ -68,6 +84,7 @@
       physics: { enabled: true, solver: 'forceAtlas2Based', forceAtlas2Based: { gravitationalConstant: -40 } },
       nodes: {
         shape: 'dot',
+        widthConstraint: { maximum: 180 }, // wrap long titles -> compact pills, not full-width bars
         scaling: { min: 8, max: 30, label: { enabled: true, min: 10, max: 16, drawThreshold: 6 } },
       },
       edges: {

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -162,6 +162,18 @@ class TestGraphExplorerHTML:
         assert "v('--accent'" in html
         assert "v('--edge'" in html
 
+    async def test_graph_resolves_canvas_colors_via_probe(self) -> None:
+        """#856: canvas node colors must be resolved to concrete rgb() through a
+        probe element (assign ``var(token)`` to a real ``color`` property, read
+        the computed value). Reading Paper tokens straight off documentElement
+        via ``getPropertyValue`` returns the literal ``var(--color-...)`` for
+        indirection tokens in older Chromium (Claude Desktop's Electron), which
+        canvas fillStyle can't parse -> nodes paint black. ``probe`` is a
+        view-specific name (not vendored-library text)."""
+        html = await get_app_html()
+        assert "probe.style.color" in html
+        assert "getComputedStyle(probe)" in html
+
     async def test_graph_semantic_match_labelled(self) -> None:
         html = await get_app_html()
         # _semanticMatch drives the dashed-pill styling in styleNodes.


### PR DESCRIPTION
## Problem

Issue #856: in Claude Desktop the Graph view renders **black nodes with invisible labels**.

`getColors()` in `graph.js` read its Paper palette with
`getComputedStyle(document.documentElement).getPropertyValue('--panel')`. Several
Paper tokens are `var()` *indirections* — `styles.css` maps `--panel`/`--ink`/`--accent`/… onto
the host's `--color-*` variables. `getPropertyValue` on a custom property returns its
**specified** value; older Chromium (the Electron that Claude Desktop ships) hands back the
unresolved literal `"var(--color-background-primary)"` rather than recursively resolving it.
vis-network feeds those strings straight to canvas `fillStyle`, which can't parse them → the
node and its label paint black. Modern Chromium happens to resolve the indirection on read, so
the bug is engine-version-dependent.

## Fix

Resolve each token through a hidden **probe element**: assign `var(--token, fallback)` to a real
`color` property, then read `getComputedStyle(probe).color`. Reading a *standard* property's
computed color returns the **resolved** value — always a concrete `rgb(...)`, with `var()`
substituted at computed-value time — in **every** engine, old or new. Host `--color-*` overrides
and `vault-theme-changed` theme flips still flow through unchanged. The probe is created, used,
and removed within the call.

Also caps node `widthConstraint` at 180px so long note titles wrap into compact pills instead of
stretching into full-width bars.

## Verification

- `getColors` now resolves via the probe; a regression test
  (`test_graph_resolves_canvas_colors_via_probe`) pins the view-specific `probe.style.color` /
  `getComputedStyle(probe)` anchors in the built `app.html`. It fails on the pre-fix
  `getPropertyValue` form.
- Per the #851 convention for runtime canvas behavior (which a static-HTML-string test cannot
  observe): the probe technique was confirmed in a browser to return concrete `rgb(...)` for both
  indirection tokens (`--panel` → `rgb(...)`) and literal-hex tokens. The cross-engine correctness
  rests on the CSS spec — `getComputedStyle(el).color` is defined to return a resolved value in
  all engines — rather than on an assertion the CPython suite can run. On-device confirmation in
  Claude Desktop is the final acceptance check.
- Gates: `ruff check`/`format` clean, `mypy` clean (156 files), full suite **2660 passed**,
  `diff-quality` 100%.
- Preflight-circus: all 5 core lenses + code-reviewer/pr-test-analyzer/comment-analyzer — no
  ≥80 code findings.

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._