### PR TITLE
refactor: move graph-view assembly from app closures into GraphFacet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ src/markdown_vault_mcp/
   facets/
     reader.py          -- ReaderFacet: search/read/list/toc/similar/context/stats/history (#604)
     writer.py          -- WriterFacet: write/edit/delete/rename/attachments (#604)
-    graph.py           -- GraphFacet: backlinks/outlinks/broken/orphans/most-linked/paths (#604)
+    graph.py           -- GraphFacet: backlinks/outlinks/broken/orphans/most-linked/paths (#604); neighborhood/hub graph views (#880)
     index.py           -- IndexFacet: build/reindex/embeddings, readiness, writer + embeddings status (#604)
   transfer/
     store.py           -- TransferStore: in-memory one-time transfer-token state machine (#622)

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -86,7 +86,7 @@ markdown-vault-mcp (new package)
 +-- facets/
 |   +-- reader.py     -- ReaderFacet: search/read/list/toc/similar/context/stats/history (#604)
 |   +-- writer.py     -- WriterFacet: write/edit/delete/rename/attachments (#604)
-|   +-- graph.py      -- GraphFacet: backlinks/outlinks/broken/orphans/most-linked/paths (#604)
+|   +-- graph.py      -- GraphFacet: backlinks/outlinks/broken/orphans/most-linked/paths (#604); neighborhood/hub graph views (#880)
 |   +-- index.py      -- IndexFacet: thin wrapper over the coordinator (#604)
 
 ifcraftcorpus (existing, refactored later)
@@ -1682,7 +1682,7 @@ root already owns:
 |-|-|-|
 | ``ReaderFacet`` | search, read, get_metadata, list, folders, tags, toc, recent, similar, context, stats, history, diff, read_attachment | ``SearchManager``, ``DocumentManager``, ``GitQueryManager``, ``require_built`` |
 | ``WriterFacet`` | write, edit, delete, rename, write_attachment | ``DocumentManager`` |
-| ``GraphFacet`` | backlinks, outlinks, broken_links, orphans, most_linked, connection_path | ``LinkManager``, ``require_built`` |
+| ``GraphFacet`` | backlinks, outlinks, broken_links, orphans, most_linked, connection_path, neighborhood/hub graph views (#880) | ``LinkManager``, ``SearchManager``, ``require_built`` |
 | ``IndexFacet`` | build/reindex/embeddings (sync + async), readiness, writer status, embeddings_status | ``IndexWriteCoordinator`` (public subset only), ``IndexManager`` (embeddings_status) |
 
 ``Vault`` constructs the facets once in ``__init__`` and exposes them via

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -11,7 +11,6 @@ instance in :func:`~markdown_vault_mcp.server.make_server`.
 from __future__ import annotations
 
 import asyncio
-import collections
 import hashlib
 import importlib.resources
 import logging
@@ -37,6 +36,7 @@ except ImportError as exc:  # pragma: no cover - dep-pin guard
     ) from exc
 
 from markdown_vault_mcp.config import _ENV_PREFIX
+from markdown_vault_mcp.types import GraphView
 from markdown_vault_mcp.vault import Vault
 
 from ._icons import _TOOL_ICONS
@@ -192,6 +192,32 @@ _SPA_SHELL_HTML = _rewrite_spa_app_tool_calls(
     .read_text(encoding="utf-8")
     .rstrip("\n")
 )
+
+
+def _graph_view_payload(view: GraphView, *, include_truncated: bool) -> dict[str, Any]:
+    """Serialize a :class:`GraphView` into the SPA graph-tool wire shape.
+
+    Edge endpoints map to ``from``/``to`` (vis-network's field names;
+    ``from`` is a Python keyword, so the dataclass uses source/target).
+    """
+    payload: dict[str, Any] = {
+        "nodes": [
+            {
+                "id": n.id,
+                "label": n.label,
+                "group": n.group,
+                "folder": n.folder,
+                "backlink_count": n.backlink_count,
+            }
+            for n in view.nodes
+        ],
+        "edges": [
+            {"from": e.source, "to": e.target, "type": e.link_type} for e in view.edges
+        ],
+    }
+    if include_truncated:
+        payload["truncated"] = view.truncated
+    return payload
 
 
 def register_apps(mcp: FastMCP) -> None:
@@ -453,150 +479,14 @@ def register_apps(mcp: FastMCP) -> None:
 
             - truncated (bool): True when BFS hit the ``max_nodes`` cap.
         """
-        nodes: dict[str, dict[str, Any]] = {}
-        edges: list[dict[str, Any]] = []
-        visited: set[str] = set()
-        queue: collections.deque[tuple[str, int]] = collections.deque([(path, 0)])
-        truncated = False
-
-        while queue:
-            if len(nodes) >= max_nodes:
-                truncated = True
-                break
-            current, d = queue.popleft()
-            if current in visited:
-                continue
-            visited.add(current)
-
-            # Add node — indexed metadata only (title/folder); reading the full
-            # document here would load it into memory and, for a note over
-            # MAX_NOTE_READ_BYTES, raise and fail the whole graph.
-            meta = await asyncio.to_thread(vault.reader.get_metadata, current)
-            label = (
-                meta.title if meta else current.rsplit("/", 1)[-1].replace(".md", "")
-            )
-            folder = meta.folder if meta else ""
-
-            if d >= depth:
-                # Boundary nodes are reachable by definition — skip DB calls
-                nodes[current] = {
-                    "id": current,
-                    "label": label,
-                    "group": "note",
-                    "folder": folder,
-                    "backlink_count": 0,
-                }
-                continue
-
-            # Fetch backlinks/outlinks for interior nodes (orphan detection + edges)
-            try:
-                backlinks = await asyncio.to_thread(vault.graph.get_backlinks, current)
-            except ValueError:
-                backlinks = []
-            try:
-                outlinks = await asyncio.to_thread(vault.graph.get_outlinks, current)
-            except ValueError:
-                outlinks = []
-            is_orphan = len(backlinks) == 0 and len(outlinks) == 0
-
-            nodes[current] = {
-                "id": current,
-                "label": label,
-                "group": "orphan" if is_orphan else "note",
-                "folder": folder,
-                "backlink_count": len(backlinks),
-            }
-
-            for bl in backlinks:
-                edges.append(
-                    {
-                        "from": bl.source_path,
-                        "to": current,
-                        "type": bl.link_type,
-                    }
-                )
-                if bl.source_path not in visited:
-                    queue.append((bl.source_path, d + 1))
-
-            # Process outlinks (already fetched above for orphan detection)
-            for ol in outlinks:
-                if ol.exists:
-                    edges.append(
-                        {
-                            "from": current,
-                            "to": ol.target_path,
-                            "type": ol.link_type,
-                        }
-                    )
-                    if ol.target_path not in visited:
-                        queue.append((ol.target_path, d + 1))
-
-        # Deduplicate explicit edges
-        seen_edges: set[tuple[str, str]] = set()
-        unique_edges: list[dict[str, Any]] = []
-        for e in edges:
-            key = (e["from"], e["to"])
-            if key not in seen_edges:
-                seen_edges.add(key)
-                unique_edges.append(e)
-
-        # Semantic similarity edges (optional, requires embeddings)
-        if include_semantic:
-            sem_seen: set[frozenset[str]] = set()
-            for node_path in list(nodes.keys()):
-                if len(nodes) >= max_nodes:
-                    truncated = True
-                    break
-                try:
-                    similar = await asyncio.to_thread(
-                        vault.reader.get_similar, node_path, limit=5
-                    )
-                except ValueError:
-                    # Expected when embeddings are not configured for this vault
-                    continue
-                except Exception:
-                    logger.warning(
-                        "get_similar failed for %s", node_path, exc_info=True
-                    )
-                    continue
-                seen_sr: set[str] = set()
-                for sr in similar:
-                    if sr.path == node_path or sr.path in seen_sr:
-                        continue
-                    seen_sr.add(sr.path)
-                    pair: frozenset[str] = frozenset({node_path, sr.path})
-                    if pair in sem_seen:
-                        continue
-                    sem_seen.add(pair)
-                    if sr.path not in nodes:
-                        if len(nodes) >= max_nodes:
-                            truncated = True
-                            break
-                        sim_meta = await asyncio.to_thread(
-                            vault.reader.get_metadata, sr.path
-                        )
-                        sim_label = (
-                            sim_meta.title
-                            if sim_meta
-                            else sr.path.rsplit("/", 1)[-1].replace(".md", "")
-                        )
-                        sim_folder = sim_meta.folder if sim_meta else ""
-                        nodes[sr.path] = {
-                            "id": sr.path,
-                            "label": sim_label,
-                            "group": "note",
-                            "folder": sim_folder,
-                            "backlink_count": 0,
-                        }
-                    unique_edges.append(
-                        {"from": node_path, "to": sr.path, "type": "semantic"}
-                    )
-
-        return {
-            "nodes": list(nodes.values()),
-            "edges": unique_edges,
-            "truncated": truncated,
-        }
+        view = await asyncio.to_thread(
+            vault.graph.get_neighborhood,
+            path,
+            depth=depth,
+            include_semantic=include_semantic,
+            max_nodes=max_nodes,
+        )
+        return _graph_view_payload(view, include_truncated=True)
 
     @mcp.tool(
         icons=_TOOL_ICONS["vault_graph_hubs"],
@@ -639,78 +529,8 @@ def register_apps(mcp: FastMCP) -> None:
               - to (str): Target node ID.
               - type (str): "markdown", "wikilink", or "reference".
         """
-        hubs = await asyncio.to_thread(vault.graph.get_most_linked, limit=limit)
-        nodes: dict[str, dict[str, Any]] = {}
-        edges: list[dict[str, Any]] = []
-        seen_edges: set[tuple[str, str]] = set()
-
-        for hub in hubs:
-            nodes[hub.path] = {
-                "id": hub.path,
-                "label": hub.title,
-                "group": "hub",
-                "backlink_count": hub.backlink_count,
-                "folder": hub.folder,
-            }
-
-        # Fetch every hub's backlinks concurrently. Each call is an independent
-        # read and FTS uses per-thread sqlite connections, so the to_thread
-        # calls run in parallel safely instead of one-at-a-time (#285).
-        async def _backlinks(path: str) -> list[Any]:
-            try:
-                return await asyncio.to_thread(vault.graph.get_backlinks, path)
-            except ValueError:
-                return []
-
-        backlinks_per_hub = await asyncio.gather(*(_backlinks(h.path) for h in hubs))
-
-        # Collect the non-hub source paths that need a label, preserving
-        # first-seen order so labels/folders are assigned deterministically,
-        # then fetch their metadata concurrently (deduplicated — a source linking
-        # several hubs is fetched once).
-        to_read: list[str] = []
-        seen_read: set[str] = set()
-        for backlinks in backlinks_per_hub:
-            for bl in backlinks:
-                if bl.source_path not in nodes and bl.source_path not in seen_read:
-                    seen_read.add(bl.source_path)
-                    to_read.append(bl.source_path)
-        meta_results = await asyncio.gather(
-            *(asyncio.to_thread(vault.reader.get_metadata, p) for p in to_read)
-        )
-        meta_by_path = dict(zip(to_read, meta_results, strict=True))
-
-        # Build nodes + edges in the original (hub, backlink) order so the
-        # output is identical to the sequential version.
-        for hub, backlinks in zip(hubs, backlinks_per_hub, strict=True):
-            for bl in backlinks:
-                if bl.source_path not in nodes:
-                    meta = meta_by_path.get(bl.source_path)
-                    label = (
-                        meta.title
-                        if meta
-                        else bl.source_path.rsplit("/", 1)[-1].replace(".md", "")
-                    )
-                    folder = meta.folder if meta else ""
-                    nodes[bl.source_path] = {
-                        "id": bl.source_path,
-                        "label": label,
-                        "group": "note",
-                        "folder": folder,
-                        "backlink_count": 0,
-                    }
-                edge_key = (bl.source_path, hub.path)
-                if edge_key not in seen_edges:
-                    seen_edges.add(edge_key)
-                    edges.append(
-                        {
-                            "from": bl.source_path,
-                            "to": hub.path,
-                            "type": bl.link_type,
-                        }
-                    )
-
-        return {"nodes": list(nodes.values()), "edges": edges}
+        view = await asyncio.to_thread(vault.graph.get_hub_graph, limit=limit)
+        return _graph_view_payload(view, include_truncated=False)
 
     @mcp.tool(
         icons=_TOOL_ICONS["vault_list"],

--- a/src/markdown_vault_mcp/facets/graph.py
+++ b/src/markdown_vault_mcp/facets/graph.py
@@ -319,6 +319,11 @@ class GraphFacet:
             IndexUnavailableError: If :meth:`IndexFacet.build_index` has not
                 been called.
         """
+        # Gate up front: with depth=0 the traversal never reaches the gated
+        # get_backlinks/get_outlinks calls, and the semantic pass swallows
+        # exceptions by design — without this, the documented
+        # IndexUnavailableError contract would silently degrade (#891 review).
+        self._require_built()
         nodes: dict[str, GraphNode] = {}
         edges: list[GraphEdge] = []
         visited: set[str] = set()

--- a/src/markdown_vault_mcp/facets/graph.py
+++ b/src/markdown_vault_mcp/facets/graph.py
@@ -10,12 +10,17 @@ delegating; the bucket-2 methods operate on a cold index.
 
 from __future__ import annotations
 
+import logging
+from collections import deque
 from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.types import GraphEdge, GraphNode, GraphView
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from markdown_vault_mcp.managers.link import LinkManager
+    from markdown_vault_mcp.managers.search import SearchManager
     from markdown_vault_mcp.types import (
         BacklinkInfo,
         BrokenLinkInfo,
@@ -24,21 +29,32 @@ if TYPE_CHECKING:
         OutlinkInfo,
     )
 
+logger = logging.getLogger(__name__)
+
 
 class GraphFacet:
     """Link-graph queries, backed by :class:`LinkManager`."""
 
     def __init__(
-        self, *, link_mgr: LinkManager, require_built: Callable[[], None]
+        self,
+        *,
+        link_mgr: LinkManager,
+        search_mgr: SearchManager,
+        require_built: Callable[[], None],
     ) -> None:
-        """Hold the link manager and the index-readiness gate.
+        """Hold the managers and the index-readiness gate.
 
         Args:
             link_mgr: The shared :class:`LinkManager` owned by the root.
+            search_mgr: The shared :class:`SearchManager`; the graph-view
+                assembly methods (#880) use it for node labels
+                (:meth:`SearchManager.get_metadata`) and semantic edges
+                (:meth:`SearchManager.get_similar`).
             require_built: Raises :exc:`IndexUnavailableError` if the index has
                 not been built; called by the bucket-3 query methods.
         """
         self._link_mgr = link_mgr
+        self._search_mgr = search_mgr
         self._require_built = require_built
 
     def get_backlinks(
@@ -146,3 +162,268 @@ class GraphFacet:
         """
         self._require_built()
         return self._link_mgr.get_connection_path(source, target, max_depth=max_depth)
+
+    # ------------------------------------------------------------------
+    # Graph-view assembly (#880) — moved out of the app-tool closures so the
+    # traversal is unit-testable and runs in a single worker thread instead
+    # of one asyncio.to_thread hop per node.
+    # ------------------------------------------------------------------
+
+    def _node_label(self, path: str) -> tuple[str, str]:
+        """Return ``(label, folder)`` for *path* from indexed metadata.
+
+        Only indexed metadata (title/folder) is consulted — reading the full
+        document would load it into memory and, for a note over
+        ``MAX_NOTE_READ_BYTES``, raise and fail the whole graph. Falls back
+        to the filename stem for unindexed paths.
+        """
+        meta = self._search_mgr.get_metadata(path)
+        label = meta.title if meta else path.rsplit("/", 1)[-1].replace(".md", "")
+        folder = meta.folder if meta else ""
+        return label, folder
+
+    def _expand_node(
+        self, current: str
+    ) -> tuple[GraphNode, list[GraphEdge], list[str]]:
+        """Build *current*'s interior node, its edges, and its link partners.
+
+        Fetches backlinks/outlinks (orphan detection + edges); a
+        ``ValueError`` from either query (e.g. an invalid path discovered
+        via a link) yields an empty edge set for that direction.
+
+        Returns:
+            Tuple ``(node, edges, partners)`` — the node, its inbound and
+            existing-outbound edges, and the partner paths for the caller
+            to enqueue (in backlink-then-outlink order).
+        """
+        label, folder = self._node_label(current)
+        try:
+            backlinks = self.get_backlinks(current)
+        except ValueError:
+            backlinks = []
+        try:
+            outlinks = self.get_outlinks(current)
+        except ValueError:
+            outlinks = []
+        is_orphan = len(backlinks) == 0 and len(outlinks) == 0
+
+        node = GraphNode(
+            id=current,
+            label=label,
+            group="orphan" if is_orphan else "note",
+            folder=folder,
+            backlink_count=len(backlinks),
+        )
+
+        edges: list[GraphEdge] = []
+        partners: list[str] = []
+        for bl in backlinks:
+            edges.append(
+                GraphEdge(source=bl.source_path, target=current, link_type=bl.link_type)
+            )
+            partners.append(bl.source_path)
+        for ol in outlinks:
+            if ol.exists:
+                edges.append(
+                    GraphEdge(
+                        source=current, target=ol.target_path, link_type=ol.link_type
+                    )
+                )
+                partners.append(ol.target_path)
+        return node, edges, partners
+
+    def _add_semantic_edges(
+        self,
+        nodes: dict[str, GraphNode],
+        edges: list[GraphEdge],
+        *,
+        max_nodes: int,
+    ) -> bool:
+        """Append dashed similarity edges for each current node.
+
+        Returns ``True`` when the node cap stopped the expansion. A
+        ``ValueError`` from :meth:`SearchManager.get_similar` (embeddings
+        not configured) silently skips the node; unexpected failures are
+        logged and skipped.
+        """
+        truncated = False
+        sem_seen: set[frozenset[str]] = set()
+        for node_path in list(nodes.keys()):
+            if len(nodes) >= max_nodes:
+                truncated = True
+                break
+            try:
+                similar = self._search_mgr.get_similar(node_path, limit=5)
+            except ValueError:
+                # Expected when embeddings are not configured for this vault.
+                continue
+            except Exception:
+                logger.warning("get_similar failed for %s", node_path, exc_info=True)
+                continue
+            seen_sr: set[str] = set()
+            for sr in similar:
+                if sr.path == node_path or sr.path in seen_sr:
+                    continue
+                seen_sr.add(sr.path)
+                pair: frozenset[str] = frozenset({node_path, sr.path})
+                if pair in sem_seen:
+                    continue
+                sem_seen.add(pair)
+                if sr.path not in nodes:
+                    if len(nodes) >= max_nodes:
+                        truncated = True
+                        break
+                    label, folder = self._node_label(sr.path)
+                    nodes[sr.path] = GraphNode(
+                        id=sr.path,
+                        label=label,
+                        group="note",
+                        folder=folder,
+                        backlink_count=0,
+                    )
+                edges.append(
+                    GraphEdge(source=node_path, target=sr.path, link_type="semantic")
+                )
+        return truncated
+
+    def get_neighborhood(
+        self,
+        path: str,
+        *,
+        depth: int = 1,
+        include_semantic: bool = False,
+        max_nodes: int = 200,
+    ) -> GraphView:
+        """Return the link neighborhood of a note as a node/edge graph.
+
+        Breadth-first traversal from *path*: interior nodes (within *depth*
+        hops) contribute their backlink/outlink edges and orphan grouping;
+        boundary nodes appear with ``backlink_count=0``. Explicit edges are
+        deduplicated per ``(source, target)``.
+
+        Args:
+            path: Center note path.
+            depth: How many hops to traverse (default 1).
+            include_semantic: When ``True``, add ``"semantic"`` similarity
+                edges for each node (requires embeddings; silently omitted
+                when unavailable).
+            max_nodes: Soft cap on returned node count. Traversal and any
+                semantic expansion both stop once the cap is hit, setting
+                :attr:`GraphView.truncated`. Bounds dense-vault depth=2
+                traversals.
+
+        Returns:
+            A :class:`~markdown_vault_mcp.types.GraphView`.
+
+        Raises:
+            IndexUnavailableError: If :meth:`IndexFacet.build_index` has not
+                been called.
+        """
+        nodes: dict[str, GraphNode] = {}
+        edges: list[GraphEdge] = []
+        visited: set[str] = set()
+        queue: deque[tuple[str, int]] = deque([(path, 0)])
+        truncated = False
+
+        while queue:
+            if len(nodes) >= max_nodes:
+                truncated = True
+                break
+            current, hop = queue.popleft()
+            if current in visited:
+                continue
+            visited.add(current)
+
+            if hop >= depth:
+                # Boundary nodes are reachable by definition — skip DB calls.
+                label, folder = self._node_label(current)
+                nodes[current] = GraphNode(
+                    id=current,
+                    label=label,
+                    group="note",
+                    folder=folder,
+                    backlink_count=0,
+                )
+                continue
+
+            node, node_edges, partners = self._expand_node(current)
+            nodes[current] = node
+            edges.extend(node_edges)
+            for partner in partners:
+                if partner not in visited:
+                    queue.append((partner, hop + 1))
+
+        # Deduplicate explicit edges.
+        seen_edges: set[tuple[str, str]] = set()
+        unique_edges: list[GraphEdge] = []
+        for e in edges:
+            key = (e.source, e.target)
+            if key not in seen_edges:
+                seen_edges.add(key)
+                unique_edges.append(e)
+
+        if include_semantic:
+            truncated = (
+                self._add_semantic_edges(nodes, unique_edges, max_nodes=max_nodes)
+                or truncated
+            )
+
+        return GraphView(
+            nodes=list(nodes.values()), edges=unique_edges, truncated=truncated
+        )
+
+    def get_hub_graph(self, *, limit: int = 20) -> GraphView:
+        """Return the most-linked notes and their inbound links as a graph.
+
+        Hub nodes come from :meth:`get_most_linked`; each hub's backlink
+        sources join as ``"note"`` nodes with edges deduplicated per
+        ``(source, hub)``.
+
+        Args:
+            limit: Maximum number of hub notes to include.
+
+        Returns:
+            A :class:`~markdown_vault_mcp.types.GraphView` (``truncated`` is
+            always ``False`` — hub views have no node cap).
+        """
+        hubs = self.get_most_linked(limit=limit)
+        nodes: dict[str, GraphNode] = {}
+        edges: list[GraphEdge] = []
+        seen_edges: set[tuple[str, str]] = set()
+
+        for hub in hubs:
+            nodes[hub.path] = GraphNode(
+                id=hub.path,
+                label=hub.title,
+                group="hub",
+                folder=hub.folder,
+                backlink_count=hub.backlink_count,
+            )
+
+        for hub in hubs:
+            try:
+                backlinks = self.get_backlinks(hub.path)
+            except ValueError:
+                backlinks = []
+            for bl in backlinks:
+                if bl.source_path not in nodes:
+                    label, folder = self._node_label(bl.source_path)
+                    nodes[bl.source_path] = GraphNode(
+                        id=bl.source_path,
+                        label=label,
+                        group="note",
+                        folder=folder,
+                        backlink_count=0,
+                    )
+                edge_key = (bl.source_path, hub.path)
+                if edge_key not in seen_edges:
+                    seen_edges.add(edge_key)
+                    edges.append(
+                        GraphEdge(
+                            source=bl.source_path,
+                            target=hub.path,
+                            link_type=bl.link_type,
+                        )
+                    )
+
+        return GraphView(nodes=list(nodes.values()), edges=edges)

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -567,6 +567,60 @@ class MostLinkedNote:
 
 
 @dataclass
+class GraphNode:
+    """One node in a link-graph view (#880).
+
+    Attributes:
+        id: Vault-relative document path (unique node identifier).
+        label: Display name — the indexed title, falling back to the
+            filename stem when the document is not indexed.
+        group: Rendering group — ``"note"``, ``"orphan"``, or ``"hub"``.
+        folder: Parent folder path (empty string for root-level documents).
+        backlink_count: Inbound-link count, ``0`` for boundary nodes whose
+            links were not expanded.
+    """
+
+    id: str
+    label: str
+    group: str
+    folder: str
+    backlink_count: int
+
+
+@dataclass
+class GraphEdge:
+    """One directed edge in a link-graph view (#880).
+
+    Attributes:
+        source: Path of the linking document.
+        target: Path of the linked document.
+        link_type: ``"markdown"``, ``"wikilink"``, ``"reference"``, or
+            ``"semantic"`` (similarity edges from
+            :meth:`~markdown_vault_mcp.facets.graph.GraphFacet.get_neighborhood`).
+    """
+
+    source: str
+    target: str
+    link_type: str
+
+
+@dataclass
+class GraphView:
+    """A node/edge graph assembled by the graph facet (#880).
+
+    Attributes:
+        nodes: Graph nodes, in first-seen traversal order.
+        edges: Directed edges, deduplicated per ``(source, target)`` for
+            explicit links.
+        truncated: ``True`` when assembly stopped at the node cap.
+    """
+
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+    truncated: bool = False
+
+
+@dataclass
 class NoteContext:
     """Consolidated context for a document, returned by :meth:`~markdown_vault_mcp.facets.reader.ReaderFacet.get_context`.
 

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -601,7 +601,7 @@ class GraphEdge:
 
     source: str
     target: str
-    link_type: str
+    link_type: Literal["markdown", "wikilink", "reference", "semantic"]
 
 
 @dataclass

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -454,7 +454,9 @@ class Vault:
         )
         self._writer_facet = WriterFacet(self._doc_mgr)
         self._graph_facet = GraphFacet(
-            link_mgr=self._link_mgr, require_built=self._require_built
+            link_mgr=self._link_mgr,
+            search_mgr=self._search_mgr,
+            require_built=self._require_built,
         )
         self._index_facet = IndexFacet(
             coordinator=self._coordinator, index_mgr=self._index_mgr

--- a/tests/test_facet_graph.py
+++ b/tests/test_facet_graph.py
@@ -80,3 +80,108 @@ class TestGraphFacetLimit:
             assert len(col.graph.get_outlinks("a.md", limit=1)) == 1
         finally:
             col.close()
+
+
+class TestGraphViews:
+    """Direct facet-level coverage of the graph-view assembly (#880)."""
+
+    @staticmethod
+    def _linked_vault(tmp_path: Path) -> Path:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "center.md").write_text(
+            "# Center\n\nSee [a](a.md).\n", encoding="utf-8"
+        )
+        (vault / "a.md").write_text(
+            "# A\n\nBack to [c](center.md).\n", encoding="utf-8"
+        )
+        (vault / "lonely.md").write_text("# Lonely\n\nno links\n", encoding="utf-8")
+        return vault
+
+    def test_neighborhood_nodes_edges_and_groups(self, tmp_path: Path) -> None:
+        col = Vault(source_dir=self._linked_vault(tmp_path))
+        col.index.build_index()
+        try:
+            view = col.graph.get_neighborhood("center.md", depth=1)
+            ids = {n.id for n in view.nodes}
+            assert "center.md" in ids
+            assert "a.md" in ids
+            by_id = {n.id: n for n in view.nodes}
+            assert by_id["center.md"].group == "note"
+            assert by_id["center.md"].label == "Center"
+            edge_pairs = {(e.source, e.target) for e in view.edges}
+            assert ("center.md", "a.md") in edge_pairs
+            assert ("a.md", "center.md") in edge_pairs
+            assert view.truncated is False
+        finally:
+            col.close()
+
+    def test_neighborhood_orphan_group(self, tmp_path: Path) -> None:
+        col = Vault(source_dir=self._linked_vault(tmp_path))
+        col.index.build_index()
+        try:
+            view = col.graph.get_neighborhood("lonely.md", depth=1)
+            by_id = {n.id: n for n in view.nodes}
+            assert by_id["lonely.md"].group == "orphan"
+            assert view.edges == []
+        finally:
+            col.close()
+
+    def test_neighborhood_max_nodes_truncates(self, tmp_path: Path) -> None:
+        col = Vault(source_dir=self._linked_vault(tmp_path))
+        col.index.build_index()
+        try:
+            view = col.graph.get_neighborhood("center.md", depth=2, max_nodes=1)
+            assert len(view.nodes) == 1
+            assert view.truncated is True
+        finally:
+            col.close()
+
+    def test_neighborhood_boundary_nodes_not_expanded(self, tmp_path: Path) -> None:
+        col = Vault(source_dir=self._linked_vault(tmp_path))
+        col.index.build_index()
+        try:
+            view = col.graph.get_neighborhood("center.md", depth=1)
+            by_id = {n.id: n for n in view.nodes}
+            # a.md sits at the depth boundary: present, but not expanded.
+            assert by_id["a.md"].backlink_count == 0
+        finally:
+            col.close()
+
+    def test_neighborhood_semantic_skipped_without_embeddings(
+        self, tmp_path: Path
+    ) -> None:
+        col = Vault(source_dir=self._linked_vault(tmp_path))
+        col.index.build_index()
+        try:
+            view = col.graph.get_neighborhood(
+                "center.md", depth=1, include_semantic=True
+            )
+            assert all(e.link_type != "semantic" for e in view.edges)
+        finally:
+            col.close()
+
+    def test_neighborhood_gates_on_cold_index(self, tmp_path: Path) -> None:
+        # depth=0 + include_semantic never reaches the gated link queries;
+        # the up-front gate must still surface the documented error (#891).
+        col = Vault(source_dir=self._linked_vault(tmp_path))
+        try:
+            with pytest.raises(IndexUnavailableError):
+                col.graph.get_neighborhood("center.md", depth=0, include_semantic=True)
+        finally:
+            col.close()
+
+    def test_hub_graph_nodes_and_edges(self, tmp_path: Path) -> None:
+        col = Vault(source_dir=self._linked_vault(tmp_path))
+        col.index.build_index()
+        try:
+            view = col.graph.get_hub_graph(limit=5)
+            by_id = {n.id: n for n in view.nodes}
+            # center.md and a.md each have one backlink -> both are hubs.
+            assert by_id["center.md"].group == "hub"
+            assert by_id["center.md"].backlink_count == 1
+            edge_pairs = {(e.source, e.target) for e in view.edges}
+            assert ("a.md", "center.md") in edge_pairs
+            assert view.truncated is False
+        finally:
+            col.close()

--- a/tests/test_mcp_apps_graph.py
+++ b/tests/test_mcp_apps_graph.py
@@ -702,7 +702,7 @@ class TestIncludeSemanticEdges:
                 return_value=mock_prov,
             ),
             patch(
-                "markdown_vault_mcp.facets.reader.ReaderFacet.get_similar",
+                "markdown_vault_mcp.managers.search.SearchManager.get_similar",
                 side_effect=ValueError("not found"),
             ),
         ):
@@ -738,7 +738,7 @@ class TestIncludeSemanticEdges:
                 return_value=mock_prov,
             ),
             patch(
-                "markdown_vault_mcp.facets.reader.ReaderFacet.get_similar",
+                "markdown_vault_mcp.managers.search.SearchManager.get_similar",
                 side_effect=RuntimeError("embedding backend unavailable"),
             ),
         ):


### PR DESCRIPTION
Closes #880. Refs #883 (audit epic).

## What

Seventh implementation PR of the #883 audit epic. The ~200-line neighborhood BFS and the hub-graph assembly lived as async closures inside `register_apps()` — domain graph traversal sitting in the MCP presentation layer, untestable without spinning up FastMCP, and paying **one `asyncio.to_thread` hop per node** (3×N thread hops per graph render, flagged by #880 as a large-vault scaling problem).

## Changes

- **`GraphFacet.get_neighborhood(path, *, depth, include_semantic, max_nodes)`** and **`get_hub_graph(*, limit)`** — the traversal moved faithfully out of the closures: per-node `ValueError` tolerance, orphan grouping, boundary-node short-circuit (no DB calls past `depth`), explicit-edge dedup, the node cap + `truncated` flag, and the semantic-expansion pass (silently skipped when embeddings are unconfigured; unexpected `get_similar` failures logged and skipped) are all unchanged. `SearchManager` is injected for node labels (`get_metadata`) and semantic edges (`get_similar` — same readiness-gated layer the reader facet used).
- **New `GraphView` / `GraphNode` / `GraphEdge` dataclasses** in `types.py`.
- **The `vault_graph_neighborhood` / `vault_graph_hubs` app tools are now thin adapters**: one `asyncio.to_thread` call plus `_graph_view_payload` serialization to the vis-network wire shape (`"from"`/`"to"` keys — `from` is a Python keyword, hence `source`/`target` on the dataclass). Wire payloads are key-for-key identical to before.
- Internal traversal calls go through the facet's own gated `get_backlinks`/`get_outlinks`/`get_most_linked`, so readiness semantics per node are exactly what the closures got via `vault.graph.*`.

## Performance note

The hub path's `asyncio.gather` per-call parallelism (#285) is superseded by a single worker thread doing sequential reads on per-thread sqlite connections — the per-call `to_thread` dispatch overhead that #285 worked around is gone entirely, and the hub assembly's output order was already explicitly pinned to the sequential version, so output is identical.

## Tests

- The **137-test app-layer suite** (`test_mcp_apps_graph.py` + foundation) pins the end-to-end wire payloads — nodes/edges/truncated shapes, orphan/hub grouping, semantic-edge behavior, caps — and passes with only two seam re-points: the `get_similar` failure-injection tests now patch `SearchManager.get_similar` (where the facet calls) instead of `ReaderFacet.get_similar`; assertions unchanged.
- The traversal is now also directly unit-testable at the facet level without FastMCP, per the issue's intent.

## Docs

- `CLAUDE.md` + `docs/design/design.md`: `GraphFacet` entries now list the graph-view methods and the `SearchManager` collaborator.
- The `vault_*` app-only tools remain intentionally undocumented in `docs/tools/index.md` (SPA-internal, never LLM-visible).

## Gates

- `uv run pytest -x -q`: 2861 passed, 6 skipped (verified on the exact pushed tree)
- `ruff check` / `ruff format --check`: clean
- `mypy src/ tests/`: clean
- `diff-quality --fail-under=100`: 100% (staged)
- Patch coverage (`diff-cover` vs `origin/main`): 95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrA7F1VkbstMav5Lw97nQa)_