### PR TITLE
fix(embeddings): skip malformed-frontmatter files in build_embeddings

### DIFF
--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -949,7 +949,7 @@ class IndexManager:
                     self._chunk_strategy,
                     title_field=self._title_field,
                 )
-            except (UnicodeDecodeError, OSError) as exc:
+            except (UnicodeDecodeError, OSError, yaml.YAMLError) as exc:
                 logger.warning("build_embeddings: skipping %s — %s", path, exc)
                 continue
             note_texts, note_meta = self._embed_inputs(

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1011,6 +1011,59 @@ class TestBuildEmbeddings:
         assert count >= 1  # build did not abort
         assert any("skip" in r.getMessage().lower() for r in caplog.records)
 
+    def test_build_embeddings_skips_malformed_frontmatter(self, tmp_path, caplog):
+        """A file whose frontmatter broke after indexing is skipped, not fatal (#955)."""
+        import logging
+
+        from tests.conftest import MockEmbeddingProvider
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text(
+            "---\ntitle: Good\n---\n# Good\n\nBody that should embed.\n",
+            encoding="utf-8",
+        )
+        (vault / "bad.md").write_text(
+            "---\ntitle: Fine\n---\n# Bad\n\nOriginal valid content.\n",
+            encoding="utf-8",
+        )
+        holder = {"vectors": None}
+        embeddings_path = tmp_path / "embeddings"
+        mgr, _fts, _ = _make_index_mgr(
+            vault,
+            tmp_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=MockEmbeddingProvider(),
+            get_vectors=lambda: holder["vectors"],
+            set_vectors=lambda v: holder.__setitem__("vectors", v),
+        )
+        # Both notes index fine with valid frontmatter → both land in FTS.
+        mgr.build_index()
+        assert len(mgr._fts.list_notes()) == 2
+
+        # Now corrupt bad.md's frontmatter on disk (warm-boot / edit-after-index path):
+        # it is still an FTS row, but re-parsing it raises yaml.YAMLError.
+        (vault / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\nbody",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            # force=True drives the cold-build parse loop that re-parses FTS rows
+            # from disk. Today this raises yaml.YAMLError and aborts.
+            count = mgr.build_embeddings(force=True)
+
+        # The run did not abort, and the good note's chunks were embedded.
+        assert count >= 1
+        # The malformed file was skipped with a warning naming it.
+        assert any(
+            "build_embeddings: skipping" in r.getMessage()
+            and "bad.md" in r.getMessage()
+            for r in caplog.records
+        )
+
     def test_build_embeddings_all_batches_fail_escalates(self, tmp_path, caplog):
         """Every batch failing returns 0, saves nothing, warns loudly (#649)."""
         import logging


### PR DESCRIPTION
## Summary

`IndexManager.build_embeddings` aborted the entire embedding run when a
single file's frontmatter was malformed. The cold-build parse loop re-parses
every FTS-indexed note from disk; its exception guard caught only
`(UnicodeDecodeError, OSError)`, so a `yaml.YAMLError` (`yaml.scanner.ScannerError`
is a subclass) from one broken file propagated and killed the whole run — one
bad file anywhere blocked the semantic index.

## Change

One line: add `yaml.YAMLError` to the existing catch tuple in the cold-build
parse loop (`managers/index.py:952`):

```python
except (UnicodeDecodeError, OSError, yaml.YAMLError) as exc:
    logger.warning("build_embeddings: skipping %s — %s", path, exc)
    continue
```

`yaml` is already imported at `index.py:18`. The malformed file is logged at
`WARNING` and skipped; every other note embeds and the sidecar saves. This
matches the resilience already present in the sibling paths:
`process_dirty_paths` (`:1396`), `flush_dirty_embeddings` (`:1473`, which also
catches `ValueError`), and `DocumentManager.read` (`document.py:359`).

## How the cold path hits it

`build_index` skips malformed-frontmatter files at scan time (via
`parse_note_categorized`), so they never enter FTS and `build_embeddings` only
re-parses files that *were* indexable. The trigger is the warm-boot /
corrupt-after-index path: a note is indexed with valid frontmatter, its
frontmatter later breaks on disk (editor mistake) before a reindex reconciles
it, and a subsequent `build_embeddings(force=True)` (or a cold build against
the preserved FTS index) re-parses it and raises `yaml.YAMLError`.

The convergence path (`_converge_embeddings`) reads `self._fts.list_chunks()`
and does not re-parse from disk, so it is unaffected by this change.

## Scope deliberately excluded

- **No `ValueError`** (chunker validation) added, though `flush_dirty_embeddings`
  catches it. The issue is frontmatter; chunker failures are a separate concern.
- **No convergence-path change** — no disk parse, no frontmatter exposure.
- **No tracker / `skip_reasons` recording** — the existing
  `UnicodeDecodeError`/`OSError` skip in this same loop records nothing, and
  `build_embeddings` does not own tracker state.
- **No broad `except Exception`** — narrow catches are the codebase convention.

## Test

`test_build_embeddings_skips_malformed_frontmatter` reproduces the real trigger:
two notes with valid frontmatter are indexed (both land in FTS), one is then
corrupted on disk (`---\ntitle: [unclosed\n---\nbody` — the same malformed
fixture used by `test_invalid_yaml_file_appears_in_skip_reasons`), and
`build_embeddings(force=True)` is called. It asserts: no raise, the good note's
chunks embed (`count >= 1`), and a `WARNING` naming the bad path is logged.

Closes #955