### PR TITLE
fix(fetch): close SSRF gaps by migrating to pvl-core's hardened fetch_url

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -14,6 +14,8 @@ Traefik
 
 # --- HTTP / URL terminology ---
 hostname
+loopback
+routable
 subpath
 URIs
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2371,8 +2371,19 @@ overrides it.
 - `delete(path)` removes file from disk and index, then fires `on_write`
 - `fetch(url, path, frontmatter?, if_match?, timeout_s?)` downloads content
   from an HTTP/HTTPS URL and dispatches to `write()` (for `.md` paths) or
-  `write_attachment()` (for other extensions). Requires `httpx` (included in
-  `[all]` extra). Only `http` and `https` schemes are allowed (SSRF guard).
+  `write_attachment()` (for other extensions). The download delegates to
+  `fastmcp_pvl_core.fetch_url`, the hardened shared primitive the tool's
+  original SSRF guard was lifted into (#862; pvl-core #219): scheme
+  allowlist (`http`/`https` only), rejection of any host resolving to a
+  non-public address (permit-list model — private, loopback, link-local,
+  CGNAT/shared 100.64/10, and reserved ranges are all blocked, with NAT64
+  embedded-IPv4 validation), DNS-rebind pinning of the validated IP,
+  `trust_env=False` (ambient `HTTP(S)_PROXY`/`.netrc` cannot divert the
+  pinned connection), redirect refusal, a streaming size cap, and
+  userinfo/query redaction in logs and errors. The tool keeps only the
+  vault-side policy: which cap applies (attachment limit vs. uncapped
+  markdown) and the operator-facing size-limit message naming
+  `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB`.
 
 These semantics are intentionally close to Claude Code's file tools for
 familiarity. LLMs that know how to read/write/edit files can use these tools
@@ -2748,7 +2759,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = ["fastmcp>=3.0,<4"]
-embeddings-api = ["httpx>=0.25", "numpy>=1.20"]  # httpx also used by fetch tool
+embeddings-api = ["httpx>=0.25", "numpy>=1.20"]
 embeddings = ["fastembed>=0.3", "numpy>=1.20"]
 all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy>=1.20"]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.1", "mypy>=1.0"]

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -499,7 +499,7 @@ Download a file from a URL and save it to the vault as a note or attachment. Des
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `url` | string | required | Source URL to download. Only `http`/`https` schemes allowed; the host is resolved and private or internal addresses are blocked; the validated IP is pinned for the connection; redirects are not followed (SSRF protection) |
+| `url` | string | required | Source URL to download. Only `http`/`https` schemes allowed; the host is resolved and blocked unless every address is publicly routable (private, loopback, link-local, CGNAT/shared, and reserved ranges are all refused); the validated IP is pinned for the connection; ambient `HTTP(S)_PROXY`/`.netrc` settings are ignored; redirects are not followed (SSRF protection) |
 | `path` | string | required | Destination path in vault. Extension determines handling: `.md` for notes, anything else for attachments |
 | `frontmatter` | object | `null` | Optional YAML frontmatter dict for `.md` files. Ignored for attachments |
 | `if_match` | string | `null` | Optional etag from a previous `read` call for optimistic concurrency |
