### PR TITLE
refactor: decompose get_file_diff into mode-specific helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,19 @@ ignore = ["E501"]
 # those imports top-level, not behind TYPE_CHECKING.
 "src/markdown_vault_mcp/config_sections/indexing.py" = ["TC003"]
 "src/markdown_vault_mcp/config_sections/content.py" = ["TC003"]
+# The git/ package exists to spawn `git` subprocesses: S603/S607 would flag
+# every call (fixed argv built from validated paths/refs; the `git` executable
+# is resolved from PATH by design), making `# noqa` routine on any diff that
+# touches these modules. Ignore both at package scope; the rest of src/ keeps
+# the checks. Only bites when the structural diff-gate adds `S` on the diff
+# pass (S isn't in the base select).
+"src/markdown_vault_mcp/git/*.py" = ["S603", "S607"]
+# query.py's module-private diff helpers mirror get_file_diff's wide surface
+# (two refs + two path forms + env + a binary flag); a param object for
+# single-caller private functions is pure ceremony. PLR0913 is gate-only
+# (not in the base select), so `# noqa` would be stripped as unused (RUF100)
+# — per-file ignore is the working mechanism, same as the DI modules above.
+"src/markdown_vault_mcp/git/query.py" = ["PLR0913"]
 # Test fixtures import vault/protocol types only used in annotations.
 "tests/conftest.py" = ["TC002", "TC003"]
 "tests/test_smoke.py" = ["TC002", "TC003"]

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -30,6 +30,93 @@ logger = logging.getLogger(__name__)
 # Used to diff a parent-less (root/orphan) commit against "nothing".
 _EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
