### PR TITLE
fix: forbid assistant-style offers in summarize output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `summarize` output no longer ends with assistant-style offers of further
+  help ("If you want I can..."): the system prompts now instruct the model
+  to output only the summary itself — a tool result is terminal, so such
+  offers are unanswerable noise (#921).
+
 - `summarize` failed with `finish_reason=length` and empty output on
   reasoning models (the default `gpt-5-mini`): the token budget covers
   internal reasoning, so the old 2048 default was exhausted before any

--- a/src/markdown_vault_mcp/managers/summarize.py
+++ b/src/markdown_vault_mcp/managers/summarize.py
@@ -28,20 +28,28 @@ logger = logging.getLogger(__name__)
 
 _VALID_MODES = ("synthesis", "per_note")
 
+# The response is a terminal tool result, not a conversation turn: offers of
+# further help ("If you want I can...") are noise nobody can answer (#921).
+_NO_META = (
+    " Output only the summary itself: no offers of further help, no "
+    "follow-up questions, and no meta-commentary about what you could do next."
+)
+
 _SYSTEM_SYNTHESIS = (
     "You summarize notes from a markdown vault. Produce a single cohesive "
     "summary that synthesizes across all the provided notes. When a point "
     "comes from a specific note, reference that note by its path (e.g. "
     "`folder/note.md`) so the reader can trace each claim back to its source. "
     "Prefer prose over bullet dumps; be faithful to the notes and do not "
-    "invent details."
+    "invent details." + _NO_META
 )
 
 _SYSTEM_PER_NOTE = (
     "You summarize notes from a markdown vault. Produce a separate concise "
     "summary for each note provided. Head each summary with the note's path "
     "exactly as given. Do not merge notes together; keep one summary per note, "
-    "in the order provided. Be faithful to the notes and do not invent details."
+    "in the order provided. Be faithful to the notes and do not invent "
+    "details." + _NO_META
 )
 
 

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -497,6 +497,9 @@ class TestSummarizeFacet:
         assert [s.path for s in result.sources] == ["alpha.md", "beta.md"]
         system, _user = fake.calls[0]
         assert "reference that note by its path" in system
+        # Tool results are terminal; the prompt must forbid assistant-style
+        # offers of further help (#921).
+        assert "no offers of further help" in system
 
     def test_subtree_expansion(self, make_vault: VaultFactory) -> None:
         vault = make_vault(summarizer=FakeSummarizer())
@@ -514,6 +517,7 @@ class TestSummarizeFacet:
         vault.summarizer.summarize(["alpha.md"], mode="per_note")
         system, _user = fake.calls[0]
         assert "separate concise summary for each note" in system
+        assert "no offers of further help" in system
 
     def test_focus_is_folded_into_system(self, make_vault: VaultFactory) -> None:
         fake = FakeSummarizer()


### PR DESCRIPTION
Closes #921

## What

Live summarize output ended with chat-assistant offers ("If you want I can: draw a diagram… tell me which and I'll produce a walkthrough…"). A tool result is terminal — nobody can answer, so it's pure noise.

Both system prompts in `managers/summarize.py` (`_SYSTEM_SYNTHESIS`, `_SYSTEM_PER_NOTE`) now share a `_NO_META` suffix instructing the model to output only the summary: no offers of further help, no follow-up questions, no meta-commentary.

## Verification

- Prompt-content assertions added to the existing synthesis and per_note manager tests; `tests/test_summarize.py` 55 passed, full suite **2922 passed** locally.
- ruff check + format clean; `mypy src/ tests/` clean; structural diff-gate 100%.
- CHANGELOG entry added; prompts are internal, so no docs-site change.

Related: #922 (truncation opacity observed during the same live testing — filed separately, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdcCCw2Y47NUApLnwUtHaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdcCCw2Y47NUApLnwUtHaZ)_