@@ -513,8 +513,9 @@ back into context.
 
 For `.md` destinations, the response may also include a `conventions` list; see [`write`](#write).
 
-!!! note "Dependency"
-    Requires `httpx`. Install with `pip install 'markdown-vault-mcp[all]'`.
+The download itself runs through `fastmcp-pvl-core`'s hardened `fetch_url`
+primitive, so the SSRF protections above are shared, audited code rather
+than a local copy.
 
 ### `git_sync`
 

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -2,18 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import ipaddress
 import logging
-import socket
 from dataclasses import asdict
 from datetime import date
 from typing import Any
-from urllib.parse import urlparse, urlunparse
 
 from fastmcp import Context, FastMCP
 from fastmcp.dependencies import CurrentContext, Depends
 from fastmcp.exceptions import ToolError
 from fastmcp.server.elicitation import AcceptedElicitation
+from fastmcp_pvl_core import fetch_url
 from mcp.shared.exceptions import McpError
 
 from markdown_vault_mcp.config import ProjectConfig
@@ -40,98 +38,10 @@ from ._common import attach_conventions
 logger = logging.getLogger(__name__)
 
 
-_ALLOWED_FETCH_SCHEMES = frozenset({"http", "https"})
-
-# SSRF protection: block private/reserved IP ranges.
-_FETCH_BLOCKED_HOSTNAMES = frozenset(
-    {"localhost", "localhost.localdomain", "metadata.google.internal"}
-)
-
-
-_BLOCKED_ADDR_MSG = (
-    "URLs targeting private, loopback, link-local, or reserved addresses "
-    "are not allowed."
-)
-
-# Default ports per scheme — omitted from the Host header (RFC 7230 §5.4:
-# a client SHOULD NOT send a port that equals the scheme default).
-_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
-
-
-def _ip_is_blocked(ip: str) -> bool:
-    """Return True if *ip* (an IP literal) is in a non-public range.
-
-    Covers private, loopback, link-local, unspecified (``0.0.0.0`` — which
-    ``is_private`` misses on older Pythons), reserved, and multicast space,
-    for both IPv4 and IPv6.
-    """
-    addr = ipaddress.ip_address(ip)
-    return (
-        addr.is_private
-        or addr.is_loopback
-        or addr.is_link_local
-        or addr.is_unspecified
-        or addr.is_reserved
-        or addr.is_multicast
-    )
-
-
-async def _resolve_pinned_ip(hostname: str, port: int) -> str:
-    """Resolve *hostname* and return one validated public IP to pin to.
-
-    SSRF guard that also closes the DNS-rebinding (TOCTOU) window: the caller
-    connects to the returned IP literal rather than the hostname, so the
-    address validated here is the address actually connected to — there is no
-    second resolution at connect time for an attacker's DNS to swap.
-
-    Fails **closed**: raises :class:`ValueError` if resolution errors, returns
-    no records, or **any** resolved address is non-public. An IP-literal
-    *hostname* is validated directly without a DNS lookup.
-
-    Args:
-        hostname: The URL host (an IP literal or a domain name).
-        port: The target port, used for the ``getaddrinfo`` service hint.
-
-    Returns:
-        A validated, public IP literal to connect to.
-
-    Raises:
-        ValueError: If the host is blocklisted, resolves to a non-public
-            address, or cannot be resolved.
-    """
-    if hostname in _FETCH_BLOCKED_HOSTNAMES:
-        raise ValueError(_BLOCKED_ADDR_MSG)
-
-    # IP-literal fast path: validate directly, no DNS lookup.
-    try:
-        ipaddress.ip_address(hostname)
-    except ValueError:
-        pass
-    else:
-        if _ip_is_blocked(hostname):
-            raise ValueError(_BLOCKED_ADDR_MSG)
-        return hostname
-
-    # Domain name: resolve and validate every returned address. Fail closed on
-    # any resolution error so a DNS hiccup can never become an SSRF bypass.
-    loop = asyncio.get_running_loop()
-    try:
-        infos = await loop.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
-    except OSError as exc:  # socket.gaierror is an OSError subclass
-        raise ValueError(
-            f"Could not resolve host {hostname!r} for the fetch URL: {exc}"
-        ) from exc
-
-    resolved = [str(info[4][0]) for info in infos]
-    if not resolved:
-        raise ValueError(f"Host {hostname!r} did not resolve to any address.")
-    for ip in resolved:
-        if _ip_is_blocked(ip):
-            raise ValueError(
-                f"Host {hostname!r} resolves to a non-public address ({ip}); "
-                "refusing to fetch."
-            )
-    return resolved[0]
+# ``fetch_url`` requires a positive size cap. Markdown fetches and
+# cap-disabled attachment fetches are intentionally unbounded, so they get a
+# bound no real download can reach.
+_FETCH_UNCAPPED_BYTES = 2**63 - 1
 
 
 async def _require_review_elicitation(ctx: Context, path: str) -> None:
@@ -673,10 +583,13 @@ def register(mcp: FastMCP) -> None:
 
         Args:
             url: Source URL to download from. Only http:// and https://
-                schemes are allowed. SSRF protection: the host is resolved and
-                rejected if any address is private, loopback, link-local, or
-                reserved, and the validated IP is pinned for the connection
-                (closing DNS rebinding). Redirects are NOT followed.
+                schemes are allowed. SSRF protection (via pvl-core's hardened
+                ``fetch_url``, #862): the host is resolved and rejected unless
+                every address is publicly routable (private, loopback,
+                link-local, CGNAT/shared, and reserved ranges are all
+                blocked), the validated IP is pinned for the connection
+                (closing DNS rebinding), ambient HTTP(S)_PROXY / .netrc
+                settings are ignored, and redirects are NOT followed.
             path: Destination path in the vault (e.g. "notes/report.md"
                 or "assets/diagram.png"). Extension determines handling:
                 .md for notes, anything else for attachments.
@@ -704,112 +617,50 @@ def register(mcp: FastMCP) -> None:
         as a new note.
 
         Raises:
-            ValueError: If the URL scheme is not http/https, the download
-                exceeds the size limit, or the response cannot be decoded.
-            ImportError: If httpx is not installed.
+            ValueError: If the URL scheme is not http/https, the host is
+                blocked or cannot be resolved, a redirect is returned, the
+                download exceeds the size limit, or the response cannot be
+                decoded.
         """
-        # Validate URL scheme (SSRF protection).
-        parsed = urlparse(url)
-        if parsed.scheme not in _ALLOWED_FETCH_SCHEMES:
-            raise ValueError(
-                f"Only http and https URLs are allowed, got {parsed.scheme!r}"
-            )
-        hostname = parsed.hostname
-        if not hostname:
-            raise ValueError("The fetch URL has no host.")
-        port = parsed.port or (443 if parsed.scheme == "https" else 80)
-        # Resolve + validate the host now, and pin the resulting IP into the
-        # connection below: the address validated here is the one actually
-        # dialled, which closes the DNS-rebinding TOCTOU window. Fails closed.
-        pinned_ip = await _resolve_pinned_ip(hostname, port)
-
-        # Conditional import — httpx is an optional dependency.
-        try:
-            import httpx
-        except ImportError:
-            raise ImportError(
-                "The 'fetch' tool requires 'httpx'. Install it with:\n"
-                "  pip install 'markdown-vault-mcp[all]'\n"
-                "  # or: pip install httpx"
-            ) from None
-
-        # Determine size limit (attachments only). This pre-check enforces
-        # the limit during streaming so we abort early without buffering the
-        # entire payload.
+        # Attachment size cap only: markdown notes are not size-limited, and
+        # a non-positive configured cap disables the limit.
         is_markdown = path.endswith(".md")
+        capped = not is_markdown and vault.max_attachment_size_mb > 0
         max_bytes = (
-            0
-            if is_markdown or vault.max_attachment_size_mb <= 0
-            else int(vault.max_attachment_size_mb * 1024 * 1024)
+            int(vault.max_attachment_size_mb * 1024 * 1024)
+            if capped
+            else _FETCH_UNCAPPED_BYTES
         )
 
-        # Connect to the validated IP, but keep the original Host header and TLS
-        # SNI so vhost routing and certificate verification still use the real
-        # hostname. httpx then dials the pinned IP without re-resolving.
-        ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
-        # Rebuild netloc from the pinned IP + port only. Any userinfo
-        # (``user:pass@``) in the original URL is intentionally dropped — the
-        # fetch tool must not relay embedded credentials to the server.
-        pinned_netloc = f"{ip_host}:{parsed.port}" if parsed.port else ip_host
-        pinned_url = urlunparse(parsed._replace(netloc=pinned_netloc))
-        # Host header carries the real hostname, omitting an explicit default
-        # port (RFC 7230 §5.4) so origin matching on strict servers still works.
-        if parsed.port is None or parsed.port == _SCHEME_DEFAULT_PORTS.get(
-            parsed.scheme
-        ):
-            host_header = hostname
-        else:
-            host_header = f"{hostname}:{parsed.port}"
+        # All SSRF hardening (scheme allowlist, non-public-address rejection
+        # incl. CGNAT, DNS-rebind pinning, trust_env=False, redirect refusal,
+        # streaming size cap, userinfo/query redaction) lives in pvl-core's
+        # fetch_url — the shared primitive this tool's guard was lifted into
+        # (#862; pvl-core #219).
+        try:
+            fetched = await fetch_url(url, max_bytes=max_bytes, timeout_s=timeout_s)
+        except ValueError as exc:
+            # Translate the size-cap refusal into the vault's operator-facing
+            # terms (which env var raises the limit). Couples to fetch_url's
+            # message text, but fails safe: on a reword the original error
+            # still propagates.
+            if capped and "exceeded the size cap" in str(exc):
+                raise ValueError(
+                    f"Download exceeded the attachment size limit "
+                    f"of {vault.max_attachment_size_mb} MB "
+                    f"({max_bytes} bytes). Raise "
+                    "MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB or "
+                    "set it to 0 to disable the limit."
+                ) from exc
+            raise
 
-        # Stream download — enforce size limit as chunks arrive.
-        chunks: list[bytes] = []
-        downloaded = 0
-        async with (
-            httpx.AsyncClient(timeout=timeout_s, follow_redirects=False) as client,
-            client.stream(
-                "GET",
-                pinned_url,
-                headers={"Host": host_header},
-                extensions={"sni_hostname": hostname},
-            ) as response,
-        ):
-            response.raise_for_status()
-            content_type = response.headers.get("content-type")
-            async for chunk in response.aiter_bytes(chunk_size=65536):
-                downloaded += len(chunk)
-                if max_bytes > 0 and downloaded > max_bytes:
-                    raise ValueError(
-                        f"Download exceeded the attachment size limit "
-                        f"of {vault.max_attachment_size_mb} MB "
-                        f"({max_bytes} bytes). Raise "
-                        "MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB or "
-                        "set it to 0 to disable the limit."
-                    )
-                chunks.append(chunk)
+        raw_bytes = fetched.body
+        content_type = fetched.content_type
+        content_length = fetched.size
 
-        raw_bytes = b"".join(chunks)
-        content_length = downloaded
-
-        # Redact userinfo and query string to avoid logging credentials
-        # (pre-signed URLs, API tokens, embedded passwords).
-        _parsed_log = urlparse(url)
-        _safe_url = urlunparse(
-            _parsed_log._replace(
-                netloc=(
-                    f"{_parsed_log.hostname}:{_parsed_log.port}"
-                    if _parsed_log.port
-                    else (_parsed_log.hostname or "")
-                ),
-                query="",
-                fragment="",
-            )
-        )
-        logger.info(
-            "fetch: downloaded %d bytes from %s → %s",
-            content_length,
-            _safe_url,
-            path,
-        )
+        # fetch_url already logs the (redacted) source URL; add the vault
+        # destination the transfer landed on.
+        logger.info("fetch: saved %d bytes to %s", content_length, path)
 
         # Dispatch to the appropriate write method.
         if is_markdown:

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -623,14 +623,19 @@ def register(mcp: FastMCP) -> None:
                 decoded.
         """
         # Attachment size cap only: markdown notes are not size-limited, and
-        # a non-positive configured cap disables the limit.
+        # a non-positive configured cap disables the limit. `capped` derives
+        # from the computed byte count, not the MB value, so a sub-byte
+        # positive setting (which floors to 0 bytes) counts as "no cap" —
+        # matching the pre-#862 guard — rather than tripping fetch_url's
+        # positive-max_bytes validation on every attachment fetch.
         is_markdown = path.endswith(".md")
-        capped = not is_markdown and vault.max_attachment_size_mb > 0
-        max_bytes = (
-            int(vault.max_attachment_size_mb * 1024 * 1024)
-            if capped
-            else _FETCH_UNCAPPED_BYTES
+        cap_bytes = (
+            0
+            if is_markdown or vault.max_attachment_size_mb <= 0
+            else int(vault.max_attachment_size_mb * 1024 * 1024)
         )
+        capped = cap_bytes > 0
+        max_bytes = cap_bytes if capped else _FETCH_UNCAPPED_BYTES
 
         # All SSRF hardening (scheme allowlist, non-public-address rejection
         # incl. CGNAT, DNS-rebind pinning, trust_env=False, redirect refusal,
@@ -641,10 +646,14 @@ def register(mcp: FastMCP) -> None:
             fetched = await fetch_url(url, max_bytes=max_bytes, timeout_s=timeout_s)
         except ValueError as exc:
             # Translate the size-cap refusal into the vault's operator-facing
-            # terms (which env var raises the limit). Couples to fetch_url's
-            # message text, but fails safe: on a reword the original error
-            # still propagates.
-            if capped and "exceeded the size cap" in str(exc):
+            # terms (which env var raises the limit). Matches fetch_url's full
+            # terminal suffix — not a substring, which URL content could spoof
+            # (e.g. a redirect refusal whose redacted URL contains the words).
+            # Couples to fetch_url's message text, but fails safe: on a reword
+            # the original error still propagates.
+            if capped and str(exc).endswith(
+                f"exceeded the size cap of {max_bytes} bytes."
+            ):
                 raise ValueError(
                     f"Download exceeded the attachment size limit "
                     f"of {vault.max_attachment_size_mb} MB "
@@ -657,10 +666,6 @@ def register(mcp: FastMCP) -> None:
         raw_bytes = fetched.body
         content_type = fetched.content_type
         content_length = fetched.size
-
-        # fetch_url already logs the (redacted) source URL; add the vault
-        # destination the transfer landed on.
-        logger.info("fetch: saved %d bytes to %s", content_length, path)
 
         # Dispatch to the appropriate write method.
         if is_markdown:
@@ -693,6 +698,10 @@ def register(mcp: FastMCP) -> None:
                 raw_bytes,
                 if_match=if_match,
             )
+
+        # fetch_url already logged the (redacted) source URL; record the vault
+        # destination only after the write actually landed.
+        logger.info("fetch_saved bytes=%d path=%s", content_length, path)
 
         data = {
             **asdict(result),

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -549,6 +549,8 @@ class TestWriteToolThreadsActor:
 class _FakeResponse:
     """Minimal stand-in for an httpx streaming response."""
 
+    status_code = 200
+
     def __init__(self, body: bytes, content_type: str) -> None:
         self._body = body
         self.headers = {"content-type": content_type}
@@ -589,8 +591,8 @@ def _make_fake_client(body: bytes, content_type: str) -> type:
     return _FakeClient
 
 
-async def _fake_resolve(_hostname: str, _port: int) -> str:
-    return "127.0.0.1"
+async def _fake_resolve(_hostname: str, _port: int) -> list[str]:
+    return ["93.184.216.34"]
 
 
 @pytest.mark.usefixtures("enforced_env")
@@ -603,8 +605,10 @@ class TestFetchThreadsActor:
         # fetch writes .md notes through DocumentManager.write, so the enricher
         # fires; the provenance actor must be the authenticated caller (#964).
         monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: "peter")
+        # The fetch tool delegates to pvl-core's fetch_url (#862); stub its
+        # documented DNS seam to a public IP so the SSRF guard passes.
         monkeypatch.setattr(
-            "markdown_vault_mcp._server_tools.writer._resolve_pinned_ip",
+            "fastmcp_pvl_core._transfer.fetch._resolve_addresses",
             _fake_resolve,
         )
         monkeypatch.setattr(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1388,6 +1388,9 @@ class TestFetchTool:
             yield raw
 
         mock_response = MagicMock()
+        # pvl-core's fetch_url range-checks the status before raise_for_status,
+        # so the mock must carry a real integer status code.
+        mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
         mock_response.headers = headers
         mock_response.aiter_bytes = mock_aiter_bytes
@@ -1587,7 +1590,8 @@ class TestFetchTool:
         with patch.object(httpx, "AsyncClient", return_value=mock_client):
             server = make_server()
             async with Client(server) as client:
-                with pytest.raises(ToolError, match="exceeded"):
+                # The refusal keeps naming the env var that raises the limit.
+                with pytest.raises(ToolError, match="MAX_ATTACHMENT_SIZE_MB"):
                     await client.call_tool(
                         "fetch",
                         {
@@ -1595,29 +1599,6 @@ class TestFetchTool:
                             "path": "assets/big.pdf",
                         },
                     )
-
-    async def test_fetch_httpx_not_installed(
-        self, _mcp_env_writable_with_attachments: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Graceful error when httpx is not available."""
-        import builtins
-
-        real_import = builtins.__import__
-
-        def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == "httpx":
-                raise ImportError("No module named 'httpx'")
-            return real_import(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mock_import)
-
-        server = make_server()
-        async with Client(server) as client:
-            with pytest.raises(ToolError, match="httpx"):
-                await client.call_tool(
-                    "fetch",
-                    {"url": "https://example.com/note.md", "path": "note.md"},
-                )
 
     async def test_fetch_frontmatter_applied(
         self, _mcp_env_writable_with_attachments: Path
@@ -1656,12 +1637,17 @@ class TestFetchTool:
     async def test_fetch_http_error_status(
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:
-        """Non-2xx HTTP response surfaces as ToolError."""
+        """Non-2xx HTTP response surfaces as ToolError.
+
+        fetch_url re-raises the status error with a redacted ``HTTP <code>
+        response from <url>`` message, so that is the asserted surface.
+        """
         from unittest.mock import AsyncMock, MagicMock, patch
 
         import httpx
 
         mock_response = MagicMock()
+        mock_response.status_code = 404
         mock_response.raise_for_status = MagicMock(
             side_effect=httpx.HTTPStatusError(
                 "Not Found",
@@ -1683,7 +1669,7 @@ class TestFetchTool:
         with patch.object(httpx, "AsyncClient", return_value=mock_client_instance):
             server = make_server()
             async with Client(server) as client:
-                with pytest.raises(ToolError, match="Not Found"):
+                with pytest.raises(ToolError, match="HTTP 404"):
                     await client.call_tool(
                         "fetch",
                         {
@@ -1730,6 +1716,61 @@ class TestFetchTool:
                     "fetch",
                     {"url": "http://0.0.0.0/admin", "path": "stolen.md"},
                 )
+
+    async def test_fetch_rejects_cgnat_ip(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        """CGNAT / shared address space (100.64.0.0/10, RFC 6598) is rejected (#862).
+
+        The old enumerated deny-list missed this range; pvl-core's permit-list
+        guard (block anything not globally routable) covers it structurally.
+        """
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(ToolError, match="private"):
+                await client.call_tool(
+                    "fetch",
+                    {"url": "http://100.64.0.1/internal", "path": "stolen.md"},
+                )
+
+    async def test_fetch_rejects_resolve_to_cgnat(
+        self,
+        _mcp_env_writable_with_attachments: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A hostname resolving into CGNAT space is blocked (#862)."""
+        self._patch_resolves_to(monkeypatch, "100.127.255.254")
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(ToolError, match="non-public"):
+                await client.call_tool(
+                    "fetch",
+                    {"url": "https://evil.example.com/x", "path": "x.md"},
+                )
+
+    async def test_fetch_client_ignores_ambient_proxy_env(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        """The outbound client is built with trust_env=False (#862).
+
+        An ambient HTTP(S)_PROXY env var must never divert the request past
+        the resolve-validate-pin chain, and .netrc must never attach ambient
+        credentials — asserted on the client constructor call.
+        """
+        import httpx
+
+        mock_client = self._mock_httpx_stream(
+            b"# Ok\n", {"content-type": "text/markdown"}
+        )
+        with patch.object(httpx, "AsyncClient", return_value=mock_client) as ctor:
+            server = make_server()
+            async with Client(server) as client:
+                await client.call_tool(
+                    "fetch",
+                    {"url": "https://example.com/note.md", "path": "noproxy.md"},
+                )
+        ctor.assert_called_once()
+        assert ctor.call_args.kwargs["trust_env"] is False
 
     async def test_fetch_rejects_resolve_to_private(
         self,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1600,6 +1600,29 @@ class TestFetchTool:
                         },
                     )
 
+    async def test_fetch_sub_byte_size_limit_means_uncapped(
+        self, _mcp_env_writable_with_attachments: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A positive cap that floors to 0 bytes disables the limit (pre-#862
+        behavior), rather than failing every attachment fetch on fetch_url's
+        positive-max_bytes validation."""
+        import httpx
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB", "0.0000005")
+
+        raw = b"x" * 2048
+        mock_client = self._mock_httpx_stream(
+            raw, {"content-type": "application/octet-stream"}
+        )
+        with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            server = make_server()
+            async with Client(server) as client:
+                result = await client.call_tool(
+                    "fetch",
+                    {"url": "https://example.com/tiny.pdf", "path": "assets/tiny.pdf"},
+                )
+        assert result.data["content_length"] == len(raw)
+
     async def test_fetch_frontmatter_applied(
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:


### PR DESCRIPTION
## Closes / Refs

Closes #862

## What & why

The `fetch` tool's local SSRF guard missed CGNAT / shared address space (`100.64.0.0/10`, RFC 6598 — the enumerated deny-list has no flag covering it) and constructed its outbound `httpx.AsyncClient` without `trust_env=False`, letting an ambient `HTTP(S)_PROXY` env var divert the request past the resolve-validate-pin chain and `.netrc` attach ambient credentials. This PR takes the issue's preferred remediation: the tool now delegates the download to `fastmcp_pvl_core.fetch_url` (pvl-core #219) — the hardened shared primitive this exact algorithm was lifted into — which blocks anything not globally routable (covering CGNAT structurally, with NAT64 embedded-IPv4 validation), sets `trust_env=False`, and catches `UnicodeError` alongside `OSError` on resolution. The vault-local `_ip_is_blocked` / `_resolve_pinned_ip` copies are removed, not left in parallel; the tool keeps only vault-side policy (attachment-cap selection and the operator-facing size-limit message naming `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB`).

New tests cover CGNAT rejection (IP literal `100.64.0.1` and a hostname resolving into `100.64/10`), assert `trust_env=False` on the client constructor, and pin the sub-byte-cap-means-uncapped behaviour. Issue #862's verification commands pass: `_ip_is_blocked` is gone from `writer.py`, and pvl-core's guard returns `True` for `100.64.0.1`.

## What this PR deliberately does NOT do

- Decouple the fetch tests from fastmcp-pvl-core private internals (the `_transfer.fetch._resolve_addresses` seam and `httpx.AsyncClient` construction patching): #1028
- Drop the message-text coupling in the size-cap translation (it matches `fetch_url`'s full terminal suffix and fails safe — the original error propagates on an upstream reword); no tracking issue, accepted as-is.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`. It surfaced four findings; three were fixed in the second commit (sub-byte cap regression, spoofable size-cap message match, premature/mis-shaped "saved" log line) and the fourth is deferred as #1028.

## Docs impact

- [ ] `README.md` — no change needed (its fetch mentions don't describe the guard's internals)
- [x] `docs/` site pages — `docs/tools/index.md`: `url` parameter's SSRF description updated (non-public incl. CGNAT blocked, ambient proxy ignored); stale "Requires httpx" install note replaced (httpx is a hard transitive dependency via fastmcp-pvl-core)
- [x] `docs/design/` — fetch tool bullet rewritten to document the delegation to `fetch_url` and the vault-side policy split; stale "httpx also used by fetch tool" comment removed
- [x] Inline docstrings — fetch tool docstring: SSRF description updated, unreachable `ImportError` raise removed

**Rule: code without matching docs is incomplete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJxWHr9ojxdN1nwhbMSxPh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJxWHr9ojxdN1nwhbMSxPh)_