### PR TITLE
refactor: close out de-fork epic #898 — strict conformance gate + docs (#906)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,9 @@ src/markdown_vault_mcp/
   tracker.py           -- hash-based change detection
   vault.py             -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
   write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
-  config.py            -- configuration loading
+  config.py            -- template-owned skeleton: ProjectConfig fields/from_env in CONFIG-* sentinels only (#900)
+  config_sections/
+    _assembly.py         -- domain config-assembly kept out of template-owned config.py: to_vault_kwargs, derive_max_chunk_chars, git-strategy builder (#900)
   domain.py            -- Service: owns the Vault lifecycle (build, boot index/reindex/embeddings jobs, file watcher); get_vault/get_config DI + vault singleton (#902)
   _instructions.py     -- build_default_instructions: domain server-instructions prose, applied in server.py's DOMAIN-WIRING (#901)
   _server_apps.py      -- template-owned MCP Apps scaffold; vault SPA + app-tools confined to DOMAIN-APP-TOOL-NAMES/DOMAIN-APP-RESOURCE/DOMAIN-APP-TOOLS sentinels (#905)

--- a/README.md
+++ b/README.md
@@ -631,6 +631,18 @@ When `copier update` introduces new dependencies, CI runs `uv sync --frozen` whi
 
 ## Upgrading from earlier versions
 
+- **Package root minimized (issue #903): import from submodules, not the package root.**
+  The `markdown_vault_mcp` root package no longer re-exports the public API. Update
+  library imports to their submodules:
+
+  ```python
+  # Before: from markdown_vault_mcp import Vault, ProjectConfig
+  # After:  from markdown_vault_mcp.vault import Vault
+  #         from markdown_vault_mcp.config import ProjectConfig
+  ```
+
+  Types such as `GroupedResult` come from `markdown_vault_mcp.types`. Only
+  `__version__` remains importable from the root.
 - **v2.0.0 (issue #469): `search`, `get_similar`, and `get_context.similar` now return grouped results.**
   Each file appears once with a `sections` list; the flat `content`, `heading`, and `score`
   fields have moved inside each `SectionHit`. Library consumers must update iteration:

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -69,7 +69,11 @@ markdown-vault-mcp (new package)
 +-- config.py         -- template-owned skeleton: ProjectConfig fields/from_env in sentinels only (#900)
 +-- config_sections/  -- domain-grouped sub-configs (git/indexing/embeddings/search/sync/content)
 |   +-- _assembly.py   -- domain config-assembly kept out of template-owned config.py: to_vault_kwargs, derive_max_chunk_chars, git-strategy builder (#900)
-+-- server.py         -- generic FastMCP server
++-- server.py         -- template-owned skeleton; domain wiring in DOMAIN-UPSTREAM/DOMAIN-WIRING (#901)
++-- _instructions.py  -- build_default_instructions: domain server-instructions prose (#901)
++-- domain.py         -- Service: owns Vault lifecycle + get_vault/set_pending_config singleton (#902)
++-- _server_apps.py   -- template-owned MCP Apps scaffold; domain apps in DOMAIN-APP-* sentinels (#905)
++-- _vault_apps.py    -- domain helpers behind _server_apps sentinels: sandbox-domain + CSP + GraphView serializer (#905)
 +-- cli.py            -- CLI entry point
 +-- utils/
 |   +-- text.py       -- text normalization and fuzzy matching
@@ -1104,9 +1108,12 @@ Vault(...)
 the vault (such as during maintenance or test teardown). It is a no-op if the
 loop was never started.
 
-In the MCP server, `close()` is called in the FastMCP lifespan `finally` block.
-Callers using `Vault` as a Python library must call `close()` explicitly
-(or use it as a context manager if one is added in future).
+In the MCP server, this lifecycle is orchestrated by the `Service` in
+`domain.py` (start/stop/close), which the template-owned `_server_deps.py`
+lifespan scaffold constructs and drives; the lifespan's `finally` block calls
+`Service.stop()`, which calls `close()` (#902/#910). Callers using `Vault` as a
+Python library must call `close()` explicitly (or use it as a context manager if
+one is added in future).
 
 ### One-Time Transfer Links (`transfer/` subsystem)
 
@@ -2079,7 +2086,11 @@ vault) and its data-egress is documented in the tool docstring and README.
 **Dynamic instructions**: the server's MCP `instructions` string varies with
 `read_only` mode. When `read_only=True`, the instructions state this is a
 read-only instance; when `read_only=False`, they describe write tool semantics.
-This signals capability status to clients and reduces irrelevant prompting.
+This signals capability status to clients and reduces irrelevant prompting. The
+default text is built by `build_default_instructions()` in `_instructions.py`
+(kept out of the template-owned `server.py`, #901) and applied in the
+`DOMAIN-WIRING` block; an operator-set `MARKDOWN_VAULT_MCP_INSTRUCTIONS`
+overrides it.
 
 **Tool semantics**:
 - `read(path)` returns full file content + frontmatter metadata
@@ -2098,8 +2109,11 @@ without special prompting.
 
 **Dependency injection**: tools and resources use FastMCP's
 ``Depends(get_vault)`` to access the Vault instance from
-lifespan context, eliminating module-level globals. Prompts are pure
-template functions with no vault dependency.
+lifespan context, eliminating module-level globals. `get_vault` and the vault
+singleton (with `set_pending_config`) are module-level functions in `domain.py`,
+alongside the `Service` that owns the Vault lifecycle — start/stop orchestration
+was moved there out of the template-owned `_server_deps.py` scaffold (#902/#910).
+Prompts are pure template functions with no vault dependency.
 
 **Resources**: the server exposes 6 read-only MCP resources:
 
@@ -2139,9 +2153,10 @@ The library layer returns typed structs (``TocEntry``, ``SubtreeNote``, ``Subtre
 Write-tagged prompts are hidden in read-only mode by the same
 ``mcp.disable(tags={"write"})`` call that hides write tools.
 
-Prompt registration is split by config-dependency (#901). The template-owned
-``make_server`` body calls ``register_prompts(mcp)``, which registers the six
-config-independent built-ins above (every one except ``create_from_template``).
+Prompt registration is split by config-dependency (#901), both entry points
+living in ``_server_prompts.py``. The template-owned ``make_server`` body calls
+``register_prompts(mcp)``, which registers the six config-independent built-ins
+above (every one except ``create_from_template``).
 The config-dependent prompts — ``create_from_template`` (needs the templates
 folder) and user-defined prompts (need the prompts folder) — are registered by
 ``register_domain_prompts(mcp, templates_folder, prompts_folder)``, called from
@@ -2436,7 +2451,9 @@ a load failure degrades to system fonts with no loss of function.
 
 **Source layout and build**: the SPA is authored as partials under `src/markdown_vault_mcp/static/spa/` (`shell.html`, `styles.css`, `core.js`, and one `views/*.js` per view). `scripts/build_spa.py` assembles them into `static/app.src.html` via recursive `/*@@FILE:path@@*/` include markers, then `scripts/vendor_spa.py` embeds the vendored libraries into the served `static/app.html`. Both `app.src.html` and `app.html` are generated, committed artifacts; edit the partials, not the generated files. Each script has a `--check` mode that gates the build in CI and pre-commit, so a stale artifact fails fast.
 
-**Domain configuration**: MCP Apps iframes are sandboxed to a specific Claude app domain. The server computes it from `MARKDOWN_VAULT_MCP_BASE_URL` via `_compute_claude_app_domain()`. Override with `MARKDOWN_VAULT_MCP_APP_DOMAIN` when `BASE_URL` does not reflect the actual hostname visible to the Claude client (such as behind a proxy, or on a custom domain).
+**Module layout**: `_server_apps.py` is the template-owned MCP Apps scaffold — the SPA shell resource and app-tools live inside its `DOMAIN-APP-TOOL-NAMES` / `DOMAIN-APP-RESOURCE` / `DOMAIN-APP-TOOLS` sentinel blocks, so everything outside them stays byte-identical to the template skeleton. The domain helpers that cannot live in the template-owned body — `_compute_claude_app_domain`, `_CDN_RESOURCE_DOMAINS`, and the `GraphView`→SPA `_graph_view_payload` serializer — live in `_vault_apps.py` (#905).
+
+**Domain configuration**: MCP Apps iframes are sandboxed to a specific Claude app domain. The server computes it from `MARKDOWN_VAULT_MCP_BASE_URL` via `_compute_claude_app_domain()` (in `_vault_apps.py`). Override with `MARKDOWN_VAULT_MCP_APP_DOMAIN` when `BASE_URL` does not reflect the actual hostname visible to the Claude client (such as behind a proxy, or on a custom domain).
 
 | Variable | Default | Description |
 |-|-|-|

--- a/tests/test_template_conformance.py
+++ b/tests/test_template_conformance.py
@@ -8,13 +8,16 @@ the template-owned body. This module renders the template pristinely with this
 repo's own answers and asserts each file matches the pristine render *outside*
 its sentinel blocks. Any out-of-sentinel divergence is a fork.
 
-The :data:`RATCHET` allowlist carries the files whose de-fork is still in
-progress. Each de-fork PR **removes its file from RATCHET in the same PR**: that
-removal flips the file from the weak "still forked" assertion to the strict
-"conforms" assertion, so a PR cannot claim a de-fork unless the file actually
-conforms. The list can only shrink truthfully — a file that already conforms
-fails the weak assertion. When RATCHET is empty the gate is permanently strict
-and blocks any new fork.
+Epic #898 is complete: all six template-owned files conform, so :data:`RATCHET`
+is empty (asserted by :func:`test_ratchet_is_empty`) and the gate is
+**unconditionally strict** — every file in :data:`FILE_MODULE_PATHS` must match
+the pristine render outside its sentinel blocks, and any new fork fails CI.
+
+During the epic, :data:`RATCHET` carried the files whose de-fork was still in
+progress: each was held to a weak "still forked" check until its de-fork PR
+removed it, the removal being the proof of conformance. That weak branch is
+gone now that the list is empty; should the template ever add a new owned file
+needing a staged de-fork, reintroduce the weak check alongside the entry.
 
 Render uses ``copier copy --trust --skip-tasks`` — ``--trust`` because the
 template declares tasks (copier refuses otherwise), ``--skip-tasks`` so the
@@ -50,9 +53,10 @@ FILE_MODULE_PATHS = {
     "cli.py": f"src/{MODULE}/cli.py",
 }
 
-# Known-forked files, de-fork in progress → tracking issue. REMOVE a file here in
-# the same PR that de-forks it; the removal is the proof (it flips the file to
-# the strict check). Epic #898. Seeded below after measuring actual conformance.
+# Empty — epic #898 is complete and every template-owned file is held to the
+# strict conformance check. Asserted empty by ``test_ratchet_is_empty``; adding
+# a file here does nothing on its own (the weak-check branch was removed at
+# close-out), so a genuine future staged de-fork must reintroduce that branch.
 RATCHET: dict[str, str] = {}
 
 _START = re.compile(r"#\s*([A-Z0-9-]+)-START\b")
@@ -414,14 +418,9 @@ def test_template_owned_file_conforms(fname: str, ctx: _Ctx) -> None:
         _significant(_strip_sentinels(pristine, legal)),
     )
 
-    if fname in RATCHET:
-        assert div is not None, (
-            f"{fname} now CONFORMS to the template skeleton but is still in RATCHET "
-            f"({RATCHET[fname]}). Remove it from RATCHET in THIS PR — that removal is "
-            f"the proof of de-fork. Epic #898."
-        )
-    else:
-        assert div is None, _fork_message(fname, rel, ctx.ref, div, repo)
+    # Unconditionally strict (epic #898 complete): every template-owned file
+    # must conform outside its sentinel blocks. See test_ratchet_is_empty.
+    assert div is None, _fork_message(fname, rel, ctx.ref, div, repo)
 
 
 def test_module_server_is_never_exempt(ctx: _Ctx) -> None:
@@ -434,6 +433,21 @@ def test_module_server_is_never_exempt(ctx: _Ctx) -> None:
 def test_ratchet_only_lists_template_owned_files() -> None:
     unknown = set(RATCHET) - set(FILE_MODULE_PATHS)
     assert not unknown, f"RATCHET lists non-template-owned files: {sorted(unknown)}"
+
+
+def test_ratchet_is_empty() -> None:
+    """Epic #898 close-out: every template-owned file is de-forked.
+
+    An empty RATCHET is the proof the epic is complete and the per-file gate is
+    unconditionally strict. A file cannot be added here to silence a fork
+    without also reintroducing the weak-check branch removed at close-out (see
+    the module docstring), so this assertion keeps the gate honest.
+    """
+    assert RATCHET == {}, (
+        f"RATCHET must stay empty post-#898 (found {sorted(RATCHET)}); the gate "
+        "is unconditionally strict. Re-opening a staged de-fork requires "
+        "restoring the weak-check branch, not just adding an entry here."
+    )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Closes out the **#898 de-fork epic**. All six template-owned files (`config.py`, `server.py`, `_server_deps.py`, `_server_apps.py`, `__init__.py`, `cli.py`) now conform to the pristine template skeleton, so this PR locks that in and reconciles the docs.

## What changed

**Conformance gate is now unconditionally strict** (`tests/test_template_conformance.py`):
- `RATCHET` is empty, so the per-file weak "still forked" branch (`if fname in RATCHET: assert div is not None; else: assert div is None`) is dead code — removed, leaving every template-owned file held to `assert div is None`.
- Added `test_ratchet_is_empty`: the empty state is now the asserted proof of completion, and a file can't be re-added to silence a fork without also restoring the weak-check branch.
- Module docstring + `RATCHET` comment updated to describe the completed, permanently-strict state.

**Docs reconciled with the relocated domain code:**
- `docs/design/design.md`: added `_instructions.py`, `domain.py`, `_server_apps.py`, `_vault_apps.py` to the package tree; noted `build_default_instructions` → `_instructions.py` (#901); named `_server_prompts.py` as the prompt-split module; documented the `domain.py` `Service` as owner of the Vault lifecycle + the `get_vault` singleton (#902/#910); noted the apps helpers live in `_vault_apps.py` (#905).
- `CLAUDE.md`: replaced the stale `config.py -- configuration loading` line and added the `config_sections/_assembly.py` subtree (#900).
- `README.md`: added an "Upgrading" entry for the #903 breaking public-API change (root no longer re-exports; import from submodules).

**Recorded the supersession**: [posted on #766](https://github.com/pvliesdonk/markdown-vault-mcp/issues/766#issuecomment-4980304152) that #898 supersedes its "sanctioned domain decision" framing — the repo carries no "sanctioned fork" language.

## Acceptance criteria (all met)

- ✅ `RATCHET` empty; gate strict for all six files; a new fork fails CI (the conformance test renders the pristine template and asserts each file conforms outside its sentinels).
- ✅ A `copier update` is clean — mechanized by the conformance test, and demonstrated end-to-end by #913 (v2.10.1 → v2.10.5 preserved all six files with zero spurious deletions).
- ✅ Docs updated; no "sanctioned fork" language remains.
- ✅ `pytest -x -q` (2907 passed / 18 skipped), ruff, mypy, structural gate (100%) all green.

## Verification

Local preflight review circus (5 core lenses + code-reviewer) ran clean at ≥80 — every relocated-symbol doc claim independently verified against the source with line citations, and the gate's strict-assertion change confirmed correct. Two sub-80 prose-precision fixes to internal `design.md` (the `domain.py` `get_vault`/`stop()`→`close()` wording) were applied after the circus; they refine already-verified-accurate claims with no reviewable behavior change.

Closes #906
Refs #898

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._