### PR TITLE
refactor: split extract_links into per-format parsers

### DIFF
--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -876,9 +876,20 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
         List of :class:`~markdown_vault_mcp.types.LinkInfo` objects.
     """
     clean = _strip_code_spans(content)
-    links: list[LinkInfo] = []
+    return [
+        *_extract_inline_links(clean, source_path),
+        *_extract_reference_links(clean, source_path),
+        *_extract_wikilinks(clean, source_path),
+    ]
 
-    # --- Inline markdown links ---
+
+def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
+    """Extract inline ``[text](path.md)`` links from code-stripped content.
+
+    Skips image links (``![alt](src)``), external URLs, and pure anchor
+    links (``#section`` within the same document).
+    """
+    links: list[LinkInfo] = []
     for m in _RE_INLINE_LINK.finditer(clean):
         # Skip image links: ![alt](src) shares the same bracket syntax.
         if m.start() > 0 and clean[m.start() - 1] == "!":
@@ -901,7 +912,18 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
             )
         )
 
-    # --- Reference-style links ---
+    return links
+
+
+def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
+    """Extract reference-style ``[text][ref]`` links from code-stripped content.
+
+    Collects the ``[ref]: path.md`` definitions first (optional CommonMark
+    titles stripped), then resolves each usage; an empty ``[ref]`` falls
+    back to the link text per CommonMark shortcut semantics. External URLs
+    and pure anchors are skipped.
+    """
+    links: list[LinkInfo] = []
     # Collect reference definitions first.
     ref_defs: dict[str, str] = {}
     for m in _RE_REF_DEF.finditer(clean):
@@ -933,7 +955,19 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
             )
         )
 
-    # --- Wikilinks ---
+    return links
+
+
+def _extract_wikilinks(clean: str, source_path: str) -> list[LinkInfo]:
+    """Extract ``[[path]]`` / ``[[path|alias]]`` wikilinks from content.
+
+    Handles the Obsidian table-cell pipe escape (#731), fragment splitting
+    before the ``.md`` append, and Obsidian vault-wide resolution
+    semantics: only explicit relative prefixes (``./`` / ``../``) resolve
+    source-relative; bare and path-qualified wikilinks are stored as-is
+    for ``FTSIndex.resolve_vault_wikilinks()`` to resolve vault-wide.
+    """
+    links: list[LinkInfo] = []
     for m in _RE_WIKILINK.finditer(clean):
         raw_path = m.group(1).strip()
         # Obsidian escapes the alias pipe as `\|` in table cells, so the target


### PR DESCRIPTION
Closes #881. Refs #883 (audit epic).

## What

Sixth implementation PR of the #883 audit epic — the smallest one. `extract_links` was three independent format parsers (inline markdown, reference-style, wikilink) fused into one **D(24)** function; per the #881 investigation, each new syntax edge case (e.g. the #731 Obsidian pipe-escape for wikilinks in table cells) raised the whole function's complexity because the three formats' rules shared one scope.

## Changes (behavior-preserving)

The three loops move **verbatim** (comments included) into `_extract_inline_links`, `_extract_reference_links`, and `_extract_wikilinks`, each with a docstring stating its format's quirks (image-link skip, CommonMark title stripping / empty-ref fallback, pipe-escape + vault-wide resolution semantics). `extract_links` is now strip-code-spans plus concatenation in the original order, so link ordering in the output is identical.

radon: `extract_links` **D(24) → A-grade shell**; the wikilink parser lands at C(11) — the only genuinely branchy format — and the other two below C.

Per the #881 issue's explicit non-goals, `HeadingChunker._budget_split` C(17) and `scan_directory` C(13) are untouched (assessed as irreducibly algorithmic / clear fault-tolerance respectively).

## Gates

- `uv run pytest -x -q`: 2861 passed, 6 skipped (verified on the exact pushed tree)
- `ruff check` / `ruff format --check`: clean
- `mypy src/ tests/`: clean
- `diff-quality --fail-under=100`: 100% (staged)
- Patch coverage (`diff-cover` vs `origin/main`): **100%**

## Docs

No user-facing change; link syntax support, resolution semantics, and output are identical. No docs updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa)_