### PR TITLE
feat: add append tool for end-of-note writes without a prior read

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,7 +90,7 @@
 # MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=60
 # Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.
 # MARKDOWN_VAULT_MCP_SOURCE_DIR=/data/vault
-# Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
+# Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
 # MARKDOWN_VAULT_MCP_READ_ONLY=true
 # Path to the SQLite FTS5 index file; unset keeps the index in memory. Set it for persistence across restarts.
 # MARKDOWN_VAULT_MCP_INDEX_PATH=

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **Frontmatter-aware**: indexes YAML frontmatter fields, supports required field enforcement
 - **OKF-aware**: recognizes [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog) bundles (an `okf_version` declaration in the root `index.md`) and annotates search/read results with each note's type, lifecycle status, staleness, and trust tier. Those dimensions are filterable and also nudge ranking on a detected bundle (deprecated and stale notes rank lower, and the reserved `index.md` / `log.md` navigation files are demoted below real notes), and the server adds an `okf_validate` conformance audit plus one-shot migration transforms (`okf_convert_links`, `okf_generate_index`, `okf_seed_log`) for moving a vault into the format, plus a downloadable bundle export served through `create_download_link` with an `okf-bundle` reference. Read semantics are controlled by `MARKDOWN_VAULT_MCP_OKF_MODE`
 - **Incremental reindexing**: hash-based change detection, only re-processes modified files; an automatic boot-time reconciliation pass picks up changes made while no server was running, and the vector index converges to the reconciled chunk set (embedding exactly the delta)
-- **Write operations**: create, edit, delete, rename documents, and move entire folder subtrees with automatic index updates
+- **Write operations**: create, edit, append to, delete, rename documents, and move entire folder subtrees with automatic index updates
 - **Folder conventions**: per-folder `_conventions.md` files carry your authoring rules, such as "reference notes stay self-contained"; the server surfaces them to LLM clients at write time via the `get_conventions` tool and in `write`/`edit` results, without interpreting them
 - **Attachment support**: read, write, delete, and list non-markdown files (PDFs, images, etc.)
 - **Git integration**: optional auto-commit and push on every write via `GIT_ASKPASS`
 - **OIDC authentication**: optional token-based auth for HTTP deployments (Authelia, Keycloak, etc.)
-- **MCP tools**: 33 LLM-visible tools including search, read, write, edit, delete, rename, `move_folder`, git history, manual git sync, one-time transfer links, and admin operations; plus 6 app-only tools for MCP Apps clients
+- **MCP tools**: 34 LLM-visible tools including search, read, write, edit, append, delete, rename, `move_folder`, git history, manual git sync, one-time transfer links, and admin operations; plus 6 app-only tools for MCP Apps clients
 - **MCP resources**: 9 resources exposing vault configuration, statistics, tags, folders, document outlines, similar notes, recent notes, and an interactive SPA
 - **MCP prompts**: 7 prompt templates including template-driven note creation
 <!-- DOMAIN-END -->
@@ -193,7 +193,7 @@ embedding-provider conventions `OLLAMA_HOST`, `OPENAI_API_KEY`,
 | `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S` | `60` | No | Maximum seconds an index-backed tool or resource waits for the FTS index to become queryable during a cold-start background build before raising IndexUnavailableError(reason="timeout"). Increase for large vaults. |
 | `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` | `60` | No | Maximum seconds an index-querying read tool waits for the IndexWriter to drain when called with wait_for_pending_writes=true. On timeout the tool answers from the current index and reports index_stale=true in the response _meta. |
 | `MARKDOWN_VAULT_MCP_SOURCE_DIR` | `/data/vault` | No | Path to the markdown vault directory. Required; the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+. |
-| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | No | Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport. |
+| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | No | Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport. |
 | `MARKDOWN_VAULT_MCP_DISABLE_APPS_UI` | `false` | No | Hide the MCP Apps UI tools (browse_vault, show_context) from the tool listing for clients that do not render MCP Apps panels. |
 | `MARKDOWN_VAULT_MCP_INDEX_PATH` | (none) | No | Path to the SQLite FTS5 index file; unset keeps the index in memory. Set it for persistence across restarts. |
 | `MARKDOWN_VAULT_MCP_STATE_PATH` | (none) | No | Path to the change-tracking state file. Defaults to {SOURCE_DIR}/.markdown_vault_mcp/state.json. |
@@ -409,6 +409,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `read` | Read a document or attachment by relative path |
 | `write` | Create or overwrite a document or attachment |
 | `edit` | Replace text in a document: exact match, line-range, or scoped match with normalized fallback |
+| `append` | Append text to the end of a note without reading it first (optional `create_if_missing`) |
 | `delete` | Delete a document or attachment and its index entries |
 | `rename` | Rename/move a document or attachment, updating all index entries; pass `update_links=true` to also rewrite backlinks in other notes |
 | `move_folder` | Move an entire folder subtree to a new prefix, rewriting all vault links that point into the moved subtree in one call |
@@ -441,7 +442,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `browse_vault` | Open the vault explorer SPA in a supporting MCP Apps client |
 | `show_context` | Open the Context Card for a specific note in a supporting MCP Apps client |
 
