### PR TITLE
fix(release): adopt template v3.2.2 — template-owned bump_manifests, non-mutating CI syncs

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v3.2.1
+_commit: v3.2.2
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,15 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --all-extras --all-groups
+        # `--locked` rather than a bare sync: an unfrozen `uv sync` re-locks
+        # when `uv.lock` is stale relative to `pyproject.toml`, which both
+        # hides the drift (the workspace silently self-heals while the branch
+        # stays broken) and mutates a tracked file mid-job. Fail loudly
+        # instead — this is the check that would have caught the release-commit
+        # lockfile drift in #325 on the release that introduced it, rather
+        # than in an unrelated workflow weeks later (#326). Fix a red install
+        # step with `uv lock`, and commit the result.
+        run: uv sync --all-extras --all-groups --locked
 
 
       - name: Verify assembled SPA source is up-to-date
@@ -70,7 +78,8 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --all-extras --all-groups
+        # `--locked` — see the lint job's install step for why.
+        run: uv sync --all-extras --all-groups --locked
 
       - name: Run mypy
         run: uv run mypy src/ tests/
@@ -120,7 +129,8 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras --all-groups
+        # `--locked` — see the lint job's install step for why.
+        run: uv sync --all-extras --all-groups --locked
 
       - name: Run tests with coverage
         run: uv run pytest --cov --cov-report=xml
@@ -404,7 +414,8 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --all-extras --all-groups
+        # `--locked` — see the lint job's install step for why.
+        run: uv sync --all-extras --all-groups --locked
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }} --depth=50

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,7 +87,18 @@ jobs:
         # Gives the reviewer a working venv so its targeted `uv run` checks
         # (freedom to investigate one finding) actually execute. REVIEW.md
         # tells it not to re-run the full gate.
-        run: uv sync --all-extras --all-groups
+        #
+        # `--frozen` because this sync must leave the workspace byte-clean:
+        # the review action switches to the PR branch internally, and an
+        # unfrozen sync against a lockfile that is stale relative to
+        # `pyproject.toml` re-locks `uv.lock` in place, so that checkout
+        # aborts ("Your local changes ... would be overwritten") for every PR
+        # whose lockfile differs from the base branch's — no review posted,
+        # deterministically (#326). `--frozen` installs from the lockfile as
+        # committed and never rewrites it; unlike `--locked` it also does not
+        # fail on drift, which is right here — a stale lockfile is CI's
+        # finding to report, not a reason to skip the review.
+        run: uv sync --all-extras --all-groups --frozen
 
       # The /code-review plugin fans out into parallel review agents. On Claude
       # Code >= 2.1.198 those dispatch as background tasks that claude-code-action

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,15 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 - `# DOCKERFILE-STATE-DIRS-START` / `-END` — state subdirectories created under `/data` (chowned to the runtime user)
 - `# DOCKERFILE-VOLUMES-START` / `-END` — `VOLUME` declarations on the final image
 
+### Release manifest extension points
+
+`scripts/bump_manifests.py` bumps `server.json` and refreshes `uv.lock`'s self-version entry inside the release commit, so the tag never points at a manifest whose version lags it. These sentinel blocks in that script are preserved across `copier update`. Add bumps for this project's own version-coupled manifests (a Claude Code `plugin.json`, an `.mcp.json`, another lockstep JSON/TOML) inside them:
+
+- `# DOMAIN-MANIFESTS-HELPERS-START` / `-END` — module-level helpers (use `_load` / `_dump` for JSON so the byte format matches what `scripts/gen_config_surface.py` asserts)
+- `# DOMAIN-MANIFESTS-START` / `-END` — the calls, inside `main()`, where `version` is in scope
+
+Every path bumped there must also appear in `pyproject.toml`'s `[tool.semantic_release] assets`, or PSR leaves it out of the release commit. The two are checked against each other by `tests/test_release_contract.py`, so a manifest named in one and not the other fails the gate rather than shipping a release commit with a stale file in it.
+
 ## Tool Registration Checklist
 
 Every MCP tool you register must carry the full set of metadata below — not just the behaviour. A tool that works but lacks a title, hints, or docs is incomplete. When adding or changing a tool, verify each item:
