### PR TITLE
docs: de-enumerate incidental write-op shorthand in docstrings and spec

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -80,12 +80,20 @@ from markdown_vault_mcp.types import NoteContent, GroupedResult, SectionHit, Not
 
 ## Callbacks
 
-**`WriteCallback`**
+**`WriteOperation`**
 
-Type alias for the `on_write` callback passed to `Vault`. Called after each successful write operation (write, edit, delete, rename).
+Type alias for the kind of write operation reported to callbacks. `WriteCallback` and the `op` argument below both reference it.
 
 ```python
-WriteCallback = Callable[[Path, str, Literal["write", "edit", "delete", "rename"]], None]
+WriteOperation = Literal["write", "edit", "delete", "rename"]
+```
+
+**`WriteCallback`**
+
+Type alias for the `on_write` callback passed to `Vault`. Called after each successful write operation.
+
+```python
+WriteCallback = Callable[[Path, str, WriteOperation], None]
 ```
 
 Arguments received by the callback:
@@ -94,4 +102,4 @@ Arguments received by the callback:
 |----------|------|-------------|
 | `path` | `Path` | Absolute path of the modified file |
 | `content` | `str` | New file content (empty string for binary attachments and deletes) |
-| `op` | `Literal[...]` | Operation type: `"write"`, `"edit"`, `"delete"`, or `"rename"` |
+| `op` | `WriteOperation` | Which write operation fired (see `WriteOperation` above) |

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1934,7 +1934,7 @@ class Vault:
 `IndexFacet.build_index`; the server builds at startup, and a cold on-disk
 start builds in the background (#513). No lazy build on first query.
 
-**Write operations** (`write`, `edit`, `delete`, `rename`) raise
+**Write operations** raise
 `ReadOnlyError` when `read_only=True`.
 
 **`write()` behavior**: creates or overwrites the document at `path`. Creates
@@ -2033,7 +2033,8 @@ matched against the relative path using `fnmatch.fnmatch()`. Example:
 **`on_write` callback**:
 
 ```python
-WriteCallback = Callable[[Path, str, Literal["write", "edit", "delete", "rename"]], None]
+WriteOperation = Literal["write", "edit", "delete", "rename"]
+WriteCallback = Callable[[Path, str, WriteOperation], None]
 ```
 
 - `path`: absolute path on disk.

--- a/src/markdown_vault_mcp/_server_tools/graph.py
+++ b/src/markdown_vault_mcp/_server_tools/graph.py
@@ -51,10 +51,10 @@ def register(mcp: FastMCP) -> None:
             limit: Maximum number of backlinks to return. Omitted (the
                 default) returns all.
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -131,10 +131,10 @@ def register(mcp: FastMCP) -> None:
             limit: Maximum number of outlinks to return. Omitted (the
                 default) returns all.
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -208,10 +208,10 @@ def register(mcp: FastMCP) -> None:
                 links from documents in this folder (e.g. "Journal").
                 Without this, checks all documents.
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -273,10 +273,10 @@ def register(mcp: FastMCP) -> None:
 
         Args:
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -335,10 +335,10 @@ def register(mcp: FastMCP) -> None:
         Args:
             limit: Maximum number of results to return. Default 10.
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -400,10 +400,10 @@ def register(mcp: FastMCP) -> None:
             target: Vault-relative path of the destination note.
             max_depth: Maximum number of hops to search. Default 10, max 10.
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -84,10 +84,10 @@ def register(mcp: FastMCP) -> None:
                 the server default. Set to 0 to return full chunk content.
                 Use read(path, section=heading) for full section recovery.
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -293,10 +293,10 @@ def register(mcp: FastMCP) -> None:
                 triage listings. Any filter excludes attachments (they
                 carry no frontmatter).
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -356,10 +356,10 @@ def register(mcp: FastMCP) -> None:
 
         Args:
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -413,10 +413,10 @@ def register(mcp: FastMCP) -> None:
                 — passing any other field silently returns an empty list, not an
                 error.
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -466,10 +466,10 @@ def register(mcp: FastMCP) -> None:
 
         Args:
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -563,10 +563,10 @@ def register(mcp: FastMCP) -> None:
                 also matches notes without a status field), stale
                 ("true"/"false"), and trust_tier.
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -661,7 +661,7 @@ def register(mcp: FastMCP) -> None:
                 must be >= 1). When more notes match, the first max_notes (by
                 path) are returned and 'truncated' is True.
             wait_for_pending_writes: When True, wait until recent
-                write/edit/delete/rename operations are applied to the index
+                document mutations are applied to the index
                 before answering. Default False answers from the current
                 index; inspect '_meta.index_stale' to tell whether a write was
                 still in flight. Bounded by a server timeout (default 60s).
