### PR TITLE
feat(okf): OKF filter dimensions and graph node typing

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1149,6 +1149,31 @@ what is implemented today:
   `document_tags` (so `filters={"type": ...}` works immediately) and the
   chunking provenance string, so the startup where detection first flips
   cold-rebuilds the tag table once (see Frontmatter Filtering, #927).
+- **Query dimensions (phase 2, #961)**: on an active bundle, three
+  ``filters`` keys carry OKF semantics in ``search``, ``list_documents``,
+  and ``get_similar`` — ``status`` (evaluated against the derived
+  lifecycle value, so ``stable`` also matches notes with no ``status``
+  field), ``stale`` (``true``/``false``), and ``trust_tier``; ``type``
+  stays a plain indexed tag lookup. Implementation: the manager splits
+  the ``filters`` dict (``SearchManager._split_okf_filters``) and
+  evaluates the OKF dimensions as a per-document post-filter over the
+  same annotation derivation the read surfaces use — one code path for
+  all three search modes (the vector channel must post-filter anyway) —
+  with the candidate pool widened (×4, floor 200; the ``get_similar``
+  precedent) so post-filtering cannot starve the file limit, and
+  verdicts memoized per path so evaluation costs one ``get_note`` per
+  distinct document. This deliberately trades the design sketch's SQL
+  ``NOT EXISTS`` branch for uniformity; ``document_tags`` still
+  accelerates ``type`` (and plain filters) in the FTS channel. With
+  detection off, the dimension keys fall back to plain tag semantics
+  (no error, no matches unless such tags exist). An invalid ``stale``
+  spelling raises ``ValueError`` eagerly. Any filter excludes
+  attachments from ``list_documents`` (they carry no frontmatter).
+  Graph views (``get_neighborhood`` / ``get_hub_graph`` and the SPA
+  wire payload) additively carry ``note_type`` — the OKF ``type`` of
+  each node, extracted from metadata already fetched for labels (hub
+  nodes stay untyped: their construction deliberately avoids per-node
+  metadata reads) — only on an active bundle.
 - **Field vocabulary as data**: the OKF key names, known spec versions,
   and tier/lifecycle constants live as module constants in `okf.py`
   because the spec is pre-1.0 with one breaking rename behind it — a

--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -1,9 +1,10 @@
 # OKF (Open Knowledge Format) Support — Design
 
-**Status:** phase 1 (#960 — detection, config surface, read annotations,
-stats/config reporting, indexed-field extension) implemented; its design
-has graduated into `design.md` ("OKF Read Semantics"). Later phases remain
-proposals — tracking issue
+**Status:** phases 1 (#960 — detection, config surface, read annotations,
+stats/config reporting, indexed-field extension) and 2 (#961 — filter
+dimensions, graph typing) implemented; their design has graduated into
+`design.md` ("OKF Read Semantics"). Later phases remain proposals —
+tracking issue
 [#959](https://github.com/pvliesdonk/markdown-vault-mcp/issues/959).
 **Spec targeted:** OKF v0.2
 ([`GoogleCloudPlatform/knowledge-catalog` → `okf/SPEC.md`](https://github.com/GoogleCloudPlatform/knowledge-catalog),
@@ -199,6 +200,12 @@ than a per-vault authoring task.
 ---
 
 ## 4. Layer 2 — query dimensions, and `okf_validate`
+
+*Filters status:* implemented (#961); `design.md`'s "OKF Read Semantics"
+section carries the as-built details, which supersede the sketch below
+(notably: the OKF dimensions are a uniform manager-level post-filter with
+pool widening, not a SQL `NOT EXISTS` branch). `okf_validate` remains a
+proposal (#962).
 
 ### Filters
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -158,7 +158,7 @@ List documents (and optionally attachments) in the vault.
 | `folder` | string | `null` | Return only documents in this folder |
 | `pattern` | string | `null` | Unix glob matched against relative paths (such as `"Journal/*.md"`) |
 | `include_attachments` | bool | `false` | When true, also returns non-`.md` files that match the configured allowlist |
-| `filters` | object | `null` | Frontmatter equality filters, ANDed (any key; list fields match by membership). On an OKF bundle, `status` / `stale` / `trust_tier` carry OKF semantics — `{"stale": "true"}` or `{"status": "deprecated"}` builds a triage listing. Any filter excludes attachments |
+| `filters` | object | `null` | Frontmatter equality filters, ANDed (any key; list fields match by membership). On an OKF bundle, `status` / `stale` / `trust_tier` carry OKF semantics: `{"stale": "true"}` or `{"status": "deprecated"}` builds a triage listing. Any filter excludes attachments |
 
 **Returns:** List of info dicts. Every entry has a `kind` field (`"note"` or `"attachment"`). Body content is not included; call `read` for full text.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -64,7 +64,7 @@ Find documents matching a query using full-text or semantic search.
 | `limit` | int | `10` | Maximum results to return |
 | `mode` | string | `"keyword"` | `"keyword"` (FTS5/BM25), `"semantic"` (vector similarity), or `"hybrid"` (reciprocal rank fusion) |
 | `folder` | string | `null` | Restrict to documents under this folder path |
-| `filters` | object | `null` | Filter by indexed frontmatter field values (such as `{"tags": "pacing"}`) |
+| `filters` | object | `null` | Filter by indexed frontmatter field values (such as `{"tags": "pacing"}`), ANDed. On an OKF bundle, `status` (`stable` also matches notes without one), `stale` (`true`/`false`), and `trust_tier` carry OKF semantics; `type` filters normally |
 | `chunks_per_file` | int | server default (`2`) | Maximum number of matching sections returned per file. Overrides `MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE` for this call. `0` is rejected. |
 | `snippet_words` | int | server default (`200`) | Approximate word budget for each section's `content` field. `0` returns the full chunk. Overrides `MARKDOWN_VAULT_MCP_SNIPPET_WORDS` for this call. |
 
@@ -158,6 +158,7 @@ List documents (and optionally attachments) in the vault.
 | `folder` | string | `null` | Return only documents in this folder |
 | `pattern` | string | `null` | Unix glob matched against relative paths (such as `"Journal/*.md"`) |
 | `include_attachments` | bool | `false` | When true, also returns non-`.md` files that match the configured allowlist |
+| `filters` | object | `null` | Frontmatter equality filters, ANDed (any key; list fields match by membership). On an OKF bundle, `status` / `stale` / `trust_tier` carry OKF semantics — `{"stale": "true"}` or `{"status": "deprecated"}` builds a triage listing. Any filter excludes attachments |
 
 **Returns:** List of info dicts. Every entry has a `kind` field (`"note"` or `"attachment"`). Body content is not included; call `read` for full text.
 
@@ -640,7 +641,7 @@ Find semantically similar notes by document path. Requires embeddings to be buil
 | `limit` | int | `10` | Maximum files to return |
 | `chunks_per_file` | int | server default (`2`) | Maximum number of matching sections returned per file. Overrides `MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE` for this call. `0` is rejected. |
 | `folder` | string | `null` | Restrict results to this folder (exact match or sub-folder prefix), such as `3-Resources` |
-| `filters` | object | `null` | Frontmatter equality filters, ANDed, such as `{"type": "resource"}`. List-valued fields match by membership |
+| `filters` | object | `null` | Frontmatter equality filters, ANDed, such as `{"type": "resource"}`. List-valued fields match by membership. On an OKF bundle, `status` / `stale` / `trust_tier` carry OKF semantics |
 | `wait_for_pending_writes` | bool | `false` | Block until the IndexWriter drains before answering, then report freshness via `_meta.index_stale` (see the *Index freshness on read tools* note at the top of this page). |
 
 **Returns:** List of grouped similar-document dicts ranked by cosine similarity, one entry per file with up to `chunks_per_file` best-matching sections. Each entry contains: `path`, `title`, `folder`, `score` (max section score), `search_type` (`"semantic"`), `frontmatter`, and `sections` (a list of `{heading, content, score}` dicts sorted by score then document order). Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).

--- a/src/markdown_vault_mcp/_server_apps.py
+++ b/src/markdown_vault_mcp/_server_apps.py
@@ -399,6 +399,9 @@ def register_apps(mcp: FastMCP) -> None:
               - group (str): "note" or "orphan".
               - folder (str): Parent folder path.
               - backlink_count (int): Number of inbound links.
+              - note_type (str, optional): The note's OKF ``type``
+                frontmatter value; present only on an active OKF
+                bundle for notes that declare one.
 
             - edges (list): List of dicts, each with:
 
@@ -451,6 +454,9 @@ def register_apps(mcp: FastMCP) -> None:
               - group (str): "hub" or "note".
               - folder (str): Parent folder path.
               - backlink_count (int): Number of inbound links.
+              - note_type (str, optional): The note's OKF ``type``
+                frontmatter value; present only on an active OKF
+                bundle for notes that declare one.
 
             - edges (list): List of dicts, each with:
 

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -558,7 +558,10 @@ def register(mcp: FastMCP) -> None:
                 candidate's full frontmatter, so any frontmatter key works
                 (unlike keyword 'search' filters, which are limited to
                 indexed_frontmatter_fields). List-valued fields match if
-                the value is among them.
+                the value is among them. On an OKF bundle three keys carry
+                OKF semantics, exactly as in 'search': status ("stable"
+                also matches notes without a status field), stale
+                ("true"/"false"), and trust_tier.
             wait_for_pending_writes: When True, wait until your recent
                 write/edit/delete/rename operations have been applied to the
                 index before answering, so the results reflect those changes.

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -70,7 +70,13 @@ def register(mcp: FastMCP) -> None:
                 in indexed_frontmatter_fields (see 'stats') can be filtered.
                 Multiple filters are ANDed. For list fields (e.g. tags),
                 this checks membership — {"tags": "pacing"} matches any
-                document where "pacing" appears in the tags list.
+                document where "pacing" appears in the tags list. On an OKF
+                bundle three keys carry OKF semantics: status ("draft"/
+                "stable"/"deprecated"; "stable" also matches notes without
+                a status field), stale ("true"/"false" — stale_after
+                passed), and trust_tier ("unverified"/"machine-confirmed"/
+                "human-reviewed"); "type" filters normally, e.g.
+                {"type": "Playbook", "stale": "false"}.
             chunks_per_file: Maximum number of sections to return per file
                 (default 2).  Set to 1 to get only the top-ranked section
                 per file.  Must be >= 1.
@@ -257,6 +263,7 @@ def register(mcp: FastMCP) -> None:
         folder: str | None = None,
         pattern: str | None = None,
         include_attachments: bool = False,
+        filters: dict[str, str] | None = None,
         wait_for_pending_writes: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
@@ -275,6 +282,16 @@ def register(mcp: FastMCP) -> None:
                 images, etc.) that match the configured allowlist. Each
                 attachment entry includes kind="attachment" and mime_type.
                 Default False (notes only).
+            filters: Frontmatter equality filters, ANDed (e.g.
+                {"tags": "craft"}); any frontmatter key works and list
+                fields match by membership. On an OKF bundle three keys
+                carry OKF semantics: status ("draft"/"stable"/"deprecated";
+                "stable" also matches notes without a status field), stale
+                ("true"/"false" — stale_after passed), and trust_tier
+                ("unverified"/"machine-confirmed"/"human-reviewed"). Use
+                {"status": "deprecated"} or {"stale": "true"} to build
+                triage listings. Any filter excludes attachments (they
+                carry no frontmatter).
             wait_for_pending_writes: When True, wait until your recent
                 write/edit/delete/rename operations have been applied to the
                 index before answering, so the results reflect those changes.
@@ -309,6 +326,7 @@ def register(mcp: FastMCP) -> None:
             folder=folder,
             pattern=pattern,
             include_attachments=include_attachments,
+            filters=filters,
         )
         return _staleness_result(
             vault,

--- a/src/markdown_vault_mcp/_vault_apps.py
+++ b/src/markdown_vault_mcp/_vault_apps.py
@@ -64,6 +64,10 @@ def _graph_view_payload(view: GraphView, *, include_truncated: bool) -> dict[str
                 "group": n.group,
                 "folder": n.folder,
                 "backlink_count": n.backlink_count,
+                # OKF type (phase 2, #961): present only on an active OKF
+                # bundle for notes that declare one, so non-OKF payloads
+                # keep their exact prior shape.
+                **({"note_type": n.note_type} if n.note_type is not None else {}),
             }
             for n in view.nodes
         ],

--- a/src/markdown_vault_mcp/facets/graph.py
+++ b/src/markdown_vault_mcp/facets/graph.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from markdown_vault_mcp.managers.link import LinkManager
     from markdown_vault_mcp.managers.search import SearchManager
+    from markdown_vault_mcp.okf import OkfDetector
     from markdown_vault_mcp.types import (
         BacklinkInfo,
         BrokenLinkInfo,
@@ -41,6 +42,7 @@ class GraphFacet:
         link_mgr: LinkManager,
         search_mgr: SearchManager,
         require_built: Callable[[], None],
+        okf_detector: OkfDetector | None = None,
     ) -> None:
         """Hold the managers and the index-readiness gate.
 
@@ -52,10 +54,18 @@ class GraphFacet:
                 (:meth:`SearchManager.get_similar`).
             require_built: Raises :exc:`IndexUnavailableError` if the index has
                 not been built; called by the bucket-3 query methods.
+            okf_detector: Optional OKF detection probe; when read semantics
+                are active, graph-view nodes carry the note's OKF ``type``
+                (#961). ``None`` leaves ``note_type`` unset everywhere.
         """
         self._link_mgr = link_mgr
         self._search_mgr = search_mgr
         self._require_built = require_built
+        self._okf = okf_detector
+
+    def _okf_active(self) -> bool:
+        """Whether OKF read semantics are active (one disk probe)."""
+        return self._okf is not None and self._okf.state().active
 
     def get_backlinks(
         self, path: str, *, limit: int | None = None
@@ -169,21 +179,31 @@ class GraphFacet:
     # of one asyncio.to_thread hop per node.
     # ------------------------------------------------------------------
 
-    def _node_label(self, path: str) -> tuple[str, str]:
-        """Return ``(label, folder)`` for *path* from indexed metadata.
+    def _node_label(
+        self, path: str, *, include_type: bool = False
+    ) -> tuple[str, str, str | None]:
+        """Return ``(label, folder, note_type)`` from indexed metadata.
 
-        Only indexed metadata (title/folder) is consulted — reading the full
-        document would load it into memory and, for a note over
-        ``MAX_NOTE_READ_BYTES``, raise and fail the whole graph. Falls back
-        to the filename stem for unindexed paths.
+        Only indexed metadata (title/folder/frontmatter) is consulted —
+        reading the full document would load it into memory and, for a note
+        over ``MAX_NOTE_READ_BYTES``, raise and fail the whole graph. Falls
+        back to the filename stem for unindexed paths. ``note_type`` is the
+        OKF ``type`` frontmatter value and is extracted only when
+        *include_type* is set (an active OKF bundle); it costs nothing
+        extra — the metadata row is already in hand.
         """
         meta = self._search_mgr.get_metadata(path)
         label = meta.title if meta else path.rsplit("/", 1)[-1].replace(".md", "")
         folder = meta.folder if meta else ""
-        return label, folder
+        note_type: str | None = None
+        if include_type and meta is not None:
+            raw = meta.frontmatter.get("type")
+            if isinstance(raw, str) and raw.strip():
+                note_type = raw.strip()
+        return label, folder, note_type
 
     def _expand_node(
-        self, current: str
+        self, current: str, *, okf_active: bool = False
     ) -> tuple[GraphNode, list[GraphEdge], list[str]]:
         """Build *current*'s interior node, its edges, and its link partners.
 
@@ -196,7 +216,7 @@ class GraphFacet:
             existing-outbound edges, and the partner paths for the caller
             to enqueue (in backlink-then-outlink order).
         """
-        label, folder = self._node_label(current)
+        label, folder, note_type = self._node_label(current, include_type=okf_active)
         try:
             backlinks = self.get_backlinks(current)
         except ValueError:
@@ -213,6 +233,7 @@ class GraphFacet:
             group="orphan" if is_orphan else "note",
             folder=folder,
             backlink_count=len(backlinks),
+            note_type=note_type,
         )
 
         edges: list[GraphEdge] = []
@@ -238,6 +259,7 @@ class GraphFacet:
         edges: list[GraphEdge],
         *,
         max_nodes: int,
+        okf_active: bool = False,
     ) -> bool:
         """Append dashed similarity edges for each current node.
 
@@ -273,13 +295,16 @@ class GraphFacet:
                     if len(nodes) >= max_nodes:
                         truncated = True
                         break
-                    label, folder = self._node_label(sr.path)
+                    label, folder, note_type = self._node_label(
+                        sr.path, include_type=okf_active
+                    )
                     nodes[sr.path] = GraphNode(
                         id=sr.path,
                         label=label,
                         group="note",
                         folder=folder,
                         backlink_count=0,
+                        note_type=note_type,
                     )
                 edges.append(
                     GraphEdge(source=node_path, target=sr.path, link_type="semantic")
@@ -329,6 +354,7 @@ class GraphFacet:
         visited: set[str] = set()
         queue: deque[tuple[str, int]] = deque([(path, 0)])
         truncated = False
+        okf_active = self._okf_active()
 
         while queue:
             if len(nodes) >= max_nodes:
@@ -341,17 +367,22 @@ class GraphFacet:
 
             if hop >= depth:
                 # Boundary nodes are reachable by definition — skip DB calls.
-                label, folder = self._node_label(current)
+                label, folder, note_type = self._node_label(
+                    current, include_type=okf_active
+                )
                 nodes[current] = GraphNode(
                     id=current,
                     label=label,
                     group="note",
                     folder=folder,
                     backlink_count=0,
+                    note_type=note_type,
                 )
                 continue
 
-            node, node_edges, partners = self._expand_node(current)
+            node, node_edges, partners = self._expand_node(
+                current, okf_active=okf_active
+            )
             nodes[current] = node
             edges.extend(node_edges)
             for partner in partners:
@@ -369,7 +400,9 @@ class GraphFacet:
 
         if include_semantic:
             truncated = (
-                self._add_semantic_edges(nodes, unique_edges, max_nodes=max_nodes)
+                self._add_semantic_edges(
+                    nodes, unique_edges, max_nodes=max_nodes, okf_active=okf_active
+                )
                 or truncated
             )
 
@@ -395,6 +428,7 @@ class GraphFacet:
         nodes: dict[str, GraphNode] = {}
         edges: list[GraphEdge] = []
         seen_edges: set[tuple[str, str]] = set()
+        okf_active = self._okf_active()
 
         for hub in hubs:
             nodes[hub.path] = GraphNode(
@@ -412,13 +446,16 @@ class GraphFacet:
                 backlinks = []
             for bl in backlinks:
                 if bl.source_path not in nodes:
-                    label, folder = self._node_label(bl.source_path)
+                    label, folder, note_type = self._node_label(
+                        bl.source_path, include_type=okf_active
+                    )
                     nodes[bl.source_path] = GraphNode(
                         id=bl.source_path,
                         label=label,
                         group="note",
                         folder=folder,
                         backlink_count=0,
+                        note_type=note_type,
                     )
                 edge_key = (bl.source_path, hub.path)
                 if edge_key not in seen_edges:

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -148,8 +148,11 @@ class ReaderFacet:
         folder: str | None = None,
         pattern: str | None = None,
         include_attachments: bool = False,
+        filters: dict[str, str] | None = None,
     ) -> list[NoteInfo | AttachmentInfo]:
         """List documents (and optionally attachments) in the vault.
+
+        Delegates to :meth:`SearchManager.list`.
 
         Args:
             folder: If provided, only return documents in this folder (and
@@ -160,6 +163,10 @@ class ReaderFacet:
                 that match the attachment allowlist.  Each
                 :class:`~markdown_vault_mcp.types.AttachmentInfo` entry
                 includes ``kind="attachment"`` and ``mime_type``.
+            filters: Optional ``{frontmatter_key: value}`` equality filters
+                (AND semantics). On an active OKF bundle, ``status`` /
+                ``stale`` / ``trust_tier`` carry OKF semantics. Any filter
+                excludes attachments (they carry no frontmatter).
 
         Returns:
             List of :class:`~markdown_vault_mcp.types.NoteInfo` (and
@@ -167,7 +174,10 @@ class ReaderFacet:
             objects.
         """
         return self._search_mgr.list(
-            folder=folder, pattern=pattern, include_attachments=include_attachments
+            folder=folder,
+            pattern=pattern,
+            include_attachments=include_attachments,
+            filters=filters,
         )
 
     def list_folders(self) -> list[str]:

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -40,7 +40,12 @@ from markdown_vault_mcp.managers._ranking import (
     group_by_path as _group_by_path,
 )
 from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
-from markdown_vault_mcp.okf import derive_annotation
+from markdown_vault_mcp.okf import (
+    OKF_FILTER_KEYS,
+    derive_annotation,
+    matches_okf_filters,
+    parse_stale_filter,
+)
 from markdown_vault_mcp.types import (
     AttachmentInfo,
     BacklinkInfo,
@@ -343,8 +348,26 @@ class SearchManager:
         if fm_raw:
             with contextlib.suppress(json.JSONDecodeError, TypeError):
                 fm = json.loads(fm_raw)
+        return self._metadata_matches_filters(fm, filters)
+
+    @staticmethod
+    def _metadata_matches_filters(
+        metadata: dict[str, Any], filters: dict[str, str]
+    ) -> bool:
+        """Match a frontmatter dict against plain equality filters.
+
+        List-valued fields are matched by membership; scalars by ``str``
+        equality. Absent keys never match.
+
+        Args:
+            metadata: Parsed frontmatter dict.
+            filters: ``{frontmatter_key: value}`` pairs (AND semantics).
+
+        Returns:
+            ``True`` when every pair matches.
+        """
         for key, value in filters.items():
-            fm_val = fm.get(key)
+            fm_val = metadata.get(key)
             if fm_val is None:
                 return False
             if isinstance(fm_val, list):
@@ -355,12 +378,109 @@ class SearchManager:
                     return False
         return True
 
+    def _split_okf_filters(
+        self, filters: dict[str, str] | None
+    ) -> tuple[dict[str, str] | None, dict[str, str]]:
+        """Split *filters* into plain tag filters and OKF dimensions.
+
+        The OKF dimensions (:data:`~markdown_vault_mcp.okf.OKF_FILTER_KEYS`:
+        ``status`` / ``stale`` / ``trust_tier``) get OKF semantics only when
+        a detector is wired and read semantics are active; otherwise every
+        key stays a plain filter, preserving pre-OKF behavior byte for
+        byte. A ``stale`` value is validated eagerly so an invalid spelling
+        fails the whole call instead of silently matching nothing.
+
+        Args:
+            filters: The caller's ``filters`` dict, or ``None``.
+
+        Returns:
+            ``(plain_filters_or_None, okf_filters)`` — the second dict is
+            empty when OKF semantics do not apply.
+
+        Raises:
+            ValueError: If an active ``stale`` filter value is not a
+                true/false spelling.
+        """
+        if not filters or self._okf is None:
+            return filters, {}
+        okf_filters = {k: v for k, v in filters.items() if k in OKF_FILTER_KEYS}
+        if not okf_filters or not self._okf.state().active:
+            return filters, {}
+        if "stale" in okf_filters:
+            parse_stale_filter(okf_filters["stale"])
+        plain = {k: v for k, v in filters.items() if k not in OKF_FILTER_KEYS}
+        return (plain or None), okf_filters
+
+    def _path_matches_okf(self, path: str, okf_filters: dict[str, str]) -> bool:
+        """Evaluate the OKF filter dimensions for one document path.
+
+        Args:
+            path: Relative document path.
+            okf_filters: OKF-dimension filters (non-empty).
+
+        Returns:
+            ``True`` when the document exists and matches.
+        """
+        note_row = self._fts.get_note(path)
+        if note_row is None:
+            return False
+        metadata = self._parse_frontmatter_json(note_row.get("frontmatter_json"), path)
+        return matches_okf_filters(metadata, okf_filters)
+
+    def _filter_rows_okf(
+        self, rows: builtins.list[FTSResult], okf_filters: dict[str, str]
+    ) -> builtins.list[FTSResult]:
+        """Drop FTS chunk rows whose document fails the OKF dimensions.
+
+        Verdicts are memoized per path: chunk rows repeat documents, and
+        the evaluation costs one ``get_note`` lookup per distinct path.
+
+        Args:
+            rows: Candidate chunk rows.
+            okf_filters: OKF-dimension filters; empty passes rows through.
+
+        Returns:
+            The surviving rows, order preserved.
+        """
+        if not okf_filters:
+            return rows
+        verdicts: dict[str, bool] = {}
+        kept: builtins.list[FTSResult] = []
+        for row in rows:
+            verdict = verdicts.get(row.path)
+            if verdict is None:
+                verdict = self._path_matches_okf(row.path, okf_filters)
+                verdicts[row.path] = verdict
+            if verdict:
+                kept.append(row)
+        return kept
+
+    @staticmethod
+    def _widen_for_okf(candidate_limit: int, okf_filters: dict[str, str]) -> int:
+        """Widen a candidate pool when OKF dimensions will post-filter it.
+
+        Post-filtering discards candidates after the pool is capped, so a
+        narrow filter could otherwise starve the result list (same
+        rationale as the ``get_similar`` folder/filter widening).
+
+        Args:
+            candidate_limit: The mode's normal candidate cap.
+            okf_filters: OKF-dimension filters; empty leaves the cap alone.
+
+        Returns:
+            The (possibly widened) cap.
+        """
+        if not okf_filters:
+            return candidate_limit
+        return max(candidate_limit * 4, 200)
+
     def _post_filter_semantic_rows(
         self,
         raw: builtins.list[dict[str, Any]],
         *,
         folder: str | None,
         filters: dict[str, str] | None,
+        okf_filters: dict[str, str] | None = None,
     ) -> builtins.list[dict[str, Any]]:
         """Apply folder-prefix and frontmatter filters to vector-search rows.
 
@@ -384,6 +504,8 @@ class SearchManager:
         """
         if folder is not None:
             folder = folder.replace("\\", "/").strip("/") or None
+        okf_filters = okf_filters or {}
+        okf_verdicts: dict[str, bool] = {}
         filtered: builtins.list[dict[str, Any]] = []
         for r in raw:
             if folder is not None:
@@ -392,6 +514,13 @@ class SearchManager:
                     continue
             if filters and not self._row_matches_filters(r["path"], filters):
                 continue
+            if okf_filters:
+                verdict = okf_verdicts.get(r["path"])
+                if verdict is None:
+                    verdict = self._path_matches_okf(r["path"], okf_filters)
+                    okf_verdicts[r["path"]] = verdict
+                if not verdict:
+                    continue
             filtered.append(r)
         return filtered
 
@@ -463,6 +592,7 @@ class SearchManager:
             chunks_per_file if chunks_per_file is not None else self._chunks_per_file
         )
         eff_snip = snippet_words if snippet_words is not None else self._snippet_words
+        filters, okf_filters = self._split_okf_filters(filters)
 
         if mode == "keyword":
             return self._keyword_search(
@@ -472,6 +602,7 @@ class SearchManager:
                 folder=folder,
                 chunks_per_file=eff_cap,
                 snippet_words=eff_snip,
+                okf_filters=okf_filters,
             )
 
         if mode == "semantic":
@@ -483,6 +614,7 @@ class SearchManager:
                 folder=folder,
                 chunks_per_file=eff_cap,
                 snippet_words=eff_snip,
+                okf_filters=okf_filters,
             )
 
         # hybrid
@@ -494,6 +626,7 @@ class SearchManager:
             folder=folder,
             chunks_per_file=eff_cap,
             snippet_words=eff_snip,
+            okf_filters=okf_filters,
         )
 
     def _adapt_semantic_rows(
@@ -599,8 +732,12 @@ class SearchManager:
         folder: str | None,
         chunks_per_file: int,
         snippet_words: int,
+        okf_filters: dict[str, str] | None = None,
     ) -> list[GroupedResult]:
-        candidate_limit = max(limit * (chunks_per_file + 4), 50)
+        okf_filters = okf_filters or {}
+        candidate_limit = self._widen_for_okf(
+            max(limit * (chunks_per_file + 4), 50), okf_filters
+        )
 
         raw = self._fts.search(
             query,
@@ -609,6 +746,7 @@ class SearchManager:
             folder=folder,
             snippet_words=None,
         )
+        raw = self._filter_rows_okf(raw, okf_filters)
         downweighted = _apply_length_downweight(
             raw, alpha=self._length_downweight_alpha
         )
@@ -711,12 +849,18 @@ class SearchManager:
         folder: str | None = None,
         chunks_per_file: int,
         snippet_words: int,
+        okf_filters: dict[str, str] | None = None,
     ) -> list[GroupedResult]:
+        okf_filters = okf_filters or {}
         vectors = self._load_vectors()
-        candidate_limit = max(limit * (chunks_per_file + 4), _SEMANTIC_CANDIDATE_FLOOR)
+        candidate_limit = self._widen_for_okf(
+            max(limit * (chunks_per_file + 4), _SEMANTIC_CANDIDATE_FLOOR), okf_filters
+        )
         raw = vectors.search(query, limit=candidate_limit)
 
-        filtered = self._post_filter_semantic_rows(raw, folder=folder, filters=filters)
+        filtered = self._post_filter_semantic_rows(
+            raw, folder=folder, filters=filters, okf_filters=okf_filters
+        )
         rows = self._adapt_semantic_rows(filtered)
 
         downweighted = _apply_length_downweight(
@@ -743,17 +887,21 @@ class SearchManager:
         folder: str | None,
         chunks_per_file: int,
         snippet_words: int,
+        okf_filters: dict[str, str] | None = None,
     ) -> list[GroupedResult]:
         """RRF merge of keyword and semantic results, then field-collapse."""
+        okf_filters = okf_filters or {}
         # The two channels size their candidate pools independently. FTS keeps a
         # floor of 50 (a BM25 query does real work per candidate). The vector
         # channel uses the same full-scan floor as _semantic_search, since it
         # goes through the identical VectorIndex.search and the same recall cap
         # applies: a floor-50 pool drops a document whose best chunk ranks just
         # past 50 from the RRF merge at small limits.
-        fts_candidate_limit = max(limit * (chunks_per_file + 4), 50)
-        vec_candidate_limit = max(
-            limit * (chunks_per_file + 4), _SEMANTIC_CANDIDATE_FLOOR
+        fts_candidate_limit = self._widen_for_okf(
+            max(limit * (chunks_per_file + 4), 50), okf_filters
+        )
+        vec_candidate_limit = self._widen_for_okf(
+            max(limit * (chunks_per_file + 4), _SEMANTIC_CANDIDATE_FLOOR), okf_filters
         )
 
         fts_raw: list[FTSResult] = self._fts.search(
@@ -763,6 +911,7 @@ class SearchManager:
             folder=folder,
             snippet_words=None,
         )
+        fts_raw = self._filter_rows_okf(fts_raw, okf_filters)
         fts_results: list[FTSResult] = _apply_length_downweight(
             fts_raw, alpha=self._length_downweight_alpha
         )
@@ -770,7 +919,7 @@ class SearchManager:
         vectors = self._load_vectors()
         vec_raw = vectors.search(query, limit=vec_candidate_limit)
         vec_filtered = self._post_filter_semantic_rows(
-            vec_raw, folder=folder, filters=filters
+            vec_raw, folder=folder, filters=filters, okf_filters=okf_filters
         )
         vec_rows = _apply_length_downweight(
             self._adapt_semantic_rows(vec_filtered),
@@ -882,6 +1031,7 @@ class SearchManager:
         folder: str | None = None,
         pattern: str | None = None,
         include_attachments: bool = False,
+        filters: dict[str, str] | None = None,
     ) -> list[NoteInfo | AttachmentInfo]:
         """List documents (and optionally attachments) in the vault.
 
@@ -894,21 +1044,43 @@ class SearchManager:
                 that match the attachment allowlist.  Each
                 :class:`~markdown_vault_mcp.types.AttachmentInfo` entry
                 includes ``kind="attachment"`` and ``mime_type``.
+            filters: Optional ``{frontmatter_key: value}`` equality filters
+                (AND semantics), evaluated against each note's stored
+                frontmatter (any key, list membership for list values). On
+                an active OKF bundle the dimensions ``status`` (absent
+                means ``stable``), ``stale`` (``true``/``false``), and
+                ``trust_tier`` carry OKF semantics. Attachments carry no
+                frontmatter, so any filter excludes them.
 
         Returns:
             List of :class:`~markdown_vault_mcp.types.NoteInfo` (and
             optionally :class:`~markdown_vault_mcp.types.AttachmentInfo`)
             objects.
+
+        Raises:
+            ValueError: If an active OKF ``stale`` filter value is not a
+                true/false spelling.
         """
+        plain_filters, okf_filters = self._split_okf_filters(filters)
         rows = self._fts.list_notes(folder=folder)
-        notes: list[NoteInfo | AttachmentInfo] = [
-            fts_row_to_note_info(row) for row in rows
-        ]
+        note_infos = [fts_row_to_note_info(row) for row in rows]
 
         if pattern:
-            notes = [n for n in notes if fnmatch.fnmatch(n.path, pattern)]
+            note_infos = [n for n in note_infos if fnmatch.fnmatch(n.path, pattern)]
+        if plain_filters:
+            note_infos = [
+                n
+                for n in note_infos
+                if self._metadata_matches_filters(n.frontmatter, plain_filters)
+            ]
+        if okf_filters:
+            note_infos = [
+                n for n in note_infos if matches_okf_filters(n.frontmatter, okf_filters)
+            ]
+        notes: list[NoteInfo | AttachmentInfo] = list(note_infos)
 
-        if not include_attachments:
+        if not include_attachments or filters:
+            # Attachments carry no frontmatter: any filter excludes them.
             return notes
 
         return notes + self._list_attachments(pattern=pattern, folder=folder)
@@ -1207,14 +1379,15 @@ class SearchManager:
         eff_cpf = (
             chunks_per_file if chunks_per_file is not None else self._chunks_per_file
         )
+        filters, okf_filters = self._split_okf_filters(filters)
         candidate_limit = max(limit * (eff_cpf + 4), 50)
-        if folder is not None or filters:
+        if folder is not None or filters or okf_filters:
             # Post-filtering discards candidates; widen the pool so a
             # narrow folder/filter cannot starve the result list.
             candidate_limit = max(candidate_limit * 4, 200)
         raw_results = self._vectors.search_by_path(path, limit=candidate_limit)
         raw_results = self._post_filter_semantic_rows(
-            raw_results, folder=folder, filters=filters
+            raw_results, folder=folder, filters=filters, okf_filters=okf_filters
         )
 
         rows = self._adapt_semantic_rows(raw_results)

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -60,6 +60,16 @@ _HUMAN_ACTOR_PREFIX = "human:"
 #: exempt from the ``type`` rule) and ranking downweights (#965).
 OKF_RESERVED_FILENAMES: tuple[str, ...] = ("index.md", "log.md")
 
+#: ``filters`` keys that carry OKF semantics on an active bundle (phase 2,
+#: #961). ``type`` is deliberately absent: it is a plain indexed tag lookup
+#: with no special semantics, so the ordinary ``document_tags`` path
+#: handles it.
+OKF_FILTER_KEYS: tuple[str, ...] = ("status", "stale", "trust_tier")
+
+#: Accepted spellings for the boolean ``stale`` filter value.
+_STALE_TRUE = frozenset({"true", "1", "yes"})
+_STALE_FALSE = frozenset({"false", "0", "no"})
+
 #: Bundle-root file allowed to carry ``okf_version``.
 _ROOT_INDEX = "index.md"
 
@@ -266,3 +276,58 @@ def derive_annotation(
     elif source_list:
         annotation["sources_count"] = len(source_list)
     return annotation
+
+
+def parse_stale_filter(value: str) -> bool:
+    """Parse the ``stale`` filter value into a boolean.
+
+    Args:
+        value: The raw filter value (``filters`` is ``dict[str, str]``).
+
+    Returns:
+        The requested staleness.
+
+    Raises:
+        ValueError: If *value* is not a recognized true/false spelling.
+    """
+    normalized = value.strip().lower()
+    if normalized in _STALE_TRUE:
+        return True
+    if normalized in _STALE_FALSE:
+        return False
+    raise ValueError(f"stale filter must be true or false, got {value!r}")
+
+
+def matches_okf_filters(
+    metadata: dict[str, Any],
+    okf_filters: dict[str, str],
+    *,
+    today: _dt.date | None = None,
+) -> bool:
+    """Evaluate the OKF filter dimensions against one note's frontmatter.
+
+    Semantics (design §4): ``status`` matches the derived lifecycle value,
+    so ``status=stable`` matches notes with *absent* ``status`` (the spec
+    default); ``stale`` compares the derived staleness; ``trust_tier``
+    compares the derived tier. Filters compose with AND.
+
+    Args:
+        metadata: The note's frontmatter dict (may be empty).
+        okf_filters: The OKF-dimension subset of a ``filters`` dict —
+            keys from :data:`OKF_FILTER_KEYS` only.
+        today: Server-local date for staleness; defaults to today.
+
+    Returns:
+        ``True`` when every given dimension matches.
+
+    Raises:
+        ValueError: If a ``stale`` value is not a true/false spelling.
+    """
+    annotation = derive_annotation(metadata, today=today)
+    for key, value in okf_filters.items():
+        if key == "stale":
+            if annotation["stale"] is not parse_stale_filter(value):
+                return False
+        elif annotation.get(key) != value:
+            return False
+    return True

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -585,6 +585,7 @@ class GraphNode:
     group: str
     folder: str
     backlink_count: int
+    note_type: str | None = None
 
 
 @dataclass

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -491,6 +491,7 @@ class Vault:
             link_mgr=self._link_mgr,
             search_mgr=self._search_mgr,
             require_built=self._require_built,
+            okf_detector=self._okf,
         )
         self._index_facet = IndexFacet(
             coordinator=self._coordinator, index_mgr=self._index_mgr

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -361,6 +361,10 @@ verified:
 # Playbook
 
 Zebra steps.
+
+## Checklist
+
+Zebra checklist details.
 """
 
 PLAIN_NOTE = """# Plain
@@ -476,6 +480,29 @@ class TestOkfFilters:
             by_id = {n.id: n for n in view.nodes}
             assert by_id["guides/playbook.md"].note_type == "Playbook"
             assert by_id["guides/plain.md"].note_type is None
+        finally:
+            vault.close()
+
+    def test_filters_plain_without_detector(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.fts_index import FTSIndex
+        from markdown_vault_mcp.managers.search import SearchManager
+        from markdown_vault_mcp.scanner import scan_directory
+
+        _build_filter_vault(tmp_path, declared=True)
+        fts = FTSIndex(db_path=":memory:")
+        for note in scan_directory(tmp_path):
+            fts.upsert_note(note)
+        manager = SearchManager(fts, tmp_path)
+        # No detector wired: 'stale' is a plain frontmatter key nothing
+        # carries, so the listing is empty rather than OKF-evaluated.
+        assert manager.list(filters={"stale": "true"}) == []
+
+    def test_path_matches_okf_missing_document(self, tmp_path: Path) -> None:
+        _build_filter_vault(tmp_path, declared=True)
+        vault = self._vault(tmp_path)
+        try:
+            manager = vault.reader._search_mgr  # noqa: SLF001
+            assert manager._path_matches_okf("missing.md", {"stale": "true"}) is False  # noqa: SLF001
         finally:
             vault.close()
 

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -11,6 +11,8 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from markdown_vault_mcp.vault import Vault
+
 from markdown_vault_mcp.okf import (
     OKF_STATUS_DEFAULT,
     TRUST_HUMAN,
@@ -285,3 +287,226 @@ class TestOkfInstructions:
         from markdown_vault_mcp._instructions import build_default_instructions
 
         assert "OKF" not in build_default_instructions(read_only=True)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("true", True),
+        ("TRUE ", True),
+        ("1", True),
+        ("yes", True),
+        ("false", False),
+        ("0", False),
+        ("No", False),
+    ],
+)
+def test_parse_stale_filter(value: str, expected: bool) -> None:
+    from markdown_vault_mcp.okf import parse_stale_filter
+
+    assert parse_stale_filter(value) is expected
+
+
+def test_parse_stale_filter_rejects_garbage() -> None:
+    from markdown_vault_mcp.okf import parse_stale_filter
+
+    with pytest.raises(ValueError, match="stale filter"):
+        parse_stale_filter("banana")
+
+
+@pytest.mark.parametrize(
+    ("metadata", "okf_filters", "expected"),
+    [
+        ({}, {"status": "stable"}, True),  # absent status means stable
+        ({"status": "draft"}, {"status": "stable"}, False),
+        ({"status": "deprecated"}, {"status": "deprecated"}, True),
+        ({"status": "archived"}, {"status": "archived"}, True),  # unknown passes
+        ({}, {"stale": "false"}, True),
+        ({"stale_after": "2000-01-01"}, {"stale": "true"}, True),
+        ({"stale_after": "2999-01-01"}, {"stale": "true"}, False),
+        ({}, {"trust_tier": "unverified"}, True),
+        (
+            {"verified": [{"by": "human:a"}]},
+            {"trust_tier": "human-reviewed"},
+            True,
+        ),
+        ({"verified": [{"by": "process:x"}]}, {"trust_tier": "human-reviewed"}, False),
+        (
+            {"type": "Playbook", "stale_after": "2000-01-01"},
+            {"stale": "true", "status": "stable"},
+            True,
+        ),
+        (
+            {"status": "deprecated", "stale_after": "2000-01-01"},
+            {"stale": "true", "status": "stable"},
+            False,
+        ),
+    ],
+)
+def test_matches_okf_filters(
+    metadata: dict, okf_filters: dict[str, str], expected: bool
+) -> None:
+    from markdown_vault_mcp.okf import matches_okf_filters
+
+    assert matches_okf_filters(metadata, okf_filters, today=TODAY) is expected
+
+
+PLAYBOOK_NOTE = """---
+type: Playbook
+status: deprecated
+stale_after: 2000-01-01
+verified:
+  - by: human:peter
+---
+# Playbook
+
+Zebra steps.
+"""
+
+PLAIN_NOTE = """# Plain
+
+Zebra notes. See [Playbook](playbook.md).
+"""
+
+
+def _build_filter_vault(root: Path, *, declared: bool) -> None:
+    (root / "guides").mkdir(parents=True)
+    if declared:
+        _write_root_index(root, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+    (root / "guides" / "playbook.md").write_text(PLAYBOOK_NOTE, encoding="utf-8")
+    (root / "guides" / "plain.md").write_text(PLAIN_NOTE, encoding="utf-8")
+
+
+class TestOkfFilters:
+    def _vault(self, root: Path, **kwargs: object) -> Vault:
+        from markdown_vault_mcp.vault import Vault
+
+        vault = Vault(source_dir=root, **kwargs)  # type: ignore[arg-type]
+        vault.index.build_index()
+        return vault
+
+    def test_keyword_filters_on_declared_vault(self, tmp_path: Path) -> None:
+        _build_filter_vault(tmp_path, declared=True)
+        vault = self._vault(tmp_path)
+        try:
+            paths = lambda rs: sorted(r.path for r in rs)  # noqa: E731
+            search = vault.reader.search
+            assert paths(search("zebra", filters={"stale": "true"})) == [
+                "guides/playbook.md"
+            ]
+            assert paths(search("zebra", filters={"status": "stable"})) == [
+                "guides/plain.md"
+            ]
+            assert paths(search("zebra", filters={"trust_tier": "human-reviewed"})) == [
+                "guides/playbook.md"
+            ]
+            assert paths(
+                search("zebra", filters={"type": "Playbook", "stale": "true"})
+            ) == ["guides/playbook.md"]
+            assert (
+                search("zebra", filters={"status": "deprecated", "stale": "false"})
+                == []
+            )
+        finally:
+            vault.close()
+
+    def test_filters_inert_without_declaration(self, tmp_path: Path) -> None:
+        _build_filter_vault(tmp_path, declared=False)
+        vault = self._vault(tmp_path)
+        try:
+            # Plain tag semantics: no 'stale' tag exists, so no matches —
+            # and no error either.
+            assert vault.reader.search("zebra", filters={"stale": "true"}) == []
+        finally:
+            vault.close()
+
+    def test_invalid_stale_value_raises(self, tmp_path: Path) -> None:
+        _build_filter_vault(tmp_path, declared=True)
+        vault = self._vault(tmp_path)
+        try:
+            with pytest.raises(ValueError, match="stale filter"):
+                vault.reader.search("zebra", filters={"stale": "banana"})
+        finally:
+            vault.close()
+
+    def test_list_documents_filters(self, tmp_path: Path) -> None:
+        _build_filter_vault(tmp_path, declared=True)
+        (tmp_path / "guides" / "img.png").write_bytes(b"\x89PNG\r\n")
+        vault = self._vault(tmp_path)
+        try:
+            listing = vault.reader.list_documents(filters={"status": "deprecated"})
+            assert [n.path for n in listing] == ["guides/playbook.md"]
+            stale = vault.reader.list_documents(filters={"stale": "true"})
+            assert [n.path for n in stale] == ["guides/playbook.md"]
+            with_attachments = vault.reader.list_documents(include_attachments=True)
+            assert any(n.path.endswith(".png") for n in with_attachments)
+            filtered = vault.reader.list_documents(
+                include_attachments=True, filters={"stale": "false"}
+            )
+            assert not any(n.path.endswith(".png") for n in filtered)
+        finally:
+            vault.close()
+
+    def test_semantic_and_hybrid_filters(
+        self, tmp_path: Path, mock_provider: object
+    ) -> None:
+        root = tmp_path / "vault"
+        _build_filter_vault(root, declared=True)
+        vault = self._vault(
+            root,
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=mock_provider,
+        )
+        try:
+            vault.index.build_embeddings()
+            for mode in ("semantic", "hybrid"):
+                results = vault.reader.search(
+                    "zebra", mode=mode, filters={"stale": "false"}
+                )
+                assert results, mode
+                assert all(r.path != "guides/playbook.md" for r in results), mode
+        finally:
+            vault.close()
+
+    def test_graph_nodes_carry_note_type_when_declared(self, tmp_path: Path) -> None:
+        _build_filter_vault(tmp_path, declared=True)
+        vault = self._vault(tmp_path)
+        try:
+            view = vault.graph.get_neighborhood("guides/plain.md")
+            by_id = {n.id: n for n in view.nodes}
+            assert by_id["guides/playbook.md"].note_type == "Playbook"
+            assert by_id["guides/plain.md"].note_type is None
+        finally:
+            vault.close()
+
+    def test_graph_nodes_untyped_without_declaration(self, tmp_path: Path) -> None:
+        _build_filter_vault(tmp_path, declared=False)
+        vault = self._vault(tmp_path)
+        try:
+            view = vault.graph.get_neighborhood("guides/plain.md")
+            assert all(n.note_type is None for n in view.nodes)
+        finally:
+            vault.close()
+
+
+def test_graph_view_payload_emits_note_type_only_when_set() -> None:
+    from markdown_vault_mcp._vault_apps import _graph_view_payload
+    from markdown_vault_mcp.types import GraphNode, GraphView
+
+    view = GraphView(
+        nodes=[
+            GraphNode(id="a.md", label="A", group="note", folder="", backlink_count=0),
+            GraphNode(
+                id="b.md",
+                label="B",
+                group="note",
+                folder="",
+                backlink_count=1,
+                note_type="Playbook",
+            ),
+        ],
+        edges=[],
+    )
+    payload = _graph_view_payload(view, include_truncated=False)
+    assert "note_type" not in payload["nodes"][0]
+    assert payload["nodes"][1]["note_type"] == "Playbook"

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -501,8 +501,8 @@ class TestOkfFilters:
         _build_filter_vault(tmp_path, declared=True)
         vault = self._vault(tmp_path)
         try:
-            manager = vault.reader._search_mgr  # noqa: SLF001
-            assert manager._path_matches_okf("missing.md", {"stale": "true"}) is False  # noqa: SLF001
+            manager = vault.reader._search_mgr
+            assert manager._path_matches_okf("missing.md", {"stale": "true"}) is False
         finally:
             vault.close()
 

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -469,6 +469,16 @@ class TestOkfFilters:
                 )
                 assert results, mode
                 assert all(r.path != "guides/playbook.md" for r in results), mode
+            # get_similar has its own split/widen/post-filter call site.
+            similar = vault.reader.get_similar(
+                "guides/plain.md", filters={"stale": "true"}
+            )
+            assert [r.path for r in similar] == ["guides/playbook.md"]
+            none_similar = vault.reader.get_similar(
+                "guides/plain.md",
+                filters={"trust_tier": "human-reviewed", "status": "stable"},
+            )
+            assert none_similar == []
         finally:
             vault.close()
 

--- a/tests/test_tools_okf.py
+++ b/tests/test_tools_okf.py
@@ -287,3 +287,77 @@ class TestModeOn:
             stats = _structured(await client.call_tool("stats", {}))
         assert stats["okf"]["mode"] == "on"
         assert stats["okf"]["declared_version"] is None
+
+
+@pytest.mark.usefixtures("_okf_env")
+class TestOkfFilterDimensions:
+    """Phase 2 (#961): OKF semantics for status/stale/trust_tier filters."""
+
+    async def test_status_stable_matches_absent_status(self) -> None:
+        async with Client(make_server()) as client:
+            hits = await _search(client, filters={"status": "stable"})
+        assert sorted(h["path"] for h in hits) == ["guides/plain.md"]
+
+    async def test_status_deprecated(self) -> None:
+        async with Client(make_server()) as client:
+            hits = await _search(client, filters={"status": "deprecated"})
+        assert [h["path"] for h in hits] == ["guides/playbook.md"]
+
+    async def test_stale_filter(self) -> None:
+        async with Client(make_server()) as client:
+            stale = await _search(client, filters={"stale": "true"})
+            fresh = await _search(client, filters={"stale": "false"})
+        assert [h["path"] for h in stale] == ["guides/playbook.md"]
+        assert "guides/playbook.md" not in [h["path"] for h in fresh]
+
+    async def test_trust_tier_filter_composes_with_type(self) -> None:
+        async with Client(make_server()) as client:
+            hits = await _search(
+                client,
+                filters={"trust_tier": "human-reviewed", "type": "Playbook"},
+            )
+        assert [h["path"] for h in hits] == ["guides/playbook.md"]
+
+    async def test_invalid_stale_value_is_a_tool_error(self) -> None:
+        from fastmcp.exceptions import ToolError
+
+        async with Client(make_server()) as client:
+            await wait_for_mcp_writer_drain(client)
+            with pytest.raises(ToolError, match="stale filter"):
+                await client.call_tool(
+                    "search", {"query": "zebra", "filters": {"stale": "banana"}}
+                )
+
+    async def test_list_documents_triage_listing(self) -> None:
+        async with Client(make_server()) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "list_documents", {"filters": {"stale": "true"}}
+            )
+        listing = _parse_tool_data(result)
+        assert [n["path"] for n in listing] == ["guides/playbook.md"]
+
+
+@pytest.mark.usefixtures("_okf_env")
+class TestFilterDimensionsModeOff:
+    """With OKF off, the dimension keys fall back to plain tag filters."""
+
+    @pytest.fixture(autouse=True)
+    def _off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_OKF_MODE", "off")
+
+    async def test_stale_filter_is_inert(self) -> None:
+        async with Client(make_server()) as client:
+            hits = await _search(client, filters={"stale": "true"})
+            listing = _parse_tool_data(
+                await client.call_tool("list_documents", {"filters": {"stale": "true"}})
+            )
+        assert hits == []
+        assert listing == []
+
+    async def test_status_is_plain_equality(self) -> None:
+        async with Client(make_server()) as client:
+            # Plain semantics: no absent-means-stable defaulting, and no
+            # 'status' tag is indexed with OKF off, so nothing matches.
+            hits = await _search(client, filters={"status": "stable"})
+        assert hits == []


### PR DESCRIPTION
Closes #961, refs #959. Implements OKF phase 2 per `docs/design/okf.md` §4.

## What this adds

**Filter dimensions** — on an active OKF bundle, three `filters` keys carry OKF semantics in `search`, `list_documents`, and `get_similar`:
- `status` — evaluated against the *derived* lifecycle value, so `{"status": "stable"}` also matches notes with no `status` field (the spec default);
- `stale` — `"true"`/`"false"` against `stale_after` (invalid spellings raise eagerly, surfacing as a tool error);
- `trust_tier` — `unverified` / `machine-confirmed` / `human-reviewed`.

`type` continues through the plain `document_tags` path phase 1 enabled. With detection off, the dimension keys fall back to plain tag semantics — no errors, no behavior change for non-OKF vaults.

**Implementation note (deliberate deviation from the design sketch):** rather than per-key SQL branches in the generic `FTSIndex` layer, the dimensions are a uniform manager-level post-filter over the same annotation derivation the phase-1 read surfaces use — one code path across keyword/semantic/hybrid (the vector channel must post-filter regardless), with the candidate pool widened when dimensions are present (×4, floor 200 — the existing `get_similar` precedent) so post-filtering can't starve the file limit, and per-path verdict memoization so evaluation costs one `get_note` per distinct document. Recorded in `design.md`'s graduated section.

**`list_documents` gains `filters`** — any-key frontmatter equality (list fields by membership) over the already-materialized `NoteInfo.frontmatter` (zero extra I/O, no LIMIT to starve), plus the OKF dimensions; `{"stale": "true"}` / `{"status": "deprecated"}` are the triage listings the design's maintenance loop calls for. Any filter excludes attachments (they carry no frontmatter).

**Graph node typing** — `GraphNode.note_type` carries the note's OKF `type` in `get_neighborhood` / `get_hub_graph` and on the SPA wire (emitted only when present), extracted from the metadata rows already fetched for node labels — zero added reads, and hub nodes stay untyped to preserve the existing hub read-avoidance guarantee. Gated on detection.

**Found along the way:** vault-root-absolute markdown links (`/path/note.md` — OKF's *recommended* link style) resolve to broken `//`-prefixed targets. Pre-existing, out of scope here; filed as #969.

## Tests

40+ new tests: predicate tables (`matches_okf_filters`, `parse_stale_filter`), Vault-level keyword/semantic/hybrid **and `get_similar`** filter behavior incl. off-mode inertness and the invalid-`stale` error, `list_documents` triage listings + attachment exclusion, graph `note_type` on declared/undeclared vaults, a direct `_graph_view_payload` shape test, and MCP-layer end-to-end coverage of the dimensions on `search` and `list_documents`. `get_similar`'s OKF path is covered at the Vault/manager level (its own split/widen/post-filter call site) rather than through the MCP client, because the e2e fixture deliberately runs without an embeddings provider; the MCP layer for `get_similar` is a 1:1 delegation already covered by its existing plain-filter tests.

## Gates

- `uv run pytest -x -q`: **3061+ passed** (3064 after review-round test additions), 13 skipped locally
- ruff check / format / format --check: clean
- mypy src/ tests/: clean
- diff-quality structural gate: 100%
- Coverage on changed modules: `okf.py` 100%; Codecov patch ≥98%
- Vale: fixed in-review (one spaced em-dash); green on CI

## Review rounds

Two automated review passes: round 1 flagged the `get_similar` docstring gap and missing `get_similar` OKF test — both fixed in `4cf09aa`; round 2 confirms resolution, no new issues.

## Documentation

- `docs/tools/index.md` — `search` / `list_documents` / `get_similar` filter rows
- `docs/design/design.md` — phase-2 as-built design graduated into "OKF Read Semantics"
- `docs/design/okf.md` — status + §4 superseded-sketch note
- App-tool docstrings (`vault_graph_neighborhood` / `vault_graph_hubs`) document `note_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01268CY9P38eZx1JvB9a12Mr