### PR TITLE
refactor(cli): de-fork cli.py onto the template skeleton (#904)

### DIFF
--- a/src/markdown_vault_mcp/_http_logging.py
+++ b/src/markdown_vault_mcp/_http_logging.py
@@ -1,0 +1,32 @@
+"""Domain-local quieting of the httpx/httpcore per-request loggers (#792).
+
+``httpx``/``httpcore`` emit a per-request ``INFO`` line ("HTTP Request: POST …
+200 OK") that floods normal embedding builds. FastMCP's ``configure_logging_from_env``
+only governs ``uvicorn.access`` / ``mcp.server.lowlevel.server`` (per the logging
+standard); these HTTP-client deps are domain-owned, so MVM quiets them itself.
+
+Kept out of the template-owned ``cli.py`` ``_root`` callback and ``server.py``
+``make_server`` scaffold (both must stay byte-identical to the template skeleton);
+called instead from the MVM-owned command bodies and the ``make_server``
+``DOMAIN-WIRING`` sentinel — every path that may construct an embedding provider.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def quiet_http_loggers() -> None:
+    """Pin httpx/httpcore to WARNING unless the root level is DEBUG.
+
+    Reads the root level that the CLI ``_root`` callback / ``configure_logging_from_env``
+    already set: DEBUG (``-v``) → ``NOTSET`` (follow root, visible), otherwise
+    ``WARNING`` (quiet). Idempotent — safe to call from multiple entry points.
+    """
+    http_level = (
+        logging.NOTSET
+        if logging.getLogger().getEffectiveLevel() <= logging.DEBUG
+        else logging.WARNING
+    )
+    logging.getLogger("httpx").setLevel(http_level)
+    logging.getLogger("httpcore").setLevel(http_level)

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -46,10 +46,11 @@ def _root(
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
         root.addHandler(handler)
-    # Quiet httpx/httpcore per-request INFO at the default level (#792); -v shows them.
-    http_level = logging.NOTSET if verbose else logging.WARNING
-    logging.getLogger("httpx").setLevel(http_level)
-    logging.getLogger("httpcore").setLevel(http_level)
+    if verbose:
+        # httpx/httpcore are noisy at DEBUG; keep them quiet.  Core doesn't
+        # own these deps, so the silencing stays domain-local.
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 
 @app.command()
@@ -167,8 +168,10 @@ def index(
     force: bool = typer.Option(False, help="Drop and rebuild the index from scratch."),
 ) -> None:
     """Build the full-text search index."""
+    from markdown_vault_mcp._http_logging import quiet_http_loggers
     from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
 
+    quiet_http_loggers()
     vault = _build_vault(source_dir, index_path)
     stats = vault.index.build_index(force=force)
     typer.echo(
@@ -202,6 +205,9 @@ def search(
     from dataclasses import asdict
     from typing import cast
 
+    from markdown_vault_mcp._http_logging import quiet_http_loggers
+
+    quiet_http_loggers()
     vault = _build_vault(source_dir, None)
     results = vault.reader.search(
         query,
@@ -228,8 +234,10 @@ def reindex(
     ),
 ) -> None:
     """Incrementally reindex the vault."""
+    from markdown_vault_mcp._http_logging import quiet_http_loggers
     from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
 
+    quiet_http_loggers()
     vault = _build_vault(source_dir, index_path)
     # reindex() needs a built index (#525); build_index() is a cheap no-op when
     # the index is already populated (a SQL row-count check, no filesystem scan).

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -223,6 +223,11 @@ def make_server(
     # DOMAIN-WIRING-START — project-specific wiring (custom HTTP routes,
     # transforms, mode toggles, alternative middleware, additional registrations);
     # kept across copier update.
+    # Quiet httpx/httpcore per-request INFO on the serve path (#792); the CLI's
+    # index/search/reindex commands do the same before their own vault builds.
+    from markdown_vault_mcp._http_logging import quiet_http_loggers
+
+    quiet_http_loggers()
     # GitHub webhook endpoint — only when secret is configured and transport
     # is HTTP/SSE (stdio has no HTTP server to receive POST requests).
     if config.sync.github_webhook_secret and transport != "stdio":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,32 +39,63 @@ def test_no_args_exits_nonzero() -> None:
     assert "serve" in result.output
 
 
-def test_root_keeps_httpx_quiet_at_default_visible_at_debug() -> None:
+def test_quiet_http_loggers_pins_warning_at_default_visible_at_debug() -> None:
     """httpx/httpcore emit a per-request INFO line that floods logs during
-    embedding builds (#792). The root callback pins them to WARNING at the
-    default level (quiet) and to NOTSET at -v (root DEBUG governs, visible)."""
+    embedding builds (#792). ``quiet_http_loggers`` — called by the domain
+    commands and by ``make_server``'s DOMAIN-WIRING, since the template-owned
+    ``_root`` callback and ``make_server`` scaffold must stay byte-identical to
+    the skeleton — pins them to WARNING when the root level is not DEBUG (quiet)
+    and to NOTSET at ``-v`` (root DEBUG governs, visible)."""
     import logging
 
-    from markdown_vault_mcp.cli import _root
+    from markdown_vault_mcp._http_logging import quiet_http_loggers
 
     root = logging.getLogger()
     httpx_log = logging.getLogger("httpx")
     httpcore_log = logging.getLogger("httpcore")
     saved = (root.level, httpx_log.level, httpcore_log.level)
-    original_handlers = root.handlers[:]
     try:
-        _root(verbose=False)
+        root.setLevel(logging.INFO)
+        quiet_http_loggers()
         assert httpx_log.level == logging.WARNING
         assert httpcore_log.level == logging.WARNING
 
-        _root(verbose=True)
+        root.setLevel(logging.DEBUG)
+        quiet_http_loggers()
         assert httpx_log.level == logging.NOTSET
         assert httpcore_log.level == logging.NOTSET
     finally:
         root.setLevel(saved[0])
         httpx_log.setLevel(saved[1])
         httpcore_log.setLevel(saved[2])
-        root.handlers[:] = original_handlers
+
+
+def test_make_server_quiets_httpx_on_serve_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The serve path (CLI ``serve`` → ``make_server``) quiets httpx/httpcore too
+    (#792) — ``make_server``'s DOMAIN-WIRING calls ``quiet_http_loggers`` so the
+    background embedding build doesn't flood at the default level."""
+    import logging
+
+    from markdown_vault_mcp.server import make_server
+
+    monkeypatch.setenv(f"{_ENV_PREFIX}_SOURCE_DIR", str(tmp_path))
+    root = logging.getLogger()
+    httpx_log = logging.getLogger("httpx")
+    httpcore_log = logging.getLogger("httpcore")
+    saved = (root.level, httpx_log.level, httpcore_log.level)
+    try:
+        root.setLevel(logging.INFO)
+        httpx_log.setLevel(logging.NOTSET)  # flood-prone default
+        httpcore_log.setLevel(logging.NOTSET)
+        make_server(transport="stdio")
+        assert httpx_log.level == logging.WARNING
+        assert httpcore_log.level == logging.WARNING
+    finally:
+        root.setLevel(saved[0])
+        httpx_log.setLevel(saved[1])
+        httpcore_log.setLevel(saved[2])
 
 
 def test_serve_help_exits_zero() -> None:

--- a/tests/test_template_conformance.py
+++ b/tests/test_template_conformance.py
@@ -58,7 +58,6 @@ RATCHET: dict[str, str] = {
     "_server_deps.py": "#902",
     "__init__.py": "#903",
     "_server_apps.py": "#905",
-    "cli.py": "#904",
 }
 
 _START = re.compile(r"#\s*([A-Z0-9-]+)-START\b")


### PR DESCRIPTION
## What

De-forks `cli.py` (#904, epic #898). Its only out-of-sentinel divergence was #792's httpx/httpcore quieting, which MVM had put inside the template-owned `_root` callback. `_root` is conformed to the skeleton verbatim, and #792's behavior moves into a new MVM-owned module `_http_logging.py`.

`cli.py` is **removed from the conformance `RATCHET`** and now strict-passes.

## Why not upstream

Siblings (paperless-mcp, etc.) don't have #792 — it's MVM's own customization. Pushing httpx-quieting into `fastmcp-pvl-core`'s `configure_logging_from_env` would force it onto all sibling repos to absorb MVM's drift. So it stays repo-side.

## How #792 is preserved (all paths, no regression)

`_http_logging.quiet_http_loggers()` reads the root level that `_root` / `configure_logging_from_env` already set — DEBUG (`-v`) → `NOTSET` (visible), otherwise `WARNING` (quiet) — reproducing #792. It's called from:

- the CLI `index` / `search` / `reindex` command bodies (before their vault builds), and
- `make_server`'s `DOMAIN-WIRING` sentinel (the `serve` path — `serve` always goes through `make_server`).

Those four are the complete set of commands that can construct an embedding provider, so the #792 flood cannot recur on any path. `_http_logging.py` is a neutral domain module, so neither `cli.py` nor `server.py` imports the other (no cycle).

The `if verbose: … setLevel(WARNING)` block that remains in `_root` is the **pristine template skeleton's own code** (required for conformance), not #792 logic; the domain call runs after `_root` and overrides it to `NOTSET` at `-v`.

## Notes

- The `server.py` change sits inside its `DOMAIN-WIRING` sentinel, so `server.py` stays forked (still ratcheted; de-forked separately in #901).
- Internal logging refactor — no user-facing surface change.

## Verification

- Full suite **2899 passed**; `mypy src/ tests/` clean; ruff clean; structural diff-gate **0 violations**; conformance gate green (`cli.py` now strict).
- New tests: `test_quiet_http_loggers_*` (direct, both levels) and `test_make_server_quiets_httpx_on_serve_path` (serve path); existing `index`-path #792 tests still green.
- Local preflight-circus: **2 rounds, final round clean** (0 findings ≥80). Round 1 surfaced the dropped `serve` coverage; round 2 (after wiring `make_server`) was clean.

Part of #898. Closes #904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