@@ -305,7 +314,7 @@ Shared infrastructure (auth providers, middleware stack, logging bootstrap, even
 - [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
 - [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, and this very section of CLAUDE.md.
 
-Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `CHANGELOG.md`, `LICENSE`) are written once and require manual reconciliation on template updates; `CLAUDE.md` and `README.md` are deliberately *not* among them — both are re-rendered on update, and only content inside their `DOMAIN-START` / `DOMAIN-END` sentinels survives — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END`, `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END`, and `CONFIG-VALIDATE-START` / `CONFIG-VALIDATE-END` sentinels) stays in this repo.
+Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `CHANGELOG.md`, `LICENSE`) are written once and require manual reconciliation on template updates; `CLAUDE.md`, `README.md`, `.pre-commit-config.yaml` and `scripts/bump_manifests.py` are deliberately *not* among them — all four are re-rendered on update, and only content inside their domain sentinels survives (`DOMAIN-START` / `DOMAIN-END` in the two Markdown files, `DOMAIN-HOOKS` in the pre-commit config, `DOMAIN-MANIFESTS-HELPERS` / `DOMAIN-MANIFESTS` in the bumper) — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END`, `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END`, and `CONFIG-VALIDATE-START` / `CONFIG-VALIDATE-END` sentinels) stays in this repo.
 
 ## Contributing fixes upstream
 

--- a/FORKING.md
+++ b/FORKING.md
@@ -68,7 +68,9 @@ strips the copier-update wording that no longer describes a detached fork: the
 `TEMPLATE-OWNED SECTIONS` banner fences (a fork owns every section, so the
 template/domain split is moot), the "Kept across copier update" notes on the
 DOMAIN blocks, the remaining "preserved/survive across copier update" notes
-(the pre-commit defaults, the `Dockerfile` sentinels, and the upstream sentinel),
+(the pre-commit defaults, the `Dockerfile` sentinels, the
+`scripts/bump_manifests.py` release-manifest sentinels, and the upstream
+sentinel),
 and the copier-specific trigger on the config-wizard spec generation note (the
 generator still runs in a fork, just not on a copier lifecycle event).
 The fork-neutral contributor guidance

--- a/README.md
+++ b/README.md
@@ -648,7 +648,16 @@ uv sync --all-extras --all-groups
 
 ### `uv.lock` refresh after `copier update`
 
-When `copier update` introduces new dependencies, CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
+When `copier update` introduces new dependencies (such as a new extra added to `pyproject.toml.jinja`), the CI install step runs `uv sync --locked`, which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
+
+CI installs with `--locked` (and the review workflow with `--frozen`) so no job ever rewrites `uv.lock` in its own workspace: a job that re-locks hides the drift it just repaired, and a dirty workspace breaks any later `git checkout` in the same job. Lockfile drift then shows up as a red install step with a clear message, not as a silent mutation.
+
+## Links
+
+- [Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)
+- [llms.txt](https://pvliesdonk.github.io/markdown-vault-mcp/llms.txt)
+- [FastMCP](https://gofastmcp.com)
+- [fastmcp-pvl-core](https://pypi.org/project/fastmcp-pvl-core/)
 
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,8 +307,14 @@ extraPaths = ["src"]
 version_toml = ["pyproject.toml:project.version"]
 commit_parser = "angular"
 tag_format = "v{version}"
-# Bump the versioned manifests inside the release commit rather than in a
-# follow-up commit + force-retag. See issue #392.
+# Bump versioned manifests (server.json) inside the release commit rather
+# than in a follow-up commit + force-retag.  If your project adds more
+# lockstep manifests (plugin.json, .mcp.json, ...), add the bump inside
+# scripts/bump_manifests.py's DOMAIN-MANIFESTS markers and the path to
+# `assets` below — the script is template-owned, so code outside those
+# markers is overwritten on the next copier update.  `assets` and the script
+# must move together: tests/test_release_contract.py fails the build if one
+# names a manifest the other does not.
 build_command = "python scripts/bump_manifests.py"
 # PSR stages and commits files listed in `assets` together with pyproject.toml
 # and CHANGELOG.md, so the release tag points at a single commit containing

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -2,21 +2,25 @@
 """Bump versioned manifests to match the semantic-release version.
 
 Invoked by python-semantic-release via ``[tool.semantic_release] build_command``.
-PSR sets ``NEW_VERSION`` in the environment and, because the three manifest
-paths are listed in ``[tool.semantic_release] assets``, PSR stages and commits
-them together with ``pyproject.toml`` + ``CHANGELOG.md`` as the single release
-commit — which is the commit it then tags.
+PSR sets ``NEW_VERSION`` in the environment and, because ``server.json`` and
+``uv.lock`` are listed in ``[tool.semantic_release] assets``, PSR stages and
+commits them together with ``pyproject.toml`` + ``CHANGELOG.md`` as the single
+release commit — which is the commit it then tags.
 
 The script runs inside PSR's Docker action container (python:3.14-slim), which
 has Python but no ``jq`` — hence Python rather than a shell+jq wrapper.
 
-This MV-specific version extends the template's single-manifest (server.json)
-bumper with two extra Claude Code plugin manifests that also need to move in
-lockstep with the released package version:
-
-- ``.claude-plugin/plugin/.claude-plugin/plugin.json`` — plugin ``version``
-- ``.claude-plugin/plugin/.mcp.json`` — ``uvx --from markdown-vault-mcp[all]==<ver>``
-  pin in the server's launch args.
+This file is TEMPLATE-OWNED: it re-renders on every ``copier update``, so a
+fix to the shared bumpers (``server.json``, ``uv.lock``) arrives whole rather
+than half — the ``assets`` half landing in the re-rendered ``pyproject.toml``
+while the script half never arrives (#325).  Projects that ship additional
+versioned manifests (e.g. a Claude Code ``plugin.json``, an ``.mcp.json``, or
+other lockstep JSON/TOML files) put their code between the
+``DOMAIN-MANIFESTS-HELPERS`` markers (module-level helpers) and the
+``DOMAIN-MANIFESTS`` markers (the calls, inside ``main()``), and list each
+extra path in ``pyproject.toml`` ``[tool.semantic_release] assets``.  Only
+content inside those markers survives an update; anything added outside them
+lands in template-owned code and is at the mercy of the next merge.
 """
 
 from __future__ import annotations
@@ -25,6 +29,7 @@ import json
 import os
 import re
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +45,88 @@ def _dump(path: Path, data: Any) -> None:
         # jq's default behavior and how a human editor would save the file.
         json.dump(data, fh, indent=2, ensure_ascii=False)
         fh.write("\n")
+
+
+def _bump_lockfile(version: str) -> None:
+    """Refresh ``uv.lock``'s self-referential ``[[package]]`` version.
+
+    PSR bumps ``pyproject.toml:project.version`` but nothing re-locks, so
+    without this the release commit ships a lockfile whose self entry still
+    carries the previous version.  That drift then self-heals as a side
+    effect of the next ``uv run`` rewriting ``uv.lock`` — tripping
+    pre-commit's "files were modified by this hook" guard on an unrelated
+    later commit.  PSR's container has no ``uv``, so rewrite the one
+    version line textually instead of running ``uv lock``.
+    """
+    lock_path = Path("uv.lock")
+    if not lock_path.exists():
+        # A fresh scaffold has no lockfile until the first `uv sync`.
+        print("bump_manifests: uv.lock not found — skipped", file=sys.stderr)
+        return
+    with Path("pyproject.toml").open("rb") as fh:
+        name = tomllib.load(fh)["project"]["name"]
+    # uv writes the PEP 503-normalized name into the lockfile.
+    normalized = re.sub(r"[-_.]+", "-", name).lower()
+    text = lock_path.read_text(encoding="utf-8")
+    pattern = (
+        r'(\[\[package\]\]\nname = "'
+        + re.escape(normalized)
+        + r'"\nversion = ")[^"]*(")'
+    )
+    new_text, n = re.subn(
+        pattern, lambda m: m.group(1) + version + m.group(2), text, count=1
+    )
+    if n == 0:
+        print(
+            f"WARNING: uv.lock has no [[package]] entry named {normalized!r} "
+            "— left unchanged",
+            file=sys.stderr,
+        )
+        return
+    lock_path.write_text(new_text, encoding="utf-8")
+    print(f"bump_manifests: uv.lock ({normalized}) → {version}")
+
+
+# DOMAIN-MANIFESTS-HELPERS-START — module-level helpers for this project's own
+# versioned manifests (a `_bump_plugin_json(version)`, a TOML rewriter, ...).
+# `_load` / `_dump` above read and write JSON in the byte format the rest of
+# the toolchain expects (indent=2, ensure_ascii=False, trailing newline) —
+# scripts/gen_config_surface.py asserts that format, so prefer them over a
+# bare `json.dump`.  Call what you define from the DOMAIN-MANIFESTS block in
+# `main()` below.  Kept across copier update.
+def _bump_plugin_manifests(version: str) -> None:
+    """Bump the two Claude Code plugin manifests to ``version``.
+
+    Both move in lockstep with the released package version (gate #7):
+
+    - ``.claude-plugin/plugin/.claude-plugin/plugin.json`` — plugin ``version``
+    - ``.claude-plugin/plugin/.mcp.json`` — the
+      ``uvx --from markdown-vault-mcp[all]==<ver>`` pin in the server's
+      launch args.
+
+    Args:
+        version: The new release version string from PSR's ``NEW_VERSION``.
+    """
+    plugin_path = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
+    plugin = _load(plugin_path)
+    plugin["version"] = version
+    _dump(plugin_path, plugin)
+
+    mcp_path = Path(".claude-plugin/plugin/.mcp.json")
+    mcp = _load(mcp_path)
+    mcp["markdown-vault-mcp"]["args"] = [
+        "--from",
+        f"markdown-vault-mcp[all]=={version}",
+        "markdown-vault-mcp",
+        "serve",
+    ]
+    _dump(mcp_path, mcp)
+
+    print(f"bump_manifests: {plugin_path} → {version}")
+    print(f"bump_manifests: {mcp_path} → markdown-vault-mcp[all]=={version}")
+
+
+# DOMAIN-MANIFESTS-HELPERS-END
 
 
 def main() -> int:
@@ -103,26 +190,17 @@ def main() -> int:
             pkg["identifier"] = new_id
     _dump(server_path, server)
 
-    # Claude Code plugin.json: plugin version, lockstep with the package.
-    plugin_path = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
-    plugin = _load(plugin_path)
-    plugin["version"] = version
-    _dump(plugin_path, plugin)
-
-    # Claude Code .mcp.json: pin uvx --from spec to the released version.
-    mcp_path = Path(".claude-plugin/plugin/.mcp.json")
-    mcp = _load(mcp_path)
-    mcp["markdown-vault-mcp"]["args"] = [
-        "--from",
-        f"markdown-vault-mcp[all]=={version}",
-        "markdown-vault-mcp",
-        "serve",
-    ]
-    _dump(mcp_path, mcp)
-
     print(f"bump_manifests: server.json → {version}")
-    print(f"bump_manifests: {plugin_path} → {version}")
-    print(f"bump_manifests: {mcp_path} → markdown-vault-mcp[all]=={version}")
+    _bump_lockfile(version)
+    # DOMAIN-MANIFESTS-START — bump this project's extra versioned manifests
+    # here; `version` is the new version string, and the repo root is the cwd.
+    # Every path touched here must also be listed in `pyproject.toml`
+    # `[tool.semantic_release] assets`, or PSR leaves it out of the release
+    # commit.  Kept across copier update; everything outside these markers is
+    # template-owned and re-rendered, which is what keeps the bumpers above in
+    # lockstep with the `assets` list they are declared against.
+    _bump_plugin_manifests(version)
+    # DOMAIN-MANIFESTS-END
     return 0
 
 

--- a/scripts/copier_update_prompts/job_b.md
+++ b/scripts/copier_update_prompts/job_b.md
@@ -43,6 +43,19 @@ To decide between `ships-automatically` and `needs-opt-in`, read
 `_exclude`. Files listed in `_skip_if_exists` are downstream-owned starter
 files — changes in those files do NOT flow to downstream automatically.
 
+**Split-ownership entries are the dangerous case.** If one CHANGELOG entry
+touches BOTH a template-owned file and a `_skip_if_exists` file, only half of
+it arrives, and the half that does arrive can assert something the missing
+half was supposed to make true. Classify these `needs-opt-in` even when the
+template-owned half looks self-sufficient, and make the summary name the
+skip-listed file plus the exact edit downstream has to make by hand. The
+shape to look for: a re-rendered config file declaring behaviour a
+skip-listed script implements — template v3.1.0 (#298) added `uv.lock` to
+`pyproject.toml`'s `[tool.semantic_release] assets` and the matching
+`_bump_lockfile()` to the then-skip-listed `scripts/bump_manifests.py`, so
+instances with an extended copy of that script started committing lockfiles
+whose version lagged the tag (#325).
+
 ## Output
 
 Write the following JSON to `/tmp/agent-job-b.json`:

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -1,0 +1,129 @@
+"""Guards for the release-commit contract between PSR and the manifest bumper.
+
+`pyproject.toml`'s `[tool.semantic_release] assets` list and
+`scripts/bump_manifests.py` are two halves of one mechanism: PSR stages every
+path in `assets` into the release commit, and the bumper is what actually
+rewrites the version inside those paths.  Declare a path in one half only and
+the release still succeeds — it just ships a file whose version lags the tag.
+
+That is not hypothetical.  v3.1.0 (#298) added `uv.lock` to `assets` and a
+`_bump_lockfile()` to the bumper in one change, but the script was
+`_skip_if_exists` at the time while `pyproject.toml` re-renders, so instances
+with a pre-existing extended copy took the `assets` half alone.  Their release
+commits shipped a lockfile whose self entry lagged `pyproject.toml`, which made
+`uv lock --check` fail on `main` and turned every `uv sync` into a workspace
+mutation (#325, #326).  The script is template-owned now, with
+`DOMAIN-MANIFESTS` seams for a project's own manifests; these tests are what
+keeps the two halves honest for anything added through those seams.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUMPER = REPO_ROOT / "scripts" / "bump_manifests.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# Manifests the template itself bumps, mapped to the marker that proves the
+# bumper still handles them.  A domain manifest added through the
+# DOMAIN-MANIFESTS seam is covered by the generic path-mention test below
+# instead — the template cannot know its function names.
+TEMPLATE_ASSETS = {
+    "server.json": "_dump(server_path, server)",
+    "uv.lock": "_bump_lockfile(version)",
+}
+
+
+def _bumper_text() -> str:
+    return BUMPER.read_text(encoding="utf-8")
+
+
+def _semantic_release_config() -> dict[str, Any]:
+    with PYPROJECT.open("rb") as fh:
+        data = tomllib.load(fh)
+    section: dict[str, Any] = data["tool"]["semantic_release"]
+    return section
+
+
+def _assets() -> list[str]:
+    assets = _semantic_release_config()["assets"]
+    assert isinstance(assets, list), "[tool.semantic_release] assets must be a list"
+    return [str(asset) for asset in assets]
+
+
+def test_build_command_invokes_the_bumper() -> None:
+    """PSR must actually run the script, or none of the rest matters."""
+    build_command = _semantic_release_config().get("build_command")
+    assert build_command is not None, "[tool.semantic_release] build_command is unset"
+    assert "scripts/bump_manifests.py" in str(build_command)
+    assert BUMPER.is_file(), f"{BUMPER} is missing"
+
+
+@pytest.mark.parametrize(("asset", "marker"), sorted(TEMPLATE_ASSETS.items()))
+def test_template_asset_is_still_bumped(asset: str, marker: str) -> None:
+    """Each template-owned asset is declared AND rewritten, or neither.
+
+    Both directions fail here: dropping the `assets` entry leaves the bumper
+    rewriting a file PSR never commits, and dropping the bumper call leaves PSR
+    committing a file nobody rewrote.
+    """
+    declared = asset in _assets()
+    bumped = marker in _bumper_text()
+    assert declared == bumped, (
+        f"{asset} is {'declared in assets' if declared else 'absent from assets'} "
+        f"but {'handled' if bumped else 'not handled'} by scripts/bump_manifests.py "
+        "— the release commit would carry a stale version for it"
+    )
+
+
+def test_every_declared_asset_is_mentioned_by_the_bumper() -> None:
+    """Anything in `assets` must at least appear in the bumper's source.
+
+    Deliberately a weak check — it cannot prove a domain manifest is rewritten
+    correctly, only that adding a path to `assets` without touching the script
+    (the #325 failure shape) does not pass silently.  `CHANGELOG.md` and
+    `pyproject.toml` are PSR's own outputs and never appear here.
+    """
+    text = _bumper_text()
+    psr_owned = {"CHANGELOG.md", "pyproject.toml"}
+    missing = [
+        asset for asset in _assets() if asset not in psr_owned and asset not in text
+    ]
+    assert not missing, (
+        f"declared in [tool.semantic_release] assets but never named in "
+        f"scripts/bump_manifests.py: {missing} — add the bump inside the "
+        "DOMAIN-MANIFESTS markers, or drop the asset"
+    )
+
+
+def test_domain_manifest_sentinels_are_present() -> None:
+    """Both seams survive as matched pairs, exactly once.
+
+    The script is template-owned, so these markers are the only copier-safe
+    place for a project's own bumps.  A dropped fence means the next update
+    silently overwrites whatever a downstream put there.
+    """
+    text = _bumper_text()
+    for name in ("DOMAIN-MANIFESTS-HELPERS", "DOMAIN-MANIFESTS"):
+        assert text.count(f"# {name}-START") == 1, f"{name}-START fence missing"
+        assert text.count(f"# {name}-END") == 1, f"{name}-END fence missing"
+
+
+def test_domain_manifest_calls_sentinel_lives_inside_main() -> None:
+    """The call seam sits in `main()`, after the template's own bumps.
+
+    Placement is the point: `version` is only in scope there, and running after
+    the shipped bumpers means a domain manifest cannot be skipped by an early
+    `return 1` on a malformed `server.json`.
+    """
+    text = _bumper_text()
+    main_def = text.index("def main()")
+    start = text.index("# DOMAIN-MANIFESTS-START")
+    end = text.index("# DOMAIN-MANIFESTS-END")
+    assert main_def < start < end
+    assert text.index("_bump_lockfile(version)") < start

--- a/uv.lock
+++ b/uv.lock
@@ -1223,7 +1223,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "3.2.0rc6"
+version = "3.2.0rc7"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Closes / Refs

Closes #1030

## What & why

Adopts fastmcp-server-template v3.2.2 (fastmcp-server-template#327), which fixes both halves of the claude-review checkout abort upstream: `scripts/bump_manifests.py` is now template-owned (the plugin-manifest bumps move into the new `DOMAIN-MANIFESTS-HELPERS` / `DOMAIN-MANIFESTS` seams, and the template's `_bump_lockfile` arrives so release commits carry a consistent `uv.lock` — fastmcp-server-template#325), and CI installs are non-mutating (`--frozen` in claude-code-review.yml, `--locked` in ci.yml — fastmcp-server-template#326). Also refreshes `uv.lock`'s self entry (`3.2.0rc6` → `3.2.0rc7`) to heal the drift the `3.2.0-rc.7` release left on main, which the new `--locked` installs require.

The rendered `tests/test_release_contract.py` now gates `assets`/bumper lockstep, so a half-delivered fix of this shape (the #1030 root cause) fails red instead of shipping a stale release commit. Verified locally: the resolved bumper diverges from the template render only inside the DOMAIN seams; an end-to-end `NEW_VERSION` run bumps all four manifests including the lockfile self entry; `uv lock --check` passes on the result.

## What this PR deliberately does NOT do

- Nothing deferred — both root-cause halves landed upstream in fastmcp-server-template#327 and are adopted here in full.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening the PR.

## Docs impact

- [x] `README.md` — template-rendered update documenting the `--locked`/`--frozen` install policy and restored Links section
- [ ] `docs/` site pages — no user-facing tool/resource/env changes
- [ ] `docs/design/` — release infrastructure is out of the design doc's scope
- [x] Inline docstrings — `_bump_plugin_manifests` documented; `CLAUDE.md` gains the "Release manifest extension points" section (template-rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gf2CEXCK1aJUHJCg8rJipZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gf2CEXCK1aJUHJCg8rJipZ)_