### PR TITLE
fix(links): resolve leading-slash markdown links against the vault root

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1699,7 +1699,10 @@ are not extracted. External URLs (`http://`, `https://`, `mailto:`) and pure anc
 
 **Path resolution for markdown links**: relative paths are resolved against the
 source document's directory. `../sibling.md` from `Journal/2024/today.md` resolves
-to `Journal/sibling.md`. Traversal above the vault root clamps to root.
+to `Journal/sibling.md`. A leading slash makes the target vault-root-relative
+(#969): `/guides/note.md` resolves to `guides/note.md` regardless of the source
+document's location — this is OKF's recommended link style. Traversal above the
+vault root clamps to root.
 
 **Fragment handling**: `path.md#heading` splits into `target_path=path.md` and
 `fragment=heading`. The fragment is preserved on `LinkInfo` but the target path

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -840,7 +840,10 @@ def _resolve_link_path(target: str, source_rel: str) -> tuple[str, str | None]:
         # style, #969): resolve against the vault root. Joining an absolute
         # path onto a base with pathlib would *replace* the base and keep
         # the leading slash, serializing as an unresolvable `//...` target.
-        resolved = PurePosixPath(target.lstrip("/"))
+        # removeprefix (not lstrip): exactly one slash marks root-relative;
+        # `//`-prefixed targets never reach here (external-URL filter), and
+        # this keeps that invariant from silently mattering.
+        resolved = PurePosixPath(target.removeprefix("/"))
     else:
         # Resolve relative to the source document's directory.
         resolved = PurePosixPath(source_rel).parent / target

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -835,9 +835,15 @@ def _resolve_link_path(target: str, source_rel: str) -> tuple[str, str | None]:
         # Link with only a fragment — points to the source document itself.
         return source_rel, fragment
 
-    # Resolve relative to the source document's directory.
-    source_dir_parts = PurePosixPath(source_rel).parent
-    resolved = source_dir_parts / target
+    if target.startswith("/"):
+        # Vault-root-absolute link (`/guides/note.md` — OKF's recommended
+        # style, #969): resolve against the vault root. Joining an absolute
+        # path onto a base with pathlib would *replace* the base and keep
+        # the leading slash, serializing as an unresolvable `//...` target.
+        resolved = PurePosixPath(target.lstrip("/"))
+    else:
+        # Resolve relative to the source document's directory.
+        resolved = PurePosixPath(source_rel).parent / target
 
     # Normalise (collapse /../ and /./) without going above root.
     parts = resolved.parts

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -122,6 +122,29 @@ class TestExtractInlineLinks:
         assert len(links) == 1
         assert links[0].target_path == "Journal/other.md"
 
+    def test_root_absolute_path_resolved(self) -> None:
+        """Leading-slash targets resolve against the vault root (#969).
+
+        This is OKF's recommended link style; pathlib's join semantics
+        previously produced an unresolvable ``//...`` target.
+        """
+        links = extract_links("[Note](/guides/playbook.md)", "guides/plain.md")
+        assert len(links) == 1
+        assert links[0].target_path == "guides/playbook.md"
+        assert links[0].raw_target == "/guides/playbook.md"
+
+    def test_root_absolute_with_fragment(self) -> None:
+        links = extract_links("[S](/a/b.md#section)", "deep/nested/src.md")
+        assert links[0].target_path == "a/b.md"
+        assert links[0].fragment == "section"
+
+    def test_root_absolute_reference_link(self) -> None:
+        links = extract_links(
+            "[Note][ref]\n\n[ref]: /guides/playbook.md", "guides/plain.md"
+        )
+        assert len(links) == 1
+        assert links[0].target_path == "guides/playbook.md"
+
     def test_traversal_above_root_clamped(self) -> None:
         """Path traversal above vault root is clamped to root level."""
         links = extract_links("[Note](../../escape.md)", "a/b/c.md")


### PR DESCRIPTION
Closes #969, refs #959.

## The bug

A vault-root-absolute inline or reference link (`[abs](/guides/playbook.md)`) resolved to target path `//guides/playbook.md` — a doubled leading slash that can never match an indexed path — so every such link landed in `get_broken_links` and produced dead graph edges.

**Cause (verified):** `_resolve_link_path` joins the raw target onto the source directory with `PurePosixPath.__truediv__`. When the right operand is absolute, pathlib *replaces* the base and keeps the leading slash; serializing the parts then yields `//...`.

## The fix

A leading-slash target is now explicitly treated as vault-root-relative — `/guides/note.md` resolves to `guides/note.md` regardless of the source document's location — for both inline and reference links, with fragments preserved. Relative resolution, traversal clamping, and wikilinks are untouched; `raw_target` still preserves the original spelling.

This matters for the OKF epic (#959): bundle-root-absolute links are the OKF spec's *recommended* style, and the phase-4 migration tooling (#963) will emit them — which is why this fix lands first.

## Tests

Three regression tests in `tests/test_links.py` (inline, with-fragment, reference-style), plus an end-to-end verification that `get_outlinks` reports the target as existing and `get_broken_links` is empty. Full suite: **3078 passed**.

## Gates

- `uv run pytest -x -q`: 3078 passed, 13 skipped
- ruff check / format --check: clean
- mypy src/ tests/: clean
- diff-quality structural gate: 100%

## Documentation

- `docs/design/design.md` "Link Extraction" — path-resolution rules now document the leading-slash form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01268CY9P38eZx1JvB9a12Mr

---
_Generated by [Claude Code](https://claude.ai/code/session_01268CY9P38eZx1JvB9a12Mr)_