### PR TITLE
refactor: unify embedding providers on the OpenAI-compatible API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Embedding providers are unified on the OpenAI-compatible wire protocol
+  via the official `openai` SDK (#916): `OpenAIProvider` now embeds through
+  the SDK, and `OllamaProvider` targets Ollama's OpenAI-compatible endpoint
+  (`{OLLAMA_HOST}/v1`) through the same shared client. No configuration
+  changes: `EMBEDDING_PROVIDER=ollama`, `OLLAMA_HOST`, `OLLAMA_MODEL`,
+  `OLLAMA_CPU_ONLY`, and auto-detection behave exactly as before.
+  `OLLAMA_CPU_ONLY` keeps using Ollama's native API (the compatibility
+  layer cannot express CPU-only inference). The `embeddings-api` extra now
+  installs the `openai` SDK alongside `httpx` and `numpy`.
+
 ### Changed (BREAKING)
 
 - The `summarize` tool's Anthropic-SDK backend was replaced by a generic

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ With optional dependencies:
 
 ```bash
 pip install markdown-vault-mcp[mcp]            # FastMCP server
-pip install markdown-vault-mcp[embeddings-api]  # Ollama/OpenAI embeddings via HTTP
+pip install markdown-vault-mcp[embeddings-api]  # Ollama/OpenAI embeddings via API
 pip install markdown-vault-mcp[embeddings]      # FastEmbed local embeddings
 pip install markdown-vault-mcp[all]             # MCP + FastEmbed + API embeddings
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,8 @@ The first three knobs adjust *ranking and rendering* and take effect immediately
     2. **Ollama** — if `OLLAMA_HOST` is reachable
     3. **FastEmbed** — if the `fastembed` package is installed
 
+    Both API providers speak the OpenAI-compatible embeddings protocol through the official `openai` SDK: the `ollama` provider is a preset that targets `{OLLAMA_HOST}/v1` with no key required. The `OLLAMA_*` settings and their behavior are unchanged; `OLLAMA_CPU_ONLY` uses Ollama's native API, which is the only way to request CPU-only inference.
+
     **Explicit vs. auto-detect failure handling:** when you set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` to a specific backend and it cannot be constructed at startup — a missing dependency, missing/empty credentials, or an unrecognised value — the server **fails fast** with a `ConfigurationError` rather than silently falling back to keyword-only search. (An unreachable Ollama/OpenAI *service* does not prevent startup — the provider still loads; the failure surfaces later as an embedding error during index build.) When the variable is *unset* (auto-detect) and no backend is available, the server logs a warning and continues with semantic search disabled. Set the variable explicitly if you want a missing provider to be a hard startup error.
 
 ## Summarization

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1983,6 +1983,21 @@ Copied from ifcraftcorpus, adapted:
 - Keep the same provider ABC and implementations (Ollama, OpenAI,
   SentenceTransformers)
 
