### PR TITLE
fix: honour process umask for newly created files (#958)

### DIFF
--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import base64
 import logging
 import mimetypes
+import os
 import shutil
 import sqlite3
 import tempfile
+import threading
 from collections import defaultdict
 from dataclasses import replace
 from pathlib import Path
@@ -71,13 +73,44 @@ from markdown_vault_mcp.utils.text import (
 )
 
 if TYPE_CHECKING:
-    import threading
     from collections.abc import Callable, Iterable
 
     from markdown_vault_mcp.fts_index import FTSIndex
     from markdown_vault_mcp.scanner import ChunkStrategy
 
 logger = logging.getLogger(__name__)
+
+
+_UMASK_LOCK = threading.Lock()
+_umask: int | None = None
+
+
+def _process_umask() -> int:
+    """Return the process umask, read once and cached.
+
+    ``os.umask`` is set-and-restore with no read-only accessor; we read it
+    once under a lock so concurrent writers serialise the set-and-restore
+    and never observe a transient mask. The umask is set by the parent
+    (shell / systemd) before Python starts and is effectively immutable
+    for the service lifetime, so a one-time read is correct.
+    """
+    global _umask
+    if _umask is not None:
+        return _umask
+    with _UMASK_LOCK:
+        # The lock serialises the set-and-restore so no writer in this
+        # module observes a transient mask. A second writer that lost the
+        # outer cache check re-reads and re-sets the same value (the umask
+        # is process-global), so no inner guard is needed.
+        mask = os.umask(0o077)
+        os.umask(mask)
+        _umask = mask
+    return _umask
+
+
+def _new_file_mode() -> int:
+    """Mode for a freshly-created file, matching a plain ``open(path, "w")``."""
+    return 0o666 & ~_process_umask()
 
 
 class DocumentManager:
@@ -630,13 +663,17 @@ class DocumentManager:
         """Write *data* to *abs_path* atomically via a sibling tempfile.
 
         The temp file lands with :meth:`Path.replace` semantics; permission
-        bits are preserved when the target already exists. On failure the
-        temp file is removed and the original is left untouched.
+        bits are preserved when the target already exists. A freshly-created
+        target is chmod'd to ``0o666 & ~umask`` after the replace so fresh
+        writes honour the process umask (matching a plain ``open``) instead
+        of the ``0o600`` ``tempfile`` hardcodes. On failure the temp file is
+        removed and the original is left untouched.
 
         Args:
             abs_path: Absolute destination path.
             data: Text (written UTF-8) or raw bytes.
         """
+        existed = abs_path.is_file()
         if isinstance(data, str):
             with tempfile.NamedTemporaryFile(
                 dir=abs_path.parent,
@@ -656,13 +693,15 @@ class DocumentManager:
             ) as tmp:
                 tmp.write(data)
                 tmp_name = tmp.name
-        if abs_path.is_file():
+        if existed:
             shutil.copymode(abs_path, tmp_name)
         try:
             Path(tmp_name).replace(abs_path)
         except Exception:
             Path(tmp_name).unlink(missing_ok=True)
             raise
+        if not existed:
+            abs_path.chmod(_new_file_mode())
 
     def write(
         self,

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -2022,19 +2022,18 @@ class TestAtomicWrites:
             f"new attachment mode is {oct(mode)}, expected 0o640 (0o666 & ~0o027)"
         )
 
-    def test_process_umask_reads_once_and_caches(self) -> None:
-        """_process_umask reads the umask once and caches it thereafter."""
+    def test_process_umask_caches_across_calls(self) -> None:
+        """_process_umask caches: repeat calls return the same value."""
         from markdown_vault_mcp.managers import document as doc
 
-        doc._umask = None  # reset cache for the test
+        doc._umask = None
         try:
             first = doc._process_umask()
             second = doc._process_umask()
             assert first == second
-            # The cache is populated.
             assert doc._umask == first
         finally:
-            doc._umask = None  # drop the cache so later tests re-read ambient
+            doc._umask = None  # test isolation: later tests re-read ambient
 
     def test_write_attachment_preserves_original_on_failed_write(
         self, writable: Vault, vault_path: Path

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import concurrent.futures
 import json
 import logging
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -1984,6 +1985,56 @@ class TestAtomicWrites:
         assert mode == 0o644, (
             f"write_attachment() changed file permissions from 0o644 to {oct(mode)}"
         )
+
+    def test_write_new_file_honours_umask(
+        self, writable: Vault, vault_path: Path
+    ) -> None:
+        """A freshly written document lands at 0o666 & ~umask, not tempfile's 0o600."""
+        from markdown_vault_mcp.managers import document as doc
+
+        old = os.umask(0o027)
+        doc._umask = None  # force a re-read of the umask we just set
+        try:
+            writable.writer.write("umask_new.md", "content")
+        finally:
+            os.umask(old)
+            doc._umask = None  # drop the cache so later tests re-read ambient
+        mode = (vault_path / "umask_new.md").stat().st_mode & 0o777
+        assert mode == 0o640, (
+            f"new file mode is {oct(mode)}, expected 0o640 (0o666 & ~0o027)"
+        )
+
+    def test_write_attachment_new_file_honours_umask(
+        self, writable: Vault, vault_path: Path
+    ) -> None:
+        """A freshly written attachment lands at 0o666 & ~umask, not 0o600."""
+        from markdown_vault_mcp.managers import document as doc
+
+        old = os.umask(0o027)
+        doc._umask = None
+        try:
+            writable.writer.write_attachment("attach_new.png", b"\x89PNG\r\n\x1a\n")
+        finally:
+            os.umask(old)
+            doc._umask = None
+        mode = (vault_path / "attach_new.png").stat().st_mode & 0o777
+        assert mode == 0o640, (
+            f"new attachment mode is {oct(mode)}, expected 0o640 (0o666 & ~0o027)"
+        )
+
+    def test_process_umask_reads_once_and_caches(self) -> None:
+        """_process_umask reads the umask once and caches it thereafter."""
+        from markdown_vault_mcp.managers import document as doc
+
+        doc._umask = None  # reset cache for the test
+        try:
+            first = doc._process_umask()
+            second = doc._process_umask()
+            assert first == second
+            # The cache is populated.
+            assert doc._umask == first
+        finally:
+            doc._umask = None  # drop the cache so later tests re-read ambient
 
     def test_write_attachment_preserves_original_on_failed_write(
         self, writable: Vault, vault_path: Path


### PR DESCRIPTION
## Summary

`DocumentManager._atomic_write` writes via `tempfile.NamedTemporaryFile` + `Path.replace`. `tempfile` hardcodes the temp file's mode to `0o600` (stdlib security default). For an **overwrite**, `shutil.copymode` preserves the existing file's mode — unaffected. But for a **new** target there is no existing file to copy from, so after the atomic replace the new document landed at `0o600` regardless of the process umask. A systemd unit setting `UMask=0027` to keep state group-readable (`0o640`) was silently defeated: every fresh MCP write was owner-only until a `git checkout` or manual `chmod` reset it.

## Fix

In `_atomic_write`, capture whether the target existed **before** the replace (`existed = abs_path.is_file()`), then after a successful replace of a **new** file, `abs_path.chmod(0o666 & ~umask)` — exactly the mode a plain `open(path, "w")` would produce. Overwrites keep `copymode` (unchanged behaviour).

The umask is read once and cached (`_process_umask` under a lock, since `os.umask` is set-and-restore with no read-only accessor). The process umask is set by the parent (shell / systemd) before Python starts and is effectively immutable for the service lifetime, so a one-time read is correct.

Four callers funnel through `_atomic_write` (`write`, `write_attachment`, `edit`, `_rewrite_links_in_source`); only `write` and `write_attachment` create new files, so this covers the issue's scope.

## Tests

Three tests in `tests/test_vault.py` (`TestAtomicWrites`): new document and new attachment land at `0o640` under `umask 0o027`; the umask helper caches across calls. Existing overwrite-mode-preservation tests continue to pass (overwrites keep `copymode`). Gates: 3207 passed / 9 skipped, ruff + mypy clean, structural diff-quality 100%, all new branches 100% covered.

## Scope excluded

No migration of existing `0o600` files (new files only — a migration would override deliberate restrictive `chmod`); no config option (behaviour matches `open()`); no change to overwrite handling or `tempfile` creation.

Closes #958.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._