### PR TITLE
fix(git): retry failed deferred pushes on the periodic pull-loop tick

### DIFF
--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -454,12 +454,14 @@ class GitWriteStrategy:
             logger.error("Git push failed", exc_info=True)
 
     def _do_push(self) -> None:
-        """Execute git push and clear pending flag.
+        """Execute git push and clear the pending flag on success.
 
-        Note: ``_push_pending`` is cleared *before* calling ``_push()``.
-        If the push fails, commits are not automatically retried — they
-        will be pushed on the next write (which resets ``_push_pending``)
-        or on the next startup via ``_push_if_unpushed()``.
+        ``_push_pending`` is cleared *after* ``_push()`` returns without
+        raising. On failure the flag stays set so the periodic pull loop
+        retries the push after its rebase step resolves any non-fast-forward
+        divergence (#957); previously the flag was cleared before the push,
+        so a failed deferred push left commits local with no retry until the
+        next write or startup.
         """
         with self._lock:
             if (
@@ -468,10 +470,8 @@ class GitWriteStrategy:
                 or self._git_root is None
             ):
                 return
-            self._push_pending = False
-
-        with self._lock:
             _push(self._git_root, self._token, self._username)
+            self._push_pending = False
             logger.info("Git: pushed to remote")
 
     def _check_identity(self) -> None:

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1567,6 +1567,11 @@ class GitWriteStrategy:
                     else:
                         with pause():
                             self._on_pull()
+                # Retry a pending push after the pull reconciled any
+                # non-fast-forward divergence via its rebase step (#957).
+                # _do_push's guard makes this a no-op when nothing is pending.
+                if self._enable_push:
+                    self._do_push_safe()
             except Exception:
                 logger.exception("Git pull loop tick failed")
             # Wait until the next interval, or stop early.

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2627,6 +2627,47 @@ class TestGitPullLoop:
         assert "local commit" in log
         assert strategy._push_pending is False
 
+    def test_pull_loop_skips_push_retry_when_push_disabled(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The pull-loop push retry is skipped when push is disabled (#957).
+
+        A push-disabled deployment keeps no off-site copy by design, so the
+        pull loop must not attempt a retry push after a tick even when a push
+        is pending. Covers the False branch of the ``_enable_push`` gate.
+        """
+        import time
+        from types import SimpleNamespace
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0, enable_push=False)
+
+        monkeypatch.setattr(strategy, "_ensure_git_root", lambda _p: tmp_path)
+        monkeypatch.setattr(
+            "markdown_vault_mcp.git.subprocess.run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            ),
+        )
+        monkeypatch.setattr(strategy, "sync_once", lambda _p: True)
+
+        # A pending push exists, and the retry hook is observable.
+        strategy._push_pending = True
+        safe_calls: list[str] = []
+        monkeypatch.setattr(
+            strategy, "_do_push_safe", lambda: safe_calls.append("push")
+        )
+
+        strategy.start(repo_path=tmp_path, pull_interval_s=3600)
+        time.sleep(0.05)
+        strategy.stop()
+
+        # The gate skipped the retry: the pending flag is unchanged and the
+        # retry hook was never invoked.
+        assert safe_calls == []
+        assert strategy._push_pending is True
+
 
 class TestManagedGitMode:
     def test_managed_mode_clones_into_empty_source_dir(

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -778,6 +778,39 @@ class TestGitWriteStrategyClass:
         assert "local only" in result.stdout
         assert "write: trigger.md" in result.stdout
 
+    def test_do_push_keeps_pending_on_failure(self, tmp_path: Path) -> None:
+        """A failed push leaves _push_pending set so the pull loop retries (#957)."""
+        from unittest.mock import patch
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        fake_exc = subprocess.CalledProcessError(
+            returncode=128,
+            cmd=["git", "push", "origin"],
+            stderr="non-fast-forward",
+        )
+        with patch("markdown_vault_mcp.git.strategy._push", side_effect=fake_exc):
+            # _do_push_safe swallows the error; the flag must stay set.
+            strategy._do_push_safe()
+
+        assert strategy._push_pending is True
+
+    def test_do_push_clears_pending_on_success(self, tmp_path: Path) -> None:
+        """A successful push clears _push_pending (#957)."""
+        from unittest.mock import patch
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        with patch("markdown_vault_mcp.git.strategy._push") as mock_push:
+            strategy._do_push()
+
+        assert mock_push.called
+        assert strategy._push_pending is False
+
 
 class TestConfigIntegration:
     def test_git_token_wires_up_strategy(self, tmp_path: Path) -> None:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -12,6 +12,8 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from tests.fixtures.git import GitRepoPair
+
 from markdown_vault_mcp.config import to_vault_kwargs
 from markdown_vault_mcp.git import (
     GitWriteStrategy,
@@ -2530,6 +2532,100 @@ class TestGitPullLoop:
         assert strategy._pull_thread.is_alive()
 
         strategy.stop()
+
+    def test_pull_loop_retries_pending_push(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The pull loop attempts a pending push after each tick (#957)."""
+        import time
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+
+        # Mirror the existing TestGitPullLoop setup so start() launches the
+        # loop: a fake git root and a subprocess.run stub for the tracking-ref
+        # check inside start().
+        monkeypatch.setattr(strategy, "_ensure_git_root", lambda _p: tmp_path)
+        monkeypatch.setattr(
+            "markdown_vault_mcp.git.subprocess.run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            ),
+        )
+        monkeypatch.setattr(strategy, "sync_once", lambda _repo: True)
+        strategy._git_root = tmp_path
+        # Simulate a deferred push that failed and left the flag set.
+        strategy._push_pending = True
+
+        push_calls: list[int] = []
+        with patch(
+            "markdown_vault_mcp.git.strategy._push",
+            side_effect=lambda *_a, **_k: push_calls.append(1),
+        ):
+            strategy.start(repo_path=tmp_path, pull_interval_s=3600)
+            time.sleep(0.05)
+            strategy.stop()
+
+        assert push_calls, "pull loop did not retry the pending push"
+
+    def test_pull_loop_retries_after_non_ff_rebase(
+        self,
+        git_repo_pair: GitRepoPair,
+        tmp_path: Path,
+    ) -> None:
+        """A non-ff push failure is retried after the pull tick rebases (#957)."""
+        import time
+
+        from tests.fixtures.git import _run_git
+
+        remote = git_repo_pair.remote_path
+        local = git_repo_pair.local_path
+
+        # A second clone of the same bare remote -- the "other client" that
+        # advances the remote and makes the strategy's local non-fast-forward.
+        other = tmp_path / "other"
+        _run_git(tmp_path, "clone", str(remote), str(other))
+        _run_git(other, "config", "user.email", "other@example.com")
+        _run_git(other, "config", "user.name", "Other")
+        (other / "other.md").write_text("other\n")
+        _run_git(other, "add", "other.md")
+        _run_git(other, "commit", "-m", "other commit")
+        _run_git(other, "push", "origin", "main")
+        # The bare remote now has a commit the strategy's local has not seen.
+
+        # The strategy owns `local`. repo_path=local makes the constructor's
+        # validate_startup() populate self._git_root. Make a local commit so
+        # there is something to push, set the pending flag (simulating a
+        # deferred push that has not fired), then attempt the push -- it must
+        # fail non-ff and leave the flag set (Task 1's invariant).
+        strategy = GitWriteStrategy(token=None, push_delay_s=0, repo_path=local)
+        (local / "local.md").write_text("local\n")
+        _run_git(local, "add", "local.md")
+        _run_git(local, "commit", "-m", "local commit")
+        strategy._push_pending = True
+        strategy._do_push_safe()
+        assert strategy._push_pending is True
+
+        # Start the pull loop with a long interval so exactly one tick fires.
+        # The tick fetches (sees the other client's commit), the ff-only merge
+        # diverges, the rebase replays the local commit on top, then the retry
+        # push succeeds and clears the flag. Poll until the flag clears.
+        strategy.start(repo_path=local, pull_interval_s=3600)
+        try:
+            deadline = time.time() + 5.0
+            while strategy._push_pending and time.time() < deadline:
+                time.sleep(0.05)
+        finally:
+            strategy.stop()
+
+        # The retry push succeeded: the bare remote now carries the local
+        # commit, and the pending flag was cleared.
+        log = _run_git(remote, "log", "--oneline")
+        assert "local commit" in log
+        assert strategy._push_pending is False
 
 
 class TestManagedGitMode:


### PR DESCRIPTION
## Summary

`GitWriteStrategy._do_push` cleared `_push_pending` *before* calling `_push`
(two lock blocks); on failure (non-fast-forward rejection racing an upstream
advance, or a transient network error) the flag was already `False`, so
nothing retried until the next write or startup. The last write of the day
could sit local with no off-site copy for an unbounded time (a 20-hour window
was measured in practice).

## Change

Two parts:

**1. Keep `_push_pending` set on push failure** (`git/strategy.py`, `_do_push`)

Collapse the two lock blocks into one that holds across the guard check, the
push, and the clear — so the flag is cleared only after `_push` returns
without raising:

```python
def _do_push(self) -> None:
    with self._lock:
        if (not self._enable_push or not self._push_pending
                or self._git_root is None):
            return
        _push(self._git_root, self._token, self._username)
        self._push_pending = False
        logger.info("Git: pushed to remote")
```

`_push` raising propagates out (skipping the clear) to `_do_push_safe`, which
logs it. The single block preserves the mutual exclusion the two-block gave:
the lock is held across push + clear, so a racing timer or pull-loop attempt
that acquires the lock next sees the flag resolved (`False` on success →
bail; `True` on failure → retry), never a double push. The old block-2
already held `self._lock` across the push's network round-trip, so collapsing
does not extend the critical section. The push path takes no file-write lock,
so the `_quiesce_writes` deadlock invariant is respected.

**2. Retry the pending push from the periodic pull loop** (`git/strategy.py`, `_pull_loop`)

After each `sync_once` (and the `_on_pull` callback), attempt a push retry
when push is enabled:

```python
if self._enable_push:
    self._do_push_safe()
```

`_do_push`'s guard makes this a cheap no-op (lock + flag check, return) when
nothing is pending. When the flag *is* set, the retry fires after the pull's
fetch + rebase has reconciled non-ff divergence and the fetch confirmed the
network is back — so the push succeeds and clears the flag.

## Failure modes addressed

- **Non-ff rejection** (remote advanced): flag stays set → pull tick rebases
  local onto remote → retry push succeeds.
- **Transient network error**: flag stays set → next pull tick's fetch
  confirms the network → retry push succeeds.
- **Persistent outage / wedged conflict**: flag stays set; each tick logs the
  fetch and push failures; repeats until resolved. No worse than today, and
  surfaced rather than silently dormant.

## Scope deliberately excluded

- **No retry timer for the no-pull deployment** (`enable_pull=False`):
  push-without-pull (a write-only/backup shape) cannot auto-resolve non-ff
  without a pull, so a timer would only help transient-network there. It keeps
  today's behaviour (retry on next write or startup).
- **No retry from the interactive `force_pull` / `git_sync(direction='pull')`
  path** — user-driven; auto-pushing after it would couple the two tools
  unexpectedly.
- **No backoff / jitter** — the pull interval (default 600 s) is the natural
  retry cadence.
- **No docs update** — no user-facing behaviour change beyond "a failed
  deferred push is retried on the next periodic pull tick instead of sitting
  local indefinitely"; no docs page promises the old no-retry behaviour.

## Test

Four tests in `tests/test_git.py`:

- `test_do_push_keeps_pending_on_failure` — patches `_push` to raise
  `CalledProcessError`; asserts `_push_pending is True` after `_do_push_safe`
  (fails on the old clear-before-push code).
- `test_do_push_clears_pending_on_success` — patches `_push` to a no-op;
  asserts the flag cleared (regression guard).
- `test_pull_loop_retries_pending_push` — sets the flag, `start()` the loop,
  asserts `_push` was invoked from the tick.
- `test_pull_loop_retries_after_non_ff_rebase` — integration: a second clone
  advances the bare remote; the strategy's local commit fails non-ff (flag
  stays set); one pull tick fetches + rebases; the retry push succeeds and the
  remote carries the commit, with the flag cleared.

Suite: 3203 passed, 9 skipped. ruff/mypy clean, structural diff-quality 100%.

Closes #957

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._