### PR TITLE
chore: update copier template to fastmcp-server-template v3.2.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v3.2.0
+_commit: v3.2.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v3.1.3
+_commit: v3.2.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@
 # MARKDOWN_VAULT_MCP_PORT=8000
 # Public base URL of the deployed server, e.g. `https://mcp.example.com`. Required for OIDC. Also the fallback source of the MCP Apps domain when `app_domain` is unset.
 # MARKDOWN_VAULT_MCP_BASE_URL=https://mcp.example.com
+# Comma-separated explicit tool names this instance exposes; every other tool is hidden from listings and cannot be invoked. Names matching no registered tool are inert. Mutually exclusive with `tools_deny`. Takes effect through `apply_tool_visibility`.
+# MARKDOWN_VAULT_MCP_TOOLS_ALLOW=
+# Comma-separated explicit tool names hidden from this instance (absent from listings, cannot be invoked). Names matching no registered tool are inert. Mutually exclusive with `tools_allow`. Takes effect through `apply_tool_visibility`.
+# MARKDOWN_VAULT_MCP_TOOLS_DENY=
 # Rename this server instance; defaults to the project name.
 # MARKDOWN_VAULT_MCP_SERVER_NAME=
 # Replaces the default MCP instructions text sent to clients.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: >
+  Something isn't working as expected. See CONTRIBUTING.md for what makes a
+  useful bug report. Do not claim a cause you did not verify.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: One sentence, expected vs actual.
+      placeholder: "A one-liner: 'expected X, got Y.'"
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed
+      description: >
+        Describe what you actually saw. Paste the real error text or trace,
+        not a summary of it. Include where it occurred.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+      description: What should have happened.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: >
+        Only include steps you actually ran and the version/commit you
+        actually checked.
+    validations:
+      required: true
+  - type: textarea
+    id: suspected-cause
+    attributes:
+      label: Suspected cause
+      description: >
+        Do **not** claim a cause you did not verify. If you haven't checked,
+        say so, mark the line `[unverified]`, and add the sentence "I have
+        not verified the cause." If you did check, write `[verified: how]`.
+    validations:
+      required: false
+  - type: textarea
+    id: open-questions
+    attributes:
+      label: Open questions / scope
+      description: >
+        Unknowns the implementer should verify (mark each `[unverified]`).
+        What this issue is *not* about.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/decay.yml
+++ b/.github/ISSUE_TEMPLATE/decay.yml
@@ -1,0 +1,36 @@
+name: Decay / structural debt
+description: >
+  An observation of structural decay worth refactoring later, not a bug or
+  feature. Constrain this to decay that will compound, not anything
+  imperfect. See CONTRIBUTING.md.
+title: "[Decay]: "
+labels: ["decay"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: The structural problem in one sentence.
+    validations:
+      required: true
+  - type: textarea
+    id: where
+    attributes:
+      label: Where
+      description: File/symbol and the metric or observation that flagged it.
+    validations:
+      required: true
+  - type: textarea
+    id: why-it-compounds
+    attributes:
+      label: Why it compounds
+      description: What gets harder or riskier if it's left.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: A starting point, not a prescribed refactor.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: >
+  Suggest a new feature or enhancement. Describe the problem, not a
+  solution. See CONTRIBUTING.md for what makes a useful request.
+title: "[Feature]: "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: >
+        Describe the problem or unmet need, not a solution. Who hits it,
+        and when?
+    validations:
+      required: true
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the outcome, not how to implement it.
+    validations:
+      required: true
+  - type: textarea
+    id: implementation-ideas
+    attributes:
+      label: Implementation ideas
+      description: >
+        Non-binding starting points only. This issue does not prescribe an
+        implementation.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,19 @@
+name: Question / support
+description: >
+  Ask a question or request support. Keeps these out of the bug and
+  feature queues.
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What I've already tried
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Closes / Refs
+
+Closes #N  (or `Refs #N` if not closing)
+
+> **No orphan PRs.** Create the issue first if none exists. Pure typo fixes
+> and Renovate dependency bumps excepted.
+
+## What & why
+
+One or two sentences, in observation terms: what changed, and why.
+
+## What this PR deliberately does NOT do
+
+List each deferral with its tracking issue number. A change that says what
+it deliberately did not do is easier to trust than one that appears to have
+found nothing.
+
+- (deferral): #N
+
+## Local review
+
+- [ ] Ran a local code-review pass on the cumulative diff before `gh pr create`.
+
+## Docs impact
+
+- [ ] `README.md`
+- [ ] `docs/` site pages
+- [ ] `docs/design/`
+- [ ] Inline docstrings
+
+**Rule: code without matching docs is incomplete.**

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -2,8 +2,9 @@ name: Bootstrap repo
 
 # Seeds repository state that checked-in config references but GitHub does not
 # create on its own:
-#   1. The `dependencies` label Renovate applies to its PRs (GitHub silently
-#      drops labels that don't exist).
+#   1. The `dependencies` label Renovate applies to its PRs, plus the
+#      `bug`/`feature`/`decay`/`question` labels the issue forms reference
+#      (GitHub silently drops labels that don't exist).
 #   2. Repository settings that make Renovate auto-merge SAFE — "Allow
 #      auto-merge" plus branch protection requiring the `CI Success` check.
 #      Without a required check, enabling auto-merge on a PR merges it
@@ -32,7 +33,7 @@ jobs:
     name: Ensure repository labels
     runs-on: ubuntu-latest
     steps:
-      - name: Create dependencies label
+      - name: Create repository labels
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -40,6 +41,22 @@ jobs:
           gh label create dependencies \
             --color 0366d6 \
             --description "Pull requests that update a dependency" \
+            --force
+          gh label create bug \
+            --color d73a4a \
+            --description "Something isn't working" \
+            --force
+          gh label create feature \
+            --color a2eeef \
+            --description "New feature or request" \
+            --force
+          gh label create decay \
+            --color fbca04 \
+            --description "Structural debt worth refactoring later" \
+            --force
+          gh label create question \
+            --color d876e3 \
+            --description "Further information is requested" \
             --force
 
   settings:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -91,11 +91,12 @@ jobs:
 
       # The /code-review plugin fans out into parallel review agents. On Claude
       # Code >= 2.1.198 those dispatch as background tasks that claude-code-action
-      # drops before they finish (runClaudeWithSdk breaks query() on the first
-      # result — claude-code-action#1499), so the review completes green and posts
-      # nothing. Pin the last synchronous-subagent release (2.1.197, verified with
-      # action@v1 in claude-code#73453) so the fan-out completes in-turn. Remove
-      # this step + path_to_claude_code_executable once #1499 is fixed upstream.
+      # drops before they finish — runClaudeWithSdk breaks the query() loop on the
+      # first result (claude-code-action#1499), so the review completes green and
+      # posts nothing (also #1087 / #1523, claude-code#85275 — all silent). Pin
+      # the last synchronous-subagent release (2.1.197, verified with action@v1 in
+      # claude-code#73453) so the fan-out completes in-turn. Remove this step and
+      # the path_to_claude_code_executable input once #1499 is fixed upstream.
       - name: Install pinned Claude Code (2.1.197, pre-background-subagents)
         run: |
           set -euo pipefail
@@ -122,10 +123,13 @@ jobs:
           # Read CI results through the built-in GitHub CI MCP server.
           additional_permissions: |
             actions: read
-          # Grant the plugin what it needs: Skill (launch the /code-review
-          # skill) and Task (dispatch its review subagents — synchronous under
-          # the pinned 2.1.197), plus the gh/inline/uv tools. contents: read
-          # keeps the reviewer from committing — it only reads and comments.
+          # Grant the built-in GitHub read/search MCP tools, the CI tools, the
+          # inline-comment tool (what lets the reviewer post inline — not in the
+          # default allow-set), `gh api`, gh pr/run read commands, scoped `uv run`
+          # for targeted investigation (REVIEW.md sets norms), plus Skill (launch
+          # the /code-review skill) and Task (dispatch its review subagents —
+          # synchronous under the pinned 2.1.197). contents: read above keeps the
+          # reviewer from committing — it only reads and comments.
           claude_args: |
             --allowedTools "Skill,Task,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,mcp__github_ci__*,mcp__github_inline_comment__*,Bash(gh api *),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,7 +26,7 @@ jobs:
         # (a bare @v46 does not resolve and fails the job before any step).
         # v46.x bundles a Renovate CLI well past the >=43.59.0 floor (fixes the
         # PEP 735 [dependency-groups] depName bug); do not pin an older renovate-version.
-        uses: renovatebot/github-action@v46.2.1
+        uses: renovatebot/github-action@v46.2.2
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,12 +133,7 @@ uv run --with vulture vulture src/                     # dead-code candidates
 
 Each analyzer is optional and degrades gracefully if absent. `vulture` over-reports on importable/decorated/framework-registered code — **confirm before deleting** and keep a whitelist.
 
-**When you notice decay outside the current change's scope** — a god class forming, a dead branch, a leaking abstraction, a name that no longer matches behaviour, or an audit hotspot — do **not** fix it inline (scope creep) and do **not** pass over it silently. **Open an issue** using this template:
-
-> **What:** the structural problem in one sentence.
-> **Where:** file/symbol and the metric or observation that flagged it.
-> **Why it compounds:** what gets harder or riskier if it's left.
-> **Suggested direction:** a starting point, not a prescribed refactor.
+**When you notice decay outside the current change's scope** — a god class forming, a dead branch, a leaking abstraction, a name that no longer matches behaviour, or an audit hotspot — do **not** fix it inline (scope creep) and do **not** pass over it silently. **Open an issue** using the **Decay** form (`.github/ISSUE_TEMPLATE/decay.yml`): What / Where / Why it compounds / Suggested direction.
 
 Constrain issues to **decay that will compound**, not anything imperfect. The diff-gate blocks new debt; these issues are the refactor-later backlog for pre-existing debt — neither blocks the current PR.
 
@@ -313,9 +308,7 @@ Fixes and improvements to shared code land in those repos and propagate here via
 
 ## Contributing fixes upstream
 
-- **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump `fastmcp-pvl-core` in this project's `pyproject.toml`. (Copier update alone won't pick it up unless the template's version constraint in `pyproject.toml.jinja` is also bumped.)
-- **Template-level fix** (anything template-owned — `Dockerfile`, workflows, `server.py` skeleton, `CLAUDE.md` sections): open a PR on `pvliesdonk/fastmcp-server-template`. After merge + release, this project gets the fix on the next weekly `copier update` cron (or dispatch the workflow manually).
-- **Domain-only fix** (anything inside a `DOMAIN-*`, `CONFIG-*`, or `PROJECT-*` sentinel block, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the three-tier routing (library to `fastmcp-pvl-core`, template to `fastmcp-server-template`, domain to this repo), the issue/PR discipline, and the uncertainty rule. CONTRIBUTING.md is the single source; this section is a pointer.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
 <!-- TEMPLATE-TRACKING-END -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+Thanks for contributing. This guide covers how to file good issues and pull
+requests, and where to send different kinds of fixes. It applies to both
+human contributors and automated agents.
+
+## Filing issues
+
+Use the issue templates in `.github/ISSUE_TEMPLATE/`:
+
+- **Bug report** — something isn't working as expected.
+- **Feature request** — a new capability or enhancement.
+- **Decay / structural debt** — refactor-later observations.
+- **Question / support** — questions and support requests.
+
+### Observation, not work order
+
+An issue records what was **observed**. It does not diagnose, design, or
+prescribe a fix. An issue that reads like a work order misleads the
+implementer into treating imagination as researched fact.
+
+- Describe what you saw: the concrete behaviour, exact error text or trace,
+  where it occurred, the version/commit you checked.
+- Do not assert a root cause you did not verify.
+- Do not propose an architecture or list implementation steps.
+
+### The uncertainty rule
+
+Every cause statement must be marked:
+
+- `[verified: how]` — you checked; here is how.
+- `[unverified]` — you have not verified this.
+
+When you have not verified the cause, this sentence is required:
+
+> I have not verified the cause.
+
+The implementer must inherit your doubt, not a false floor of confidence.
+
+### One issue, one observed problem
+
+If you notice a second suspected problem while writing, do not add it to the
+body. If you genuinely suspect it shares a code path, add one line under Open
+Questions: `[unverified]: <suspected problem> may share this code path`. Open
+a separate issue for it.
+
+### Remove before posting
+
+| What you wrote | What to do instead |
+|----------------|-------------------|
+| "Root cause is X; fix by doing Y" | Cause: `[unverified]` + observed behaviour only |
+| Any sentence starting with "Fix by", "We should", "Refactor", "Add a", "The solution is" | Delete the sentence |
+| "Import is probably similarly broken" | One Open Questions line: `[unverified]: import may share this path` |
+| A cause asserted without a `[verified]` or `[unverified]` marker | Add the marker; add "I have not verified the cause" if unverified |
+| An "Additional context" section that introduces new problems | Open a separate issue |
+| Implementation steps (a numbered list of code changes) | Remove entirely |
+
+## Pull requests
+
+Every PR must have at least one associated issue. If the work has no issue
+yet, a bug found in the wild or an opportunistic cleanup, create the issue
+first, then open the PR with `Closes #N` (or `Refs #N`) in the body. A single
+PR may close multiple issues (`Closes #A, closes #B`); the rule is "no orphan
+PRs", not "one PR per issue". Trivial exceptions: pure typo fixes and
+automated dependency bumps (Renovate) may skip the issue.
+
+State what the PR deliberately does **not** do, with each deferral's tracking
+issue. A change that says what it left out is easier to trust than one that
+appears to have found nothing.
+
+Run a local code-review pass on the cumulative diff before `gh pr create`.
+Code without matching docs is incomplete; check `README.md`, the `docs/`
+site, `docs/design/`, and inline docstrings.
+
+## Where to send fixes
+
+- **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a
+  PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump
+  `fastmcp-pvl-core` in this project's `pyproject.toml`. Copier update alone
+  won't pick it up unless the template's version constraint in
+  `pyproject.toml.jinja` is also bumped.
+- **Template-level fix** (anything template-owned: `Dockerfile`, workflows,
+  `server.py` skeleton, `CLAUDE.md` sections): open a PR on
+  `pvliesdonk/fastmcp-server-template`. After merge + release, this project
+  gets the fix on the next weekly `copier update` cron, or dispatch the
+  workflow manually.
+- **Domain-only fix** (anything inside a `DOMAIN-*`, `CONFIG-*`, or
+  `PROJECT-*` sentinel block, `tools.py`, `resources.py`, `prompts.py`,
+  `domain.py`, `tests/`): PR on this repo directly.

--- a/config-presentation.yml
+++ b/config-presentation.yml
@@ -166,6 +166,10 @@ packaging:
   "{PREFIX}_SERVER_NAME": [pypi, oci]
   "{PREFIX}_INSTRUCTIONS": [pypi, oci]
   "{PREFIX}_HTTP_PATH": [oci]
+  # Not HTTP-specific: apply_tool_visibility runs in make_server regardless
+  # of transport, so a stdio (pypi/uvx) install can trim its tool set too.
+  "{PREFIX}_TOOLS_ALLOW": [pypi, oci]
+  "{PREFIX}_TOOLS_DENY": [pypi, oci]
   "{PREFIX}_BASE_URL": [oci]
   "{PREFIX}_AUTH_MODE": [oci]
   "{PREFIX}_BEARER_TOKEN": [oci]
@@ -289,6 +293,8 @@ wizard_labels:
   "{PREFIX}_ACL_PATH": "ACL path"
   "{PREFIX}_AUTHZ_CLAIM": "Authorization claim"
   "{PREFIX}_AUTHZ_GRANTS": "Authorization grants (JSON)"
+  "{PREFIX}_TOOLS_ALLOW": "Tool allowlist (CSV)"
+  "{PREFIX}_TOOLS_DENY": "Tool denylist (CSV)"
   "FASTMCP_LOG_LEVEL": "Log level"
   "FASTMCP_ENABLE_RICH_LOGGING": "Rich logging"
 
@@ -300,6 +306,26 @@ wizard_labels:
 wizard_help:
   "{PREFIX}_KV_STORE_URL": "Persistent-state backend URL: memory://, file:///path, redis://, dynamodb://, or mongodb://. Defaults to file:///data/state when unset."
   "{PREFIX}_OIDC_JWT_SIGNING_KEY": "Optional signing key for issued JWTs. When unset it is derived from the client secret; set explicitly to keep tokens valid across a secret rotation. Generate: openssl rand -hex 32."
+  "{PREFIX}_TOOLS_ALLOW": "Comma-separated tool names this instance exposes; every other tool is hidden. Leave empty to expose all tools. Mutually exclusive with the denylist."
+  "{PREFIX}_TOOLS_DENY": "Comma-separated tool names to hide from this instance. Mutually exclusive with the allowlist."
+
+# Wizard-hint overrides, keyed by full var name — same lookup shape as
+# `examples` and `wizard_labels`, and the only lever that can change a core
+# var's wizard *placement* (group/when/control), which core's own field
+# metadata owns. An entry replaces the var's hint wholesale and clears the
+# `inferred` shorthand; an entry naming a var no provenance collected fails
+# generation loudly, so a stale override cannot outlive the upstream fix it
+# papers over.
+#
+# TOOLS_ALLOW / TOOLS_DENY: core 4.10.1 tags both `"wizard": "inferred"`,
+# but `inferred` means "value derived from another setting" (true of
+# AUTH_MODE, which auto-detects) — nothing derives these two; they are
+# ordinary operator inputs (#321/#322). No `when`: apply_tool_visibility
+# runs regardless of transport, so a stdio deployment can trim tools too.
+# Drop both entries once core stops shipping them as inferred.
+wizard_hints:
+  "{PREFIX}_TOOLS_ALLOW": {group: Tools}
+  "{PREFIX}_TOOLS_DENY": {group: Tools}
 
 # Wizard routing questions that emit a var rather than mapping 1:1 to one.
 wizard_routing:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,21 @@ variables (`MARKDOWN_VAULT_MCP_TRANSPORT`, `MARKDOWN_VAULT_MCP_HOST`,
 !!! note "Configuration is validated at startup"
     Numeric variables are validated against the **Type** column below (such as `int ≥ 1`). A non-numeric or out-of-range value makes the server **fail fast** at startup with a `ConfigurationError` naming the offending setting, rather than silently falling back to a default. A typo in an env var surfaces immediately instead of producing surprising behavior later.
 
+## Tool visibility
+
+Operators can trim which tools this instance exposes. Each variable takes a
+comma-separated list of explicit tool names:
+
+- `MARKDOWN_VAULT_MCP_TOOLS_ALLOW`: expose *only* the listed tools.
+- `MARKDOWN_VAULT_MCP_TOOLS_DENY`: hide the listed tools.
+
+Hidden tools disappear from `tools/list` and are rejected on `tools/call`;
+resources and prompts are unaffected. Setting both variables, or setting one
+to a value with no names in it, is a startup error. A name matching no
+registered tool is ignored, but an allowlist that matches nothing logs a
+startup `WARNING` since the instance then exposes zero tools. See
+`fastmcp-pvl-core`'s README for the full semantics.
+
 <!-- DOMAIN-CONFIG-VARS-START -->
 ## Core
 

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -274,6 +274,22 @@
       }
     },
     {
+      "id": "tools_allow",
+      "label": "Tool allowlist (CSV)",
+      "type": "text",
+      "var": "MARKDOWN_VAULT_MCP_TOOLS_ALLOW",
+      "help": "Comma-separated tool names this instance exposes; every other tool is hidden. Leave empty to expose all tools. Mutually exclusive with the denylist.",
+      "advancedGroup": "Tools"
+    },
+    {
+      "id": "tools_deny",
+      "label": "Tool denylist (CSV)",
+      "type": "text",
+      "var": "MARKDOWN_VAULT_MCP_TOOLS_DENY",
+      "help": "Comma-separated tool names to hide from this instance. Mutually exclusive with the allowlist.",
+      "advancedGroup": "Tools"
+    },
+    {
       "id": "bearer_tokens_file",
       "label": "Bearer tokens file (TOML)",
       "type": "text",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "fastmcp-pvl-core>=4.9.0,<5",
+    # >=4.10.1 for apply_tool_visibility (operator TOOLS_ALLOW / TOOLS_DENY);
+    # 4.10.0 was tagged but never reached PyPI (its publish failed), and the
+    # config-surface generator pins the floor exactly, so the floor must name
+    # a version that exists on PyPI.
+    "fastmcp-pvl-core>=4.10.1,<5",
     "typer>=0.12",
 
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update

--- a/scripts/gen_config_surface.py
+++ b/scripts/gen_config_surface.py
@@ -533,6 +533,40 @@ def _presentation_root(project_root: Path) -> Path:
     return _project_root()
 
 
+def _apply_wizard_hint_overrides(
+    collected: list[Var], presentation: Mapping[str, Any]
+) -> list[Var]:
+    """Apply the presentation's `wizard_hints` override map to *collected*.
+
+    Keyed by full var name like `examples` — the correction lever for a var
+    whose provenance owns its hint but got it wrong (core 4.10.1 ships
+    TOOLS_ALLOW/TOOLS_DENY as ``"wizard": "inferred"``, though nothing
+    derives their values — see #321/#322). An entry replaces the var's wizard
+    mapping wholesale and clears the `inferred` shorthand; content is
+    validated later by `_validate_wizard_hint`, exactly like a hint from any
+    other source. An entry naming a var no provenance collected fails loudly
+    rather than silently doing nothing: the map exists to paper over upstream
+    metadata until it is fixed there, and a stale entry outliving that fix
+    (or a typo never matching anything) is a bug in config-presentation.yml.
+    """
+    hints_map: dict[str, Any] = presentation.get("wizard_hints", {}) or {}
+    if not hints_map:
+        return collected
+    unknown_hints = sorted(set(hints_map) - {v.name for v in collected})
+    if unknown_hints:
+        raise SystemExit(
+            "ERROR: config-presentation.yml wizard_hints names var(s) no "
+            f"provenance collected: {', '.join(unknown_hints)}. Remove "
+            "the stale entry, or fix the name."
+        )
+    return [
+        dataclasses.replace(v, wizard=dict(hints_map[v.name]), inferred=False)
+        if v.name in hints_map
+        else v
+        for v in collected
+    ]
+
+
 def collect_vars(
     project_root: Path | str, answers: Mapping[str, object]
 ) -> tuple[Var, ...]:
@@ -636,6 +670,8 @@ def collect_vars(
             else v
             for v in collected
         ]
+
+    collected = _apply_wizard_hint_overrides(collected, presentation)
 
     seen_names: dict[str, str] = {}
     for var in collected:

--- a/server.json
+++ b/server.json
@@ -25,6 +25,14 @@
           "default": "file:///data/state"
         },
         {
+          "name": "MARKDOWN_VAULT_MCP_TOOLS_ALLOW",
+          "description": "Comma-separated explicit tool names this instance exposes; every other tool is hidden from listings and cannot be invoked. Names matching no registered tool are inert. Mutually exclusive with `tools_deny`. Takes effect through `apply_tool_visibility`."
+        },
+        {
+          "name": "MARKDOWN_VAULT_MCP_TOOLS_DENY",
+          "description": "Comma-separated explicit tool names hidden from this instance (absent from listings, cannot be invoked). Names matching no registered tool are inert. Mutually exclusive with `tools_allow`. Takes effect through `apply_tool_visibility`."
+        },
+        {
           "name": "MARKDOWN_VAULT_MCP_SERVER_NAME",
           "description": "Rename this server instance; defaults to the project name."
         },
@@ -501,6 +509,14 @@
         {
           "name": "MARKDOWN_VAULT_MCP_APP_DOMAIN",
           "description": "MCP Apps iframe domain, used for CSP sandboxing. Overrides the host derived from `base_url`."
+        },
+        {
+          "name": "MARKDOWN_VAULT_MCP_TOOLS_ALLOW",
+          "description": "Comma-separated explicit tool names this instance exposes; every other tool is hidden from listings and cannot be invoked. Names matching no registered tool are inert. Mutually exclusive with `tools_deny`. Takes effect through `apply_tool_visibility`."
+        },
+        {
+          "name": "MARKDOWN_VAULT_MCP_TOOLS_DENY",
+          "description": "Comma-separated explicit tool names hidden from this instance (absent from listings, cannot be invoked). Names matching no registered tool are inert. Mutually exclusive with `tools_allow`. Takes effect through `apply_tool_visibility`."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_AUTH_MODE",

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -15,6 +15,7 @@ from importlib.metadata import version as _pkg_version
 from fastmcp import FastMCP
 from fastmcp_pvl_core import (
     ServerConfig,  # noqa: F401  — re-exported for downstream projects' convenience
+    apply_tool_visibility,
     build_auth,
     build_event_store,  # noqa: F401  — re-exported for downstream projects' convenience
     build_instructions,
@@ -289,5 +290,12 @@ def make_server(
         # solely via external tooling beyond the model's reach.
         mcp.disable(tags={"okf-enforce"})
     # DOMAIN-WIRING-END
+
+    # Operator tool visibility (MARKDOWN_VAULT_MCP_TOOLS_ALLOW /
+    # MARKDOWN_VAULT_MCP_TOOLS_DENY) applies last: fastmcp resolves visibility
+    # transforms in call order, so the operator's lists win over any
+    # visibility calls in the wiring above, and pvl-core's zero-tools-exposed
+    # diagnostic judges the full registered tool set.
+    apply_tool_visibility(mcp, config.server)
 
     return mcp

--- a/tests/test_config_wizard_spec.py
+++ b/tests/test_config_wizard_spec.py
@@ -258,11 +258,6 @@ NOT_IN_WIZARD = {
     # from credential presence (BEARER_TOKEN / OIDC_*), not an explicit selector,
     # and AUTH_MODE is undocumented in this project's configuration surface.
     f"{PREFIX}_AUTH_MODE": "upstream explicit auth-mode override; wizard derives from credentials",
-    # Operator tool-visibility trimming (template v3.2.0) — per-instance
-    # hardening knobs, not deployment-setup questions; documented in
-    # docs/configuration.md and emitted into the env examples instead.
-    f"{PREFIX}_TOOLS_ALLOW": "operator tool allowlist; not a setup question",
-    f"{PREFIX}_TOOLS_DENY": "operator tool denylist; not a setup question",
     # Bare OPENAI_* fallbacks -- the wizard emits the prefixed forms instead.
     "OPENAI_BASE_URL": "bare fallback; wizard emits MARKDOWN_VAULT_MCP_OPENAI_BASE_URL",
     "OPENAI_EMBEDDING_MODEL": "bare fallback; wizard emits MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL",

--- a/tests/test_config_wizard_spec.py
+++ b/tests/test_config_wizard_spec.py
@@ -258,6 +258,11 @@ NOT_IN_WIZARD = {
     # from credential presence (BEARER_TOKEN / OIDC_*), not an explicit selector,
     # and AUTH_MODE is undocumented in this project's configuration surface.
     f"{PREFIX}_AUTH_MODE": "upstream explicit auth-mode override; wizard derives from credentials",
+    # Operator tool-visibility trimming (template v3.2.0) — per-instance
+    # hardening knobs, not deployment-setup questions; documented in
+    # docs/configuration.md and emitted into the env examples instead.
+    f"{PREFIX}_TOOLS_ALLOW": "operator tool allowlist; not a setup question",
+    f"{PREFIX}_TOOLS_DENY": "operator tool denylist; not a setup question",
     # Bare OPENAI_* fallbacks -- the wizard emits the prefixed forms instead.
     "OPENAI_BASE_URL": "bare fallback; wizard emits MARKDOWN_VAULT_MCP_OPENAI_BASE_URL",
     "OPENAI_EMBEDDING_MODEL": "bare fallback; wizard emits MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL",

--- a/uv.lock
+++ b/uv.lock
@@ -784,15 +784,15 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "4.9.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/61/eb3f3e322181d8d66c91a9bca4bc37d151371439193916e0680005946faf/fastmcp_pvl_core-4.9.0.tar.gz", hash = "sha256:f9c1fcc865de9e8e2f1bdc8c36faac365aa904755fa16437e637d00d2abcb7cc", size = 459405, upload-time = "2026-08-09T10:58:45.097Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/e4/cf5604204ad4efbaee89804a84b280bcb1a9f32290c3ceae2888eb447da3/fastmcp_pvl_core-4.10.1.tar.gz", hash = "sha256:d9cab503335c70bcd2117f4ec892dba850dd25d9e3a8c3572e2ffee94308a05d", size = 466278, upload-time = "2026-08-11T14:35:35.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/88/1cbe8f4d817eac3622de93e381396bb6bee6da88f8d346f8a6ad5970e595/fastmcp_pvl_core-4.9.0-py3-none-any.whl", hash = "sha256:11b549d13926d7f55ff36c40feb5f0915eb2f20d07275062df0bc27145374a41", size = 92131, upload-time = "2026-08-09T10:58:43.62Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/31/978b98d97c5a80188ca390b6619d5dd74044461b84519b4b2f0d1920f7d6/fastmcp_pvl_core-4.10.1-py3-none-any.whl", hash = "sha256:765b7f8e4e7b17e28f42784a3dbad977a2153ee3c3a04232381ec19de5d9bdd6", size = 95573, upload-time = "2026-08-11T14:35:33.636Z" },
 ]
 
 [package.optional-dependencies]
@@ -1105,7 +1105,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1550,7 +1550,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.3" },
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "fastmcp-pvl-core", specifier = ">=4.9.0,<5" },
+    { name = "fastmcp-pvl-core", specifier = ">=4.10.1,<5" },
     { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25" },
     { name = "httpx", marker = "extra == 'embeddings-api'", specifier = ">=0.25" },


### PR DESCRIPTION
## Closes / Refs

Closes #1012

## What & why

Runs `copier update` from template v3.1.3 to **v3.2.1** (two commits: v3.1.3→v3.2.0, then v3.2.0→v3.2.1; same flags as the `copier-update` workflow: `--trust --defaults --skip-answered --conflict=inline`).

**v3.2.0** — operator tool visibility: `MARKDOWN_VAULT_MCP_TOOLS_ALLOW` / `MARKDOWN_VAULT_MCP_TOOLS_DENY` are wired through `apply_tool_visibility` at the end of `make_server()`, with the `fastmcp-pvl-core` floor bumped to `>=4.10.1`. Also adds GitHub issue forms (bug/feature/decay/question), a PR template, and `CONTRIBUTING.md`, seeds the labels those forms reference in `bootstrap.yml`, slims CLAUDE.md to point at the new Decay form and CONTRIBUTING.md, and bumps the Renovate action to v46.2.2.

**v3.2.1** — completes the tool-visibility story on the wizard side: a new `wizard_hints` override map in `config-presentation.yml` / `gen_config_surface.py` surfaces both vars as real config-wizard questions (Tools group), correcting core 4.10.1's spurious `"wizard": "inferred"` tagging, and the packaging matrix now emits them for both pypi and oci channels.

Reconciliation on top of the raw updates:

- Resolved the two v3.2.0 inline conflicts toward the template side: `pyproject.toml` (core floor bump with rationale comment) and `claude-code-review.yml` (comment-only wording).
- Re-ran `scripts/gen_config_surface.py` inside the project venv after v3.2.0. The copier post-task ran it without domain deps installed, which truncated the generated surface to 33 template vars; the proper run restores all 101. `--check` passes.
- No `NOT_IN_WIZARD` changes survive: the entries added for v3.2.0 (when the wizard didn't cover the vars) were removed again at v3.2.1, which makes them wizard questions.

## What this PR deliberately does NOT do

- Nothing deferred — v3.2.1 closed the one gap noted in the earlier revision (wizard coverage of `TOOLS_ALLOW`/`TOOLS_DENY`).

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening the PR.

## Docs impact

- [x] `README.md` — regenerated by `gen_config_surface.py` (no net change)
- [x] `docs/` site pages — `docs/configuration.md` gains the template-rendered "Tool visibility" section; the config-wizard page now asks about both vars via the regenerated `wizard-spec.json`
- [ ] `docs/design/` — no design-level change; all deltas are template-owned scaffolding
- [x] Inline docstrings — no first-party API changes

All gates run locally at v3.2.1: 3255 passed / 20 skipped, ruff check+format clean, mypy clean (187 files), `diff-quality` 100%, `gen_config_surface.py --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJyWhQRSLHo1uhFfqUNU67