-Write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`. `git_sync` also requires managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` set), and `create_upload_link` an HTTP transport with `BASE_URL` configured.
+Write tools (`write`, `edit`, `append`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`) are only available when `MARKDOWN_VAULT_MCP_READ_ONLY=false`. `git_sync` also requires managed git mode (`MARKDOWN_VAULT_MCP_GIT_REPO_URL` set), and `create_upload_link` an HTTP transport with `BASE_URL` configured.
 
 `summarize` is registered only when a summarization backend is configured: an `OPENAI_API_KEY`, or an OpenAI-compatible base URL for local endpoints that need no key. It needs the `openai` SDK (`pip install 'markdown-vault-mcp[summarize]'`) and sends note content to the model provider. Any OpenAI-compatible endpoint works: OpenAI itself, a local Ollama (`http://localhost:11434/v1`, no key needed), the Anthropic compatibility endpoint (`https://api.anthropic.com/v1`), vLLM, and others. See [Configuration](https://pvliesdonk.github.io/markdown-vault-mcp/latest/configuration/) for provider recipes.
 

--- a/docs/api/facets.md
+++ b/docs/api/facets.md
@@ -36,7 +36,7 @@ and attachment reads.
 
 ## WriterFacet
 
-Create, edit, delete, rename, and attachment writes.
+Create, edit, append, delete, rename, and attachment writes.
 
 <!-- vale off -->
 ::: markdown_vault_mcp.facets.writer.WriterFacet

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1839,7 +1839,7 @@ operations to them. No manager holds a back-reference to Vault.
 | ``LinkManager`` | Backlinks, outlinks, broken links, orphans, hubs, connection paths | ``FTSIndex``, ``source_dir`` |
 | ``SearchManager`` | Keyword/semantic/hybrid search, list, folders, tags, recent, similar, context, stats, get_metadata | ``FTSIndex``, ``source_dir``, embedding config, ``LinkManager`` |
 | ``IndexManager`` | build_index, reindex, build_embeddings, process_dirty_paths, flush_dirty_embeddings | ``FTSIndex``, ``ChangeTracker``, ``source_dir``, chunk strategy (no lock; driven by the single-owner :class:`~markdown_vault_mcp.indexing.IndexWriter`, #559) |
-| ``DocumentManager`` | read, write, edit, delete, rename, attachments, TOC | ``FTSIndex``, ``source_dir``, ``_file_write_lock`` (file-mutation atomicity only; see #559), ``mark_paths_dirty`` hook, callbacks |
+| ``DocumentManager`` | read, write, edit, append, delete, rename, attachments, TOC | ``FTSIndex``, ``source_dir``, ``_file_write_lock`` (file-mutation atomicity only; see #559), ``mark_paths_dirty`` hook, callbacks |
 | ``GitQueryManager`` | Git history / diff reads (read-only, #610) | ``GitWriteStrategy`` (or ``None`` when not a git repo), ``source_dir`` |
 
 Each manager receives its dependencies as constructor arguments. This enables
@@ -1856,7 +1856,7 @@ root already owns:
 | Facet | Surface | Collaborators |
 |-|-|-|
 | ``ReaderFacet`` | search, read, get_metadata, list, folders, tags, toc, recent, similar, context, stats, history, diff, read_attachment | ``SearchManager``, ``DocumentManager``, ``GitQueryManager``, ``require_built`` |
-| ``WriterFacet`` | write, edit, delete, rename, write_attachment | ``DocumentManager`` |
+| ``WriterFacet`` | write, edit, append, delete, rename, write_attachment | ``DocumentManager`` |
 | ``GraphFacet`` | backlinks, outlinks, broken_links, orphans, most_linked, connection_path, neighborhood/hub graph views (#880) | ``LinkManager``, ``SearchManager``, ``require_built`` |
 | ``IndexFacet`` | build/reindex/embeddings (sync + async), readiness, writer status, embeddings_status | ``IndexWriteCoordinator`` (public subset only), ``IndexManager`` (embeddings_status) |
 
@@ -2208,6 +2208,7 @@ pattern). Each tool is annotated with MCP `ToolAnnotations`:
 | `list_documents` | List documents, optionally filtered | `True` | `False` | `True` |
 | `write` | Create or overwrite a document | `False` | `False` | `True` |
 | `edit` | Patch a section (read-before-edit) | `False` | `False` | `False` |
+| `append` | Append text to the end of a note (no read needed, #980) | `False` | `False` | `False` |
 | `rename` | Rename/move a document (Phase 2-3) | `False` | `False` | `False` |
 | `delete` | Delete a document | `False` | **`True`** | `True` |
 | `list_folders` | List all folders | `True` | `False` | `True` |
@@ -2230,14 +2231,27 @@ pattern). Each tool is annotated with MCP `ToolAnnotations`:
 | `get_summary` | Retrieve a promoted `summarize` job by `job_id` (#937) | `True` | `False` | **`False`** |
 | `fetch` | Download from URL and save to vault (MCP-to-MCP transfer) | `False` | `False` | `True` |
 
+**Append semantics (#980)**: `append` adds `content` at the end of an
+existing note without requiring a prior `read` — the cheap path for purely
+additive changes (log entries, journal additions) that with `edit` would
+force the whole note through the model context first. A newline is inserted
+between the existing content and the appended text when the file does not
+already end with one. `create_if_missing` (default `false`) opts into
+creating a missing note instead of raising `DocumentNotFoundError`, so a
+mistyped path fails loudly by default. The operation flows through
+`DocumentManager.append` and is treated as an `edit` `WriteOperation` for
+the OKF enforced-write enricher, folder-convention maintenance, and the git
+commit callback; it returns a `WriteResult` (`created` is `true` only when
+`create_if_missing` created the file).
+
 **Tool name note**: the MCP tool is registered as `list_documents` (not `list`)
 to avoid shadowing Python's built-in `list`. The underlying
 `ReaderFacet.list_documents()` method matches the MCP name; both deliberately
 avoid the bare name `list` so type annotations like `list[NoteInfo]` are not
 mis-resolved against the method in class scope.
 
-**Tag-based visibility**: the write tools (`write`, `edit`, `delete`,
-`rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools,
+**Tag-based visibility**: the write tools (`write`, `edit`, `append`,
+`delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools,
 `create_upload_link`) are registered with ``tags={"write"}``. When
 ``read_only=True``, the server calls ``mcp.disable(tags={"write"})`` to hide
 them from clients. This also hides any prompts sharing the ``write`` tag

--- a/docs/guides/claude-code-plugin.md
+++ b/docs/guides/claude-code-plugin.md
@@ -56,7 +56,7 @@ The plugin wires up the following env vars. Vars with a default are filled in wh
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `MARKDOWN_VAULT_MCP_SOURCE_DIR` | _(required)_ | Path to your vault directory |
-| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | Set to `false` to enable the write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`) |
+| `MARKDOWN_VAULT_MCP_READ_ONLY` | `true` | Set to `false` to enable the write tools (`write`, `edit`, `append`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`) |
 | `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | _(empty)_ | Embedding backend (`fastembed`, `ollama`, `openai`); leave empty for keyword-only search |
 | `MARKDOWN_VAULT_MCP_EXCLUDE` | `.obsidian/**,.trash/**,.git/**` | Comma-separated glob patterns to exclude from indexing |
 | `MARKDOWN_VAULT_MCP_GIT_REPO_URL` | _(empty)_ | Remote repository URL for git-backed vault sync; leave empty to disable git integration |

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -168,7 +168,7 @@ Add the highlighted lines to your existing config:
 
 **What these do:**
 
-- `READ_ONLY=false`: enables the write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`)
+- `READ_ONLY=false`: enables the write tools (`write`, `edit`, `append`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`)
 - `GIT_REPO_URL`: enables managed mode (clone/remote validation)
 - `GIT_USERNAME` / `GIT_TOKEN`: HTTPS auth for pull/push
 - `GIT_PUSH_DELAY_S=60`: batches rapid writes, pushing after 60 seconds of idle time

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -110,7 +110,7 @@ MARKDOWN_VAULT_MCP_EXCLUDE=.obsidian/**,.trash/**
 
 **What these do:**
 
-- `READ_ONLY=false`: enables the write tools (`write`, `edit`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`)
+- `READ_ONLY=false`: enables the write tools (`write`, `edit`, `append`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`)
 - `GIT_REPO_URL`: enables managed mode (clone/remote validation)
 - `GIT_USERNAME` / `GIT_TOKEN`: HTTPS auth for pull/push
 - `GIT_PUSH_DELAY_S=30`: push after 30 seconds of write-idle time

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,14 +12,14 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 - **Hybrid search**: Reciprocal Rank Fusion combining FTS5 and vector results
 - **Frontmatter-aware**: indexes YAML frontmatter fields, supports required field enforcement
 - **Incremental reindexing**: hash-based change detection, only re-processes modified files
-- **Write operations**: create, edit, delete, rename documents with automatic index updates
+- **Write operations**: create, edit, append to, delete, rename documents with automatic index updates
 - **Folder conventions**: per-folder `_conventions.md` files carry your authoring rules, surfaced to LLM clients at write time via [`get_conventions`](tools/index.md#get_conventions) and in `write`/`edit` results
 - **[Open Knowledge Format](guides/okf.md)**: recognizes OKF bundles (an `okf_version` declaration in the root `index.md`) and annotates search/read results with each note's type, lifecycle status, staleness, and trust tier; those dimensions are filterable and nudge ranking, and the server ships an `okf_validate` audit, one-shot migration transforms, an optional enforced write layer (provenance + verification + `log.md`/`index.md` upkeep), and a downloadable bundle export
 - **Attachment support**: read, write, delete, and list non-markdown files (PDFs, images, and so on)
 - **LLM summarization**: optional `summarize` tool condenses a note, a set of notes, or a subtree with a language model via any OpenAI-compatible endpoint (OpenAI, Ollama, Anthropic, vLLM, and others); the synthesis references the individual source notes by path. Gated on `OPENAI_API_KEY` or a configured base URL.
 - **Git integration**: optional auto-commit and push on every write via `GIT_ASKPASS`
 - **OIDC authentication**: optional token-based auth for HTTP deployments
-- **MCP tools**: search, read, write, edit, delete, rename, link graph analysis, and admin operations
+- **MCP tools**: search, read, write, edit, append, delete, rename, link graph analysis, and admin operations
 - **MCP resources**: vault configuration, statistics, tags, folders, document outlines, similar notes, and recent notes
 - **MCP prompts**: summarize, research, discuss, create from template, compare, and find related notes
 - **MCP Apps**: browser-based views (Context Card, Graph Explorer, Vault Browser, and Note Preview) for clients supporting the MCP Apps protocol

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -422,7 +422,7 @@
       "label": "Read Only",
       "type": "bool",
       "var": "MARKDOWN_VAULT_MCP_READ_ONLY",
-      "help": "Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport."
+      "help": "Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport."
     },
     {
       "id": "disable_apps_ui",

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -372,14 +372,14 @@ Append text to the end of an existing `.md` note without reading it first.
 | `path` | string | Yes | Relative path to the document |
 | `content` | string | Yes | Text to append (must be non-empty) |
 | `if_match` | string | No | Etag from `read` for optimistic concurrency |
-| `create_if_missing` | boolean | No | When `true`, a missing note is created with `content` as its body. Default `false` — a typo in `path` fails loudly rather than silently creating a new note |
+| `create_if_missing` | bool | No | When `true`, a missing note is created with `content` as its body. Default `false`, so a typo in `path` fails loudly rather than silently creating a new note |
 
 **Returns:** `{"path": "Journal/2026.md", "created": false}`
 
 `created` is `true` only when `create_if_missing` created a new note. The response may also include a `conventions` list; see [`write`](#write).
 
 !!! tip "Cheaper than `edit` for additive changes"
-    Unlike `edit`, no prior `read` is needed, so the existing note content never enters the LLM context — ideal for log entries, journal additions, and checklist items. A newline is inserted between the existing content and the appended text when the file does not already end with one; include leading blank lines or heading markers in `content` yourself for a separating paragraph or section.
+    Unlike `edit`, no prior `read` is needed, so the existing note content never enters the LLM context. This makes it ideal for log entries, journal additions, and checklist items. A newline is inserted between the existing content and the appended text when the file does not already end with one; include leading blank lines or heading markers in `content` yourself for a separating paragraph or section.
 
 ### `delete`
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -39,6 +39,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`build_embeddings`](#build_embeddings) | Build Embeddings | Admin | Build or rebuild vector embeddings |
 | [`write`](#write) | Write Note | Write | Create or overwrite a document or attachment |
 | [`edit`](#edit) | Edit Note | Write | Replace a unique text span in a document |
+| [`append`](#append) | Append to Note | Write | Append text to the end of a note without reading it first |
 | [`delete`](#delete) | Delete Note | Write | Delete a document or attachment |
 | [`rename`](#rename) | Rename Note | Write | Rename/move a document or attachment |
 | [`move_folder`](#move_folder) | Move Folder | Write | Move an entire folder subtree and rewrite vault links |
@@ -359,6 +360,26 @@ Make a targeted text replacement in an existing document. Supports three modes:
 
 !!! warning "Diagnostic errors"
     When no match is found, the error message reports the closest matching line number and the character position of the first difference, along with short snippets showing what was expected vs. what was found. This helps identify the exact mismatch.
+
+### `append`
+
+Append text to the end of an existing `.md` note without reading it first.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | Yes | Relative path to the document |
+| `content` | string | Yes | Text to append (must be non-empty) |
+| `if_match` | string | No | Etag from `read` for optimistic concurrency |
+| `create_if_missing` | boolean | No | When `true`, a missing note is created with `content` as its body. Default `false` — a typo in `path` fails loudly rather than silently creating a new note |
+
+**Returns:** `{"path": "Journal/2026.md", "created": false}`
+
+`created` is `true` only when `create_if_missing` created a new note. The response may also include a `conventions` list; see [`write`](#write).
+
+!!! tip "Cheaper than `edit` for additive changes"
+    Unlike `edit`, no prior `read` is needed, so the existing note content never enters the LLM context — ideal for log entries, journal additions, and checklist items. A newline is inserted between the existing content and the appended text when the file does not already end with one; include leading blank lines or heading markers in `content` yourself for a separating paragraph or section.
 
 ### `delete`
 

--- a/examples/bearer-auth.env
+++ b/examples/bearer-auth.env
@@ -19,7 +19,7 @@ MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S=60
 MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=60
 # Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.
 MARKDOWN_VAULT_MCP_SOURCE_DIR=/data/vault
-# Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
+# Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
 MARKDOWN_VAULT_MCP_READ_ONLY=true
 # Hide the MCP Apps UI tools (browse_vault, show_context) from the tool listing for clients that do not render MCP Apps panels.
 MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=false

--- a/examples/oidc.env
+++ b/examples/oidc.env
@@ -31,7 +31,7 @@ MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S=60
 MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=60
 # Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.
 MARKDOWN_VAULT_MCP_SOURCE_DIR=/data/vault
-# Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
+# Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
 MARKDOWN_VAULT_MCP_READ_ONLY=true
 # Hide the MCP Apps UI tools (browse_vault, show_context) from the tool listing for clients that do not render MCP Apps panels.
 MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=false

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -31,7 +31,7 @@ MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S=60
 MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S=60
 # Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.
 MARKDOWN_VAULT_MCP_SOURCE_DIR=/data/vault
-# Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
+# Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.
 MARKDOWN_VAULT_MCP_READ_ONLY=true
 # Hide the MCP Apps UI tools (browse_vault, show_context) from the tool listing for clients that do not render MCP Apps panels.
 MARKDOWN_VAULT_MCP_DISABLE_APPS_UI=false

--- a/packaging/mcpb/manifest.json.in
+++ b/packaging/mcpb/manifest.json.in
@@ -65,7 +65,7 @@
     "read_only": {
       "type": "boolean",
       "title": "Read-only mode",
-      "description": "When true, the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link) are hidden.",
+      "description": "When true, the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link) are hidden.",
       "required": false,
       "default": true
     },

--- a/server.json
+++ b/server.json
@@ -96,7 +96,7 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_READ_ONLY",
-          "description": "Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.",
+          "description": "Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.",
           "format": "boolean",
           "default": "true"
         },
@@ -614,7 +614,7 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_READ_ONLY",
-          "description": "Set to false to enable the write tools (write, edit, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.",
+          "description": "Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.",
           "format": "boolean",
           "default": "true"
         },

--- a/src/markdown_vault_mcp/_icons.py
+++ b/src/markdown_vault_mcp/_icons.py
@@ -70,6 +70,9 @@ _TOOL_ICONS: dict[str, list[Icon]] = {
     ]
 }
 
+# append reuses the edit icon (#980).
+_TOOL_ICONS["append"] = _TOOL_ICONS["edit"]
+
 # Status tools reuse existing icons rather than introducing new SVG files.
 _TOOL_ICONS["get_index_status"] = _TOOL_ICONS["embeddings_status"]
 

--- a/src/markdown_vault_mcp/_instructions.py
+++ b/src/markdown_vault_mcp/_instructions.py
@@ -61,12 +61,13 @@ def build_default_instructions(
         if read_only
         else (
             " Write tools: use 'write' to create, 'edit' for targeted changes "
-            "(read first), 'rename' to move (pass update_links=True to fix links "
+            "(read first), 'append' to add to the end of a note (no read "
+            "needed), 'rename' to move (pass update_links=True to fix links "
             "in other notes), 'delete' to remove. Use 'move_folder(old_dir, new_dir)' "
             "to move an entire folder subtree and rewrite all vault links in one call. "
             "All write operations update the "
             "search index immediately — never call 'reindex' after write, edit, "
-            "delete, or rename."
+            "append, delete, or rename."
         )
     )
     search_guidance = (

--- a/src/markdown_vault_mcp/_server_tools/_common.py
+++ b/src/markdown_vault_mcp/_server_tools/_common.py
@@ -47,7 +47,7 @@ async def attach_conventions(
 
     The ``conventions`` key is omitted entirely when no conventions apply,
     keeping the enrichment additive and non-breaking. Shared by the
-    ``write`` / ``edit`` / ``fetch`` / ``get_context`` tools so the result
+    ``write`` / ``edit`` / ``append`` / ``fetch`` / ``get_context`` tools so the result
     shape stays consistent across all of them.
 
     Args:

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -435,9 +435,8 @@ def register(mcp: FastMCP) -> None:
 
         Args:
             path: Relative path to the document (e.g. "Journal/2026.md").
-            content: Text to append (must be non-empty). Appended verbatim
-                at the end of the file, after frontmatter and all existing
-                content.
+            content: Text to append (must be non-empty). Added at the end
+                of the file, after frontmatter and all existing content.
             if_match: Optional etag obtained from a previous 'read' call.
                 When provided, the append only proceeds if the file has not
                 been modified since that read (optimistic concurrency).

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -403,6 +403,78 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool(
         tags={"write"},
+        icons=_TOOL_ICONS["append"],
+        annotations={
+            "title": "Append to Note",
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": False,
+        },
+    )
+    async def append(
+        path: str,
+        content: str,
+        if_match: str | None = None,
+        create_if_missing: bool = False,
+        vault: Vault = Depends(get_vault),
+    ) -> dict[str, Any]:
+        """Append text to the end of an existing .md note without reading it.
+
+        The cheapest way to add content at the end of a note (log entries,
+        journal additions, checklist items): unlike 'edit', no prior 'read'
+        is needed, so the existing note content never enters the context.
+        Prefer this over 'edit' whenever the change is purely additive at
+        the end of the note.
+
+        A newline is inserted between the existing content and the appended
+        text when the file does not already end with one, so the appended
+        text starts on its own line. Include leading blank lines or heading
+        markers in 'content' yourself if you want a separating paragraph or
+        section. The search index is updated immediately; do not call
+        'reindex' afterward.
+
+        Args:
+            path: Relative path to the document (e.g. "Journal/2026.md").
+            content: Text to append (must be non-empty). Appended verbatim
+                at the end of the file, after frontmatter and all existing
+                content.
+            if_match: Optional etag obtained from a previous 'read' call.
+                When provided, the append only proceeds if the file has not
+                been modified since that read (optimistic concurrency).
+                Omit to append unconditionally.
+            create_if_missing: When true, a missing note is created with
+                'content' as its body instead of failing. Default false —
+                a typo in 'path' fails loudly rather than silently creating
+                a new note.
+
+        Returns:
+            - **path** (str): path of the document.
+            - **created** (bool): true only when create_if_missing created
+              a new note.
+            - **conventions** (list, optional): the user's authoring
+              conventions for the note's folder (root-first list of
+              {folder, path, content}). When present, verify the appended
+              content complies and issue a follow-up 'edit' if it does not.
+
+        Raises:
+            ValueError: If content is empty.
+            DocumentNotFoundError: If no file exists at the given path and
+                create_if_missing is false.
+            McpError: If if_match is provided and the file has been modified
+                (ConcurrentModificationError).
+        """
+        with okf_write_intent(OkfWriteIntent(actor=resolve_write_actor())):
+            result = await asyncio.to_thread(
+                vault.writer.append,
+                path,
+                content,
+                if_match=if_match,
+                create_if_missing=create_if_missing,
+            )
+        return await attach_conventions(vault, asdict(result), path)
+
+    @mcp.tool(
+        tags={"write"},
         icons=_TOOL_ICONS["delete"],
         annotations={
             "title": "Delete Note",

--- a/src/markdown_vault_mcp/_write_tools.py
+++ b/src/markdown_vault_mcp/_write_tools.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 WRITE_TOOL_NAMES: tuple[str, ...] = (
     "write",
     "edit",
+    "append",
     "delete",
     "rename",
     "move_folder",

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -1,7 +1,8 @@
 """Writer facet: the document-mutation surface (#604).
 
 A thin view over :class:`~markdown_vault_mcp.managers.document.DocumentManager`
-exposing the vault's write / edit / delete / rename / attachment operations.
+exposing the vault's write / edit / append / delete / rename / attachment
+operations.
 Part of the ``vault.py`` facade decomposition (#576); reached via the
 ``Vault.writer`` accessor.
 """

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -182,6 +182,49 @@ class WriterFacet:
             self._convention_maintainer.maintain(path, "edit")
         return result
 
+    def append(
+        self,
+        path: str,
+        content: str,
+        if_match: str | None = None,
+        *,
+        create_if_missing: bool = False,
+    ) -> WriteResult:
+        """Append text to the end of a document without reading it first (#980).
+
+        A newline is inserted between the existing content and *content*
+        when the file does not already end with one.
+
+        Args:
+            path: Relative document path.
+            content: Text to append (must be non-empty).
+            if_match: Optional etag for optimistic concurrency; see
+                :meth:`WriterFacet.write`.
+            create_if_missing: When ``True``, create a missing document with
+                *content* as its body instead of raising.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.WriteResult`.
+
+        Raises:
+            ReadOnlyError: If the vault is read-only.
+            DocumentNotFoundError: If the file does not exist and
+                *create_if_missing* is ``False``.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match.
+            ValueError: If *content* is empty or *path* escapes the source
+                directory.
+        """
+        result = self._doc_mgr.append(
+            path,
+            content,
+            if_match=if_match,
+            create_if_missing=create_if_missing,
+        )
+        if self._convention_maintainer is not None:
+            self._convention_maintainer.maintain(path, "edit")
+        return result
+
     def delete(self, path: str, if_match: str | None = None) -> DeleteResult:
         """Delete a document or attachment.
 

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -763,6 +763,80 @@ class DocumentManager:
 
         return result
 
+    def append(
+        self,
+        path: str,
+        content: str,
+        if_match: str | None = None,
+        *,
+        create_if_missing: bool = False,
+    ) -> WriteResult:
+        """Append *content* to the end of a document (#980).
+
+        Unlike :meth:`edit`, no prior read is required: the existing file
+        content is never part of the request.  When the file does not end
+        with a newline, one is inserted before *content* so the appended
+        text starts on its own line; otherwise *content* is written
+        verbatim after the existing content.
+
+        Args:
+            path: Relative document path.
+            content: Text to append.  Must be non-empty.
+            if_match: Optional etag from a previous :meth:`read` call.
+                When provided, the append is only performed if the current
+                file hash matches this value.  Pass ``None`` (default) to
+                append unconditionally.
+            create_if_missing: When ``True``, a missing document is created
+                with *content* as its body instead of raising
+                :exc:`~markdown_vault_mcp.exceptions.DocumentNotFoundError`.
+
+        Returns:
+            :class:`~markdown_vault_mcp.types.WriteResult` — ``created`` is
+            ``True`` only when *create_if_missing* created a new file.
+
+        Raises:
+            ReadOnlyError: If the vault is read-only.
+            DocumentNotFoundError: If the file does not exist and
+                *create_if_missing* is ``False``.
+            ConcurrentModificationError: If *if_match* is provided and does
+                not match the current file hash (or the file is missing).
+            ValueError: If *content* is empty or *path* escapes the source
+                directory.
+        """
+        self._check_writable()
+        if not content:
+            raise ValueError("content must not be empty")
+
+        with self._file_write_lock:
+            abs_path = self._validate_path(path)
+            existed = abs_path.is_file()
+            if not existed and not create_if_missing:
+                raise DocumentNotFoundError(f"Document not found: {path}")
+            self._check_if_match(abs_path, path, if_match)
+
+            if existed:
+                file_content = _read_text_utf8(abs_path)
+                needs_newline = bool(file_content) and not file_content.endswith("\n")
+                new_content = file_content + ("\n" if needs_newline else "") + content
+            else:
+                abs_path.parent.mkdir(parents=True, exist_ok=True)
+                new_content = content
+
+            # An append is a content edit for the enforced-write layer and
+            # the git commit callback alike.
+            if self._okf_write_enrich is not None:
+                new_content = self._okf_write_enrich(new_content, "edit")
+
+            self._atomic_write(abs_path, new_content)
+
+            if self._mark_paths_dirty is not None:
+                self._mark_paths_dirty([path])
+
+            result = WriteResult(path=path, created=not existed)
+            self._on_write_callback(abs_path, new_content, "edit")
+
+        return result
+
     def write_attachment(
         self,
         path: str,

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -1,6 +1,6 @@
 """Document CRUD, attachment, and path-validation manager.
 
-Handles all read/write/edit/delete/rename operations, attachment I/O,
+Handles all read/write/edit/append/delete/rename operations, attachment I/O,
 path validation, and backlink updates — all with dependency injection
 and no back-reference to :class:`Vault`.
 """
@@ -750,18 +750,38 @@ class DocumentManager:
             else:
                 file_content = content
 
-            if self._okf_write_enrich is not None:
-                file_content = self._okf_write_enrich(file_content, "write")
-
-            self._atomic_write(abs_path, file_content)
-
-            if self._mark_paths_dirty is not None:
-                self._mark_paths_dirty([path])
-
+            self._finalize_content_write(abs_path, path, file_content, "write")
             result = WriteResult(path=path, created=created)
-            self._on_write_callback(abs_path, file_content, "write")
 
         return result
+
+    def _finalize_content_write(
+        self,
+        abs_path: Path,
+        path: str,
+        content: str,
+        operation: WriteOperation,
+    ) -> None:
+        """Run the shared tail of every content write.
+
+        Enriches *content* through the OKF enforced-write hook (when wired),
+        writes it atomically, marks the path dirty for the index writer, and
+        fires the write callback.  Must be called with ``_file_write_lock``
+        held.
+
+        Args:
+            abs_path: Absolute path of the target file.
+            path: Vault-relative path of the target file.
+            content: Full file content to persist.
+            operation: The write operation reported to the enricher and the
+                write callback.
+        """
+        if self._okf_write_enrich is not None:
+            content = self._okf_write_enrich(content, operation)
+        self._atomic_write(abs_path, content)
+        if self._mark_paths_dirty is not None:
+            self._mark_paths_dirty([path])
+        self._on_write_callback(abs_path, content, operation)
 
     def append(
         self,
@@ -777,7 +797,10 @@ class DocumentManager:
         content is never part of the request.  When the file does not end
         with a newline, one is inserted before *content* so the appended
         text starts on its own line; otherwise *content* is written
-        verbatim after the existing content.
+        directly after the existing content.  Like every content write,
+        the file is persisted in the vault's normalized form (UTF-8, no
+        BOM, ``\\n`` line endings), so a CRLF file is normalized on its
+        first append.
 
         Args:
             path: Relative document path.
@@ -824,16 +847,8 @@ class DocumentManager:
 
             # An append is a content edit for the enforced-write layer and
             # the git commit callback alike.
-            if self._okf_write_enrich is not None:
-                new_content = self._okf_write_enrich(new_content, "edit")
-
-            self._atomic_write(abs_path, new_content)
-
-            if self._mark_paths_dirty is not None:
-                self._mark_paths_dirty([path])
-
+            self._finalize_content_write(abs_path, path, new_content, "edit")
             result = WriteResult(path=path, created=not existed)
-            self._on_write_callback(abs_path, new_content, "edit")
 
         return result
 
@@ -979,15 +994,7 @@ class DocumentManager:
                     file_content, old_text, new_text, path
                 )
 
-            if self._okf_write_enrich is not None:
-                new_content = self._okf_write_enrich(new_content, "edit")
-
-            self._atomic_write(abs_path, new_content)
-
-            if self._mark_paths_dirty is not None:
-                self._mark_paths_dirty([path])
-
-            self._on_write_callback(abs_path, new_content, "edit")
+            self._finalize_content_write(abs_path, path, new_content, "edit")
 
         return EditResult(path=path, replacements=1, match_type=match_type)
 

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -588,7 +588,7 @@ class Vault:
 
     @property
     def writer(self) -> WriterFacet:
-        """Document-mutation facet: write, edit, delete, rename, attachments."""
+        """Document-mutation facet: write/edit/append/delete/rename/attachments."""
         return self._writer_facet
 
     @property

--- a/tests/test_facet_writer.py
+++ b/tests/test_facet_writer.py
@@ -48,6 +48,19 @@ class TestWriterFacetBehaviour:
         writable.writer.edit("facet_edit.md", old_text="alpha", new_text="gamma")
         assert "gamma" in (vault_path / "facet_edit.md").read_text()
 
+    def test_append_extends_document(self, writable: Vault, vault_path: Path) -> None:
+        writable.writer.write("facet_append.md", "# Log\n")
+        result = writable.writer.append("facet_append.md", "- entry\n")
+        assert result.created is False
+        assert (vault_path / "facet_append.md").read_text() == "# Log\n- entry\n"
+
+    def test_append_create_if_missing(self, writable: Vault) -> None:
+        result = writable.writer.append(
+            "facet_append_new.md", "# New\n", create_if_missing=True
+        )
+        assert result.created is True
+        assert writable.reader.read("facet_append_new.md") is not None
+
     def test_delete_removes_document(self, writable: Vault) -> None:
         writable.writer.write("facet_del.md", "x\n")
         writable.writer.delete("facet_del.md")

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -317,6 +317,86 @@ class TestEdit:
 
 
 # ---------------------------------------------------------------------------
+# Append tests (#980)
+# ---------------------------------------------------------------------------
+
+
+class TestAppend:
+    """Tests for DocumentManager.append()."""
+
+    def test_append_to_existing(self, doc_mgr: DocumentManager) -> None:
+        result = doc_mgr.append("alpha.md", "Appended line.\n")
+        assert result.path == "alpha.md"
+        assert result.created is False
+
+        note = doc_mgr.read("alpha.md")
+        assert note is not None
+        assert note.content.endswith("Hello world.\nAppended line.\n")
+
+    def test_append_inserts_newline_when_missing(
+        self, doc_mgr: DocumentManager, doc_vault: Path
+    ) -> None:
+        (doc_vault / "no_newline.md").write_text("# Note\n\nTail", encoding="utf-8")
+        doc_mgr.append("no_newline.md", "Appended.")
+        text = (doc_vault / "no_newline.md").read_text(encoding="utf-8")
+        assert text == "# Note\n\nTail\nAppended."
+
+    def test_append_verbatim_after_trailing_newline(
+        self, doc_mgr: DocumentManager, doc_vault: Path
+    ) -> None:
+        (doc_vault / "newline.md").write_text("# Note\n", encoding="utf-8")
+        doc_mgr.append("newline.md", "- item\n")
+        text = (doc_vault / "newline.md").read_text(encoding="utf-8")
+        assert text == "# Note\n- item\n"
+
+    def test_append_updates_fts(self, doc_mgr: DocumentManager) -> None:
+        doc_mgr.append("alpha.md", "\nZanzibar content marker.\n")
+        results = doc_mgr._fts.search("Zanzibar")
+        assert any(r.path == "alpha.md" for r in results)
+
+    def test_append_nonexistent_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(DocumentNotFoundError):
+            doc_mgr.append("missing.md", "content\n")
+
+    def test_append_create_if_missing(
+        self, doc_mgr: DocumentManager, doc_vault: Path
+    ) -> None:
+        result = doc_mgr.append(
+            "new/journal.md", "# Journal\n\nFirst entry.\n", create_if_missing=True
+        )
+        assert result.created is True
+        text = (doc_vault / "new" / "journal.md").read_text(encoding="utf-8")
+        assert text == "# Journal\n\nFirst entry.\n"
+
+    def test_append_empty_content_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError, match="content must not be empty"):
+            doc_mgr.append("alpha.md", "")
+
+    def test_append_read_only_raises(self, ro_doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ReadOnlyError):
+            ro_doc_mgr.append("alpha.md", "x\n")
+
+    def test_append_etag_validation(self, doc_mgr: DocumentManager) -> None:
+        note = doc_mgr.read("alpha.md")
+        assert note is not None
+        doc_mgr.append("alpha.md", "First append.\n", if_match=note.etag)
+        with pytest.raises(ConcurrentModificationError):
+            doc_mgr.append("alpha.md", "Second append.\n", if_match=note.etag)
+
+    def test_append_if_match_on_missing_file_raises(
+        self, doc_mgr: DocumentManager
+    ) -> None:
+        with pytest.raises(ConcurrentModificationError):
+            doc_mgr.append(
+                "missing.md", "x\n", if_match="deadbeef", create_if_missing=True
+            )
+
+    def test_append_path_traversal_raises(self, doc_mgr: DocumentManager) -> None:
+        with pytest.raises(ValueError):
+            doc_mgr.append("../outside.md", "x\n")
+
+
+# ---------------------------------------------------------------------------
 # Delete tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -384,6 +384,17 @@ class TestInvalidationMatrix:
         assert "verified" not in meta
         assert meta["generated"]["by"].startswith("markdown-vault-mcp/")
 
+    def test_body_append_clears_verified(self, enforced_vault: Vault) -> None:
+        (enforced_vault._source_dir / "note.md").write_text(
+            _VERIFIED_NOTE, encoding="utf-8"
+        )
+        enforced_vault.index.build_index()
+        enforced_vault.writer.append("note.md", "Appended line.\n")
+        wait_for_writer_drain(enforced_vault)
+        meta = _meta(enforced_vault, "note.md")
+        assert "verified" not in meta
+        assert meta["generated"]["by"].startswith("markdown-vault-mcp/")
+
     def test_frontmatter_only_edit_clears_verified(self, enforced_vault: Vault) -> None:
         (enforced_vault._source_dir / "note.md").write_text(
             _VERIFIED_NOTE, encoding="utf-8"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -168,6 +168,7 @@ class TestToolListing:
         # Write tools absent when read_only=true (default)
         assert "write" not in names
         assert "edit" not in names
+        assert "append" not in names
         assert "delete" not in names
         assert "rename" not in names
 
@@ -181,6 +182,7 @@ class TestToolListing:
         # Write tools present when read_only=false
         assert "write" in names
         assert "edit" in names
+        assert "append" in names
         assert "delete" in names
         assert "rename" in names
 
@@ -356,6 +358,7 @@ class TestToolManifest:
         names = sorted(t.name for t in tools)
 
         assert names == [
+            "append",
             "build_embeddings",
             "delete",
             "edit",
@@ -434,7 +437,7 @@ class TestToolAnnotations:
             assert ann.readOnlyHint is False, f"{name} readOnlyHint"
 
         # Write tools — not readOnly
-        for name in ("write", "edit", "rename", "okf_seed_log"):
+        for name in ("write", "edit", "append", "rename", "okf_seed_log"):
             ann = by_name[name].annotations
             assert ann is not None
             assert ann.readOnlyHint is False, f"{name} readOnlyHint"
@@ -806,6 +809,45 @@ class TestWriteTool:
         assert isinstance(data, dict)
         assert data["created"] is True
         assert data["path"] == "fm_note.md"
+
+
+class TestAppendTool:
+    """Test the append MCP tool (#980)."""
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_append_extends_document(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "append", {"path": "simple.md", "content": "Appended tail.\n"}
+            )
+        data = result.data
+        assert data["path"] == "simple.md"
+        assert data["created"] is False
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_append_nonexistent_returns_error(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool_mcp(
+                "append", {"path": "nonexistent.md", "content": "x\n"}
+            )
+        assert result.isError is True
+
+    @pytest.mark.usefixtures("_mcp_env_writable")
+    async def test_append_create_if_missing(self) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "append",
+                {
+                    "path": "appended_new.md",
+                    "content": "# Fresh\n",
+                    "create_if_missing": True,
+                },
+            )
+        data = result.data
+        assert data["created"] is True
 
 
 class TestEditTool:

--- a/tests/test_write_tool_enumeration.py
+++ b/tests/test_write_tool_enumeration.py
@@ -126,7 +126,7 @@ class TestDerivedTextLockstep:
     def test_phrase_renderings(self) -> None:
         """Pin both renderings: okf family collapsed, others verbatim."""
         plain = write_tools_phrase()
-        assert plain.startswith("write, edit, delete, rename, ")
+        assert plain.startswith("write, edit, append, delete, rename, ")
         assert "the okf_* tools" in plain
         assert "okf_convert_links" not in plain
         assert write_tools_phrase(markdown=True).count("`") == 2 * (


### PR DESCRIPTION
## Closes / Refs

Closes #980

## What & why

Adds a dedicated `append` MCP tool (backed by `DocumentManager.append` and `WriterFacet.append`) that adds content at the end of a note without requiring a prior `read`. Previously, purely additive changes had to go through `edit`, which forces the entire note through the model context first — costly in tokens and error-prone, as reported in #980.

Semantics:

- A newline is inserted between the existing content and the appended text when the file does not already end with one.
- Optional `if_match` optimistic concurrency, same as `write`/`edit`.
- `create_if_missing` (default `false`) opts into creating a missing note; a mistyped path fails loudly by default.
- Treated as an `edit` `WriteOperation` for the OKF enforced-write enricher, folder-convention maintenance, and the git commit callback.
- Registered with `tags={"write"}` (hidden in read-only mode), full tool metadata (title, hints, icon), and added to `WRITE_TOOL_NAMES` with regenerated config-surface artifacts (`server.json`, wizard spec, env examples, README env table).

A follow-up commit applies local-review findings: the shared enrich → atomic-write → mark-dirty → callback tail of `write`/`edit`/`append` is extracted into `_finalize_content_write`, and internal docstring enumerations now include `append`.

## What this PR deliberately does NOT do

- Does not preserve CRLF line endings on append: like `edit` (and like the documented BOM handling), the file is persisted in the vault's normalized form (UTF-8, no BOM, LF), so a CRLF file is normalized on its first append. Documented in the `append` docstring; no tracking issue since it matches existing vault-wide write behavior.
- Does not widen the `WriteOperation` literal with an `append` variant; append reports as `edit` to the enricher, convention maintainer, and git commit callback.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.

## Docs impact

- [x] `README.md`
- [x] `docs/` site pages (`docs/tools/index.md`, `docs/index.md`, `docs/api/facets.md`, guides, generated wizard spec/env examples)
- [x] `docs/design/` (tool table, append-semantics paragraph, write-tag enumeration, manager/facet tables)
- [x] Inline docstrings

**Rule: code without matching docs is incomplete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6j3qoFgivZL1CQDr2pE7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6j3qoFgivZL1CQDr2pE7Y)_