### PR TITLE
fix(deps): bump transitive mcp 1.28.0 → 1.28.1 (CVE-2026-59950)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1681,7 +1681,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1699,9 +1699,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #933.

## Problem

The `Dependency Audit` CI gate fails on the default branch and every PR:

```
mcp  1.28.0  CVE-2026-59950  Fix Versions: 1.28.1
```

`mcp` is a transitive dependency (via `fastmcp` / `fastmcp-pvl-core`), pinned to the vulnerable `1.28.0` in `uv.lock`.

## Fix

Lockfile-only bump of `mcp` to the patched `1.28.1` (`uv lock --upgrade-package mcp`). `fastmcp`'s constraint already permits `1.28.1`, so no `pyproject.toml` change is required. The diff is limited to `mcp`'s three lockfile lines (version, sdist, wheel).

## Testing

- No code change; nothing but the locked `mcp` patch version.
- Unblocks the `Dependency Audit` gate for this and all other PRs once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS24VpW2X5u7RmmhWnYdE7)_