### PR TITLE
test(conformance): ratcheting template-conformance gate (#899)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "pip-audit>=2.7",
     "watchdog>=4.0",
     "jsonschema>=4.18",
+    "copier>=9.4",  # template-conformance gate renders the template pristinely (#899)
 ]
 docs = [
     "mike>=2",

--- a/tests/test_template_conformance.py
+++ b/tests/test_template_conformance.py
@@ -1,0 +1,459 @@
+"""Template-conformance gate — the anti-excuse device for the de-fork epic #898.
+
+Six files are fully owned by the copier template ``fastmcp-server-template``
+(they are not in the template's ``_skip_if_exists`` / ``_exclude``, so a
+``copier update`` re-renders them every time). Domain code in those files must
+live inside a declared sentinel block or in a dedicated domain module — never in
+the template-owned body. This module renders the template pristinely with this
+repo's own answers and asserts each file matches the pristine render *outside*
+its sentinel blocks. Any out-of-sentinel divergence is a fork.
+
+The :data:`RATCHET` allowlist carries the files whose de-fork is still in
+progress. Each de-fork PR **removes its file from RATCHET in the same PR**: that
+removal flips the file from the weak "still forked" assertion to the strict
+"conforms" assertion, so a PR cannot claim a de-fork unless the file actually
+conforms. The list can only shrink truthfully — a file that already conforms
+fails the weak assertion. When RATCHET is empty the gate is permanently strict
+and blocks any new fork.
+
+Render uses ``copier copy --trust --skip-tasks`` — ``--trust`` because the
+template declares tasks (copier refuses otherwise), ``--skip-tasks`` so the
+``vendor_spa`` post-task never runs (no network, no ``app.html`` fabrication).
+Only the ``.py`` files are compared, and copier writes them before tasks run.
+A render failure is a **loud skip**, never a silent pass.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from itertools import zip_longest
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE = "markdown_vault_mcp"
+ANSWERS = REPO_ROOT / ".copier-answers.yml"
+
+# Fully template-owned files → their repo-relative paths. Match on the full
+# path (never the basename): the template skip-lists ``packaging/mcpb/src/server.py``,
+# which must NOT exempt the module ``server.py`` (guarded below).
+FILE_MODULE_PATHS = {
+    "config.py": f"src/{MODULE}/config.py",
+    "server.py": f"src/{MODULE}/server.py",
+    "_server_deps.py": f"src/{MODULE}/_server_deps.py",
+    "_server_apps.py": f"src/{MODULE}/_server_apps.py",
+    "__init__.py": f"src/{MODULE}/__init__.py",
+    "cli.py": f"src/{MODULE}/cli.py",
+}
+
+# Known-forked files, de-fork in progress → tracking issue. REMOVE a file here in
+# the same PR that de-forks it; the removal is the proof (it flips the file to
+# the strict check). Epic #898. Seeded below after measuring actual conformance.
+RATCHET: dict[str, str] = {
+    "config.py": "#900",
+    "server.py": "#901",
+    "_server_deps.py": "#902",
+    "__init__.py": "#903",
+    "_server_apps.py": "#905",
+    "cli.py": "#904",
+}
+
+_START = re.compile(r"#\s*([A-Z0-9-]+)-START\b")
+_END = re.compile(r"#\s*([A-Z0-9-]+)-END\b")
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (unit-tested below so the strict path is covered regardless of
+# how many files are still on the RATCHET).
+# --------------------------------------------------------------------------- #
+def _normalize(text: str) -> list[str]:
+    """Minimal normalization applied identically to both sides.
+
+    Strips trailing whitespace and one-or-more trailing blank lines, normalizes
+    CRLF→LF. Deliberately does NOT sort imports or tolerate docstring drift —
+    both are forks that cause ``copier update`` churn.
+    """
+    lines = [ln.rstrip() for ln in text.replace("\r\n", "\n").split("\n")]
+    while lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def _sentinel_names(pristine_lines: list[str]) -> set[str]:
+    """Legal sentinel names = those the *pristine* render declares.
+
+    Authoritative source: a fork cannot legitimize itself by inventing a
+    sentinel the template does not ship. Raises on unbalanced markers.
+    """
+    names: set[str] = set()
+    stack: list[str] = []
+    for ln in pristine_lines:
+        start = _START.search(ln)
+        if start:
+            stack.append(start.group(1))
+            names.add(start.group(1))
+            continue
+        end = _END.search(ln)
+        if end:
+            assert stack and stack[-1] == end.group(1), (
+                f"unbalanced sentinel {end.group(1)}-END in pristine render"
+            )
+            stack.pop()
+    assert not stack, f"unclosed sentinel(s) in pristine render: {stack}"
+    return names
+
+
+def _strip_sentinels(lines: list[str], legal: set[str]) -> list[str]:
+    """Replace each inclusive ``NAME-START..NAME-END`` block with one token.
+
+    Marker-anchored (not index-anchored), so equal blocks line up regardless of
+    interior length, block order is enforced, and marker-comment prose drift is
+    tolerated. Only blocks whose name is ``legal`` are collapsed — an invented
+    sentinel's content stays in the remainder and surfaces as a fork.
+    """
+    out: list[str] = []
+    i, n = 0, len(lines)
+    while i < n:
+        start = _START.search(lines[i])
+        if start and start.group(1) in legal:
+            name = start.group(1)
+            j = i + 1
+            while j < n:
+                end = _END.search(lines[j])
+                if end and end.group(1) == name:
+                    break
+                j += 1
+            if j < n:  # matched END found → collapse the inclusive block
+                out.append(f"@@SENTINEL:{name}@@")
+                i = j + 1
+                continue
+        out.append(lines[i])
+        i += 1
+    return out
+
+
+def _first_divergence(
+    repo_lines: list[str], pristine_lines: list[str]
+) -> tuple[int, str | None, str | None] | None:
+    """Return ``(index, repo_line, pristine_line)`` of the first mismatch, or None."""
+    for idx, (r, p) in enumerate(zip_longest(repo_lines, pristine_lines)):
+        if r != p:
+            return idx, r, p
+    return None
+
+
+def _fork_message(
+    fname: str, rel: str, ref: str, div: tuple[int, str | None, str | None]
+) -> str:
+    idx, repo_line, pristine_line = div
+    return (
+        f"FORK DETECTED in {rel} (template-owned, ref={ref}).\n"
+        f"  First out-of-sentinel divergence at stripped-remainder line {idx}:\n"
+        f"      repo:     {repo_line!r}\n"
+        f"      pristine: {pristine_line!r}\n"
+        f"  This is OUTSIDE every sentinel block, so `copier update` will overwrite "
+        f"it (or cause merge churn). Fix by reverting to pristine, moving the change "
+        f"INTO a sentinel block, or relocating it to a domain module. Epic #898. "
+        f"Do NOT add {fname} to RATCHET to silence this unless it is a genuine "
+        f"work-in-progress fork tracked by an issue."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Pristine render (session-scoped) + exemption discovery.
+# --------------------------------------------------------------------------- #
+def _answers() -> dict:
+    return yaml.safe_load(ANSWERS.read_text())
+
+
+def _template_git_dir(tmp_path_factory: pytest.TempPathFactory, src_url: str) -> Path:
+    """A local git checkout of the template — the sibling checkout if present
+    (offline-friendly), else a blobless clone of ``_src_path``.
+
+    When no sibling checkout exists the clone needs network. Probe the remote
+    first with a short timeout so an offline environment skips in seconds
+    (loudly) instead of stalling on the multi-minute clone/fetch timeouts.
+    """
+    local = REPO_ROOT.parent / "fastmcp-server-template"
+    if (local / ".git").is_dir():
+        return local
+    dest = tmp_path_factory.mktemp("template")
+    try:
+        subprocess.run(  # pragma: no cover — clone path only runs without a sibling
+            ["git", "ls-remote", "--exit-code", src_url, "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        subprocess.run(
+            ["git", "clone", "--filter=blob:none", src_url, str(dest)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        subprocess.run(
+            ["git", "-C", str(dest), "fetch", "--tags"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:  # pragma: no cover
+        pytest.skip(
+            "template-conformance gate: cannot obtain the template — SKIPPED, "
+            f"not a pass ({exc})"
+        )
+    return dest
+
+
+def _ensure_ref(template_git: Path, ref: str) -> None:
+    """Guarantee ``ref`` resolves in ``template_git``; fetch once if not.
+
+    A persistent sibling checkout (the documented template-reconciliation
+    workflow) can lag ``.copier-answers.yml``'s ``_commit`` after a bump. Rather
+    than let a later ``git show <ref>:...`` hard-error, fetch once and, if the
+    ref is still absent, skip loudly — never a silent pass or an ugly traceback.
+    """
+
+    def _resolves() -> bool:
+        return (
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(template_git),
+                    "rev-parse",
+                    "--verify",
+                    "--quiet",
+                    f"{ref}^{{commit}}",
+                ],
+                capture_output=True,
+                text=True,
+            ).returncode
+            == 0
+        )
+
+    if _resolves():
+        return
+    try:  # pragma: no cover — only when a local checkout lags the pinned ref
+        subprocess.run(
+            ["git", "-C", str(template_git), "fetch", "--tags"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:  # pragma: no cover
+        pytest.skip(
+            f"template-conformance gate: cannot fetch template ref {ref} — "
+            f"SKIPPED, not a pass ({exc})"
+        )
+    if not _resolves():  # pragma: no cover
+        pytest.skip(
+            f"template-conformance gate: template ref {ref} not found after "
+            "fetch — SKIPPED, not a pass"
+        )
+
+
+def _exempt_paths(template_git: Path, ref: str, python_module: str) -> set[str]:
+    """Repo-relative paths the template will not re-render (skip-listed/excluded).
+
+    Rendered from the template ``copier.yml`` at ``ref`` — so if a file is added
+    to ``_skip_if_exists`` upstream it auto-exempts here with no test edit.
+    """
+    raw = subprocess.run(
+        ["git", "-C", str(template_git), "show", f"{ref}:copier.yml"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    cfg = yaml.safe_load(raw)
+    entries = list(cfg.get("_skip_if_exists", []) or []) + list(
+        cfg.get("_exclude", []) or []
+    )
+    # Render the one Jinja variable these path entries use, tolerant of spacing.
+    var = re.compile(r"\{\{\s*python_module\s*\}\}")
+    return {var.sub(python_module, str(e)) for e in entries}
+
+
+class _Ctx:
+    def __init__(self, render_dir: Path, exempt: set[str], ref: str) -> None:
+        self.render_dir = render_dir
+        self.exempt = exempt
+        self.ref = ref
+
+
+@pytest.fixture(scope="session")
+def ctx(tmp_path_factory: pytest.TempPathFactory) -> _Ctx:
+    answers = _answers()
+    ref = answers["_commit"]
+    template_git = _template_git_dir(tmp_path_factory, answers["_src_path"])
+    _ensure_ref(template_git, ref)
+    dest = tmp_path_factory.mktemp("pristine")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "copier",
+                "copy",
+                "--trust",
+                "--skip-tasks",
+                "--defaults",
+                "--overwrite",
+                "--data-file",
+                str(ANSWERS),
+                "--vcs-ref",
+                ref,
+                str(template_git),
+                str(dest),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:  # pragma: no cover
+        pytest.skip(
+            f"template-conformance gate: pristine render errored — SKIPPED, "
+            f"not a pass ({exc})"
+        )
+    # Render success = clean exit AND every watched file present. Inferring it
+    # from one file would turn a partial render into a spurious per-file FAIL.
+    missing = [rel for rel in FILE_MODULE_PATHS.values() if not (dest / rel).exists()]
+    if proc.returncode != 0 or missing:  # pragma: no cover
+        pytest.skip(
+            "template-conformance gate: pristine render FAILED — SKIPPED, not a "
+            f"pass. rc={proc.returncode} missing={missing}\n{proc.stderr[-2000:]}"
+        )
+    try:
+        exempt = _exempt_paths(template_git, ref, answers["python_module"])
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:  # pragma: no cover
+        pytest.skip(
+            "template-conformance gate: cannot read template copier.yml — "
+            f"SKIPPED, not a pass ({exc})"
+        )
+    return _Ctx(dest, exempt, ref)
+
+
+# --------------------------------------------------------------------------- #
+# The gate.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("fname", sorted(FILE_MODULE_PATHS))
+def test_template_owned_file_conforms(fname: str, ctx: _Ctx) -> None:
+    rel = FILE_MODULE_PATHS[fname]
+    repo_path = REPO_ROOT / rel
+    pristine_path = ctx.render_dir / rel
+
+    # Env-gated like the render/clone branches: no watched file is skip-listed
+    # at the pinned ref, so this never runs in practice — pragma for parity.
+    if rel in ctx.exempt:  # pragma: no cover
+        assert repo_path.exists(), f"{fname} is template-exempt but missing from repo"
+        assert fname not in RATCHET, f"{fname} is exempt — remove it from RATCHET"
+        return
+
+    assert pristine_path.exists(), (
+        f"pristine render did not produce {rel}; gate cannot verify it"
+    )
+    pristine = _normalize(pristine_path.read_text())
+    repo = _normalize(repo_path.read_text())
+    legal = _sentinel_names(pristine)
+    div = _first_divergence(
+        _strip_sentinels(repo, legal), _strip_sentinels(pristine, legal)
+    )
+
+    if fname in RATCHET:
+        assert div is not None, (
+            f"{fname} now CONFORMS to the template skeleton but is still in RATCHET "
+            f"({RATCHET[fname]}). Remove it from RATCHET in THIS PR — that removal is "
+            f"the proof of de-fork. Epic #898."
+        )
+    else:
+        assert div is None, _fork_message(fname, rel, ctx.ref, div)
+
+
+def test_module_server_is_never_exempt(ctx: _Ctx) -> None:
+    """`packaging/mcpb/src/server.py` is skip-listed; the module `server.py` must
+    never be — a basename-based exemption would silently stop guarding it.
+    """
+    assert f"src/{MODULE}/server.py" not in ctx.exempt
+
+
+def test_ratchet_only_lists_template_owned_files() -> None:
+    unknown = set(RATCHET) - set(FILE_MODULE_PATHS)
+    assert not unknown, f"RATCHET lists non-template-owned files: {sorted(unknown)}"
+
+
+# --------------------------------------------------------------------------- #
+# Unit tests for the pure comparison logic (cover the strict path independent of
+# how many files are still on the RATCHET).
+# --------------------------------------------------------------------------- #
+_SKELETON = [
+    "x = 1",
+    "# DOMAIN-WIRING-START — add wiring",
+    "PLACEHOLDER",
+    "# DOMAIN-WIRING-END",
+    "y = 2",
+]
+
+
+def test_conforming_file_has_no_divergence() -> None:
+    repo = [
+        "x = 1",
+        "# DOMAIN-WIRING-START — add wiring",
+        "custom_wiring()",  # domain content inside the sentinel — allowed
+        "more_wiring()",
+        "# DOMAIN-WIRING-END",
+        "y = 2",
+    ]
+    legal = _sentinel_names(_SKELETON)
+    assert (
+        _first_divergence(
+            _strip_sentinels(repo, legal), _strip_sentinels(_SKELETON, legal)
+        )
+        is None
+    )
+
+
+def test_out_of_sentinel_change_is_a_fork() -> None:
+    repo = ["x = 999", *_SKELETON[1:]]  # changed a line OUTSIDE the sentinel
+    legal = _sentinel_names(_SKELETON)
+    div = _first_divergence(
+        _strip_sentinels(repo, legal), _strip_sentinels(_SKELETON, legal)
+    )
+    assert div is not None
+    assert div[0] == 0 and div[1] == "x = 999"
+    assert "FORK DETECTED" in _fork_message("f.py", "src/f.py", "v1", div)
+
+
+def test_invented_sentinel_content_is_not_stripped() -> None:
+    """A sentinel the pristine render does not declare must not shield content."""
+    repo = [
+        "x = 1",
+        "# DOMAIN-WIRING-START — add wiring",
+        "PLACEHOLDER",
+        "# DOMAIN-WIRING-END",
+        "# DOMAIN-INVENTED-START",
+        "sneaky()",
+        "# DOMAIN-INVENTED-END",
+        "y = 2",
+    ]
+    legal = _sentinel_names(_SKELETON)  # only DOMAIN-WIRING is legal
+    div = _first_divergence(
+        _strip_sentinels(repo, legal), _strip_sentinels(_SKELETON, legal)
+    )
+    assert div is not None  # the invented block diverges
+
+
+def test_normalize_ignores_trailing_whitespace_and_blank_lines() -> None:
+    assert _normalize("a  \nb\n\n\n") == _normalize("a\nb\n")
+
+
+def test_unbalanced_sentinel_raises() -> None:
+    with pytest.raises(AssertionError):
+        _sentinel_names(["# FOO-START", "x = 1"])  # never closed

--- a/uv.lock
+++ b/uv.lock
@@ -447,6 +447,30 @@ wheels = [
 ]
 
 [[package]]
+name = "copier"
+version = "9.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "dunamai" },
+    { name = "funcy" },
+    { name = "jinja2" },
+    { name = "jinja2-ansible-filters" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "plumbum" },
+    { name = "pydantic" },
+    { name = "pygments" },
+    { name = "pyyaml" },
+    { name = "questionary" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/c7/3cd18cd539ff41e8e7a95b0146dbace0ba332a4c97f468066b2c2daca2ed/copier-9.16.0.tar.gz", hash = "sha256:4db1a9861d0760f745cc6241f99be37b476f849b8ad700133e2f620b7df92eb2", size = 643997, upload-time = "2026-06-23T17:09:04.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/a4/cf8df35b6488c04cae9aa7338c7b531a87aae2515da3993d2906d49b1dc1/copier-9.16.0-py3-none-any.whl", hash = "sha256:fadc55a22db6fb0f99d52878d3df4df3fa9c314dd96b0d81fef785a5e803114b", size = 65483, upload-time = "2026-06-23T17:09:03.617Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +732,18 @@ wheels = [
 ]
 
 [[package]]
+name = "dunamai"
+version = "1.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/67/d5611975faaa5e4a920f4b19e4caccd5df0facb925687850f1e45f5876f2/dunamai-1.26.1.tar.gz", hash = "sha256:3b46007bd65b00b4824ead0a1aee365fd22d0ec2b9c219497d4fd48f52860c8b", size = 45567, upload-time = "2026-04-04T14:07:11.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/bc/8b8ec5a4bfc5b9cf3ce27a118339e994f88410be5677c96493e0ea28e76d/dunamai-1.26.1-py3-none-any.whl", hash = "sha256:2727d939c5b4257cb01ea404372803b477f5176e5a347c43beaf89cd5072e853", size = 27332, upload-time = "2026-04-04T14:07:10.079Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -858,6 +894,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "funcy"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/b8/c6081521ff70afdff55cd9512b2220bbf4fa88804dae51d1b57b4b58ef32/funcy-2.0.tar.gz", hash = "sha256:3963315d59d41c6f30c04bc910e10ab50a3ac4a225868bfa96feed133df075cb", size = 537931, upload-time = "2023-03-28T06:22:46.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/08/c2409cb01d5368dcfedcbaffa7d044cc8957d57a9d0855244a5eb4709d30/funcy-2.0-py2.py3-none-any.whl", hash = "sha256:53df23c8bb1651b12f095df764bfb057935d49537a56de211b098f4c79614bb0", size = 30891, upload-time = "2023-03-28T06:22:42.576Z" },
 ]
 
 [[package]]
@@ -1150,6 +1195,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jinja2-ansible-filters"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/27/fa186af4b246eb869ffca8ffa42d92b05abaec08c99329e74d88b2c46ec7/jinja2-ansible-filters-1.3.2.tar.gz", hash = "sha256:07c10cf44d7073f4f01102ca12d9a2dc31b41d47e4c61ed92ef6a6d2669b356b", size = 16945, upload-time = "2022-06-30T14:08:50.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/b9/313e8f2f2e9517ae050a692ae7b3e4b3f17cc5e6dfea0db51fe14e586580/jinja2_ansible_filters-1.3.2-py3-none-any.whl", hash = "sha256:e1082f5564917649c76fed239117820610516ec10f87735d0338688800a55b34", size = 18975, upload-time = "2022-06-30T14:08:49.571Z" },
 ]
 
 [[package]]
@@ -1484,6 +1542,7 @@ browser = [
     { name = "pytest-playwright" },
 ]
 dev = [
+    { name = "copier" },
     { name = "diff-cover" },
     { name = "jsonschema" },
     { name = "mypy" },
@@ -1529,6 +1588,7 @@ provides-extras = ["mcp", "embeddings-api", "embeddings", "file-watcher", "summa
 [package.metadata.requires-dev]
 browser = [{ name = "pytest-playwright", specifier = ">=0.5" }]
 dev = [
+    { name = "copier", specifier = ">=9.4" },
     { name = "diff-cover", specifier = ">=9.0" },
     { name = "jsonschema", specifier = ">=4.18" },
     { name = "mypy", specifier = ">=1.0,<2" },
@@ -2458,6 +2518,18 @@ wheels = [
 ]
 
 [[package]]
+name = "plumbum"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/6a/1d1b143420fcdfc8902f2db6b7d1d2325211461c5f2a43c849de7afad688/plumbum-2.0.1.tar.gz", hash = "sha256:61623f856dcb09eb20dcd5aa708dfb3cd04b6f4ab10224d39303b163bb1c4c61", size = 377668, upload-time = "2026-06-08T14:44:06.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/2d/d741fbbbcba7eb6f9f1a829373c558114d59cb882b95f941aa0dc060861f/plumbum-2.0.1-py3-none-any.whl", hash = "sha256:27a454980f91689aae8f18242a36daaf2636219171cf0e6a849744aa1d6fff85", size = 164460, upload-time = "2026-06-08T14:44:04.75Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2471,6 +2543,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -3022,6 +3106,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds `tests/test_template_conformance.py` — the mechanical, un-gameable acceptance gate for the de-fork epic #898. It renders the copier template pristinely with this repo's own answers and asserts each fully template-owned file matches the pristine skeleton **outside** its declared sentinel blocks. Any out-of-sentinel divergence is a fork.

## The ratchet (the anti-excuse device)

A `RATCHET` allowlist carries the six still-forked files (`config.py`, `server.py`, `_server_deps.py`, `_server_apps.py`, `__init__.py`, `cli.py`), each mapped to its tracking issue:

- A file **not** in `RATCHET` gets a **strict** check — any out-of-sentinel diff fails, with a message naming the exact line and pointing to the epic.
- A file **in** `RATCHET` gets a **weak** check — it must *still* diverge, so the list can't be padded with already-clean files and can only shrink truthfully.
- **Each de-fork PR removes its file from `RATCHET` in the same PR.** That removal flips the file to the strict check, so a PR cannot claim a de-fork unless the file actually conforms.

When `RATCHET` is empty the gate is permanently strict and blocks any new fork.

## How it renders

`python -m copier copy --trust --skip-tasks` — `--trust` because the template declares tasks (copier refuses otherwise), `--skip-tasks` so the `vendor_spa` post-task never runs (no network, no `app.html` fabrication). Only the `.py` files are compared, and copier writes them before tasks run. Uses a sibling template checkout when present (offline-friendly), else a blobless clone with a fast remote-reachability probe. Any subprocess/render/ref failure is a **loud skip**, never a silent pass.

The sentinel comparison collapses each `NAME-START..NAME-END` block to a single marker-anchored token (robust to domain content changing line counts, enforces block order, tolerates marker-prose drift) and only honours sentinel names the pristine render actually declares — so an invented sentinel can't shield a fork. Exemptions are auto-derived from the template `copier.yml` `_skip_if_exists`/`_exclude` (matched on full path; `packaging/mcpb/src/server.py` never exempts the module `server.py`).

Adds `copier>=9.4` to the dev dependency group so the gate is hermetic in CI.

## Verification

- `uv run pytest tests/test_template_conformance.py` → 13 passed; all six files currently satisfy the weak "still forked" assertion (confirming the baseline).
- Pure comparison helpers are unit-tested independently (conforming / out-of-sentinel-fork / invented-sentinel / unbalanced-marker), so the strict path is covered regardless of how many files remain forked.
- Full suite green (2895 passed); ruff + `mypy src/ tests/` clean; patch coverage 94%; structural diff-gate clean.

Part of #898. Closes #899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