@@ -720,10 +720,10 @@ def register(mcp: FastMCP) -> None:
             folder: Optional folder filter. When provided, only returns
                 notes from this folder (e.g. "Journal").
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's
@@ -794,10 +794,10 @@ def register(mcp: FastMCP) -> None:
             link_limit: Maximum number of backlinks and outlinks to include
                 each (default 10).
             wait_for_pending_writes: When True, wait until your recent
-                write/edit/delete/rename operations have been applied to the
+                document mutations have been applied to the
                 index before answering, so the results reflect those changes.
                 Use it right after modifying notes when this read must see
-                them (e.g. right after a write/edit/delete/rename whose
+                them (e.g. right after a document mutation whose
                 effect this read should reflect). Default
                 False answers immediately from the current index — almost
                 always already up to date; inspect the response's

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -547,7 +547,7 @@ class IndexManager:
         Thread-safety: this method runs on the single-owner
         :class:`~markdown_vault_mcp.indexing.IndexWriter` thread (#559), so
         no internal lock is required.  Concurrent
-        write/edit/delete/rename operations route through the writer's
+        document mutations route through the writer's
         FIFO queue and serialise against this job.
 
         Returns:
@@ -1323,7 +1323,7 @@ class IndexManager:
         once over the whole vault so newly-added, edited, deleted, and
         renamed documents all leave the link graph consistent — this
         mirrors the behavior that the pre-#559 inline DocumentManager
-        callsites delivered (write/edit/delete/rename each ended with
+        callsites delivered (every document mutation ended with
         ``resolve_vault_wikilinks()``).
 
         Per-path file-read failures (``OSError``, ``UnicodeDecodeError``),

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -169,7 +169,7 @@ class Vault:
             :class:`~markdown_vault_mcp.scanner.ChunkStrategy` instance.
         on_write: Optional callback invoked after every successful write
             operation.  Signature:
-            ``Callable[[Path, str, Literal["write","edit","delete","rename"]], None]``.
+            :obj:`~markdown_vault_mcp.types.WriteCallback`.
         git_strategy: Optional git strategy used for background git tasks (e.g.
             periodic fetch + ff-only updates). Started via :meth:`start`.
         git_pull_interval_s: Interval in seconds for periodic pulls. ``0``
@@ -699,7 +699,7 @@ class Vault:
         """Block file-mutation write operations until the context exits.
 
         Holds the :attr:`_file_write_lock` so concurrent
-        :class:`DocumentManager` write/edit/delete/rename calls block on
+        :class:`DocumentManager` document-mutation calls block on
         the lock until the context exits. Index mutations on the
         :class:`IndexWriter` thread continue unaffected — the writer
         thread does not contend on this lock.  Reads and search remain


### PR DESCRIPTION
## What

The write-operation set (`write, edit, delete, rename`) is spelled out by name across the docs and docstring surface. Where it appears as **incidental shorthand in a flowing-prose sentence** — a synonym for "a mutation occurred" — this de-enumerates it to the house term **"document mutations"**, and converts the three docstring/reference copies of the `WriteCallback` `Literal` to the `WriteOperation` alias single-sourced in `types.py` (#1006), which realigns the docs with the source.

## Scope rule (applied consistently to the whole class)

- **De-enumerate** flowing-prose sentences: the `wait_for_pending_writes` tool docstrings (`reader.py`/`graph.py`), the `IndexManager` thread-safety and pre-#559 history notes, the vault write-lock docstring, a `design.md` invariant, and a `types.md` prose aside.
- **Keep enumerated** every structured reference where the list *is* the content: the facet/manager responsibility tables **and the one-line surface labels that mirror them** (module docstrings, the project-structure tree in `design.md` + `CLAUDE.md`, the `api/facets.md` section headers), the precise method-signature/exception tables, the write-tag visibility set, the roadmap note, the user-facing tool catalogs, and the canonical `WriteOperation` alias itself.

Keeping the surface labels **together with** their tables is deliberate: de-enumerating a source docstring while leaving its `design.md`/`CLAUDE.md` mirror enumerated would make the source and its own spec disagree (this is the inconsistency a pre-flight review caught on an earlier attempt).

Wording is "document mutations", **not** "write operations", because a distinct MCP tool is named `write`.

## Honest limit

Because the KEEP set genuinely should name the operations, a future operation (e.g. `append`, #980) will still touch them. This removes the *incidental* sweep, not all of it.

## Deferred and tracked

- **#1009** — single-source the user-facing config help + guides + packaging enumerations from the `tags={"write"}` registry (kept enumerated here).
- **#1010** — collapse the duplicated `wait_for_pending_writes` parameter docstrings into a shared fragment (swept in place here).

## Verification

- `uv run mypy src/ tests/` — clean (187 files); `ruff check` / `format --check` — clean; Vale on `docs/api/types.md` — clean.
- `uv run pytest` — 3257 passed, 18 skipped (pre-existing, unrelated).
- Structural diff gate — 100% (33 lines, 0 violations).
- Preflight circus — clear, 0 findings across 11 lenses.

Documentation and docstrings only — no code or behaviour change.

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)