### PR TITLE
fix: hybrid search vector channel misses folder normalization

### DIFF
--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -958,15 +958,9 @@ class SearchManager:
 
         vectors = self._load_vectors()
         vec_raw = vectors.search(query, limit=vec_candidate_limit)
-        vec_filtered: list[dict[str, Any]] = []
-        for r in vec_raw:
-            if folder is not None:
-                r_folder = r.get("folder", "")
-                if r_folder != folder and not r_folder.startswith(folder + "/"):
-                    continue
-            if filters and not self._row_matches_filters(r["path"], filters):
-                continue
-            vec_filtered.append(r)
+        vec_filtered = self._post_filter_semantic_rows(
+            vec_raw, folder=folder, filters=filters
+        )
 
         vec_chunk_counts = self._fts.get_chunk_counts({r["path"] for r in vec_filtered})
         vec_rows: list[_SemanticRow] = [

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -840,6 +840,28 @@ def test_hybrid_search_caps_per_file_after_rrf(
         assert len(r.sections) <= 1
 
 
+def test_hybrid_folder_filter_normalizes_trailing_slash(
+    search_mgr_with_embeddings: SearchManager,
+) -> None:
+    """Hybrid's vector channel shares semantic's folder normalization (#878).
+
+    A natural ``"notes/"`` (trailing slash) must not silently filter the
+    vector channel to nothing while ``mode="semantic"`` handles the same
+    input correctly.
+    """
+    with_slash = search_mgr_with_embeddings.search(
+        "world", mode="hybrid", folder="notes/", limit=10
+    )
+    assert with_slash, "expected hybrid results within notes/"
+    assert all(r.path.startswith("notes/") for r in with_slash)
+    # The vector channel must surface the same files the semantic mode does
+    # for the identical un-normalized input.
+    semantic = search_mgr_with_embeddings.search(
+        "world", mode="semantic", folder="notes/", limit=10
+    )
+    assert {r.path for r in with_slash} == {r.path for r in semantic}
+
+
 def test_hybrid_search_uses_fts_snippet_for_keyword_hits(
     search_mgr_with_embeddings: SearchManager,
 ) -> None:


### PR DESCRIPTION
Closes #878. Refs #759.

## What

`_hybrid_search` carried an inline copy of the semantic post-filter that predates the folder normalization added to `_post_filter_semantic_rows` in #877, so `search(mode="hybrid", folder="X/")` (trailing slash or backslashes) silently dropped every vector-channel candidate while `mode="semantic"` handled the same input correctly — a concrete instance of the duplication tax documented in the #759 investigation.

## Change

- Replace the inline filter loop in `_hybrid_search` with a call to the shared `_post_filter_semantic_rows` helper (net −9/+3 lines in `managers/search.py`).
- Add `test_hybrid_folder_filter_normalizes_trailing_slash`, pinning both the non-empty result for `folder="notes/"` and set-equality with the semantic channel for the identical un-normalized input.

Deliberately **not** in scope (tracked in #878's "wider inconsistency" section): normalizing the keyword channel and deciding the `""` (root-only vs no-restriction) semantics across channels — that's a small design decision, not a mechanical fix.

## Gates

- `uv run pytest -x -q`: 2855 passed, 6 skipped
- `ruff check --fix` / `ruff format --check`: clean
- `mypy src/ tests/`: clean
- `diff-quality --fail-under=100`: 100%
- Patch coverage: changed lines exercised by the new test plus the existing hybrid suite (`managers/search.py` at 90% from `test_managers_search.py` alone)

## Context

This branch also carried the maintainability audit requested for this session: investigation assessments posted on #759–#763, new issues #878–#881 opened for untracked decay, and a coupling note on #727 regarding Dependabot #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa)_