+**Unified wire protocol (#916)**: both API providers embed through one
+shared OpenAI-compatible transport built on the official ``openai`` SDK
+(``_OpenAICompatEmbeddings``). ``OpenAIProvider`` passes its configured
+base URL and key straight through; ``OllamaProvider`` is a preset over the
+same client (``base_url = {OLLAMA_HOST}/v1``, placeholder key). The
+user-facing config surface (``EMBEDDING_PROVIDER=ollama``, ``OLLAMA_HOST``,
+``OLLAMA_MODEL``, ``OLLAMA_CPU_ONLY``, reachability auto-detect) is
+unchanged — provider names are the contract, the wire protocol is an
+implementation detail. Three Ollama capabilities have no OpenAI-API
+equivalent and stay on the native REST API: CPU-only inference
+(``options.num_gpu`` via ``/api/embed``, taken when ``cpu_only`` is set),
+the ``/api/show`` context-length probe, and the ``/api/tags`` reachability
+probe in ``get_embedding_provider``. ``fastembed`` (in-process, non-API)
+is unaffected.
+
 ### `tracker.py`: Change Detection
 
 ```python

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ With optional dependencies:
     ```bash
     pip install markdown-vault-mcp[embeddings-api]
     ```
-    Adds httpx + numpy for Ollama/OpenAI embeddings via HTTP.
+    Adds the openai SDK + httpx + numpy for Ollama/OpenAI embeddings via API.
 
 === "Local embeddings"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 [project.optional-dependencies]
 # PROJECT-EXTRAS-START — add domain-specific optional-dependency groups below; kept across copier update
 mcp = ["fastmcp>=3.0,<4"]
-embeddings-api = ["httpx>=0.25", "numpy>=1.20"]
+embeddings-api = ["httpx>=0.25", "numpy>=1.20", "openai>=1.45"]
 embeddings = ["fastembed>=0.3", "numpy>=1.20"]
 file-watcher = ["watchdog>=4.0"]
 # LLM-backed summarize tool (OpenAI-compatible chat-completions backend:

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -2,9 +2,17 @@
 
 Provides an :class:`EmbeddingProvider` ABC and three concrete implementations:
 
-- :class:`OllamaProvider` — HTTP client to Ollama REST API.
-- :class:`OpenAIProvider` — HTTP client to OpenAI Embeddings API.
+- :class:`OllamaProvider` — Ollama server; embeds via Ollama's
+  OpenAI-compatible endpoint (``{host}/v1``), with the native REST API kept
+  for capabilities the compatibility layer cannot express (CPU-only
+  inference, the context-length probe).
+- :class:`OpenAIProvider` — OpenAI-compatible Embeddings API via the
+  official ``openai`` SDK.
 - :class:`FastEmbedProvider` — local fastembed/ONNX runtime embeddings.
+
+Both API providers share one wire protocol and one client
+(:class:`_OpenAICompatEmbeddings`); the provider names are ergonomic presets
+over it, not separate code paths (#916).
 
 Use :func:`get_embedding_provider` to auto-detect and return the best
 available provider based on a :class:`ProjectConfig` instance.
@@ -14,7 +22,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.exceptions import ConfigurationError
 
@@ -48,6 +56,66 @@ _OPENAI_CONTEXT_LENGTHS: dict[str, int] = {
     "text-embedding-3-large": 8191,
     "text-embedding-ada-002": 8191,
 }
+
+
+# The openai SDK requires a non-None api_key string even for servers that
+# ignore auth (Ollama's own docs suggest this placeholder).
+_PLACEHOLDER_API_KEY = "ollama"
+
+
+class _OpenAICompatEmbeddings:
+    """Shared OpenAI-compatible embeddings transport (official openai SDK).
+
+    Owns the SDK client, the ``embeddings.create`` call, input-order
+    restoration, and error mapping. :class:`OpenAIProvider` and
+    :class:`OllamaProvider` are thin presets over this one code path.
+
+    Args:
+        api_key: API key, or ``None`` for keyless endpoints (a placeholder
+            is sent; e.g. Ollama ignores it).
+        base_url: OpenAI-compatible endpoint base URL.
+        model: Embedding model name.
+        label: Provider label used in error messages.
+    """
+
+    def __init__(
+        self, api_key: str | None, *, base_url: str, model: str, label: str
+    ) -> None:
+        try:
+            import openai
+        except ImportError as exc:
+            raise ImportError(
+                f"{label} requires the 'openai' SDK. "
+                "Install it with: pip install 'markdown-vault-mcp[embeddings-api]'"
+            ) from exc
+        self._openai = openai
+        self._client = openai.OpenAI(
+            api_key=api_key or _PLACEHOLDER_API_KEY, base_url=base_url, timeout=30.0
+        )
+        self._model = model
+        self._label = label
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts, returning vectors in input order.
+
+        Args:
+            texts: List of strings to embed.
+
+        Returns:
+            List of embedding vectors, one per input text.
+
+        Raises:
+            RuntimeError: If the embeddings request fails.
+        """
+        try:
+            response = self._client.embeddings.create(model=self._model, input=texts)
+        except self._openai.OpenAIError as exc:
+            raise RuntimeError(
+                f"{self._label} embeddings request failed: {exc}"
+            ) from exc
+        # Sort by index to guarantee input order is preserved.
+        items = sorted(response.data, key=lambda d: d.index)
+        return [item.embedding for item in items]
 
 
 class EmbeddingProvider(ABC):
@@ -101,13 +169,20 @@ class EmbeddingProvider(ABC):
 
 
 class OllamaProvider(EmbeddingProvider):
-    """Embedding provider backed by the Ollama REST API.
+    """Embedding provider backed by an Ollama server.
+
+    Embeds via Ollama's OpenAI-compatible endpoint (``{host}/v1``) through
+    the shared :class:`_OpenAICompatEmbeddings` transport — the provider is
+    a preset over one wire protocol, not a second code path (#916). Two
+    capabilities have no OpenAI-API equivalent and keep the native REST API:
+    CPU-only inference (``options.num_gpu``, ``embed()`` when *cpu_only*)
+    and the ``/api/show`` context-length probe.
 
     Args:
         host: Base URL of the Ollama server.
         model: Model name to use for embeddings.
         cpu_only: When ``True``, request CPU-only inference (sets
-            ``num_gpu=0`` in the Ollama options payload).
+            ``num_gpu=0`` in the Ollama options payload; native API).
     """
 
     def __init__(self, host: str, model: str, *, cpu_only: bool = False) -> None:
@@ -119,7 +194,9 @@ class OllamaProvider(EmbeddingProvider):
             cpu_only: When ``True``, request CPU-only inference.
 
         Raises:
-            ImportError: If ``httpx`` is not installed.
+            ImportError: If ``httpx`` is not installed, or the ``openai``
+                SDK is not installed (unless *cpu_only*, which only needs
+                the native API).
         """
         try:
             import httpx
@@ -133,6 +210,18 @@ class OllamaProvider(EmbeddingProvider):
         self._host = host.rstrip("/")
         self._model = model
         self._cpu_only = cpu_only
+        # CPU-only requests need options.num_gpu, which the OpenAI-compat
+        # endpoint cannot express — that path stays native and needs no SDK.
+        self._compat = (
+            None
+            if cpu_only
+            else _OpenAICompatEmbeddings(
+                None,
+                base_url=f"{self._host}/v1",
+                model=model,
+                label="OllamaProvider",
+            )
+        )
         self._dimension: int | None = None
         self._context_length: int | None = None
         self._context_queried = False
@@ -144,8 +233,8 @@ class OllamaProvider(EmbeddingProvider):
             self._cpu_only,
         )
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
-        """Embed a batch of texts via the Ollama REST API.
+    def _embed_native(self, texts: list[str]) -> list[list[float]]:
+        """Embed via the native ``/api/embed`` endpoint (CPU-only path).
 
         Args:
             texts: List of strings to embed.
@@ -156,10 +245,11 @@ class OllamaProvider(EmbeddingProvider):
         Raises:
             RuntimeError: If the Ollama API returns an error response.
         """
-        payload: dict[str, object] = {"model": self._model, "input": texts}
-        if self._cpu_only:
-            payload["options"] = {"num_gpu": 0}
-
+        payload: dict[str, object] = {
+            "model": self._model,
+            "input": texts,
+            "options": {"num_gpu": 0},
+        }
         url = f"{self._host}/api/embed"
         logger.debug("POST %s model=%s texts=%d", url, self._model, len(texts))
 
@@ -173,6 +263,27 @@ class OllamaProvider(EmbeddingProvider):
 
         data = response.json()
         embeddings: list[list[float]] = data["embeddings"]
+        return embeddings
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts.
+
+        Uses the OpenAI-compatible endpoint; falls back to the native API
+        only when *cpu_only* was requested.
+
+        Args:
+            texts: List of strings to embed.
+
+        Returns:
+            List of embedding vectors, one per input text.
+
+        Raises:
+            RuntimeError: If the embeddings request fails.
+        """
+        if self._compat is None:
+            embeddings = self._embed_native(texts)
+        else:
+            embeddings = self._compat.embed(texts)
 
         # Cache dimension from first successful call.
         if self._dimension is None and embeddings:
@@ -288,24 +399,19 @@ class OpenAIProvider(EmbeddingProvider):
             model: Embedding model name.
 
         Raises:
-            ImportError: If ``httpx`` is not installed.
+            ImportError: If the ``openai`` SDK is not installed.
             RuntimeError: If ``api_key`` is empty.
         """
-        try:
-            import httpx
-        except ImportError as exc:
-            raise ImportError(
-                "OpenAIProvider requires 'httpx'. "
-                "Install it with: pip install 'markdown-vault-mcp[embeddings-api]'"
-            ) from exc
-
-        self._httpx = httpx
         if not api_key:
             raise RuntimeError("OpenAIProvider requires a non-empty api_key.")
-        self._api_key = api_key
         self._base_url = (base_url or self._BASE_URL).rstrip("/")
-        self._endpoint = f"{self._base_url}/embeddings"
         self._model = model or self._MODEL
+        self._compat = _OpenAICompatEmbeddings(
+            api_key,
+            base_url=self._base_url,
+            model=self._model,
+            label="OpenAIProvider",
+        )
         self._dimension: int | None = None
 
         logger.debug(
@@ -315,7 +421,7 @@ class OpenAIProvider(EmbeddingProvider):
         )
 
     def embed(self, texts: list[str]) -> list[list[float]]:
-        """Embed a batch of texts via the OpenAI Embeddings API.
+        """Embed a batch of texts via the OpenAI-compatible Embeddings API.
 
         Args:
             texts: List of strings to embed.
@@ -324,32 +430,9 @@ class OpenAIProvider(EmbeddingProvider):
             List of embedding vectors in input order.
 
         Raises:
-            RuntimeError: If the OpenAI API returns an error response.
+            RuntimeError: If the embeddings request fails.
         """
-        payload = {"input": texts, "model": self._model}
-        headers = {
-            "Authorization": f"Bearer {self._api_key}",
-            "Content-Type": "application/json",
-        }
-
-        logger.debug(
-            "POST %s model=%s texts=%d", self._endpoint, self._model, len(texts)
-        )
-
-        with self._httpx.Client() as client:
-            response = client.post(
-                self._endpoint, json=payload, headers=headers, timeout=30.0
-            )
-
-        if response.status_code != 200:
-            raise RuntimeError(
-                f"OpenAI API error {response.status_code}: {response.text}"
-            )
-
-        data = response.json()
-        # Sort by index to guarantee input order is preserved.
-        items: list[dict[str, Any]] = sorted(data["data"], key=lambda d: d["index"])
-        embeddings: list[list[float]] = [item["embedding"] for item in items]
+        embeddings = self._compat.embed(texts)
 
         # Cache dimension from first successful call.
         if self._dimension is None and embeddings:
@@ -591,7 +674,7 @@ def get_embedding_provider(config: ProjectConfig) -> EmbeddingProvider:
 
     raise RuntimeError(
         "No embedding provider is available. Install one of:\n"
-        "  pip install 'markdown-vault-mcp[embeddings-api]'  # httpx for Ollama or OpenAI\n"
+        "  pip install 'markdown-vault-mcp[embeddings-api]'  # OpenAI or Ollama (API)\n"
         "  pip install 'markdown-vault-mcp[embeddings]'       # fastembed (local)\n"
         "Or set OPENAI_API_KEY for the OpenAI provider, "
         "or start an Ollama server for the Ollama provider."

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,6 +40,63 @@ def _make_httpx_mock(
     return mock_client, mock_response
 
 
+def _install_fake_openai(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    vectors: list[list[float]] | None = None,
+    indexed: list[tuple[int, list[float]]] | None = None,
+    raise_error: bool = False,
+) -> dict[str, Any]:
+    """Inject a minimal fake ``openai`` module; return a capture dict.
+
+    The capture dict records the constructor's ``api_key`` / ``base_url``
+    and a ``create_calls`` list with the kwargs of every
+    ``embeddings.create`` invocation. ``indexed`` supplies out-of-order
+    (index, vector) pairs for the input-order-restoration test.
+    """
+    captured: dict[str, Any] = {"create_calls": []}
+
+    class OpenAIError(Exception):
+        pass
+
+    class _Item:
+        def __init__(self, index: int, embedding: list[float]) -> None:
+            self.index = index
+            self.embedding = embedding
+
+    class _Response:
+        def __init__(self, data: list[_Item]) -> None:
+            self.data = data
+
+    class _Embeddings:
+        def create(self, **kwargs: Any) -> _Response:
+            captured["create_calls"].append(kwargs)
+            if raise_error:
+                raise OpenAIError("upstream boom")
+            if indexed is not None:
+                return _Response([_Item(i, v) for i, v in indexed])
+            vecs = vectors if vectors is not None else [[0.1, 0.2, 0.3]]
+            return _Response([_Item(i, v) for i, v in enumerate(vecs)])
+
+    class OpenAI:
+        def __init__(
+            self,
+            api_key: str | None = None,
+            base_url: str | None = None,
+            timeout: float | None = None,
+        ) -> None:
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+            captured["timeout"] = timeout
+            self.embeddings = _Embeddings()
+
+    mod = types.ModuleType("openai")
+    mod.OpenAI = OpenAI  # type: ignore[attr-defined]
+    mod.OpenAIError = OpenAIError  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "openai", mod)
+    return captured
+
+
 def _config(**embedding_overrides: object) -> ProjectConfig:
     """Build a minimal ProjectConfig with optional embedding overrides."""
     return ProjectConfig(
@@ -46,32 +106,27 @@ def _config(**embedding_overrides: object) -> ProjectConfig:
 
 
 class TestOllamaProvider:
-    def test_embed_posts_to_correct_url(self) -> None:
-        mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.1, 0.2, 0.3]]})
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider(
-                host="http://localhost:11434", model="nomic-embed-text"
-            )
-            result = provider.embed(["hello"])
+    def test_embed_uses_openai_compat_endpoint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1, 0.2, 0.3]])
+        provider = OllamaProvider(
+            host="http://localhost:11434", model="nomic-embed-text"
+        )
+        result = provider.embed(["hello"])
 
-        _, kwargs = mock_client.post.call_args
-        assert kwargs["json"]["model"] == "nomic-embed-text"
+        assert captured["base_url"] == "http://localhost:11434/v1"
+        assert captured["api_key"] == "ollama"  # placeholder; Ollama ignores it
+        (kwargs,) = captured["create_calls"]
+        assert kwargs["model"] == "nomic-embed-text"
+        assert kwargs["input"] == ["hello"]
         assert result == [[0.1, 0.2, 0.3]]
         assert provider.provider_name == "ollama"
         assert provider.model_name == "nomic-embed-text"
 
-    def test_embed_payload_includes_model_and_input(self) -> None:
-        mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.5, 0.6]]})
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider(host="http://localhost:11434", model="test-model")
-            provider.embed(["alpha", "beta"])
-
-        _, call_kwargs = mock_client.post.call_args
-        payload = call_kwargs["json"]
-        assert payload["model"] == "test-model"
-        assert payload["input"] == ["alpha", "beta"]
-
-    def test_embed_cpu_only_includes_num_gpu_zero(self) -> None:
+    def test_embed_cpu_only_uses_native_api_with_num_gpu_zero(self) -> None:
+        # options.num_gpu has no OpenAI-API equivalent; cpu_only stays on
+        # the native /api/embed path.
         mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[1.0, 2.0]]})
         with patch("httpx.Client", return_value=mock_client):
             provider = OllamaProvider(
@@ -81,87 +136,70 @@ class TestOllamaProvider:
             )
             provider.embed(["test"])
 
-        _, call_kwargs = mock_client.post.call_args
-        assert call_kwargs["json"].get("options") == {"num_gpu": 0}
+        call_args = mock_client.post.call_args
+        url = call_args[0][0] if call_args[0] else call_args[1]["url"]
+        assert url == "http://localhost:11434/api/embed"
+        assert call_args[1]["json"].get("options") == {"num_gpu": 0}
 
-    def test_embed_cpu_only_false_no_options_key(self) -> None:
-        mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[1.0, 2.0]]})
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider(
-                host="http://localhost:11434",
-                model="nomic-embed-text",
-                cpu_only=False,
-            )
-            provider.embed(["test"])
-
-        _, call_kwargs = mock_client.post.call_args
-        assert "options" not in call_kwargs["json"]
-
-    def test_embed_raises_on_non_200_status(self) -> None:
+    def test_cpu_only_native_error_raises(self) -> None:
         mock_client, _ = _make_httpx_mock(status_code=503, text="Service Unavailable")
         with patch("httpx.Client", return_value=mock_client):
             provider = OllamaProvider(
-                host="http://localhost:11434", model="nomic-embed-text"
+                host="http://localhost:11434", model="nomic-embed-text", cpu_only=True
             )
             with pytest.raises(RuntimeError, match="503"):
                 provider.embed(["hello"])
 
-    def test_dimension_triggers_embed_on_first_access(self) -> None:
-        mock_client, _ = _make_httpx_mock(
-            json_body={"embeddings": [[0.1, 0.2, 0.3, 0.4]]}
+    def test_compat_api_error_becomes_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch, raise_error=True)
+        provider = OllamaProvider(
+            host="http://localhost:11434", model="nomic-embed-text"
         )
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider(
-                host="http://localhost:11434", model="nomic-embed-text"
-            )
-            assert provider.dimension == 4
+        with pytest.raises(RuntimeError, match="embeddings request failed"):
+            provider.embed(["hello"])
 
-    def test_dimension_cached_after_first_embed(self) -> None:
-        mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.1, 0.2, 0.3]]})
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider(
-                host="http://localhost:11434", model="nomic-embed-text"
-            )
-            provider.embed(["prime"])
-            _ = provider.dimension
-            _ = provider.dimension
+    def test_dimension_triggers_embed_on_first_access(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch, vectors=[[0.1, 0.2, 0.3, 0.4]])
+        provider = OllamaProvider(
+            host="http://localhost:11434", model="nomic-embed-text"
+        )
+        assert provider.dimension == 4
 
-        assert mock_client.post.call_count == 1
+    def test_dimension_cached_after_first_embed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1, 0.2, 0.3]])
+        provider = OllamaProvider(
+            host="http://localhost:11434", model="nomic-embed-text"
+        )
+        provider.embed(["prime"])
+        _ = provider.dimension
+        _ = provider.dimension
 
-    def test_custom_host_changes_base_url(self) -> None:
-        mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.9]]})
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider(
-                host="http://remote-host:12345", model="nomic-embed-text"
-            )
-            provider.embed(["x"])
+        assert len(captured["create_calls"]) == 1
 
-        call_args = mock_client.post.call_args
-        url = call_args[0][0] if call_args[0] else call_args[1]["url"]
-        assert url == "http://remote-host:12345/api/embed"
+    def test_host_trailing_slash_stripped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _install_fake_openai(monkeypatch)
+        provider = OllamaProvider(host="http://myhost:9999/", model="nomic-embed-text")
+        provider.embed(["y"])
 
-    def test_host_trailing_slash_stripped(self) -> None:
-        mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.1]]})
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider(
-                host="http://myhost:9999/", model="nomic-embed-text"
-            )
-            provider.embed(["y"])
+        assert captured["base_url"] == "http://myhost:9999/v1"
 
-        call_args = mock_client.post.call_args
-        url = call_args[0][0] if call_args[0] else call_args[1]["url"]
-        assert url == "http://myhost:9999/api/embed"
+    def test_custom_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.3, 0.4]])
+        provider = OllamaProvider(
+            host="http://localhost:11434", model="my-custom-model"
+        )
+        provider.embed(["test"])
 
-    def test_custom_model(self) -> None:
-        mock_client, _ = _make_httpx_mock(json_body={"embeddings": [[0.3, 0.4]]})
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OllamaProvider(
-                host="http://localhost:11434", model="my-custom-model"
-            )
-            provider.embed(["test"])
-
-        _, call_kwargs = mock_client.post.call_args
-        assert call_kwargs["json"]["model"] == "my-custom-model"
+        (kwargs,) = captured["create_calls"]
+        assert kwargs["model"] == "my-custom-model"
         assert provider.model_name == "my-custom-model"
 
     def test_missing_httpx_raises_import_error(self) -> None:
@@ -180,104 +218,102 @@ class TestOllamaProvider:
         ):
             OllamaProvider(host="http://localhost:11434", model="nomic-embed-text")
 
+    def test_missing_openai_sdk_raises_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "openai", None)  # force ImportError
+        with pytest.raises(ImportError, match="markdown-vault-mcp\\[embeddings-api\\]"):
+            OllamaProvider(host="http://localhost:11434", model="nomic-embed-text")
+
+    def test_cpu_only_does_not_need_openai_sdk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The native path is self-sufficient: no compat client is built.
+        monkeypatch.setitem(sys.modules, "openai", None)  # force ImportError
+        provider = OllamaProvider(
+            host="http://localhost:11434", model="nomic-embed-text", cpu_only=True
+        )
+        assert provider.provider_name == "ollama"
+
 
 class TestOpenAIProvider:
     def test_init_raises_without_api_key(self) -> None:
-        with (
-            patch("httpx.Client"),
-            pytest.raises(RuntimeError, match="non-empty api_key"),
-        ):
+        with pytest.raises(RuntimeError, match="non-empty api_key"):
             OpenAIProvider(api_key="")
 
-    def test_embed_sends_bearer_token(self) -> None:
-        mock_client, _ = _make_httpx_mock(
-            json_body={"data": [{"index": 0, "embedding": [0.1, 0.2]}]}
-        )
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider(api_key="sk-test-key-123")
-            provider.embed(["hello"])
+    def test_embed_passes_key_and_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1, 0.2]])
+        provider = OpenAIProvider(api_key="sk-test-key-123")
+        provider.embed(["hello"])
 
-        _, call_kwargs = mock_client.post.call_args
-        assert call_kwargs["headers"]["Authorization"] == "Bearer sk-test-key-123"
+        assert captured["api_key"] == "sk-test-key-123"
+        assert captured["base_url"] == "https://api.openai.com/v1"
+        (kwargs,) = captured["create_calls"]
+        assert kwargs["model"] == "text-embedding-3-small"
+        assert kwargs["input"] == ["hello"]
         assert provider.provider_name == "openai"
         assert provider.model_name == "text-embedding-3-small"
 
-    def test_embed_sorts_by_index(self) -> None:
-        mock_client, _ = _make_httpx_mock(
-            json_body={
-                "data": [
-                    {"index": 1, "embedding": [9.0, 8.0]},
-                    {"index": 0, "embedding": [1.0, 2.0]},
-                ]
-            }
-        )
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider(api_key="sk-test")
-            result = provider.embed(["first", "second"])
+    def test_embed_sorts_by_index(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_openai(monkeypatch, indexed=[(1, [9.0, 8.0]), (0, [1.0, 2.0])])
+        provider = OpenAIProvider(api_key="sk-test")
+        result = provider.embed(["first", "second"])
         assert result == [[1.0, 2.0], [9.0, 8.0]]
 
-    def test_embed_raises_on_non_200_status(self) -> None:
-        mock_client, _ = _make_httpx_mock(status_code=401, text="Unauthorized")
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider(api_key="sk-test")
-            with pytest.raises(RuntimeError, match="401"):
-                provider.embed(["secret"])
+    def test_embed_maps_sdk_error_to_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch, raise_error=True)
+        provider = OpenAIProvider(api_key="sk-test")
+        with pytest.raises(RuntimeError, match="embeddings request failed"):
+            provider.embed(["secret"])
 
-    def test_dimension_caches_after_first_embed(self) -> None:
-        mock_client, _ = _make_httpx_mock(
-            json_body={"data": [{"index": 0, "embedding": [0.1, 0.2, 0.3]}]}
-        )
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider(api_key="sk-test")
-            provider.embed(["probe"])
-            dim1 = provider.dimension
-            dim2 = provider.dimension
+    def test_dimension_caches_after_first_embed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1, 0.2, 0.3]])
+        provider = OpenAIProvider(api_key="sk-test")
+        provider.embed(["probe"])
+        dim1 = provider.dimension
+        dim2 = provider.dimension
 
         assert dim1 == 3
         assert dim2 == 3
-        assert mock_client.post.call_count == 1
+        assert len(captured["create_calls"]) == 1
 
-    def test_dimension_triggers_embed_when_uncached(self) -> None:
-        mock_client, _ = _make_httpx_mock(
-            json_body={"data": [{"index": 0, "embedding": [0.5, 0.6, 0.7, 0.8]}]}
-        )
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider(api_key="sk-test")
-            dim = provider.dimension
+    def test_dimension_triggers_embed_when_uncached(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.5, 0.6, 0.7, 0.8]])
+        provider = OpenAIProvider(api_key="sk-test")
+        dim = provider.dimension
 
         assert dim == 4
-        mock_client.post.assert_called_once()
+        assert len(captured["create_calls"]) == 1
 
-    def test_embed_posts_to_openai_endpoint(self) -> None:
-        mock_client, _ = _make_httpx_mock(
-            json_body={"data": [{"index": 0, "embedding": [0.1]}]}
+    def test_custom_base_url_and_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
+        provider = OpenAIProvider(
+            api_key="sk-test",
+            base_url="https://api.siliconflow.cn/v1/",
+            model="BAAI/bge-m3",
         )
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider(api_key="sk-test")
-            provider.embed(["hello"])
+        provider.embed(["hello"])
 
-        call_args = mock_client.post.call_args
-        url = call_args[0][0] if call_args[0] else call_args[1]["url"]
-        assert url == "https://api.openai.com/v1/embeddings"
-
-    def test_custom_base_url_and_model(self) -> None:
-        mock_client, _ = _make_httpx_mock(
-            json_body={"data": [{"index": 0, "embedding": [0.1]}]}
-        )
-        with patch("httpx.Client", return_value=mock_client):
-            provider = OpenAIProvider(
-                api_key="sk-test",
-                base_url="https://api.siliconflow.cn/v1/",
-                model="BAAI/bge-m3",
-            )
-            provider.embed(["hello"])
-
-        call_args = mock_client.post.call_args
-        url = call_args[0][0] if call_args[0] else call_args[1]["url"]
-        assert url == "https://api.siliconflow.cn/v1/embeddings"
-        _, call_kwargs = mock_client.post.call_args
-        assert call_kwargs["json"]["model"] == "BAAI/bge-m3"
+        # Trailing slash is stripped before the SDK client is built.
+        assert captured["base_url"] == "https://api.siliconflow.cn/v1"
+        (kwargs,) = captured["create_calls"]
+        assert kwargs["model"] == "BAAI/bge-m3"
         assert provider.model_name == "BAAI/bge-m3"
+
+    def test_missing_openai_sdk_raises_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "openai", None)  # force ImportError
+        with pytest.raises(ImportError, match="markdown-vault-mcp\\[embeddings-api\\]"):
+            OpenAIProvider(api_key="sk-test")
 
 
 class TestFastEmbedProvider:
@@ -344,22 +380,26 @@ class TestGetEmbeddingProvider:
         mock_client.get.return_value = mock_response
         return mock_client
 
-    def test_explicit_openai_returns_openai_provider(self) -> None:
+    def test_explicit_openai_returns_openai_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch)
         cfg = _config(
             provider="openai",
             openai_api_key="sk-test",
             openai_base_url="https://api.siliconflow.cn/v1",
             openai_embedding_model="BAAI/bge-m3",
         )
-        with patch("httpx.Client"):
-            provider = get_embedding_provider(cfg)
+        provider = get_embedding_provider(cfg)
         assert isinstance(provider, OpenAIProvider)
         assert provider.model_name == "BAAI/bge-m3"
 
-    def test_explicit_ollama_returns_ollama_provider(self) -> None:
+    def test_explicit_ollama_returns_ollama_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch)
         cfg = _config(provider="ollama")
-        with patch("httpx.Client"):
-            provider = get_embedding_provider(cfg)
+        provider = get_embedding_provider(cfg)
         assert isinstance(provider, OllamaProvider)
 
     def test_explicit_fastembed_returns_fastembed_provider(self) -> None:
@@ -379,19 +419,19 @@ class TestGetEmbeddingProvider:
         ):
             get_embedding_provider(cfg)
 
-    def test_autodetect_openai_key_present(self) -> None:
+    def test_autodetect_openai_key_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch)
         cfg = _config(openai_api_key="sk-autodetect")
-        with patch("httpx.Client"):
-            provider = get_embedding_provider(cfg)
+        provider = get_embedding_provider(cfg)
         assert isinstance(provider, OpenAIProvider)
 
-    def test_autodetect_ollama_reachable(self) -> None:
+    def test_autodetect_ollama_reachable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_openai(monkeypatch)
         cfg = _config()
         probe_client = self._ollama_mock_client(reachable=True)
-        ollama_client = MagicMock()
-        ollama_client.__enter__ = lambda _: ollama_client
-        ollama_client.__exit__ = MagicMock(return_value=False)
-        with patch("httpx.Client", side_effect=[probe_client, ollama_client]):
+        with patch("httpx.Client", return_value=probe_client):
             provider = get_embedding_provider(cfg)
         assert isinstance(provider, OllamaProvider)
 
@@ -463,6 +503,7 @@ def test_ollama_context_length_parses_api_show(monkeypatch):
         def post(self, url, json, timeout):  # noqa: ARG002
             return _Resp()
 
+    _install_fake_openai(monkeypatch)
     p = OllamaProvider(host="http://x:11434", model="bge-m3:latest")
     monkeypatch.setattr(p._httpx, "Client", lambda *a, **k: _Client())  # noqa: ARG005
     assert p.context_length == 8192
@@ -499,6 +540,7 @@ def test_ollama_context_length_none_on_network_error(monkeypatch, err_kind):
         def post(self, *a, **k):  # noqa: ARG002
             raise exc
 
+    _install_fake_openai(monkeypatch)
     p = OllamaProvider(host="http://x:11434", model="bge-m3:latest")
     monkeypatch.setattr(p._httpx, "Client", lambda *a, **k: _Client())  # noqa: ARG005
     assert p.context_length is None
@@ -524,6 +566,7 @@ def test_ollama_context_length_none_on_malformed_body(monkeypatch):
         def post(self, *a, **k):  # noqa: ARG002
             return _Resp()
 
+    _install_fake_openai(monkeypatch)
     p = OllamaProvider(host="http://x:11434", model="bge-m3:latest")
     monkeypatch.setattr(p._httpx, "Client", lambda *a, **k: _Client())  # noqa: ARG005
     assert p.context_length is None
@@ -549,6 +592,7 @@ def test_ollama_context_length_none_on_non_200(monkeypatch):
         def post(self, *a, **k):  # noqa: ARG002
             return _Resp()
 
+    _install_fake_openai(monkeypatch)
     p = OllamaProvider(host="http://x:11434", model="bge-m3:latest")
     monkeypatch.setattr(p._httpx, "Client", lambda *a, **k: _Client())  # noqa: ARG005
     assert p.context_length is None
@@ -574,6 +618,7 @@ def test_ollama_context_length_none_when_field_absent(monkeypatch):
         def post(self, *a, **k):  # noqa: ARG002
             return _Resp()
 
+    _install_fake_openai(monkeypatch)
     p = OllamaProvider(host="http://x:11434", model="bge-m3:latest")
     monkeypatch.setattr(p._httpx, "Client", lambda *a, **k: _Client())  # noqa: ARG005
     assert p.context_length is None
@@ -609,6 +654,7 @@ def test_ollama_context_length_none_on_non_dict_body(monkeypatch, body):
         def post(self, *a, **k):  # noqa: ARG002
             return _Resp()
 
+    _install_fake_openai(monkeypatch)
     p = OllamaProvider(host="http://x:11434", model="bge-m3:latest")
     monkeypatch.setattr(p._httpx, "Client", lambda *a, **k: _Client())  # noqa: ARG005
     assert p.context_length is None

--- a/uv.lock
+++ b/uv.lock
@@ -1507,6 +1507,7 @@ embeddings = [
 embeddings-api = [
     { name = "httpx" },
     { name = "numpy" },
+    { name = "openai" },
 ]
 file-watcher = [
     { name = "watchdog" },
@@ -1557,6 +1558,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.20" },
     { name = "numpy", marker = "extra == 'embeddings-api'", specifier = ">=1.20" },
     { name = "openai", marker = "extra == 'all'", specifier = ">=1.45" },
+    { name = "openai", marker = "extra == 'embeddings-api'", specifier = ">=1.45" },
     { name = "openai", marker = "extra == 'summarize'", specifier = ">=1.45" },
     { name = "python-frontmatter", specifier = ">=1.0" },
     { name = "requests", specifier = ">=2.33.0" },


### PR DESCRIPTION
Closes #916

## What

Follow-up to #917. The embedding layer previously implemented two wire protocols: `OpenAIProvider` on raw httpx against `/v1/embeddings`, and `OllamaProvider` on Ollama's native `/api/embed`. Both now ride one shared OpenAI-compatible transport (`_OpenAICompatEmbeddings`) built on the official `openai` SDK — provider names become ergonomic presets over a single client, matching the summarizer's design.

## Zero config breakage (the hard constraint from #916)

`EMBEDDING_PROVIDER=ollama`, `OLLAMA_HOST`, `OLLAMA_MODEL`, `OLLAMA_CPU_ONLY`, and the reachability auto-detect all behave exactly as released. Ollama serves both APIs from one port, so switching the embed call to `{OLLAMA_HOST}/v1/embeddings` is invisible to users (same host, same models, same vectors).

## What stays on Ollama's native API (deliberately)

- **CPU-only inference** — `options.num_gpu=0` has no OpenAI-API equivalent, so `cpu_only=True` keeps the native `/api/embed` path (and skips building the SDK client entirely).
- **Context-length probe** — `/api/show` (drives the chunker's char cap).
- **Reachability auto-detect** — `/api/tags` in `get_embedding_provider`.

Because of these, `httpx` remains in the `embeddings-api` extra; the extra now additionally installs `openai>=1.45`. `fastembed` (in-process, non-API) is untouched.

## Details

- `OpenAIProvider`: same constructor surface (non-empty key check, base_url default + trailing-slash strip, model default); `embed()` delegates to the shared client; input order restored by sorting on `index`; `openai.OpenAIError` maps to a user-facing `RuntimeError`.
- `OllamaProvider`: compat client at `{host}/v1` with the SDK's required key satisfied by a placeholder (`"ollama"`, per Ollama's own docs); dimension caching unchanged.
- Docs: `docs/design/design.md` providers section, `docs/configuration.md` embeddings note, `docs/installation.md` / README extra descriptions, CHANGELOG (non-breaking Changed entry).
- No env var changes → config wizard untouched (drift tests unaffected).

## Verification

- Full suite: **2919 passed** locally; `tests/test_providers.py` reworked around a fake `openai` module (43 tests: compat endpoint/base-url/placeholder-key threading, input-order restoration, SDK-error mapping, cpu_only native path incl. `num_gpu=0` payload and its independence from the openai SDK, ImportError paths for both httpx and openai, dimension caching, factory branches and auto-detect unchanged).
- `ruff check` + `format --check` clean; `mypy src/ tests/` clean; structural diff-gate 100%; provider module coverage 95% (uncovered lines are pre-existing abstract bodies and defensive guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdcCCw2Y47NUApLnwUtHaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdcCCw2Y47NUApLnwUtHaZ)_