### PR TITLE
fix: make incremental reindex inline embedding resilient to provider timeouts (#930)

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -706,6 +706,24 @@ merely leaves a larger diff for the next successful run to converge. A
 cold build (empty vector index) and `force=True` behave exactly as
 before.
 
+The **incremental reindex** honours the same contract when the vector
+sidecar is already loaded (#930). `reindex()` upserts every changed note
+into the FTS index and then inline-embeds it, in the same bounded batches
+as the cold and convergence paths — never a note's whole chunk list in one
+oversized request. A provider failure (a request timeout being the
+motivating case, but also token-context rejection or a transient outage)
+is logged and skipped for that one note, leaving its existing vectors
+intact, rather than aborting the whole reindex. This keeps the FTS
+refresh — including the `document_tags` structured-filter set — committed
+for **all** changed notes even while the embedding backend is timing out,
+so filters on freshly-edited frontmatter work immediately; the skipped
+notes converge on the next `build_embeddings` pass (their FTS rows differ
+from the stale vectors, so the signature diff re-embeds them). Before this
+fix a single inline-embed timeout raised out of `reindex()`, stranding the
+FTS/`document_tags` refresh half-applied while the tracker never advanced,
+so every retry re-detected the same diff and failed identically until a
+cold-boot rebuild ran the resilient batch path instead.
+
 ### Error Handling
 
 Two-layer model:

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -720,6 +720,12 @@ class IndexManager:
         Inline embedding runs only when the vector sidecar is already
         loaded — :meth:`reindex` deliberately keeps provider failures on
         the converge-and-skip path otherwise (see the purge comments).
+        When it does run, a provider failure for one note is logged and
+        skipped rather than aborting the whole reindex (#930): the FTS
+        refresh must commit for every changed note (so structured filters
+        on freshly-edited frontmatter work immediately) even while the
+        embedding backend is timing out, and the skipped note's vectors
+        converge on the next ``build_embeddings`` pass.
 
         Args:
             parsed: ``(path, note)`` pairs from :meth:`_parse_changed_notes`.
@@ -731,6 +737,7 @@ class IndexManager:
         """
         indexed_added = 0
         indexed_modified = 0
+        embed_failed = 0
         for path, note in parsed:
             try:
                 self._fts.upsert_note(note)
@@ -743,17 +750,74 @@ class IndexManager:
                 indexed_modified += 1
 
             if vectors is not None and self._embeddings_path is not None:
-                vectors.delete_by_path(note.path)
-                texts, meta = self._embed_inputs(
-                    path=note.path,
-                    title=note.title,
-                    folder=_derive_folder(note.path),
-                    frontmatter=note.frontmatter,
-                    chunks=note.chunks,
-                )
-                if texts:
-                    vectors.add(texts, meta)
+                embed_failed += self._embed_note_inline(vectors, note)
+        if embed_failed:
+            logger.warning(
+                "reindex_inline_embed_failed_docs total=%d "
+                "(existing vectors kept; retried on the next build_embeddings)",
+                embed_failed,
+            )
         return indexed_added, indexed_modified
+
+    def _embed_note_inline(self, vectors: VectorIndex, note: ParsedNote) -> int:
+        """Embed one changed note's chunks inline, resiliently (#930).
+
+        Mirrors the cold-build / convergence contract: chunks are embedded
+        in bounded batches (:data:`_EMBEDDING_BATCH_SIZE`) — not the whole
+        note in one oversized request — and a provider failure (a request
+        timeout being the motivating case, but also token-context rejection
+        or a transient outage) is logged and swallowed, leaving the note's
+        existing vectors untouched. Embedding runs to completion *before*
+        the index is mutated, so a mid-note failure can neither drop the
+        old vectors nor leave a partial row set. A failed note is left for
+        the next ``build_embeddings`` convergence pass to re-embed (its FTS
+        row differs from the stale vector, so the signature diff refreshes
+        it).
+
+        Args:
+            vectors: The loaded vector index to mutate.
+            note: The parsed note whose chunks to (re-)embed.
+
+        Returns:
+            ``0`` on success (including an empty chunk set), ``1`` when the
+            provider failed and the note's vectors were left unchanged.
+        """
+        if self._embedding_provider is None:
+            return 0
+        texts, meta = self._embed_inputs(
+            path=note.path,
+            title=note.title,
+            folder=_derive_folder(note.path),
+            frontmatter=note.frontmatter,
+            chunks=note.chunks,
+        )
+        if not texts:
+            # No embeddable content — drop any stale vectors for the path.
+            vectors.delete_by_path(note.path)
+            return 0
+        raw: list[list[float]] = []
+        try:
+            for start in range(0, len(texts), _EMBEDDING_BATCH_SIZE):
+                raw.extend(
+                    self._embedding_provider.embed(
+                        texts[start : start + _EMBEDDING_BATCH_SIZE]
+                    )
+                )
+        except Exception as exc:
+            # Broad by design: providers raise heterogeneous types for a
+            # timeout or oversized batch (RuntimeError, httpx errors, ...).
+            # Keep the traceback diagnosable while the reindex carries on.
+            logger.warning(
+                "reindex_inline_embed_skip_doc path=%s chunks=%d err=%s",
+                note.path,
+                len(texts),
+                exc,
+                exc_info=True,
+            )
+            return 1
+        vectors.delete_by_path(note.path)
+        vectors.add_vectors(raw, meta)
+        return 0
 
     # ------------------------------------------------------------------
     # Embeddings

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -703,6 +703,71 @@ class TestSkipStateMemory:
         # search stays usable until convergence re-embeds them.
         assert "alpha.md" in vectors.chunks_by_path()
 
+    def test_embed_note_inline_empty_chunks_drops_stale_vectors(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """A note that parses to zero chunks drops its stale vectors (#930).
+
+        Inline embedding of a chunkless note must remove any existing
+        vectors for the path and report success (0 failures) without
+        calling the provider.
+        """
+        from markdown_vault_mcp.types import ParsedNote
+
+        mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+        assert "alpha.md" in vectors.chunks_by_path()
+
+        # A parsed note with no embeddable chunks.
+        note = ParsedNote(
+            path="alpha.md",
+            frontmatter={},
+            title="Alpha",
+            chunks=[],
+            content_hash="deadbeef",
+            modified_at=0.0,
+        )
+        failed = mgr._embed_note_inline(vectors, note)
+
+        assert failed == 0
+        assert "alpha.md" not in vectors.chunks_by_path()
+
+    def test_embed_note_inline_without_provider_is_noop(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """The defensive provider guard returns 0 and touches nothing (#930).
+
+        ``_embed_note_inline`` narrows ``_embedding_provider`` before use;
+        with it cleared the helper must short-circuit, leaving the note's
+        existing vectors intact.
+        """
+        from markdown_vault_mcp.types import ParsedNote
+
+        mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+        assert "alpha.md" in vectors.chunks_by_path()
+
+        mgr._embedding_provider = None
+        note = ParsedNote(
+            path="alpha.md",
+            frontmatter={},
+            title="Alpha",
+            chunks=[],
+            content_hash="deadbeef",
+            modified_at=0.0,
+        )
+        failed = mgr._embed_note_inline(vectors, note)
+
+        assert failed == 0
+        # Untouched: the guard returned before any delete/add.
+        assert "alpha.md" in vectors.chunks_by_path()
+
 
 # ---------------------------------------------------------------------------
 # build_embeddings

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -658,6 +658,51 @@ class TestSkipStateMemory:
         assert result.deleted == 1
         vectors.save.assert_called_once()
 
+    def test_inline_embed_timeout_does_not_abort_reindex(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """A provider timeout during inline reindex embedding is non-fatal (#930).
+
+        The cold-boot path tolerates provider failures per batch; the
+        incremental path must do the same. A timeout while embedding one
+        changed note may not abort the whole reindex — the FTS refresh must
+        still commit for that note (so structured filters on freshly-edited
+        frontmatter work immediately) and the note's existing vectors must
+        be left intact for the next ``build_embeddings`` convergence pass.
+        """
+        mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+        # Old vectors exist for alpha.md before the edit.
+        assert "alpha.md" in vectors.chunks_by_path()
+
+        # Arm the provider to time out on every embed call from now on.
+        def _boom(_texts: list[str]) -> list[list[float]]:
+            raise RuntimeError("OllamaProvider embeddings request failed: timed out")
+
+        mgr._embedding_provider.embed = _boom  # type: ignore[method-assign,union-attr]
+
+        (index_vault / "alpha.md").write_text(
+            "---\ntitle: Alpha\nstatus: active\n---\n# Alpha\n\nEdited body.\n",
+            encoding="utf-8",
+        )
+
+        # Reindex must NOT raise even though every embed call fails.
+        result = mgr.reindex()
+        assert result.modified == 1
+
+        # FTS committed the edit: the new body is queryable/filterable.
+        alpha_text = "\n".join(
+            r["content"] for r in mgr._fts.list_chunks() if r["path"] == "alpha.md"
+        )
+        assert "Edited body." in alpha_text
+
+        # The stale vectors for alpha.md are kept (not dropped) so semantic
+        # search stays usable until convergence re-embeds them.
+        assert "alpha.md" in vectors.chunks_by_path()
+
 
 # ---------------------------------------------------------------------------
 # build_embeddings

--- a/uv.lock
+++ b/uv.lock
@@ -1479,7 +1479,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "3.2.0rc4"
+version = "3.2.0rc6"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Closes #930.

## Problem

After an `INDEXED_FIELDS` change invalidated the persisted vector index, every incremental `reindex` (push-triggered or explicit) failed with `OllamaProvider embeddings request failed: Request timed out.` and never committed its FTS refresh, while a cold-boot restart rebuilt the same data successfully.

## Root cause

`reindex()` inline-embeds each changed note in `_upsert_parsed_notes` via `vectors.add(texts, meta)`. This was the **only** embedding site without a per-note exception guard — the cold build (`build_embeddings`) and the boot convergence (`_converge_embeddings`) both catch provider failures per batch/per document and carry on, which is the design's documented self-healing contract.

So when the Ollama provider timed out (30 s), the `RuntimeError` propagated straight out of `reindex()`, which:

1. **Aborted the whole reindex** — only notes processed before the failing one got FTS-upserted; the remaining changed notes never reached `document_tags`, so structured filters on freshly-edited frontmatter silently returned stale/empty results.
2. **Skipped the tail** of `reindex()` (`resolve_vault_wikilinks`, `vectors.save`, `tracker.update_state`) — the tracker never advanced, so every retry re-detected the same diff and failed identically (the repeated-failure loop from the report).
3. Left `get_index_status` reporting `status: queryable` (a captured build error is diagnostic state, not a queryability gate) while filters were stale.

The cold-boot path succeeds on the same workload precisely because it batches embedding and skips failed units instead of aborting. A secondary aggravating factor: the inline path sent a note's *entire* chunk list in one unbatched request, versus the `_EMBEDDING_BATCH_SIZE=4` batching used everywhere else.

## Fix

Extract `_embed_note_inline`, which mirrors the cold/convergence contract:

- Embeds each changed note's chunks in bounded `_EMBEDDING_BATCH_SIZE` batches — never one oversized request.
- Embeds to completion **before** mutating the index, so a mid-note failure can neither drop the old vectors nor leave a partial row set.
- On any provider failure, logs a WARNING and skips that one note (its existing vectors stay intact), returning a failure count that `_upsert_parsed_notes` surfaces in a summary WARNING.

The FTS refresh — including the `document_tags` structured-filter set — now commits for **all** changed notes even while the embedding backend is timing out, so filters on freshly-edited frontmatter work immediately. Skipped notes converge on the next `build_embeddings` pass (their FTS rows differ from the stale vectors, so the signature diff re-embeds them).

## Tests

- `test_inline_embed_timeout_does_not_abort_reindex`: arms the provider to raise on every embed, edits a note, then asserts reindex does not raise, the FTS edit is committed (queryable/filterable), and the note's stale vectors are preserved for convergence.

## Docs

- Added an "incremental reindex" resilience paragraph to the Embedding Convergence section of `docs/design/design.md`.

## Gates

- `uv run pytest -x -q` — 2946 passed, 6 skipped
- `ruff check` / `ruff format --check` — clean
- `uv run mypy src/ tests/` — clean
- Patch coverage: new `_embed_note_inline` (success + failure branches) fully exercised
- `diff-quality` structural gate — 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS24VpW2X5u7RmmhWnYdE7)_