### PR TITLE
chore: update copier template to v3.1.3

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v3.1.1
+_commit: v3.1.3
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -112,9 +112,16 @@ jobs:
           # Grant the built-in GitHub read/search MCP tools, the CI tools, the
           # inline-comment tool (what lets the reviewer post inline — not in the
           # default allow-set), `gh api` for read-only API access, gh pr/run read
-          # commands, and scoped `uv run` for targeted investigation (REVIEW.md
-          # sets norms). contents: read above keeps the reviewer from committing —
-          # it only reads and comments.
+          # commands, scoped `uv run` for targeted investigation (REVIEW.md sets
+          # norms), and Task. contents: read above keeps the reviewer from
+          # committing — it only reads and comments.
+          #
+          # Task is required: the /code-review plugin fans out into review
+          # subagents via the Task tool. Tag mode's fixed allow-set omits it, so
+          # under acceptEdits + headless (no prompt handler) each dispatch is
+          # silently denied and the review stalls with no findings. Subagents
+          # inherit this same set under contents: read — delegation, not new
+          # capability.
           claude_args: |
-            --allowedTools "mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,mcp__github_ci__*,mcp__github_inline_comment__*,Bash(gh api *),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"
+            --allowedTools "Task,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,mcp__github_ci__*,mcp__github_inline_comment__*,Bash(gh api *),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,9 +54,15 @@ jobs:
           include_fix_links: false
 
           # Grant the built-in GitHub MCP servers' read/search/CI tools, the
-          # inline-comment tool, and `gh api` for read-only GitHub access. These
-          # ADD to the action's defaults (Edit/Write/git stay available), but
-          # `contents: read` above is what keeps this workflow from committing.
+          # inline-comment tool, `gh api` for read-only GitHub access, and Task.
+          # These ADD to the action's defaults (Edit/Write/git stay available),
+          # but `contents: read` above is what keeps this workflow from committing.
+          #
+          # Task lets @claude fan out into parallel subagents: it dispatches them
+          # via the Task tool, which tag mode's fixed allow-set omits, so under
+          # acceptEdits + headless (no prompt handler) every dispatch is silently
+          # denied and the run stalls. Subagents inherit this same curated set
+          # under `contents: read`, so Task adds delegation, not new capability.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           claude_args: |
-            --allowedTools "mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,mcp__github_ci__*,mcp__github_inline_comment__*,Bash(gh api *)"
+            --allowedTools "Task,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,mcp__github_ci__*,mcp__github_inline_comment__*,Bash(gh api *)"


### PR DESCRIPTION
## Summary

Adopts template patch releases **v3.1.2** and **v3.1.3** from `pvliesdonk/fastmcp-server-template` (was pinned to `v3.1.1`).

The one material change is the `Task` grant to the Claude CI workflows; everything else is a no-op here.

## Template delta (v3.1.1 → v3.1.3)

| PR | Release | Effect on this project |
|----|---------|------------------------|
| #310 / #313 | v3.1.3 | **Adopted.** Add `Task` to the `claude.yml` and `claude-code-review.yml` allow-sets. Without it, `/code-review` and `@claude` cannot fan out into subagents under `acceptEdits` + headless — each dispatch is silently denied and the run stalls with no findings. This restores the automated review this repo relies on as a merge gate. Subagents inherit the same curated set under `contents: read`, so it adds delegation, not capability. |
| #309 | v3.1.2 | **No-op.** Template added transfer-subsystem *example comments* to the `DOMAIN-WIRING` block. This project already implements that wiring (#981), so the examples are dropped on merge and the real wiring is preserved. |
| — | v3.1.2 | Template bumped `fastmcp-pvl-core` floor `>=4.6.1` → `>=4.8.0`. This project already pins `>=4.9.0`, which is kept (no downgrade). |

## Net change (config-only)

- `.copier-answers.yml`: `_commit` `v3.1.1` → `v3.1.3`
- `.github/workflows/claude.yml`: add `Task` to `allowedTools`
- `.github/workflows/claude-code-review.yml`: add `Task` to `allowedTools`

`src/markdown_vault_mcp/server.py` and `pyproject.toml` are **byte-identical to `main`** after resolving the two expected `copier update` conflicts (keep project wiring; keep `>=4.9.0`). No Python changes.

## Verification

- `copier update --vcs-ref v3.1.3` ran clean (exit 0); two expected sentinel/pin conflicts resolved in favour of the project.
- Both workflow YAML files parse; `ruff check`, `ruff format`, and `mypy src/ tests/` pass.
- No test/coverage/structural impact — the diff adds no Python.

## Documentation

None required — internal CI tooling and a template-ref bump; nothing user-facing changes.

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcoD5hM8esRpbLudjnpj56

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcoD5hM8esRpbLudjnpj56)_