### PR TITLE
fix: guard inline/converge vector mutation against dimension mismatch (#935)

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -702,8 +702,9 @@ rejection, transient outage) skips exactly that document (its existing
 vectors stay intact) and the rest still converge. The subsequent vector
 mutation is guarded the same way (#935): an embedding-dimension mismatch
 raises `ValueError` from `VectorIndex.add_vectors`, and that too skips only
-the offending document rather than aborting the pass — the document is
-counted as failed and re-tried on the next run. This is also the
+the offending document rather than aborting the pass — tallied separately
+(its stale vectors were already removed, so it is logged as *dropped*
+rather than *kept*) and re-tried on the next run. This is also the
 self-healing property: a boot `BuildEmbeddings` job that failed outright
 (recorded in `last_build_embeddings_error`, never retried in-process)
 merely leaves a larger diff for the next successful run to converge. A

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -699,7 +699,11 @@ the vault, so a steady-state boot does zero embedding work.
 Convergence embeds per document, in the same bounded batches as the cold
 build (#159): a provider failure on one document's chunks (token-context
 rejection, transient outage) skips exactly that document (its existing
-vectors stay intact) and the rest still converge. This is also the
+vectors stay intact) and the rest still converge. The subsequent vector
+mutation is guarded the same way (#935): an embedding-dimension mismatch
+raises `ValueError` from `VectorIndex.add_vectors`, and that too skips only
+the offending document rather than aborting the pass — the document is
+counted as failed and re-tried on the next run. This is also the
 self-healing property: a boot `BuildEmbeddings` job that failed outright
 (recorded in `last_build_embeddings_error`, never retried in-process)
 merely leaves a larger diff for the next successful run to converge. A
@@ -713,7 +717,10 @@ as the cold and convergence paths — never a note's whole chunk list in one
 oversized request. A provider failure (a request timeout being the
 motivating case, but also token-context rejection or a transient outage)
 is logged and skipped for that one note, leaving its existing vectors
-intact, rather than aborting the whole reindex. This keeps the FTS
+intact, rather than aborting the whole reindex. The vector mutation that
+follows is guarded identically to the convergence path (#935): a dimension
+mismatch from `add_vectors` skips just that note instead of aborting the
+loop. This keeps the FTS
 refresh — including the `document_tags` structured-filter set — committed
 for **all** changed notes even while the embedding backend is timing out,
 so filters on freshly-edited frontmatter work immediately; the skipped

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -49,6 +49,15 @@ logger = logging.getLogger(__name__)
 # when the entire corpus is sent in one batch (see issue #159).
 _EMBEDDING_BATCH_SIZE = 4
 
+# Disposition codes returned by IndexManager._embed_note_inline so the caller
+# can log an accurate aggregate: a provider failure is caught before the index
+# is touched (old vectors kept), whereas a dimension mismatch is caught after
+# delete_by_path has run (old vectors removed) — the two must not share a
+# "vectors kept" message (#935).
+_EMBED_OK = 0  # embedded (or nothing to embed)
+_EMBED_KEPT = 1  # provider failed before mutation — existing vectors preserved
+_EMBED_DROPPED = 2  # dimension mismatch after delete — existing vectors removed
+
 
 class IndexManager:
     """Manages index building, reindexing, and embedding lifecycle.
@@ -737,7 +746,8 @@ class IndexManager:
         """
         indexed_added = 0
         indexed_modified = 0
-        embed_failed = 0
+        embed_kept = 0
+        embed_dropped = 0
         for path, note in parsed:
             try:
                 self._fts.upsert_note(note)
@@ -750,12 +760,22 @@ class IndexManager:
                 indexed_modified += 1
 
             if vectors is not None and self._embeddings_path is not None:
-                embed_failed += self._embed_note_inline(vectors, note)
-        if embed_failed:
+                outcome = self._embed_note_inline(vectors, note)
+                if outcome == _EMBED_KEPT:
+                    embed_kept += 1
+                elif outcome == _EMBED_DROPPED:
+                    embed_dropped += 1
+        if embed_kept:
             logger.warning(
                 "reindex_inline_embed_failed_docs total=%d "
                 "(existing vectors kept; retried on the next build_embeddings)",
-                embed_failed,
+                embed_kept,
+            )
+        if embed_dropped:
+            logger.warning(
+                "reindex_inline_embed_dropped_docs total=%d "
+                "(vectors removed; re-embedded on the next build_embeddings)",
+                embed_dropped,
             )
         return indexed_added, indexed_modified
 
@@ -775,7 +795,11 @@ class IndexManager:
         mismatch raises :class:`ValueError` from
         :meth:`~markdown_vault_mcp.vector_index.VectorIndex.add_vectors`, and
         that too must skip only this one note rather than abort the whole
-        reindex loop. Either way a failed note is left for the next
+        reindex loop. The two failure dispositions differ, though — a provider
+        failure is caught *before* the index is touched (old vectors kept),
+        while a dimension mismatch is caught *after* ``delete_by_path`` (old
+        vectors removed) — so they return distinct codes for accurate
+        aggregate logging. Either way the note is left for the next
         ``build_embeddings`` convergence pass to re-embed (its FTS row differs
         from the stale vector, so the signature diff refreshes it).
 
@@ -784,12 +808,13 @@ class IndexManager:
             note: The parsed note whose chunks to (re-)embed.
 
         Returns:
-            ``0`` on success (including an empty chunk set), ``1`` when the
-            provider failed or the vector mutation was rejected, leaving the
-            note for the next convergence pass.
+            :data:`_EMBED_OK` on success (including an empty chunk set),
+            :data:`_EMBED_KEPT` when the provider failed before any mutation
+            (existing vectors preserved), or :data:`_EMBED_DROPPED` when the
+            vector mutation was rejected after the stale vectors were removed.
         """
         if self._embedding_provider is None:
-            return 0
+            return _EMBED_OK
         texts, meta = self._embed_inputs(
             path=note.path,
             title=note.title,
@@ -800,7 +825,7 @@ class IndexManager:
         if not texts:
             # No embeddable content — drop any stale vectors for the path.
             vectors.delete_by_path(note.path)
-            return 0
+            return _EMBED_OK
         raw: list[list[float]] = []
         try:
             for start in range(0, len(texts), _EMBEDDING_BATCH_SIZE):
@@ -813,6 +838,7 @@ class IndexManager:
             # Broad by design: providers raise heterogeneous types for a
             # timeout or oversized batch (RuntimeError, httpx errors, ...).
             # Keep the traceback diagnosable while the reindex carries on.
+            # Caught before any mutation, so the note's old vectors are kept.
             logger.warning(
                 "reindex_inline_embed_skip_doc path=%s chunks=%d err=%s",
                 note.path,
@@ -820,7 +846,7 @@ class IndexManager:
                 exc,
                 exc_info=True,
             )
-            return 1
+            return _EMBED_KEPT
         try:
             vectors.delete_by_path(note.path)
             vectors.add_vectors(raw, meta)
@@ -828,7 +854,8 @@ class IndexManager:
             # A dimension mismatch (add_vectors, vector_index.py) must not
             # abort the reindex loop with the note half-updated (#935).
             # Narrow to ValueError so genuine programming errors still
-            # surface; the note is left for the next convergence pass.
+            # surface; delete_by_path has already run, so the note's old
+            # vectors are gone until the next convergence pass re-embeds it.
             logger.warning(
                 "reindex_inline_embed_dim_mismatch path=%s chunks=%d err=%s",
                 note.path,
@@ -836,8 +863,8 @@ class IndexManager:
                 exc,
                 exc_info=True,
             )
-            return 1
-        return 0
+            return _EMBED_DROPPED
+        return _EMBED_OK
 
     # ------------------------------------------------------------------
     # Embeddings
@@ -1098,6 +1125,7 @@ class IndexManager:
         added = 0
         removed = 0
         failed = 0
+        dropped = 0
         # Embed per document, in bounded batches (#159), so a provider
         # failure affects exactly one document: its old vectors stay
         # untouched and every other document still converges.
@@ -1156,8 +1184,10 @@ class IndexManager:
                 # A dimension mismatch (add_vectors, vector_index.py) must
                 # skip only this document, not abort the whole convergence
                 # pass (#935). Narrow to ValueError so genuine programming
-                # errors still surface; the doc converges on the next run.
-                failed += len(texts)
+                # errors still surface. delete_by_path has already run, so
+                # this document's vectors are removed (unlike the provider
+                # branch above); tracked separately for an accurate log.
+                dropped += len(texts)
                 logger.warning(
                     "build_embeddings_converge_dim_mismatch path=%s chunks=%d err=%s",
                     path,
@@ -1178,6 +1208,12 @@ class IndexManager:
                 "build_embeddings_converge_failed_chunks total=%d "
                 "(existing vectors kept; retried on the next run)",
                 failed,
+            )
+        if dropped:
+            logger.warning(
+                "build_embeddings_converge_dropped_chunks total=%d "
+                "(vectors removed; re-embedded on the next run)",
+                dropped,
             )
         logger.info(
             "build_embeddings_converged added=%d removed=%d up_to_date=%d",

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -769,10 +769,15 @@ class IndexManager:
         or a transient outage) is logged and swallowed, leaving the note's
         existing vectors untouched. Embedding runs to completion *before*
         the index is mutated, so a mid-note failure can neither drop the
-        old vectors nor leave a partial row set. A failed note is left for
-        the next ``build_embeddings`` convergence pass to re-embed (its FTS
-        row differs from the stale vector, so the signature diff refreshes
-        it).
+        old vectors nor leave a partial row set.
+
+        The index mutation is likewise guarded (#935): an embedding-dimension
+        mismatch raises :class:`ValueError` from
+        :meth:`~markdown_vault_mcp.vector_index.VectorIndex.add_vectors`, and
+        that too must skip only this one note rather than abort the whole
+        reindex loop. Either way a failed note is left for the next
+        ``build_embeddings`` convergence pass to re-embed (its FTS row differs
+        from the stale vector, so the signature diff refreshes it).
 
         Args:
             vectors: The loaded vector index to mutate.
@@ -780,7 +785,8 @@ class IndexManager:
 
         Returns:
             ``0`` on success (including an empty chunk set), ``1`` when the
-            provider failed and the note's vectors were left unchanged.
+            provider failed or the vector mutation was rejected, leaving the
+            note for the next convergence pass.
         """
         if self._embedding_provider is None:
             return 0
@@ -815,8 +821,22 @@ class IndexManager:
                 exc_info=True,
             )
             return 1
-        vectors.delete_by_path(note.path)
-        vectors.add_vectors(raw, meta)
+        try:
+            vectors.delete_by_path(note.path)
+            vectors.add_vectors(raw, meta)
+        except ValueError as exc:
+            # A dimension mismatch (add_vectors, vector_index.py) must not
+            # abort the reindex loop with the note half-updated (#935).
+            # Narrow to ValueError so genuine programming errors still
+            # surface; the note is left for the next convergence pass.
+            logger.warning(
+                "reindex_inline_embed_dim_mismatch path=%s chunks=%d err=%s",
+                note.path,
+                len(texts),
+                exc,
+                exc_info=True,
+            )
+            return 1
         return 0
 
     # ------------------------------------------------------------------
@@ -1129,8 +1149,23 @@ class IndexManager:
                     exc_info=True,
                 )
                 continue
