### PR TITLE
refactor: extract per-thread sqlite connection registry from FTSIndex

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ src/markdown_vault_mcp/
     routes.py          -- ASGI handler for the /transfer/{token} download/upload route (#622)
   scanner.py           -- file discovery, frontmatter parsing, chunking
   fts_index.py         -- SQLite FTS5 schema, BM25 search
+  _fts_connection.py   -- per-thread sqlite connection registry + SQLITE_LOCKED retry (#760)
   vector_index.py      -- numpy embeddings, cosine similarity
   providers.py         -- embedding provider ABC + implementations
   tracker.py           -- hash-based change detection

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -925,13 +925,15 @@ This is the contract that issue #513 (non-blocking MCP initialize via
 background indexing) depends on; PRs #510, #515, #516, #518 all failed
 because the single-connection model violated it on Python 3.12+.
 
-The mechanism is **per-thread `sqlite3.Connection` instances** managed by
-`FTSIndex`:
+The mechanism is **per-thread `sqlite3.Connection` instances** owned by
+`SqliteConnectionRegistry` (`_fts_connection.py`, extracted from
+`FTSIndex` in #760); `FTSIndex` composes the registry and delegates
+`_conn()`/`close()` to it:
 
 - Each thread that touches the index opens its own connection on first
   call, via `_conn()` (which routes through `threading.local`).
-- A side registry (`_all_conns: list[sqlite3.Connection]`, guarded by
-  `_reg_lock`) holds strong references to every opened connection so
+- A side registry (`all_conns: list[sqlite3.Connection]`, guarded by
+  `reg_lock`) holds strong references to every opened connection so
   `close()` can close all of them, including those opened by threads
   that have since exited. `check_same_thread=False` is set on every
   connection so `close()` can iterate cross-thread.
@@ -940,8 +942,8 @@ The mechanism is **per-thread `sqlite3.Connection` instances** managed by
   Per-thread opens apply only per-connection pragmas (`foreign_keys=ON`,
   `busy_timeout=5000`, `synchronous=NORMAL`); **pragmas apply BEFORE
   schema/migrations** so `busy_timeout` is active during `ALTER TABLE`.
-- `_closed: bool` uses double-checked locking: the fast path is lock-free;
-  the slow path re-checks under `_reg_lock` so a concurrent `close()`
+- `closed: bool` uses double-checked locking: the fast path is lock-free;
+  the slow path re-checks under `reg_lock` so a concurrent `close()`
   cannot race with a new-thread connection open.
 - Slow-path open + pragma + register is wrapped in `except BaseException`
   so `KeyboardInterrupt` / `SystemExit` / `asyncio.CancelledError` during
@@ -955,7 +957,7 @@ The mechanism is **per-thread `sqlite3.Connection` instances** managed by
   connection to the URI and raises `RuntimeError` with a clear error
   message if `SQLITE_ENABLE_SHARED_CACHE` is unavailable.
 
-Dead-thread connections accumulate in `_all_conns` until `close()`. This
+Dead-thread connections accumulate in `all_conns` until `close()`. This
 is bounded for the MCP server's threading model (long-lived lifespan
 thread + bounded `asyncio.to_thread` pool of ~30 recycled workers) and
 is preferred over the `weakref` approach that introduced a 3-finding

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -948,8 +948,8 @@ The mechanism is **per-thread `sqlite3.Connection` instances** owned by
 - Slow-path open + pragma + register is wrapped in `except BaseException`
   so `KeyboardInterrupt` / `SystemExit` / `asyncio.CancelledError` during
   interpreter teardown cannot leak the half-initialized connection.
-- `_primary_conn` is a strong instance attribute (alongside
-  `self._local.conn`) so the primary connection survives the constructing
+- `primary_conn` is a strong instance attribute (alongside
+  `self.local.conn`) so the primary connection survives the constructing
   thread's exit; the registry-based `close()` then still closes it.
 - `:memory:` databases are translated to a unique-per-instance shared-cache
   URI (`file:fts_<uuid4hex>?mode=memory&cache=shared`) so every per-thread

--- a/src/markdown_vault_mcp/_fts_connection.py
+++ b/src/markdown_vault_mcp/_fts_connection.py
@@ -1,0 +1,319 @@
+"""Per-thread SQLite connection registry and SQLITE_LOCKED retry policy.
+
+The thread-safety core extracted from ``fts_index.py`` (#760): every
+thread that touches the index opens its own ``sqlite3.Connection`` on
+first use, a side registry holds strong refs so ``close()`` can close
+every connection — including those opened by threads that have since
+exited — and application-level retry covers FTS5's ``SQLITE_LOCKED``
+errors that SQLite's C-level busy handler never retries (#560).
+
+:class:`FTSIndex <markdown_vault_mcp.fts_index.FTSIndex>` composes a
+:class:`SqliteConnectionRegistry` and keeps thin delegating shims for its
+historical private surface. See ``docs/design/design.md`` "Vault
+thread-safety contract" for the full contract (#519).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import logging
+import sqlite3
+import threading
+import time
+import uuid
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+# Match the busy_timeout setting; SQLITE_LOCKED needs application-level retry
+# because sqlite3.OperationalError("...locked...") is error code 6 (LOCKED)
+# rather than 5 (BUSY), and Python's sqlite3 / SQLite C-level busy_handler
+# only handles BUSY. See https://www.sqlite.org/rescode.html#locked.
+_SQLITE_LOCKED_RETRY_TIMEOUT_S = 5.0
+_SQLITE_LOCKED_INITIAL_SLEEP_S = 0.01
+_SQLITE_LOCKED_MAX_SLEEP_S = 0.5
+
+
+def retry_on_sqlite_locked(
+    operation: Callable[[], _T],
+    *,
+    timeout: float = _SQLITE_LOCKED_RETRY_TIMEOUT_S,
+) -> _T:
+    """Retry *operation* on transient SQLite "locked" errors.
+
+    Python's ``sqlite3.Connection``'s ``busy_timeout`` only retries on
+    ``SQLITE_BUSY`` (error code 5). FTS5 virtual-table internal locking
+    raises ``SQLITE_LOCKED`` (error code 6) which is never retried by the
+    SQLite C-level busy handler — see #560. This helper provides
+    application-level retry with exponential backoff so transient FTS5
+    locks (writer mid-upsert blocking a concurrent reader, or vice
+    versa) don't surface as user-visible failures.
+
+    Non-"locked" ``OperationalError``s propagate immediately.
+
+    Args:
+        operation: Callable to invoke. Re-invoked on each retry, so the
+            caller is responsible for any state reset (e.g. running
+            inside a fresh ``with conn:`` transaction that auto-rolls
+            back).
+        timeout: Maximum total wall-clock retry budget in seconds.
+
+    Returns:
+        Whatever *operation* returns on success.
+
+    Raises:
+        sqlite3.OperationalError: If the operation continues to raise a
+            "locked" error past *timeout*, or if it raises an
+            ``OperationalError`` that does not mention "locked".
+    """
+    deadline = time.monotonic() + timeout
+    sleep = _SQLITE_LOCKED_INITIAL_SLEEP_S
+    while True:
+        try:
+            return operation()
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower():
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            # Cap the sleep to the remaining budget so the contract
+            # "retry for at most *timeout* seconds" is honoured even
+            # near the deadline — without this, the final sleep could
+            # push us up to _SQLITE_LOCKED_MAX_SLEEP_S past *timeout*.
+            time.sleep(min(sleep, _SQLITE_LOCKED_MAX_SLEEP_S, remaining))
+            sleep *= 2
+
+
+def retry_on_locked(method: Callable[..., _T]) -> Callable[..., _T]:
+    """Method decorator: retry the method body on SQLITE_LOCKED.
+
+    Wraps the method so the entire body (including any ``with conn:``
+    transaction) is re-invoked on a locked error. This is safe because
+    Python's sqlite3 ``with conn:`` block rolls back the transaction on
+    exception before the wrapper sees it — the retry starts from a
+    clean state.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self: object, *args: object, **kwargs: object) -> _T:
+        return retry_on_sqlite_locked(lambda: method(self, *args, **kwargs))
+
+    return wrapper
+
+
+def resolve_connect_uri(db_path: Path | str) -> tuple[str, bool, bool]:
+    """Resolve a db_path into (connect_string, uses_uri, is_memory).
+
+    For ``":memory:"`` returns a shared-cache URI unique to this call so that
+    every per-thread ``sqlite3.connect()`` joins the same in-memory database
+    (required for the per-thread connection model — see #519). For file paths
+    returns the path string directly.
+
+    The shared-cache URI is unique per registry instance (uuid4 token) so
+    distinct in-process vaults do not collide.
+    """
+    if str(db_path) == ":memory:":
+        token = uuid.uuid4().hex
+        return f"file:fts_{token}?mode=memory&cache=shared", True, True
+    return str(db_path), False, False
+
+
+class SqliteConnectionRegistry:
+    """Per-thread ``sqlite3.Connection`` registry with a closeable lifecycle.
+
+    Owns the thread-safety machinery behind ``FTSIndex`` (#519): a
+    thread-local fast path, a strong-ref registry of every opened
+    connection (guarded by ``reg_lock``) so :meth:`close` reaches
+    connections whose threads have exited, and the BaseException-hardened
+    bootstrap/open paths that keep the registry consistent under
+    interrupts.
+
+    Args:
+        db_path: SQLite database file path, or ``":memory:"`` for a
+            shared-cache in-memory database.
+        owner_name: Class name used in the closed-error message so callers
+            see the facade they actually hold.
+    """
+
+    def __init__(self, db_path: Path | str, *, owner_name: str = "FTSIndex") -> None:
+        self.db_path = db_path
+        self._owner_name = owner_name
+        # Resolve URI (translates ``:memory:`` to a shared-cache URI so that
+        # per-thread opens see the same in-memory DB).
+        self.connect_uri, self.uses_uri, self.is_memory = resolve_connect_uri(db_path)
+        # Thread-safety state — see #519 and docs/design/design.md.
+        self.local = threading.local()
+        self.all_conns: list[sqlite3.Connection] = []
+        self.reg_lock = threading.Lock()
+        self.closed = False
+        self.primary_conn: sqlite3.Connection | None = None
+
+    def connect(self) -> sqlite3.Connection:
+        """Open a raw sqlite3 connection to this registry's URI."""
+        conn = sqlite3.connect(
+            self.connect_uri,
+            check_same_thread=False,
+            uri=self.uses_uri,
+        )
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def apply_pragmas(self, conn: sqlite3.Connection) -> None:
+        """Apply per-connection pragmas (foreign_keys, busy_timeout, synchronous).
+
+        Called on every ``sqlite3.connect()`` — the primary connection and
+        every per-thread open. These are per-connection settings that do NOT
+        persist across opens.
+        """
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        conn.execute("PRAGMA synchronous = NORMAL")
+
+    def open_primary(
+        self,
+        init_schema: Callable[[sqlite3.Connection], None],
+        probe_shared_cache: Callable[[], None],
+    ) -> None:
+        """Open and register the primary connection on the calling thread.
+
+        The whole pragma + *init_schema* + probe sequence runs under one
+        BaseException cleanup block so any failure (pragma, ALTER TABLE, or
+        the shared-cache probe) closes the primary connection — symmetric
+        with the slow-path cleanup in :meth:`conn`.
+
+        Args:
+            init_schema: Owner callback that runs DDL/migrations/WAL on the
+                primary connection (exactly once per owner instance).
+            probe_shared_cache: Owner callback invoked for in-memory
+                databases after registration; must raise when a second
+                connection cannot see the schema (fail-fast for SQLite
+                builds without ``SQLITE_ENABLE_SHARED_CACHE``).
+        """
+        primary = self.connect()
+        try:
+            # PRAGMAS FIRST — busy_timeout must be active for ALTER TABLE
+            # migrations in init_schema (per #519 carryover).
+            self.apply_pragmas(primary)
+            init_schema(primary)
+            self.local.conn = primary
+            self.primary_conn = primary
+            self.all_conns.append(primary)
+            # Fail-fast probe: if shared-cache ``:memory:`` translation is in
+            # use but SQLITE_ENABLE_SHARED_CACHE was disabled at build time, a
+            # second connection to the URI will see an empty DB. Surface that
+            # immediately instead of letting per-thread reads fail mysteriously
+            # downstream.
+            if self.is_memory:
+                probe_shared_cache()
+        except BaseException:
+            # Close the primary regardless of how far init progressed (the
+            # probe call may fail after append, leaving primary in
+            # all_conns; reset both paths to a clean state).
+            try:
+                primary.close()
+            except Exception:
+                logger.debug(
+                    "connection_registry.open_primary cleanup: error closing primary",
+                    exc_info=True,
+                )
+            # Mirror the conn() slow-path TLS clear: if a partially-built
+            # owner's local.conn still pointed at the now-closed primary,
+            # a caller holding the instance after __init__ raised would
+            # fast-path the closed conn instead of getting ProgrammingError.
+            self.local.conn = None
+            self.all_conns.clear()
+            self.primary_conn = None
+            raise
+
+    def conn(self) -> sqlite3.Connection:
+        """Return this thread's sqlite3 connection, opening one on first touch.
+
+        Uses double-checked locking: the fast path is lock-free; the slow path
+        re-checks ``closed`` under ``reg_lock`` so a concurrent ``close()``
+        cannot race with a new-thread open.
+
+        Raises:
+            sqlite3.ProgrammingError: If ``close()`` has been called.
+
+        Note on connection accumulation: dead-thread connections remain in
+        ``all_conns`` (strong refs) until ``close()``. This is bounded for
+        the MCP server's workload (long-lived lifespan thread + bounded
+        ``asyncio.to_thread`` pool) and is preferred over weakrefs (see
+        ``feedback_519_weakref_whackamole.md``).
+        """
+        if self.closed:
+            raise sqlite3.ProgrammingError(
+                f"Cannot operate on a closed {self._owner_name}"
+            )
+        existing: sqlite3.Connection | None = getattr(self.local, "conn", None)
+        if existing is not None:
+            return existing
+        new_conn = self.connect()
+        try:
+            self.apply_pragmas(new_conn)
+            with self.reg_lock:
+                if self.closed:
+                    raise sqlite3.ProgrammingError(
+                        f"Cannot operate on a closed {self._owner_name}"
+                    )
+                self.local.conn = new_conn
+                self.all_conns.append(new_conn)
+        except BaseException:
+            # Cover KeyboardInterrupt / SystemExit / asyncio.CancelledError —
+            # sqlite3.Error alone would leak the open connection on teardown.
+            # Clear the TLS slot first: CPython delivers signals at bytecode
+            # boundaries, so an interrupt between the local.conn assignment
+            # and the registry append would otherwise leave a closed conn in
+            # TLS for the next fast-path call to silently return.
+            self.local.conn = None
+            # Re-acquire reg_lock for the registry mutation: a concurrent
+            # close() iterates all_conns under the lock, so an unguarded
+            # remove() here could trigger "list changed size during iteration"
+            # in close().
+            with self.reg_lock, contextlib.suppress(ValueError):
+                self.all_conns.remove(new_conn)
+            new_conn.close()
+            raise
+        return new_conn
+
+    def close(self) -> None:
+        """Close every per-thread connection and mark this registry closed.
+
+        Idempotent: a second call finds an empty registry and performs no
+        connection closes. After ``close()``, any thread calling
+        :meth:`conn` raises ``sqlite3.ProgrammingError``.
+        """
+        with self.reg_lock:
+            self.closed = True
+            try:
+                for conn in self.all_conns:
+                    try:
+                        conn.close()
+                    except sqlite3.ProgrammingError:
+                        logger.debug(
+                            "connection_registry.close: connection already closed"
+                        )
+                    except Exception:
+                        # Catch non-sqlite3.Error subclasses too (e.g. OSError
+                        # from underlying file handle, RuntimeError from C
+                        # wrappers) so the loop never exits mid-iteration and
+                        # leaves connections un-closed. KeyboardInterrupt /
+                        # SystemExit still propagate.
+                        logger.error(
+                            "connection_registry.close: error closing connection",
+                            exc_info=True,
+                        )
+            finally:
+                # Ensure the registry is cleared even if a BaseException
+                # (KeyboardInterrupt / SystemExit) interrupts the loop, so a
+                # subsequent close() retry sees a clean state.
+                self.all_conns.clear()
+                self.primary_conn = None

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -77,8 +77,8 @@ def _json_default(obj: Any) -> str:
 
 
 # DDL executed once on connection open. `foreign_keys` is intentionally NOT
