### PR TITLE
fix: make Vault Explorer app honor host container dimensions (mobile sizing)

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2207,6 +2207,8 @@ MCP Apps are browser-based views that MCP clients supporting the protocol can re
 - **Inline**: rendered in a client sidebar or panel alongside the conversation
 - **Fullscreen**: rendered in a dedicated tab or window
 
+**Sizing model** (#859): the app derives a size mode from the host's reported `containerDimensions` (part of the host context) rather than hard-pinning `height: 100vh`. A fixed height axis means the host owns the frame size, so the app fills it and scrolls internally; a flexible (`maxHeight`) or unbounded axis means the app controls its own height — it grows to content and, with the ext-apps SDK's `autoResize` enabled, reports its size via `size-changed` so the host sizes the iframe to it. The size mode is derived from the reported dimensions alone, not from `platform` (which only gates auto-fullscreen). This is what makes the views usable in a flexible or unbounded frame — as used by mobile inline hosts and sidebars — where a hard `100vh` collapsed content to the top of an over-tall iframe. The app also consumes `safeAreaInsets` (padding to clear mobile notches / system UI) and only auto-expands to fullscreen on first load off mobile (`platform !== 'mobile'`), where fullscreen has no reliable inline return path.
+
 **Four views** are bundled in the single resource:
 
 | View | `view` value | Description |

--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -93,7 +93,8 @@ The app integrates with the host client via the ext-apps SDK:
 - **`app.callServerTool()`**: calls app-only tools to fetch data
 - **`app.sendMessage()`**: sends note content to the LLM conversation
 - **`app.updateModelContext()`**: keeps the LLM aware of which note the user is viewing
-- **`app.requestDisplayMode()`**: requests fullscreen or inline display
+- **`app.requestDisplayMode()`**: requests fullscreen or inline display (auto-expands to fullscreen on first load on desktop and web, but stays inline on mobile)
+- **Adaptive sizing**: honors the host's reported container dimensions and safe-area insets. It fills a fixed-height frame with internal scrolling, or, when the host reports a flexible or unbounded frame (as mobile inline hosts and sidebars typically do), grows to its content and reports its height so the host can size the view
 - **Theme sync**: automatically adapts to the host's light/dark theme and CSS variables
 
 ### Visual identity ("Paper")

--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -182,6 +182,13 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  /* Sizing model (#859): the host tells us via containerDimensions whether it
+     gives a fixed-height frame or a flexible/unbounded one; core.js sets
+     html[data-size-mode] and the safe-area vars accordingly. Base (attribute
+     unset) = fixed/fill; it is the pre-context default (no collapsed-content
+     flash before the host context arrives) and also the steady state for a
+     fixed-height host. The mode is chosen from the reported dimensions, not the
+     platform. */
   body {
     font-family: var(--font-body);
     background: var(--panel);
@@ -195,7 +202,15 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     display: flex;
     flex-direction: column;
     height: 100vh;
+    /* safe-area insets (mobile notches / system UI); 0 until the host reports
+       them. border-box (set globally) keeps the box at 100vh incl. padding. */
+    padding: var(--safe-top, 0px) var(--safe-right, 0px) var(--safe-bottom, 0px) var(--safe-left, 0px);
   }
+  /* Flexible/unbounded frame (mobile inline, sidebars): grow to content and let
+     the SDK's autoResize report our height so the host sizes the iframe. Do NOT
+     pin to 100vh here — inside a content-sized iframe vh is circular. */
+  html[data-size-mode="flexible"] body { height: auto; overflow: visible; }
+  html[data-size-mode="flexible"] .app-container { height: auto; }
   /* Tab bar */
   .tab-bar {
     display: flex;
@@ -548,7 +563,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:bd6655ec90c154dbaed0b5eaee39de7a65e7c35beb383b75deea2f31836e15cb -->
+<!-- vendor-spa-source-sha256:83085409fa2bf5c61dda3482773cc0fcabd5a0ca9df956d356443efe6634ca97 -->
 </head>
 <body>
 <div class="app-container">
@@ -654,10 +669,16 @@ import { App, applyDocumentTheme, applyHostStyleVariables, applyHostFonts }
 try {
 
 // ── Globals ──────────────────────────────────────────────────────────────
+// autoResize:true (the SDK default) — the SDK observes our content size and
+// reports it to the host via size-changed so the host can size the iframe. The
+// app pairs this with containerDimensions-aware CSS (see applySizeMode): a
+// fixed-height host frame is filled with internal scroll; a flexible/unbounded
+// frame (mobile inline, sidebars) grows to content. Disabling autoResize + a
+// hard height:100vh left mobile hosts unable to learn our height (#859).
 const app = new App(
   { name: "Vault Explorer", version: "1.0.0" },
   {},
-  { autoResize: false }
+  { autoResize: true }
 );
 let currentTab = 'context';
 let isFullscreen = false;
@@ -690,9 +711,38 @@ function parseToolResult(result) {
   return null;
 }
 
+// ── Host-driven sizing ────────────────────────────────────────────────────
+// The host reports containerDimensions (per-axis: a fixed `height`/`width`, or a
+// `maxHeight`/`maxWidth` cap, or neither = unbounded) and safeAreaInsets. We
+// derive a size mode from the height axis: a fixed height means the host owns
+// our frame size and we fill it (internal scroll); anything else means the app
+// controls its own height and the SDK's autoResize reports it so the host sizes
+// the iframe to content. The CSS branches on html[data-size-mode]; the base
+// (attribute unset) is the fixed/fill layout, so before the first context
+// arrives there is no collapsed-content flash. The steady-state mode is chosen
+// here from the reported height axis, independent of `platform`. Must receive
+// the complete (merged) host context — see the call in handleHostContext. #859.
+function applySizeMode(ctx) {
+  const cd = ctx.containerDimensions;
+  const fixedHeight = !!cd && typeof cd.height === 'number';
+  document.documentElement.dataset.sizeMode = fixedHeight ? 'fixed' : 'flexible';
+  const s = ctx.safeAreaInsets;
+  const root = document.documentElement.style;
+  root.setProperty('--safe-top', (s?.top || 0) + 'px');
+  root.setProperty('--safe-right', (s?.right || 0) + 'px');
+  root.setProperty('--safe-bottom', (s?.bottom || 0) + 'px');
+  root.setProperty('--safe-left', (s?.left || 0) + 'px');
+}
+
 // ── Host theming ─────────────────────────────────────────────────────────
 function handleHostContext(ctx) {
   if (!ctx) return;
+  // onhostcontextchanged delivers a PARTIAL delta (only the changed fields);
+  // the SDK has already merged it into getHostContext(). Derive size mode +
+  // insets from the merged snapshot, not the delta, so an unrelated change
+  // (e.g. a theme-only delta) can't reset them to their absent-field defaults.
+  // Fall back to ctx if no snapshot is available yet.
+  applySizeMode(app.getHostContext() || ctx);
   if (ctx.theme) {
     applyDocumentTheme(ctx.theme);
     window.dispatchEvent(new CustomEvent('vault-theme-changed', { detail: { theme: ctx.theme } }));
@@ -1904,8 +1954,12 @@ if (hostContext) handleHostContext(hostContext);
 
 const fullscreenAvailable = hostContext?.availableDisplayModes?.includes('fullscreen') === true;
 updateFullscreenButton(fullscreenAvailable);
-// Auto-expand on first load — complex multi-view app benefits from more space
-if (fullscreenAvailable && !isFullscreen) {
+// Auto-expand on first load — a complex multi-view app benefits from more space
+// on desktop/web. NOT on mobile: there fullscreen is the whole screen with no
+// working return path on some hosts (leaving it can tear the app down), and the
+// content-driven inline layout is the right default (#859). platform may be
+// undefined on older hosts — treat that as non-mobile so desktop is unchanged.
+if (fullscreenAvailable && !isFullscreen && hostContext?.platform !== 'mobile') {
   app.requestDisplayMode({ mode: 'fullscreen' }).catch(() => {});
 }
 

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -68,6 +68,13 @@
     --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  /* Sizing model (#859): the host tells us via containerDimensions whether it
+     gives a fixed-height frame or a flexible/unbounded one; core.js sets
+     html[data-size-mode] and the safe-area vars accordingly. Base (attribute
+     unset) = fixed/fill; it is the pre-context default (no collapsed-content
+     flash before the host context arrives) and also the steady state for a
+     fixed-height host. The mode is chosen from the reported dimensions, not the
+     platform. */
   body {
     font-family: var(--font-body);
     background: var(--panel);
@@ -81,7 +88,15 @@
     display: flex;
     flex-direction: column;
     height: 100vh;
+    /* safe-area insets (mobile notches / system UI); 0 until the host reports
+       them. border-box (set globally) keeps the box at 100vh incl. padding. */
+    padding: var(--safe-top, 0px) var(--safe-right, 0px) var(--safe-bottom, 0px) var(--safe-left, 0px);
   }
+  /* Flexible/unbounded frame (mobile inline, sidebars): grow to content and let
+     the SDK's autoResize report our height so the host sizes the iframe. Do NOT
+     pin to 100vh here — inside a content-sized iframe vh is circular. */
+  html[data-size-mode="flexible"] body { height: auto; overflow: visible; }
+  html[data-size-mode="flexible"] .app-container { height: auto; }
   /* Tab bar */
   .tab-bar {
     display: flex;
@@ -536,10 +551,16 @@ import { App, applyDocumentTheme, applyHostStyleVariables, applyHostFonts }
 try {
 
 // ── Globals ──────────────────────────────────────────────────────────────
+// autoResize:true (the SDK default) — the SDK observes our content size and
+// reports it to the host via size-changed so the host can size the iframe. The
+// app pairs this with containerDimensions-aware CSS (see applySizeMode): a
+// fixed-height host frame is filled with internal scroll; a flexible/unbounded
+// frame (mobile inline, sidebars) grows to content. Disabling autoResize + a
+// hard height:100vh left mobile hosts unable to learn our height (#859).
 const app = new App(
   { name: "Vault Explorer", version: "1.0.0" },
   {},
-  { autoResize: false }
+  { autoResize: true }
 );
 let currentTab = 'context';
 let isFullscreen = false;
@@ -572,9 +593,38 @@ function parseToolResult(result) {
   return null;
 }
 
+// ── Host-driven sizing ────────────────────────────────────────────────────
+// The host reports containerDimensions (per-axis: a fixed `height`/`width`, or a
+// `maxHeight`/`maxWidth` cap, or neither = unbounded) and safeAreaInsets. We
+// derive a size mode from the height axis: a fixed height means the host owns
+// our frame size and we fill it (internal scroll); anything else means the app
+// controls its own height and the SDK's autoResize reports it so the host sizes
+// the iframe to content. The CSS branches on html[data-size-mode]; the base
+// (attribute unset) is the fixed/fill layout, so before the first context
+// arrives there is no collapsed-content flash. The steady-state mode is chosen
+// here from the reported height axis, independent of `platform`. Must receive
+// the complete (merged) host context — see the call in handleHostContext. #859.
+function applySizeMode(ctx) {
+  const cd = ctx.containerDimensions;
+  const fixedHeight = !!cd && typeof cd.height === 'number';
+  document.documentElement.dataset.sizeMode = fixedHeight ? 'fixed' : 'flexible';
+  const s = ctx.safeAreaInsets;
+  const root = document.documentElement.style;
+  root.setProperty('--safe-top', (s?.top || 0) + 'px');
+  root.setProperty('--safe-right', (s?.right || 0) + 'px');
+  root.setProperty('--safe-bottom', (s?.bottom || 0) + 'px');
+  root.setProperty('--safe-left', (s?.left || 0) + 'px');
+}
+
 // ── Host theming ─────────────────────────────────────────────────────────
 function handleHostContext(ctx) {
   if (!ctx) return;
+  // onhostcontextchanged delivers a PARTIAL delta (only the changed fields);
+  // the SDK has already merged it into getHostContext(). Derive size mode +
+  // insets from the merged snapshot, not the delta, so an unrelated change
+  // (e.g. a theme-only delta) can't reset them to their absent-field defaults.
+  // Fall back to ctx if no snapshot is available yet.
+  applySizeMode(app.getHostContext() || ctx);
   if (ctx.theme) {
     applyDocumentTheme(ctx.theme);
     window.dispatchEvent(new CustomEvent('vault-theme-changed', { detail: { theme: ctx.theme } }));
@@ -1786,8 +1836,12 @@ if (hostContext) handleHostContext(hostContext);
 
 const fullscreenAvailable = hostContext?.availableDisplayModes?.includes('fullscreen') === true;
 updateFullscreenButton(fullscreenAvailable);
-// Auto-expand on first load — complex multi-view app benefits from more space
-if (fullscreenAvailable && !isFullscreen) {
+// Auto-expand on first load — a complex multi-view app benefits from more space
+// on desktop/web. NOT on mobile: there fullscreen is the whole screen with no
+// working return path on some hosts (leaving it can tear the app down), and the
+// content-driven inline layout is the right default (#859). platform may be
+// undefined on older hosts — treat that as non-mobile so desktop is unchanged.
+if (fullscreenAvailable && !isFullscreen && hostContext?.platform !== 'mobile') {
   app.requestDisplayMode({ mode: 'fullscreen' }).catch(() => {});
 }
 

--- a/src/markdown_vault_mcp/static/spa/core.js
+++ b/src/markdown_vault_mcp/static/spa/core.js
@@ -7,10 +7,16 @@ import { App, applyDocumentTheme, applyHostStyleVariables, applyHostFonts }
 try {
 
 // ── Globals ──────────────────────────────────────────────────────────────
+// autoResize:true (the SDK default) — the SDK observes our content size and
+// reports it to the host via size-changed so the host can size the iframe. The
+// app pairs this with containerDimensions-aware CSS (see applySizeMode): a
+// fixed-height host frame is filled with internal scroll; a flexible/unbounded
+// frame (mobile inline, sidebars) grows to content. Disabling autoResize + a
+// hard height:100vh left mobile hosts unable to learn our height (#859).
 const app = new App(
   { name: "Vault Explorer", version: "1.0.0" },
   {},
-  { autoResize: false }
+  { autoResize: true }
 );
 let currentTab = 'context';
 let isFullscreen = false;
@@ -43,9 +49,38 @@ function parseToolResult(result) {
   return null;
 }
 
+// ── Host-driven sizing ────────────────────────────────────────────────────
+// The host reports containerDimensions (per-axis: a fixed `height`/`width`, or a
+// `maxHeight`/`maxWidth` cap, or neither = unbounded) and safeAreaInsets. We
+// derive a size mode from the height axis: a fixed height means the host owns
+// our frame size and we fill it (internal scroll); anything else means the app
+// controls its own height and the SDK's autoResize reports it so the host sizes
+// the iframe to content. The CSS branches on html[data-size-mode]; the base
+// (attribute unset) is the fixed/fill layout, so before the first context
+// arrives there is no collapsed-content flash. The steady-state mode is chosen
+// here from the reported height axis, independent of `platform`. Must receive
+// the complete (merged) host context — see the call in handleHostContext. #859.
+function applySizeMode(ctx) {
+  const cd = ctx.containerDimensions;
+  const fixedHeight = !!cd && typeof cd.height === 'number';
+  document.documentElement.dataset.sizeMode = fixedHeight ? 'fixed' : 'flexible';
+  const s = ctx.safeAreaInsets;
+  const root = document.documentElement.style;
+  root.setProperty('--safe-top', (s?.top || 0) + 'px');
+  root.setProperty('--safe-right', (s?.right || 0) + 'px');
+  root.setProperty('--safe-bottom', (s?.bottom || 0) + 'px');
+  root.setProperty('--safe-left', (s?.left || 0) + 'px');
+}
+
 // ── Host theming ─────────────────────────────────────────────────────────
 function handleHostContext(ctx) {
   if (!ctx) return;
+  // onhostcontextchanged delivers a PARTIAL delta (only the changed fields);
+  // the SDK has already merged it into getHostContext(). Derive size mode +
+  // insets from the merged snapshot, not the delta, so an unrelated change
+  // (e.g. a theme-only delta) can't reset them to their absent-field defaults.
+  // Fall back to ctx if no snapshot is available yet.
+  applySizeMode(app.getHostContext() || ctx);
   if (ctx.theme) {
     applyDocumentTheme(ctx.theme);
     window.dispatchEvent(new CustomEvent('vault-theme-changed', { detail: { theme: ctx.theme } }));
@@ -202,8 +237,12 @@ if (hostContext) handleHostContext(hostContext);
 
 const fullscreenAvailable = hostContext?.availableDisplayModes?.includes('fullscreen') === true;
 updateFullscreenButton(fullscreenAvailable);
-// Auto-expand on first load — complex multi-view app benefits from more space
-if (fullscreenAvailable && !isFullscreen) {
+// Auto-expand on first load — a complex multi-view app benefits from more space
+// on desktop/web. NOT on mobile: there fullscreen is the whole screen with no
+// working return path on some hosts (leaving it can tear the app down), and the
+// content-driven inline layout is the right default (#859). platform may be
+// undefined on older hosts — treat that as non-mobile so desktop is unchanged.
+if (fullscreenAvailable && !isFullscreen && hostContext?.platform !== 'mobile') {
   app.requestDisplayMode({ mode: 'fullscreen' }).catch(() => {});
 }
 

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -54,6 +54,13 @@
     --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  /* Sizing model (#859): the host tells us via containerDimensions whether it
+     gives a fixed-height frame or a flexible/unbounded one; core.js sets
+     html[data-size-mode] and the safe-area vars accordingly. Base (attribute
+     unset) = fixed/fill; it is the pre-context default (no collapsed-content
+     flash before the host context arrives) and also the steady state for a
+     fixed-height host. The mode is chosen from the reported dimensions, not the
+     platform. */
   body {
     font-family: var(--font-body);
     background: var(--panel);
@@ -67,7 +74,15 @@
     display: flex;
     flex-direction: column;
     height: 100vh;
+    /* safe-area insets (mobile notches / system UI); 0 until the host reports
+       them. border-box (set globally) keeps the box at 100vh incl. padding. */
+    padding: var(--safe-top, 0px) var(--safe-right, 0px) var(--safe-bottom, 0px) var(--safe-left, 0px);
   }
+  /* Flexible/unbounded frame (mobile inline, sidebars): grow to content and let
+     the SDK's autoResize report our height so the host sizes the iframe. Do NOT
+     pin to 100vh here — inside a content-sized iframe vh is circular. */
+  html[data-size-mode="flexible"] body { height: auto; overflow: visible; }
+  html[data-size-mode="flexible"] .app-container { height: auto; }
   /* Tab bar */
   .tab-bar {
     display: flex;

--- a/tests/test_mcp_apps_foundation.py
+++ b/tests/test_mcp_apps_foundation.py
@@ -162,6 +162,72 @@ class TestSPAShellResource:
             assert "fullscreenBtn" in html
             assert "requestDisplayMode" in html
 
+    async def test_html_sizing_is_container_dimensions_aware(self) -> None:
+        """#859: the app must derive its size mode from the host's
+        containerDimensions (fixed height -> fill/scroll; flexible -> grow to
+        content) instead of hard-pinning height:100vh. Anchored to the
+        view-specific applySizeMode logic and the flexible CSS branch, not
+        vendored-library text."""
+        server = make_server()
+        async with Client(server) as client:
+            resource = await client.read_resource("ui://vault/app.html")
+            html = (
+                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
+            )
+            assert "applySizeMode" in html
+            assert "containerDimensions" in html
+            assert "data-size-mode" in html
+            # Must derive size mode from the merged host snapshot, not the
+            # partial onhostcontextchanged delta — else a theme-only delta
+            # (no containerDimensions) would reset the mode. This also pins the
+            # call site, so deleting the wiring can't stay green.
+            assert "applySizeMode(app.getHostContext() || ctx)" in html
+            # The flexible branch must relax the height pin so content drives —
+            # assert the actual declaration, not just the selector, so a revert
+            # to height:100vh in that branch can't stay green (would reintroduce
+            # the collapsed-to-top-third bug).
+            assert 'html[data-size-mode="flexible"] body { height: auto' in html
+
+    async def test_html_enables_autoresize(self) -> None:
+        """#859: autoResize must be on so the SDK reports the app's content
+        height and the host can size the iframe. The old `autoResize: false`
+        (which left mobile hosts unable to learn our height) must be gone."""
+        server = make_server()
+        async with Client(server) as client:
+            resource = await client.read_resource("ui://vault/app.html")
+            html = (
+                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
+            )
+            assert "autoResize: true" in html
+            assert "autoResize: false" not in html
+
+    async def test_html_auto_fullscreen_skips_mobile(self) -> None:
+        """#859: auto-fullscreen on load must be gated off mobile, where
+        fullscreen has no reliable return path and the inline layout is the
+        right default."""
+        server = make_server()
+        async with Client(server) as client:
+            resource = await client.read_resource("ui://vault/app.html")
+            html = (
+                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
+            )
+            assert "platform !== 'mobile'" in html
+
+    async def test_html_applies_safe_area_insets(self) -> None:
+        """#859: the app must consume the host's safeAreaInsets so content
+        clears mobile notches / system UI."""
+        server = make_server()
+        async with Client(server) as client:
+            resource = await client.read_resource("ui://vault/app.html")
+            html = (
+                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
+            )
+            assert "safeAreaInsets" in html
+            # The layout must actually consume the insets, not just define the
+            # vars — assert the padding declaration so dropping it (while the JS
+            # still sets --safe-*) can't stay green.
+            assert "padding: var(--safe-top" in html
+
     async def test_html_contains_ontoolinput(self) -> None:
         server = make_server()
         async with Client(server) as client:


### PR DESCRIPTION
## Problem

Issue #859: on **Claude for Android** the Vault Explorer app renders into only the top third of the frame, with no working inline mode.

`core.js` opted out of the SDK's sizing mechanism (`autoResize: false`) and hard-pinned `height: 100vh` on `body`/`.app-container`. That combination is only correct when the host provides a **fixed-height** container: the app never reported its content height, so a host that hands it a **flexible** frame (mobile inline) left the iframe at a small/stale height with content clipped to the top and the host's background below. Git archaeology confirms this sizing model is **byte-for-byte identical pre/post Epic #809** — it was never spec-conformant; it merely happened to work wherever fullscreen mapped to a fixed full-screen iframe that `100vh` filled. The likely trigger is a host-side change (a flexible container on mobile) exposing the latent bug.

## Fix

Honor the MCP Apps sizing contract:

- **Enable `autoResize`** (the SDK default) so the SDK reports content size via `size-changed` and the host sizes the iframe.
- **Derive a size mode from the host's `containerDimensions`**: a fixed `height` axis → the host owns the frame (fill it, scroll internally); a `maxHeight`/unbounded axis → the app controls its own height and grows to content. `core.js` sets `html[data-size-mode]`; CSS branches on it. Base (attribute unset) is the fixed/fill layout, so desktop is unchanged and there is no collapsed-content flash.
- **Read from the merged host snapshot**, not the partial `onhostcontextchanged` delta: `applySizeMode(app.getHostContext() || ctx)`. The SDK merges each delta into `getHostContext()` before invoking the handler, so deriving size mode from the delta would let an unrelated change (e.g. a theme toggle) reset it.
- **Apply `safeAreaInsets`** as padding so content clears mobile notches / system UI.
- **Gate auto-fullscreen off mobile** (`platform !== 'mobile'`), where fullscreen has no reliable inline return path; desktop/web auto-expand is unchanged.

The size mode is derived from the reported **dimensions alone**, not `platform` (which only gates auto-fullscreen).

## Verification

- **Browser-verified** the size-mode CSS branch: flexible mode grows `body` to content (3188px for tall content vs an 840px viewport) while fixed clamps and scrolls internally; safe-area insets apply as container padding; the built `app.html` loads and the module executes.
- The partial-delta fix is grounded in the ext-apps 1.3.1 SDK source (`app.ts:532` merges the delta into `_hostContext`; `getHostContext()` returns the merged context inside the callback).
- New string-assertion tests pin the fix in the built bundle — including the flexible-branch `height: auto` declaration, the safe-area `padding: var(--safe-top` consumption, and the merged-context call — and fail on the pre-fix code (verified empirically).
- Gates: ruff/mypy clean, full suite **2664 passed**, `diff-quality` 100%. Preflight-circus clean (a partial-delta regression it caught mid-review is fixed and re-verified against the SDK).
- **On-device (mobile + desktop) is the final acceptance check** — a static-bundle test suite cannot observe runtime iframe sizing.

## Follow-ups (out of scope here)

- A separate upstream step should bump the template-owned ext-apps SDK pin (`vendor_spa.py`) **1.3.1 → 1.7.4** (fleet-wide), for the residual autoResize width-measurement fix (ext-apps PR #567); this PR does not change it. The App API we import is verified stable across that bump.
- Symptom "Exit Fullscreen quits the app" is host-side; correct inline sizing should stop the post-exit collapse, but full confirmation is part of on-device verification.

Refs #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
