### PR TITLE
feat: map-reduce summarization for inputs beyond one model request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `summarize` now handles inputs larger than one model request map-reduce
+  style (#922): notes are packed into batches of at most
+  `SUMMARIZE_MAX_INPUT_CHARS` characters, each batch is summarized (with
+  bounded parallelism), and the partial summaries are combined into the
+  final result. `SUMMARIZE_MAX_INPUT_CHARS` is therefore now a per-request
+  budget rather than a coverage cap — content that previously fell off the
+  end of one request is now covered, at the cost of additional model calls
+  on large selections. Coverage remains capped by `SUMMARIZE_MAX_NOTES`.
+  The response gains `notes_included` / `notes_omitted` counts so callers
+  can see exactly how much of the selection the summary covers.
+
 ### Fixed
 
 - `summarize` output no longer ends with assistant-style offers of further

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,7 @@ Powers the optional [`summarize`](tools/index.md#summarize) tool. The backend sp
 | `MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_BASE_URL` | string | `https://api.openai.com/v1` | OpenAI-compatible endpoint base URL. Setting it enables the tool even without a key (local endpoints) |
 | `MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_MODEL` | string | `gpt-5-mini` | Chat model id used for summaries |
 | `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_TOKENS` | int | `8192` | Upper bound on generated tokens per call. On reasoning models (such as the default `gpt-5-mini`) this budget also covers internal reasoning tokens, so it must be comfortably larger than the summary itself; the server requests low reasoning effort where supported. Raise this if summarize fails with an exhausted-budget error |
-| `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_NOTES` | int | `50` | Cap on notes summarised per tool call — the coverage and cost lever. Notes beyond it are omitted and counted in the response's `notes_omitted` |
+| `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_NOTES` | int | `50` | Cap on notes summarised per tool call; this is the coverage and cost lever. Notes beyond it are omitted and counted in the response's `notes_omitted` |
 | `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_INPUT_CHARS` | int | `200000` | Character budget of a single model request. A larger input is split into batches, each batch summarized, and the partial summaries combined (map-reduce), so this bounds request size, not coverage. Smaller values mean more model calls |
 
 The bare `OPENAI_BASE_URL` is honored as a *value* fallback when a key is set (such as an organization-wide proxy), but it never enables the tool by itself: setting it purely for embeddings does not switch summarization on.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,8 +136,8 @@ Powers the optional [`summarize`](tools/index.md#summarize) tool. The backend sp
 | `MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_BASE_URL` | string | `https://api.openai.com/v1` | OpenAI-compatible endpoint base URL. Setting it enables the tool even without a key (local endpoints) |
 | `MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_MODEL` | string | `gpt-5-mini` | Chat model id used for summaries |
 | `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_TOKENS` | int | `8192` | Upper bound on generated tokens per call. On reasoning models (such as the default `gpt-5-mini`) this budget also covers internal reasoning tokens, so it must be comfortably larger than the summary itself; the server requests low reasoning effort where supported. Raise this if summarize fails with an exhausted-budget error |
-| `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_NOTES` | int | `50` | Cap on notes summarised per call (subtree expansion is truncated to this many) |
-| `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_INPUT_CHARS` | int | `200000` | Aggregate cap on note characters sent to the model per call |
+| `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_NOTES` | int | `50` | Cap on notes summarised per tool call — the coverage and cost lever. Notes beyond it are omitted and counted in the response's `notes_omitted` |
+| `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_INPUT_CHARS` | int | `200000` | Character budget of a single model request. A larger input is split into batches, each batch summarized, and the partial summaries combined (map-reduce), so this bounds request size, not coverage. Smaller values mean more model calls |
 
 The bare `OPENAI_BASE_URL` is honored as a *value* fallback when a key is set (such as an organization-wide proxy), but it never enables the tool by itself: setting it purely for embeddings does not switch summarization on.
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2099,6 +2099,20 @@ is read-only with respect to the vault but sends note content to the external
 model provider, so it stays available in read-only mode (it never mutates the
 vault) and its data-egress is documented in the tool docstring and README.
 
+``SummarizeManager`` handles oversize inputs map-reduce style (#922):
+``SUMMARIZE_MAX_INPUT_CHARS`` is the character budget of a *single* model
+request, not a coverage cap. Notes (each clipped to one budget if necessary)
+are greedily packed in order into batches; a single batch takes the direct
+one-call path with the standard prompts, while multiple batches are
+summarized with a partial-summary map prompt (bounded thread-pool
+parallelism, currently 4) and combined by a reduce prompt — recursively
+re-packed if the partial summaries themselves exceed one budget, with a
+forced pairwise merge as the termination guard. ``per_note`` mode simply
+concatenates batch outputs in order (no reduce). Coverage is capped by
+``SUMMARIZE_MAX_NOTES`` alone; the result carries ``notes_included`` /
+``notes_omitted`` so callers can tell exactly how much of the selection the
+summary covers, rather than inferring from a bare ``truncated`` flag.
+
 **Dynamic instructions**: the server's MCP `instructions` string varies with
 `read_only` mode. When `read_only=True`, the instructions state this is a
 read-only instance; when `read_only=False`, they describe write tool semantics.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -840,7 +840,7 @@ Inputs larger than one model request are handled map-reduce style. Notes are pac
 - `summary` (string): the generated summary text.
 - `sources` (list of `{path, title}`): the notes that were summarised, always populated so individual notes are attributable even when the prose does not name every one.
 - `mode` (string): the mode used.
-- `truncated` (bool): `true` when content was lost to a cap. Either more notes matched than the server's note limit, or content was cut to fit the per-request character budget (a single note, or a partial summary while combining results).
+- `truncated` (bool): `true` when content was lost to a cap. This covers the server's note limit and the per-request character budget, which can cut a single note as well as a partial summary during the combine step.
 - `notes_included` (int): notes whose content reached the model.
 - `notes_omitted` (int): matched notes dropped by the note limit. When non-zero, the summary does not cover the whole selection.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -825,6 +825,8 @@ Summarize a note, a set of notes, or a folder subtree with a language model. In 
 
 The tool is only registered when a summarization backend is configured: an `OPENAI_API_KEY`, or an explicit OpenAI-compatible base URL for local endpoints that need no key. Otherwise it does not appear in the tool listing. Any OpenAI-compatible endpoint works: OpenAI, a local Ollama, the Anthropic compatibility endpoint, vLLM, and others.
 
+Inputs larger than one model request are handled map-reduce style: notes are packed into batches of at most `SUMMARIZE_MAX_INPUT_CHARS` characters, each batch is summarized, and the partial summaries are combined into the final result. Large folders therefore issue several model calls and take proportionally longer. Coverage is capped at `SUMMARIZE_MAX_NOTES` notes; the response reports exactly how many notes made it in (`notes_included`) and how many were dropped (`notes_omitted`).
+
 **Parameters:**
 
 | Parameter | Type | Default | Description |
@@ -838,7 +840,9 @@ The tool is only registered when a summarization backend is configured: an `OPEN
 - `summary` (string): the generated summary text.
 - `sources` (list of `{path, title}`): the notes that were summarised, always populated so individual notes are attributable even when the prose does not name every one.
 - `mode` (string): the mode used.
-- `truncated` (bool): `true` when the input was capped (a subtree had more notes than the server limit, or the aggregate note text exceeded the character budget and was cut).
+- `truncated` (bool): `true` when the input was capped (more notes matched than the server's note limit, or a single note exceeded the per-request character budget and was cut).
+- `notes_included` (int): notes whose content reached the model.
+- `notes_omitted` (int): matched notes dropped by the note limit. When non-zero, the summary does not cover the whole selection.
 
 **Errors:** raises if `paths` is empty, `mode` is invalid, no readable notes were found, or the backend call fails.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -840,7 +840,7 @@ Inputs larger than one model request are handled map-reduce style. Notes are pac
 - `summary` (string): the generated summary text.
 - `sources` (list of `{path, title}`): the notes that were summarised, always populated so individual notes are attributable even when the prose does not name every one.
 - `mode` (string): the mode used.
-- `truncated` (bool): `true` when content was lost to a cap: the server's note limit, a single note cut to fit the per-request character budget, or a partial summary clipped while combining results.
+- `truncated` (bool): `true` when content was lost to a cap. Either more notes matched than the server's note limit, or content was cut to fit the per-request character budget (a single note, or a partial summary while combining results).
 - `notes_included` (int): notes whose content reached the model.
 - `notes_omitted` (int): matched notes dropped by the note limit. When non-zero, the summary does not cover the whole selection.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -840,7 +840,7 @@ Inputs larger than one model request are handled map-reduce style. Notes are pac
 - `summary` (string): the generated summary text.
 - `sources` (list of `{path, title}`): the notes that were summarised, always populated so individual notes are attributable even when the prose does not name every one.
 - `mode` (string): the mode used.
-- `truncated` (bool): `true` when the input was capped (more notes matched than the server's note limit, or a single note exceeded the per-request character budget and was cut).
+- `truncated` (bool): `true` when content was lost to a cap (more notes matched than the server's note limit, a single note exceeded the per-request character budget and was cut, or a partial summary was clipped while combining results).
 - `notes_included` (int): notes whose content reached the model.
 - `notes_omitted` (int): matched notes dropped by the note limit. When non-zero, the summary does not cover the whole selection.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -825,7 +825,7 @@ Summarize a note, a set of notes, or a folder subtree with a language model. In 
 
 The tool is only registered when a summarization backend is configured: an `OPENAI_API_KEY`, or an explicit OpenAI-compatible base URL for local endpoints that need no key. Otherwise it does not appear in the tool listing. Any OpenAI-compatible endpoint works: OpenAI, a local Ollama, the Anthropic compatibility endpoint, vLLM, and others.
 
-Inputs larger than one model request are handled map-reduce style: notes are packed into batches of at most `SUMMARIZE_MAX_INPUT_CHARS` characters, each batch is summarized, and the partial summaries are combined into the final result. Large folders therefore issue several model calls and take proportionally longer. Coverage is capped at `SUMMARIZE_MAX_NOTES` notes; the response reports exactly how many notes made it in (`notes_included`) and how many were dropped (`notes_omitted`).
+Inputs larger than one model request are handled map-reduce style. Notes are packed into batches of at most `SUMMARIZE_MAX_INPUT_CHARS` characters and each batch is summarized on its own; a final pass combines the partial summaries into one result. Large folders issue several model calls and take proportionally longer. Coverage is capped at `SUMMARIZE_MAX_NOTES` notes; the response reports exactly how many notes made it in (`notes_included`) and how many were dropped (`notes_omitted`).
 
 **Parameters:**
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -840,7 +840,7 @@ Inputs larger than one model request are handled map-reduce style. Notes are pac
 - `summary` (string): the generated summary text.
 - `sources` (list of `{path, title}`): the notes that were summarised, always populated so individual notes are attributable even when the prose does not name every one.
 - `mode` (string): the mode used.
-- `truncated` (bool): `true` when content was lost to a cap (more notes matched than the server's note limit, a single note exceeded the per-request character budget and was cut, or a partial summary was clipped while combining results).
+- `truncated` (bool): `true` when content was lost to a cap: the server's note limit, a single note cut to fit the per-request character budget, or a partial summary clipped while combining results.
 - `notes_included` (int): notes whose content reached the model.
 - `notes_omitted` (int): matched notes dropped by the note limit. When non-zero, the summary does not cover the whole selection.
 

--- a/src/markdown_vault_mcp/_server_tools/summarize.py
+++ b/src/markdown_vault_mcp/_server_tools/summarize.py
@@ -43,6 +43,12 @@ def register(mcp: FastMCP) -> None:
         individual source notes by path, so each point can be traced back to
         its origin. In "per_note" mode it returns one summary per note instead.
 
+        Inputs larger than one model request are handled automatically: notes
+        are split into batches, each batch is summarized, and the partial
+        summaries are combined into the final result (several model calls, so
+        large folders take proportionally longer). Coverage is capped at the
+        server's note limit; check ``notes_omitted`` in the response.
+
         Only available when a summarization backend is configured (an
         OPENAI_API_KEY or an OpenAI-compatible base URL). Note content is
         sent to the external model provider; do not summarize notes whose
@@ -68,9 +74,13 @@ def register(mcp: FastMCP) -> None:
               ``path`` and ``title`` — always populated so individual notes are
               attributable even when the prose does not name every one.
             - mode (str): The mode used ("synthesis" or "per_note").
-            - truncated (bool): True when the input was capped (a subtree had
-              more notes than the server's limit, or the aggregate note text
-              exceeded the character budget and was cut).
+            - truncated (bool): True when the input was capped (more notes
+              matched than the server's note limit, or a single note exceeded
+              the per-request character budget and was cut).
+            - notes_included (int): Notes whose content reached the model.
+            - notes_omitted (int): Matched notes dropped by the note limit.
+              When non-zero, the summary does not cover the whole selection —
+              surface that to the reader.
 
         Raises:
             ValueError: If ``paths`` is empty, ``mode`` is invalid, or no

--- a/src/markdown_vault_mcp/managers/summarize.py
+++ b/src/markdown_vault_mcp/managers/summarize.py
@@ -169,14 +169,16 @@ class SummarizeManager:
             raise ValueError("No readable notes found for the given paths.")
 
         batches = self._pack_batches(notes)
-        summary = self._summarize_batches(batches, focus=focus, mode=mode)
+        summary, reduce_clipped = self._summarize_batches(
+            batches, focus=focus, mode=mode
+        )
 
         omitted = matched - len(notes)
         return SummaryResult(
             summary=summary,
             sources=[SummarySource(path=p, title=t) for p, t, _ in notes],
             mode=mode,
-            truncated=omitted > 0 or note_clipped,
+            truncated=omitted > 0 or note_clipped or reduce_clipped,
             notes_included=len(notes),
             notes_omitted=omitted,
         )
@@ -280,14 +282,19 @@ class SummarizeManager:
         *,
         focus: str | None,
         mode: str,
-    ) -> str:
-        """Run the map phase over *batches* and reduce to one summary."""
+    ) -> tuple[str, bool]:
+        """Run the map phase over *batches* and reduce to one summary.
+
+        Returns the summary and whether any partial summary was clipped to
+        fit a request budget during the reduce phase.
+        """
         if len(batches) == 1:
             # Single request: identical to the pre-#922 direct path.
             system = _SYSTEM_SYNTHESIS if mode == "synthesis" else _SYSTEM_PER_NOTE
-            return self._summarizer.summarize(
+            summary = self._summarizer.summarize(
                 _with_focus(system, focus), self._join_blocks(batches[0])
             )
+            return summary, False
 
         logger.info(
             "summarize_map_reduce batches=%d notes=%d mode=%s",
@@ -303,7 +310,7 @@ class SummarizeManager:
         )
         if mode == "per_note":
             # Per-note output is already in note order; no reduce needed.
-            return "\n\n".join(partials)
+            return "\n\n".join(partials), False
         return self._reduce(partials, focus=focus)
 
     def _join_blocks(self, batch: list[tuple[str, str, str]]) -> str:
@@ -322,30 +329,47 @@ class SummarizeManager:
                 pool.map(lambda user: self._summarizer.summarize(system, user), users)
             )
 
-    def _reduce(self, partials: list[str], *, focus: str | None) -> str:
-        """Combine partial summaries, recursively if they exceed one budget."""
+    def _reduce(self, partials: list[str], *, focus: str | None) -> tuple[str, bool]:
+        """Combine partial summaries, recursively if they exceed one budget.
+
+        Returns the combined summary and whether any partial was clipped to
+        fit a request budget along the way.
+        """
         system = _with_focus(_SYSTEM_REDUCE, focus)
+        clipped = False
         while True:
-            groups = self._pack_texts(partials)
+            if len(partials) == 1:
+                # A previous round already collapsed everything into one
+                # summary; re-summarizing it would be a wasted, lossy call.
+                return partials[0], clipped
+            groups, group_clipped = self._pack_texts(partials)
+            clipped = clipped or group_clipped
             if len(groups) == 1:
-                return self._summarizer.summarize(system, groups[0])
+                return self._summarizer.summarize(system, groups[0]), clipped
             if len(groups) >= len(partials):
                 # Every group is a singleton (each partial nearly fills the
                 # budget): force pairwise merges, clipped to the budget, so
                 # each round strictly shrinks the list and terminates.
-                groups = [
-                    "\n\n".join(partials[i : i + 2])[: self._max_input_chars]
-                    for i in range(0, len(partials), 2)
+                merged = [
+                    "\n\n".join(partials[i : i + 2]) for i in range(0, len(partials), 2)
                 ]
+                clipped = clipped or any(len(m) > self._max_input_chars for m in merged)
+                groups = [m[: self._max_input_chars] for m in merged]
             partials = self._run_parallel(groups, system)
 
-    def _pack_texts(self, texts: list[str]) -> list[str]:
-        """Greedily join texts, in order, into per-request character budgets."""
+    def _pack_texts(self, texts: list[str]) -> tuple[list[str], bool]:
+        """Greedily join texts, in order, into per-request character budgets.
+
+        Returns the groups and whether any single text had to be clipped to
+        fit one budget on its own.
+        """
         groups: list[str] = []
         current: list[str] = []
         used = 0
+        any_clipped = False
         for text in texts:
             clipped = text[: self._max_input_chars]
+            any_clipped = any_clipped or len(clipped) < len(text)
             size = len(clipped) + 2  # joined with a blank line
             if current and used + size > self._max_input_chars:
                 groups.append("\n\n".join(current))
@@ -355,4 +379,4 @@ class SummarizeManager:
             used += size
         if current:
             groups.append("\n\n".join(current))
-        return groups
+        return groups, any_clipped

--- a/src/markdown_vault_mcp/managers/summarize.py
+++ b/src/markdown_vault_mcp/managers/summarize.py
@@ -1,16 +1,26 @@
 """LLM-backed note summarization manager.
 
 Resolves a note, a set of notes, or a folder subtree into note bodies, builds
-a prompt, and delegates generation to a provider-neutral
+prompts, and delegates generation to a provider-neutral
 :class:`~markdown_vault_mcp.summarizer.Summarizer`.  Reuses
 :meth:`DocumentManager.get_toc` for subtree expansion and
 :meth:`DocumentManager.read` for bodies, so it depends only on the document
 manager and the summarizer.
+
+Large inputs are handled map-reduce style (#922): notes are packed into
+batches of at most ``max_input_chars`` characters, each batch is summarized
+independently (the map phase, with bounded parallelism), and in synthesis
+mode the batch summaries are combined by a final reduce call (recursively,
+should the summaries themselves exceed one request budget).  A single batch
+takes the direct one-call path, identical to the pre-#922 behavior.  Total
+coverage is governed by ``max_notes``; ``max_input_chars`` bounds each
+individual model request.
 """
 
 from __future__ import annotations
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.types import (
@@ -27,6 +37,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _VALID_MODES = ("synthesis", "per_note")
+
+# Ceiling used when expanding subtrees so the pre-cap match count is known
+# (get_toc caps listings itself); the configured max_notes still governs how
+# many notes are actually summarized.
+_RESOLVE_CAP = 10_000
+
+# Concurrent map-phase backend calls. Bounded and small: the library is sync
+# (the MCP layer wraps it in a thread), so this is a nested, short-lived pool.
+_MAP_CONCURRENCY = 4
+
+# Block separator in user prompts; accounted for when packing batches.
+_SEPARATOR = "\n\n---\n\n"
 
 # The response is a terminal tool result, not a conversation turn: offers of
 # further help ("If you want I can...") are noise nobody can answer (#921).
@@ -52,6 +74,34 @@ _SYSTEM_PER_NOTE = (
     "details." + _NO_META
 )
 
+# Map phase over one batch of a larger set: keep enough specifics (and the
+# path references) for the reduce phase to combine partial summaries.
+_SYSTEM_MAP = (
+    "You summarize notes from a markdown vault. The notes provided are one "
+    "part of a larger collection; other parts are summarized separately. "
+    "Produce a detailed partial summary of these notes that preserves "
+    "concrete specifics, and reference each note by its path (e.g. "
+    "`folder/note.md`) so the partial summaries can be combined without "
+    "losing attribution. Be faithful to the notes and do not invent "
+    "details." + _NO_META
+)
+
+# Reduce phase: combine partial summaries into the final synthesis.
+_SYSTEM_REDUCE = (
+    "You combine partial summaries, each covering a different subset of "
+    "notes from one markdown vault, into a single cohesive summary that "
+    "reads as one text. Merge overlapping points, keep the note-path "
+    "references intact, prefer prose over bullet dumps, and do not invent "
+    "details beyond the partial summaries." + _NO_META
+)
+
+
+def _with_focus(system: str, focus: str | None) -> str:
+    """Fold an optional focus instruction into a system prompt."""
+    if focus and focus.strip():
+        return f"{system} Focus specifically on: {focus.strip()}"
+    return system
+
 
 class SummarizeManager:
     """Turn a set of note/subtree paths into an LLM-generated summary."""
@@ -69,8 +119,11 @@ class SummarizeManager:
         Args:
             doc_mgr: Document reads + subtree table-of-contents.
             summarizer: The generation backend.
-            max_notes: Cap on notes summarised per call.
-            max_input_chars: Aggregate cap on note characters sent to the model.
+            max_notes: Cap on notes summarised per call (the coverage and
+                cost lever).
+            max_input_chars: Character budget of a single model request; a
+                larger input is split into batches and combined map-reduce
+                style (#922).
         """
         self._doc_mgr = doc_mgr
         self._summarizer = summarizer
@@ -100,94 +153,88 @@ class SummarizeManager:
         Raises:
             ValueError: If *mode* is invalid, *paths* is empty, or no readable
                 notes were found for the given paths.
-            RuntimeError: If the summarization backend call fails.
+            RuntimeError: If a summarization backend call fails.
         """
         if mode not in _VALID_MODES:
             raise ValueError(f"mode must be one of {_VALID_MODES}, got {mode!r}")
         if not paths:
             raise ValueError("paths must contain at least one note or folder path.")
 
-        resolved, truncated_paths = self._resolve_paths(paths)
+        resolved, matched = self._resolve_paths(paths)
         if not resolved:
             raise ValueError("No notes found for the given paths.")
 
-        notes, truncated_input = self._gather_notes(resolved)
+        notes, note_clipped = self._gather_notes(resolved)
         if not notes:
             raise ValueError("No readable notes found for the given paths.")
 
-        system, user = self._build_prompt(notes, focus=focus, mode=mode)
-        summary = self._summarizer.summarize(system, user)
+        batches = self._pack_batches(notes)
+        summary = self._summarize_batches(batches, focus=focus, mode=mode)
 
+        omitted = matched - len(notes)
         return SummaryResult(
             summary=summary,
             sources=[SummarySource(path=p, title=t) for p, t, _ in notes],
             mode=mode,
-            truncated=truncated_paths or truncated_input,
+            truncated=omitted > 0 or note_clipped,
+            notes_included=len(notes),
+            notes_omitted=omitted,
         )
 
-    def _resolve_paths(self, paths: list[str]) -> tuple[list[str], bool]:
+    def _resolve_paths(self, paths: list[str]) -> tuple[list[str], int]:
         """Expand folders to notes and dedupe; cap at ``max_notes``.
 
-        Returns the ordered, de-duplicated note paths and whether the set was
-        truncated (a subtree exceeded its own cap, or the total exceeded
-        ``max_notes``).
+        Returns the ordered, de-duplicated note paths (capped at
+        ``max_notes``) and the total number of matched notes before the cap,
+        so callers can report how many were omitted (#922).
         """
         resolved: list[str] = []
         seen: set[str] = set()
-        truncated = False
         for path in paths:
-            candidates, sub_truncated = self._expand_path(path)
-            truncated = truncated or sub_truncated
-            for candidate in candidates:
+            for candidate in self._expand_path(path):
                 if candidate not in seen:
                     seen.add(candidate)
                     resolved.append(candidate)
-        if len(resolved) > self._max_notes:
-            resolved = resolved[: self._max_notes]
-            truncated = True
-        return resolved, truncated
+        matched = len(resolved)
+        return resolved[: self._max_notes], matched
 
-    def _expand_path(self, path: str) -> tuple[list[str], bool]:
+    def _expand_path(self, path: str) -> list[str]:
         """Resolve one input path to note paths (single note or subtree)."""
         if path.endswith(".md"):
-            return [path], False
-        # Pass the configured cap through: get_toc defaults max_notes to 200,
-        # which would silently override a SUMMARIZE_MAX_NOTES set above it (the
-        # post-hoc cap in _resolve_paths only masks this when max_notes < 200).
-        toc = self._doc_mgr.get_toc(path, max_notes=self._max_notes)
+            return [path]
+        # Expand generously so the pre-cap match count is known; the
+        # max_notes cap is applied by _resolve_paths afterwards.
+        cap = max(_RESOLVE_CAP, self._max_notes)
+        toc = self._doc_mgr.get_toc(path, max_notes=cap)
         if isinstance(toc, SubtreeToc):
-            return [note.path for note in toc.notes], toc.truncated
-        return [], False
+            return [note.path for note in toc.notes]
+        return []
 
     def _gather_notes(
         self, resolved: list[str]
     ) -> tuple[list[tuple[str, str, str]], bool]:
-        """Read note bodies, enforcing the aggregate character cap.
+        """Read note bodies, clipping any single body to one request budget.
 
-        Returns ``(path, title, body)`` triples in order and whether the input
-        was truncated (a body was cut or later notes were dropped at the cap).
-        Missing or unreadable notes are skipped.
+        Returns ``(path, title, body)`` triples in order and whether any body
+        was cut. Missing or unreadable notes are skipped. There is no
+        aggregate cap here: oversize totals are handled by batching (#922).
         """
         notes: list[tuple[str, str, str]] = []
-        total = 0
-        truncated = False
+        clipped = False
         for path in resolved:
             note = self._read_note(path)
             if note is None:
                 continue
-            remaining = self._max_input_chars - total
-            if remaining <= 0:
-                truncated = True
-                break
             body = note.content
-            if len(body) > remaining:
-                body = body[:remaining]
-                truncated = True
-            total += len(body)
+            # A block must fit one request on its own; leave room for the
+            # header and separator the prompt adds around the body.
+            overhead = len(self._format_block(path, note.title, "")) + len(_SEPARATOR)
+            budget = max(1, self._max_input_chars - overhead)
+            if len(body) > budget:
+                body = body[:budget]
+                clipped = True
             notes.append((path, note.title, body))
-            if truncated:
-                break
-        return notes, truncated
+        return notes, clipped
 
     def _read_note(self, path: str) -> NoteContent | None:
         """Read a note, skipping missing/oversized/unparseable ones.
@@ -204,18 +251,108 @@ class SummarizeManager:
             return None
 
     @staticmethod
-    def _build_prompt(
-        notes: list[tuple[str, str, str]],
+    def _format_block(path: str, title: str, body: str) -> str:
+        """Format one note as a prompt block."""
+        return f"### {path}\n(title: {title})\n\n{body}"
+
+    def _pack_batches(
+        self, notes: list[tuple[str, str, str]]
+    ) -> list[list[tuple[str, str, str]]]:
+        """Greedily pack notes, in order, into per-request character budgets."""
+        batches: list[list[tuple[str, str, str]]] = []
+        current: list[tuple[str, str, str]] = []
+        used = 0
+        for path, title, body in notes:
+            size = len(self._format_block(path, title, body)) + len(_SEPARATOR)
+            if current and used + size > self._max_input_chars:
+                batches.append(current)
+                current = []
+                used = 0
+            current.append((path, title, body))
+            used += size
+        if current:
+            batches.append(current)
+        return batches
+
+    def _summarize_batches(
+        self,
+        batches: list[list[tuple[str, str, str]]],
         *,
         focus: str | None,
         mode: str,
-    ) -> tuple[str, str]:
-        """Build the (system, user) prompt for the given notes."""
-        system = _SYSTEM_SYNTHESIS if mode == "synthesis" else _SYSTEM_PER_NOTE
-        if focus and focus.strip():
-            system = f"{system} Focus specifically on: {focus.strip()}"
-        blocks = [
-            f"### {path}\n(title: {title})\n\n{body}" for path, title, body in notes
-        ]
-        user = "\n\n---\n\n".join(blocks)
-        return system, user
+    ) -> str:
+        """Run the map phase over *batches* and reduce to one summary."""
+        if len(batches) == 1:
+            # Single request: identical to the pre-#922 direct path.
+            system = _SYSTEM_SYNTHESIS if mode == "synthesis" else _SYSTEM_PER_NOTE
+            return self._summarizer.summarize(
+                _with_focus(system, focus), self._join_blocks(batches[0])
+            )
+
+        logger.info(
+            "summarize_map_reduce batches=%d notes=%d mode=%s",
+            len(batches),
+            sum(len(b) for b in batches),
+            mode,
+        )
+        map_system = _with_focus(
+            _SYSTEM_MAP if mode == "synthesis" else _SYSTEM_PER_NOTE, focus
+        )
+        partials = self._run_parallel(
+            [self._join_blocks(batch) for batch in batches], map_system
+        )
+        if mode == "per_note":
+            # Per-note output is already in note order; no reduce needed.
+            return "\n\n".join(partials)
+        return self._reduce(partials, focus=focus)
+
+    def _join_blocks(self, batch: list[tuple[str, str, str]]) -> str:
+        """Join a batch of notes into one user prompt."""
+        return _SEPARATOR.join(
+            self._format_block(path, title, body) for path, title, body in batch
+        )
+
+    def _run_parallel(self, users: list[str], system: str) -> list[str]:
+        """Summarize *users* with bounded parallelism, preserving order."""
+        if len(users) == 1:
+            return [self._summarizer.summarize(system, users[0])]
+        workers = min(_MAP_CONCURRENCY, len(users))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            return list(
+                pool.map(lambda user: self._summarizer.summarize(system, user), users)
+            )
+
+    def _reduce(self, partials: list[str], *, focus: str | None) -> str:
+        """Combine partial summaries, recursively if they exceed one budget."""
+        system = _with_focus(_SYSTEM_REDUCE, focus)
+        while True:
+            groups = self._pack_texts(partials)
+            if len(groups) == 1:
+                return self._summarizer.summarize(system, groups[0])
+            if len(groups) >= len(partials):
+                # Every group is a singleton (each partial nearly fills the
+                # budget): force pairwise merges, clipped to the budget, so
+                # each round strictly shrinks the list and terminates.
+                groups = [
+                    "\n\n".join(partials[i : i + 2])[: self._max_input_chars]
+                    for i in range(0, len(partials), 2)
+                ]
+            partials = self._run_parallel(groups, system)
+
+    def _pack_texts(self, texts: list[str]) -> list[str]:
+        """Greedily join texts, in order, into per-request character budgets."""
+        groups: list[str] = []
+        current: list[str] = []
+        used = 0
+        for text in texts:
+            clipped = text[: self._max_input_chars]
+            size = len(clipped) + 2  # joined with a blank line
+            if current and used + size > self._max_input_chars:
+                groups.append("\n\n".join(current))
+                current = []
+                used = 0
+            current.append(clipped)
+            used += size
+        if current:
+            groups.append("\n\n".join(current))
+        return groups

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -769,15 +769,21 @@ class SummaryResult:
             the model — always populated so individual notes are attributable
             even when the prose does not name every one.
         mode: ``"synthesis"`` or ``"per_note"``.
-        truncated: True when the input was capped — either more notes matched a
-            subtree than ``max_notes``, or the aggregate note text exceeded
-            ``max_input_chars`` and was cut.
+        truncated: True when the input was capped — more notes matched than
+            ``max_notes``, or a single note body exceeded the per-request
+            character budget (``max_input_chars``) and was cut.
+        notes_included: Number of notes whose content reached the model.
+        notes_omitted: Number of matched notes that were dropped by the
+            ``max_notes`` cap (or skipped as unreadable). Callers should
+            surface a warning when this is non-zero (#922).
     """
 
     summary: str
     sources: list[SummarySource]
     mode: str
     truncated: bool
+    notes_included: int = 0
+    notes_omitted: int = 0
 
 
 WriteOperation = Literal["write", "edit", "delete", "rename"]

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -769,9 +769,10 @@ class SummaryResult:
             the model — always populated so individual notes are attributable
             even when the prose does not name every one.
         mode: ``"synthesis"`` or ``"per_note"``.
-        truncated: True when the input was capped — more notes matched than
-            ``max_notes``, or a single note body exceeded the per-request
-            character budget (``max_input_chars``) and was cut.
+        truncated: True when content was lost to a cap — more notes matched
+            than ``max_notes``, a single note body exceeded the per-request
+            character budget (``max_input_chars``) and was cut, or a partial
+            summary was clipped during the reduce phase.
         notes_included: Number of notes whose content reached the model.
         notes_omitted: Number of matched notes that were dropped by the
             ``max_notes`` cap (or skipped as unreadable). Callers should

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -531,6 +531,9 @@ class TestSummarizeFacet:
         result = vault.summarizer.summarize(["sub"])
         assert len(result.sources) == 1
         assert result.truncated is True
+        # The omission is quantified, not just flagged (#922).
+        assert result.notes_included == 1
+        assert result.notes_omitted == 1
 
     def test_max_input_chars_truncation(self, make_vault: VaultFactory) -> None:
         vault = make_vault(
@@ -540,19 +543,21 @@ class TestSummarizeFacet:
         result = vault.summarizer.summarize(["alpha.md", "beta.md"])
         assert result.truncated is True
 
-    def test_input_cap_exact_boundary_drops_next_note(
+    def test_over_budget_input_spills_into_batches_not_dropped(
         self, make_vault: VaultFactory
     ) -> None:
-        # First note body is exactly the cap → not cut, but the second note
-        # sees zero remaining and is dropped.
+        # Pre-#922 the second note was dropped at the aggregate cap; now the
+        # cap is per-request and both notes are covered via batching.
         vault = make_vault(
             summarizer=FakeSummarizer(),
             notes={"a.md": "hello", "b.md": "world"},
-            summarize_max_input_chars=5,
+            summarize_max_input_chars=40,
         )
         result = vault.summarizer.summarize(["a.md", "b.md"])
-        assert [s.path for s in result.sources] == ["a.md"]
-        assert result.truncated is True
+        assert [s.path for s in result.sources] == ["a.md", "b.md"]
+        assert result.truncated is False
+        assert result.notes_included == 2
+        assert result.notes_omitted == 0
 
     def test_subtree_cap_honours_configured_max_notes_above_200(
         self, make_vault: VaultFactory
@@ -611,6 +616,128 @@ class TestSummarizeFacet:
         vault = make_vault(summarizer=None)
         with pytest.raises(RuntimeError, match="Summarization is not configured"):
             _ = vault.summarizer
+
+
+# ---------------------------------------------------------------------------
+# Map-reduce batching (#922)
+# ---------------------------------------------------------------------------
+
+
+_THREE_NOTES = {
+    "one.md": "# One\n\n" + ("alpha " * 12),
+    "two.md": "# Two\n\n" + ("bravo " * 12),
+    "three.md": "# Three\n\n" + ("charlie " * 10),
+}
+# Each formatted block is ~100 chars: a 130-char request budget fits exactly
+# one block per batch, forcing three map calls.
+_SMALL_BUDGET = 130
+
+
+class TestMapReduce:
+    def test_multi_batch_synthesis_maps_then_reduces(
+        self, make_vault: VaultFactory
+    ) -> None:
+        fake = FakeSummarizer("PART")
+        vault = make_vault(
+            summarizer=fake,
+            notes=_THREE_NOTES,
+            summarize_max_input_chars=_SMALL_BUDGET,
+        )
+        result = vault.summarizer.summarize(["one.md", "two.md", "three.md"])
+
+        # Three parallel map calls plus one final reduce.
+        assert len(fake.calls) == 4
+        map_calls = [c for c in fake.calls if "one part of a larger" in c[0]]
+        reduce_calls = [c for c in fake.calls if "combine partial summaries" in c[0]]
+        assert len(map_calls) == 3
+        assert len(reduce_calls) == 1
+        # The reduce is last and consumes the map outputs.
+        assert "combine partial summaries" in fake.calls[-1][0]
+        assert "PART" in fake.calls[-1][1]
+        assert result.summary == "PART"
+        assert [s.path for s in result.sources] == ["one.md", "two.md", "three.md"]
+        assert result.truncated is False
+        assert result.notes_included == 3
+        assert result.notes_omitted == 0
+
+    def test_multi_batch_per_note_concatenates_without_reduce(
+        self, make_vault: VaultFactory
+    ) -> None:
+        fake = FakeSummarizer("NOTE-SUM")
+        vault = make_vault(
+            summarizer=fake,
+            notes=_THREE_NOTES,
+            summarize_max_input_chars=_SMALL_BUDGET,
+        )
+        result = vault.summarizer.summarize(
+            ["one.md", "two.md", "three.md"], mode="per_note"
+        )
+
+        assert len(fake.calls) == 3
+        assert all("separate concise summary" in system for system, _ in fake.calls)
+        assert not any("combine partial" in system for system, _ in fake.calls)
+        assert result.summary == "NOTE-SUM\n\nNOTE-SUM\n\nNOTE-SUM"
+
+    def test_focus_threads_into_map_and_reduce(self, make_vault: VaultFactory) -> None:
+        fake = FakeSummarizer()
+        vault = make_vault(
+            summarizer=fake,
+            notes=_THREE_NOTES,
+            summarize_max_input_chars=_SMALL_BUDGET,
+        )
+        vault.summarizer.summarize(
+            ["one.md", "two.md", "three.md"], focus="action items"
+        )
+        assert all(
+            "Focus specifically on: action items" in system for system, _ in fake.calls
+        )
+
+    def test_single_batch_keeps_direct_prompt(self, make_vault: VaultFactory) -> None:
+        # Small inputs must not pay map-reduce overhead or prompt changes.
+        fake = FakeSummarizer()
+        vault = make_vault(summarizer=fake, notes=_THREE_NOTES)
+        vault.summarizer.summarize(["one.md", "two.md", "three.md"])
+        assert len(fake.calls) == 1
+        system, _user = fake.calls[0]
+        assert "single cohesive" in system
+        assert "one part of a larger" not in system
+
+    def test_reduce_recurses_when_partials_exceed_budget(
+        self, make_vault: VaultFactory
+    ) -> None:
+        # The fake returns ~100-char summaries against a 130-char budget, so
+        # no two partials fit one request: the reduce phase must recurse
+        # (via the forced pairwise merge) and still terminate.
+        fake = FakeSummarizer("R" * 100)
+        vault = make_vault(
+            summarizer=fake,
+            notes=_THREE_NOTES,
+            summarize_max_input_chars=_SMALL_BUDGET,
+        )
+        result = vault.summarizer.summarize(["one.md", "two.md", "three.md"])
+
+        assert result.summary == "R" * 100
+        reduce_calls = [c for c in fake.calls if "combine partial summaries" in c[0]]
+        # More than one reduce round ran, and the pipeline still converged.
+        assert len(reduce_calls) >= 2
+        assert "combine partial summaries" in fake.calls[-1][0]
+
+    def test_oversized_note_clipped_to_request_budget(
+        self, make_vault: VaultFactory
+    ) -> None:
+        fake = FakeSummarizer()
+        vault = make_vault(
+            summarizer=fake,
+            notes={"big.md": "# Big\n\n" + ("x" * 500)},
+            summarize_max_input_chars=120,
+        )
+        result = vault.summarizer.summarize(["big.md"])
+        assert len(fake.calls) == 1
+        _system, user = fake.calls[0]
+        assert len(user) <= 120
+        assert result.truncated is True
+        assert result.notes_included == 1
+        assert result.notes_omitted == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -612,6 +612,13 @@ class TestSummarizeFacet:
         with pytest.raises(ValueError, match="No readable notes"):
             vault.summarizer.summarize(["missing.md"])
 
+    def test_nonexistent_folder_raises_no_notes_found(
+        self, make_vault: VaultFactory
+    ) -> None:
+        vault = make_vault(summarizer=FakeSummarizer())
+        with pytest.raises(ValueError, match="No notes found"):
+            vault.summarizer.summarize(["no-such-folder"])
+
     def test_unconfigured_vault_raises(self, make_vault: VaultFactory) -> None:
         vault = make_vault(summarizer=None)
         with pytest.raises(RuntimeError, match="Summarization is not configured"):

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -725,9 +725,14 @@ class TestMapReduce:
 
         assert result.summary == "R" * 100
         reduce_calls = [c for c in fake.calls if "combine partial summaries" in c[0]]
-        # More than one reduce round ran, and the pipeline still converged.
-        assert len(reduce_calls) >= 2
+        # Round one pairwise-merges 3 partials into 2 calls, round two merges
+        # those into 1; the lone survivor is returned without a redundant
+        # extra summarize pass (review finding on #924).
+        assert len(reduce_calls) == 3
         assert "combine partial summaries" in fake.calls[-1][0]
+        # The forced pairwise merges clipped content to fit the budget, and
+        # that loss is surfaced (review finding on #924).
+        assert result.truncated is True
 
     def test_oversized_note_clipped_to_request_budget(
         self, make_vault: VaultFactory


### PR DESCRIPTION
Closes #922

## Problem (observed live)

Summarizing a 262-note folder returned `truncated: true` with only 11 notes actually included — the 200k-char aggregate cap filled after the first few large notes and everything else was silently dropped, in path order. The flag existed but carried no magnitude; the summary read as folder-wide coverage while seeing ~4% of it.

## Design

`SUMMARIZE_MAX_INPUT_CHARS` changes meaning: it is now the **character budget of a single model request**, not a coverage cap. No new env vars.

- **Pack**: notes (each clipped to one budget if a single note exceeds it) are greedily packed, in order, into batches.
- **Map**: each batch is summarized. One batch → the exact pre-existing single-call path with the standard prompts (small inputs pay zero overhead and see zero behavior change). Multiple batches → a partial-summary prompt that preserves specifics and path references, run with bounded thread-pool parallelism (4).
- **Reduce** (`synthesis` mode): partial summaries are combined by a dedicated combine prompt; if the partials themselves exceed one budget they are re-packed and reduced recursively, with a forced pairwise merge as the termination guard. `per_note` mode simply concatenates batch outputs in order — no reduce needed.
- **Coverage and cost lever**: `SUMMARIZE_MAX_NOTES` alone caps coverage. Worst-case model calls ≈ ⌈total_chars / budget⌉ + reduce rounds, bounded by the note cap.
- **Visibility**: `SummaryResult` gains `notes_included` / `notes_omitted`; `truncated` now means "notes omitted or a note clipped" precisely.

## Behavior change

Selections that previously fell off the end of one request are now fully covered (up to the note cap) at the cost of additional model calls; a 10-batch folder issues 10 map calls + 1 reduce instead of 1 silently-partial call. Documented in CHANGELOG under Changed.

## Verification

- 6 new tests: multi-batch synthesis (3 map + 1 reduce, reduce consumes map outputs), per_note concatenation without reduce, focus threading into map+reduce, single-batch prompt identity, oversized-note clipping, recursive reduce with forced pairwise merge termination. Two pre-existing tests updated to the new semantics (spill-to-batches instead of drop-at-cap; omission counts on `max_notes` truncation). `tests/test_summarize.py`: **61 passed**; full suite **2928 passed** locally; manager coverage 97%+.
- ruff check + format clean; `mypy src/ tests/` clean; structural diff-gate 100%.
- Docs: `docs/tools/index.md` (batching semantics + new response fields), `docs/configuration.md` (both knobs reworded), `docs/design/design.md` (map-reduce design paragraph), tool docstring, CHANGELOG.

## Notes for review

- `_resolve_paths` now expands subtrees against a generous cap (10k) purely to know the pre-cap match count for `notes_omitted`; expansion is path-listing only, bodies are read solely for the kept notes.
- Wall-clock: multi-batch calls are parallelized (4 workers) because MCP clients impose tool timeouts; a very large folder is still inherently slower than before — that's the price of actually reading it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdcCCw2Y47NUApLnwUtHaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdcCCw2Y47NUApLnwUtHaZ)_