### PR TITLE
refactor: single-source the user-facing write-tool enumeration from the write tag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,7 +90,7 @@
 # MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=60
 # Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.
 # MARKDOWN_VAULT_MCP_SOURCE_DIR=/data/vault
-# Set to false to enable write tools (write, edit, delete, rename).
+# Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
 # MARKDOWN_VAULT_MCP_READ_ONLY=true
 # Path to the SQLite FTS5 index file; unset keeps the index in memory. Set it for persistence across restarts.
 # MARKDOWN_VAULT_MCP_INDEX_PATH=

--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -24,6 +24,11 @@ id_token
 # --- OKF (Open Knowledge Format) tool identifiers ---
 okf_verify
 
+# --- Write-tool identifiers (READ_ONLY-gated set, #1009) ---
+create_upload_link
+git_sync
+move_folder
+
 # --- Python / runtime ecosystem ---
 debugpy
 mypy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ src/markdown_vault_mcp/
   vault.py             -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
   write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
   summary_jobs.py      -- SummaryJobStore: in-memory background-summarize job store backing the get_summary poll tool (#937)
+  _write_tools.py      -- WRITE_TOOL_NAMES + write_tools_phrase: single source for the user-facing write-tool enumeration (#1009)
   config.py            -- template-owned skeleton: flat metadata-carrying ProjectConfig fields + section-view properties + from_env, all inside CONFIG-* sentinels (#900, #952)
   config_sections/
     _assembly.py         -- domain config-assembly kept out of template-owned config.py: to_vault_kwargs, derive_max_chunk_chars, git-strategy builder, from_env value resolvers (#900, #952)

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ embedding-provider conventions `OLLAMA_HOST`, `OPENAI_API_KEY`,
 | `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` | `60` | No | Maximum seconds an index-backed tool or resource waits for the FTS index to become queryable during a cold-start background build before raising IndexUnavailableError(reason="timeout"). Increase for large vaults. |
 | `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` | `60` | No | Maximum seconds an index-querying read tool waits for the IndexWriter to drain when called with wait_for_pending_writes=true. On timeout the tool answers from the current index and reports index_stale=true in the response _meta. |
 | `MARKDOWN_VAULT_MCP_SOURCE_DIR` | `/data/vault` | No | Path to the markdown vault directory. Required; the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+. |
-| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | No | Set to false to enable write tools (write, edit, delete, rename). |
+| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | No | Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport. |
 | `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` | `false` | No | Hide the MCP Apps UI tools (browse_vault, show_context) from the tool listing for clients that do not render MCP Apps panels. |
 | `MARKDOWN_VAULT_MCP_INDEX_PATH` | (none) | No | Path to the SQLite FTS5 index file; unset keeps the index in memory. Set it for persistence across restarts. |
 | `MARKDOWN_VAULT_MCP_STATE_PATH` | (none) | No | Path to the change-tracking state file. Defaults to {SOURCE_DIR}/.markdown_vault_mcp/state.json. |
@@ -441,7 +441,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `browse_vault` | Open the vault explorer SPA in a supporting MCP Apps client |
 | `show_context` | Open the Context Card for a specific note in a supporting MCP Apps client |
 
-Write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, `create_upload_link`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`. `git_sync` also requires managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` set).
+Write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`. `git_sync` also requires managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` set), and `create_upload_link` an HTTP transport with `BASE_URL` configured.
 
 `summarize` is registered only when a summarization backend is configured: an `OPENAI_API_KEY`, or an OpenAI-compatible base URL for local endpoints that need no key. It needs the `openai` SDK (`pip install 'markdown-vault-mcp[summarize]'`) and sends note content to the model provider. Any OpenAI-compatible endpoint works: OpenAI itself, a local Ollama (`http://localhost:11434/v1`, no key needed), the Anthropic compatibility endpoint (`https://api.anthropic.com/v1`), vLLM, and others. See [Configuration](https://pvliesdonk.github.io/markdown-vault-mcp/latest/configuration/) for provider recipes.
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2236,12 +2236,23 @@ to avoid shadowing Python's built-in `list`. The underlying
 avoid the bare name `list` so type annotations like `list[NoteInfo]` are not
 mis-resolved against the method in class scope.
 
-**Tag-based visibility**: `write`, `edit`, `delete`, `rename`, `fetch` are always
-registered but tagged with ``tags={"write"}``. When ``read_only=True``, the
-server calls ``mcp.disable(tags={"write"})`` to hide them from clients.
-This also hides any prompts sharing the ``write`` tag (such as ``research``,
-``discuss``, ``create_from_template``). The Vault still raises ``ReadOnlyError`` as a defence-in-depth
-guard if a write method is somehow called on a read-only instance.
+**Tag-based visibility**: the write tools (`write`, `edit`, `delete`,
+`rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools,
+`create_upload_link`) are registered with ``tags={"write"}``. When
+``read_only=True``, the server calls ``mcp.disable(tags={"write"})`` to hide
+them from clients. This also hides any prompts sharing the ``write`` tag
+(such as ``research``, ``discuss``, ``create_from_template``). The ``write``
+tag is deliberately a strict subset of ``readOnlyHint=False``: ``reindex``
+and ``build_embeddings`` mutate index state, not the vault, and stay
+available on a read-only server. The user-facing enumeration of the
+write-tagged set is single-sourced from ``_write_tools.WRITE_TOOL_NAMES``
+(#1009): the ``read_only`` config help derives its wording from
+``write_tools_phrase()`` (propagated into the generated config artifacts by
+``scripts/gen_config_surface.py``), and ``tests/test_write_tool_enumeration.py``
+pins the hand-written doc sites to the same phrase while asserting the
+constant matches the registry's actual write-tagged tools. The Vault still
+raises ``ReadOnlyError`` as a defence-in-depth guard if a write method is
+somehow called on a read-only instance.
 
 The MCP-Apps UI tools ``browse_vault`` and ``show_context`` are tagged with
 ``tags={"apps-ui"}``. When ``MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=true``, the

--- a/docs/guides/claude-code-plugin.md
+++ b/docs/guides/claude-code-plugin.md
@@ -56,7 +56,7 @@ The plugin wires up the following env vars. Vars with a default are filled in wh
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `MARKDOWN_VAULT_MCP_SOURCE_DIR` | _(required)_ | Path to your vault directory |
-| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | Set to `false` to enable write/edit/delete/rename tools |
+| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | Set to `false` to enable the write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`) |
 | `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | _(empty)_ | Embedding backend (`fastembed`, `ollama`, `openai`); leave empty for keyword-only search |
 | `MARKDOWN_VAULT_MCP_EXCLUDE` | `.obsidian/**,.trash/**,.git/**` | Comma-separated glob patterns to exclude from indexing |
 | `MARKDOWN_VAULT_MCP_GIT_REPO_URL` | _(empty)_ | Remote repository URL for git-backed vault sync; leave empty to disable git integration |

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -168,7 +168,7 @@ Add the highlighted lines to your existing config:
 
 **What these do:**
 
-- `READ_ONLY=false`: enables the write, edit, delete, and rename tools
+- `READ_ONLY=false`: enables the write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`)
 - `GIT_REPO_URL`: enables managed mode (clone/remote validation)
 - `GIT_USERNAME` / `GIT_TOKEN`: HTTPS auth for pull/push
 - `GIT_PUSH_DELAY_S=60`: batches rapid writes, pushing after 60 seconds of idle time

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -110,7 +110,7 @@ MARKDOWN_VAULT_MCP_EXCLUDE=.obsidian/**,.trash/**
 
 **What these do:**
 
-- `READ_ONLY=false`: enables write, edit, delete, rename tools
+- `READ_ONLY=false`: enables the write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`)
 - `GIT_REPO_URL`: enables managed mode (clone/remote validation)
 - `GIT_USERNAME` / `GIT_TOKEN`: HTTPS auth for pull/push
 - `GIT_PUSH_DELAY_S=30`: push after 30 seconds of write-idle time

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -422,7 +422,7 @@
       "label": "Read Only",
       "type": "bool",
       "var": "MARKDOWN_VAULT_MCP_READ_ONLY",
-      "help": "Set to false to enable write tools (write, edit, delete, rename)."
+      "help": "Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport."
     },
     {
       "id": "disable_apps_ui",

--- a/examples/bearer-auth.env
+++ b/examples/bearer-auth.env
@@ -19,7 +19,7 @@ MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S=60
 MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=60
 # Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.
 MARKDOWN_VAULT_MCP_SOURCE_DIR=/data/vault
-# Set to false to enable write tools (write, edit, delete, rename).
+# Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
 MARKDOWN_VAULT_MCP_READ_ONLY=true
 # Hide the MCP Apps UI tools (browse_vault, show_context) from the tool listing for clients that do not render MCP Apps panels.
 MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=false

--- a/examples/oidc.env
+++ b/examples/oidc.env
@@ -31,7 +31,7 @@ MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S=60
 MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=60
 # Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.
 MARKDOWN_VAULT_MCP_SOURCE_DIR=/data/vault
-# Set to false to enable write tools (write, edit, delete, rename).
+# Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
 MARKDOWN_VAULT_MCP_READ_ONLY=true
 # Hide the MCP Apps UI tools (browse_vault, show_context) from the tool listing for clients that do not render MCP Apps panels.
 MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=false

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -31,7 +31,7 @@ MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S=60
 MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=60
 # Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.
 MARKDOWN_VAULT_MCP_SOURCE_DIR=/data/vault
-# Set to false to enable write tools (write, edit, delete, rename).
+# Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
 MARKDOWN_VAULT_MCP_READ_ONLY=true
 # Hide the MCP Apps UI tools (browse_vault, show_context) from the tool listing for clients that do not render MCP Apps panels.
 MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=false

--- a/packaging/mcpb/manifest.json.in
+++ b/packaging/mcpb/manifest.json.in
@@ -65,7 +65,7 @@
     "read_only": {
       "type": "boolean",
       "title": "Read-only mode",
-      "description": "When true, write/edit/delete/rename tools are hidden.",
+      "description": "When true, the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link) are hidden.",
       "required": false,
       "default": true
     },

--- a/server.json
+++ b/server.json
@@ -96,7 +96,7 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_READ_ONLY",
-          "description": "Set to false to enable write tools (write, edit, delete, rename).",
+          "description": "Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.",
           "format": "boolean",
           "default": "true"
         },
@@ -614,7 +614,7 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_READ_ONLY",
-          "description": "Set to false to enable write tools (write, edit, delete, rename).",
+          "description": "Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.",
           "format": "boolean",
           "default": "true"
         },

--- a/src/markdown_vault_mcp/_write_tools.py
+++ b/src/markdown_vault_mcp/_write_tools.py
@@ -1,0 +1,76 @@
+"""Single source for the user-facing write-tool enumeration (#1009).
+
+``read_only=True`` hides every component tagged ``write`` via
+``mcp.disable(tags={"write"})`` (see ``server.py``). Several user-facing
+texts *intentionally* enumerate those tools so operators know what the
+flag gates — but hand-copied lists drift. This module is the single
+source they all derive from:
+
+- ``config.py``'s ``read_only`` field help interpolates
+  :func:`write_tools_phrase` at import time; ``scripts/gen_config_surface.py``
+  propagates it into ``server.json``, the config-wizard spec, the env
+  examples, and the README env-var table.
+- The hand-written sites (README prose, the guides, the mcpb manifest,
+  the design doc) are pinned to the rendered phrase by
+  ``tests/test_write_tool_enumeration.py``, which also builds the full
+  tool registry and asserts the write-tagged set equals
+  :data:`WRITE_TOOL_NAMES` — so the constant cannot drift from the
+  registry either.
+
+The ``write`` tag is deliberately a strict subset of
+``readOnlyHint=False``: ``reindex`` and ``build_embeddings`` mutate index
+state, not the vault, and stay available on a read-only server.
+"""
+
+from __future__ import annotations
+
+#: Every tool registered with ``tags={"write"}``, in user-facing order.
+#: ``git_sync`` additionally requires managed git mode;
+#: ``create_upload_link`` (registered by fastmcp-pvl-core's transfer
+#: routes) additionally requires an HTTP transport.
+WRITE_TOOL_NAMES: tuple[str, ...] = (
+    "write",
+    "edit",
+    "delete",
+    "rename",
+    "move_folder",
+    "fetch",
+    "git_sync",
+    "okf_convert_links",
+    "okf_generate_index",
+    "okf_seed_log",
+    "okf_verify",
+    "create_upload_link",
+)
+
+_OKF_PREFIX = "okf_"
+
+
+def write_tools_phrase(*, markdown: bool = False) -> str:
+    """Render the write-tool enumeration for user-facing prose.
+
+    The ``okf_*`` family is collapsed to one token so the phrase stays
+    readable as the family grows.
+
+    Args:
+        markdown: Wrap each tool name in backticks (for Markdown sites);
+            plain text otherwise (env-file comments, JSON descriptions).
+
+    Returns:
+        A comma-separated enumeration such as
+        ``"write, edit, ..., git_sync, the okf_* tools, create_upload_link"``.
+    """
+
+    def fmt(name: str) -> str:
+        return f"`{name}`" if markdown else name
+
+    tokens: list[str] = []
+    okf_collapsed = False
+    for name in WRITE_TOOL_NAMES:
+        if name.startswith(_OKF_PREFIX):
+            if not okf_collapsed:
+                tokens.append(f"the {fmt(_OKF_PREFIX + '*')} tools")
+                okf_collapsed = True
+        else:
+            tokens.append(fmt(name))
+    return ", ".join(tokens)

--- a/src/markdown_vault_mcp/_write_tools.py
+++ b/src/markdown_vault_mcp/_write_tools.py
@@ -46,6 +46,31 @@ WRITE_TOOL_NAMES: tuple[str, ...] = (
 _OKF_PREFIX = "okf_"
 
 
+def gated_tool(name: str) -> str:
+    """Return *name*, asserting it is a write-tagged tool.
+
+    For prose that singles out one gated tool (e.g. the ``read_only`` help's
+    caveat naming ``git_sync``): referencing the name through this accessor
+    makes a rename that updates :data:`WRITE_TOOL_NAMES` fail loudly at
+    import time instead of leaving a stale name in derived text.
+
+    Args:
+        name: A tool name expected to be in :data:`WRITE_TOOL_NAMES`.
+
+    Returns:
+        *name*, unchanged.
+
+    Raises:
+        ValueError: If *name* is not in :data:`WRITE_TOOL_NAMES`.
+    """
+    if name not in WRITE_TOOL_NAMES:
+        raise ValueError(
+            f"{name!r} is not a write-tagged tool; update the reference "
+            "alongside WRITE_TOOL_NAMES"
+        )
+    return name
+
+
 def write_tools_phrase(*, markdown: bool = False) -> str:
     """Render the write-tool enumeration for user-facing prose.
 

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from fastmcp_pvl_core import ServerConfig, TransferConfig
 
+from markdown_vault_mcp._write_tools import write_tools_phrase
 from markdown_vault_mcp.config_sections import (
     ContentConfig,
     EmbeddingsConfig,
@@ -88,7 +89,11 @@ class ProjectConfig:
     read_only: bool = field(
         default=True,
         metadata={
-            "help": "Set to false to enable write tools (write, edit, delete, rename).",
+            "help": (
+                "Set to false to enable the write tools "
+                f"({write_tools_phrase()}). git_sync also needs managed git "
+                "mode; create_upload_link needs an HTTP transport."
+            ),
             "tags": ("vault",),
         },
     )

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from fastmcp_pvl_core import ServerConfig, TransferConfig
 
-from markdown_vault_mcp._write_tools import write_tools_phrase
+from markdown_vault_mcp._write_tools import gated_tool, write_tools_phrase
 from markdown_vault_mcp.config_sections import (
     ContentConfig,
     EmbeddingsConfig,
@@ -91,8 +91,9 @@ class ProjectConfig:
         metadata={
             "help": (
                 "Set to false to enable the write tools "
-                f"({write_tools_phrase()}). git_sync also needs managed git "
-                "mode; create_upload_link needs an HTTP transport."
+                f"({write_tools_phrase()}). {gated_tool('git_sync')} also "
+                f"needs managed git mode; {gated_tool('create_upload_link')} "
+                "needs an HTTP transport."
             ),
             "tags": ("vault",),
         },

--- a/tests/test_write_tool_enumeration.py
+++ b/tests/test_write_tool_enumeration.py
@@ -114,6 +114,15 @@ class TestDerivedTextLockstep:
             f"update it to include: {phrase}"
         )
 
+    def test_gated_tool_accessor(self) -> None:
+        """``gated_tool`` returns members verbatim and rejects non-members,
+        so prose singling out one gated tool fails loudly on a rename."""
+        from markdown_vault_mcp._write_tools import gated_tool
+
+        assert gated_tool("git_sync") == "git_sync"
+        with pytest.raises(ValueError, match="not a write-tagged tool"):
+            gated_tool("reindex")
+
     def test_phrase_renderings(self) -> None:
         """Pin both renderings: okf family collapsed, others verbatim."""
         plain = write_tools_phrase()

--- a/tests/test_write_tool_enumeration.py
+++ b/tests/test_write_tool_enumeration.py
@@ -1,0 +1,125 @@
+"""Lockstep guards for the single-sourced write-tool enumeration (#1009).
+
+``_write_tools.WRITE_TOOL_NAMES`` is the single source every user-facing
+enumeration of the ``read_only``-gated tools derives from. Two directions
+are pinned here:
+
+- registry → constant: the actual ``tags={"write"}`` tool set must equal
+  the constant, so a new/renamed write tool fails loudly until the
+  constant (and, transitively, every derived text) is updated;
+- constant → docs: every hand-written site that names the set must carry
+  the currently rendered phrase, so none of them can silently drift.
+
+The *generated* sites (``server.json``, the wizard spec, the env
+examples, the README env-var table) are not asserted here — they derive
+from ``config.py``'s ``read_only`` help via ``scripts/gen_config_surface.py``,
+whose ``--check`` mode guards them in CI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields, replace
+from pathlib import Path
+
+import pytest
+
+from markdown_vault_mcp._write_tools import WRITE_TOOL_NAMES, write_tools_phrase
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# (repo-relative path, phrase variant expected in it). Markdown sites carry
+# the backticked rendering; the mcpb manifest is JSON prose, so plain.
+_DOC_SITES: tuple[tuple[str, str], ...] = (
+    ("README.md", write_tools_phrase(markdown=True)),
+    ("docs/guides/claude-code-plugin.md", write_tools_phrase(markdown=True)),
+    ("docs/guides/claude-desktop.md", write_tools_phrase(markdown=True)),
+    ("docs/guides/docker.md", write_tools_phrase(markdown=True)),
+    ("docs/design/design.md", write_tools_phrase(markdown=True)),
+    ("packaging/mcpb/manifest.json.in", write_tools_phrase()),
+)
+
+
+class TestRegistryLockstep:
+    """The constant must mirror the actual write-tagged tool registry."""
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_write_tagged_registry_matches_constant(self) -> None:
+        """``WRITE_TOOL_NAMES`` equals the actual ``tags={"write"}`` tool set.
+
+        Builds the full surface via the ``register_*`` functions plus core's
+        transfer routes — bypassing ``make_server``'s tag-based disable
+        passes, mirroring ``test_every_registered_tool_has_title`` — so
+        conditionally-visible tools (``git_sync``, ``create_upload_link``)
+        are asserted too, and reads the unfiltered registry via
+        ``_list_tools()``.
+        """
+        from fastmcp import FastMCP
+        from fastmcp_pvl_core import register_transfer_routes
+
+        from markdown_vault_mcp._server_apps import register_apps
+        from markdown_vault_mcp._server_tools import register_tools
+        from markdown_vault_mcp._transfer_sink import VaultTransferSink
+        from markdown_vault_mcp.config import ProjectConfig
+
+        mcp = FastMCP("write-tag-lockstep")
+        register_tools(mcp)
+        register_apps(mcp)
+        config = ProjectConfig.from_env()
+        config = replace(
+            config,
+            server=replace(
+                config.server,
+                base_url="https://example.test",
+                kv_store_url="memory://",
+            ),
+        )
+        sink = VaultTransferSink(config)
+        register_transfer_routes(
+            mcp, config.server, config.transfer, sink=sink, validate=sink.validate
+        )
+
+        tools = await mcp._list_tools()
+        write_tagged = {t.name for t in tools if "write" in (t.tags or set())}
+        assert write_tagged == set(WRITE_TOOL_NAMES), (
+            "tags={'write'} registry and _write_tools.WRITE_TOOL_NAMES "
+            "disagree — update the constant (and re-run "
+            "scripts/gen_config_surface.py) when adding/renaming a write tool"
+        )
+
+    def test_constant_has_no_duplicates(self) -> None:
+        assert len(WRITE_TOOL_NAMES) == len(set(WRITE_TOOL_NAMES))
+
+
+class TestDerivedTextLockstep:
+    """Every intentional user-facing enumeration derives from the constant."""
+
+    def test_read_only_help_carries_phrase(self) -> None:
+        """The ``read_only`` field help (source of every generated artifact)
+        interpolates the derived phrase rather than hand-listing tools."""
+        from markdown_vault_mcp.config import ProjectConfig
+
+        (read_only,) = [f for f in fields(ProjectConfig) if f.name == "read_only"]
+        assert write_tools_phrase() in read_only.metadata["help"]
+
+    @pytest.mark.parametrize(("rel_path", "phrase"), _DOC_SITES)
+    def test_doc_site_carries_current_phrase(self, rel_path: str, phrase: str) -> None:
+        """Hand-written sites must contain the current rendering verbatim.
+
+        Whitespace is collapsed before matching so prose may wrap the phrase
+        across lines.
+        """
+        text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        assert phrase in " ".join(text.split()), (
+            f"{rel_path} does not carry the current write-tool enumeration; "
+            f"update it to include: {phrase}"
+        )
+
+    def test_phrase_renderings(self) -> None:
+        """Pin both renderings: okf family collapsed, others verbatim."""
+        plain = write_tools_phrase()
+        assert plain.startswith("write, edit, delete, rename, ")
+        assert "the okf_* tools" in plain
+        assert "okf_convert_links" not in plain
+        assert write_tools_phrase(markdown=True).count("`") == 2 * (
+            len([n for n in WRITE_TOOL_NAMES if not n.startswith("okf_")]) + 1
+        )


### PR DESCRIPTION
## Closes / Refs

Closes #1009

## What & why

The tools gated by `READ_ONLY` were hand-enumerated across the config help, README prose, three guides, the mcpb manifest, and the design doc, and the copies had drifted (4 vs 8 names against 12 actual write-tagged tools). This PR adds `_write_tools.py` as the single source: `WRITE_TOOL_NAMES` (the canonical `tags={"write"}` set) plus `write_tools_phrase()` (plain and Markdown renderings, `okf_*` family collapsed to one token).

- `config.py`'s `read_only` help interpolates the phrase at import time; `scripts/gen_config_surface.py` propagates it into `server.json`, the wizard spec, `.env.example`, `examples/*.env`, `packaging/env.example`, and the README env table (all regenerated here).
- The hand-written sites (README §Tools prose, `claude-code-plugin`/`claude-desktop`/`docker` guides, `packaging/mcpb/manifest.json.in`, `docs/design/design.md`) now carry the derived phrase.
- `tests/test_write_tool_enumeration.py` pins both directions: the constant must equal the actual write-tagged registry (built via the `register_*` functions plus core's transfer routes, so `git_sync` and `create_upload_link` are asserted too), and every hand-written site must contain the current rendering.
- Single-tool references in the help caveat (`git_sync`, `create_upload_link`) go through a `gated_tool()` accessor that raises at import time if the name leaves the canonical set, so a rename can't strand stale names in generated artifacts.
- `design.md` now also documents that the `write` tag is a strict subset of `readOnlyHint=False` (`reindex`/`build_embeddings` mutate index state, not the vault) — the gap flagged in the #1009 audit.

## What this PR deliberately does NOT do

- Does not pin the *gating-condition* prose (e.g. README's "`git_sync` also requires managed git mode…" wording) to a single source — only the tool-name enumeration, per #1009's scope. Tool names inside those sentences are still covered by the phrase assertion or `gated_tool()`.
- Does not touch incidental library-API mentions of write/edit/delete/rename (`WriteOperation`, facet docstrings) — those were deliberately kept by #1007/#1011.
- Does not generate the hand-written doc sites; they stay prose, pinned by the lockstep test instead.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.

## Docs impact

- [x] `README.md` — env table (regenerated) + §Tools prose
- [x] `docs/` site pages — three guides updated
- [x] `docs/design/` — Tag-based visibility section rewritten (canonical set, single-source mechanism, write-tag vs `readOnlyHint` distinction)
- [x] Inline docstrings — new module and helpers carry Google-style docstrings

**Rule: code without matching docs is incomplete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mivdEJr4znLWi45yApkNS

---
_Generated by [Claude Code](https://claude.ai/code/session_019mivdEJr4znLWi45yApkNS)_