### PR TITLE
fix: inherit host neutrals, keep Paper terracotta accent (drop blue info alias)

### DIFF
--- a/src/markdown_vault_mcp/static/app.html
+++ b/src/markdown_vault_mcp/static/app.html
@@ -128,33 +128,27 @@ if(__exports != exports)module.exports = exports;return module.exports}));
 </script>
 <style>
   :root {
-    /* Host theme vars — the fallback VALUES carry the Paper "light" identity,
-       so a host that pushes its own --color-* overrides Paper; otherwise Paper
-       shows. The Paper semantic tokens below map onto these. */
-    --color-background-primary: #fbf8f1;
-    --color-background-secondary: #f2ecdf;
-    --color-text-primary: #2a2620;
-    --color-text-secondary: #7a7161;
-    --color-text-inverse: #ffffff;
-    --color-text-info: #b25a35;
-    --color-text-success: #22c55e;
-    --color-text-danger: #b4472c;
-    --color-border-primary: #e4dbc9;
-    /* Paper semantic tokens (map onto host vars so the host can override) */
-    --panel: var(--color-background-primary);
-    --panel-2: var(--color-background-secondary);
-    --ink: var(--color-text-primary);
-    --muted: var(--color-text-secondary);
-    --border: var(--color-border-primary);
-    --accent: var(--color-text-info);
-    --accent-ink: var(--color-text-inverse);
-    /* Paper-only tokens (no host equivalent; flip under [data-theme="dark"]) */
-    --page: #eceae4;
-    --ink-2: #5c5446;
-    --border-2: #efe8d9;
-    --edge: #d3c7ad;
+    /* Neutrals: inherit the host's chrome, fall back to Paper "light". A host
+       that pushes its own --color-* wins; otherwise the Paper fallback shows. */
+    --panel:     var(--color-background-primary,   #fbf8f1);
+    --panel-2:   var(--color-background-secondary, #f2ecdf);
+    --ink:       var(--color-text-primary,         #2a2620);
+    --ink-2:     var(--color-text-secondary,       #5c5446);
+    --muted:     var(--color-text-tertiary,        #928975);
+    --border:    var(--color-border-primary,       #e4dbc9);
+    --border-2:  var(--color-border-secondary,     #efe8d9);
+    --edge:      var(--color-border-primary,       #d3c7ad);   /* graph link color */
+    /* Accent: ALWAYS Paper terracotta — never aliased to a host semantic slot,
+       or the host's blue "info" color leaks into links/tabs/buttons. By SDK
+       convention the host supplies the neutral/semantic ramp; the accent is the
+       app's own token (ext-apps ref theme: basic-server-*/global.css). */
+    --accent:      #b25a35;
+    --accent-ink:  #ffffff;
     --accent-soft: #f3e4d8;
-    --warn: #b4472c;
+    /* Semantic state: host danger with a Paper fallback (the "missing" badge). */
+    --warn: var(--color-text-danger, #b4472c);
+    /* Paper-only structural tokens (no host equivalent; some flip in dark). */
+    --page: #eceae4;
     --radius: 11px;
     --radius-sm: 7px;
     --pad: 15px;
@@ -164,21 +158,19 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
   }
   [data-theme="dark"] {
-    --color-background-primary: #252118;
-    --color-background-secondary: #2e281d;
-    --color-text-primary: #ece4d4;
-    --color-text-secondary: #978d78;
-    --color-text-inverse: #241a12;
-    --color-text-info: #d68a5f;
-    --color-text-success: #4ade80;
-    --color-text-danger: #e08163;
-    --color-border-primary: #39311f;
-    --page: #111112;
-    --ink-2: #bcb29c;
-    --border-2: #433a26;
-    --edge: #4c4230;
+    --panel:     var(--color-background-primary,   #252118);
+    --panel-2:   var(--color-background-secondary, #2e281d);
+    --ink:       var(--color-text-primary,         #ece4d4);
+    --ink-2:     var(--color-text-secondary,       #bcb29c);
+    --muted:     var(--color-text-tertiary,        #8f8571);
+    --border:    var(--color-border-primary,       #39311f);
+    --border-2:  var(--color-border-secondary,     #433a26);
+    --edge:      var(--color-border-primary,       #4c4230);
+    --accent:      #d68a5f;
+    --accent-ink:  #241a12;
     --accent-soft: #39291d;
-    --warn: #e08163;
+    --warn: var(--color-text-danger, #e08163);
+    --page: #111112;
     --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -305,17 +297,17 @@ if(__exports != exports)module.exports = exports;return module.exports}));
   .ghost-btn:hover { color: var(--ink); border-color: var(--muted); }
   .accent-btn { background: var(--accent); border: 1px solid var(--accent); color: var(--accent-ink); }
   .accent-btn:hover { opacity: 0.9; }
-  /* Legacy action buttons — still used by the graph toolbar; they pick up Paper
-     colors via the --color-* mapping until that view is restyled. */
+  /* Legacy action buttons — graph toolbar. Primary uses the Paper accent, the
+     secondary variant uses Paper neutrals. */
   .action-btn {
-    background: var(--color-text-info); color: var(--color-text-inverse); border: none; padding: 4px 10px;
+    background: var(--accent); color: var(--accent-ink); border: none; padding: 4px 10px;
     border-radius: var(--radius-sm); cursor: pointer; font-size: 12px; font-family: var(--font-body); white-space: nowrap;
   }
   .action-btn:hover { opacity: 0.85; }
   .action-btn--secondary {
-    background: var(--color-background-secondary);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-border-primary);
+    background: var(--panel-2);
+    color: var(--ink);
+    border: 1px solid var(--border);
   }
   .action-btn.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
   /* Context card */
@@ -563,7 +555,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     font: 600 11px/1 var(--font-body); cursor: not-allowed; opacity: 0.7; margin-left: auto;
   }
 </style>
-<!-- vendor-spa-source-sha256:83085409fa2bf5c61dda3482773cc0fcabd5a0ca9df956d356443efe6634ca97 -->
+<!-- vendor-spa-source-sha256:e8555bd8d64375296df643dce5b238985c98f41fe756497a40cb17f2e7978b9b -->
 </head>
 <body>
 <div class="app-container">
@@ -1165,7 +1157,7 @@ app.onteardown = () => {
     // Resolve each token to a concrete rgb() string via a probe element.
     // getComputedStyle(documentElement).getPropertyValue('--panel') can return
     // the literal "var(--color-background-primary)" when a Paper token is an
-    // indirection (styles.css maps --panel/--ink/--accent/... onto --color-*).
+    // indirection (styles.css maps --panel/--ink/... onto host --color-* tokens).
     // Modern Chromium resolves that, but older Chromium (Claude Desktop's
     // Electron) returns the unresolved string, which canvas fillStyle can't
     // parse -> vis-network paints black. Assigning `var(...)` to a real
@@ -1980,7 +1972,7 @@ console.log('Vault Explorer connected');
   console.error('Vault Explorer error:', err);
   const container = document.querySelector('.app-container');
   const el = document.createElement('div');
-  el.style.cssText = 'padding:24px;text-align:center;color:var(--color-text-secondary);';
+  el.style.cssText = 'padding:24px;text-align:center;color:var(--ink-2);';
   const h = document.createElement('h2');
   h.textContent = 'Vault Explorer';
   const p1 = document.createElement('p');

--- a/src/markdown_vault_mcp/static/app.src.html
+++ b/src/markdown_vault_mcp/static/app.src.html
@@ -14,33 +14,27 @@
 <script src="https://unpkg.com/dompurify@3.3.3/dist/purify.min.js"></script>
 <style>
   :root {
-    /* Host theme vars — the fallback VALUES carry the Paper "light" identity,
-       so a host that pushes its own --color-* overrides Paper; otherwise Paper
-       shows. The Paper semantic tokens below map onto these. */
-    --color-background-primary: #fbf8f1;
-    --color-background-secondary: #f2ecdf;
-    --color-text-primary: #2a2620;
-    --color-text-secondary: #7a7161;
-    --color-text-inverse: #ffffff;
-    --color-text-info: #b25a35;
-    --color-text-success: #22c55e;
-    --color-text-danger: #b4472c;
-    --color-border-primary: #e4dbc9;
-    /* Paper semantic tokens (map onto host vars so the host can override) */
-    --panel: var(--color-background-primary);
-    --panel-2: var(--color-background-secondary);
-    --ink: var(--color-text-primary);
-    --muted: var(--color-text-secondary);
-    --border: var(--color-border-primary);
-    --accent: var(--color-text-info);
-    --accent-ink: var(--color-text-inverse);
-    /* Paper-only tokens (no host equivalent; flip under [data-theme="dark"]) */
-    --page: #eceae4;
-    --ink-2: #5c5446;
-    --border-2: #efe8d9;
-    --edge: #d3c7ad;
+    /* Neutrals: inherit the host's chrome, fall back to Paper "light". A host
+       that pushes its own --color-* wins; otherwise the Paper fallback shows. */
+    --panel:     var(--color-background-primary,   #fbf8f1);
+    --panel-2:   var(--color-background-secondary, #f2ecdf);
+    --ink:       var(--color-text-primary,         #2a2620);
+    --ink-2:     var(--color-text-secondary,       #5c5446);
+    --muted:     var(--color-text-tertiary,        #928975);
+    --border:    var(--color-border-primary,       #e4dbc9);
+    --border-2:  var(--color-border-secondary,     #efe8d9);
+    --edge:      var(--color-border-primary,       #d3c7ad);   /* graph link color */
+    /* Accent: ALWAYS Paper terracotta — never aliased to a host semantic slot,
+       or the host's blue "info" color leaks into links/tabs/buttons. By SDK
+       convention the host supplies the neutral/semantic ramp; the accent is the
+       app's own token (ext-apps ref theme: basic-server-*/global.css). */
+    --accent:      #b25a35;
+    --accent-ink:  #ffffff;
     --accent-soft: #f3e4d8;
-    --warn: #b4472c;
+    /* Semantic state: host danger with a Paper fallback (the "missing" badge). */
+    --warn: var(--color-text-danger, #b4472c);
+    /* Paper-only structural tokens (no host equivalent; some flip in dark). */
+    --page: #eceae4;
     --radius: 11px;
     --radius-sm: 7px;
     --pad: 15px;
@@ -50,21 +44,19 @@
     --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
   }
   [data-theme="dark"] {
-    --color-background-primary: #252118;
-    --color-background-secondary: #2e281d;
-    --color-text-primary: #ece4d4;
-    --color-text-secondary: #978d78;
-    --color-text-inverse: #241a12;
-    --color-text-info: #d68a5f;
-    --color-text-success: #4ade80;
-    --color-text-danger: #e08163;
-    --color-border-primary: #39311f;
-    --page: #111112;
-    --ink-2: #bcb29c;
-    --border-2: #433a26;
-    --edge: #4c4230;
+    --panel:     var(--color-background-primary,   #252118);
+    --panel-2:   var(--color-background-secondary, #2e281d);
+    --ink:       var(--color-text-primary,         #ece4d4);
+    --ink-2:     var(--color-text-secondary,       #bcb29c);
+    --muted:     var(--color-text-tertiary,        #8f8571);
+    --border:    var(--color-border-primary,       #39311f);
+    --border-2:  var(--color-border-secondary,     #433a26);
+    --edge:      var(--color-border-primary,       #4c4230);
+    --accent:      #d68a5f;
+    --accent-ink:  #241a12;
     --accent-soft: #39291d;
-    --warn: #e08163;
+    --warn: var(--color-text-danger, #e08163);
+    --page: #111112;
     --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -191,17 +183,17 @@
   .ghost-btn:hover { color: var(--ink); border-color: var(--muted); }
   .accent-btn { background: var(--accent); border: 1px solid var(--accent); color: var(--accent-ink); }
   .accent-btn:hover { opacity: 0.9; }
-  /* Legacy action buttons — still used by the graph toolbar; they pick up Paper
-     colors via the --color-* mapping until that view is restyled. */
+  /* Legacy action buttons — graph toolbar. Primary uses the Paper accent, the
+     secondary variant uses Paper neutrals. */
   .action-btn {
-    background: var(--color-text-info); color: var(--color-text-inverse); border: none; padding: 4px 10px;
+    background: var(--accent); color: var(--accent-ink); border: none; padding: 4px 10px;
     border-radius: var(--radius-sm); cursor: pointer; font-size: 12px; font-family: var(--font-body); white-space: nowrap;
   }
   .action-btn:hover { opacity: 0.85; }
   .action-btn--secondary {
-    background: var(--color-background-secondary);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-border-primary);
+    background: var(--panel-2);
+    color: var(--ink);
+    border: 1px solid var(--border);
   }
   .action-btn.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
   /* Context card */
@@ -1047,7 +1039,7 @@ app.onteardown = () => {
     // Resolve each token to a concrete rgb() string via a probe element.
     // getComputedStyle(documentElement).getPropertyValue('--panel') can return
     // the literal "var(--color-background-primary)" when a Paper token is an
-    // indirection (styles.css maps --panel/--ink/--accent/... onto --color-*).
+    // indirection (styles.css maps --panel/--ink/... onto host --color-* tokens).
     // Modern Chromium resolves that, but older Chromium (Claude Desktop's
     // Electron) returns the unresolved string, which canvas fillStyle can't
     // parse -> vis-network paints black. Assigning `var(...)` to a real
@@ -1862,7 +1854,7 @@ console.log('Vault Explorer connected');
   console.error('Vault Explorer error:', err);
   const container = document.querySelector('.app-container');
   const el = document.createElement('div');
-  el.style.cssText = 'padding:24px;text-align:center;color:var(--color-text-secondary);';
+  el.style.cssText = 'padding:24px;text-align:center;color:var(--ink-2);';
   const h = document.createElement('h2');
   h.textContent = 'Vault Explorer';
   const p1 = document.createElement('p');

--- a/src/markdown_vault_mcp/static/spa/core.js
+++ b/src/markdown_vault_mcp/static/spa/core.js
@@ -263,7 +263,7 @@ console.log('Vault Explorer connected');
   console.error('Vault Explorer error:', err);
   const container = document.querySelector('.app-container');
   const el = document.createElement('div');
-  el.style.cssText = 'padding:24px;text-align:center;color:var(--color-text-secondary);';
+  el.style.cssText = 'padding:24px;text-align:center;color:var(--ink-2);';
   const h = document.createElement('h2');
   h.textContent = 'Vault Explorer';
   const p1 = document.createElement('p');

--- a/src/markdown_vault_mcp/static/spa/styles.css
+++ b/src/markdown_vault_mcp/static/spa/styles.css
@@ -1,32 +1,26 @@
 
   :root {
-    /* Host theme vars — the fallback VALUES carry the Paper "light" identity,
-       so a host that pushes its own --color-* overrides Paper; otherwise Paper
-       shows. The Paper semantic tokens below map onto these. */
-    --color-background-primary: #fbf8f1;
-    --color-background-secondary: #f2ecdf;
-    --color-text-primary: #2a2620;
-    --color-text-secondary: #7a7161;
-    --color-text-inverse: #ffffff;
-    --color-text-info: #b25a35;
-    --color-text-success: #22c55e;
-    --color-text-danger: #b4472c;
-    --color-border-primary: #e4dbc9;
-    /* Paper semantic tokens (map onto host vars so the host can override) */
-    --panel: var(--color-background-primary);
-    --panel-2: var(--color-background-secondary);
-    --ink: var(--color-text-primary);
-    --muted: var(--color-text-secondary);
-    --border: var(--color-border-primary);
-    --accent: var(--color-text-info);
-    --accent-ink: var(--color-text-inverse);
-    /* Paper-only tokens (no host equivalent; flip under [data-theme="dark"]) */
-    --page: #eceae4;
-    --ink-2: #5c5446;
-    --border-2: #efe8d9;
-    --edge: #d3c7ad;
+    /* Neutrals: inherit the host's chrome, fall back to Paper "light". A host
+       that pushes its own --color-* wins; otherwise the Paper fallback shows. */
+    --panel:     var(--color-background-primary,   #fbf8f1);
+    --panel-2:   var(--color-background-secondary, #f2ecdf);
+    --ink:       var(--color-text-primary,         #2a2620);
+    --ink-2:     var(--color-text-secondary,       #5c5446);
+    --muted:     var(--color-text-tertiary,        #928975);
+    --border:    var(--color-border-primary,       #e4dbc9);
+    --border-2:  var(--color-border-secondary,     #efe8d9);
+    --edge:      var(--color-border-primary,       #d3c7ad);   /* graph link color */
+    /* Accent: ALWAYS Paper terracotta — never aliased to a host semantic slot,
+       or the host's blue "info" color leaks into links/tabs/buttons. By SDK
+       convention the host supplies the neutral/semantic ramp; the accent is the
+       app's own token (ext-apps ref theme: basic-server-*/global.css). */
+    --accent:      #b25a35;
+    --accent-ink:  #ffffff;
     --accent-soft: #f3e4d8;
-    --warn: #b4472c;
+    /* Semantic state: host danger with a Paper fallback (the "missing" badge). */
+    --warn: var(--color-text-danger, #b4472c);
+    /* Paper-only structural tokens (no host equivalent; some flip in dark). */
+    --page: #eceae4;
     --radius: 11px;
     --radius-sm: 7px;
     --pad: 15px;
@@ -36,21 +30,19 @@
     --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
   }
   [data-theme="dark"] {
-    --color-background-primary: #252118;
-    --color-background-secondary: #2e281d;
-    --color-text-primary: #ece4d4;
-    --color-text-secondary: #978d78;
-    --color-text-inverse: #241a12;
-    --color-text-info: #d68a5f;
-    --color-text-success: #4ade80;
-    --color-text-danger: #e08163;
-    --color-border-primary: #39311f;
-    --page: #111112;
-    --ink-2: #bcb29c;
-    --border-2: #433a26;
-    --edge: #4c4230;
+    --panel:     var(--color-background-primary,   #252118);
+    --panel-2:   var(--color-background-secondary, #2e281d);
+    --ink:       var(--color-text-primary,         #ece4d4);
+    --ink-2:     var(--color-text-secondary,       #bcb29c);
+    --muted:     var(--color-text-tertiary,        #8f8571);
+    --border:    var(--color-border-primary,       #39311f);
+    --border-2:  var(--color-border-secondary,     #433a26);
+    --edge:      var(--color-border-primary,       #4c4230);
+    --accent:      #d68a5f;
+    --accent-ink:  #241a12;
     --accent-soft: #39291d;
-    --warn: #e08163;
+    --warn: var(--color-text-danger, #e08163);
+    --page: #111112;
     --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 18px 40px -20px rgba(0, 0, 0, .6);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -177,17 +169,17 @@
   .ghost-btn:hover { color: var(--ink); border-color: var(--muted); }
   .accent-btn { background: var(--accent); border: 1px solid var(--accent); color: var(--accent-ink); }
   .accent-btn:hover { opacity: 0.9; }
-  /* Legacy action buttons — still used by the graph toolbar; they pick up Paper
-     colors via the --color-* mapping until that view is restyled. */
+  /* Legacy action buttons — graph toolbar. Primary uses the Paper accent, the
+     secondary variant uses Paper neutrals. */
   .action-btn {
-    background: var(--color-text-info); color: var(--color-text-inverse); border: none; padding: 4px 10px;
+    background: var(--accent); color: var(--accent-ink); border: none; padding: 4px 10px;
     border-radius: var(--radius-sm); cursor: pointer; font-size: 12px; font-family: var(--font-body); white-space: nowrap;
   }
   .action-btn:hover { opacity: 0.85; }
   .action-btn--secondary {
-    background: var(--color-background-secondary);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-border-primary);
+    background: var(--panel-2);
+    color: var(--ink);
+    border: 1px solid var(--border);
   }
   .action-btn.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
   /* Context card */

--- a/src/markdown_vault_mcp/static/spa/views/graph.js
+++ b/src/markdown_vault_mcp/static/spa/views/graph.js
@@ -35,7 +35,7 @@
     // Resolve each token to a concrete rgb() string via a probe element.
     // getComputedStyle(documentElement).getPropertyValue('--panel') can return
     // the literal "var(--color-background-primary)" when a Paper token is an
-    // indirection (styles.css maps --panel/--ink/--accent/... onto --color-*).
+    // indirection (styles.css maps --panel/--ink/... onto host --color-* tokens).
     // Modern Chromium resolves that, but older Chromium (Claude Desktop's
     // Electron) returns the unresolved string, which canvas fillStyle can't
     // parse -> vis-network paints black. Assigning `var(...)` to a real

--- a/tests/test_mcp_apps_context.py
+++ b/tests/test_mcp_apps_context.py
@@ -82,9 +82,12 @@ class TestContextCardHTML:
 
     async def test_host_css_variables(self) -> None:
         html = await get_app_html()
-        assert "var(--color-text-info" in html
+        # Neutral chrome inherits the host's --color-* tokens (with Paper
+        # fallbacks). The accent is NOT among them: aliasing it to the semantic
+        # --color-text-info slot leaked the host's blue into links/tabs/buttons.
         assert "var(--color-border-primary" in html
         assert "var(--color-text-secondary" in html
+        assert "--color-text-info" not in html
 
     async def test_update_model_context_on_view(self) -> None:
         html = await get_app_html()
@@ -224,4 +227,7 @@ class TestNoHardcodedColors:
 
     async def test_accent_fg_color_is_variable(self) -> None:
         html = await get_app_html()
-        assert "var(--color-text-inverse" in html
+        # Accent-on-accent text is consumed via the Paper --accent-ink token
+        # (a literal), not a hardcoded colour or a host semantic slot.
+        assert "var(--accent-ink)" in html
+        assert "--color-text-inverse" not in html

--- a/tests/test_mcp_apps_foundation.py
+++ b/tests/test_mcp_apps_foundation.py
@@ -140,6 +140,75 @@ class TestSPAShellResource:
             assert "--color-background-primary" in html
             assert "--color-text-primary" in html
 
+    async def test_accent_is_paper_literal_not_host_semantic(self) -> None:
+        """The Paper accent ramp is terracotta literals in both themes, never
+        aliased to a host semantic slot (aliasing ``--accent`` to
+        ``--color-text-info`` leaked the host's blue into links/tabs/buttons)."""
+        server = make_server()
+        async with Client(server) as client:
+            resource = await client.read_resource("ui://vault/app.html")
+            html = (
+                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
+            )
+            # Whole class purged — the semantic info/inverse slots must not appear
+            # anywhere (the accent alias and the graph .action-btn both used them).
+            assert "--color-text-info" not in html
+            assert "--color-text-inverse" not in html
+            # The whole accent ramp is Paper literals in both themes. Collapse
+            # whitespace so column alignment in the source isn't load-bearing.
+            norm = " ".join(html.split())
+            accent_literals = [
+                "--accent: #b25a35",  # light
+                "--accent-ink: #ffffff",
+                "--accent-soft: #f3e4d8",
+                "--accent: #d68a5f",  # dark
+                "--accent-ink: #241a12",
+                "--accent-soft: #39291d",
+            ]
+            for decl in accent_literals:
+                assert decl in norm, f"accent not a Paper literal: {decl}"
+            # The graph toolbar's primary button uses the Paper accent.
+            assert "background: var(--accent); color: var(--accent-ink)" in norm
+
+    async def test_neutrals_inherit_host_with_paper_fallback(self) -> None:
+        """Every neutral chrome token (and the ``--warn`` state) inherits its host
+        ``--color-*`` slot with a Paper fallback, in both the light (``:root``)
+        and dark (``[data-theme="dark"]``) blocks. Each is pinned with its
+        theme's fallback hex, so a revert of any token to a hardcoded literal in
+        either theme fails here."""
+        server = make_server()
+        async with Client(server) as client:
+            resource = await client.read_resource("ui://vault/app.html")
+            html = (
+                resource[0].text if hasattr(resource[0], "text") else str(resource[0])
+            )
+            # Collapse whitespace so column alignment in the source isn't load-bearing.
+            norm = " ".join(html.split())
+            host_inherited = [
+                # light (:root) block
+                "--panel: var(--color-background-primary, #fbf8f1)",
+                "--panel-2: var(--color-background-secondary, #f2ecdf)",
+                "--ink: var(--color-text-primary, #2a2620)",
+                "--ink-2: var(--color-text-secondary, #5c5446)",
+                "--muted: var(--color-text-tertiary, #928975)",
+                "--border: var(--color-border-primary, #e4dbc9)",
+                "--border-2: var(--color-border-secondary, #efe8d9)",
+                "--edge: var(--color-border-primary, #d3c7ad)",
+                "--warn: var(--color-text-danger, #b4472c)",
+                # dark ([data-theme="dark"]) block
+                "--panel: var(--color-background-primary, #252118)",
+                "--panel-2: var(--color-background-secondary, #2e281d)",
+                "--ink: var(--color-text-primary, #ece4d4)",
+                "--ink-2: var(--color-text-secondary, #bcb29c)",
+                "--muted: var(--color-text-tertiary, #8f8571)",
+                "--border: var(--color-border-primary, #39311f)",
+                "--border-2: var(--color-border-secondary, #433a26)",
+                "--edge: var(--color-border-primary, #4c4230)",
+                "--warn: var(--color-text-danger, #e08163)",
+            ]
+            for decl in host_inherited:
+                assert decl in norm, f"neutral not host-inherited: {decl}"
+
     async def test_html_handlers_before_connect(self) -> None:
         server = make_server()
         async with Client(server) as client:

--- a/uv.lock
+++ b/uv.lock
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "3.1.0rc1"
+version = "3.1.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

Closes #861.

The SPA (Vault Explorer MCP App) aliased its accent to the host's **semantic info** slot:

```css
--accent: var(--color-text-info);   /* host info state = blue */
```

`--color-text-info` is the host's semantic *info* color (blue), not a UI accent — so this alias injected Claude's blue into links, active tabs, the graph focus node, semantic edges, and buttons. That blue appears nowhere else in the client; **that** was the clash (#861's root-cause line), not blending itself.

This decouples the two layers:

- **Neutrals inherit the host** — `--panel/-2`, `--ink/-2`, `--muted`, `--border/-2`, `--edge` now resolve to `var(--color-*, <Paper fallback>)`, expanded to also pick up `--color-text-tertiary` and `--color-border-secondary` for a fuller native blend (light + dark).
- **Accent is pure Paper terracotta literals** — `--accent`/`--accent-ink`/`--accent-soft`, never aliased to a host semantic slot. Per the ext-apps SDK convention the host supplies only the neutral/semantic ramp; `--color-accent` is the app's own token (see the SDK reference themes, `examples/basic-server-*/src/global.css`, where `--color-accent` is app-defined "customize for your brand"). So Paper owns the accent.
- **`--warn` → `var(--color-text-danger, …)`** — a genuine semantic state (the "missing note" badge).
- Repointed `.action-btn` / `.action-btn--secondary` and the JS error screen off the purged `--color-text-info`/`--color-text-inverse` slots; updated a now-stale `getColors()` comment in `views/graph.js`.

The graph canvas follows automatically via the existing probe (`getColors()` in `views/graph.js`): focus node + semantic edges render terracotta, surfaces/edges take host/Paper neutrals.

## Relationship to #861

#861 proposed pinning the graph's **entire** palette (neutrals included) to Paper literals. This PR instead keeps the graph's neutrals **host-inherited** and pins only the accent to Paper — a deliberate, newer design decision (native blend: surfaces match the host client, terracotta identity stays). #861's actual reported symptom (blue focus pill / semantic edges / highlights) is resolved either way; the "fully-Paper graph" mechanism is intentionally not adopted.

## Not in scope

- **#859 (mobile display-mode/sizing)** is a separate subsystem (already handled by #860, in `main`); this change touches only the color/token layer.
- **Graph-canvas color resolution** remains covered by the `getColors()` probe (older Electron/Chromium can't resolve `var()` indirection on canvas), not by these token tests — unchanged by this PR.

## Tests

`tests/test_mcp_apps_foundation.py`: new `test_accent_is_paper_literal_not_host_semantic` (pins all three accent tokens as literals in both themes; asserts the `--color-text-info`/`--color-text-inverse` class is purged everywhere) and `test_neutrals_inherit_host_with_paper_fallback` (pins every neutral + `--warn` as host-inherited with its theme-specific fallback in both the `:root` and `[data-theme="dark"]` blocks). `tests/test_mcp_apps_context.py`: rewrote two tests that had encoded the old host-semantic aliases. Full suite: 2666 passed; mypy, ruff, structural diff (100%), and build/vendor reproducibility all green.

## Note

Includes an incidental `uv.lock` sync (`3.1.0rc1 → rc2`) that `uv` regenerates on any invocation — `main`'s lock was stale relative to the `3.1.0-rc.2` version bump.

## Verification

Token wiring is confirmed against the ext-apps host-styling contract, so no live host probe is needed to validate correctness. What remains is an on-device visual pass in Claude Desktop (light + dark) to confirm the exact host hues balance well; fallbacks render as Paper in a plain browser.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