-# set here — `_apply_pragmas` sets it on every connection (primary and
-# per-thread) before `_init_schema` runs.
+# set here — `SqliteConnectionRegistry.apply_pragmas` sets it on every
+# connection (primary and per-thread) before `_init_schema` runs.
 _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS documents (
     id INTEGER PRIMARY KEY,

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -2,105 +2,30 @@
 
 from __future__ import annotations
 
-import contextlib
 import datetime
-import functools
 import json
 import logging
 import sqlite3
-import threading
-import time
-import uuid
 from collections import deque
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple
 
+from markdown_vault_mcp._fts_connection import (
+    SqliteConnectionRegistry,
+)
+from markdown_vault_mcp._fts_connection import (
+    retry_on_locked as _retry_on_locked,
+)
+from markdown_vault_mcp._fts_connection import (
+    retry_on_sqlite_locked as _retry_on_sqlite_locked,
+)
 from markdown_vault_mcp.embed_text import fields_text as _fields_text
 from markdown_vault_mcp.types import FTSResult, ParsedNote, SubtreeNote, TocEntry
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
-
-
-_T = TypeVar("_T")
-
-# Match the busy_timeout setting; SQLITE_LOCKED needs application-level retry
-# because sqlite3.OperationalError("...locked...") is error code 6 (LOCKED)
-# rather than 5 (BUSY), and Python's sqlite3 / SQLite C-level busy_handler
-# only handles BUSY. See https://www.sqlite.org/rescode.html#locked.
-_SQLITE_LOCKED_RETRY_TIMEOUT_S = 5.0
-_SQLITE_LOCKED_INITIAL_SLEEP_S = 0.01
-_SQLITE_LOCKED_MAX_SLEEP_S = 0.5
-
-
-def _retry_on_sqlite_locked(
-    operation: Callable[[], _T],
-    *,
-    timeout: float = _SQLITE_LOCKED_RETRY_TIMEOUT_S,
-) -> _T:
-    """Retry *operation* on transient SQLite "locked" errors.
-
-    Python's ``sqlite3.Connection``'s ``busy_timeout`` only retries on
-    ``SQLITE_BUSY`` (error code 5). FTS5 virtual-table internal locking
-    raises ``SQLITE_LOCKED`` (error code 6) which is never retried by the
-    SQLite C-level busy handler — see #560. This helper provides
-    application-level retry with exponential backoff so transient FTS5
-    locks (writer mid-upsert blocking a concurrent reader, or vice
-    versa) don't surface as user-visible failures.
-
-    Non-"locked" ``OperationalError``s propagate immediately.
-
-    Args:
-        operation: Callable to invoke. Re-invoked on each retry, so the
-            caller is responsible for any state reset (e.g. running
-            inside a fresh ``with conn:`` transaction that auto-rolls
-            back on exception).
-        timeout: Maximum total wall-clock retry budget in seconds.
-
-    Returns:
-        Whatever *operation* returns on success.
-
-    Raises:
-        sqlite3.OperationalError: If the operation continues to raise a
-            "locked" error past *timeout*, or if it raises an
-            ``OperationalError`` that does not mention "locked".
-    """
-    deadline = time.monotonic() + timeout
-    sleep = _SQLITE_LOCKED_INITIAL_SLEEP_S
-    while True:
-        try:
-            return operation()
-        except sqlite3.OperationalError as exc:
-            if "locked" not in str(exc).lower():
-                raise
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise
-            # Cap the sleep to the remaining budget so the contract
-            # "retry for at most *timeout* seconds" is honoured even
-            # near the deadline — without this, the final sleep could
-            # push us up to _SQLITE_LOCKED_MAX_SLEEP_S past *timeout*.
-            time.sleep(min(sleep, _SQLITE_LOCKED_MAX_SLEEP_S, remaining))
-            sleep *= 2
-
-
-def _retry_on_locked(method: Callable[..., _T]) -> Callable[..., _T]:
-    """Method decorator: retry the method body on SQLITE_LOCKED.
-
-    Wraps the method so the entire body (including any ``with conn:``
-    transaction) is re-invoked on a locked error. This is safe because
-    Python's sqlite3 ``with conn:`` block rolls back the transaction on
-    exception before the wrapper sees it — the retry starts from a
-    clean state.
-    """
-
-    @functools.wraps(method)
-    def wrapper(self: object, *args: object, **kwargs: object) -> _T:
-        return _retry_on_sqlite_locked(lambda: method(self, *args, **kwargs))
-
-    return wrapper
 
 
 # Thresholds for running FTS5 'optimize' after a bulk purge.  Deleting rows
@@ -316,23 +241,6 @@ def _derive_folder(path: str) -> str:
     return "" if folder == "." else folder
 
 
-def _resolve_connect_uri(db_path: Path | str) -> tuple[str, bool, bool]:
-    """Resolve a db_path into (connect_string, uses_uri, is_memory).
-
-    For ``":memory:"`` returns a shared-cache URI unique to this call so that
-    every per-thread ``sqlite3.connect()`` joins the same in-memory database
-    (required for the per-thread connection model — see #519). For file paths
-    returns the path string directly.
-
-    The shared-cache URI is unique per ``FTSIndex`` instance (uuid4 token) so
-    distinct in-process vaults do not collide.
-    """
-    if str(db_path) == ":memory:":
-        token = uuid.uuid4().hex
-        return f"file:fts_{token}?mode=memory&cache=shared", True, True
-    return str(db_path), False, False
-
-
 class FTSIndex:
     """SQLite FTS5 index providing BM25 search and tag filtering.
 
@@ -403,79 +311,12 @@ class FTSIndex:
                 sorted(unknown_weight_cols),
                 ", ".join(self._FTS_COLUMNS),
             )
-        # Resolve URI (translates ``:memory:`` to a shared-cache URI so that
-        # per-thread opens see the same in-memory DB).
-        self._connect_uri, self._uses_uri, self._is_memory = _resolve_connect_uri(
-            db_path
-        )
-        # Thread-safety state — see #519 and docs/design/design.md.
-        self._local = threading.local()
-        self._all_conns: list[sqlite3.Connection] = []
-        self._reg_lock = threading.Lock()
-        self._closed = False
-        self._primary_conn: sqlite3.Connection | None = None
-
-        # Open primary connection on the constructing thread. The whole
-        # init-schema + probe sequence runs under one BaseException cleanup
-        # block so any failure (pragma, ALTER TABLE, or the shared-cache
-        # probe) closes the primary connection — symmetric with the
-        # slow-path cleanup in _conn().
-        primary = self._connect()
-        try:
-            # PRAGMAS FIRST — busy_timeout must be active for ALTER TABLE migrations
-            # in _init_schema (per #519 carryover).
-            self._apply_pragmas(primary)
-            self._init_schema(primary)
-            self._local.conn = primary
-            self._primary_conn = primary
-            self._all_conns.append(primary)
-            # Fail-fast probe: if shared-cache ``:memory:`` translation is in
-            # use but SQLITE_ENABLE_SHARED_CACHE was disabled at build time, a
-            # second connection to the URI will see an empty DB. Surface that
-            # immediately instead of letting per-thread reads fail mysteriously
-            # downstream.
-            if self._is_memory:
-                self._probe_shared_cache()
-        except BaseException:
-            # Close the primary regardless of how far init progressed (the
-            # probe call may fail after append, leaving primary in
-            # _all_conns; reset both paths to a clean state).
-            try:
-                primary.close()
-            except Exception:
-                logger.debug(
-                    "fts_index.__init__ cleanup: error closing primary",
-                    exc_info=True,
-                )
-            # Mirror the _conn() slow-path TLS clear: if a partially-built
-            # FTSIndex's _local.conn still pointed at the now-closed primary,
-            # a caller holding the instance after __init__ raised would
-            # fast-path the closed conn instead of getting ProgrammingError.
-            self._local.conn = None
-            self._all_conns.clear()
-            self._primary_conn = None
-            raise
-
-    def _connect(self) -> sqlite3.Connection:
-        """Open a raw sqlite3 connection to this index's URI."""
-        conn = sqlite3.connect(
-            self._connect_uri,
-            check_same_thread=False,
-            uri=self._uses_uri,
-        )
-        conn.row_factory = sqlite3.Row
-        return conn
-
-    def _apply_pragmas(self, conn: sqlite3.Connection) -> None:
-        """Apply per-connection pragmas (foreign_keys, busy_timeout, synchronous).
-
-        Called on every ``sqlite3.connect()`` — the primary connection and
-        every per-thread open. These are per-connection settings that do NOT
-        persist across opens.
-        """
-        conn.execute("PRAGMA foreign_keys = ON")
-        conn.execute("PRAGMA busy_timeout = 5000")
-        conn.execute("PRAGMA synchronous = NORMAL")
+        # Thread-safety core (#519): per-thread connections, the strong-ref
+        # close registry, and the BaseException-hardened bootstrap live in
+        # the extracted SqliteConnectionRegistry (#760). Schema DDL and the
+        # shared-cache probe stay FTSIndex-owned and run via callbacks.
+        self._registry = SqliteConnectionRegistry(db_path)
+        self._registry.open_primary(self._init_schema, self._probe_shared_cache)
 
     def _init_schema(self, conn: sqlite3.Connection) -> None:
         """Run DDL, migrations, and WAL on the primary connection.
@@ -532,7 +373,7 @@ class FTSIndex:
         self._persist_rank_config(conn)
         # WAL is a DB-header pragma — persists across opens. Skip for in-memory
         # databases (SQLite silently falls back to 'memory' journal mode there).
-        if not self._is_memory:
+        if not self._registry.is_memory:
             result = conn.execute("PRAGMA journal_mode = WAL").fetchone()
             if result is None or str(result[0]).lower() != "wal":
                 logger.warning(
@@ -638,11 +479,11 @@ class FTSIndex:
         would then fail with confusing OperationalErrors. Surface that
         condition immediately with an operator-actionable error.
         """
-        # The probe connection intentionally bypasses _all_conns: it is opened
-        # and closed entirely within this method before the FTSIndex instance
-        # is exposed to any caller, so the registry-based close() machinery is
-        # not needed for it.
-        probe = self._connect()
+        # The probe connection intentionally bypasses the close registry: it
+        # is opened and closed entirely within this method before the FTSIndex
+        # instance is exposed to any caller, so the registry-based close()
+        # machinery is not needed for it.
+        probe = self._registry.connect()
         try:
             row = probe.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='documents'"
@@ -665,51 +506,14 @@ class FTSIndex:
     def _conn(self) -> sqlite3.Connection:
         """Return this thread's sqlite3 connection, opening one on first touch.
 
-        Uses double-checked locking: the fast path is lock-free; the slow path
-        re-checks ``_closed`` under ``_reg_lock`` so a concurrent ``close()``
-        cannot race with a new-thread open.
+        Delegates to :meth:`SqliteConnectionRegistry.conn` — see there for
+        the double-checked-locking contract and the note on connection
+        accumulation.
 
         Raises:
             sqlite3.ProgrammingError: If ``close()`` has been called.
-
-        Note on connection accumulation: dead-thread connections remain in
-        ``_all_conns`` (strong refs) until ``close()``. This is bounded for
-        the MCP server's workload (long-lived lifespan thread + bounded
-        ``asyncio.to_thread`` pool) and is preferred over weakrefs (see
-        ``feedback_519_weakref_whackamole.md``).
         """
-        if self._closed:
-            raise sqlite3.ProgrammingError("Cannot operate on a closed FTSIndex")
-        existing: sqlite3.Connection | None = getattr(self._local, "conn", None)
-        if existing is not None:
-            return existing
-        new_conn = self._connect()
-        try:
-            self._apply_pragmas(new_conn)
-            with self._reg_lock:
-                if self._closed:
-                    raise sqlite3.ProgrammingError(
-                        "Cannot operate on a closed FTSIndex"
-                    )
-                self._local.conn = new_conn
-                self._all_conns.append(new_conn)
-        except BaseException:
-            # Cover KeyboardInterrupt / SystemExit / asyncio.CancelledError —
-            # sqlite3.Error alone would leak the open connection on teardown.
-            # Clear the TLS slot first: CPython delivers signals at bytecode
-            # boundaries, so an interrupt between the _local.conn assignment
-            # and the registry append would otherwise leave a closed conn in
-            # TLS for the next fast-path call to silently return.
-            self._local.conn = None
-            # Re-acquire _reg_lock for the registry mutation: a concurrent
-            # close() iterates _all_conns under the lock, so an unguarded
-            # remove() here could trigger "list changed size during iteration"
-            # in close().
-            with self._reg_lock, contextlib.suppress(ValueError):
-                self._all_conns.remove(new_conn)
-            new_conn.close()
-            raise
-        return new_conn
+        return self._registry.conn()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -2202,32 +2006,9 @@ class FTSIndex:
     def close(self) -> None:
         """Close every per-thread connection and mark this index closed.
 
-        Idempotent: a second call finds an empty registry and performs no
-        connection closes. After ``close()``, any thread calling a public
-        method raises ``sqlite3.ProgrammingError`` from ``_conn()``.
+        Idempotent — delegates to :meth:`SqliteConnectionRegistry.close`.
+        After ``close()``, any thread calling a public method raises
+        ``sqlite3.ProgrammingError`` from ``_conn()``.
         """
-        with self._reg_lock:
-            self._closed = True
-            try:
-                for conn in self._all_conns:
-                    try:
-                        conn.close()
-                    except sqlite3.ProgrammingError:
-                        logger.debug("fts_index.close: connection already closed")
-                    except Exception:
-                        # Catch non-sqlite3.Error subclasses too (e.g. OSError
-                        # from underlying file handle, RuntimeError from C
-                        # wrappers) so the loop never exits mid-iteration and
-                        # leaves connections un-closed. KeyboardInterrupt /
-                        # SystemExit still propagate.
-                        logger.error(
-                            "fts_index.close: error closing connection",
-                            exc_info=True,
-                        )
-            finally:
-                # Ensure the registry is cleared even if a BaseException
-                # (KeyboardInterrupt / SystemExit) interrupts the loop, so a
-                # subsequent close() retry sees a clean state.
-                self._all_conns.clear()
-                self._primary_conn = None
+        self._registry.close()
         logger.debug("FTSIndex closed (db_path=%s)", self._db_path)

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -250,7 +250,8 @@ class FTSIndex:
     **Thread safety (issue #519):** every public method is safe to call from
     any thread. Each thread that touches the index opens its own
     ``sqlite3.Connection`` on first use via :meth:`_conn`; a side registry
-    (``_all_conns``, guarded by ``_reg_lock``) holds strong refs so
+    (``SqliteConnectionRegistry.all_conns`` in ``_fts_connection.py``,
+    guarded by ``reg_lock``) holds strong refs so
     :meth:`close` can close every connection — including those opened by
     threads that have since exited. Concurrent index mutations are
     serialised by the single-owner :class:`IndexWriter` thread (#559),

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -155,7 +155,7 @@ def test_pragmas_applied_per_connection(fts: FTSIndex) -> None:
 def test_pragmas_applied_before_schema(
     monkeypatch: pytest.MonkeyPatch, tmp_db: Path
 ) -> None:
-    """`_apply_pragmas` must run BEFORE `_init_schema` so busy_timeout is active
+    """`SqliteConnectionRegistry.apply_pragmas` must run BEFORE `_init_schema` so busy_timeout is active
     during ALTER TABLE migrations.
 
     Capture the call order by patching both methods on the class.
@@ -487,7 +487,7 @@ def test_init_baseexception_cleanup_clears_tls_slot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If __init__ raises AFTER the primary's TLS assignment (e.g. during
-    `_probe_shared_cache`), the cleanup must clear ``self._local.conn`` —
+    `_probe_shared_cache`), the cleanup must clear ``registry.local.conn`` —
     otherwise a caller holding the partially-built instance would fast-path
     a closed connection instead of seeing ProgrammingError.
 
@@ -548,7 +548,7 @@ def test_conn_slow_path_baseexception_cleanup(
     fts: FTSIndex,
     close_tracker: tuple[list[object], type],
 ) -> None:
-    """If _apply_pragmas fails on a per-thread open, the new connection
+    """If apply_pragmas fails on a per-thread open, the new connection
     must be closed and the TLS slot left unset so a retry re-opens."""
 
     closed, tracker_cls = close_tracker
@@ -584,13 +584,13 @@ def test_conn_slow_path_baseexception_cleanup(
 
 
 def test_conn_slow_path_failure_clears_tls_slot(fts: FTSIndex) -> None:
-    """If the slow-path open fails AFTER ``self._local.conn`` was set but
+    """If the slow-path open fails AFTER ``registry.local.conn`` was set but
     BEFORE registration completes (e.g. a BaseException between the two
     writes inside the lock), the cleanup MUST clear the TLS slot so the
     next ``_conn()`` call does not fast-path return a closed connection.
 
-    Regression for the bug where ``self._local.conn = new_conn`` was
-    assigned and a BaseException between that and ``_all_conns.append``
+    Regression for the bug where ``registry.local.conn = new_conn`` was
+    assigned and a BaseException between that and ``registry.all_conns.append``
     left a closed conn in TLS for subsequent silent reuse.
 
     Injection method: patch ``list.append`` on the registry's ``all_conns`` so the

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -23,6 +23,7 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
+from markdown_vault_mcp._fts_connection import SqliteConnectionRegistry
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.vault import Vault
 from tests.conftest import wait_for_writer_drain
@@ -160,7 +161,7 @@ def test_pragmas_applied_before_schema(
     Capture the call order by patching both methods on the class.
     """
     order: list[str] = []
-    real_apply = FTSIndex._apply_pragmas  # type: ignore[attr-defined]
+    real_apply = SqliteConnectionRegistry.apply_pragmas
     real_init = FTSIndex._init_schema  # type: ignore[attr-defined]
 
     def spy_apply(self, conn):  # type: ignore[no-untyped-def]
@@ -171,7 +172,7 @@ def test_pragmas_applied_before_schema(
         order.append("schema")
         return real_init(self, conn)
 
-    monkeypatch.setattr(FTSIndex, "_apply_pragmas", spy_apply)
+    monkeypatch.setattr(SqliteConnectionRegistry, "apply_pragmas", spy_apply)
     monkeypatch.setattr(FTSIndex, "_init_schema", spy_init)
 
     idx = FTSIndex(db_path=tmp_db)
@@ -313,7 +314,7 @@ def test_registry_uses_strong_refs(fts: FTSIndex) -> None:
     gc.collect()
 
     # Registry still holds the worker conn.
-    assert any(id(c) == worker_id[0] for c in fts._all_conns), (
+    assert any(id(c) == worker_id[0] for c in fts._registry.all_conns), (
         "worker conn must survive thread exit + gc in strong-ref registry"
     )
 
@@ -466,7 +467,7 @@ def test_init_baseexception_cleanup_closes_primary(
         return tracker_cls(real_connect(*args, **kwargs))  # type: ignore[return-value,arg-type,no-any-return]
 
     monkeypatch.setattr(
-        "markdown_vault_mcp.fts_index.sqlite3.connect", tracking_connect
+        "markdown_vault_mcp._fts_connection.sqlite3.connect", tracking_connect
     )
 
     def boom_schema(_self: object, _conn: object) -> None:
@@ -505,12 +506,13 @@ def test_init_baseexception_cleanup_clears_tls_slot(
         FTSIndex(db_path=":memory:")
 
     assert len(captured) == 1
-    assert getattr(captured[0]._local, "conn", None) is None, (
-        "__init__ cleanup must clear self._local.conn after post-TLS failure"
+    registry = captured[0]._registry
+    assert getattr(registry.local, "conn", None) is None, (
+        "__init__ cleanup must clear the registry's TLS slot after post-TLS failure"
     )
-    # _all_conns must also be cleared by the cleanup.
-    assert captured[0]._all_conns == []
-    assert captured[0]._primary_conn is None
+    # The close registry must also be cleared by the cleanup.
+    assert registry.all_conns == []
+    assert registry.primary_conn is None
 
 
 def test_probe_shared_cache_raises_when_documents_invisible(
@@ -533,7 +535,9 @@ def test_probe_shared_cache_raises_when_documents_invisible(
             return real_connect(":memory:", check_same_thread=False)
         return real_connect(*args, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr("markdown_vault_mcp.fts_index.sqlite3.connect", fake_connect)
+    monkeypatch.setattr(
+        "markdown_vault_mcp._fts_connection.sqlite3.connect", fake_connect
+    )
 
     with pytest.raises(RuntimeError, match="shared-cache probe failed"):
         FTSIndex(db_path=":memory:")
@@ -554,13 +558,13 @@ def test_conn_slow_path_baseexception_cleanup(
         return tracker_cls(real_connect(*args, **kwargs))  # type: ignore[return-value,arg-type,no-any-return]
 
     monkeypatch.setattr(
-        "markdown_vault_mcp.fts_index.sqlite3.connect", tracking_connect
+        "markdown_vault_mcp._fts_connection.sqlite3.connect", tracking_connect
     )
 
     def boom_pragmas(_self: object, _conn: object) -> None:
         raise RuntimeError("simulated pragma failure")
 
-    monkeypatch.setattr(FTSIndex, "_apply_pragmas", boom_pragmas)
+    monkeypatch.setattr(SqliteConnectionRegistry, "apply_pragmas", boom_pragmas)
 
     errors: list[BaseException] = []
 
@@ -589,7 +593,7 @@ def test_conn_slow_path_failure_clears_tls_slot(fts: FTSIndex) -> None:
     assigned and a BaseException between that and ``_all_conns.append``
     left a closed conn in TLS for subsequent silent reuse.
 
-    Injection method: patch ``list.append`` on ``_all_conns`` so the
+    Injection method: patch ``list.append`` on the registry's ``all_conns`` so the
     append raises after the TLS assignment has already happened.
     """
     append_calls = {"n": 0}
@@ -605,7 +609,7 @@ def test_conn_slow_path_failure_clears_tls_slot(fts: FTSIndex) -> None:
 
     # Swap registry with the exploding subclass, preserving the primary
     # connection entry the fixture registered before the patch.
-    fts._all_conns = _ExplodingList(fts._all_conns)
+    fts._registry.all_conns = _ExplodingList(fts._registry.all_conns)
 
     first_error: list[BaseException] = []
     second_result: list[sqlite3.Connection] = []
@@ -653,7 +657,7 @@ def test_close_continues_when_one_connection_raises(fts: FTSIndex) -> None:
     t.join()
     second = second_holder["c"]
     assert primary is not second
-    assert len(fts._all_conns) == 2
+    assert len(fts._registry.all_conns) == 2
 
     # Replace one connection's close with a function that raises OSError.
     # We can't monkey-patch sqlite3.Connection.close (read-only attr), so we
@@ -676,8 +680,8 @@ def test_close_continues_when_one_connection_raises(fts: FTSIndex) -> None:
     good = _GoodCloser(second)
     # Replace registry contents with [bad, good]. Drop the real primary +
     # second so they aren't double-closed by close() then by the fixture.
-    fts._all_conns[:] = [bad, good]  # type: ignore[list-item]
-    fts._primary_conn = None
+    fts._registry.all_conns[:] = [bad, good]  # type: ignore[list-item]
+    fts._registry.primary_conn = None
     primary.close()  # close the original primary out-of-band
 
     # close() must reach `good` despite `bad` raising.

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -5,8 +5,8 @@ must address. Run individually with ``uv run pytest tests/test_thread_safety.py`
 
 The carryover design (per ``project_issue_519_attempt_1_abandon.md``) is:
 per-thread ``sqlite3.Connection`` via ``threading.local``, strong-ref
-registry guarded by ``_reg_lock``, ``_closed`` flag with double-checked
-locking, ``BaseException`` cleanup on slow-path open, ``_primary_conn``
+registry guarded by ``reg_lock``, ``closed`` flag with double-checked
+locking, ``BaseException`` cleanup on slow-path open, ``primary_conn``
 strong attribute, shared-cache URI translation for ``:memory:`` with
 startup probe, and pragmas applied BEFORE schema/migrations.
 """


### PR DESCRIPTION
Closes #760. Refs #883 (audit epic).

## What

Fifth implementation PR of the #883 audit epic. The #760 investigation found `fts_index.py` (largest file, 34 public methods, PLR0904) is a *benign* god class: its method clusters share **no mutable state except the per-thread connection machinery** — ~300 lines of the repo's most safety-critical threading code (#519), entangled with everything. The assessment's single highest-value move: extract that registry into a standalone collaborator so the remaining clusters become separable.

## Changes (behavior-preserving)

New **`_fts_connection.py`** owns the thread-safety core, moved verbatim:

- **`retry_on_sqlite_locked` / `retry_on_locked`** + the `SQLITE_LOCKED` backoff constants (#560). `fts_index.py` re-imports them under the old private names, so the ~28 `@_retry_on_locked` decorations and `test_fts_index_retry.py`'s imports are unchanged.
- **`resolve_connect_uri`** — the shared-cache `:memory:` URI translation (#519/#520).
- **`SqliteConnectionRegistry`** — thread-local fast path, strong-ref close registry under `reg_lock`, the `BaseException`-hardened `open_primary` bootstrap and per-thread `conn()` slow path (TLS-clear-before-deregister ordering preserved comment-for-comment), and idempotent `close()`.

**Ownership boundary:** schema DDL/migrations and the shared-cache probe stay `FTSIndex`-owned and run via `open_primary(init_schema, probe_shared_cache)` callbacks — so pragmas-before-schema ordering is enforced in one place and the class-level `_init_schema`/`_probe_shared_cache` test seams keep working. `FTSIndex._conn()`/`close()` are now thin delegates.

## Tests

Six `test_thread_safety.py` tests re-point their injection seams at the new owner — `SqliteConnectionRegistry.apply_pragmas` (pragma-order and per-thread-failure tests), `fts._registry.all_conns` / `primary_conn` / `local` (strong-refs, init-cleanup, exploding-list TLS, close-continues tests), and `markdown_vault_mcp._fts_connection.sqlite3.connect` (connection trackers). **Every assertion is unchanged** — same contracts, new seam, same pattern as #888's four re-targets. All other FTS suites (`test_fts_index.py`, retry, optimize, snippet, subtree-toc, chunk-count, links, coordinator — 276 tests) pass unmodified.

## Docs

- `docs/design/design.md` "Vault thread-safety contract": mechanism now attributed to `SqliteConnectionRegistry` with `FTSIndex` composing it; field names updated.
- `CLAUDE.md` project tree: `_fts_connection.py` entry added.
- No user-facing change.

## Follow-up (deferred per the assessment)

Cluster peeling (graph reads → own collaborator first, then queries/writer/meta behind the facade) is the assessment's optional endgame — now a pure code move since the clusters share nothing but the injectable registry. It can land incrementally if/when churn warrants, under the #883 ground rules.

## Gates

- `uv run pytest -x -q`: 2861 passed, 6 skipped (verified on the exact pushed tree)
- `ruff check` / `ruff format --check`: clean
- `mypy src/ tests/`: clean
- `diff-quality --fail-under=100`: 100% (all changes staged)
- Patch coverage (`diff-cover` vs `origin/main`): 96%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa)_