### PR TITLE
fix: recover keyword/hybrid search for hyphenated terms (#866)

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -81,6 +81,8 @@ Find documents matching a query using full-text or semantic search.
     - Use `mode="semantic"` for meaning-based similarity
     - Check `stats` to see if `semantic_search_available` is true
 
+    Keyword and hybrid modes accept FTS5 operators (`AND`, `OR`, `NEAR`, `"exact phrase"`, `prefix*`). A natural-language query whose terms contain characters FTS5 reserves (a hyphenated slug such as `vault-mcp`, or a colon) is matched literally rather than failing, so plain queries do not need escaping.
+
 **Example usage:**
 
 ```json

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -220,6 +220,49 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def _is_fts5_query_error(exc: sqlite3.OperationalError) -> bool:
+    """True when an ``OperationalError`` is an FTS5 *query-syntax* error.
+
+    Distinguishes a malformed MATCH expression (user input problem, safe to
+    recover from) from an environmental error such as a database lock (must
+    propagate). Matches the error strings SQLite emits for FTS5 query
+    problems: ``fts5: syntax error``, ``no such column`` (a bareword parsed as
+    a column filter), and ``unterminated string``.
+    """
+    msg = str(exc).lower()
+    return (
+        "fts5" in msg
+        or "syntax error" in msg
+        or "no such column" in msg
+        or "unterminated" in msg
+    )
+
+
+def _quote_fts_query(query: str) -> str:
+    """Quote each whitespace-separated token as an FTS5 string literal.
+
+    FTS5 query syntax treats characters like ``-`` and ``:`` between barewords
+    as operators/column filters, so a natural-language query such as
+    ``File-back Ingest Lint`` or a slug like ``vault-mcp`` is rejected with an
+    ``OperationalError`` (#866). Wrapping each token in a string literal
+    (``"File-back" "Ingest" "Lint"`` — case is preserved; FTS5's tokenizer
+    handles case-folding) turns the query into an implicit-AND of phrase
+    literals: the special characters are matched literally, a compound
+    like ``File-back`` becomes an adjacency phrase over its tokens, and no
+    token can be mistaken for an operator or column reference. Internal quotes
+    are escaped by doubling, per FTS5's literal grammar.
+
+    Args:
+        query: The raw user query that FTS5 rejected.
+
+    Returns:
+        A space-joined string of quoted literals, or ``""`` when *query* has
+        no tokens (the caller then returns no results).
+    """
+    tokens = query.split()
+    return " ".join(f'"{token.replace(chr(34), chr(34) * 2)}"' for token in tokens)
+
+
 def _derive_folder(path: str) -> str:
     """Derive the folder from a document's relative path.
 
@@ -1066,7 +1109,14 @@ class FTSIndex:
         """Full-text search using BM25 ranking.
 
         Args:
-            query: FTS5 query string.
+            query: FTS5 query string. Well-formed operator syntax (``AND`` /
+                ``OR`` / ``NEAR`` / phrases / prefixes) is honoured as-is. A
+                query FTS5 rejects as malformed — most commonly a
+                natural-language query with a hyphenated term or slug (e.g.
+                ``vault-mcp``), which parses as a column filter — is retried
+                once with every token quoted as a phrase literal, so it
+                degrades to an implicit-AND term search instead of returning
+                ``[]`` (#866).
             limit: Maximum number of results to return.
             folder: If provided, only return documents whose ``folder``
                 starts with this string.
@@ -1164,13 +1214,12 @@ class FTSIndex:
         if not query:
             return []
 
-        params: list[object] = [
-            *snippet_params,
-            query,
-            *folder_params,
-            *tag_params,
-            limit,
-        ]
+        def _execute(match: str) -> sqlite3.Cursor:
+            return self._conn().execute(
+                sql,
+                [*snippet_params, match, *folder_params, *tag_params, limit],
+            )
+
         logger.debug(
             "FTS search: query=%r folder=%r filters=%r limit=%d snippet_words=%r",
             query,
@@ -1180,18 +1229,42 @@ class FTSIndex:
             snippet_words,
         )
         try:
-            cur = self._conn().execute(sql, params)
+            cur = _execute(query)
         except sqlite3.OperationalError as exc:
-            msg = str(exc).lower()
-            if (
-                "fts5" in msg
-                or "syntax error" in msg
-                or "no such column" in msg
-                or "unterminated" in msg
-            ):
-                logger.debug("FTS search: malformed query %r — %s", query, exc)
+            if not _is_fts5_query_error(exc):
+                raise
+            # #866: FTS5 rejected the raw query — e.g. a hyphenated slug like
+            # `vault-mcp` parses as a column filter ("no such column: mcp").
+            # Retry once with every token quoted so a natural-language query
+            # degrades to an implicit-AND of phrase literals instead of
+            # silently returning [] (which, in hybrid mode, masks the failure
+            # as a semantic-only result).
+            fallback = _quote_fts_query(query)
+            if not fallback:
+                logger.debug("FTS search: unrecoverable query %r — %s", query, exc)
                 return []
-            raise
+            logger.debug(
+                "FTS search: query %r rejected by FTS5 (%s); retrying quoted %r",
+                query,
+                exc,
+                fallback,
+            )
+            try:
+                cur = _execute(fallback)
+            except sqlite3.OperationalError as retry_exc:
+                if not _is_fts5_query_error(retry_exc):
+                    raise
+                # Degraded but continuing: the query could not execute even
+                # after quoting every token, so the caller gets []. Log at
+                # WARNING (per the logging standard) so this is visible at the
+                # default level rather than masking as an empty result set.
+                logger.warning(
+                    "fts_search_unexecutable query=%r fallback=%r reason=%s",
+                    query,
+                    fallback,
+                    retry_exc,
+                )
+                return []
         rows = cur.fetchall()
         logger.debug("FTS search: %d results for query=%r", len(rows), query)
 

--- a/tests/test_fts_index.py
+++ b/tests/test_fts_index.py
@@ -312,8 +312,10 @@ class TestSearch:
         results = idx.search("")
         assert results == []
 
-    def test_search_malformed_fts5_syntax_returns_empty_results(self) -> None:
-        """search() returns an empty list for malformed FTS5 syntax (no exception)."""
+    def test_search_malformed_fts5_syntax_degrades_to_term_search(self) -> None:
+        """A query FTS5 rejects (unclosed quote) degrades to a quoted term
+        search rather than silently returning [] — the terms are still found
+        when present (#866)."""
         idx = FTSIndex(":memory:")
         idx.upsert_note(
             make_note(
@@ -322,18 +324,20 @@ class TestSearch:
                     Chunk(
                         heading=None,
                         heading_level=0,
-                        content="hello world",
+                        content="hello unclosed world",
                         start_line=0,
                     )
                 ],
             )
         )
-        # Unclosed quote is invalid FTS5 syntax
-        results = idx.search('"unclosed quote')
-        assert results == []
+        # Unclosed quote is invalid FTS5 syntax; the fallback quotes each token
+        # so the real word "unclosed" is still matched.
+        results = idx.search('"unclosed world')
+        assert [r.path for r in results] == ["a.md"]
 
-    def test_search_invalid_fts5_column_returns_empty_results(self) -> None:
-        """search() returns an empty list for an invalid FTS5 column reference."""
+    def test_search_invalid_fts5_column_degrades_to_term_search(self) -> None:
+        """A `foo:bar` query where `foo` is not an FTS column degrades to a
+        term search instead of returning [] (#866)."""
         idx = FTSIndex(":memory:")
         idx.upsert_note(
             make_note(
@@ -342,15 +346,19 @@ class TestSearch:
                     Chunk(
                         heading=None,
                         heading_level=0,
-                        content="hello world",
+                        content="the value lives here",
                         start_line=0,
                     )
                 ],
             )
         )
-        # FTS5 column filters for non-existent columns raise OperationalError
-        results = idx.search("nonexistent_column:value")
-        assert results == []
+        # `nonexistent_column:value` raises "no such column"; the fallback
+        # quotes it into one phrase literal ("nonexistent column value", a
+        # single adjacency phrase) — those tokens are not adjacent in the doc,
+        # so no match.
+        assert idx.search("nonexistent_column:value") == []
+        # ...but the bare word does match once the column syntax is gone.
+        assert [r.path for r in idx.search("value")] == ["a.md"]
 
     def test_search_non_fts5_operational_error_propagates(self) -> None:
         """Non-FTS5 OperationalError (e.g. DB lock) must propagate, not return []."""
@@ -365,6 +373,177 @@ class TestSearch:
 
         with pytest.raises(sqlite3.OperationalError, match="database is locked"):
             idx.search("hello")
+
+    def _hyphen_idx(self) -> FTSIndex:
+        idx = FTSIndex(":memory:")
+        idx.upsert_note(
+            make_note(
+                "doc.md",
+                chunks=[
+                    Chunk(
+                        heading=None,
+                        heading_level=0,
+                        content="Ingest File-back Lint pipeline",
+                        start_line=0,
+                    )
+                ],
+            )
+        )
+        return idx
+
+    def test_hyphenated_query_finds_document(self) -> None:
+        """#866 repro: a hyphenated natural-language query returned [] because
+        FTS5 rejected it and the error was swallowed. It must now find the doc."""
+        idx = self._hyphen_idx()
+        results = idx.search("File-back Ingest Lint")
+        assert [r.path for r in results] == ["doc.md"]
+        idx.close()
+
+    def test_single_hyphenated_slug_finds_document(self) -> None:
+        """A lone slug like `vault-mcp` (raises 'no such column') must match."""
+        idx = FTSIndex(":memory:")
+        idx.upsert_note(
+            make_note(
+                "s.md",
+                chunks=[
+                    Chunk(
+                        heading=None,
+                        heading_level=0,
+                        content="the vault-mcp server rocks",
+                        start_line=0,
+                    )
+                ],
+            )
+        )
+        assert [r.path for r in idx.search("vault-mcp")] == ["s.md"]
+        idx.close()
+
+    def test_wellformed_boolean_query_bypasses_fallback(self) -> None:
+        """A valid FTS5 OR query must keep operator semantics (not be quoted).
+
+        `Ingest OR zzzmissing` parses cleanly and matches on `Ingest`; if the
+        quote-fallback fired it would AND three literals (incl. `or`) and match
+        nothing. Returning the doc proves well-formed queries bypass the
+        fallback — the documented FTS5-query contract is preserved.
+        """
+        idx = self._hyphen_idx()
+        assert [r.path for r in idx.search("Ingest OR zzzmissing")] == ["doc.md"]
+        idx.close()
+
+    def test_wellformed_phrase_and_prefix_queries_still_work(self) -> None:
+        idx = self._hyphen_idx()
+        assert [r.path for r in idx.search('"Ingest File"')] == ["doc.md"]  # phrase
+        assert [r.path for r in idx.search(" Inge*")] == ["doc.md"]  # prefix
+        idx.close()
+
+    def test_hyphenated_query_with_absent_terms_returns_empty(self) -> None:
+        """The fallback still returns [] when the quoted terms aren't present —
+        graceful degradation, not a false positive."""
+        idx = self._hyphen_idx()
+        assert idx.search("absent-slug notpresent") == []
+        idx.close()
+
+    def test_search_retry_non_fts5_error_propagates(self) -> None:
+        """A non-FTS5 error on the *quoted retry* must propagate, not be
+        swallowed to [] — the same guarantee as the first execute (#866)."""
+        from unittest.mock import MagicMock
+
+        idx = FTSIndex(":memory:")
+        mock_conn = MagicMock()
+        # First execute: FTS5 syntax error (triggers the retry). Retry: a
+        # genuine environmental error that must not be masked. Use a non-locked
+        # error so the @_retry_on_locked decorator doesn't re-drive search().
+        mock_conn.execute.side_effect = [
+            sqlite3.OperationalError('fts5: syntax error near "-"'),
+            sqlite3.OperationalError("disk I/O error"),
+        ]
+        idx._conn = lambda: mock_conn  # type: ignore[method-assign]
+        with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+            idx.search("vault-mcp")
+
+    def test_search_retry_still_malformed_returns_empty_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If the quoted retry is *also* rejected as an FTS5 query error, the
+        search degrades to [] — and logs at WARNING (degraded but continuing),
+        not silently."""
+        import logging
+        from unittest.mock import MagicMock
+
+        idx = FTSIndex(":memory:")
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = [
+            sqlite3.OperationalError('fts5: syntax error near "-"'),
+            sqlite3.OperationalError("fts5: unterminated string"),
+        ]
+        idx._conn = lambda: mock_conn  # type: ignore[method-assign]
+        with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.fts_index"):
+            assert idx.search("vault-mcp") == []
+        assert any("fts_search_unexecutable" in r.getMessage() for r in caplog.records)
+
+    def test_search_whitespace_only_query_with_fts_error_returns_empty(self) -> None:
+        """A truthy query with no quotable tokens that FTS5 rejects degrades to
+        [] (the unrecoverable-fallback guard)."""
+        from unittest.mock import MagicMock
+
+        idx = FTSIndex(":memory:")
+        mock_conn = MagicMock()
+        # A one-element side_effect: only the FIRST execute may run. If the
+        # `if not fallback: return []` guard were removed, the code would call
+        # execute a second time (with the empty match) and StopIteration would
+        # fail the test — so this genuinely pins the guard branch.
+        mock_conn.execute.side_effect = [
+            sqlite3.OperationalError("fts5: syntax error"),
+        ]
+        idx._conn = lambda: mock_conn  # type: ignore[method-assign]
+        # "   " is truthy (bypasses the empty-query guard) but tokenizes to no
+        # quotable tokens, so the fallback is empty and search returns [].
+        assert idx.search("   ") == []
+
+    def test_fallback_honours_folder_filter(self) -> None:
+        """A hyphenated query that triggers the quoted retry must still respect
+        the folder= filter — the retry reuses the same folder/tag params."""
+        idx = FTSIndex(":memory:")
+        for path in ("Journal/a.md", "Notes/b.md"):
+            idx.upsert_note(
+                make_note(
+                    path,
+                    chunks=[
+                        Chunk(
+                            heading=None,
+                            heading_level=0,
+                            content="the vault-mcp pipeline",
+                            start_line=0,
+                        )
+                    ],
+                )
+            )
+        results = idx.search("vault-mcp", folder="Journal")
+        assert [r.path for r in results] == ["Journal/a.md"]
+        idx.close()
+
+    def test_fallback_escapes_embedded_quote(self) -> None:
+        """A token containing a double-quote is matched via the quote-doubling
+        escape, not re-broken into malformed FTS5 syntax that masks as []."""
+        idx = FTSIndex(":memory:")
+        idx.upsert_note(
+            make_note(
+                "q.md",
+                chunks=[
+                    Chunk(
+                        heading=None,
+                        heading_level=0,
+                        content='he said "hi" today',
+                        start_line=0,
+                    )
+                ],
+            )
+        )
+        # `said"hi` is an unterminated FTS5 string; the fallback must produce
+        # "said""hi" (doubled quote) and still find the doc.
+        results = idx.search('said"hi')
+        assert [r.path for r in results] == ["q.md"]
+        idx.close()
 
     def test_search_returns_start_line(self) -> None:
         """search() propagates start_line from the sections row.

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -130,6 +130,24 @@ class TestKeywordSearch:
         results = search_mgr.search("zzzznonexistent")
         assert results == []
 
+    def test_hyphenated_query_finds_document_through_keyword_leg(
+        self, tmp_path: Path
+    ) -> None:
+        """#866: a hyphenated query must flow through the SearchManager keyword
+        leg (which delegates to FTSIndex.search) and return the doc."""
+        vault = tmp_path / "hyphen_vault"
+        vault.mkdir()
+        (vault / "slug.md").write_text(
+            "# Slug\n\nThe vault-mcp File-back pipeline runs nightly.\n",
+            encoding="utf-8",
+        )
+        fts = FTSIndex(db_path=":memory:")
+        for note in scan_directory(vault):
+            fts.upsert_note(note)
+        mgr = SearchManager(fts=fts, source_dir=vault)
+        results = mgr.search("vault-mcp File-back", mode="keyword")
+        assert [r.path for r in results] == ["slug.md"]
+
 
 # ---------------------------------------------------------------------------
 # semantic search


### PR DESCRIPTION
## Summary

Closes #866.

A keyword/hybrid search query containing a hyphenated term or slug (`File-back Ingest Lint`, `vault-mcp`, `e5-large`) silently returned **zero results**. FTS5 parses the `-`/`:` between barewords as an operator/column filter and raises `OperationalError: no such column: ...`, which `FTSIndex.search()` caught and swallowed to `[]`. In `hybrid` mode this was worse: the keyword leg contributed nothing and the query fell back to semantic-only ranking with no signal to the caller.

## Fix

On an FTS5 **query-syntax** error (not a lock or other environmental error — those still propagate on both the first and the retry execute), `search()` retries the MATCH once with every whitespace token quoted as an FTS5 phrase literal (`"file-back" "ingest" "lint"`, implicit AND). Special characters are then matched literally, and a compound like `File-back` becomes an adjacency phrase over its tokens. Well-formed operator queries (`AND`/`OR`/`NEAR`/phrases/prefixes) parse cleanly and never hit the fallback, so the documented FTS5-query contract is preserved. The one fix in `search()` covers keyword and the hybrid keyword leg (both delegate to it).

Two new helpers: `_is_fts5_query_error` (extracted from the prior inline discriminator, preserving the #327/#560 "don't swallow real DB errors" invariant) and `_quote_fts_query`.

## Behaviour

- `search("File-back Ingest Lint")` / `search("vault-mcp")` now find the doc (keyword **and** hybrid).
- `search("Ingest OR zzzmissing")` keeps operator semantics (bypasses the fallback).
- A non-FTS5 error (DB lock, disk I/O) still propagates on the first **and** the retry execute.
- A query rejected even after quoting degrades to `[]` and logs at **WARNING** (per the logging standard), no longer silently.

## Tests

Hyphen recovery (FTSIndex + SearchManager keyword leg), well-formed operator/phrase/prefix bypass, retry-path non-FTS5 propagation, retry-path FTS5-again → `[]` + WARNING, empty-fallback guard, fallback preserving folder filters, and the quote-doubling escape. The two prior tests asserting `malformed → []` are rewritten to assert graceful degradation. Full suite: 2867 passed. Reviewed locally with the preflight-circus (five context lenses + specialist reviewers) before opening.

## Documentation

`docs/tools/index.md` search note; `FTSIndex.search()` docstring.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._