### PR TITLE
feat: add first-class Voyage embedding provider

### DIFF
--- a/.claude-plugin/plugin/README.md
+++ b/.claude-plugin/plugin/README.md
@@ -39,7 +39,7 @@ Optional environment variables:
 | Variable | Default | Purpose |
 |---|---|---|
 | `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | Disable write tools. |
-| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | *(empty)* | `fastembed` / `ollama` / `openai`. Leave blank for keyword-only search. |
+| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | *(empty)* | `fastembed` / `ollama` / `openai` / `voyage`. Leave blank for keyword-only search. |
 | `MARKDOWN_VAULT_MCP_EXCLUDE` | `.obsidian/**,.trash/**,.git/**` | Glob patterns to skip. |
 
 For the full list of env vars, see the

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 
 <!-- DOMAIN-START -->
 - **Full-text search** — SQLite FTS5 with BM25 scoring, porter stemming
-- **Semantic search** — cosine similarity over embedding vectors (FastEmbed, Ollama, or OpenAI)
+- **Semantic search** — cosine similarity over embedding vectors (FastEmbed, Ollama, OpenAI, or Voyage AI)
 - **Hybrid search** — Reciprocal Rank Fusion combining FTS5 and vector results
 - **Diversity-aware ranking** — each search result list caps a single document at 2 chunks (configurable), downweights chunks of long documents, and returns sentence-scale snippets — bounded LLM context cost per query, with full-section recovery via `read(path, section=heading)`
 - **Adaptive heading-level chunking** — long sections are recursively re-split at deeper heading levels (H1 → H6) until each chunk fits a configurable word budget, improving retrieval precision on synthesising essays without manual restructuring
@@ -62,7 +62,7 @@ With optional dependencies:
 
 ```bash
 pip install markdown-vault-mcp[mcp]            # FastMCP server
-pip install markdown-vault-mcp[embeddings-api]  # Ollama/OpenAI embeddings via API
+pip install markdown-vault-mcp[embeddings-api]  # Ollama/OpenAI/Voyage embeddings via API
 pip install markdown-vault-mcp[embeddings]      # FastEmbed local embeddings
 pip install markdown-vault-mcp[all]             # MCP + FastEmbed + API embeddings
 ```
@@ -83,7 +83,7 @@ docker pull ghcr.io/pvliesdonk/markdown-vault-mcp:latest
 ```
 
 <!-- DOMAIN-START -->
-The Docker image uses `[all]` (MCP + FastEmbed + API embeddings). By default, semantic search works locally with FastEmbed and can switch to Ollama/OpenAI when configured. A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
+The Docker image uses `[all]` (MCP + FastEmbed + API embeddings). By default, semantic search works locally with FastEmbed and can switch to Ollama/OpenAI/Voyage when configured. A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
 
 To attach a remote Python debugger (development only; the protocol is unauthenticated), see [Remote debugging](docs/deployment/docker.md#remote-debugging).
 
@@ -213,11 +213,13 @@ All configuration is via environment variables with the `MARKDOWN_VAULT_MCP_` pr
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | auto-detect | Embedding provider: `openai`, `ollama`, or `fastembed` |
+| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | auto-detect | Embedding provider: `openai`, `voyage`, `ollama`, or `fastembed`. Only the first three are auto-detected; `voyage` is opt-in |
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL (**not** `MARKDOWN_VAULT_MCP_`-prefixed) |
 | `OPENAI_API_KEY` | — | OpenAI API key for the OpenAI embedding provider (**not** `MARKDOWN_VAULT_MCP_`-prefixed) |
 | `MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` / `OPENAI_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible API base URL for embeddings |
 | `MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL` / `OPENAI_EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI-compatible embedding model name |
+| `VOYAGE_API_KEY` | — | Voyage AI API key for the `voyage` embedding provider (**not** `MARKDOWN_VAULT_MCP_`-prefixed) |
+| `MARKDOWN_VAULT_MCP_VOYAGE_MODEL` | `voyage-4` | Voyage AI embedding model name |
 | `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` | `nomic-embed-text` | Ollama embedding model name |
 | `MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY` | `false` | Force Ollama to use CPU only |
 | `MARKDOWN_VAULT_MCP_FASTEMBED_MODEL` | `BAAI/bge-small-en-v1.5` | FastEmbed model name |

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -1,6 +1,6 @@
 # Embedding Providers
 
-The `providers` module defines an abstract base class for embedding providers and three concrete implementations for OpenAI, Ollama, and FastEmbed.
+The `providers` module defines an abstract base class for embedding providers and four concrete implementations for OpenAI, Voyage AI, Ollama, and FastEmbed.
 
 ## Quick Start
 
@@ -23,11 +23,16 @@ The `get_embedding_provider()` function auto-detects the best available provider
 2. **Ollama** (if `OLLAMA_HOST` is reachable)
 3. **FastEmbed** (if the package is installed)
 
-Override with `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai|ollama|fastembed`.
+Override with `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai|voyage|ollama|fastembed`.
 For OpenAI-compatible APIs, set `OPENAI_BASE_URL` and
 `OPENAI_EMBEDDING_MODEL`, or the prefixed equivalents
 `MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` and
 `MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL`.
+
+`voyage` is a preset over the same OpenAI-compatible transport, pinned to
+`https://api.voyageai.com/v1` and configured with `VOYAGE_API_KEY` and
+`MARKDOWN_VAULT_MCP_VOYAGE_MODEL`. It is never auto-detected: select it
+explicitly.
 
 ## API Reference
 
@@ -37,6 +42,8 @@ For OpenAI-compatible APIs, set `OPENAI_BASE_URL` and
 ::: markdown_vault_mcp.providers.OllamaProvider
 
 ::: markdown_vault_mcp.providers.OpenAIProvider
+
+::: markdown_vault_mcp.providers.VoyageProvider
 
 ::: markdown_vault_mcp.providers.FastEmbedProvider
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,12 +102,14 @@ The first three knobs adjust *ranking and rendering* and take effect immediately
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | string | auto-detect | Embedding provider: `openai`, `ollama`, or `fastembed`. **Breaking change** from `EMBEDDING_PROVIDER` in older versions |
+| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | string | auto-detect | Embedding provider: `openai`, `voyage`, `ollama`, or `fastembed`. `voyage` must be selected explicitly (it is not auto-detected). **Breaking change** from `EMBEDDING_PROVIDER` in older versions |
 | `MARKDOWN_VAULT_MCP_EMBED_CONTEXT` | bool | `false` | Enrich each chunk's embedding input with the note title, the chunk heading, and (on the first chunk) the `SEARCHABLE_FIELDS` values, improving semantic recall for short or context-poor chunks. The raw note content on disk and in search snippets is unchanged. The active format is recorded in the vector sidecar, so flipping this (or changing `SEARCHABLE_FIELDS`) re-embeds the whole vault once on next startup |
 | `OLLAMA_HOST` | url | `http://localhost:11434` | Ollama server URL. **Not** `MARKDOWN_VAULT_MCP_`-prefixed |
 | `OPENAI_API_KEY` | string | (none) | OpenAI API key for the OpenAI embedding provider. **Not** `MARKDOWN_VAULT_MCP_`-prefixed |
 | `MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` / `OPENAI_BASE_URL` | url | `https://api.openai.com/v1` | OpenAI-compatible API base URL for embeddings |
 | `MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL` / `OPENAI_EMBEDDING_MODEL` | string | `text-embedding-3-small` | OpenAI-compatible embedding model name |
+| `VOYAGE_API_KEY` | string | (none) | Voyage AI API key for the `voyage` embedding provider. **Not** `MARKDOWN_VAULT_MCP_`-prefixed |
+| `MARKDOWN_VAULT_MCP_VOYAGE_MODEL` | string | `voyage-4` | Voyage AI embedding model name. `voyage-4-large` for quality, `voyage-4-lite` for cost |
 | `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` | string | `nomic-embed-text` | Ollama embedding model name |
 | `MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY` | bool | `false` | Force Ollama to use CPU only |
 | `MARKDOWN_VAULT_MCP_FASTEMBED_MODEL` | string | `BAAI/bge-small-en-v1.5` | FastEmbed model name |
@@ -120,7 +122,9 @@ The first three knobs adjust *ranking and rendering* and take effect immediately
     2. **Ollama** — if `OLLAMA_HOST` is reachable
     3. **FastEmbed** — if the `fastembed` package is installed
 
-    Both API providers speak the OpenAI-compatible embeddings protocol through the official `openai` SDK: the `ollama` provider is a preset that targets `{OLLAMA_HOST}/v1` with no key required. The `OLLAMA_*` settings and their behavior are unchanged; `OLLAMA_CPU_ONLY` uses Ollama's native API, which is the only way to request CPU-only inference.
+    All three API providers speak the OpenAI-compatible embeddings protocol through the official `openai` SDK: the `ollama` provider is a preset that targets `{OLLAMA_HOST}/v1` with no key required, and `voyage` is a preset that targets `https://api.voyageai.com/v1`. The `OLLAMA_*` settings and their behavior are unchanged; `OLLAMA_CPU_ONLY` uses Ollama's native API, which is the only way to request CPU-only inference.
+
+    `voyage` is not in the auto-detect chain: a `VOYAGE_API_KEY` exported for another tool must not silently take over an existing index, so set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=voyage` to use it.
 
     **Explicit vs. auto-detect failure handling:** when you set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` to a specific backend and it cannot be constructed at startup — a missing dependency, missing/empty credentials, or an unrecognised value — the server **fails fast** with a `ConfigurationError` rather than silently falling back to keyword-only search. (An unreachable Ollama/OpenAI *service* does not prevent startup — the provider still loads; the failure surfaces later as an embedding error during index build.) When the variable is *unset* (auto-detect) and no backend is available, the server logs a warning and continues with semantic search disabled. Set the variable explicitly if you want a missing provider to be a hard startup error.
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -62,7 +62,7 @@ markdown-vault-mcp (new package)
 +-- scanner.py        -- file discovery, frontmatter parsing, chunking
 +-- fts_index.py      -- SQLite FTS5 schema, BM25 search
 +-- vector_index.py   -- numpy embeddings, cosine similarity
-+-- providers.py      -- Ollama / OpenAI / SentenceTransformers
++-- providers.py      -- Ollama / OpenAI / Voyage / SentenceTransformers
 +-- tracker.py        -- hash-based change detection
 +-- vault.py          -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
 +-- write_callback.py -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
@@ -2038,7 +2038,7 @@ Copied from ifcraftcorpus, adapted:
 - Keep the same provider ABC and implementations (Ollama, OpenAI,
   SentenceTransformers)
 
-**Unified wire protocol (#916)**: both API providers embed through one
+**Unified wire protocol (#916)**: all API providers embed through one
 shared OpenAI-compatible transport built on the official ``openai`` SDK
 (``_OpenAICompatEmbeddings``). ``OpenAIProvider`` passes its configured
 base URL and key straight through; ``OllamaProvider`` is a preset over the
@@ -2052,6 +2052,23 @@ equivalent and stay on the native REST API: CPU-only inference
 the ``/api/show`` context-length probe, and the ``/api/tags`` reachability
 probe in ``get_embedding_provider``. ``fastembed`` (in-process, non-API)
 is unaffected.
+
+**Voyage preset**: ``VoyageProvider`` is a third preset over the same
+transport, with ``base_url`` pinned to ``https://api.voyageai.com/v1`` and
+its own ``VOYAGE_API_KEY`` / ``MARKDOWN_VAULT_MCP_VOYAGE_MODEL`` surface
+(default ``voyage-4``, the balanced member of the family; the voyage-4 and
+voyage-3.5 families accept 32k tokens, ``voyage-law-2`` 16k). Voyage rejects
+OpenAI fields it does not implement — ``dimensions`` and ``user`` return HTTP
+400 and ``encoding_format="float"`` is refused in favour of ``base64`` — so
+the transport's "send only ``model`` and ``input``, let the SDK pick the
+encoding" shape is a compatibility requirement, not an accident.
+``EMBEDDING_PROVIDER=openai`` with ``OPENAI_BASE_URL`` pointed at Voyage
+remains wire-identical and supported; the provider name exists so the
+endpoint, key variable and model default are discoverable and so the vector
+sidecar records ``voyage`` as its provider identity. Unlike the other three,
+``voyage`` is **not** in the auto-detect chain: a ``VOYAGE_API_KEY`` exported
+for an unrelated tool must not silently take over an index and force a
+re-embed.
 
 ### `tracker.py`: Change Detection
 
@@ -2385,7 +2402,7 @@ For MCP server deployment:
 | `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` | Maximum attachment size in MB, enforced by the `read` / `write` / `fetch` MCP tools (not the vault library); `0` disables the limit | `1.0` |
 | `MARKDOWN_VAULT_MCP_MAX_NOTE_READ_BYTES` | Maximum bytes returned by full-document `read()` for `.md` files; raises `ValueError` if exceeded. `read(path, section=...)` for partial reads bypasses the cap. `0` disables the limit | `262144` (256 KB) |
 | `MARKDOWN_VAULT_MCP_APP_DOMAIN` | Claude app domain for MCP Apps iframe sandboxing; auto-computed from `BASE_URL` via `_compute_claude_app_domain()` | derived from `BASE_URL` |
-| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | `openai`, `ollama`, `fastembed` | auto-detect |
+| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | `openai`, `voyage`, `ollama`, `fastembed` (only the first, third and fourth are auto-detected) | auto-detect |
 | `OLLAMA_HOST` | Ollama server URL | `http://localhost:11434` |
 | `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` | Ollama embedding model | `nomic-embed-text` |
 | `MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY` | Force CPU-only inference | `false` |
@@ -2394,6 +2411,8 @@ For MCP server deployment:
 | `OPENAI_API_KEY` | OpenAI API key | none |
 | `OPENAI_BASE_URL` / `MARKDOWN_VAULT_MCP_OPENAI_BASE_URL` | OpenAI-compatible API base URL (SiliconFlow, Together, internal gateways, …) | `https://api.openai.com/v1` |
 | `OPENAI_EMBEDDING_MODEL` / `MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL` | OpenAI-compatible embedding model name | `text-embedding-3-small` |
+| `VOYAGE_API_KEY` | Voyage AI API key | none |
+| `MARKDOWN_VAULT_MCP_VOYAGE_MODEL` | Voyage AI embedding model name | `voyage-4` |
 
 #### Example Configurations
 

--- a/docs/guides/claude-code-plugin.md
+++ b/docs/guides/claude-code-plugin.md
@@ -57,7 +57,7 @@ The plugin wires up the following env vars. Vars with a default are filled in wh
 |---------|---------|-------------|
 | `MARKDOWN_VAULT_MCP_SOURCE_DIR` | _(required)_ | Path to your vault directory |
 | `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | Set to `false` to enable write/edit/delete/rename tools |
-| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | _(empty)_ | Embedding backend (`fastembed`, `ollama`, `openai`); leave empty for keyword-only search |
+| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | _(empty)_ | Embedding backend (`fastembed`, `ollama`, `openai`, `voyage`); leave empty for keyword-only search |
 | `MARKDOWN_VAULT_MCP_EXCLUDE` | `.obsidian/**,.trash/**,.git/**` | Comma-separated glob patterns to exclude from indexing |
 | `MARKDOWN_VAULT_MCP_GIT_REPO_URL` | _(empty)_ | Remote repository URL for git-backed vault sync; leave empty to disable git integration |
 | `MARKDOWN_VAULT_MCP_GIT_TOKEN` | _(empty)_ | Personal access token for the git remote; leave empty to disable git integration |

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -275,7 +275,7 @@ You should see a commit from `markdown-vault-mcp`. Delete the test note when don
 **Key env vars:**
 
 - `MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH`: where to persist embedding vectors on disk (required to enable semantic search)
-- `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER`: `fastembed`, `ollama`, or `openai`
+- `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER`: `fastembed`, `ollama`, `openai`, or `voyage`
 - `MARKDOWN_VAULT_MCP_FASTEMBED_MODEL` / `MARKDOWN_VAULT_MCP_OLLAMA_MODEL`: which model to use
 
 ### Pre-build embeddings before first launch

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -7,8 +7,9 @@ This guide covers configuring each supported embedding provider for semantic sea
 | [Ollama](#ollama) | Yes | No (CPU works fine) | No | ~2 GB (model) | ~2-4 GB (separate process) |
 | [FastEmbed](#fastembed) | Yes | No | First run only (model download) | Small runtime + model | ~1-2 GB (in-process) |
 | [OpenAI](#openai) | No (API call) | N/A | Yes | Minimal | Negligible |
+| [Voyage AI](#voyage-ai) | No (API call) | N/A | Yes | Minimal | Negligible |
 
-All three providers produce embeddings that enable the `semantic` and `hybrid` search modes in the `search` tool.
+All four providers produce embeddings that enable the `semantic` and `hybrid` search modes in the `search` tool.
 
 ## Ollama
 
@@ -213,6 +214,55 @@ You should get a JSON response with an embedding array. After starting the serve
 
 ---
 
+## Voyage AI
+
+Uses [Voyage AI](https://www.voyageai.com/) embeddings (`voyage-4` by default). Voyage serves its Embeddings API in the OpenAI request/response shape, so this provider is the `openai` one with the base URL pinned to `https://api.voyageai.com/v1` and its own key and model variables.
+
+### Get an API key
+
+1. Go to the [Voyage dashboard](https://dashboard.voyageai.com/)
+2. Create an API key
+3. Copy it
+
+### Configure
+
+```bash
+MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=voyage
+VOYAGE_API_KEY=pa-your-api-key-here
+MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH=/path/to/store/embeddings
+```
+
+To pick a different model:
+
+```bash
+MARKDOWN_VAULT_MCP_VOYAGE_MODEL=voyage-4-large
+```
+
+The default is `voyage-4`, the balanced member of the family; `voyage-4-large` trades cost for retrieval quality and `voyage-4-lite` trades quality for cost. The voyage-4 and voyage-3.5 families take 32,000 tokens of input and return 1024-dimensional vectors by default. Changing the model re-embeds the vault once on the next startup.
+
+!!! note "Voyage must be selected explicitly"
+    Unlike the other three, `voyage` is not in the auto-detection chain. A `VOYAGE_API_KEY` exported for some other tool would otherwise take over an existing index and force a full re-embed.
+
+!!! warning "Privacy"
+    Document content (titles, headings, body text) is sent to Voyage AI for embedding. Use Ollama or FastEmbed for fully local, private embeddings.
+
+!!! info "You could always do this by hand"
+    Setting `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai` with `OPENAI_BASE_URL=https://api.voyageai.com/v1` still works and is wire-identical. The `voyage` name exists so the endpoint, the key variable, and a sensible model default are discoverable, and so the vector sidecar records `voyage` as the provider rather than `openai`.
+
+### Verify
+
+```bash
+# Test your API key (replace $VOYAGE_API_KEY with your key, or export it first)
+curl https://api.voyageai.com/v1/embeddings \
+  -H "Authorization: Bearer $VOYAGE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input": "test", "model": "voyage-4"}'
+```
+
+You should get a JSON response with an embedding array.
+
+---
+
 ## Auto-detection
 
 If you don't set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER`, the server tries providers in this order:
@@ -220,6 +270,8 @@ If you don't set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER`, the server tries provi
 1. **OpenAI:** if `OPENAI_API_KEY` is set
 2. **Ollama:** if `OLLAMA_HOST` is reachable
 3. **FastEmbed:** if the package is installed
+
+`voyage` is never auto-detected; select it explicitly.
 
 Set `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` explicitly to avoid surprises when your environment changes (setting `OPENAI_API_KEY` for another tool will cause the server to switch from Ollama to OpenAI).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 ## Features
 
 - **Full-text search**: SQLite FTS5 with BM25 scoring, porter stemming
-- **Semantic search**: cosine similarity over embedding vectors (FastEmbed, Ollama, or OpenAI)
+- **Semantic search**: cosine similarity over embedding vectors (FastEmbed, Ollama, OpenAI, or Voyage AI)
 - **Hybrid search**: Reciprocal Rank Fusion combining FTS5 and vector results
 - **Frontmatter-aware**: indexes YAML frontmatter fields, supports required field enforcement
 - **Incremental reindexing**: hash-based change detection, only re-processes modified files

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ With optional dependencies:
     ```bash
     pip install markdown-vault-mcp[embeddings-api]
     ```
-    Adds the openai SDK + httpx + numpy for Ollama/OpenAI embeddings via API.
+    Adds the openai SDK + httpx + numpy for Ollama/OpenAI/Voyage embeddings via API.
 
 === "Local embeddings"
 
@@ -56,7 +56,7 @@ uv sync --all-extras --all-groups
 docker pull ghcr.io/pvliesdonk/markdown-vault-mcp:latest
 ```
 
-The Docker image uses `[all]` (MCP + FastEmbed + API embeddings). Semantic search is available by default with FastEmbed and can switch to Ollama/OpenAI when configured.
+The Docker image uses `[all]` (MCP + FastEmbed + API embeddings). Semantic search is available by default with FastEmbed and can switch to Ollama/OpenAI/Voyage when configured.
 
 For early adopters who want to test unreleased changes, an `:unstable` tag is published by the release workflow's pre-release mode. It tracks the latest release candidate and may include in-progress features. The floating `:latest`, `:vN`, and `:vN.M` tags only move on stable releases.
 

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -8,6 +8,7 @@
   "secretKeys": [
     "MARKDOWN_VAULT_MCP_GIT_TOKEN",
     "OPENAI_API_KEY",
+    "VOYAGE_API_KEY",
     "MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_API_KEY",
     "MARKDOWN_VAULT_MCP_BEARER_TOKEN",
     "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET",
@@ -96,7 +97,7 @@
     {
       "id": "embeddings",
       "label": "Semantic search (embeddings)",
-      "help": "FTS-only needs no model. fastembed is local & zero-config. ollama/openai need a backend.",
+      "help": "FTS-only needs no model. fastembed is local & zero-config. ollama/openai/voyage need a backend.",
       "type": "select",
       "options": [
         {
@@ -123,6 +124,13 @@
           "emit": {
             "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "openai"
           }
+        },
+        {
+          "value": "voyage",
+          "label": "Voyage AI",
+          "emit": {
+            "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "voyage"
+          }
         }
       ]
     },
@@ -136,7 +144,8 @@
         "embeddings": [
           "fastembed",
           "ollama",
-          "openai"
+          "openai",
+          "voyage"
         ]
       },
       "dockerPath": "/data/state/embeddings/embeddings"
@@ -208,6 +217,31 @@
       "showIf": {
         "embeddings": [
           "openai"
+        ]
+      },
+      "advancedGroup": "Embeddings"
+    },
+    {
+      "id": "voyage_api_key",
+      "label": "Voyage API key",
+      "help": "Browser-only; never sent anywhere and never put in the shareable link.",
+      "type": "text",
+      "var": "VOYAGE_API_KEY",
+      "showIf": {
+        "embeddings": [
+          "voyage"
+        ]
+      }
+    },
+    {
+      "id": "voyage_model",
+      "label": "Voyage embedding model",
+      "help": "Default voyage-4 (balanced). voyage-4-large for quality, voyage-4-lite for cost.",
+      "type": "text",
+      "var": "MARKDOWN_VAULT_MCP_VOYAGE_MODEL",
+      "showIf": {
+        "embeddings": [
+          "voyage"
         ]
       },
       "advancedGroup": "Embeddings"

--- a/examples/zettelkasten/README.md
+++ b/examples/zettelkasten/README.md
@@ -58,7 +58,7 @@ export MARKDOWN_VAULT_MCP_PROMPTS_FOLDER=/path/to/examples/zettelkasten/prompts
 
 # Embeddings (optional)
 export MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH=/path/to/vault/.vault/embeddings.npy
-export MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=fastembed  # or ollama, openai
+export MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=fastembed  # or ollama, openai, voyage
 
 # Persistence
 export MARKDOWN_VAULT_MCP_INDEX_PATH=/path/to/vault/.vault/index.db

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -88,7 +88,8 @@ MARKDOWN_VAULT_MCP_INDEX_PATH=/var/lib/markdown-vault-mcp/index.db
 # Embeddings Provider
 # ---------------------------------------------------------------------------
 
-# Embedding provider: "fastembed" (local), "openai", or "ollama". Unset = auto-detect.
+# Embedding provider: "fastembed" (local), "openai", "voyage", or "ollama". Unset = auto-detect.
+# "voyage" is never auto-detected; set it explicitly to use it.
 #MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=fastembed
 
 # FastEmbed model name (used when MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=fastembed or auto-detected).
@@ -108,6 +109,13 @@ MARKDOWN_VAULT_MCP_INDEX_PATH=/var/lib/markdown-vault-mcp/index.db
 # OpenAI-compatible embedding model name. Must be valid for the configured OPENAI_BASE_URL.
 # (default: text-embedding-3-small — valid against api.openai.com)
 #OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+
+# Voyage AI API key (required when MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=voyage).
+#VOYAGE_API_KEY=
+
+# Voyage AI embedding model name. voyage-4-large for quality, voyage-4-lite for cost.
+# (default: voyage-4)
+#MARKDOWN_VAULT_MCP_VOYAGE_MODEL=voyage-4
 
 # Ollama server URL. (default: http://localhost:11434)
 #OLLAMA_HOST=http://localhost:11434

--- a/server.json
+++ b/server.json
@@ -84,6 +84,7 @@
           "description": "Embedding provider to use",
           "choices": [
             "openai",
+            "voyage",
             "ollama",
             "fastembed",
             "fastembed-gpu"
@@ -103,6 +104,16 @@
           "name": "OPENAI_EMBEDDING_MODEL",
           "description": "OpenAI-compatible embedding model name; also accepts MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL",
           "default": "text-embedding-3-small"
+        },
+        {
+          "name": "VOYAGE_API_KEY",
+          "description": "Voyage AI API key (required when MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=voyage)",
+          "isSecret": true
+        },
+        {
+          "name": "MARKDOWN_VAULT_MCP_VOYAGE_MODEL",
+          "description": "Voyage AI embedding model name",
+          "default": "voyage-4"
         },
         {
           "name": "MARKDOWN_VAULT_MCP_OLLAMA_MODEL",
@@ -316,6 +327,7 @@
           "description": "Embedding provider to use",
           "choices": [
             "openai",
+            "voyage",
             "ollama",
             "fastembed",
             "fastembed-gpu"
@@ -335,6 +347,16 @@
           "name": "OPENAI_EMBEDDING_MODEL",
           "description": "OpenAI-compatible embedding model name; also accepts MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL",
           "default": "text-embedding-3-small"
+        },
+        {
+          "name": "VOYAGE_API_KEY",
+          "description": "Voyage AI API key (required when MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=voyage)",
+          "isSecret": true
+        },
+        {
+          "name": "MARKDOWN_VAULT_MCP_VOYAGE_MODEL",
+          "description": "Voyage AI embedding model name",
+          "default": "voyage-4"
         },
         {
           "name": "MARKDOWN_VAULT_MCP_OLLAMA_MODEL",

--- a/src/markdown_vault_mcp/config_sections/embeddings.py
+++ b/src/markdown_vault_mcp/config_sections/embeddings.py
@@ -16,6 +16,8 @@ class EmbeddingsConfig:
     openai_api_key: str | None = None
     openai_base_url: str = "https://api.openai.com/v1"
     openai_embedding_model: str = "text-embedding-3-small"
+    voyage_api_key: str | None = None
+    voyage_model: str = "voyage-4"
     fastembed_model: str = "BAAI/bge-small-en-v1.5"
     fastembed_cache_dir: str | None = None
     embed_context: bool = False
@@ -31,9 +33,10 @@ class EmbeddingsConfig:
     def from_env(cls, prefix: str) -> EmbeddingsConfig:
         """Construct EmbeddingsConfig by reading ``{prefix}_*`` env vars.
 
-        Reads ``OLLAMA_HOST`` and ``OPENAI_API_KEY`` from the bare (unprefixed)
-        environment, matching the ecosystem conventions.  ``OPENAI_BASE_URL``
-        and ``OPENAI_EMBEDDING_MODEL`` use prefixed-wins-bare-fallback semantics.
+        Reads ``OLLAMA_HOST``, ``OPENAI_API_KEY`` and ``VOYAGE_API_KEY`` from the
+        bare (unprefixed) environment, matching the ecosystem conventions.
+        ``OPENAI_BASE_URL`` and ``OPENAI_EMBEDDING_MODEL`` use
+        prefixed-wins-bare-fallback semantics.
 
         Args:
             prefix: Env var prefix, e.g. ``"MARKDOWN_VAULT_MCP"``.
@@ -67,6 +70,8 @@ class EmbeddingsConfig:
             openai_api_key=(os.environ.get("OPENAI_API_KEY") or "").strip() or None,
             openai_base_url=openai_base_url,
             openai_embedding_model=openai_model,
+            voyage_api_key=(os.environ.get("VOYAGE_API_KEY") or "").strip() or None,
+            voyage_model=env(prefix, "VOYAGE_MODEL") or "voyage-4",
             fastembed_model=env(prefix, "FASTEMBED_MODEL") or "BAAI/bge-small-en-v1.5",
             fastembed_cache_dir=env(prefix, "FASTEMBED_CACHE_DIR") or None,
             embed_context=(

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -1,6 +1,6 @@
 """Embedding providers for markdown-vault-mcp.
 
-Provides an :class:`EmbeddingProvider` ABC and three concrete implementations:
+Provides an :class:`EmbeddingProvider` ABC and four concrete implementations:
 
 - :class:`OllamaProvider` — Ollama server; embeds via Ollama's
   OpenAI-compatible endpoint (``{host}/v1``), with the native REST API kept
@@ -8,9 +8,11 @@ Provides an :class:`EmbeddingProvider` ABC and three concrete implementations:
   inference, the context-length probe).
 - :class:`OpenAIProvider` — OpenAI-compatible Embeddings API via the
   official ``openai`` SDK.
+- :class:`VoyageProvider` — Voyage AI's OpenAI-compatible Embeddings API,
+  with the base URL pinned to ``https://api.voyageai.com/v1``.
 - :class:`FastEmbedProvider` — local fastembed/ONNX runtime embeddings.
 
-Both API providers share one wire protocol and one client
+All three API providers share one wire protocol and one client
 (:class:`_OpenAICompatEmbeddings`); the provider names are ergonomic presets
 over it, not separate code paths (#916).
 
@@ -55,6 +57,22 @@ _OPENAI_CONTEXT_LENGTHS: dict[str, int] = {
     "text-embedding-3-small": 8191,
     "text-embedding-3-large": 8191,
     "text-embedding-ada-002": 8191,
+}
+
+# Voyage's embeddings API does not report a model's context length either, so
+# the same table treatment applies. Values from https://docs.voyageai.com —
+# the voyage-4 and voyage-3.5 families, voyage-code-3 and voyage-finance-2 all
+# take 32k tokens; voyage-law-2 takes 16k. Unknown models return None and fall
+# back to a conservative chunk cap.
+_VOYAGE_CONTEXT_LENGTHS: dict[str, int] = {
+    "voyage-4-large": 32000,
+    "voyage-4": 32000,
+    "voyage-4-lite": 32000,
+    "voyage-3.5": 32000,
+    "voyage-3.5-lite": 32000,
+    "voyage-code-3": 32000,
+    "voyage-finance-2": 32000,
+    "voyage-law-2": 16000,
 }
 
 
@@ -476,6 +494,119 @@ class OpenAIProvider(EmbeddingProvider):
         return _OPENAI_CONTEXT_LENGTHS.get(self._model)
 
 
+class VoyageProvider(EmbeddingProvider):
+    """Embedding provider backed by Voyage AI's Embeddings API.
+
+    Voyage serves ``/v1/embeddings`` in the OpenAI request/response shape, so
+    this is a preset over the shared :class:`_OpenAICompatEmbeddings`
+    transport with the base URL pinned to Voyage's endpoint — the same
+    relationship :class:`OllamaProvider` has to it (#916). Pointing
+    :class:`OpenAIProvider` at ``https://api.voyageai.com/v1`` by hand keeps
+    working; the dedicated provider name exists so the endpoint, the key
+    variable and the model default are discoverable rather than folklore.
+
+    Voyage rejects OpenAI request fields it does not implement: ``dimensions``
+    and ``user`` are answered with HTTP 400, and ``encoding_format="float"``
+    with "accepted values are 'base64'". The shared transport sends only
+    ``model`` and ``input`` and leaves ``encoding_format`` to the ``openai``
+    SDK, whose base64 default Voyage accepts — so no request shaping is needed
+    here, but none of those three fields may start being sent either.
+
+    Args:
+        api_key: Voyage API key for authentication.
+        model: Embedding model name.
+    """
+
+    # Voyage's own guidance is voyage-4-large for the best quality,
+    # voyage-4-lite for the lowest latency and cost, and voyage-4 for the
+    # balance between them, so the balanced member is the default — the same
+    # posture as text-embedding-3-small for OpenAI. The whole voyage-4 family
+    # returns 1024-dimensional vectors by default.
+    _MODEL = "voyage-4"
+    _BASE_URL = "https://api.voyageai.com/v1"
+
+    def __init__(self, api_key: str, *, model: str = _MODEL) -> None:
+        """Initialise VoyageProvider with an explicit API key.
+
+        Args:
+            api_key: Voyage API key for authentication.
+            model: Embedding model name.
+
+        Raises:
+            ImportError: If the ``openai`` SDK is not installed.
+            RuntimeError: If ``api_key`` is empty.
+        """
+        if not api_key:
+            raise RuntimeError(
+                "VoyageProvider requires a non-empty api_key. Set VOYAGE_API_KEY."
+            )
+        self._model = model or self._MODEL
+        self._compat = _OpenAICompatEmbeddings(
+            api_key,
+            base_url=self._BASE_URL,
+            model=self._model,
+            label="VoyageProvider",
+        )
+        self._dimension: int | None = None
+
+        logger.debug("VoyageProvider initialised: model=%s", self._model)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts via Voyage's Embeddings API.
+
+        Args:
+            texts: List of strings to embed.
+
+        Returns:
+            List of embedding vectors in input order.
+
+        Raises:
+            RuntimeError: If the embeddings request fails.
+        """
+        embeddings = self._compat.embed(texts)
+
+        # Cache dimension from first successful call.
+        if self._dimension is None and embeddings:
+            self._dimension = len(embeddings[0])
+
+        return embeddings
+
+    @property
+    def dimension(self) -> int:
+        """Embedding dimension size.
+
+        Embeds a test string on first access to determine the dimension.
+
+        Returns:
+            Integer dimension of each embedding vector.
+        """
+        if self._dimension is None:
+            self.embed(["dimension probe"])
+        if self._dimension is None:
+            raise RuntimeError(
+                "VoyageProvider.embed() returned no embeddings; "
+                "cannot determine dimension."
+            )
+        return self._dimension
+
+    @property
+    def provider_name(self) -> str:
+        return "voyage"
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def context_length(self) -> int | None:
+        """Return the model's context length from the known-model table.
+
+        Returns None for models absent from the table; callers fall back to a
+        conservative chunk cap.
+        """
+        return _VOYAGE_CONTEXT_LENGTHS.get(self._model)
+
+
 class FastEmbedProvider(EmbeddingProvider):
     """Embedding provider backed by the local fastembed library.
 
@@ -573,6 +704,59 @@ class FastEmbedProvider(EmbeddingProvider):
         return _FASTEMBED_CONTEXT_LENGTHS.get(self._model_name)
 
 
+def _explicit_provider(name: str, config: ProjectConfig) -> EmbeddingProvider:
+    """Build the provider named by ``EMBEDDING_PROVIDER``.
+
+    Split out of :func:`get_embedding_provider` so the explicit dispatch and
+    the auto-detect probe stay independently readable as provider names are
+    added.
+
+    Args:
+        name: Normalised (stripped, lower-cased) provider name; never empty.
+        config: Vault configuration containing embedding settings.
+
+    Returns:
+        An initialised :class:`EmbeddingProvider` instance.
+
+    Raises:
+        ConfigurationError: If *name* is not a recognised provider.
+    """
+    if name == "openai":
+        logger.info("Using OpenAIProvider (embedding_provider=openai)")
+        return OpenAIProvider(
+            api_key=config.embeddings.openai_api_key or "",
+            base_url=config.embeddings.openai_base_url,
+            model=config.embeddings.openai_embedding_model,
+        )
+
+    if name == "voyage":
+        logger.info("Using VoyageProvider (embedding_provider=voyage)")
+        return VoyageProvider(
+            api_key=config.embeddings.voyage_api_key or "",
+            model=config.embeddings.voyage_model,
+        )
+
+    if name == "ollama":
+        logger.info("Using OllamaProvider (embedding_provider=ollama)")
+        return OllamaProvider(
+            host=config.embeddings.ollama_host,
+            model=config.embeddings.ollama_model,
+            cpu_only=config.embeddings.ollama_cpu_only,
+        )
+
+    if name == "fastembed":
+        logger.info("Using FastEmbedProvider (embedding_provider=%s)", name)
+        return FastEmbedProvider(
+            model_name=config.embeddings.fastembed_model,
+            cache_dir=config.embeddings.fastembed_cache_dir,
+        )
+
+    raise ConfigurationError(
+        f"Unrecognised embedding_provider value: {name!r}. "
+        "Valid values: 'openai', 'voyage', 'ollama', 'fastembed'."
+    )
+
+
 def get_embedding_provider(config: ProjectConfig) -> EmbeddingProvider:
     """Auto-detect and return an embedding provider from config.
 
@@ -585,6 +769,10 @@ def get_embedding_provider(config: ProjectConfig) -> EmbeddingProvider:
     3. If ``fastembed`` can be imported →
        :class:`FastEmbedProvider`.
     4. Raises :class:`RuntimeError` with installation instructions.
+
+    :class:`VoyageProvider` is deliberately absent from that probe: a
+    ``VOYAGE_API_KEY`` exported for some other tool must not silently take over
+    an existing index. Select it explicitly with ``EMBEDDING_PROVIDER=voyage``.
 
     Args:
         config: Vault configuration containing embedding settings.
@@ -601,37 +789,8 @@ def get_embedding_provider(config: ProjectConfig) -> EmbeddingProvider:
     """
     explicit = (config.embeddings.provider or "").strip().lower()
 
-    if explicit == "openai":
-        logger.info("Using OpenAIProvider (embedding_provider=openai)")
-        return OpenAIProvider(
-            api_key=config.embeddings.openai_api_key or "",
-            base_url=config.embeddings.openai_base_url,
-            model=config.embeddings.openai_embedding_model,
-        )
-
-    if explicit == "ollama":
-        logger.info("Using OllamaProvider (embedding_provider=ollama)")
-        return OllamaProvider(
-            host=config.embeddings.ollama_host,
-            model=config.embeddings.ollama_model,
-            cpu_only=config.embeddings.ollama_cpu_only,
-        )
-
-    if explicit == "fastembed":
-        logger.info(
-            "Using FastEmbedProvider (embedding_provider=%s)",
-            explicit,
-        )
-        return FastEmbedProvider(
-            model_name=config.embeddings.fastembed_model,
-            cache_dir=config.embeddings.fastembed_cache_dir,
-        )
-
     if explicit:
-        raise ConfigurationError(
-            f"Unrecognised embedding_provider value: {explicit!r}. "
-            "Valid values: 'openai', 'ollama', 'fastembed'."
-        )
+        return _explicit_provider(explicit, config)
 
     # Auto-detect: OpenAI API key present?
     if config.embeddings.openai_api_key:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # an ambient key doesn't silently enable a gated feature mid-test.
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
 
 
 def _parse_tool_data(result: Any) -> Any:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1568,6 +1568,7 @@ class TestEmbeddingsConfigFromEnv:
             "OLLAMA_MODEL",
             "OLLAMA_CPU_ONLY",
             "OPENAI_EMBEDDING_MODEL",
+            "VOYAGE_MODEL",
             "FASTEMBED_MODEL",
             "FASTEMBED_CACHE_DIR",
         ):
@@ -1576,6 +1577,7 @@ class TestEmbeddingsConfigFromEnv:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
         monkeypatch.delenv("OPENAI_EMBEDDING_MODEL", raising=False)
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
         cfg = EmbeddingsConfig.from_env("MARKDOWN_VAULT_MCP")
         assert cfg == EmbeddingsConfig()
 
@@ -1610,6 +1612,16 @@ class TestEmbeddingsConfigFromEnv:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test123")
         cfg = EmbeddingsConfig.from_env("MARKDOWN_VAULT_MCP")
         assert cfg.openai_api_key == "sk-test123"
+
+    def test_voyage_api_key_bare_read_and_prefixed_model(self, monkeypatch):
+        """VOYAGE_API_KEY is bare (ecosystem convention); the model is prefixed."""
+        from markdown_vault_mcp.config_sections import EmbeddingsConfig
+
+        monkeypatch.setenv("VOYAGE_API_KEY", "pa-test123")
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_VOYAGE_MODEL", "voyage-4-large")
+        cfg = EmbeddingsConfig.from_env("MARKDOWN_VAULT_MCP")
+        assert cfg.voyage_api_key == "pa-test123"
+        assert cfg.voyage_model == "voyage-4-large"
 
     def test_post_init_still_normalizes_on_direct_construction(self):
         from markdown_vault_mcp.config_sections import EmbeddingsConfig

--- a/tests/test_config_wizard_spec.py
+++ b/tests/test_config_wizard_spec.py
@@ -53,6 +53,7 @@ _BARE_NAMES = {
     "OPENAI_API_KEY",
     "OPENAI_BASE_URL",
     "OPENAI_EMBEDDING_MODEL",
+    "VOYAGE_API_KEY",
 }
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -16,6 +16,7 @@ from markdown_vault_mcp.providers import (
     FastEmbedProvider,
     OllamaProvider,
     OpenAIProvider,
+    VoyageProvider,
     get_embedding_provider,
 )
 
@@ -316,6 +317,92 @@ class TestOpenAIProvider:
             OpenAIProvider(api_key="sk-test")
 
 
+class TestVoyageProvider:
+    def test_init_raises_without_api_key(self) -> None:
+        with pytest.raises(RuntimeError, match="VOYAGE_API_KEY"):
+            VoyageProvider(api_key="")
+
+    def test_embed_pins_voyage_base_url_and_default_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1, 0.2]])
+        provider = VoyageProvider(api_key="pa-test-key-123")
+        result = provider.embed(["hello"])
+
+        assert captured["api_key"] == "pa-test-key-123"
+        assert captured["base_url"] == "https://api.voyageai.com/v1"
+        (kwargs,) = captured["create_calls"]
+        assert kwargs["model"] == "voyage-4"
+        assert kwargs["input"] == ["hello"]
+        assert result == [[0.1, 0.2]]
+        assert provider.provider_name == "voyage"
+        assert provider.model_name == "voyage-4"
+
+    def test_embed_sends_no_params_voyage_rejects(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only ``model``/``input`` go on the wire.
+
+        Voyage answers ``dimensions`` and ``user`` with HTTP 400 and rejects
+        ``encoding_format="float"`` outright, so the request must carry neither
+        — ``encoding_format`` is left to the SDK, whose base64 default Voyage
+        accepts.
+        """
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
+        VoyageProvider(api_key="pa-test").embed(["hello"])
+
+        (kwargs,) = captured["create_calls"]
+        assert set(kwargs) == {"model", "input"}
+
+    def test_custom_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
+        provider = VoyageProvider(api_key="pa-test", model="voyage-4-large")
+        provider.embed(["hello"])
+
+        (kwargs,) = captured["create_calls"]
+        assert kwargs["model"] == "voyage-4-large"
+        assert provider.model_name == "voyage-4-large"
+
+    def test_blank_model_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch)
+        assert VoyageProvider(api_key="pa-test", model="").model_name == "voyage-4"
+
+    def test_embed_maps_sdk_error_to_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch, raise_error=True)
+        provider = VoyageProvider(api_key="pa-test")
+        with pytest.raises(RuntimeError, match="VoyageProvider embeddings request"):
+            provider.embed(["hello"])
+
+    def test_dimension_triggers_embed_then_caches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1] * 1024])
+        provider = VoyageProvider(api_key="pa-test")
+
+        assert provider.dimension == 1024
+        assert provider.dimension == 1024
+        assert len(captured["create_calls"]) == 1
+
+    def test_dimension_raises_on_empty_embeddings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch, indexed=[])
+        provider = VoyageProvider(api_key="pa-test")
+        with pytest.raises(RuntimeError, match="cannot determine dimension"):
+            _ = provider.dimension
+
+    def test_missing_openai_sdk_raises_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "openai", None)  # force ImportError
+        with pytest.raises(ImportError, match="markdown-vault-mcp\\[embeddings-api\\]"):
+            VoyageProvider(api_key="pa-test")
+
+
 class TestFastEmbedProvider:
     def test_embed_uses_fastembed_model_and_cache(self) -> None:
         vec = MagicMock()
@@ -394,6 +481,38 @@ class TestGetEmbeddingProvider:
         assert isinstance(provider, OpenAIProvider)
         assert provider.model_name == "BAAI/bge-m3"
 
+    def test_explicit_voyage_returns_voyage_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_openai(monkeypatch)
+        cfg = _config(
+            provider="voyage",
+            voyage_api_key="pa-test",
+            voyage_model="voyage-4-lite",
+        )
+        provider = get_embedding_provider(cfg)
+        assert isinstance(provider, VoyageProvider)
+        assert provider.model_name == "voyage-4-lite"
+
+    def test_explicit_voyage_without_key_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing VOYAGE_API_KEY fails fast instead of embedding anonymously."""
+        _install_fake_openai(monkeypatch)
+        with pytest.raises(RuntimeError, match="VOYAGE_API_KEY"):
+            get_embedding_provider(_config(provider="voyage"))
+
+    def test_voyage_key_alone_does_not_autodetect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Voyage is opt-in: a stray VOYAGE_API_KEY never takes over the index."""
+        _install_fake_openai(monkeypatch)
+        cfg = _config(voyage_api_key="pa-test")
+        probe_client = self._ollama_mock_client(reachable=True)
+        with patch("httpx.Client", return_value=probe_client):
+            provider = get_embedding_provider(cfg)
+        assert isinstance(provider, OllamaProvider)
+
     def test_explicit_ollama_returns_ollama_provider(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -415,7 +534,8 @@ class TestGetEmbeddingProvider:
 
         cfg = _config(provider="unknown_value")
         with pytest.raises(
-            ConfigurationError, match="Valid values: 'openai', 'ollama', 'fastembed'"
+            ConfigurationError,
+            match="Valid values: 'openai', 'voyage', 'ollama', 'fastembed'",
         ):
             get_embedding_provider(cfg)
 
@@ -679,4 +799,16 @@ def test_openai_context_length_table():
     p._model = "text-embedding-3-small"
     assert p.context_length == 8191
     p._model = "unknown-embedding-model"
+    assert p.context_length is None
+
+
+def test_voyage_context_length_table():
+    from markdown_vault_mcp.providers import VoyageProvider
+
+    p = VoyageProvider.__new__(VoyageProvider)
+    p._model = "voyage-4"
+    assert p.context_length == 32000
+    p._model = "voyage-law-2"  # the one 16k model in the family
+    assert p.context_length == 16000
+    p._model = "voyage-99-unreleased"
     assert p.context_length is None


### PR DESCRIPTION
## What changed

- add `voyage` as a fourth value for `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER`, alongside `openai`, `ollama`, and `fastembed`
- `VoyageProvider` is a preset over the existing `_OpenAICompatEmbeddings` transport — the same relationship `OllamaProvider` already has to it (#916): base URL pinned to `https://api.voyageai.com/v1`, reading `VOYAGE_API_KEY` and `MARKDOWN_VAULT_MCP_VOYAGE_MODEL` (default `voyage-4`). No new HTTP client, no change to the `EmbeddingProvider` ABC
- wire the new provider and both env vars into the config wizard (`VOYAGE_API_KEY` in `secretKeys`) and both `server.json` package blocks, keeping the drift guards green
- document the provider everywhere the other three are enumerated (design spec, embeddings guide, configuration reference, API docs, README, install/client guides, `packaging/env.example`)
- add a `context_length` table for the current Voyage families (32k for voyage-4 / voyage-3.5 / voyage-code-3 / voyage-finance-2, 16k for voyage-law-2, per docs.voyageai.com), `None` for anything unknown

## Why

Voyage already works today — you point the OpenAI provider at it:

```bash
MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai
OPENAI_API_KEY=pa-...          # actually a Voyage key
OPENAI_BASE_URL=https://api.voyageai.com/v1
OPENAI_EMBEDDING_MODEL=voyage-4
```

That is wire-identical to what this PR does, and it keeps working. The problem is that it is folklore: nothing in the docs, the config wizard, `server.json`, or the provider list says it is possible, you have to know Voyage's base URL and a valid model name, and the vector sidecar records the provider as `openai`, so two vaults embedded with different backends look interchangeable when they are not. This PR turns that configuration into a named provider so the endpoint, the key variable, the model default, and the persisted provider identity are all discoverable.

## Usage

```bash
MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=voyage
VOYAGE_API_KEY=pa-...
# optional, defaults to voyage-4:
MARKDOWN_VAULT_MCP_VOYAGE_MODEL=voyage-4-large
```

| Variable | Default | Notes |
|---|---|---|
| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=voyage` | — | opt-in; never auto-detected |
| `VOYAGE_API_KEY` | (none) | bare name, matching the `OPENAI_API_KEY` / `OLLAMA_HOST` convention |
| `MARKDOWN_VAULT_MCP_VOYAGE_MODEL` | `voyage-4` | prefixed, matching `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` |

## Design notes worth reviewing

- **Guarded params.** Voyage is strict about OpenAI fields it does not implement: `dimensions` → HTTP 400, `user` → HTTP 400, and `encoding_format: "float"` → 400 with *"accepted values are 'base64'"* (verified against the live API). The shared transport already sends only `model` and `input` and lets the `openai` SDK apply its base64 default, which Voyage accepts — so this needed no request shaping, but it is now an explicit constraint in the docstring and pinned by a test asserting the request carries exactly `{model, input}`.
- **Default model `voyage-4`.** Voyage's own guidance is *"voyage-4-large for the best quality, voyage-4-lite for the lowest latency and cost, and voyage-4 for a balance between the two"* — the balanced member is the default, the same posture as `text-embedding-3-small` for the OpenAI provider.
- **Not auto-detected.** `voyage` must be selected explicitly. Adding it to the auto-detect chain would mean a `VOYAGE_API_KEY` exported for an unrelated tool could silently take over an existing index and force a full re-embed. The existing chain (`openai` → `ollama` → `fastembed`) is unchanged.
- **`_explicit_provider()` extraction.** Not cosmetic: a seventh `return` in `get_embedding_provider` trips `PLR0911` under the structural diff gate, and splitting explicit dispatch from the auto-detect probe was the honest fix rather than a `# noqa`.

## Deliberately out of scope

- **`input_type`.** Voyage's asymmetric `query` / `document` prefixes measurably help retrieval, but they need a per-call parameter on `EmbeddingProvider.embed` and a way for the search path to say which side it is on. That is an ABC change affecting all four providers and belongs in its own PR.
- **Batch-size tuning.** `_EMBEDDING_BATCH_SIZE` is 4, sized for local ONNX memory bounds (#159); that is small for a remote API, but raising it per-provider is its own change.
- **`VOYAGE_BASE_URL`.** No override is offered. Anyone needing a proxy or gateway in front of Voyage still has the `openai` provider with `OPENAI_BASE_URL`, which is exactly the escape hatch this PR is formalising.

## Verification

- `uv run pytest -q` — 2983 passed, 25 skipped; no test touches the network, the `openai` SDK is faked in-process throughout
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run mypy src/ tests/` — clean
- `diff-cover --compare-branch=origin/main` — 100% patch coverage (46 changed lines, 0 missing)
- `diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --fail-under=100` — 100%, 0 violations
- `uv run mkdocs build --strict` and `vale docs/` — clean

Closes #949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
