### PR TITLE
refactor(server): de-fork server.py onto the template skeleton; config-honoring DOMAIN-WIRING (#901)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ src/markdown_vault_mcp/
   write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
   config.py            -- configuration loading
   domain.py            -- Service: owns the Vault lifecycle (build, boot index/reindex/embeddings jobs, file watcher); get_vault/get_config DI + vault singleton (#902)
-  server.py            -- generic FastMCP server factory (make_server) with tool annotations
+  _instructions.py     -- build_default_instructions: domain server-instructions prose, applied in server.py's DOMAIN-WIRING (#901)
+  server.py            -- generic FastMCP server factory (make_server); template-owned, domain customization confined to DOMAIN-UPSTREAM/DOMAIN-WIRING (#901)
   cli.py               -- CLI entry point
 ```
 <!-- DOMAIN-END -->

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2121,23 +2121,34 @@ queries the existing ``sections`` table (no file I/O).
 
 The library layer returns typed structs (``TocEntry``, ``SubtreeNote``, ``SubtreeToc``, defined in ``types.py``); the MCP boundary serializes them to the JSON shapes above via ``utils/serialization.toc_payload``, keeping the wire format unchanged.
 
-**Prompts**: 6 built-in prompt templates, plus optional user-defined prompts:
+**Prompts**: 7 built-in prompt templates, plus optional user-defined prompts:
 
 | Prompt | Parameters | Tags | Description |
 |-|-|-|-|
 | ``summarize`` | ``path`` | | Summarize a document |
 | ``research`` | ``topic`` | ``write`` | Search and consolidate as new note |
 | ``discuss`` | ``path`` | ``write`` | Analyze and suggest improvements |
-| ``create_from_template`` | ``template_name`` (optional) | ``write`` | Discover/read/fill/write from a template |
 | ``related`` | ``path`` | | Find related notes, suggest cross-references |
 | ``compare`` | ``path1, path2`` | | Compare two documents |
+| ``propose-links`` | ``scope`` (optional), ``per_note_limit`` (optional) | ``write`` | Propose new links between semantically-close notes |
+| ``create_from_template`` | ``template_name`` (optional) | ``write`` | Discover/read/fill/write from a template |
 
 Write-tagged prompts are hidden in read-only mode by the same
 ``mcp.disable(tags={"write"})`` call that hides write tools.
 
+Prompt registration is split by config-dependency (#901). The template-owned
+``make_server`` body calls ``register_prompts(mcp)``, which registers the six
+config-independent built-ins above (every one except ``create_from_template``).
+The config-dependent prompts — ``create_from_template`` (needs the templates
+folder) and user-defined prompts (need the prompts folder) — are registered by
+``register_domain_prompts(mcp, templates_folder, prompts_folder)``, called from
+``make_server``'s
+``DOMAIN-WIRING`` block with the already-resolved ``config.content`` folders (no
+second environment read; a caller-supplied config is honored — #609).
+
 **User-defined prompts**: when ``MARKDOWN_VAULT_MCP_PROMPTS_FOLDER`` is set,
-``register_prompts()`` scans the directory for ``.md`` files at startup and
-registers each as an MCP prompt. The file stem becomes the prompt name.
+``register_domain_prompts()`` scans the directory for ``.md`` files at startup
+and registers each as an MCP prompt. The file stem becomes the prompt name.
 Frontmatter defines metadata:
 
 ```yaml
@@ -2157,19 +2168,26 @@ tags:
 Prompt content here. Use $path and $topic as placeholders (string.Template syntax).
 ```
 
-**Override semantics**: if a user-defined prompt has the same name as a
-built-in, the built-in is skipped and the user's version is registered.
-Domain-specific prompts (such as ``zettelkasten`` or ``para-triage``)
-can live outside the core server and be mounted at deployment time.
+**Override semantics**: a user-defined prompt with the same name as a built-in
+takes priority. Because ``register_prompts()`` registers all built-ins up front
+(before user names are known), ``register_domain_prompts()`` removes the shadowed
+built-in — via ``mcp.local_provider.remove_prompt(name)``, tolerating a
+``KeyError`` when the built-in never registered — before registering the user
+version, so the override replaces cleanly with no "component already exists"
+warning and the built-in text never appears. Domain-specific prompts (such as
+``zettelkasten`` or ``para-triage``) can live outside the core server and be
+mounted at deployment time.
 
-**Registration robustness**: ``register_prompts()`` guards each prompt
-registration independently, so one malformed prompt is logged and skipped rather
-than aborting registration of the remaining prompts. Invalid argument names or a
-signature that cannot be built are caught inside the per-prompt helper and logged
-at ``WARNING`` for both built-in and user prompts. A failure that propagates out
-of the helper, such as a missing definition key or a ``mcp.prompt`` rejection, is
-caught by the loop backstop: at ``WARNING`` for a user prompt, and at ``ERROR``
-for a built-in, since a broken first-party prompt is a packaging defect.
+**Registration robustness**: both ``register_prompts()`` (built-ins) and
+``register_domain_prompts()`` (user prompts) guard each prompt registration
+independently, so one malformed prompt is logged and skipped rather than aborting
+registration of the remaining prompts. Invalid argument names or a signature that
+cannot be built are caught inside the per-prompt helper and logged at ``WARNING``
+for both built-in and user prompts. A failure that propagates out of the helper,
+such as a missing definition key or a ``mcp.prompt`` rejection, is caught by the
+loop backstop: at ``WARNING`` for a user prompt (in ``register_domain_prompts``),
+and at ``ERROR`` for a built-in (in ``register_prompts``), since a broken
+first-party prompt is a packaging defect.
 
 ## Configuration
 

--- a/src/markdown_vault_mcp/_instructions.py
+++ b/src/markdown_vault_mcp/_instructions.py
@@ -1,0 +1,80 @@
+"""Domain-specific server-instructions composition.
+
+Holds :func:`build_default_instructions`, the markdown-vault guidance that
+:func:`~markdown_vault_mcp.server.make_server` applies to the FastMCP instance
+after construction (in its ``DOMAIN-WIRING`` block). Lives outside the
+template-owned ``server.py`` so the domain prose never re-conflicts on a
+``copier update``.
+"""
+
+from __future__ import annotations
+
+from fastmcp_pvl_core import build_instructions as _core_build_instructions
+
+from markdown_vault_mcp.config import _ENV_PREFIX
+
+
+def build_default_instructions(
+    *, read_only: bool, conventions_file: str | None = None
+) -> str:
+    """Build the default instructions string based on read-only state.
+
+    Composes MV's domain-specific guidance into a ``domain_line`` and
+    delegates to :func:`fastmcp_pvl_core.build_instructions` for the
+    read-only/read-write line and operator override hint.
+
+    The folder-conventions sentence is emitted whenever *conventions_file*
+    is configured, not gated on convention files existing on disk: in
+    managed-git mode the clone happens inside the server lifespan, after
+    instructions are composed, so a file-presence check here would silently
+    miss on first boot.
+
+    Args:
+        read_only: Whether write tools are disabled; selects the write-guidance
+            sentence and the read-only/read-write line.
+        conventions_file: The configured per-folder conventions filename, or
+            ``None`` when conventions are not configured.
+
+    Returns:
+        The composed instructions string.
+    """
+    prelude = (
+        "A searchable markdown document vault. "
+        "Paths are always relative (e.g. 'Journal/note.md')."
+    )
+    write_guidance = (
+        ""
+        if read_only
+        else (
+            " Write tools: use 'write' to create, 'edit' for targeted changes "
+            "(read first), 'rename' to move (pass update_links=True to fix links "
+            "in other notes), 'delete' to remove. Use 'move_folder(old_dir, new_dir)' "
+            "to move an entire folder subtree and rewrite all vault links in one call. "
+            "All write operations update the "
+            "search index immediately — never call 'reindex' after write, edit, "
+            "delete, or rename."
+        )
+    )
+    search_guidance = (
+        " Use 'search' (mode='hybrid' preferred when available) to find documents, "
+        "'read' for full content, 'list_documents' to enumerate, 'stats' to check "
+        "capabilities. 'browse_vault' and 'show_context' open a visual UI for the "
+        "user — do not call them to retrieve vault content; use 'search', 'read', "
+        "'list_documents', or 'get_context' instead."
+    )
+    conventions_guidance = (
+        ""
+        if conventions_file is None
+        else (
+            f" Folders may carry authoring conventions in '{conventions_file}' "
+            "files; call 'get_conventions(path)' before creating or "
+            "restructuring notes, and follow any 'conventions' returned by "
+            "write/edit results."
+        )
+    )
+    domain_line = f"{prelude}{write_guidance}{search_guidance}{conventions_guidance}"
+    return _core_build_instructions(
+        read_only=read_only,
+        env_prefix=_ENV_PREFIX,
+        domain_line=domain_line,
+    )

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 
 import frontmatter
 from fastmcp import FastMCP
-from fastmcp.prompts import Prompt
 
 from ._icons import _TOOL_ICONS
 from .utils.text import read_text_utf8
@@ -252,12 +251,11 @@ def _register_one_user_prompt(mcp: FastMCP, name: str, defn: dict[str, Any]) -> 
     fn.__name__ = name
     fn.__doc__ = description or f"User-defined prompt: {name}"
 
-    # ``add_prompt`` (not the ``mcp.prompt`` decorator) so a user prompt whose
-    # name matches a built-in registered earlier by ``register_prompts`` silently
-    # replaces it (last-wins) instead of logging a "component already exists"
-    # warning — preserving the pre-split "user overrides built-in" semantics now
-    # that the built-ins are registered up front rather than skipped.
-    mcp.add_prompt(Prompt.from_function(fn, name=name, tags=tags or None))
+    decorator_kwargs: dict[str, Any] = {}
+    if tags:
+        decorator_kwargs["tags"] = tags
+
+    mcp.prompt(**decorator_kwargs)(fn)
     logger.debug("Registered user-defined prompt: %s", name)
 
 
@@ -460,9 +458,11 @@ def register_domain_prompts(
     :func:`register_prompts` has registered the config-independent built-ins.
 
     User-defined prompts take priority: a user prompt whose name matches a
-    built-in (registered earlier by :func:`register_prompts`, or the inline
-    ``create_from_template``) silently replaces it via ``add_prompt`` (last
-    wins), so the built-in text never appears.
+    built-in registered earlier by :func:`register_prompts` shadows it — the
+    shadowed built-in is removed before the user prompt is registered, so the
+    built-in text never appears and no "component already exists" warning is
+    logged. ``create_from_template`` is guarded the same way (skipped when a
+    user prompt of that name exists).
 
     Args:
         mcp: The :class:`~fastmcp.FastMCP` instance to register prompts on.
@@ -481,6 +481,15 @@ def register_domain_prompts(
 
     if "create_from_template" not in user_prompt_defs:
         _register_create_from_template(mcp, templates_folder)
+
+    # Drop any built-in that a user prompt shadows before re-registering under
+    # that name, so the override replaces cleanly instead of colliding (which
+    # would log a spurious "component already exists" WARNING). register_prompts
+    # registered all built-ins up front; here — where the user names are known —
+    # is the first point we can prune the shadowed ones.
+    for name in user_prompt_defs:
+        if name in _BUILTIN_PROMPT_NAMES:
+            mcp.local_provider.remove_prompt(name)
 
     # --- Pass 3: register user-defined prompts ---
     for name, defn in user_prompt_defs.items():

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -486,10 +486,17 @@ def register_domain_prompts(
     # that name, so the override replaces cleanly instead of colliding (which
     # would log a spurious "component already exists" WARNING). register_prompts
     # registered all built-ins up front; here — where the user names are known —
-    # is the first point we can prune the shadowed ones.
+    # is the first point we can prune the shadowed ones. A built-in that failed
+    # to register (missing static file, or a #799 backstop-caught error) is
+    # simply absent: tolerate the KeyError so one bad built-in + a same-named
+    # user prompt does not abort server construction (the user prompt then
+    # registers fresh, with nothing to collide against).
     for name in user_prompt_defs:
         if name in _BUILTIN_PROMPT_NAMES:
-            mcp.local_provider.remove_prompt(name)
+            try:
+                mcp.local_provider.remove_prompt(name)
+            except KeyError:
+                logger.debug("no built-in %r to prune before user override", name)
 
     # --- Pass 3: register user-defined prompts ---
     for name, defn in user_prompt_defs.items():

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -21,8 +21,12 @@ if TYPE_CHECKING:
 
 import frontmatter
 from fastmcp import FastMCP
+from fastmcp_pvl_core import env
 
 from ._icons import _TOOL_ICONS
+from .config import _ENV_PREFIX
+from .config_sections._assembly import require_source_dir
+from .config_sections.content import ContentConfig
 from .utils.text import read_text_utf8
 
 _BUILTIN_PROMPTS_DIR = importlib.resources.files("markdown_vault_mcp").joinpath(
@@ -30,6 +34,12 @@ _BUILTIN_PROMPTS_DIR = importlib.resources.files("markdown_vault_mcp").joinpath(
 )
 
 logger = logging.getLogger(__name__)
+
+# Sentinel distinguishing "folder argument not passed" (→ resolve from config)
+# from an explicit ``None`` (→ that folder is disabled). Lets the production call
+# site stay ``register_prompts(mcp)`` (template-owned server.py conformance) while
+# tests keep passing folders explicitly.
+_FROM_CONFIG: Any = object()
 
 # Argument names must be plain, non-keyword Python identifiers: they become
 # parameters of a synthetic inspect.Signature (see _build_prompt_fn), so a name
@@ -340,8 +350,8 @@ def _register_one_builtin_prompt(mcp: FastMCP, name: str, defn: dict[str, Any]) 
 
 def register_prompts(
     mcp: FastMCP,
-    templates_folder: str | None,
-    prompts_folder: str | None = None,
+    templates_folder: str | None = _FROM_CONFIG,
+    prompts_folder: str | None = _FROM_CONFIG,
 ) -> None:
     """Register all built-in MCP prompts on *mcp*, with user-defined overrides.
 
@@ -352,13 +362,31 @@ def register_prompts(
     Args:
         mcp: The :class:`~fastmcp.FastMCP` instance to register prompts on.
         templates_folder: The configured templates folder path, or ``None``
-            when templates are not configured.  Passed in from
-            :func:`~markdown_vault_mcp.server.make_server` so that
-            ``create_from_template`` can close over this value without
-            re-reading environment variables.
+            when templates are not configured.  Omit (the default) to resolve
+            it from :meth:`ProjectConfig.from_env` — the production call site
+            (``make_server``) does so, matching the template's no-arg
+            ``register_prompts(mcp)`` shape; tests pass it explicitly.
         prompts_folder: Path to a directory of user-defined ``.md`` prompt
-            files.  ``None`` disables user-defined prompt loading.
+            files.  ``None`` disables user-defined prompt loading; omit to
+            resolve from config alongside *templates_folder*.
     """
+    if templates_folder is _FROM_CONFIG or prompts_folder is _FROM_CONFIG:
+        # Resolve unspecified folders from the environment. Go through
+        # ``ContentConfig.from_env`` (the same derivation ``ProjectConfig`` uses)
+        # rather than reading env directly, so the prompts-folder source_dir join
+        # (see config_sections/content.py) is applied identically and can't drift.
+        # This parses only the content section — no vault, no ProjectConfig — so
+        # the production ``register_prompts(mcp)`` call site (which the template
+        # skeleton mandates) matches paperless-mcp's config-independent shape
+        # without a second ``ProjectConfig.from_env`` (#609).
+        content = ContentConfig.from_env(
+            _ENV_PREFIX, require_source_dir(env(_ENV_PREFIX, "SOURCE_DIR"))
+        )
+        if templates_folder is _FROM_CONFIG:
+            templates_folder = content.templates_folder
+        if prompts_folder is _FROM_CONFIG:
+            prompts_folder = content.prompts_folder
+
     # --- Pass 1: collect user-defined prompt names (for override semantics) ---
     user_prompt_defs = _load_user_prompt_defs(prompts_folder)
     if user_prompt_defs:

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -21,25 +21,25 @@ if TYPE_CHECKING:
 
 import frontmatter
 from fastmcp import FastMCP
-from fastmcp_pvl_core import env
+from fastmcp.prompts import Prompt
 
 from ._icons import _TOOL_ICONS
-from .config import _ENV_PREFIX
-from .config_sections._assembly import require_source_dir
-from .config_sections.content import ContentConfig
 from .utils.text import read_text_utf8
 
 _BUILTIN_PROMPTS_DIR = importlib.resources.files("markdown_vault_mcp").joinpath(
     "static/prompts"
 )
 
-logger = logging.getLogger(__name__)
+_BUILTIN_PROMPT_NAMES = (
+    "summarize",
+    "research",
+    "discuss",
+    "related",
+    "compare",
+    "propose-links",
+)
 
-# Sentinel distinguishing "folder argument not passed" (→ resolve from config)
-# from an explicit ``None`` (→ that folder is disabled). Lets the production call
-# site stay ``register_prompts(mcp)`` (template-owned server.py conformance) while
-# tests keep passing folders explicitly.
-_FROM_CONFIG: Any = object()
+logger = logging.getLogger(__name__)
 
 # Argument names must be plain, non-keyword Python identifiers: they become
 # parameters of a synthetic inspect.Signature (see _build_prompt_fn), so a name
@@ -252,11 +252,12 @@ def _register_one_user_prompt(mcp: FastMCP, name: str, defn: dict[str, Any]) -> 
     fn.__name__ = name
     fn.__doc__ = description or f"User-defined prompt: {name}"
 
-    decorator_kwargs: dict[str, Any] = {}
-    if tags:
-        decorator_kwargs["tags"] = tags
-
-    mcp.prompt(**decorator_kwargs)(fn)
+    # ``add_prompt`` (not the ``mcp.prompt`` decorator) so a user prompt whose
+    # name matches a built-in registered earlier by ``register_prompts`` silently
+    # replaces it (last-wins) instead of logging a "component already exists"
+    # warning — preserving the pre-split "user overrides built-in" semantics now
+    # that the built-ins are registered up front rather than skipped.
+    mcp.add_prompt(Prompt.from_function(fn, name=name, tags=tags or None))
     logger.debug("Registered user-defined prompt: %s", name)
 
 
@@ -348,70 +349,25 @@ def _register_one_builtin_prompt(mcp: FastMCP, name: str, defn: dict[str, Any]) 
     logger.debug("Registered built-in prompt: %s", name)
 
 
-def register_prompts(
-    mcp: FastMCP,
-    templates_folder: str | None = _FROM_CONFIG,
-    prompts_folder: str | None = _FROM_CONFIG,
-) -> None:
-    """Register all built-in MCP prompts on *mcp*, with user-defined overrides.
+def register_prompts(mcp: FastMCP) -> None:
+    """Register the config-independent built-in prompts on *mcp*.
 
-    User-defined prompts from *prompts_folder* take priority.  Any built-in
-    whose name matches a user-defined prompt is skipped.  User-defined prompts
-    are registered after the built-ins.
+    Registers the static built-in prompts shipped under ``static/prompts/*.md``
+    (each has frontmatter — description, arguments, tags, icons — and a body
+    that uses ``$var`` / ``${var}`` :class:`string.Template` substitution).
+
+    This is the template-mandated no-arg ``register_prompts(mcp)`` call site.
+    The config-dependent prompts — ``create_from_template`` (needs the templates
+    folder) and user-defined prompts (need the prompts folder) — are registered
+    separately by :func:`register_domain_prompts`, called from ``make_server``'s
+    ``DOMAIN-WIRING`` block where the resolved config is in scope. A user prompt
+    whose name matches one of these built-ins silently overrides it (see
+    :func:`register_domain_prompts`).
 
     Args:
         mcp: The :class:`~fastmcp.FastMCP` instance to register prompts on.
-        templates_folder: The configured templates folder path, or ``None``
-            when templates are not configured.  Omit (the default) to resolve
-            it from :meth:`ProjectConfig.from_env` — the production call site
-            (``make_server``) does so, matching the template's no-arg
-            ``register_prompts(mcp)`` shape; tests pass it explicitly.
-        prompts_folder: Path to a directory of user-defined ``.md`` prompt
-            files.  ``None`` disables user-defined prompt loading; omit to
-            resolve from config alongside *templates_folder*.
     """
-    if templates_folder is _FROM_CONFIG or prompts_folder is _FROM_CONFIG:
-        # Resolve unspecified folders from the environment. Go through
-        # ``ContentConfig.from_env`` (the same derivation ``ProjectConfig`` uses)
-        # rather than reading env directly, so the prompts-folder source_dir join
-        # (see config_sections/content.py) is applied identically and can't drift.
-        # This parses only the content section — no vault, no ProjectConfig — so
-        # the production ``register_prompts(mcp)`` call site (which the template
-        # skeleton mandates) matches paperless-mcp's config-independent shape
-        # without a second ``ProjectConfig.from_env`` (#609).
-        content = ContentConfig.from_env(
-            _ENV_PREFIX, require_source_dir(env(_ENV_PREFIX, "SOURCE_DIR"))
-        )
-        if templates_folder is _FROM_CONFIG:
-            templates_folder = content.templates_folder
-        if prompts_folder is _FROM_CONFIG:
-            prompts_folder = content.prompts_folder
-
-    # --- Pass 1: collect user-defined prompt names (for override semantics) ---
-    user_prompt_defs = _load_user_prompt_defs(prompts_folder)
-    if user_prompt_defs:
-        logger.info(
-            "User-defined prompts found in %r: %s",
-            prompts_folder,
-            sorted(user_prompt_defs),
-        )
-
-    # --- Pass 2: register built-ins from static/prompts/*.md ---
-    #
-    # Each .md file has frontmatter (description, arguments, tags, icons) and
-    # a body that uses $var / ${var} (string.Template) substitution.
-    # ``create_from_template`` has path-traversal safety logic and stays inline.
-
-    for md_name in [
-        "summarize",
-        "research",
-        "discuss",
-        "related",
-        "compare",
-        "propose-links",
-    ]:
-        if md_name in user_prompt_defs:
-            continue
+    for md_name in _BUILTIN_PROMPT_NAMES:
         defn = _load_builtin_prompt(md_name)
         if defn is not None:
             # Per-prompt backstop: a malformed built-in (missing def-dict key, or
@@ -428,56 +384,103 @@ def register_prompts(
                     exc_info=True,
                 )
 
-    if "create_from_template" not in user_prompt_defs:
 
-        @mcp.prompt(tags={"write"}, icons=_TOOL_ICONS["write"])
-        def create_from_template(template_name: str | None = None) -> str:
-            """Create a new note from a vault template. Pass template_name (e.g. "meeting-notes" or "meeting-notes.md") to skip discovery, or omit to browse available templates first."""
-            template_hint = "None" if template_name is None else repr(template_name)
-            template_name_clean = (
-                (template_name or "").strip().replace("\\", "/").lstrip("/")
-            )
-            if template_name_clean:
-                resolved: list[str] = []
-                for part in PurePosixPath(template_name_clean).parts:
-                    if part in ("", "."):
-                        continue
-                    elif part == "..":
-                        if resolved:
-                            resolved.pop()
-                    else:
-                        resolved.append(part)
-                template_name_clean = str(PurePosixPath(*resolved)) if resolved else ""
-            template_path = (
-                str(PurePosixPath(templates_folder) / template_name_clean)
-                if template_name_clean and templates_folder is not None
-                else ""
-            )
-            return (
-                "## Role\n"
-                "You are a note assistant that creates new notes from vault templates.\n\n"
-                "## Context\n"
-                f"- Templates folder: `{templates_folder}`\n"
-                f"- Requested template_name: {template_hint}\n"
-                "- Templates are normal markdown files. Do not use server-side variable substitution.\n\n"
-                "## Task\n"
-                "Guide the user through this workflow: discover template -> read template -> gather values -> write the new note.\n\n"
-                "## Format\n"
-                "Follow these exact steps in order:\n"
-                "1. If `template_name` is missing, call `list_documents(folder=<templates folder>)`, "
-                "show available templates, and ask the user to pick one.\n"
-                "2. Resolve template path and call `read(path=<template path>)`.\n"
-                f"   If a name is already provided, start with `read(path='{template_path or '<templates_folder>/<template_name>'}')`.\n"
-                "3. Present the template structure and ask the user for missing values.\n"
-                "4. Propose a target note path. Prefer frontmatter convention if present; otherwise ask the user.\n"
-                "5. Call `write(path=..., content=..., frontmatter=...)` with the filled note.\n\n"
-                "## Constraints\n"
-                "- Use only vault tools (`list_documents`, `read`, `write`) for this flow.\n"
-                "- Never overwrite an existing file without explicit user confirmation.\n"
-                "- If the selected template does not exist, return a clear error and ask for another template.\n"
-                "- Keep paths relative to the vault root.\n"
-                "- Repeat: discover -> read -> fill -> write.\n"
-            )
+def _register_create_from_template(mcp: FastMCP, templates_folder: str | None) -> None:
+    """Register the built-in ``create_from_template`` prompt on *mcp*.
+
+    The prompt body closes over *templates_folder* so the guidance references
+    the configured templates directory. Path components in ``template_name`` are
+    normalized inline (``..`` segments are popped) so the displayed example path
+    cannot escape the templates folder.
+    """
+
+    @mcp.prompt(tags={"write"}, icons=_TOOL_ICONS["write"])
+    def create_from_template(template_name: str | None = None) -> str:
+        """Create a new note from a vault template. Pass template_name (e.g. "meeting-notes" or "meeting-notes.md") to skip discovery, or omit to browse available templates first."""
+        template_hint = "None" if template_name is None else repr(template_name)
+        template_name_clean = (
+            (template_name or "").strip().replace("\\", "/").lstrip("/")
+        )
+        if template_name_clean:
+            resolved: list[str] = []
+            for part in PurePosixPath(template_name_clean).parts:
+                if part in ("", "."):
+                    continue
+                elif part == "..":
+                    if resolved:
+                        resolved.pop()
+                else:
+                    resolved.append(part)
+            template_name_clean = str(PurePosixPath(*resolved)) if resolved else ""
+        template_path = (
+            str(PurePosixPath(templates_folder) / template_name_clean)
+            if template_name_clean and templates_folder is not None
+            else ""
+        )
+        return (
+            "## Role\n"
+            "You are a note assistant that creates new notes from vault templates.\n\n"
+            "## Context\n"
+            f"- Templates folder: `{templates_folder}`\n"
+            f"- Requested template_name: {template_hint}\n"
+            "- Templates are normal markdown files. Do not use server-side variable substitution.\n\n"
+            "## Task\n"
+            "Guide the user through this workflow: discover template -> read template -> gather values -> write the new note.\n\n"
+            "## Format\n"
+            "Follow these exact steps in order:\n"
+            "1. If `template_name` is missing, call `list_documents(folder=<templates folder>)`, "
+            "show available templates, and ask the user to pick one.\n"
+            "2. Resolve template path and call `read(path=<template path>)`.\n"
+            f"   If a name is already provided, start with `read(path='{template_path or '<templates_folder>/<template_name>'}')`.\n"
+            "3. Present the template structure and ask the user for missing values.\n"
+            "4. Propose a target note path. Prefer frontmatter convention if present; otherwise ask the user.\n"
+            "5. Call `write(path=..., content=..., frontmatter=...)` with the filled note.\n\n"
+            "## Constraints\n"
+            "- Use only vault tools (`list_documents`, `read`, `write`) for this flow.\n"
+            "- Never overwrite an existing file without explicit user confirmation.\n"
+            "- If the selected template does not exist, return a clear error and ask for another template.\n"
+            "- Keep paths relative to the vault root.\n"
+            "- Repeat: discover -> read -> fill -> write.\n"
+        )
+
+
+def register_domain_prompts(
+    mcp: FastMCP,
+    templates_folder: str | None,
+    prompts_folder: str | None,
+) -> None:
+    """Register the config-dependent prompts on *mcp*.
+
+    Registers ``create_from_template`` (which closes over *templates_folder*)
+    and any user-defined prompts from *prompts_folder*. Both folder values come
+    from the caller's already-resolved config (``make_server`` passes
+    ``config.content.templates_folder`` / ``config.content.prompts_folder``), so
+    no environment re-read happens here and a caller-supplied config is honored
+    exactly (#609). Called from ``make_server``'s ``DOMAIN-WIRING`` block, after
+    :func:`register_prompts` has registered the config-independent built-ins.
+
+    User-defined prompts take priority: a user prompt whose name matches a
+    built-in (registered earlier by :func:`register_prompts`, or the inline
+    ``create_from_template``) silently replaces it via ``add_prompt`` (last
+    wins), so the built-in text never appears.
+
+    Args:
+        mcp: The :class:`~fastmcp.FastMCP` instance to register prompts on.
+        templates_folder: The configured templates folder path, or ``None``
+            when templates are not configured.
+        prompts_folder: Path to a directory of user-defined ``.md`` prompt
+            files.  ``None`` disables user-defined prompt loading.
+    """
+    user_prompt_defs = _load_user_prompt_defs(prompts_folder)
+    if user_prompt_defs:
+        logger.info(
+            "User-defined prompts found in %r: %s",
+            prompts_folder,
+            sorted(user_prompt_defs),
+        )
+
+    if "create_from_template" not in user_prompt_defs:
+        _register_create_from_template(mcp, templates_folder)
 
     # --- Pass 3: register user-defined prompts ---
     for name, defn in user_prompt_defs.items():

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -149,18 +149,22 @@ def make_server(
     # index/search/reindex commands do the same before their own vault builds.
     quiet_http_loggers()
 
-    # Domain server identity: attach the vault icon and, unless the operator set
-    # INSTRUCTIONS, replace the baseline instructions with the read-only-aware,
-    # conventions-aware domain guidance. Applied post-construction so server.py's
-    # make_server() body stays byte-identical to the template skeleton. FastMCP's
-    # ``icons`` property is read-only (only the constructor accepts icons, which
-    # the skeleton body does not), so write the low-level server field it reads.
+    # Domain server identity: attach the vault icon and resolve instructions from
+    # THIS config — the operator's config.instructions when set, else the
+    # read-only-aware, conventions-aware domain default. Set unconditionally
+    # (not gated on config.instructions is None) so a caller-supplied
+    # config.instructions is honored even when the MARKDOWN_VAULT_MCP_INSTRUCTIONS
+    # env var the skeleton body reads is unset; config.instructions is populated
+    # from that same env var, so the from_env path is unchanged. Applied
+    # post-construction so make_server()'s body stays byte-identical to the
+    # template skeleton. FastMCP's ``icons`` property is read-only (only the
+    # constructor accepts icons, which the skeleton body does not), so write the
+    # low-level server field it reads.
     mcp._mcp_server.icons = _SERVER_ICON
-    if config.instructions is None:
-        mcp.instructions = build_default_instructions(
-            read_only=is_read_only,
-            conventions_file=config.content.conventions_file,
-        )
+    mcp.instructions = config.instructions or build_default_instructions(
+        read_only=is_read_only,
+        conventions_file=config.content.conventions_file,
+    )
 
     logger.info(
         "vault_startup mode=%s vault=%s embeddings=%s",

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -1,12 +1,9 @@
-"""Generic FastMCP server for markdown vaults.
+"""Markdown Vault MCP — FastMCP server entry point.
 
-Exposes :class:`~markdown_vault_mcp.vault.Vault` methods as MCP tools
-with proper ``ToolAnnotations``.  Uses a lifespan hook to build the
-``Vault`` once at startup and tear it down on shutdown.
-
-The server is configured entirely via environment variables (see
-:mod:`markdown_vault_mcp.config`).  Call :func:`make_server` to build a
-configured :class:`~fastmcp.FastMCP` instance.
+Composes the primitives from ``fastmcp-pvl-core`` into a
+project-specific ``make_server()``.  See
+https://gofastmcp.com/servers for the FastMCP server surface and
+``fastmcp-pvl-core``'s README for the composable helpers used below.
 """
 
 from __future__ import annotations
@@ -17,146 +14,59 @@ from importlib.metadata import version as _pkg_version
 
 from fastmcp import FastMCP
 from fastmcp_pvl_core import (
+    ServerConfig,  # noqa: F401  — re-exported for downstream projects' convenience
     build_auth,
+    build_event_store,  # noqa: F401  — re-exported for downstream projects' convenience
+    build_instructions,
     build_kv_store,  # noqa: F401  — re-exported for downstream projects' convenience
-    configure_logging_from_env,  # noqa: F401  — re-exported for downstream projects' convenience
+    configure_logging_from_env,
+    env,
     register_server_info_tool,
     resolve_auth_mode,
     wire_middleware_stack,
 )
-from fastmcp_pvl_core import (
-    build_instructions as _core_build_instructions,
-)
 
-from markdown_vault_mcp.config import (
-    _ENV_PREFIX,
-    ProjectConfig,
-)
-
-from ._icons import _SERVER_ICON
-from ._server_apps import register_apps
-from ._server_deps import server_lifespan
-from ._server_prompts import register_prompts
-from ._server_resources import register_resources
-from ._server_tools import register_tools
+from markdown_vault_mcp._server_apps import register_apps
+from markdown_vault_mcp._server_deps import server_lifespan
+from markdown_vault_mcp._server_prompts import register_prompts
+from markdown_vault_mcp._server_resources import register_resources
+from markdown_vault_mcp._server_tools import register_tools
+from markdown_vault_mcp.config import ProjectConfig
 
 logger = logging.getLogger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Server factory
-# ---------------------------------------------------------------------------
-
-
-def _build_default_instructions(
-    *, read_only: bool, conventions_file: str | None = None
-) -> str:
-    """Build the default instructions string based on read-only state.
-
-    Composes MV's domain-specific guidance into a ``domain_line`` and
-    delegates to :func:`fastmcp_pvl_core.build_instructions` for the
-    read-only/read-write line and operator override hint.
-
-    The folder-conventions sentence is emitted whenever *conventions_file*
-    is configured, not gated on convention files existing on disk: in
-    managed-git mode the clone happens inside the server lifespan, after
-    instructions are composed, so a file-presence check here would silently
-    miss on first boot.
-    """
-    prelude = (
-        "A searchable markdown document vault. "
-        "Paths are always relative (e.g. 'Journal/note.md')."
-    )
-    write_guidance = (
-        ""
-        if read_only
-        else (
-            " Write tools: use 'write' to create, 'edit' for targeted changes "
-            "(read first), 'rename' to move (pass update_links=True to fix links "
-            "in other notes), 'delete' to remove. Use 'move_folder(old_dir, new_dir)' "
-            "to move an entire folder subtree and rewrite all vault links in one call. "
-            "All write operations update the "
-            "search index immediately — never call 'reindex' after write, edit, "
-            "delete, or rename."
-        )
-    )
-    search_guidance = (
-        " Use 'search' (mode='hybrid' preferred when available) to find documents, "
-        "'read' for full content, 'list_documents' to enumerate, 'stats' to check "
-        "capabilities. 'browse_vault' and 'show_context' open a visual UI for the "
-        "user — do not call them to retrieve vault content; use 'search', 'read', "
-        "'list_documents', or 'get_context' instead."
-    )
-    conventions_guidance = (
-        ""
-        if conventions_file is None
-        else (
-            f" Folders may carry authoring conventions in '{conventions_file}' "
-            "files; call 'get_conventions(path)' before creating or "
-            "restructuring notes, and follow any 'conventions' returned by "
-            "write/edit results."
-        )
-    )
-    domain_line = f"{prelude}{write_guidance}{search_guidance}{conventions_guidance}"
-    return _core_build_instructions(
-        read_only=read_only,
-        env_prefix=_ENV_PREFIX,
-        domain_line=domain_line,
-    )
+_ENV_PREFIX = "MARKDOWN_VAULT_MCP"
 
 
 def make_server(
-    transport: str = "stdio", config: ProjectConfig | None = None
+    *,
+    transport: str = "stdio",
+    config: ProjectConfig | None = None,
 ) -> FastMCP:
-    """Create and configure the FastMCP server.
-
-    Reads configuration from environment variables via
-    :meth:`~markdown_vault_mcp.config.ProjectConfig.from_env`.
-    Write tools are tagged with ``{"write"}`` and hidden via
-    ``mcp.disable(tags={"write"})`` when ``READ_ONLY=true``.
-
-    Server identity is configurable via:
-
-    - ``MARKDOWN_VAULT_MCP_SERVER_NAME``: MCP server name shown to clients
-      (default ``"markdown-vault-mcp"``).
-    - ``MARKDOWN_VAULT_MCP_INSTRUCTIONS``: system-level instructions injected
-      into LLM context (default: dynamic description reflecting read-only state).
-    - ``MARKDOWN_VAULT_MCP_PROMPTS_FOLDER``: directory of user-defined ``.md``
-      prompt files.  User prompts with the same name as a built-in override the
-      built-in.  Default: disabled.
+    """Construct the Markdown Vault MCP FastMCP server.
 
     Args:
-        transport: ``"stdio"`` / ``"http"`` / ``"sse"`` / ``"streamable-http"``.
-            Used to gate HTTP-only wiring (e.g. the GitHub webhook route) and
-            as ``transport=%s`` in the startup log.
-        config: A pre-built :class:`~markdown_vault_mcp.config.ProjectConfig`.
-            When ``None`` (the default) the config is read from the environment
-            via ``from_env``. Callers that already hold a config (e.g. the HTTP
-            serve path, which also needs ``config.server`` for the event store)
-            pass it here to avoid parsing the environment twice (#609).
+        transport: ``"stdio"`` / ``"http"`` / ``"sse"``.  Used here for
+            logging only.
+        config: Optional pre-loaded config; default loads from env.
 
     Returns:
-        A fully configured :class:`~fastmcp.FastMCP` instance ready to run.
+        A configured :class:`fastmcp.FastMCP` instance.
     """
-    if config is None:
-        config = ProjectConfig.from_env()
-    is_read_only = config.read_only
+    config = config or ProjectConfig.from_env()
+    configure_logging_from_env()
 
-    server_name = config.server_name
-    if config.instructions is not None:
-        instructions = config.instructions
-    else:
-        instructions = _build_default_instructions(
-            read_only=is_read_only,
-            conventions_file=config.content.conventions_file,
-        )
+    # Operator overrides: SERVER_NAME renames this instance; INSTRUCTIONS
+    # replaces the default instructions text (the latter is the override that
+    # build_instructions' hint advertises). Both fall back when unset/empty.
+    server_name = env(_ENV_PREFIX, "SERVER_NAME", "markdown-vault-mcp")
+    instructions = env(_ENV_PREFIX, "INSTRUCTIONS") or build_instructions(
+        read_only=True,
+        env_prefix=_ENV_PREFIX,
+        domain_line="Generic markdown vault MCP server with FTS5 + semantic search",
+    )
 
     auth = build_auth(config.server)
-    # build_auth returns None only for mode="none" or precondition-miss inside an
-    # OIDC builder (missing required fields).  pvl-core 2.0 raises ConfigurationError
-    # on actual discovery failures (httpx missing, network error, malformed discovery
-    # doc), so this no longer needs to defend against the "discovery silently failed"
-    # case — fail-fast at startup means we never reach this line in that scenario.
     auth_mode = resolve_auth_mode(config.server) if auth is not None else "none"
     if auth_mode == "none":
         logger.warning(
@@ -171,40 +81,27 @@ def make_server(
         pkg_ver = "unknown"
 
     logger.info(
-        "Server config: version=%s name=%s transport=%s auth=%s mode=%s vault=%s embeddings=%s",
+        "Server config: version=%s name=%s transport=%s auth=%s",
         pkg_ver,
         server_name,
         transport,
         auth_mode,
-        "read-only" if is_read_only else "read-write",
-        config.source_dir,
-        "enabled" if config.indexing.embeddings_path else "disabled",
     )
 
     mcp = FastMCP(
-        server_name,
+        name=server_name,
         instructions=instructions,
-        icons=_SERVER_ICON,
         lifespan=server_lifespan,
         auth=auth,
     )
 
-    # 3.x: kwargs removed; installs one tool-aware logging middleware.
     wire_middleware_stack(mcp)
 
     register_tools(mcp)
     register_resources(mcp)
+    register_prompts(mcp)
     register_apps(mcp)
-    register_prompts(
-        mcp,
-        templates_folder=config.content.templates_folder,
-        prompts_folder=config.content.prompts_folder,
-    )
 
-    # ``register_server_info_tool`` is intentionally read-only and stays
-    # enabled in read-only mode (no ``tags={"write"}``) — operators need
-    # ``get_server_info`` to confirm the deployed version regardless of
-    # the read/write posture.
     register_server_info_tool(
         mcp,
         server_name=server_name,
@@ -213,7 +110,10 @@ def make_server(
         # that talk to a remote service (paperless-mcp, etc.). The provider is
         # a zero-arg callable; the simplest pattern is a module-level upstream
         # client (typically constructed from env vars at import time) whose
-        # version method is referenced here.
+        # version method is referenced here. ``CurrentContext()`` is a FastMCP
+        # DI marker — it only resolves to a live context when used as a
+        # parameter default in a tool/resource handler, so it cannot be called
+        # directly from a zero-arg provider.
         # Uncomment the kwargs below as additional arguments to this call:
         # upstream_version=lambda: _upstream_client.remote_version(),
         # upstream_label="paperless",
@@ -222,17 +122,42 @@ def make_server(
 
     # DOMAIN-WIRING-START — project-specific wiring (custom HTTP routes,
     # transforms, mode toggles, alternative middleware, additional registrations);
-    # kept across copier update.
-    # Hand the already-loaded config to the no-arg server_lifespan's Service so it
-    # builds the vault from this config, not a second from_env() read (#609).
+    # kept across copier update. Leave empty for projects that don't customise
+    # make_server() beyond the standard scaffold.
+    from markdown_vault_mcp._http_logging import quiet_http_loggers
+    from markdown_vault_mcp._icons import _SERVER_ICON
+    from markdown_vault_mcp._instructions import build_default_instructions
     from markdown_vault_mcp.domain import set_pending_config
 
+    is_read_only = config.read_only
+
+    # Hand the already-loaded config to the no-arg server_lifespan's Service so it
+    # builds the vault from this config, not a second from_env() read (#609).
     set_pending_config(config)
     # Quiet httpx/httpcore per-request INFO on the serve path (#792); the CLI's
     # index/search/reindex commands do the same before their own vault builds.
-    from markdown_vault_mcp._http_logging import quiet_http_loggers
-
     quiet_http_loggers()
+
+    # Domain server identity: attach the vault icon and, unless the operator set
+    # INSTRUCTIONS, replace the baseline instructions with the read-only-aware,
+    # conventions-aware domain guidance. Applied post-construction so server.py's
+    # make_server() body stays byte-identical to the template skeleton. FastMCP's
+    # ``icons`` property is read-only (only the constructor accepts icons, which
+    # the skeleton body does not), so write the low-level server field it reads.
+    mcp._mcp_server.icons = _SERVER_ICON
+    if config.instructions is None:
+        mcp.instructions = build_default_instructions(
+            read_only=is_read_only,
+            conventions_file=config.content.conventions_file,
+        )
+
+    logger.info(
+        "Vault startup: mode=%s vault=%s embeddings=%s",
+        "read-only" if is_read_only else "read-write",
+        config.source_dir,
+        "enabled" if config.indexing.embeddings_path else "disabled",
+    )
+
     # GitHub webhook endpoint — only when secret is configured and transport
     # is HTTP/SSE (stdio has no HTTP server to receive POST requests).
     if config.sync.github_webhook_secret and transport != "stdio":
@@ -241,20 +166,16 @@ def make_server(
         mcp.custom_route("/github-webhook", methods=["POST"])(
             make_webhook_handler(config.sync.github_webhook_secret)
         )
-    # DOMAIN-WIRING-END
 
-    # DOMAIN-FILE-EXCHANGE-START — one-time transfer-link wiring (#622), kept
-    # across copier update.  HTTP/SSE only: stdio has no server to receive
-    # requests.  Registers the create_*_link tools and the /transfer/{token}
-    # route, sharing one in-memory TransferStore.
+    # One-time transfer-link wiring (#622). HTTP/SSE only: stdio has no server to
+    # receive requests. Registers the create_*_link tools and the
+    # /transfer/{token} route, sharing one in-memory TransferStore.
     if transport != "stdio":
         from markdown_vault_mcp._server_transfer import register_transfer
 
         register_transfer(mcp, config)
-    # DOMAIN-FILE-EXCHANGE-END
 
     # --- Visibility: hide write-tagged components in read-only mode ---
-
     if is_read_only:
         mcp.disable(tags={"write"})
 
@@ -287,5 +208,6 @@ def make_server(
     # listing (saves a few tokens; the LLM cannot call them anyway).
     if config.disable_apps_ui:
         mcp.disable(tags={"apps-ui"})
+    # DOMAIN-WIRING-END
 
     return mcp

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -167,21 +167,18 @@ def make_server(
     )
 
     # Honor the passed config's server name the same way as instructions/icons.
-    # The skeleton body sources the name from the SERVER_NAME env var, which
-    # config.server_name mirrors for from_env configs; a programmatically-built
-    # config can diverge. Act only when they differ (a no-op on the from_env
-    # path). FastMCP.name is read-only, so write the low-level field, and
-    # re-register get_server_info so its reported name stays in sync with the
-    # client-facing name (the skeleton registered it above with the env value).
-    # The re-registration carries no upstream_version — a markdown vault has no
-    # remote upstream, so DOMAIN-UPSTREAM stays empty; mirror it here if that
-    # ever changes.
+    # The skeleton body sources the client-facing name from the SERVER_NAME env
+    # var, which config.server_name mirrors for from_env configs; a
+    # programmatically-built config can diverge. Act only when they differ (a
+    # no-op on the from_env path). FastMCP.name is read-only, so write the
+    # low-level field. get_server_info is intentionally NOT re-registered here:
+    # it is registered once in the skeleton body (with the DOMAIN-UPSTREAM
+    # block), so re-registering would be a second, silently-diverging call site
+    # for that upstream wiring. Its reported server_name stays the SERVER_NAME
+    # env identity (a deployment-verification value that matches on the from_env
+    # path), while the live instance name honors the passed config.
     if config.server_name != server_name:
         mcp._mcp_server.name = config.server_name
-        mcp.local_provider.remove_tool("get_server_info")
-        register_server_info_tool(
-            mcp, server_name=config.server_name, server_version=pkg_ver
-        )
 
     logger.info(
         "vault_startup mode=%s vault=%s embeddings=%s",

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -127,9 +127,20 @@ def make_server(
     from markdown_vault_mcp._http_logging import quiet_http_loggers
     from markdown_vault_mcp._icons import _SERVER_ICON
     from markdown_vault_mcp._instructions import build_default_instructions
+    from markdown_vault_mcp._server_prompts import register_domain_prompts
     from markdown_vault_mcp.domain import set_pending_config
 
     is_read_only = config.read_only
+
+    # Config-dependent prompts (create_from_template + user prompts): registered
+    # here, not at the template-mandated no-arg register_prompts(mcp) above, so
+    # their folders come from this already-loaded config rather than a second env
+    # read (#609). User prompts silently override the built-ins registered above.
+    register_domain_prompts(
+        mcp,
+        config.content.templates_folder,
+        config.content.prompts_folder,
+    )
 
     # Hand the already-loaded config to the no-arg server_lifespan's Service so it
     # builds the vault from this config, not a second from_env() read (#609).
@@ -152,7 +163,7 @@ def make_server(
         )
 
     logger.info(
-        "Vault startup: mode=%s vault=%s embeddings=%s",
+        "vault_startup mode=%s vault=%s embeddings=%s",
         "read-only" if is_read_only else "read-write",
         config.source_dir,
         "enabled" if config.indexing.embeddings_path else "disabled",

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -166,6 +166,23 @@ def make_server(
         conventions_file=config.content.conventions_file,
     )
 
+    # Honor the passed config's server name the same way as instructions/icons.
+    # The skeleton body sources the name from the SERVER_NAME env var, which
+    # config.server_name mirrors for from_env configs; a programmatically-built
+    # config can diverge. Act only when they differ (a no-op on the from_env
+    # path). FastMCP.name is read-only, so write the low-level field, and
+    # re-register get_server_info so its reported name stays in sync with the
+    # client-facing name (the skeleton registered it above with the env value).
+    # The re-registration carries no upstream_version — a markdown vault has no
+    # remote upstream, so DOMAIN-UPSTREAM stays empty; mirror it here if that
+    # ever changes.
+    if config.server_name != server_name:
+        mcp._mcp_server.name = config.server_name
+        mcp.local_provider.remove_tool("get_server_info")
+        register_server_info_tool(
+            mcp, server_name=config.server_name, server_version=pkg_ver
+        )
+
     logger.info(
         "vault_startup mode=%s vault=%s embeddings=%s",
         "read-only" if is_read_only else "read-write",

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -627,25 +627,79 @@ class TestUserPromptOverride:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Overriding a built-in prunes it first, so FastMCP logs no duplicate warning.
 
         register_domain_prompts removes the shadowed built-in before registering
         the user prompt; without that, FastMCP's default ``on_duplicate="warn"``
-        would emit "Component already exists: prompt:summarize" on every startup
+        would emit "Component already exists: prompt:summarize@" on every startup
         for a fully-supported override.
+
+        The warning rides FastMCP's own ``fastmcp`` logger, which sets
+        ``propagate=False`` — so pytest's root-attached ``caplog`` never sees it.
+        Capture that logger directly, and neutralize ``configure_logging_from_env``
+        (make_server calls it, and it re-installs the ``fastmcp`` logger's handlers
+        + propagate) so the capture handler survives.
         """
         import logging
+
+        monkeypatch.setattr(
+            "markdown_vault_mcp.server.configure_logging_from_env",
+            lambda *_a, **_k: None,
+        )
+        records: list[str] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record.getMessage())
 
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
         (prompts_dir / "summarize.md").write_text("OVERRIDE", encoding="utf-8")
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
 
-        with caplog.at_level(logging.WARNING, logger="fastmcp"):
+        fastmcp_logger = logging.getLogger("fastmcp")
+        handler = _Capture()
+        prev_level = fastmcp_logger.level
+        fastmcp_logger.setLevel(logging.WARNING)
+        fastmcp_logger.addHandler(handler)
+        try:
             make_server()
-        assert "already exists" not in caplog.text
+        finally:
+            fastmcp_logger.removeHandler(handler)
+            fastmcp_logger.setLevel(prev_level)
+        assert not any("already exists" in m for m in records)
+
+    @pytest.mark.usefixtures("_clear_vars")
+    async def test_override_of_unregistered_builtin_does_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A user prompt shadowing a built-in that failed to register must not crash.
+
+        register_domain_prompts prunes the shadowed built-in before re-registering;
+        if that built-in was never registered (missing static file, or a #799
+        backstop-caught error), remove_prompt raises KeyError. The prune is guarded
+        so server construction still succeeds — the user prompt registers fresh.
+        """
+        from markdown_vault_mcp import _server_prompts
+
+        # "summarize" never registers (loader returns None), yet the operator
+        # ships a summarize.md — the prune would KeyError without the guard.
+        original = _server_prompts._load_builtin_prompt
+        monkeypatch.setattr(
+            _server_prompts,
+            "_load_builtin_prompt",
+            lambda name: None if name == "summarize" else original(name),
+        )
+        prompts_dir = tmp_path / "prompts"
+        prompts_dir.mkdir()
+        (prompts_dir / "summarize.md").write_text("USER SUMMARIZE", encoding="utf-8")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
+
+        server = make_server()  # must not raise
+        async with Client(server) as client:
+            names = {p.name for p in await client.list_prompts()}
+        assert "summarize" in names  # the user prompt registered
 
 
 class TestUserPromptWriteTag:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -752,7 +752,7 @@ class TestRegisterPromptsPerPromptGuard:
         from fastmcp import FastMCP
 
         from markdown_vault_mcp import _server_prompts
-        from markdown_vault_mcp._server_prompts import register_prompts
+        from markdown_vault_mcp._server_prompts import register_domain_prompts
 
         monkeypatch.setattr(
             _server_prompts,
@@ -772,7 +772,9 @@ class TestRegisterPromptsPerPromptGuard:
         with caplog.at_level(
             logging.WARNING, logger="markdown_vault_mcp._server_prompts"
         ):
-            register_prompts(mcp, templates_folder=None, prompts_folder="/whatever")
+            register_domain_prompts(
+                mcp, templates_folder=None, prompts_folder="/whatever"
+            )
 
         assert "User prompt 'bad' failed to register" in caplog.text
         async with Client(mcp) as client:
@@ -806,7 +808,7 @@ class TestRegisterPromptsPerPromptGuard:
         with caplog.at_level(
             logging.ERROR, logger="markdown_vault_mcp._server_prompts"
         ):
-            register_prompts(mcp, templates_folder=None, prompts_folder=None)
+            register_prompts(mcp)
 
         assert "Built-in prompt 'summarize' failed to register" in caplog.text
         assert "packaging defect" in caplog.text
@@ -827,7 +829,7 @@ class TestRegisterPromptsPerPromptGuard:
         from fastmcp import FastMCP
 
         from markdown_vault_mcp import _server_prompts
-        from markdown_vault_mcp._server_prompts import register_prompts
+        from markdown_vault_mcp._server_prompts import register_domain_prompts
 
         monkeypatch.setattr(
             _server_prompts,
@@ -856,7 +858,9 @@ class TestRegisterPromptsPerPromptGuard:
         with caplog.at_level(
             logging.WARNING, logger="markdown_vault_mcp._server_prompts"
         ):
-            register_prompts(mcp, templates_folder=None, prompts_folder="/whatever")
+            register_domain_prompts(
+                mcp, templates_folder=None, prompts_folder="/whatever"
+            )
 
         assert "cannot form a valid signature" in caplog.text
         assert "failed to register" not in caplog.text
@@ -876,7 +880,7 @@ class TestRegisterPromptsPerPromptGuard:
         from fastmcp import FastMCP
 
         from markdown_vault_mcp import _server_prompts
-        from markdown_vault_mcp._server_prompts import register_prompts
+        from markdown_vault_mcp._server_prompts import register_domain_prompts
 
         original_build = _server_prompts._build_prompt_fn
 
@@ -918,7 +922,9 @@ class TestRegisterPromptsPerPromptGuard:
         with caplog.at_level(
             logging.WARNING, logger="markdown_vault_mcp._server_prompts"
         ):
-            register_prompts(mcp, templates_folder=None, prompts_folder="/whatever")
+            register_domain_prompts(
+                mcp, templates_folder=None, prompts_folder="/whatever"
+            )
 
         assert "User prompt 'bad' failed to register" in caplog.text
         async with Client(mcp) as client:
@@ -972,7 +978,7 @@ class TestRegisterPromptsPerPromptGuard:
         with caplog.at_level(
             logging.ERROR, logger="markdown_vault_mcp._server_prompts"
         ):
-            register_prompts(mcp, templates_folder=None, prompts_folder=None)
+            register_prompts(mcp)
 
         assert "Built-in prompt 'summarize' failed to register" in caplog.text
         assert "packaging defect" in caplog.text

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -622,6 +622,31 @@ class TestUserPromptOverride:
         summarize_entries = [p for p in prompts if p.name == "summarize"]
         assert len(summarize_entries) == 1
 
+    @pytest.mark.usefixtures("_clear_vars")
+    async def test_override_does_not_log_component_already_exists(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Overriding a built-in prunes it first, so FastMCP logs no duplicate warning.
+
+        register_domain_prompts removes the shadowed built-in before registering
+        the user prompt; without that, FastMCP's default ``on_duplicate="warn"``
+        would emit "Component already exists: prompt:summarize" on every startup
+        for a fully-supported override.
+        """
+        import logging
+
+        prompts_dir = tmp_path / "prompts"
+        prompts_dir.mkdir()
+        (prompts_dir / "summarize.md").write_text("OVERRIDE", encoding="utf-8")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", str(prompts_dir))
+
+        with caplog.at_level(logging.WARNING, logger="fastmcp"):
+            make_server()
+        assert "already exists" not in caplog.text
+
 
 class TestUserPromptWriteTag:
     """User prompts tagged 'write' are hidden in read-only mode."""
@@ -734,12 +759,14 @@ class TestProposeLinks:
 
 
 class TestRegisterPromptsPerPromptGuard:
-    """register_prompts skips a malformed prompt and keeps registering siblings.
+    """A malformed prompt is skipped and its siblings still register.
 
     The per-prompt helpers can raise *outside* their narrow ``except ValueError``
     handlers — a def-dict missing a key (``KeyError``) or a ``mcp.prompt(...)``
-    rejection. The loop backstop in ``register_prompts`` catches these so one bad
-    prompt does not abort registration of the rest (#799).
+    rejection. A loop backstop catches these so one bad prompt does not abort
+    registration of the rest (#799). Built-in failures go through the backstop in
+    :func:`register_prompts`; user-prompt failures through the one in
+    :func:`register_domain_prompts`.
     """
 
     async def test_user_prompt_registration_failure_skips_and_warns(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -290,15 +290,19 @@ class TestConfigDrivenPrompts:
 
         # env carries NO SERVER_NAME override ...
         monkeypatch.delenv("MARKDOWN_VAULT_MCP_SERVER_NAME", raising=False)
-        # ... while the provided config sets one. Both the instance name and the
-        # get_server_info tool must report it (not the env default).
+        # ... while the provided config sets one. The live instance name honors
+        # it (would be the env default "markdown-vault-mcp" if env drove it).
         config = ProjectConfig(source_dir=tmp_path, server_name="custom-vault")
 
         server = make_server(config=config)
         assert server.name == "custom-vault"
+        # get_server_info is intentionally left on its single skeleton
+        # registration (keeping the DOMAIN-UPSTREAM block the one source of truth
+        # for upstream wiring), so it reports the SERVER_NAME env identity — here
+        # the default, since the env var is unset — not the programmatic override.
         async with Client(server) as client:
             result = await client.call_tool("get_server_info", {})
-        assert result.data["server_name"] == "custom-vault"
+        assert result.data["server_name"] == "markdown-vault-mcp"
 
 
 class TestGithubWebhookWiring:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import patch
 
 import pytest
-from fastmcp import Client
+from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
 from mcp.shared.exceptions import McpError
 
@@ -211,6 +211,36 @@ class TestDisableAppsUi:
         # Non-apps-ui tools must remain available.
         assert "search" in names
         assert "read" in names
+
+
+class TestGithubWebhookWiring:
+    """Cover the GitHub-webhook custom-route gate in make_server's DOMAIN-WIRING."""
+
+    @staticmethod
+    def _route_paths(server: FastMCP) -> set[str]:
+        return {r.path for r in server._additional_http_routes}
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_webhook_route_registered_when_secret_and_http(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GITHUB_WEBHOOK_SECRET", "s3cret")
+        server = make_server(transport="http")
+        assert "/github-webhook" in self._route_paths(server)
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_webhook_route_absent_on_stdio(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A secret is set, but stdio has no HTTP server to receive POSTs.
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GITHUB_WEBHOOK_SECRET", "s3cret")
+        server = make_server(transport="stdio")
+        assert "/github-webhook" not in self._route_paths(server)
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_webhook_route_absent_without_secret(self) -> None:
+        server = make_server(transport="http")
+        assert "/github-webhook" not in self._route_paths(server)
 
 
 class TestToolManifest:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -266,6 +266,22 @@ class TestConfigDrivenPrompts:
             names = {p.name for p in await client.list_prompts()}
         assert "greet" in names
 
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_instructions_resolved_from_provided_config_not_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp.config import ProjectConfig
+
+        # env carries NO instructions override ...
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_INSTRUCTIONS", raising=False)
+        # ... while the provided config sets one. It must win over both the
+        # generic env-baseline and the domain default (DOMAIN-WIRING is gated on
+        # config.instructions, not the env var).
+        config = ProjectConfig(source_dir=tmp_path, instructions="Custom vault brief.")
+
+        server = make_server(config=config)
+        assert server.instructions == "Custom vault brief."
+
 
 class TestGithubWebhookWiring:
     """Cover the GitHub-webhook custom-route gate in make_server's DOMAIN-WIRING."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -282,6 +282,24 @@ class TestConfigDrivenPrompts:
         server = make_server(config=config)
         assert server.instructions == "Custom vault brief."
 
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_server_name_resolved_from_provided_config_not_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp.config import ProjectConfig
+
+        # env carries NO SERVER_NAME override ...
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_SERVER_NAME", raising=False)
+        # ... while the provided config sets one. Both the instance name and the
+        # get_server_info tool must report it (not the env default).
+        config = ProjectConfig(source_dir=tmp_path, server_name="custom-vault")
+
+        server = make_server(config=config)
+        assert server.name == "custom-vault"
+        async with Client(server) as client:
+            result = await client.call_tool("get_server_info", {})
+        assert result.data["server_name"] == "custom-vault"
+
 
 class TestGithubWebhookWiring:
     """Cover the GitHub-webhook custom-route gate in make_server's DOMAIN-WIRING."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -213,6 +213,60 @@ class TestDisableAppsUi:
         assert "read" in names
 
 
+class TestServerIcon:
+    """Guard the post-construction server-icon attachment in DOMAIN-WIRING.
+
+    ``make_server`` writes the low-level ``mcp._mcp_server.icons`` field because
+    FastMCP's public ``icons`` property is read-only and the template-skeleton
+    constructor carries no icons. This test fails loudly if a FastMCP upgrade
+    renames that field, rather than silently dropping the icon.
+    """
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_server_icon_attached(self) -> None:
+        from markdown_vault_mcp._icons import _SERVER_ICON
+
+        server = make_server()
+        assert server.icons  # non-empty
+        assert server.icons == _SERVER_ICON
+
+
+class TestConfigDrivenPrompts:
+    """make_server(config=X) resolves prompt folders from X, not the environment.
+
+    Regression guard for the server.py de-fork: config-dependent prompts are
+    registered in DOMAIN-WIRING from the passed config's ``ContentConfig`` (via
+    ``register_domain_prompts``), never a second environment read — so a
+    programmatically-built config whose ``prompts_folder`` differs from the
+    environment is honored (#901 review).
+    """
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_user_prompt_resolved_from_provided_config_not_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp.config import ProjectConfig
+        from markdown_vault_mcp.config_sections.content import ContentConfig
+
+        # env deliberately carries NO prompts folder ...
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_PROMPTS_FOLDER", raising=False)
+        # ... while the provided config points at one holding a user prompt. If
+        # register_domain_prompts read the env instead of this config, "greet"
+        # would be absent.
+        prompts_dir = tmp_path / "cfg_prompts"
+        prompts_dir.mkdir()
+        (prompts_dir / "greet.md").write_text("Hello from config", encoding="utf-8")
+        config = ProjectConfig(
+            source_dir=tmp_path,
+            content=ContentConfig(prompts_folder=str(prompts_dir)),
+        )
+
+        server = make_server(config=config)
+        async with Client(server) as client:
+            names = {p.name for p in await client.list_prompts()}
+        assert "greet" in names
+
+
 class TestGithubWebhookWiring:
     """Cover the GitHub-webhook custom-route gate in make_server's DOMAIN-WIRING."""
 

--- a/tests/test_template_conformance.py
+++ b/tests/test_template_conformance.py
@@ -54,7 +54,6 @@ FILE_MODULE_PATHS = {
 # the same PR that de-forks it; the removal is the proof (it flips the file to
 # the strict check). Epic #898. Seeded below after measuring actual conformance.
 RATCHET: dict[str, str] = {
-    "server.py": "#901",
     "__init__.py": "#903",
     "_server_apps.py": "#905",
 }


### PR DESCRIPTION
## What

De-forks the template-owned `server.py` (#901, epic #898). `make_server()`'s body is now **byte-identical to the pristine copier-template skeleton** outside the `DOMAIN-UPSTREAM` / `DOMAIN-WIRING` sentinels; all MVM customization moves into `DOMAIN-WIRING` or dedicated domain modules. `server.py` is removed from the conformance `RATCHET` and now strict-passes — the removal is the proof.

**Domain customization relocated:**

- **`_build_default_instructions` → new `_instructions.py`** (`build_default_instructions`), applied post-construction via the `mcp.instructions` setter in `DOMAIN-WIRING`.
- **Server icon** attached post-construction (`mcp._mcp_server.icons` — FastMCP's `icons` property is read-only and the skeleton ctor carries no icons).
- **Invented `DOMAIN-FILE-EXCHANGE` sentinel folded into `DOMAIN-WIRING`** (transfer wiring); the tag-visibility disable block folded in too.
- **`register_prompts(mcp)`** matches the template's no-arg shape. Prompt registration is **split** by config-dependency: `register_prompts(mcp)` registers the config-independent built-ins at the skeleton call site; a new `register_domain_prompts(mcp, templates_folder, prompts_folder)` — called from `DOMAIN-WIRING` with `make_server`'s already-resolved `config.content` — registers `create_from_template` + user prompts. A user prompt shadowing a built-in prunes it first (`mcp.local_provider.remove_prompt`, guarded against `KeyError`) so the override replaces cleanly with no "component already exists" warning.

## Config is honored, not re-read from env (#609)

The skeleton body sources `SERVER_NAME` / `INSTRUCTIONS` from the environment. `DOMAIN-WIRING` re-applies them from the **passed** config so `make_server(config=X)` honors `X` even when the env var is unset (the `from_env` path is unchanged, since `config.*` mirrors the same env var):

- `mcp.instructions = config.instructions or build_default_instructions(...)` (unconditional).
- server name: when `config.server_name` differs from the env-derived value, `mcp._mcp_server.name` is overridden. `get_server_info` is intentionally **not** re-registered — it stays on its single skeleton registration (keeping the `DOMAIN-UPSTREAM` block the sole source of truth for upstream wiring) and reports the `SERVER_NAME` env identity.
- prompt folders come from `config.content` (via `register_domain_prompts`), never a second env read.

Regression tests pin all three (`test_instructions_resolved_from_provided_config_not_env`, `test_server_name_resolved_from_provided_config_not_env`, `test_user_prompt_resolved_from_provided_config_not_env`).

## Review

Local preflight-circus ran to convergence — **5 full rounds** (5 core lenses + code-reviewer + test/type analysts each round). It caught, and this PR fixes, several real defects the first pass introduced:

1. `register_prompts` re-read env for prompt folders → `make_server(config=X)` registered prompts against the wrong root. Fixed by the config-dependency split.
2. Same class for **instructions** and **server_name** (baseline read env; override gated on config) → operator's programmatic config silently dropped. Fixed to honor config.
3. The built-in override logged a spurious `Component already exists` WARNING on every startup (`add_prompt` is not silent). Fixed by pruning the shadowed built-in first — and the guard test was found **vacuous** (the `fastmcp` logger sets `propagate=False` and `configure_logging_from_env` resets it, so `caplog` saw nothing) and rewritten to capture the logger directly.
4. The prune could crash `make_server` (`remove_prompt` raises `KeyError`) if a built-in failed to register and a user prompt shadowed it. Guarded.
5. The server-name fix initially re-registered `get_server_info`, creating a latent lockstep hazard with the `DOMAIN-UPSTREAM` block. Simplified away (Option above).

**Known follow-up (not fixable in this PR):** the skeleton `make_server` docstring calls the `transport` param *"logging only,"* but `transport` gates the webhook/transfer wiring in `DOMAIN-WIRING`. That docstring is template-owned and conformance-frozen; correcting it requires an upstream fix, filed as **pvliesdonk/fastmcp-server-template#246**. The accurate behavior is documented at the wiring sites.

## Gates

Full suite **2909 passed, 18 skipped**; `mypy src/ tests/` clean; ruff clean; structural diff-gate **0 violations**; conformance gate green (`server.py` now strict). Patch coverage on changed modules ≥ 94%.

Part of #898. Closes #901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