+# Diff payloads larger than this are truncated with a byte-count marker.
+_DIFF_MAX_BYTES = 50 * 1024  # 50 KB
+
+
+def _truncate_diff(diff: str) -> str:
+    """Cap *diff* at :data:`_DIFF_MAX_BYTES`, appending an omission marker.
+
+    Truncation is byte-based (UTF-8), decoding the kept prefix with
+    ``errors="replace"`` so a multi-byte character split at the boundary
+    cannot raise.
+    """
+    if len(diff.encode()) <= _DIFF_MAX_BYTES:
+        return diff
+    omitted = len(diff.encode()) - _DIFF_MAX_BYTES
+    diff = diff.encode()[:_DIFF_MAX_BYTES].decode(errors="replace")
+    return diff + f"\n[diff truncated: {omitted} bytes omitted]"
+
+
+def _resolve_since_timestamp(
+    git_root: Path, since_timestamp: str, env: dict[str, str] | None
+) -> str | None:
+    """Resolve *since_timestamp* to the most recent commit at or before it.
+
+    Returns:
+        The commit SHA, or ``None`` when no commit exists at or before the
+        timestamp (inclusive boundary: a commit whose committer date equals
+        the timestamp is returned).
+
+    Raises:
+        ValueError: If ``git rev-list`` exits non-zero.
+    """
+    try:
+        rev_result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(git_root),
+                "rev-list",
+                f"--before={since_timestamp}",
+                "-1",
+                "HEAD",
+                # No path filter: git rev-list has no --follow, so
+                # filtering by current path silently misses pre-rename
+                # commits.  Resolve the timestamp globally and let the
+                # subsequent diff (which uses -- path_str) handle scope.
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(
+            f"Could not resolve timestamp {since_timestamp!r}: "
+            f"{(exc.stderr or '').strip()}"
+        ) from exc
+    return rev_result.stdout.strip() or None
+
+
+def _rename_aware_diff_args(
+    git_root: Path,
+    from_ref: str,
+    to_ref: str,
+    cur_rel: str | None,
+    pathspec: str,
+    env: dict[str, str] | None,
+) -> tuple[list[str], str | None]:
+    """Build diff args for ``from_ref..to_ref``, resolving renames.
+
+    Resolves the path *cur_rel* had at *from_ref*; when it differs from the
+    current name, the diff targets the two blob specs so git pairs the
+    rename instead of reporting delete+add.
+
+    Returns:
+        Tuple ``(diff_args, old_path)`` where *diff_args* is the ref/path
+        portion of the ``git diff`` invocation and *old_path* is the
+        resolved historical path (``None`` when no rename was resolved).
+    """
+    old_path = (
+        resolve_path_at_ref(git_root, from_ref, cur_rel, env, to_ref=to_ref)
+        if cur_rel is not None
+        else None
+    )
+    if old_path is None or cur_rel is None or old_path == cur_rel:
+        return [f"{from_ref}..{to_ref}", "--", pathspec], old_path
+    return [f"{from_ref}:{old_path}", f"{to_ref}:{cur_rel}"], old_path
+
 
 def _diff_is_binary(
     git_root: Path, diff_args: list[str], env: dict[str, str] | None
@@ -312,295 +399,307 @@ def get_file_diff(
         ValueError: If *ref* is not found in history, *since_timestamp*
             cannot be resolved, or a git subprocess exits non-zero.
     """
-    _DIFF_MAX_BYTES = 50 * 1024  # 50 KB
-
     if git_root is None:
-        if per_commit:
-            return []
-        return ""
+        return [] if per_commit else ""
 
-    path_str = str(path)
     env = git_env(token, username)
     try:
         if since_timestamp is not None:
-            # Resolve the ISO timestamp to the most recent commit before it.
-            try:
-                rev_result = subprocess.run(
-                    [
-                        "git",
-                        "-C",
-                        str(git_root),
-                        "rev-list",
-                        f"--before={since_timestamp}",
-                        "-1",
-                        "HEAD",
-                        # No path filter: git rev-list has no --follow, so
-                        # filtering by current path silently misses pre-rename
-                        # commits.  Resolve the timestamp globally and let the
-                        # subsequent diff (which uses -- path_str) handle scope.
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=env,
-                )
-            except subprocess.CalledProcessError as exc:
-                raise ValueError(
-                    f"Could not resolve timestamp {since_timestamp!r}: "
-                    f"{(exc.stderr or '').strip()}"
-                ) from exc
-            ref = rev_result.stdout.strip()
-            if not ref:
+            ref = _resolve_since_timestamp(git_root, since_timestamp, env)
+            if ref is None:
                 return [] if per_commit else ""
 
         if ref is None:
             raise ValueError("Either 'ref' or 'since_timestamp' must be provided")
 
         if not per_commit:
-            # Resolve the path-at-ref once so renames are handled uniformly for
-            # binary detection, the --stat summary, and the full diff.
-            try:
-                cur_rel = path.resolve().relative_to(git_root).as_posix()
-            except ValueError:
-                cur_rel = None
-            old_path = (
-                resolve_path_at_ref(git_root, ref, cur_rel, env)
-                if cur_rel is not None
-                else None
+            return _range_diff(
+                git_root, path, ref, env, summarize_binary=summarize_binary
             )
-            if old_path is None or cur_rel is None or old_path == cur_rel:
-                diff_args = [f"{ref}..HEAD", "--", path_str]
-            else:
-                diff_args = [f"{ref}:{old_path}", f"HEAD:{cur_rel}"]
+        return _per_commit_diffs(
+            git_root, path, ref, limit, env, summarize_binary=summarize_binary
+        )
+    finally:
+        cleanup_git_env(env)
 
-            # Binary attachments: a unified patch is meaningless, so emit a
-            # --stat summary instead.  Text attachments (and notes, since the
-            # default is summarize_binary=False) fall through to the full diff.
-            if summarize_binary and _diff_is_binary(git_root, diff_args, env):
-                try:
-                    stat = subprocess.run(
-                        ["git", "-C", str(git_root), "diff", "--stat", *diff_args],
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                        env=env,
-                    )
-                except subprocess.CalledProcessError as exc:
-                    raise ValueError(
-                        f"Could not compute diff summary against {ref!r}: invalid ref "
-                        "or path not present at that revision"
-                    ) from exc
-                return stat.stdout
 
-            diff_cmd = ["git", "-C", str(git_root), "diff", *diff_args]
-            try:
-                result = subprocess.run(
-                    diff_cmd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=env,
-                )
-            except subprocess.CalledProcessError as exc:
-                raise ValueError(
-                    f"Could not compute diff against {ref!r}: invalid ref or "
-                    f"path not present at that revision"
-                ) from exc
-            diff = result.stdout
-            if len(diff.encode()) > _DIFF_MAX_BYTES:
-                omitted = len(diff.encode()) - _DIFF_MAX_BYTES
-                diff = diff.encode()[:_DIFF_MAX_BYTES].decode(errors="replace")
-                diff += f"\n[diff truncated: {omitted} bytes omitted]"
-            return diff
+def _range_diff(
+    git_root: Path,
+    path: Path,
+    ref: str,
+    env: dict[str, str] | None,
+    *,
+    summarize_binary: bool,
+) -> str:
+    """Return the single unified diff of *path* from *ref* to HEAD.
 
-        # per_commit=True: enumerate commits in range then show each.
-        # Use --name-only with a sentinel so we can recover the path the
-        # file had at each commit — critical for correct diffs across
-        # renames (git show sha -- new.md returns nothing for pre-rename
-        # commits; we must pass the old filename instead).
-        _PC_SENTINEL = "\x1e"
-        log_cmd = [
-            "git",
-            "-C",
-            str(git_root),
-            "log",
-            "--follow",
-            f"--format={_PC_SENTINEL}%H%x00%h%x00%aI%x00%s",
-            "--name-only",
-        ]
-        if limit is not None:
-            clamped_limit = min(max(1, limit), 100)
-            log_cmd.append(f"-n{clamped_limit}")
-        log_cmd += [f"{ref}..HEAD", "--", path_str]
+    Handles rename resolution, the binary ``--stat`` summary (#342), and
+    truncation.  Raises :exc:`ValueError` on an invalid ref or a path not
+    present at that revision.
+    """
+    path_str = str(path)
+    # Resolve the path-at-ref once so renames are handled uniformly for
+    # binary detection, the --stat summary, and the full diff.
+    try:
+        cur_rel = path.resolve().relative_to(git_root).as_posix()
+    except ValueError:
+        cur_rel = None
+    diff_args, _old_path = _rename_aware_diff_args(
+        git_root, ref, "HEAD", cur_rel, path_str, env
+    )
+
+    # Binary attachments: a unified patch is meaningless, so emit a
+    # --stat summary instead.  Text attachments (and notes, since the
+    # default is summarize_binary=False) fall through to the full diff.
+    if summarize_binary and _diff_is_binary(git_root, diff_args, env):
         try:
-            log_result = subprocess.run(
-                log_cmd,
+            stat = subprocess.run(
+                ["git", "-C", str(git_root), "diff", "--stat", *diff_args],
                 capture_output=True,
                 text=True,
                 check=True,
                 env=env,
             )
         except subprocess.CalledProcessError as exc:
-            raise ValueError(f"Commit {ref!r} not found in history") from exc
+            raise ValueError(
+                f"Could not compute diff summary against {ref!r}: invalid ref "
+                "or path not present at that revision"
+            ) from exc
+        return stat.stdout
 
-        # Repo-relative posix path — the correct fallback when a --name-only
-        # block has no path line (git returns posix-relative paths, so the
-        # absolute platform-native path_str would break rename resolution on
-        # Windows).
-        try:
-            rel_fallback = path.resolve().relative_to(git_root).as_posix()
-        except ValueError:
-            rel_fallback = path_str
+    diff_cmd = ["git", "-C", str(git_root), "diff", *diff_args]
+    try:
+        result = subprocess.run(
+            diff_cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(
+            f"Could not compute diff against {ref!r}: invalid ref or "
+            f"path not present at that revision"
+        ) from exc
+    return _truncate_diff(result.stdout)
 
-        diffs: list[CommitDiff] = []
-        for block in log_result.stdout.split(_PC_SENTINEL):
-            block = block.strip()
-            if not block:
-                continue
-            lines = block.splitlines()
-            if not lines:
-                continue
-            parts = lines[0].split("\x00")
-            if len(parts) < 4:
-                continue
-            sha, short_sha, timestamp, message = parts[:4]
-            # Recover the path the file had at this specific commit.
-            # With --follow, this will be the old name for pre-rename commits.
-            commit_path = next(
-                (ln.strip() for ln in lines[1:] if ln.strip()), rel_fallback
-            )
 
-            # Build a rename-aware diff target for THIS commit vs its parent,
-            # mirroring the non-per-commit branch, so a renamed binary pairs into
-            # `{old => new} | Bin OLD -> NEW` instead of an add/text stat (#683).
-            parent = f"{sha}^"
-            old_at_parent = resolve_path_at_ref(
-                git_root, parent, commit_path, env, to_ref=sha
-            )
-            if old_at_parent is not None and old_at_parent != commit_path:
-                commit_args = [f"{parent}:{old_at_parent}", f"{sha}:{commit_path}"]
-            else:
-                commit_args = [f"{parent}..{sha}", "--", commit_path]
-            # Classify binariness for THIS commit (not the whole range).
-            commit_binary = summarize_binary and _diff_is_binary(
-                git_root, commit_args, env
-            )
-            diff_cmd = [
+def _root_commit_diff(
+    git_root: Path,
+    sha: str,
+    commit_path: str,
+    env: dict[str, str] | None,
+    *,
+    summarize_binary: bool,
+) -> str:
+    """Render the add-form diff of a parent-less (root/orphan) commit.
+
+    Classifies binariness against the empty tree (so a root binary still
+    gets ``--stat``) and falls back to ``git show``.  Raises
+    :exc:`ValueError` when even the fallback fails.
+    """
+    # Resolve the empty-tree object for this repo's hash algorithm
+    # (the hardcoded SHA-1 constant is invalid in SHA-256 repos);
+    # fall back to the SHA-1 constant if resolution fails.
+    empty_tree = _EMPTY_TREE_SHA
+    try:
+        res = subprocess.run(
+            [
                 "git",
                 "-C",
                 str(git_root),
-                "diff",
-                "--stat" if commit_binary else "-p",
-                *commit_args,
-            ]
-            try:
-                show_result = subprocess.run(
-                    diff_cmd, capture_output=True, text=True, check=True, env=env
-                )
-            except subprocess.CalledProcessError as exc:
-                # A failure here is expected ONLY for a parent-less (root/orphan)
-                # commit, where `{sha}^` can't resolve. Any other failure is real
-                # and must surface rather than silently degrade to an add-form,
-                # rename-unaware diff.
-                parent_exists = (
-                    subprocess.run(
-                        [
-                            "git",
-                            "-C",
-                            str(git_root),
-                            "rev-parse",
-                            "--verify",
-                            "--quiet",
-                            f"{sha}^",
-                        ],
-                        capture_output=True,
-                        env=env,
-                    ).returncode
-                    == 0
-                )
-                if parent_exists:
-                    raise ValueError(
-                        f"Could not retrieve diff for commit {sha!r}"
-                    ) from exc
-                # Genuinely parent-less: classify against the empty tree (so a root
-                # binary still gets --stat) and render the add-form.
-                # Resolve the empty-tree object for this repo's hash algorithm
-                # (the hardcoded SHA-1 constant is invalid in SHA-256 repos);
-                # fall back to the SHA-1 constant if resolution fails.
-                empty_tree = _EMPTY_TREE_SHA
-                try:
-                    res = subprocess.run(
-                        [
-                            "git",
-                            "-C",
-                            str(git_root),
-                            "hash-object",
-                            "-t",
-                            "tree",
-                            "--stdin",
-                        ],
-                        input="",
-                        capture_output=True,
-                        text=True,
-                        env=env,
-                        check=True,
-                    )
-                    empty_tree = res.stdout.strip() or _EMPTY_TREE_SHA
-                except subprocess.CalledProcessError:
-                    pass
-                root_binary = summarize_binary and _diff_is_binary(
-                    git_root, [empty_tree, sha, "--", commit_path], env
-                )
-                fallback_cmd = [
-                    "git",
-                    "-C",
-                    str(git_root),
-                    "show",
-                    "--format=",
-                    "--stat" if root_binary else "-p",
-                    sha,
-                    "--",
-                    commit_path,
-                ]
-                try:
-                    show_result = subprocess.run(
-                        fallback_cmd,
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                        env=env,
-                    )
-                except subprocess.CalledProcessError as exc2:
-                    raise ValueError(
-                        f"Could not retrieve diff for commit {sha!r}"
-                    ) from exc2
-            commit_diff = show_result.stdout.lstrip("\n")
-            if (
-                not commit_diff
-                and old_at_parent is not None
-                and old_at_parent != commit_path
-            ):
-                # Pure rename with byte-identical content: the two-blob diff
-                # of identical blobs is empty, so the rename would otherwise be
-                # invisible. Synthesize a marker rather than emit an empty diff (#683).
-                commit_diff = (
-                    f"{old_at_parent} => {commit_path} (renamed, no content change)\n"
-                )
-            if len(commit_diff.encode()) > _DIFF_MAX_BYTES:
-                omitted = len(commit_diff.encode()) - _DIFF_MAX_BYTES
-                commit_diff = commit_diff.encode()[:_DIFF_MAX_BYTES].decode(
-                    errors="replace"
-                )
-                commit_diff += f"\n[diff truncated: {omitted} bytes omitted]"
-            diffs.append(
-                CommitDiff(
-                    sha=sha,
-                    short_sha=short_sha,
-                    timestamp=timestamp,
-                    message=message,
-                    diff=commit_diff,
-                )
+                "hash-object",
+                "-t",
+                "tree",
+                "--stdin",
+            ],
+            input="",
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+        empty_tree = res.stdout.strip() or _EMPTY_TREE_SHA
+    except subprocess.CalledProcessError:
+        pass
+    root_binary = summarize_binary and _diff_is_binary(
+        git_root, [empty_tree, sha, "--", commit_path], env
+    )
+    fallback_cmd = [
+        "git",
+        "-C",
+        str(git_root),
+        "show",
+        "--format=",
+        "--stat" if root_binary else "-p",
+        sha,
+        "--",
+        commit_path,
+    ]
+    try:
+        show_result = subprocess.run(
+            fallback_cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"Could not retrieve diff for commit {sha!r}") from exc
+    return show_result.stdout
+
+
+def _parse_log_block(block: str, rel_fallback: str) -> tuple[str, ...] | None:
+    """Parse one sentinel-delimited ``git log --name-only`` block.
+
+    Returns:
+        ``(sha, short_sha, timestamp, message, commit_path)``, or ``None``
+        for an empty or malformed block.  *commit_path* is the path the
+        file had at that commit (the old name for pre-rename commits,
+        thanks to ``--follow``), falling back to *rel_fallback* when the
+        block carries no path line.
+    """
+    block = block.strip()
+    if not block:
+        return None
+    lines = block.splitlines()
+    if not lines:
+        return None
+    parts = lines[0].split("\x00")
+    if len(parts) < 4:
+        return None
+    sha, short_sha, timestamp, message = parts[:4]
+    commit_path = next((ln.strip() for ln in lines[1:] if ln.strip()), rel_fallback)
+    return sha, short_sha, timestamp, message, commit_path
+
+
+def _per_commit_diffs(
+    git_root: Path,
+    path: Path,
+    ref: str,
+    limit: int | None,
+    env: dict[str, str] | None,
+    *,
+    summarize_binary: bool,
+) -> list[CommitDiff]:
+    """Return one :class:`CommitDiff` per commit in ``ref..HEAD``.
+
+    Enumerates commits with ``git log --follow --name-only`` (with a
+    sentinel) so the path the file had at each commit can be recovered —
+    critical for correct diffs across renames (``git show sha -- new.md``
+    returns nothing for pre-rename commits; the old filename must be
+    passed instead).  Raises :exc:`ValueError` when *ref* is not found or
+    a per-commit diff fails for a commit that does have a parent.
+    """
+    path_str = str(path)
+    _PC_SENTINEL = "\x1e"
+    log_cmd = [
+        "git",
+        "-C",
+        str(git_root),
+        "log",
+        "--follow",
+        f"--format={_PC_SENTINEL}%H%x00%h%x00%aI%x00%s",
+        "--name-only",
+    ]
+    if limit is not None:
+        clamped_limit = min(max(1, limit), 100)
+        log_cmd.append(f"-n{clamped_limit}")
+    log_cmd += [f"{ref}..HEAD", "--", path_str]
+    try:
+        log_result = subprocess.run(
+            log_cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"Commit {ref!r} not found in history") from exc
+
+    # Repo-relative posix path — the correct fallback when a --name-only
+    # block has no path line (git returns posix-relative paths, so the
+    # absolute platform-native path_str would break rename resolution on
+    # Windows).
+    try:
+        rel_fallback = path.resolve().relative_to(git_root).as_posix()
+    except ValueError:
+        rel_fallback = path_str
+
+    diffs: list[CommitDiff] = []
+    for block in log_result.stdout.split(_PC_SENTINEL):
+        parsed = _parse_log_block(block, rel_fallback)
+        if parsed is None:
+            continue
+        sha, short_sha, timestamp, message, commit_path = parsed
+
+        # Build a rename-aware diff target for THIS commit vs its parent,
+        # mirroring the single-range branch, so a renamed binary pairs into
+        # `{old => new} | Bin OLD -> NEW` instead of an add/text stat (#683).
+        parent = f"{sha}^"
+        commit_args, old_at_parent = _rename_aware_diff_args(
+            git_root, parent, sha, commit_path, commit_path, env
+        )
+        # Classify binariness for THIS commit (not the whole range).
+        commit_binary = summarize_binary and _diff_is_binary(git_root, commit_args, env)
+        diff_cmd = [
+            "git",
+            "-C",
+            str(git_root),
+            "diff",
+            "--stat" if commit_binary else "-p",
+            *commit_args,
+        ]
+        try:
+            show_result = subprocess.run(
+                diff_cmd, capture_output=True, text=True, check=True, env=env
             )
-        return diffs
-    finally:
-        cleanup_git_env(env)
+            commit_diff_raw = show_result.stdout
+        except subprocess.CalledProcessError as exc:
+            # A failure here is expected ONLY for a parent-less (root/orphan)
+            # commit, where `{sha}^` can't resolve. Any other failure is real
+            # and must surface rather than silently degrade to an add-form,
+            # rename-unaware diff.
+            parent_exists = (
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(git_root),
+                        "rev-parse",
+                        "--verify",
+                        "--quiet",
+                        f"{sha}^",
+                    ],
+                    capture_output=True,
+                    env=env,
+                ).returncode
+                == 0
+            )
+            if parent_exists:
+                raise ValueError(f"Could not retrieve diff for commit {sha!r}") from exc
+            commit_diff_raw = _root_commit_diff(
+                git_root, sha, commit_path, env, summarize_binary=summarize_binary
+            )
+        commit_diff = commit_diff_raw.lstrip("\n")
+        if (
+            not commit_diff
+            and old_at_parent is not None
+            and old_at_parent != commit_path
+        ):
+            # Pure rename with byte-identical content: the two-blob diff
+            # of identical blobs is empty, so the rename would otherwise be
+            # invisible. Synthesize a marker rather than emit an empty diff (#683).
+            commit_diff = (
+                f"{old_at_parent} => {commit_path} (renamed, no content change)\n"
+            )
+        diffs.append(
+            CommitDiff(
+                sha=sha,
+                short_sha=short_sha,
+                timestamp=timestamp,
+                message=message,
+                diff=_truncate_diff(commit_diff),
+            )
+        )
+    return diffs

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3089,6 +3089,56 @@ class TestGetFileDiff:
         assert diffs[0].message == "edit: note.md"
         assert diffs[0].diff
 
+    def _grow_note_past_truncation(self, repo: Path) -> None:
+        """Commit a note.md rewrite large enough to exceed the 50 KB cap."""
+        big = "".join(f"unique padding line {i:06d}\n" for i in range(4000))
+        (repo / "note.md").write_text(big)
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "edit: grow note.md"],
+            capture_output=True,
+            check=True,
+        )
+
+    def test_single_diff_truncates_oversized_payload(self, tmp_path: Path) -> None:
+        """A single diff over 50 KB is capped with an omission marker."""
+        repo, first_sha = self._make_repo_with_commits(tmp_path)
+        self._grow_note_past_truncation(repo)
+        strategy = GitWriteStrategy()
+        diff = strategy.get_file_diff(
+            repo, repo / "note.md", first_sha, per_commit=False
+        )
+        assert isinstance(diff, str)
+        assert "[diff truncated:" in diff
+        assert "bytes omitted]" in diff
+        # Payload is the 50 KB cap plus the short marker line.
+        assert len(diff.encode()) < 50 * 1024 + 100
+
+    def test_per_commit_diff_truncates_oversized_payload(self, tmp_path: Path) -> None:
+        """Each oversized per-commit diff is capped with an omission marker."""
+        repo, first_sha = self._make_repo_with_commits(tmp_path)
+        self._grow_note_past_truncation(repo)
+        strategy = GitWriteStrategy()
+        diffs = strategy.get_file_diff(
+            repo, repo / "note.md", first_sha, per_commit=True
+        )
+        assert isinstance(diffs, list)
+        oversized = [d for d in diffs if "[diff truncated:" in d.diff]
+        assert oversized, "expected at least one truncated per-commit diff"
+        for d in oversized:
+            assert len(d.diff.encode()) < 50 * 1024 + 100
+
+    def test_parse_log_block_rejects_malformed_blocks(self) -> None:
+        """Empty and header-short log blocks are skipped, not parsed."""
+        from markdown_vault_mcp.git.query import _parse_log_block
+
+        assert _parse_log_block("", "fallback.md") is None
+        assert _parse_log_block("   \n  ", "fallback.md") is None
+        # Header with fewer than 4 NUL-separated fields is malformed.
+        assert _parse_log_block("sha\x00short\x00ts", "fallback.md") is None
+
     def test_no_git_root_returns_empty(self, tmp_path: Path) -> None:
         """get_file_diff returns empty when not in a git repo."""
         non_repo = tmp_path / "not_a_repo"


### PR DESCRIPTION
Closes #763. Refs #883 (audit epic).

## What

Second implementation PR of the #883 audit epic: `get_file_diff` in `git/query.py` was the most complex function in the repo (**CCN 44 / radon F**, ~346 lines) — per the #763 investigation, four functions merged into one body plus literal duplications. It is now a guard → resolve → dispatch shell at **radon B(8)**, with the public signature and behavior unchanged.

## Changes

Extracted module-private helpers (all take `env` explicitly; all subprocess calls stay module-qualified `subprocess.run` per the module's test-monkeypatch contract; `cleanup_git_env` remains in `get_file_diff`'s outermost `try/finally`):

- **`_truncate_diff`** — the 50 KB cap, previously duplicated byte-for-byte in the single-range and per-commit paths (`_DIFF_MAX_BYTES` promoted to a module constant).
- **`_resolve_since_timestamp`** — `git rev-list --before` timestamp→SHA resolution.
- **`_rename_aware_diff_args`** — rename-aware diff-arg construction, previously duplicated between the range branch and the per-commit branch.
- **`_range_diff`** — the `per_commit=False` mode: rename resolution, binary `--stat` summary (#342), checked diff, truncation.
- **`_root_commit_diff`** — the parent-less-commit fallback (SHA-256-aware empty-tree resolution + `git show`), formerly **77 lines nested four levels deep** inside an `except` handler inside a loop.
- **`_per_commit_diffs` + `_parse_log_block`** — the `per_commit=True` walk, with block parsing separated out.

Deliberately untouched: `get_file_history` C(20) — the #763 assessment rates its companion `_parse_log_blocks` unification as lower value; it can ride along with a future touch of this file.

## Ruff per-file ignores (structural gate)

Moving these lines made the diff gate re-lint them, surfacing gate-only codes that predate the diff gate:
- `git/*.py`: **S603/S607** — the package's purpose is spawning `git` subprocesses (fixed argv from validated paths/refs); without this, every future diff touching these modules needs routine noqas.
- `git/query.py`: **PLR0913** — the private helpers mirror `get_file_diff`'s wide surface; `# noqa: PLR0913` cannot work here because PLR0913 is not in the base select, so base `ruff check --fix` strips the comment as unused (RUF100). Per-file-ignore is the repo's established mechanism for exactly this (see the `_server_*.py` entries).

## Tests

- **New: the previously missing 50 KB truncation coverage** (`test_single_diff_truncates_oversized_payload`, `test_per_commit_diff_truncates_oversized_payload`) — the #763 assessment flagged this as the one dedupe target with zero coverage.
- New `test_parse_log_block_rejects_malformed_blocks` for the block-parser guards.
- The existing ~30-test `TestGetFileDiff` suite (renames both modes, binary stat, parent-less fallback incl. fallback-also-fails, SHA-256 empty tree, pure-rename marker, copy-as-add, timestamp resolution, limits, invalid ref) drives everything through `GitWriteStrategy`, so the extraction is invisible to it.

## Gates

- `uv run pytest -x -q`: 2858 passed, 6 skipped
- `ruff check` / `ruff format --check`: clean
- `mypy src/ tests/`: clean
- `diff-quality --fail-under=100`: 100%
- Patch coverage (`diff-cover` vs `origin/main`, git test files only): 87.9% → higher under the full CI suite; well above the 80% gate

## Docs

No user-facing change — tool surface, parameters, return shapes, and error messages are identical. No `docs/`/`README` updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa)_