### PR TITLE
refactor(git): single-source WriteOperation alias in strategy.py

### DIFF
--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -13,12 +13,12 @@ import re
 import subprocess
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
-    from markdown_vault_mcp.types import CommitDiff, HistoryEntry
+    from markdown_vault_mcp.types import CommitDiff, HistoryEntry, WriteOperation
 
 from fastmcp.server.dependencies import get_access_token as _get_access_token
 
@@ -359,7 +359,7 @@ class GitWriteStrategy:
         self,
         path: Path,
         content: str,  # noqa: ARG002
-        operation: Literal["write", "edit", "delete", "rename"],
+        operation: WriteOperation,
     ) -> None:
         """WriteCallback interface: stage + commit, then schedule push."""
         if self._closed:
@@ -1789,7 +1789,7 @@ def _sanitize_git_identity(value: str) -> str:
 def _stage_and_commit(
     git_root: Path,
     path: Path,
-    operation: Literal["write", "edit", "delete", "rename"],
+    operation: WriteOperation,
     commit_name: str = GitWriteStrategy.DEFAULT_COMMIT_NAME,
     commit_email: str = GitWriteStrategy.DEFAULT_COMMIT_EMAIL,
     author_name: str | None = None,


### PR DESCRIPTION
## What

The `WriteOperation` type alias (`Literal["write", "edit", "delete", "rename"]`, canonically defined at `types.py:799`) was hand-redeclared inline in two places in `git/strategy.py` instead of imported, so the "these are the only valid write-operation kinds" invariant had three independent definitions the type checker could not keep in sync.

This imports the canonical alias and deletes the two divergent copies:
- `GitWriteStrategy.__call__` (was `strategy.py:362`)
- `_stage_and_commit` (was `strategy.py:1787`)

`WriteOperation` is added to the existing `if TYPE_CHECKING:` import from `markdown_vault_mcp.types` — safe because the module already has `from __future__ import annotations`, so the annotation resolves lazily, exactly like the neighbouring `CommitDiff`/`HistoryEntry` imports. `Literal` is dropped from the `typing` import since those two sites were its only uses.

Three other modules (`_okf_convention.py`, `_okf_write.py`, `write_callback.py`) already imported the alias correctly — these two were the last divergent copies. A future widening of the operation set (e.g. adding `append`) is now a one-line edit in `types.py` instead of a hand-sync across three files, and a divergence from the canonical alias is a type error rather than silent drift.

## Scope

**Type-level only, zero behavior change.** The prose/docstring de-enumeration originally bundled with this issue (the `vault.py` docstring, `design.md`, README, generated config surface) is a different and much larger class of change, deliberately out of scope here and tracked separately as #1007.

## Verification

- `uv run mypy src/ tests/` — clean (187 files)
- `uv run ruff check` / `ruff format --check` — clean
- structural diff gate — 100% (4 lines, 0 violations)
- `uv run pytest` — 3257 passed, 18 skipped (pre-existing, unrelated)
- preflight circus — clear, 0 findings across 11 lenses

No docs or version-manifest changes (internal type-level refactor).

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)