### PR TITLE
feat(index)!: make reindex and build_embeddings dual-mode background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,9 +418,9 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `list_documents` | List indexed documents; pass `include_attachments=true` to also list non-markdown files |
 | `list_folders` | List all folder paths in the vault |
 | `list_tags` | List all unique frontmatter tag values |
-| `reindex` | Force a full reindex of the vault |
+| `reindex` | Incrementally reindex files changed outside the server; fast runs answer inline with real counts, slow runs promote to a job (`get_job_result`) |
 | `stats` | Get vault statistics (document count, chunk count, link health metrics, etc.) |
-| `build_embeddings` | Build or rebuild vector embeddings for semantic search |
+| `build_embeddings` | Build or rebuild vector embeddings for semantic search; fast convergence answers inline, slow builds promote to a job (`get_job_result`) |
 | `embeddings_status` | Check embedding provider and index status |
 | `get_index_status` | Check background FTS build state (`queryable` / `building` / `failed`) |
 | `get_backlinks` | Find all documents that link to a given document |
@@ -434,7 +434,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `get_most_linked` | Find the most-linked-to notes ranked by backlink count |
 | `get_connection_path` | Find the shortest path between two notes via BFS on the undirected link graph (max 10 hops) |
 | `summarize` | Summarize a note, a set of notes, or a folder subtree with an LLM; the synthesis references the individual source notes by path. Dual-mode: a task-capable MCP client runs it as a native background task, and for any other client a slow summary is promoted to a background job (retrieved via `get_job_result`) so the tool never hangs. Hidden unless an OpenAI-compatible backend is configured (`OPENAI_API_KEY` or a base URL). Sends note content to the model provider. |
-| `get_job_result` | Retrieve the outcome of a background job started by a long-running tool (today: a promoted `summarize` call), by its `job_id`. Registered alongside `summarize`. |
+| `get_job_result` | Retrieve the outcome of a background job started by a long-running tool (a promoted `summarize`, `reindex`, or `build_embeddings` call), by its `job_id`. Always registered. |
 | `get_history` | List commits that touched a note, attachment, folder, or the whole vault (git-backed vaults only) |
 | `get_diff` | Return a diff of a note or attachment between a reference commit/timestamp and HEAD; binary attachments return a `--stat` size summary instead of a unified patch (git-backed vaults only) |
 | `git_sync` | Force an immediate git pull / push / both, bypassing the periodic loops. Returns structured state (SHAs, commit counts, Syncthing-style conflict file paths if any). Hidden when `MARKDOWN_VAULT_MCP_GIT_REPO_URL` isn't set or `READ_ONLY=true`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,7 +202,7 @@ The bare `OPENAI_BASE_URL` is honored as a *value* fallback when a key is set (s
 
 ## Background Jobs
 