-            removed += vectors.delete_by_path(path)
-            added += vectors.add_vectors(raw, metas)
+            try:
+                removed += vectors.delete_by_path(path)
+                added += vectors.add_vectors(raw, metas)
+            except ValueError as exc:
+                # A dimension mismatch (add_vectors, vector_index.py) must
+                # skip only this document, not abort the whole convergence
+                # pass (#935). Narrow to ValueError so genuine programming
+                # errors still surface; the doc converges on the next run.
+                failed += len(texts)
+                logger.warning(
+                    "build_embeddings_converge_dim_mismatch path=%s chunks=%d err=%s",
+                    path,
+                    len(texts),
+                    exc,
+                    exc_info=True,
+                )
+                continue
 
         for path in stale_paths:
             removed += vectors.delete_by_path(path)

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -1057,6 +1057,16 @@ class IndexManager:
         also what makes a failed boot ``BuildEmbeddings`` job self-heal:
         the drift it left behind is just a larger diff for the next run.
 
+        The vector mutation is guarded the same way (#935): an
+        embedding-dimension mismatch raises :class:`ValueError` from
+        :meth:`~markdown_vault_mcp.vector_index.VectorIndex.add_vectors`
+        and skips only that document rather than aborting the pass. Unlike
+        a provider failure (caught before the index is touched), this fires
+        *after* ``delete_by_path`` has run, so the document's stale vectors
+        are removed — tallied under the separate ``dropped`` counter (logged
+        as ``build_embeddings_converge_dropped_chunks``) and re-embedded on
+        the next run.
+
         Thread-safety: runs on the single-owner
         :class:`~markdown_vault_mcp.indexing.IndexWriter` thread via
         :meth:`build_embeddings`, so no internal lock is required.

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -768,6 +768,54 @@ class TestSkipStateMemory:
         # Untouched: the guard returned before any delete/add.
         assert "alpha.md" in vectors.chunks_by_path()
 
+    def test_inline_embed_dimension_mismatch_does_not_abort_reindex(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """A dimension mismatch on one note skips it, not the whole loop (#935).
+
+        ``add_vectors`` raises ``ValueError`` when a note's fresh vectors do
+        not match the dimension of the vectors already in the index. That
+        must skip only the offending note — the FTS refresh still commits and
+        every other document's vectors survive — rather than propagating out
+        of ``reindex()``.
+        """
+        mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+        # The vault has several docs; the others keep the index at dim 32 so a
+        # dim-16 re-embed of alpha.md is a genuine mismatch (not an empty-index
+        # reset that would accept any dimension).
+        before = vectors.chunks_by_path()
+        assert {"alpha.md", "beta.md"} <= set(before)
+
+        # Return a differently-dimensioned vector for every embed from now on.
+        def _wrong_dim(texts: list[str]) -> list[list[float]]:
+            return [[0.1] * 16 for _ in texts]
+
+        mgr._embedding_provider.embed = _wrong_dim  # type: ignore[method-assign,union-attr]
+
+        (index_vault / "alpha.md").write_text(
+            "---\ntitle: Alpha\nstatus: active\n---\n# Alpha\n\nEdited body.\n",
+            encoding="utf-8",
+        )
+
+        # Must NOT raise even though add_vectors rejects the mismatched batch.
+        result = mgr.reindex()
+        assert result.modified == 1
+
+        # FTS committed the edit.
+        alpha_text = "\n".join(
+            r["content"] for r in mgr._fts.list_chunks() if r["path"] == "alpha.md"
+        )
+        assert "Edited body." in alpha_text
+
+        # Only alpha.md's vectors were disturbed; every other doc survives.
+        after = vectors.chunks_by_path()
+        assert "beta.md" in after
+        assert "alpha.md" not in after
+
 
 # ---------------------------------------------------------------------------
 # build_embeddings
@@ -803,6 +851,57 @@ class TestBuildEmbeddings:
         count = mgr.build_embeddings()
         assert count >= 4
         assert vectors_holder["vectors"] is not None
+
+    def test_converge_dimension_mismatch_skips_only_that_document(
+        self, index_vault: Path, tmp_path: Path
+    ) -> None:
+        """A dim mismatch on one doc skips it, not the whole converge (#935).
+
+        Convergence embeds per document and mutates the index per document;
+        an ``add_vectors`` dimension mismatch must skip just the offending
+        document (counted as failed, retried next run) while every other
+        document still converges — not abort ``build_embeddings``.
+        """
+        from tests.conftest import MockEmbeddingProvider
+
+        provider = MockEmbeddingProvider()
+        holder: dict = {"vectors": None}
+        mgr, _fts, _ = _make_index_mgr(
+            index_vault,
+            tmp_path,
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=provider,
+            get_vectors=lambda: holder["vectors"],
+            set_vectors=lambda v: holder.__setitem__("vectors", v),
+        )
+        mgr.build_index()
+        mgr.build_embeddings()
+        vectors = holder["vectors"]
+        assert vectors is not None
+        assert {"alpha.md", "beta.md"} <= set(vectors.chunks_by_path())
+
+        # Edit alpha.md and rebuild the FTS index so alpha's chunk signature
+        # diverges from its stored vectors — making it the sole refresh path
+        # for the next convergence pass. The vector index is untouched.
+        (index_vault / "alpha.md").write_text(
+            "---\ntitle: Alpha\n---\n# Alpha\n\nDiverged body.\n",
+            encoding="utf-8",
+        )
+        mgr.build_index(force=True)
+
+        # Now every embed returns a mismatched dimension.
+        def _wrong_dim(texts: list[str]) -> list[list[float]]:
+            return [[0.1] * 16 for _ in texts]
+
+        provider.embed = _wrong_dim  # type: ignore[method-assign]
+
+        # Converge must not raise; alpha is skipped (0 net adds), others stay.
+        added = mgr.build_embeddings()
+        assert added == 0
+
+        after = vectors.chunks_by_path()
+        assert "beta.md" in after
+        assert "alpha.md" not in after
 
     def test_progress_logging_throttled_and_per_batch_at_debug(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -659,7 +659,7 @@ class TestSkipStateMemory:
         vectors.save.assert_called_once()
 
     def test_inline_embed_timeout_does_not_abort_reindex(
-        self, index_vault: Path, tmp_path: Path
+        self, index_vault: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """A provider timeout during inline reindex embedding is non-fatal (#930).
 
@@ -690,7 +690,8 @@ class TestSkipStateMemory:
         )
 
         # Reindex must NOT raise even though every embed call fails.
-        result = mgr.reindex()
+        with caplog.at_level(logging.WARNING):
+            result = mgr.reindex()
         assert result.modified == 1
 
         # FTS committed the edit: the new body is queryable/filterable.
@@ -702,6 +703,12 @@ class TestSkipStateMemory:
         # The stale vectors for alpha.md are kept (not dropped) so semantic
         # search stays usable until convergence re-embeds them.
         assert "alpha.md" in vectors.chunks_by_path()
+
+        # A provider failure is caught before mutation, so the aggregate log
+        # accurately reports the vectors as kept — not dropped (#935).
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("reindex_inline_embed_failed_docs" in m for m in messages)
+        assert not any("reindex_inline_embed_dropped_docs" in m for m in messages)
 
     def test_embed_note_inline_empty_chunks_drops_stale_vectors(
         self, index_vault: Path, tmp_path: Path
@@ -769,7 +776,7 @@ class TestSkipStateMemory:
         assert "alpha.md" in vectors.chunks_by_path()
 
     def test_inline_embed_dimension_mismatch_does_not_abort_reindex(
-        self, index_vault: Path, tmp_path: Path
+        self, index_vault: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """A dimension mismatch on one note skips it, not the whole loop (#935).
 
@@ -777,7 +784,9 @@ class TestSkipStateMemory:
         not match the dimension of the vectors already in the index. That
         must skip only the offending note — the FTS refresh still commits and
         every other document's vectors survive — rather than propagating out
-        of ``reindex()``.
+        of ``reindex()``. Because ``delete_by_path`` runs before the mismatch
+        is raised, the note's own vectors are *removed*, so the aggregate log
+        must report them as dropped, not kept.
         """
         mgr, holder = self._mgr_with_embeddings(index_vault, tmp_path)
         mgr.build_index()
@@ -802,7 +811,8 @@ class TestSkipStateMemory:
         )
 
         # Must NOT raise even though add_vectors rejects the mismatched batch.
-        result = mgr.reindex()
+        with caplog.at_level(logging.WARNING):
+            result = mgr.reindex()
         assert result.modified == 1
 
         # FTS committed the edit.
@@ -815,6 +825,12 @@ class TestSkipStateMemory:
         after = vectors.chunks_by_path()
         assert "beta.md" in after
         assert "alpha.md" not in after
+
+        # The aggregate log reports the removed vectors accurately — dropped,
+        # not "kept" (#935).
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("reindex_inline_embed_dropped_docs" in m for m in messages)
+        assert not any("reindex_inline_embed_failed_docs" in m for m in messages)
 
 
 # ---------------------------------------------------------------------------
@@ -853,13 +869,13 @@ class TestBuildEmbeddings:
         assert vectors_holder["vectors"] is not None
 
     def test_converge_dimension_mismatch_skips_only_that_document(
-        self, index_vault: Path, tmp_path: Path
+        self, index_vault: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """A dim mismatch on one doc skips it, not the whole converge (#935).
 
         Convergence embeds per document and mutates the index per document;
         an ``add_vectors`` dimension mismatch must skip just the offending
-        document (counted as failed, retried next run) while every other
+        document (counted as dropped, retried next run) while every other
         document still converges — not abort ``build_embeddings``.
         """
         from tests.conftest import MockEmbeddingProvider
@@ -896,12 +912,18 @@ class TestBuildEmbeddings:
         provider.embed = _wrong_dim  # type: ignore[method-assign]
 
         # Converge must not raise; alpha is skipped (0 net adds), others stay.
-        added = mgr.build_embeddings()
+        with caplog.at_level(logging.WARNING):
+            added = mgr.build_embeddings()
         assert added == 0
 
         after = vectors.chunks_by_path()
         assert "beta.md" in after
         assert "alpha.md" not in after
+
+        # alpha's vectors were removed by delete_by_path before the mismatch,
+        # so the aggregate log reports them as dropped, not kept (#935).
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("build_embeddings_converge_dropped_chunks" in m for m in messages)
 
     def test_progress_logging_throttled_and_per_batch_at_debug(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
Closes #935.

## Problem

Both inline-embedding helpers call `vectors.delete_by_path()` immediately followed by `vectors.add_vectors()` **outside** the per-unit `try/except`:

- `_embed_note_inline` (reindex path, `src/markdown_vault_mcp/managers/index.py`)
- `_converge_embeddings` (boot/convergence path)

`VectorIndex.add_vectors` raises `ValueError` on an embedding-dimension mismatch (`vector_index.py:319-327`). Because the mutation sat outside the guard, that `ValueError` propagated past the note/doc-level handling and **aborted the entire reindex/convergence loop** — with the unit's vectors already deleted. This is the same "one bad unit aborts everything" failure mode #930 fixed for provider timeouts, just triggered by a dimension mismatch instead (e.g. a provider returning a differently-dimensioned vector under an unchanged provider/model fingerprint that the load-time `VectorIndexCompatibilityError` check doesn't catch).

Surfaced by the automated review on #932 as a pre-existing, out-of-scope observation; filed as #935 and fixed here.

## Fix

Wrap the `delete_by_path` + `add_vectors` mutation in a `try/except` narrowed to `ValueError` in **both** helpers, mirroring the existing provider-failure handling:

- The offending note/document is logged (`reindex_inline_embed_dim_mismatch` / `build_embeddings_converge_dim_mismatch`), counted as failed, and left for the next `build_embeddings` convergence pass.
- Every other unit still converges; the loop is never aborted.
- The catch is narrowed to `ValueError` so genuine programming errors from the numpy mutation still surface.

## Tests

- `test_inline_embed_dimension_mismatch_does_not_abort_reindex` — a mismatched re-embed of one note during `reindex()`: asserts no raise, the FTS edit commits, and every other document's vectors survive.
- `test_converge_dimension_mismatch_skips_only_that_document` — a mismatched refresh during `build_embeddings` convergence: asserts `0` net adds, no raise, and the other documents are untouched.

## Docs

- Updated the Embedding Convergence resilience paragraphs in `docs/design/design.md` to name dimension-mismatch as a skip-and-heal case for both the convergence and incremental-reindex paths.

## Gates

- `uv run pytest -x -q` — 2950 passed, 6 skipped
- `ruff check` / `ruff format --check` — clean
- `uv run mypy src/ tests/` — clean
- `diff-quality` structural gate — 100%
- Patch coverage: both new `except ValueError` branches exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS24VpW2X5u7RmmhWnYdE7)_