-Long-running tools (today, `summarize`) are dual-mode: an MCP client that
+Long-running tools (`summarize`, `reindex`, `build_embeddings`) are dual-mode: an MCP client that
 speaks background tasks runs them as protocol-native tasks (see
 [Background tasks](#background-tasks) for the backend), while any other
 client runs them in the foreground up to a soft deadline. A call that beats

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -789,10 +789,12 @@ The writer accepts five job kinds, each a frozen dataclass:
 
 Submission returns a `concurrent.futures.Future`; callers wait via
 `.result()` for synchronous semantics (library-level `build_index()`,
-`reindex()`, `build_embeddings()`) or fire-and-forget via the `*_async`
-counterparts (MCP-tool-level `reindex` and `build_embeddings`, both of
-which return `{"status": "queued"}` immediately and let the writer thread
-do the work).
+`reindex()`, `build_embeddings()`) or take the `*_async` counterparts'
+Future. The MCP-tool-level `reindex` and `build_embeddings` are dual-mode
+long-running tools (#1033): they await their submission's Future, so a
+fast run returns its real result inline, and a run outliving the jobs
+soft deadline is promoted to a background job polled via
+``get_job_result`` while the writer thread keeps working.
 
 **Boot reconciliation (#665).** The server lifespan submits
 `reindex_async()` immediately after `build_index_async()`. On a warm
@@ -2227,7 +2229,7 @@ pattern). Each tool is annotated with MCP `ToolAnnotations`:
 | `get_most_linked` | Find notes ranked by number of inbound links | `True` | `False` | `True` |
 | `get_connection_path` | Shortest undirected path between two notes (BFS, max 10 hops) | `True` | `False` | `True` |
 | `summarize` | LLM summary of a note/set/subtree (references sources by path); dual-mode: native background task, or promotion to a pollable job (#1033) | `True` | `False` | **`False`** |
-| `get_job_result` | Retrieve a background job (today: a promoted `summarize`) by `job_id`; pvl-core-owned generic poller (#1033) | `True` | `False` | **`False`** |
+| `get_job_result` | Retrieve a background job (a promoted `summarize`, `reindex`, or `build_embeddings`) by `job_id`; pvl-core-owned generic poller (#1033) | `True` | `False` | **`False`** |
 | `fetch` | Download from URL and save to vault (MCP-to-MCP transfer) | `False` | `False` | `True` |
 
 **Append semantics (#980)**: `append` adds `content` at the end of an
@@ -2350,21 +2352,27 @@ contain this, both operator-tunable:
   ``{"status": "working", "job_id": …, "poll_with": "get_job_result"}``.
   The generic ``get_job_result`` tool (``register_job_tools``, one polling
   contract per server) resolves the job to ``working`` / ``completed``
-  (with the full summary payload under ``result``) / ``failed``. Job
-  records live in the unified KV backend (namespace ``jobs``; when
-  ``KV_STORE_URL`` is unset the jobs store falls back to in-process
-  memory, not the file default — ``/data/state`` only exists in the
-  Docker image, and records are ephemeral by design), are scoped
-  to the calling subject, and expire ``JOBS_RESULT_TTL_S`` after creation
-  — the same non-durable posture as index status and transfer tokens (a
-  promoted job dies with the process; durable execution is the native task
-  path's job, with a ``redis://`` tasks backend). Because the ``Jobs``
-  mechanics are built from the loaded config, the summarize group is
-  registered from the DOMAIN-WIRING block (the ``register_domain_prompts``
-  pattern) rather than the config-free ``register_tools()`` layer. Both
-  ``summarize`` and ``get_job_result`` (tags ``summarize`` / ``jobs``) are
-  hidden by the same backend gate while summarize is the only job
-  producer.
+  (with the full result payload under ``result``) / ``failed``. Job
+  records live in the unified KV backend (namespace ``jobs``; with
+  ``KV_STORE_URL`` unset, core >=4.11.1 defaults to ``file:///data/state``
+  where that directory is usable — the Docker image — and in-process
+  memory everywhere else), are scoped to the calling subject, and expire
+  ``JOBS_RESULT_TTL_S`` after creation — the same non-durable posture as
+  index status and transfer tokens (a promoted job dies with the process;
+  durable execution is the native task path's job, with a ``redis://``
+  tasks backend). Because the ``Jobs`` mechanics are built from the loaded
+  config, the summarize group and the index-maintenance jobs
+  (``register_index_jobs``) are registered from the DOMAIN-WIRING block
+  (the ``register_domain_prompts`` pattern) rather than the config-free
+  ``register_tools()`` layer. The backend gate hides only ``summarize``;
+  ``get_job_result`` is always registered, because ``reindex`` and
+  ``build_embeddings`` produce job handles regardless of the summarize
+  backend. Those two tools await their writer-submission Future
+  dual-mode: a fast run answers inline with its real result (reindex
+  counts / ``chunks_embedded``) and a slow run promotes, while
+  ``get_index_status`` / ``embeddings_status`` stay as independent
+  observability tools — they also report boot-time builds and
+  file-watcher reindexes that no client call initiated.
 
 **Dynamic instructions**: the server's MCP `instructions` string varies with
 `read_only` mode. When `read_only=True`, the instructions state this is a
@@ -3099,3 +3107,4 @@ Later decisions (2026-08-13, #1033):
 |-|-|-|-|
 | 17 | Long-running tools | Dual-mode via `fastmcp_pvl_core.jobs` (`register_long_running_tool` + generic `get_job_result`); the hand-rolled `SummaryJobStore` + `get_summary` pair is retired | Framework-owned machinery over per-tool queue-and-poll reimplementations; native MCP-tasks execution for capable clients, uniform polling fallback for the rest (no Anthropic client speaks tasks yet) |
 | 18 | Client-model summarization (MCP sampling) | Rejected | Sampling is deprecated by the MCP spec (2026-07-28, SEP-2577) and was never supported by Anthropic clients; client-side fan-out, if ever, arrives via prompts/skills, not sampling |
+| 19 | Index-maintenance tools | `reindex` / `build_embeddings` become dual-mode jobs awaiting their writer-submission `Future`; `get_index_status` / `embeddings_status` stay as observability tools | A fast run returns real results inline instead of `{"status": "queued"}`; slow runs promote to `get_job_result`; the status tools also cover boot/watcher work no call initiated, so they are not job pollers |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -35,8 +35,8 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`get_job_result`](#get_job_result) | Get Job Result | AI | Retrieve the outcome of a background job started by a long-running tool |
 | [`get_history`](#get_history) | Note History | Read (git) | List commits that touched a note, attachment, folder, or the whole vault |
 | [`get_diff`](#get_diff) | Note Diff | Read (git) | Return a diff of a note or attachment between two points in history |
-| [`reindex`](#reindex) | Reindex Vault | Admin | Force a full reindex of the vault |
-| [`build_embeddings`](#build_embeddings) | Build Embeddings | Admin | Build or rebuild vector embeddings |
+| [`reindex`](#reindex) | Reindex Vault | Admin | Incremental reindex; inline result when fast, job promotion when slow |
+| [`build_embeddings`](#build_embeddings) | Build Embeddings | Admin | Build or rebuild vector embeddings; inline result when fast, job promotion when slow |
 | [`write`](#write) | Write Note | Write | Create or overwrite a document or attachment |
 | [`edit`](#edit) | Edit Note | Write | Replace a unique text span in a document |
 | [`append`](#append) | Append to Note | Write | Append text to the end of a note without reading it first |
@@ -270,12 +270,12 @@ No parameters.
 
 Incrementally update the full-text search index to reflect file changes made outside this server. Only changed files are processed; unchanged documents are skipped, and files deliberately excluded from the index (missing required frontmatter, exclude-pattern matches, unparseable content) are remembered across scans so they are not re-parsed or re-reported until their content changes (#665).
 
-If semantic search is configured, the queued reindex job re-embeds the changed documents on the writer thread. Poll `get_index_status` and watch the `dirty_embeddings` counter to observe completion.
+If semantic search is configured, the reindex job re-embeds the changed documents on the writer thread. Poll `get_index_status` and watch the `dirty_embeddings` counter to observe embedding convergence.
 
 !!! note "Boot reconciliation"
     The server lifespan automatically queues one incremental reindex at every startup (#665), so files added, modified, or deleted while no server was running are reconciled without a manual `reindex` call. Reads served before that job completes report `index_stale: true` in `_meta`.
 
-**Returns:** `{"status": "queued"}`. The reindex runs asynchronously on the single-owner :class:`IndexWriter` thread (#559); poll `get_server_info` or `get_index_status` for completion. `get_index_status` exposes `queue_depth`, `in_flight`, `dirty_paths`, and `dirty_embeddings` so you can observe progress without blocking.
+**Returns:** The tool is dual-mode. A fast reindex (the common case, since work scales with the drift, not the vault) completes inline with `"status": "completed"` and its real counts: `added`, `modified`, `deleted`, `unchanged`, and `skipped`. A reindex still running at the jobs soft deadline (`JOBS_SOFT_DEADLINE_S`, default 25 s) continues on the single-owner :class:`IndexWriter` thread (#559) and returns `{"status": "working", "job_id": ...}` immediately; fetch the outcome with [`get_job_result`](#get_job_result). A failure within the deadline raises immediately; after promotion it is reported through `get_job_result` (and mirrored in `get_index_status`'s `last_reindex_error`). `get_index_status` remains the non-blocking observability view (`queue_depth`, `in_flight`, `dirty_paths`, `dirty_embeddings`), covering boot-time and file-watcher work no client call initiated.
 
 ### `build_embeddings`
 
@@ -289,7 +289,7 @@ Without `force`, an existing vector index is **converged** to the FTS chunk set 
 |-----------|------|---------|-------------|
 | `force` | bool | `false` | When true, discards existing embeddings and rebuilds from scratch. Use only if the embedding model has changed |
 
-**Returns:** `{"status": "queued"}`. The build runs asynchronously on the single-owner :class:`IndexWriter` thread (#559); poll `get_server_info` or `get_index_status` for completion.
+**Returns:** The tool is dual-mode. A fast convergence (small drift) completes inline with `"status": "completed"` and `chunks_embedded` (the total number of chunks embedded). A build still running at the jobs soft deadline (typical for a `force=true` rebuild of a large vault) continues on the single-owner :class:`IndexWriter` thread (#559) and returns `{"status": "working", "job_id": ...}` immediately; fetch the outcome with [`get_job_result`](#get_job_result). A failure within the deadline raises immediately (a missing embedding provider now surfaces here instead of landing only in `get_index_status`); after promotion it is reported through `get_job_result`.
 
 !!! note "When to use"
     Normally never: the server queues a `build_embeddings` job at every startup, which converges the vector index to whatever the boot reconciliation reindex found (#665). Manual calls are needed in three cases: embedding a vault for the first time without restarting; retrying after a provider outage; or rebuilding from scratch after an embedding-model change (pass `force=true`).
@@ -956,9 +956,9 @@ When the work is promoted to a background job, a dict with `"status": "working"`
 
 ### `get_job_result`
 
-Retrieve the outcome of a background job started by a long-running tool on this server (today, a [`summarize`](#summarize) call promoted past the jobs soft deadline). When such a call returns `{"status": "working", "job_id": ...}`, pass that `job_id` here to fetch the result, polling every few seconds while it is still running.
+Retrieve the outcome of a background job started by a long-running tool on this server: a [`summarize`](#summarize), [`reindex`](#reindex), or [`build_embeddings`](#build_embeddings) call promoted past the jobs soft deadline. When such a call returns `{"status": "working", "job_id": ...}`, pass that `job_id` here to fetch the result, polling every few seconds while it is still running.
 
-The tool is provided by the shared jobs subsystem (`fastmcp-pvl-core`), so its name, payload, and lifecycle vocabulary are uniform across the `*-mcp` server family. It is shown under the same conditions as `summarize` (a summarization backend must be configured), since promoted summaries are currently the only job producers. Retrieval is scoped to the calling subject: another caller's `job_id` answers exactly like an unknown one. Job records expire `JOBS_RESULT_TTL_S` seconds after creation (default one hour) and a promoted job does not survive a server restart, so fetch results soon after completion.
+The tool is provided by the shared jobs subsystem (`fastmcp-pvl-core`), so its name, payload, and lifecycle vocabulary are uniform across the `*-mcp` server family, and it is always registered (the index-maintenance tools produce job handles regardless of whether a summarize backend is configured). Retrieval is scoped to the calling subject: another caller's `job_id` answers exactly like an unknown one. Job records expire `JOBS_RESULT_TTL_S` seconds after creation (default one hour) and a promoted job does not survive a server restart, so fetch results soon after completion.
 
 **Parameters:**
 

--- a/src/markdown_vault_mcp/_server_tools/index.py
+++ b/src/markdown_vault_mcp/_server_tools/index.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
+from fastmcp_pvl_core import register_long_running_tool
 
 from markdown_vault_mcp.vault import Vault
 
@@ -12,9 +14,21 @@ from .._icons import _TOOL_ICONS
 from .._server_queryable import needs_queryable
 from ..domain import get_vault
 
+if TYPE_CHECKING:
+    from fastmcp_pvl_core import Jobs
+
 
 def register(mcp: FastMCP) -> None:
-    """Register index-management tools on *mcp*."""
+    """Register the config-free index-observability tools on *mcp*.
+
+    The call-initiated maintenance tools (``reindex``, ``build_embeddings``)
+    are registered separately by :func:`register_index_jobs` from
+    ``make_server``'s DOMAIN-WIRING block: they are dual-mode long-running
+    tools (#1033) and need the config-built ``Jobs`` mechanics. The status
+    tools below stay here on purpose — they also report work no client call
+    initiated (boot-time builds, file-watcher reindexes), so they remain
+    independent observability surfaces rather than job pollers.
+    """
 
     @mcp.tool(
         icons=_TOOL_ICONS["embeddings_status"],
@@ -100,7 +114,26 @@ def register(mcp: FastMCP) -> None:
         """
         return await asyncio.to_thread(vault.index.get_index_status)
 
-    @mcp.tool(
+
+def register_index_jobs(mcp: FastMCP, jobs: Jobs) -> None:
+    """Register the dual-mode index-maintenance tools on *mcp* (#1033).
+
+    ``reindex`` and ``build_embeddings`` submit work to the single-owner
+    writer thread and await the submission's own ``Future``, so a fast run
+    returns its real result inline; a run still going at the jobs soft
+    deadline is promoted to a background job polled via ``get_job_result``.
+    Registered from ``make_server``'s DOMAIN-WIRING block (the same pattern
+    as the summarize group) because the ``Jobs`` mechanics are built from
+    the loaded config.
+
+    Args:
+        mcp: The server to register on.
+        jobs: The server's shared jobs mechanics (``build_jobs`` result).
+    """
+
+    @register_long_running_tool(
+        mcp,
+        jobs,
         icons=_TOOL_ICONS["reindex"],
         annotations={
             "title": "Reindex Vault",
@@ -113,7 +146,7 @@ def register(mcp: FastMCP) -> None:
     async def reindex(
         vault: Vault = Depends(get_vault),
     ) -> dict[str, Any]:
-        """Submit an incremental reindex job to the writer.
+        """Run an incremental reindex on the writer thread.
 
         Only needed when files are modified outside this server — for example,
         by a text editor, a sync tool, or another process writing directly to
@@ -124,21 +157,46 @@ def register(mcp: FastMCP) -> None:
         To rebuild all embeddings from scratch (e.g. after changing the
         embedding model), use 'build_embeddings' with force=True.
 
+        A fast reindex (the common case — work scales with the drift, not
+        the vault) returns its result inline. A reindex still running at the
+        server's soft deadline continues in the background and returns
+        ``{"status": "working", "job_id": ...}`` immediately — fetch the
+        outcome with ``get_job_result``. ``get_index_status`` remains the
+        observability view of the index (it also covers boot-time builds and
+        file-watcher reindexes no client call initiated).
+
         Returns:
-            Dict with ``status: "queued"``. The reindex runs asynchronously on
-            the writer thread. Poll ``get_index_status`` for completion:
+            On inline completion, a dict with ``"status": "completed"`` plus
+            the reindex counts:
 
-            - ``status == "queryable"`` AND ``queue_depth == 0`` AND
-              ``in_flight is None`` → reindex completed.
-            - ``last_reindex_error`` not ``None`` → the most recent async
-              reindex failed on the writer thread; the value is the
-              stringified exception.  Operators can re-run ``reindex`` to
-              retry; a subsequent successful run clears the field.
+            - added (int): Documents added since the last index.
+            - modified (int): Documents that changed since the last index.
+            - deleted (int): Documents removed since the last index.
+            - unchanged (int): Documents with no changes.
+            - skipped (int): Files deliberately not indexed (missing required
+              frontmatter, exclude patterns, unparseable).
+
+            When promoted, a dict with ``"status": "working"``, a ``job_id``,
+            and a ``poll_with`` field naming ``get_job_result``.
+
+        Raises:
+            IndexUnavailableError: If the index is not queryable (cold-start
+                build pending/failed, or a SQLite failure remapped by the
+                ``needs_queryable`` layer). Any other failure within the
+                soft deadline re-raises the writer job's own exception; a
+                failure after promotion is reported through
+                ``get_job_result`` instead (and mirrored in
+                ``get_index_status``'s ``last_reindex_error``). If the
+                per-subject job cap is hit at promotion time, the call
+                fails with a job-limit error and the queued reindex is
+                cancelled — retry after fetching pending job results.
         """
-        vault.index.reindex_async()
-        return {"status": "queued"}
+        result = await asyncio.wrap_future(vault.index.reindex_async())
+        return {**asdict(result), "status": "completed"}
 
-    @mcp.tool(
+    @register_long_running_tool(
+        mcp,
+        jobs,
         icons=_TOOL_ICONS["build_embeddings"],
         annotations={
             "title": "Build Embeddings",
@@ -160,6 +218,13 @@ def register(mcp: FastMCP) -> None:
         the FTS chunk set: missing or changed documents are embedded,
         orphaned vectors are removed, unchanged chunks are untouched.
 
+        A fast convergence (small drift) returns its result inline. A build
+        still running at the server's soft deadline — typical for a
+        force=True rebuild of a large vault — continues in the background
+        and returns ``{"status": "working", "job_id": ...}`` immediately;
+        fetch the outcome with ``get_job_result``. ``embeddings_status``
+        remains the observability view of the vector index.
+
         Args:
             force: When True, discards existing embeddings and rebuilds from
                 scratch. Use only if the embedding model has changed.
@@ -168,16 +233,24 @@ def register(mcp: FastMCP) -> None:
                 not the size of the vault (#665).
 
         Returns:
-            Dict with ``status: "queued"``. The build runs asynchronously on
-            the writer thread. Poll ``get_index_status`` for completion:
+            On inline completion, a dict with ``"status": "completed"`` and
+            ``chunks_embedded`` (int): the total number of chunks embedded.
+            When promoted, a dict with ``"status": "working"``, a ``job_id``,
+            and a ``poll_with`` field naming ``get_job_result``.
 
-            - ``status == "queryable"`` AND ``queue_depth == 0`` AND
-              ``in_flight is None`` → build completed.
-            - ``last_build_embeddings_error`` not ``None`` → the most
-              recent async build failed on the writer thread; the value is
-              the stringified exception.  Operators can re-run
-              ``build_embeddings`` to retry; a subsequent successful run
-              clears the field.
+        Raises:
+            EmbeddingsNotConfiguredError: If no embedding provider is
+                configured — this now surfaces immediately instead of
+                landing only in ``get_index_status``. Any other failure
+                within the soft deadline re-raises the writer job's own
+                exception; a failure after promotion is reported through
+                ``get_job_result`` instead (and mirrored in
+                ``last_build_embeddings_error``). If the per-subject job
+                cap is hit at promotion time, the call fails with a
+                job-limit error and the queued build is cancelled — retry
+                after fetching pending job results.
         """
-        vault.index.build_embeddings_async(force=force)
-        return {"status": "queued"}
+        embedded = await asyncio.wrap_future(
+            vault.index.build_embeddings_async(force=force)
+        )
+        return {"status": "completed", "chunks_embedded": embedded}

--- a/src/markdown_vault_mcp/_server_tools/index.py
+++ b/src/markdown_vault_mcp/_server_tools/index.py
@@ -239,6 +239,9 @@ def register_index_jobs(mcp: FastMCP, jobs: Jobs) -> None:
             and a ``poll_with`` field naming ``get_job_result``.
 
         Raises:
+            IndexUnavailableError: If the index is not queryable (cold-start
+                build pending/failed, or a SQLite failure remapped by the
+                ``needs_queryable`` layer).
             EmbeddingsNotConfiguredError: If no embedding provider is
                 configured — this now surfaces immediately instead of
                 landing only in ``get_index_status``. Any other failure

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -270,15 +270,16 @@ def make_server(
     if config.git.repo_url is None:
         mcp.disable(tags={"git-managed"})
 
-    # The LLM-backed summarize tool is registered here rather than in the
-    # config-free register_tools() layer: it is a dual-mode long-running tool
-    # (#1033), and the Jobs mechanics it promotes slow calls onto are built
-    # from this already-loaded config (the register_domain_prompts pattern,
-    # #609). A client that speaks MCP tasks gets native task execution; any
-    # other client past the JOBS_SOFT_DEADLINE_S soft deadline gets a job
-    # handle to poll via the generic get_job_result tool.
+    # The dual-mode long-running tools (#1033) are registered here rather
+    # than in the config-free register_tools() layer: the Jobs mechanics
+    # their slow calls promote onto are built from this already-loaded
+    # config (the register_domain_prompts pattern, #609). A client that
+    # speaks MCP tasks gets native task execution; any other client past
+    # the JOBS_SOFT_DEADLINE_S soft deadline gets a job handle to poll via
+    # the generic get_job_result tool.
     from fastmcp_pvl_core import build_jobs, register_job_tools
 
+    from markdown_vault_mcp._server_tools import index as index_tools
     from markdown_vault_mcp._server_tools import summarize as summarize_tools
 
     # With no KV backend configured, core's default (>=4.11.1) is
@@ -287,10 +288,14 @@ def make_server(
     # needs no domain-side backend selection.
     jobs = build_jobs(config.server, config.jobs)
     summarize_tools.register(mcp, jobs)
+    index_tools.register_index_jobs(mcp, jobs)
     register_job_tools(
         mcp,
         jobs,
-        note=("On this server, background jobs come from slow summarize calls."),
+        note=(
+            "On this server, background jobs come from slow summarize, "
+            "reindex, and build_embeddings calls."
+        ),
     )
 
     # Hide the LLM-backed summarize tool unless a summarization backend is
@@ -299,13 +304,11 @@ def make_server(
     # provider. Checked directly
     # (not via to_vault_kwargs(), which builds an embedding provider and may
     # clone a git repo as a side effect — see the git-managed gate above).
-    # The generic jobs poller is hidden alongside it: summarize is currently
-    # the only producer of job handles, so without a backend the poller has
-    # nothing to resolve. Un-gate the "jobs" tag when another long-running
-    # tool joins.
+    # The generic jobs poller stays visible either way: reindex and
+    # build_embeddings produce job handles regardless of the summarize
+    # backend.
     if not config.summarize.has_provider():
         mcp.disable(tags={"summarize"})
-        mcp.disable(tags={"jobs"})
     else:
         # Substitute the live note limit into the tool description so calling
         # models can plan folder splits before their first call (#925).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -356,7 +356,6 @@ class TestToolManifest:
 
         assert names == [
             "append",
-            "build_embeddings",
             "delete",
             "edit",
             "embeddings_status",
@@ -386,7 +385,6 @@ class TestToolManifest:
             "okf_validate",
             "okf_verify",
             "read",
-            "reindex",
             "rename",
             "search",
             "stats",
@@ -507,10 +505,12 @@ class TestToolAnnotations:
         # full-registry sweep keeps asserting their metadata.
         from fastmcp_pvl_core import build_jobs, register_job_tools
 
+        from markdown_vault_mcp._server_tools import index as index_tools
         from markdown_vault_mcp._server_tools import summarize as summarize_tools
 
         jobs = build_jobs(config.server, config.jobs)
         summarize_tools.register(mcp, jobs)
+        index_tools.register_index_jobs(mcp, jobs)
         register_job_tools(mcp, jobs)
 
         tools = await mcp._list_tools()
@@ -727,26 +727,95 @@ class TestReindexTool:
     """Test the reindex MCP tool."""
 
     @pytest.mark.usefixtures("_mcp_env")
-    async def test_reindex_returns_queued_immediately(self) -> None:
-        """reindex submits a job to the writer and returns {'status': 'queued'}."""
+    async def test_reindex_fast_run_returns_inline_counts(self) -> None:
+        """A fast reindex completes inline with its real counts (#1033)."""
         server = make_server()
         async with Client(server) as client:
             result = await client.call_tool("reindex", {})
         data = result.data
-        assert data == {"status": "queued"}
+        assert data["status"] == "completed"
+        for key in ("added", "modified", "deleted", "unchanged", "skipped"):
+            assert isinstance(data[key], int)
+        assert "job_id" not in data
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_reindex_slow_run_promotes_to_job(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reindex outliving the soft deadline promotes to a pollable job."""
+        import asyncio
+        import threading
+        from concurrent.futures import Future
+
+        from markdown_vault_mcp.facets.index import IndexFacet
+        from markdown_vault_mcp.types import ReindexResult
+
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_JOBS_SOFT_DEADLINE_S", "0.15")
+
+        def slow_reindex_async(_self: IndexFacet) -> Future[ReindexResult]:
+            fut: Future[ReindexResult] = Future()
+            threading.Timer(
+                0.5,
+                lambda: fut.set_result(
+                    ReindexResult(added=1, modified=0, deleted=0, unchanged=0)
+                ),
+            ).start()
+            return fut
+
+        monkeypatch.setattr(IndexFacet, "reindex_async", slow_reindex_async)
+        server = make_server()
+        async with Client(server) as client:
+            res = await client.call_tool("reindex", {})
+            assert res.data["status"] == "working"
+            assert res.data["poll_with"] == "get_job_result"
+            job_id = res.data["job_id"]
+            out: dict[str, Any] = {}
+            for _ in range(40):
+                out = (
+                    await client.call_tool("get_job_result", {"job_id": job_id})
+                ).data
+                if out["status"] != "working":
+                    break
+                await asyncio.sleep(0.1)
+        assert out["status"] == "completed"
+        assert out["result"]["added"] == 1
 
 
 class TestBuildEmbeddingsTool:
     """Test the build_embeddings MCP tool."""
 
     @pytest.mark.usefixtures("_mcp_env")
-    async def test_build_embeddings_returns_queued_immediately(self) -> None:
-        """build_embeddings submits a job and returns {'status': 'queued'}."""
+    async def test_build_embeddings_fast_run_returns_inline_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fast build completes inline with its chunks_embedded count."""
+        from concurrent.futures import Future
+
+        from markdown_vault_mcp.facets.index import IndexFacet
+
+        def fast_build_async(_self: IndexFacet, *, force: bool = False) -> Future[int]:  # noqa: ARG001 — signature must match the patched method
+            fut: Future[int] = Future()
+            fut.set_result(7)
+            return fut
+
+        monkeypatch.setattr(IndexFacet, "build_embeddings_async", fast_build_async)
         server = make_server()
         async with Client(server) as client:
             result = await client.call_tool("build_embeddings", {})
-        data = result.data
-        assert data == {"status": "queued"}
+        assert result.data == {"status": "completed", "chunks_embedded": 7}
+
+    @pytest.mark.usefixtures("_mcp_env")
+    async def test_build_embeddings_without_provider_fails_inline(self) -> None:
+        """With no provider, the failure surfaces immediately (#1033).
+
+        Previously the tool answered {'status': 'queued'} and the
+        EmbeddingsNotConfiguredError landed only in get_index_status's
+        last_build_embeddings_error field.
+        """
+        server = make_server()
+        async with Client(server) as client:
+            with pytest.raises(ToolError, match=r"[Ee]mbedding"):
+                await client.call_tool("build_embeddings", {})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_summarize_tool.py
+++ b/tests/test_summarize_tool.py
@@ -160,9 +160,12 @@ class TestSummarizeDualMode:
         assert ann.readOnlyHint is True
         assert ann.destructiveHint is False
 
-    async def test_job_tools_hidden_without_backend(
+    async def test_summarize_hidden_but_job_tools_stay_without_backend(
         self, vault_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """No backend hides summarize, but the generic jobs poller stays:
+        reindex and build_embeddings produce job handles regardless of the
+        summarize backend (#1033)."""
         for name in _SUMMARIZE_ENV:
             monkeypatch.delenv(name, raising=False)
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(vault_path))
@@ -170,4 +173,4 @@ class TestSummarizeDualMode:
         async with Client(server) as client:
             names = {t.name for t in await client.list_tools()}
         assert "summarize" not in names
-        assert "get_job_result" not in names
+        assert "get_job_result" in names


### PR DESCRIPTION
## Closes / Refs

Closes #1033 — this migrates the last two hand-rolled queue-and-poll surfaces onto the jobs seam, completing what #1034 started for `summarize`.

## What & why

`reindex` and `build_embeddings` no longer answer `{"status": "queued"}` and leave callers inferring completion from `get_index_status` (`queue_depth == 0 && in_flight is None`). Each now awaits its own writer-submission `Future` through `register_long_running_tool`: a fast run (the common case — work scales with drift) returns its real result inline (reindex counts / `chunks_embedded`); a run outliving `JOBS_SOFT_DEADLINE_S` promotes to a background job polled via the generic `get_job_result` tool while the single-owner writer keeps working. Failures within the deadline surface immediately — a missing embedding provider now raises on the call instead of landing only in `get_index_status`.

The open question from #1033 is resolved as discussed: `get_index_status` / `embeddings_status` **stay** as independent observability tools, because they also report boot-time builds and file-watcher reindexes no client call initiated. `get_job_result` is now always registered (index tools produce handles regardless of the summarize backend), so the `jobs` tag is no longer disabled alongside `summarize`.

**Breaking**: the `{"status": "queued"}` return shape is gone; fast calls answer `status=completed` with real results, slow calls answer `{"status": "working", "job_id": …}`, and in-deadline backend failures raise on the call itself.

## What this PR deliberately does NOT do

- (deferral) Client-side subagent summarization recipe — #1035
- (deferral) Plugin-channel summarization workflow — #1036
- (accepted edge, documented in the docstrings) a promotion rejected at the per-subject job cap cancels the queued writer job instead of silently continuing fire-and-forget; the caller gets an explicit job-limit error and can retry

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening the PR. Three findings, all addressed: a missing success-contract test for `build_embeddings` (added), inaccurate `Raises:` docstrings naming `RuntimeError` instead of the real exception types (corrected to `IndexUnavailableError` / `EmbeddingsNotConfiguredError` semantics), and the job-cap cancellation edge (documented in both docstrings and this PR).

## Docs impact

- [x] `README.md` (tool rows for `reindex`, `build_embeddings`, `get_job_result`)
- [x] `docs/` site pages (`tools/index.md` dual-mode sections; `configuration.md` Background Jobs producer list)
- [x] `docs/design/` (writer-submission prose, jobs section incl. corrected 4.11.1 KV-default description, decision-log entry 19)
- [x] Inline docstrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4q7LaqTAVDivjkdckKvtf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4q7LaqTAVDivjkdckKvtf)_