### PR TITLE
feat(packaging): adopt template v3.4.0 — generated mcpb screen, curated fields, pre-release checks

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v3.3.0
+_commit: v3.4.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/actions/build-mcpb/action.yml
+++ b/.github/actions/build-mcpb/action.yml
@@ -1,0 +1,80 @@
+name: Build mcpb bundle
+description: >
+  Render the packaging/mcpb templates at a given version, validate the
+  manifest with the mcpb CLI, pack the bundle into dist/, and smoke-test
+  the packed artifact. Shared by release.yml's build-mcpb job and the
+  pre-release-check workflow so the pre-release path can never drift from
+  what a real release executes (#331).
+
+inputs:
+  version:
+    description: Version string rendered into the ${VERSION} placeholders (no v prefix).
+    required: true
+  mcpb-version:
+    description: npm version of @anthropic-ai/mcpb to install.
+    required: false
+    default: "2.1.2"
+
+outputs:
+  bundle:
+    description: Path of the packed .mcpb bundle.
+    value: ${{ steps.pack.outputs.bundle }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install mcpb CLI
+      shell: bash
+      run: npm install -g "@anthropic-ai/mcpb@${{ inputs.mcpb-version }}"
+
+    - name: Render templates
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        mkdir -p build/mcpb/src
+        # Restrict substitution to ${VERSION} only — other ${...} tokens
+        # (e.g. ${DOCUMENTS}, ${user_config.*}) are runtime placeholders
+        # for the mcpb host and must survive intact.
+        envsubst '${VERSION}' < packaging/mcpb/manifest.json.in  > build/mcpb/manifest.json
+        envsubst '${VERSION}' < packaging/mcpb/pyproject.toml.in > build/mcpb/pyproject.toml
+        cp packaging/mcpb/src/server.py build/mcpb/src/server.py
+
+    - name: Validate and pack
+      id: pack
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        mcpb validate build/mcpb/manifest.json
+        mkdir -p dist
+        mcpb pack build/mcpb "dist/markdown-vault-mcp-${VERSION}.mcpb"
+        echo "bundle=dist/markdown-vault-mcp-${VERSION}.mcpb" >> "$GITHUB_OUTPUT"
+
+    - name: Smoke-test bundle artifact
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        bundle="dist/markdown-vault-mcp-${VERSION}.mcpb"
+        test -f "$bundle" || { echo "::error::bundle missing: $bundle"; exit 1; }
+
+        work=$(mktemp -d)
+        trap 'rm -rf "$work"' EXIT
+        unzip -q "$bundle" -d "$work"
+
+        test -f "$work/manifest.json"  || { echo "::error::manifest.json missing from bundle"; exit 1; }
+        test -f "$work/pyproject.toml" || { echo "::error::pyproject.toml missing from bundle"; exit 1; }
+        test -f "$work/src/server.py"  || { echo "::error::src/server.py missing from bundle"; exit 1; }
+
+        bundled_version=$(jq -r .version "$work/manifest.json")
+        test "$bundled_version" = "$VERSION" \
+          || { echo "::error::manifest version $bundled_version != release $VERSION"; exit 1; }
+
+        jq -e '.server.mcp_config.env' "$work/manifest.json" > /dev/null \
+          || { echo "::error::manifest missing server.mcp_config.env"; exit 1; }
+        jq -e '.user_config' "$work/manifest.json" > /dev/null \
+          || { echo "::error::manifest missing user_config"; exit 1; }
+        # The envsubst render must not have eaten the host-side placeholders.
+        grep -qF '${user_config.' "$work/manifest.json" \
+          || { echo "::error::\${user_config.*} references were expanded away by the render"; exit 1; }

--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -1,0 +1,75 @@
+# Pre-release smoke test for the release artifacts (#331): everything the
+# release pipeline builds only becomes testable AFTER the tag is cut and
+# public — this workflow runs the same bundle build (via the shared
+# .github/actions/build-mcpb composite, so it cannot drift from release.yml)
+# against any branch, on demand, before a release exists.
+name: Pre-release check
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version string rendered into the artifacts (no v prefix).'
+        type: string
+        default: '0.0.0-dev'
+      publish_prerelease:
+        description: 'Attach the bundle to a deletable v<version>-rc GitHub pre-release for manual install testing.'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  mcpb-bundle:
+    runs-on: ubuntu-latest
+    permissions:
+      # Only exercised by the publish_prerelease path; harmless otherwise.
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build and smoke-test mcpb bundle
+        id: build
+        uses: ./.github/actions/build-mcpb
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Project-specific artifact checks
+        env:
+          VERSION: ${{ inputs.version }}
+          BUNDLE: ${{ steps.build.outputs.bundle }}
+        run: |
+          # Domain seam: a project that ships more release artifacts (a
+          # Claude Code plugin, extra bundles) asserts them in this script.
+          # The file is project-owned and never rendered by the template,
+          # so template updates leave it untouched; VERSION and BUNDLE are
+          # exported for it. Absence just skips the step.
+          if [ -x packaging/pre-release-checks.sh ]; then
+            ./packaging/pre-release-checks.sh
+          else
+            echo "no packaging/pre-release-checks.sh — skipping project-specific checks"
+          fi
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: mcpb-bundle
+          path: dist/markdown-vault-mcp-*.mcpb
+          if-no-files-found: error
+
+      - name: Attach to a deletable pre-release
+        if: inputs.publish_prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          tag="v${VERSION}-rc"
+          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create "$tag" \
+                 --prerelease \
+                 --title "$tag (pre-release smoke test)" \
+                 --notes "Disposable pre-release for manual install testing — safe to delete along with its tag." \
+                 --target "${{ github.sha }}" \
+                 --repo "${{ github.repository }}"
+          gh release upload "$tag" dist/markdown-vault-mcp-*.mcpb --clobber \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,55 +324,17 @@ jobs:
     needs: release
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
-    env:
-      MCPB_VERSION: "2.1.2"
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release.outputs.tag }}
-      - name: Install mcpb CLI
-        run: npm install -g @anthropic-ai/mcpb@$MCPB_VERSION
-      - name: Render templates
-        env:
-          VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          mkdir -p build/mcpb/src
-          # Restrict substitution to ${VERSION} only — other ${...} tokens
-          # (e.g. ${DOCUMENTS}, ${user_config.*}) are runtime placeholders
-          # for the mcpb host and must survive intact.
-          envsubst '${VERSION}' < packaging/mcpb/manifest.json.in  > build/mcpb/manifest.json
-          envsubst '${VERSION}' < packaging/mcpb/pyproject.toml.in > build/mcpb/pyproject.toml
-          cp packaging/mcpb/src/server.py build/mcpb/src/server.py
-      - name: Validate and pack
-        env:
-          VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          mcpb validate build/mcpb/manifest.json
-          mkdir -p dist
-          mcpb pack build/mcpb "dist/markdown-vault-mcp-${VERSION}.mcpb"
-      - name: Smoke-test bundle artifact
-        env:
-          VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          bundle="dist/markdown-vault-mcp-${VERSION}.mcpb"
-          test -f "$bundle" || { echo "::error::bundle missing: $bundle"; exit 1; }
-
-          work=$(mktemp -d)
-          trap 'rm -rf "$work"' EXIT
-          unzip -q "$bundle" -d "$work"
-
-          test -f "$work/manifest.json"  || { echo "::error::manifest.json missing from bundle"; exit 1; }
-          test -f "$work/pyproject.toml" || { echo "::error::pyproject.toml missing from bundle"; exit 1; }
-          test -f "$work/src/server.py"  || { echo "::error::src/server.py missing from bundle"; exit 1; }
-
-          bundled_version=$(jq -r .version "$work/manifest.json")
-          test "$bundled_version" = "$VERSION" \
-            || { echo "::error::manifest version $bundled_version != release $VERSION"; exit 1; }
-
-          jq -e '.server.mcp_config.env' "$work/manifest.json" > /dev/null \
-            || { echo "::error::manifest missing server.mcp_config.env"; exit 1; }
-          jq -e '.user_config' "$work/manifest.json" > /dev/null \
-            || { echo "::error::manifest missing user_config"; exit 1; }
+      # Render/validate/pack/smoke live in the shared composite action so
+      # the pre-release-check workflow exercises the exact same steps a
+      # real release runs (#331).
+      - name: Build and smoke-test mcpb bundle
+        uses: ./.github/actions/build-mcpb
+        with:
+          version: ${{ needs.release.outputs.version }}
       - uses: actions/upload-artifact@v7
         with:
           name: mcpb-bundle
@@ -400,18 +362,41 @@ jobs:
             --clobber \
             --repo "${{ github.repository }}"
 
-  publish-claude-plugin-pr:
+  # Publishes the marketplace catalog entry by committing straight to the
+  # catalog's default branch — a release must not end at an open PR awaiting
+  # a human merge (fastmcp-server-template#333; 15 such PRs once went stale).
+  # The plugin-artifact check guards against publishing a git-subdir entry
+  # whose path does not exist at the tag, which is uninstallable; projects
+  # without a .claude-plugin/plugin directory skip with a warning rather
+  # than failing the release.
+  publish-claude-plugin:
     needs: release
     if: needs.release.outputs.released == 'true' && !inputs.prerelease
     runs-on: ubuntu-latest
     steps:
+      - name: Check plugin artifact exists at tag
+        id: plugin_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          if gh api --silent \
+            "repos/${{ github.repository }}/contents/.claude-plugin/plugin/.claude-plugin/plugin.json?ref=${TAG}"
+          then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::.claude-plugin/plugin missing at ${TAG} — skipping marketplace publish; a git-subdir entry pointing at a missing path would be uninstallable"
+          fi
       - name: Checkout catalog repo
+        if: steps.plugin_check.outputs.present == 'true'
         uses: actions/checkout@v7
         with:
           repository: pvliesdonk/claude-plugins
           token: ${{ secrets.RELEASE_TOKEN }}
           path: catalog
       - name: Bump marketplace.json entry
+        if: steps.plugin_check.outputs.present == 'true'
         env:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
@@ -443,18 +428,45 @@ jobs:
             )
           ' marketplace.json > marketplace.json.tmp
           mv marketplace.json.tmp marketplace.json
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
-        with:
-          path: catalog
-          token: ${{ secrets.RELEASE_TOKEN }}
-          branch: bump/markdown-vault-mcp-${{ needs.release.outputs.version }}
-          title: "chore: bump markdown-vault-mcp to v${{ needs.release.outputs.version }}"
-          body: |
-            Auto-generated bump from [markdown-vault-mcp ${{ needs.release.outputs.tag }}](https://github.com/pvliesdonk/markdown-vault-mcp/releases/tag/${{ needs.release.outputs.tag }}).
-          commit-message: "chore: bump markdown-vault-mcp to v${{ needs.release.outputs.version }}"
-          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          # The catalog must never be pushed malformed or with a mismatched
+          # entry: validate before anything is committed.
+          jq empty marketplace.json
+          jq -e --arg name "markdown-vault-mcp" --arg v "$VERSION" '
+            .plugins[] | select(.name == $name)
+            | select(.version == $v and .source.ref == ("v" + $v))
+          ' marketplace.json > /dev/null
+      - name: Commit and push to catalog
+        if: steps.plugin_check.outputs.present == 'true'
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          cd catalog
+          if git diff --quiet -- marketplace.json; then
+            echo "marketplace.json already at v${VERSION}; nothing to publish"
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          git add marketplace.json
+          git commit -m "chore: bump markdown-vault-mcp to v${VERSION}"
+          # Concurrent sibling releases race on the same file; rebase-retry
+          # instead of failing. Bumping existing entries touches distinct
+          # lines and rebases cleanly; only two simultaneous *first*
+          # releases (both appending at the array tail) can conflict, and
+          # that fails loudly below for a manual job re-run.
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:${BRANCH}"; then
+              exit 0
+            fi
+            if ! git pull --rebase origin "${BRANCH}"; then
+              git rebase --abort || true
+              echo "::error::concurrent catalog change conflicts with this bump; re-run this job"
+              exit 1
+            fi
+          done
+          echo "::error::could not push marketplace bump after 5 attempts"
+          exit 1
 
   publish-registry:
     needs: [release, publish-pypi, publish-docker]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,10 @@ To change what the wizard asks:
 - **A var the scan cannot see** (a deprecated alias no longer read inside `ProjectConfig.from_env`, or something read outside it entirely) — declare it in `config-presentation.domain.yml` instead.
 - **Coverage is enforced, not automatic** — the generator fails loudly (`SystemExit`, naming the var and its tags) if a collected `Var`'s tags match no env-file section, rather than silently dropping it from every generated file. Giving a domain field a tag no section lists is a config-presentation bug, and this catches it at generation time instead of shipping an undocumented var. There is, however, **no orphan check**: a stale or mistaken entry in `config-presentation.domain.yml` that nothing actually reads will generate into the wizard and env files anyway. Keep that file's contents matched to real reads yourself.
 
+### mcpb install screen
+
+`packaging/mcpb/manifest.json.in`'s `user_config` and `server.mcp_config.env` objects are **generated** the same way (`kind: mcpb-user-config`): both derive from one curated `fields:` map, so a screen field and its env wiring cannot drift apart, and hand edits to those two objects are overwritten on the next generation — the rest of the manifest stays yours. The template baseline shows a deliberately minimal screen (server name, log level). Curate this project's screen in `config-presentation.domain.yml` under `files:` → `packaging/mcpb/manifest.json.in` → `fields:`: map an env var name to `{id: ..., title: ..., type: string|boolean|number|directory|file, required: ..., default: ..., sensitive: ...}` (everything but `id` falls back to the var's own metadata), or to `null` to drop a baseline field. A `files:` entry for a path the template does not declare is taken wholesale — that is how a project drives its own additional install-channel manifest from the same source of truth.
+
 ### Tool icons
 
 Drop SVG / PNG / ICO / JPEG files into `src/markdown_vault_mcp/static/icons/` and bulk-attach them to registered tools via `fastmcp_pvl_core.register_tool_icons(mcp, {"tool_name": "filename.svg"}, static_dir=...)` at the end of `register_tools()` — or attach at decoration time with `@mcp.tool(icons=[make_icon(STATIC / "x.svg")])` (where `STATIC = Path(__file__).parent / "static" / "icons"` is a shorthand you define at module level). The scaffold ships an empty `static/icons/` directory; commented-out wiring lives in `tools.py`.
@@ -287,6 +291,10 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 - `# DOMAIN-MANIFESTS-START` / `-END` — the calls, inside `main()`, where `version` is in scope
 
 Every path bumped there must also appear in `pyproject.toml`'s `[tool.semantic_release] assets`, or PSR leaves it out of the release commit. The two are checked against each other by `tests/test_release_contract.py`, so a manifest named in one and not the other fails the gate rather than shipping a release commit with a stale file in it.
+
+## Pre-release artifact smoke test
+
+The `Pre-release check` workflow (Actions tab, `workflow_dispatch`) builds and validates the mcpb bundle from any branch at a caller-supplied version (default `0.0.0-dev`), uploads it as a workflow artifact for manual install testing, and can optionally attach it to a deletable `v<version>-rc` pre-release. It runs the exact same steps a real release runs — both call the shared `.github/actions/build-mcpb` composite — so a green pre-release check means the release path's bundle build is green too. Project-specific artifact assertions (extra bundles, plugin manifests) belong in `packaging/pre-release-checks.sh` — an executable script the workflow runs when present, with `VERSION` and `BUNDLE` exported; the file is project-owned, and template updates never touch it.
 
 ## Tool Registration Checklist
 

--- a/config-presentation.domain.yml
+++ b/config-presentation.domain.yml
@@ -84,3 +84,58 @@ wizard_routing: []
 
 # Extra wizard guards specific to this project.
 wizard_guards: []
+
+# Claude Desktop mcpb install screen — this project's curation of the
+# template-declared `packaging/mcpb/manifest.json.in` channel (#1041).
+# Field ids match the pre-generation hand-maintained screen so values
+# Claude Desktop already stored for existing installs stay attached.
+# Deliberately reduced from the old 26-field screen: HTTP-auth fields
+# (bearer/OIDC) cannot apply to a stdio bundle, and operator tuning
+# (state/index/embeddings paths, cache dirs, push-delay) stays reachable
+# via env vars per docs/configuration.md. One line per field to adjust.
+files:
+  packaging/mcpb/manifest.json.in:
+    fields:
+      "{PREFIX}_SOURCE_DIR":
+        id: source_dir
+        title: "Vault directory"
+        type: directory
+        required: true
+        default: "${DOCUMENTS}/Vault"
+      "{PREFIX}_READ_ONLY":
+        id: read_only
+        title: "Read-only mode"
+        default: true
+      "{PREFIX}_EXCLUDE":
+        id: exclude_patterns
+        title: "Exclude patterns"
+      "{PREFIX}_EMBEDDING_PROVIDER":
+        id: embedding_provider
+        title: "Embedding provider"
+        description: "Semantic-search backend: fastembed, ollama, or openai. Leave empty to disable embeddings."
+      OLLAMA_HOST:
+        id: ollama_host
+        title: "Ollama host"
+      "{PREFIX}_OLLAMA_MODEL":
+        id: ollama_model
+        title: "Ollama embedding model"
+      "{PREFIX}_FASTEMBED_MODEL":
+        id: fastembed_model
+        title: "FastEmbed model"
+      OPENAI_API_KEY:
+        id: openai_api_key
+        title: "OpenAI API key"
+        sensitive: true
+      OPENAI_BASE_URL:
+        id: openai_base_url
+        title: "OpenAI base URL"
+      OPENAI_EMBEDDING_MODEL:
+        id: openai_embedding_model
+        title: "OpenAI embedding model"
+      "{PREFIX}_GIT_REPO_URL":
+        id: git_repo_url
+        title: "Git sync repository URL"
+      "{PREFIX}_GIT_TOKEN":
+        id: git_token
+        title: "Git access token"
+        sensitive: true

--- a/config-presentation.yml
+++ b/config-presentation.yml
@@ -525,3 +525,24 @@ files:
         packaging: pypi
       - path: [packages, 1, environmentVariables]
         packaging: oci
+
+  # Claude Desktop mcpb install screen. Replaces exactly two objects in the
+  # manifest — top-level `user_config` and `server.mcp_config.env` — both
+  # derived from the `fields:` map below, so a screen field and its env
+  # wiring cannot drift apart. Everything else (including the ${VERSION}
+  # placeholders the release flow envsubsts) survives untouched, and the
+  # file stays `_skip_if_exists` like the other generated-and-seeded
+  # artifacts. The baseline below is deliberately minimal; a project
+  # curates its own screen by overlaying `fields:` on this entry in
+  # config-presentation.domain.yml — adding domain fields (an `id:` plus
+  # any of title/description/type/required/default/sensitive), overriding
+  # these two, or removing them with `null`.
+  packaging/mcpb/manifest.json.in:
+    kind: mcpb-user-config
+    fields:
+      "{PREFIX}_SERVER_NAME":
+        id: server_name
+        title: "Server name"
+      FASTMCP_LOG_LEVEL:
+        id: log_level
+        title: "Log level"

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2997,10 +2997,16 @@ distinct channels via a single `workflow_dispatch` trigger:
 - **Stable** (`prerelease: false`): full pipeline. semantic-release
   cuts a `vX.Y.Z` tag, PyPI receives the wheel + sdist, the Docker
   image publishes `:latest`, `:vX.Y.Z`, `:vX.Y`, `:vX`, `.deb`/`.rpm`
-  packages attach to the GitHub Release, the Claude Code catalog PR
-  opens in `pvliesdonk/claude-plugins`, and the MCP Registry receives
-  the new `server.json`. Intended for promoting a verified build to
-  every distribution surface.
+  packages attach to the GitHub Release, the Claude Code catalog entry
+  in `pvliesdonk/claude-plugins` is updated by a direct commit to that
+  repo's default branch (template v3.4.0: the job first verifies
+  `.claude-plugin/plugin` exists at the tag — a `git-subdir` entry
+  pointing at a missing path is uninstallable — validates the bumped
+  `marketplace.json`, then pushes with a five-attempt rebase-retry
+  loop for concurrent sibling releases; no human-merged PR remains in
+  the loop), and the MCP Registry receives the new `server.json`.
+  Intended for promoting a verified build to every distribution
+  surface.
 
 - **Pre-release** (`prerelease: true`, the dispatch default):
   exercises the full pipeline without touching public catalogs.
@@ -3009,7 +3015,7 @@ distinct channels via a single `workflow_dispatch` trigger:
   and `:vX.Y.Z-rc.N` only; `:latest`, `:vX.Y`, `:vX` never move on
   a pre-release. The mcpb bundle is built and attached to the
   pre-release for manual smoke-test in Claude Desktop. PyPI, linux
-  packages, the Claude Code catalog PR, and the MCP Registry publish
+  packages, the Claude Code catalog publish, and the MCP Registry publish
   are all skipped. This is the default dispatch mode so real releases
   require an explicit opt-out.
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3021,10 +3021,17 @@ distinct channels via a single `workflow_dispatch` trigger:
 
 The `build-mcpb` and `publish-mcpb` jobs run unchanged in both modes:
 `build-mcpb` reads `needs.release.outputs.version` (which already
-carries the rc suffix on pre-release) and threads it through
-`envsubst '${VERSION}'` into `packaging/mcpb/manifest.json.in` and
-`pyproject.toml.in`, then `publish-mcpb` uploads the resulting
-`.mcpb` to the GitHub Release. No committed manifest bump is needed
+carries the rc suffix on pre-release) and delegates to the shared
+`.github/actions/build-mcpb` composite action (template v3.4.0), which
+threads the version through `envsubst '${VERSION}'` into
+`packaging/mcpb/manifest.json.in` and `pyproject.toml.in`, runs
+`mcpb validate`, packs the bundle, and smoke-tests the packed artifact;
+`publish-mcpb` then uploads the resulting `.mcpb` to the GitHub
+Release. The same composite action backs the manually dispatched
+`Pre-release check` workflow, which additionally runs
+`packaging/pre-release-checks.sh` for the plugin-manifest and
+vault-screen assertions — so a pre-release smoke test exercises exactly
+the steps a real release runs. No committed manifest bump is needed
 for the bundle.
 
 ### Future Work

--- a/docs/guides/claude-desktop.md
+++ b/docs/guides/claude-desktop.md
@@ -29,7 +29,7 @@ This is the easiest option for non-technical users.
 3. Claude Desktop opens a GUI wizard that prompts for the required env vars. No manual JSON editing needed.
 
 !!! note "Configured through the GUI wizard"
-    The `.mcpb` bundle surfaces a broad set of env vars in Claude Desktop's wizard: vault path, read-only mode, state/index/embedding paths, the embedding provider and its per-provider model settings, git configuration, and auth (bearer / OIDC), among others. If you need to set an option the wizard doesn't expose, use Step 1 (manual config) instead.
+    The `.mcpb` bundle's wizard shows a deliberately small set of fields, generated from the server's configuration surface so it can never drift from the code: the vault directory (required), read-only mode, exclude patterns, the embedding provider with its per-provider settings and API key, git sync with its access token, and the server name and log level. Everything else (state and index paths, tuning, HTTP auth) stays configurable the documented way through env vars (see [Configuration](../configuration.md)); if you need one of those, use Step 1 (manual config) instead.
 
 ---
 

--- a/packaging/mcpb/manifest.json.in
+++ b/packaging/mcpb/manifest.json.in
@@ -17,223 +17,146 @@
   "documentation": "https://pvliesdonk.github.io/markdown-vault-mcp/",
   "support": "https://github.com/pvliesdonk/markdown-vault-mcp/issues",
   "license": "MIT",
-  "keywords": ["markdown", "vault", "obsidian", "search", "fts5", "embeddings", "zettelkasten", "para"],
+  "keywords": [
+    "markdown",
+    "vault",
+    "obsidian",
+    "search",
+    "fts5",
+    "embeddings",
+    "zettelkasten",
+    "para"
+  ],
   "server": {
     "type": "uv",
     "entry_point": "src/server.py",
     "mcp_config": {
       "command": "uvx",
-      "args": ["--from", "markdown-vault-mcp[all]==${VERSION}", "markdown-vault-mcp", "serve"],
+      "args": [
+        "--from",
+        "markdown-vault-mcp[all]==${VERSION}",
+        "markdown-vault-mcp",
+        "serve"
+      ],
       "env": {
-        "MARKDOWN_VAULT_MCP_SOURCE_DIR":       "${user_config.source_dir}",
-        "MARKDOWN_VAULT_MCP_READ_ONLY":        "${user_config.read_only}",
-        "MARKDOWN_VAULT_MCP_SERVER_NAME":      "${user_config.server_name}",
-        "MARKDOWN_VAULT_MCP_EXCLUDE":          "${user_config.exclude_patterns}",
-        "MARKDOWN_VAULT_MCP_STATE_PATH":       "${user_config.state_path}",
+        "MARKDOWN_VAULT_MCP_SERVER_NAME": "${user_config.server_name}",
+        "FASTMCP_LOG_LEVEL": "${user_config.log_level}",
+        "MARKDOWN_VAULT_MCP_SOURCE_DIR": "${user_config.source_dir}",
+        "MARKDOWN_VAULT_MCP_READ_ONLY": "${user_config.read_only}",
+        "MARKDOWN_VAULT_MCP_EXCLUDE": "${user_config.exclude_patterns}",
         "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER": "${user_config.embedding_provider}",
-        "OLLAMA_HOST":                         "${user_config.ollama_host}",
-        "MARKDOWN_VAULT_MCP_OLLAMA_MODEL":     "${user_config.ollama_model}",
-        "MARKDOWN_VAULT_MCP_FASTEMBED_MODEL":  "${user_config.fastembed_model}",
-        "OPENAI_API_KEY":                      "${user_config.openai_api_key}",
-        "OPENAI_BASE_URL":                     "${user_config.openai_base_url}",
-        "OPENAI_EMBEDDING_MODEL":              "${user_config.openai_embedding_model}",
-        "MARKDOWN_VAULT_MCP_GIT_REPO_URL":     "${user_config.git_repo_url}",
-        "MARKDOWN_VAULT_MCP_GIT_TOKEN":        "${user_config.git_token}",
-        "MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S": "${user_config.git_push_delay_s}",
-        "MARKDOWN_VAULT_MCP_BEARER_TOKEN":           "${user_config.bearer_token}",
-        "MARKDOWN_VAULT_MCP_OIDC_AUDIENCE":          "${user_config.oidc_audience}",
-        "MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID":         "${user_config.oidc_client_id}",
-        "MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET":     "${user_config.oidc_client_secret}",
-        "MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL":        "${user_config.oidc_config_url}",
-        "MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY":   "${user_config.oidc_jwt_signing_key}",
-        "MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES":   "${user_config.oidc_required_scopes}",
-        "MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH":        "${user_config.embeddings_path}",
-        "MARKDOWN_VAULT_MCP_INDEX_PATH":             "${user_config.index_path}",
-        "MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR":    "${user_config.fastembed_cache_dir}",
-        "FASTMCP_LOG_LEVEL":                   "${user_config.log_level}"
+        "OLLAMA_HOST": "${user_config.ollama_host}",
+        "MARKDOWN_VAULT_MCP_OLLAMA_MODEL": "${user_config.ollama_model}",
+        "MARKDOWN_VAULT_MCP_FASTEMBED_MODEL": "${user_config.fastembed_model}",
+        "OPENAI_API_KEY": "${user_config.openai_api_key}",
+        "OPENAI_BASE_URL": "${user_config.openai_base_url}",
+        "OPENAI_EMBEDDING_MODEL": "${user_config.openai_embedding_model}",
+        "MARKDOWN_VAULT_MCP_GIT_REPO_URL": "${user_config.git_repo_url}",
+        "MARKDOWN_VAULT_MCP_GIT_TOKEN": "${user_config.git_token}"
       }
     }
   },
   "user_config": {
+    "server_name": {
+      "type": "string",
+      "title": "Server name",
+      "description": "Rename this server instance; defaults to the project name.",
+      "required": false
+    },
+    "log_level": {
+      "type": "string",
+      "title": "Log level",
+      "description": "Log level for FastMCP internals and app loggers (DEBUG / INFO / WARNING / ERROR / CRITICAL). The -v CLI flag overrides to DEBUG.",
+      "required": false,
+      "default": "INFO"
+    },
     "source_dir": {
       "type": "directory",
       "title": "Vault directory",
-      "description": "Absolute path to your markdown vault.",
+      "description": "Path to the markdown vault directory. Required — the server refuses to start without it. Symbolic links inside the vault are followed on Python 3.13+.",
       "required": true,
       "default": "${DOCUMENTS}/Vault"
     },
     "read_only": {
       "type": "boolean",
       "title": "Read-only mode",
-      "description": "When true, the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link) are hidden.",
+      "description": "Set to false to enable the write tools (write, edit, append, delete, rename, move_folder, fetch, git_sync, the okf_* tools, create_upload_link). git_sync also needs managed git mode; create_upload_link needs an HTTP transport.",
       "required": false,
       "default": true
-    },
-    "server_name": {
-      "type": "string",
-      "title": "Server name",
-      "description": "Name shown in the Claude tool list.",
-      "required": false,
-      "default": "markdown-vault-mcp"
     },
     "exclude_patterns": {
       "type": "string",
       "title": "Exclude patterns",
-      "description": "Comma-separated glob patterns to exclude from indexing.",
-      "required": false,
-      "default": ".obsidian/**,.trash/**,.git/**"
-    },
-    "state_path": {
-      "type": "file",
-      "title": "State file path",
-      "description": "Path to the change-tracking state JSON file. Blank uses {source_dir}/.markdown_vault_mcp/state.json.",
-      "required": false
-    },
-    "index_path": {
-      "type": "file",
-      "title": "FTS5 index path",
-      "description": "Path to the SQLite FTS5 index file. Blank uses an in-memory index (rebuilt on every startup).",
-      "required": false
-    },
-    "embeddings_path": {
-      "type": "file",
-      "title": "Embeddings sidecar base path",
-      "description": "Base path for the embeddings .npy sidecar (suffix is appended by the runtime). Blank disables embeddings.",
-      "required": false
-    },
-    "fastembed_cache_dir": {
-      "type": "directory",
-      "title": "FastEmbed cache directory",
-      "description": "Where FastEmbed caches downloaded model files. Blank uses the default user cache.",
+      "description": "Comma-separated glob patterns excluded from scanning, e.g. .obsidian/**,.trash/**.",
       "required": false
     },
     "embedding_provider": {
       "type": "string",
       "title": "Embedding provider",
-      "description": "One of: fastembed, ollama, openai. Leave blank to disable semantic search.",
+      "description": "Semantic-search backend: fastembed, ollama, or openai. Leave empty to disable embeddings.",
       "required": false
-    },
-    "fastembed_model": {
-      "type": "string",
-      "title": "FastEmbed model",
-      "description": "Only used when embedding_provider=fastembed.",
-      "required": false,
-      "default": "BAAI/bge-small-en-v1.5"
     },
     "ollama_host": {
       "type": "string",
       "title": "Ollama host",
-      "description": "Only used when embedding_provider=ollama.",
+      "description": "Ollama server URL for the ollama embedding provider. Bare (not MARKDOWN_VAULT_MCP_-prefixed), matching the Ollama ecosystem convention.",
       "required": false,
       "default": "http://localhost:11434"
     },
     "ollama_model": {
       "type": "string",
-      "title": "Ollama model",
-      "description": "Only used when embedding_provider=ollama.",
+      "title": "Ollama embedding model",
+      "description": "Ollama embedding model name.",
       "required": false,
       "default": "nomic-embed-text"
+    },
+    "fastembed_model": {
+      "type": "string",
+      "title": "FastEmbed model",
+      "description": "FastEmbed model name.",
+      "required": false,
+      "default": "BAAI/bge-small-en-v1.5"
     },
     "openai_api_key": {
       "type": "string",
       "title": "OpenAI API key",
-      "description": "Only used when embedding_provider=openai. Stored in the OS keychain.",
+      "description": "OpenAI API key for the openai embedding provider, and the fallback key for the summarize tool when MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_API_KEY is unset. Bare (not MARKDOWN_VAULT_MCP_-prefixed), matching the OpenAI ecosystem convention.",
       "required": false,
       "sensitive": true
     },
     "openai_base_url": {
       "type": "string",
-      "title": "OpenAI-compatible API base URL",
-      "description": "Override to point at SiliconFlow, Together, OpenRouter, or an internal gateway. Only used when embedding_provider=openai.",
-      "required": false,
-      "default": "https://api.openai.com/v1"
+      "title": "OpenAI base URL",
+      "description": "Bare fallback for MARKDOWN_VAULT_MCP_OPENAI_BASE_URL (embeddings). For the summarize tool it only routes traffic when an API key already enables the feature; it never enables summarize by itself.",
+      "required": false
     },
     "openai_embedding_model": {
       "type": "string",
-      "title": "OpenAI-compatible embedding model",
-      "description": "Embedding model name. Must be valid for the configured OpenAI base URL. Only used when embedding_provider=openai.",
-      "required": false,
-      "default": "text-embedding-3-small"
+      "title": "OpenAI embedding model",
+      "description": "Bare fallback for MARKDOWN_VAULT_MCP_OPENAI_EMBEDDING_MODEL.",
+      "required": false
     },
     "git_repo_url": {
       "type": "string",
-      "title": "Git repository URL",
-      "description": "Set to enable managed git mode (auto-commit and push on write).",
+      "title": "Git sync repository URL",
+      "description": "HTTPS remote URL for managed git mode: the server clones into an empty SOURCE_DIR on startup (or validates an existing origin) and enables the pull loop, auto-commit, and deferred push.",
       "required": false
     },
     "git_token": {
       "type": "string",
-      "title": "Git personal access token",
-      "description": "HTTPS auth for the configured git repository.",
+      "title": "Git access token",
+      "description": "Token/password for HTTPS git auth; remotes must be HTTPS when set.",
       "required": false,
       "sensitive": true
-    },
-    "git_push_delay_s": {
-      "type": "number",
-      "title": "Git push delay (seconds)",
-      "description": "Batches rapid writes. 0 disables delayed push.",
-      "required": false,
-      "default": 30,
-      "min": 0,
-      "max": 3600
-    },
-    "bearer_token": {
-      "type": "string",
-      "title": "Bearer token",
-      "description": "Static bearer token for HTTP transports. Leave blank to disable bearer auth.",
-      "required": false,
-      "sensitive": true
-    },
-    "oidc_config_url": {
-      "type": "string",
-      "title": "OIDC discovery URL",
-      "description": "Issuer's .well-known/openid-configuration URL. Set this to enable OIDC; leave blank to disable.",
-      "required": false
-    },
-    "oidc_audience": {
-      "type": "string",
-      "title": "OIDC audience",
-      "description": "Expected audience claim for OIDC token validation.",
-      "required": false
-    },
-    "oidc_required_scopes": {
-      "type": "string",
-      "title": "OIDC required scopes",
-      "description": "Space-separated scopes required on validated OIDC tokens. Leave blank for no scope requirement (recommended for multi-auth setups).",
-      "required": false,
-      "default": ""
-    },
-    "oidc_client_id": {
-      "type": "string",
-      "title": "OIDC client ID",
-      "description": "Client ID for OIDC proxy mode (Authelia and other non-DCR providers).",
-      "required": false
-    },
-    "oidc_client_secret": {
-      "type": "string",
-      "title": "OIDC client secret",
-      "description": "Client secret for OIDC proxy mode. Stored in the OS keychain.",
-      "required": false,
-      "sensitive": true
-    },
-    "oidc_jwt_signing_key": {
-      "type": "string",
-      "title": "OIDC JWT signing key",
-      "description": "PEM-encoded signing key issued for proxied OIDC tokens. Stored in the OS keychain.",
-      "required": false,
-      "sensitive": true
-    },
-    "log_level": {
-      "type": "string",
-      "title": "Log level",
-      "description": "One of: DEBUG, INFO, WARNING, ERROR.",
-      "required": false,
-      "default": "INFO"
     }
   },
   "compatibility": {
     "claude_desktop": ">=0.10.0",
-    "platforms": ["darwin", "win32", "linux"],
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
     "runtimes": {
       "python": ">=3.10,<4.0"
     }

--- a/packaging/pre-release-checks.sh
+++ b/packaging/pre-release-checks.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Project-specific pre-release artifact assertions, run by the template's
+# `Pre-release check` workflow after the shared mcpb build/smoke steps
+# (see CLAUDE.md "Pre-release artifact smoke test"). VERSION holds the
+# rendered version string and BUNDLE the packed .mcpb path (#351).
+#
+# Covers the Claude Code plugin channel, which is domain-owned in this
+# repo: the two version-lockstep manifests (CLAUDE.md gate #7) and the
+# shipped skill, plus the vault-specific mcpb screen invariants the
+# generic smoke test cannot know about.
+set -euo pipefail
+
+fail() { echo "::error::$1"; exit 1; }
+
+PLUGIN_JSON=".claude-plugin/plugin/.claude-plugin/plugin.json"
+MCP_JSON=".claude-plugin/plugin/.mcp.json"
+
+test -f "$PLUGIN_JSON" || fail "$PLUGIN_JSON missing"
+test -f "$MCP_JSON" || fail "$MCP_JSON missing"
+test -f ".claude-plugin/plugin/skills/vault-workflow/SKILL.md" \
+  || fail "vault-workflow skill missing from plugin"
+
+jq -e '.name == "markdown-vault-mcp" and (.version | length > 0)' "$PLUGIN_JSON" > /dev/null \
+  || fail "$PLUGIN_JSON missing name/version"
+
+# The two plugin manifests move in lockstep: .mcp.json's uvx --from pin
+# must name the same version plugin.json declares.
+plugin_version=$(jq -r .version "$PLUGIN_JSON")
+jq -e --arg v "$plugin_version" '
+  .["markdown-vault-mcp"].args | index("--from") as $i
+  | .[$i + 1] | contains("==" + $v)
+' "$MCP_JSON" > /dev/null \
+  || fail ".mcp.json --from pin does not match plugin.json version ${plugin_version}"
+
+# Vault-specific mcpb screen invariants on the rendered manifest inside
+# the packed bundle: the required vault picker is wired, and the
+# ${DOCUMENTS} host placeholder survived the render.
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+unzip -q "$BUNDLE" -d "$work"
+jq -e '.user_config.source_dir.required == true and .user_config.source_dir.type == "directory"' \
+  "$work/manifest.json" > /dev/null \
+  || fail "bundle manifest lost the required source_dir directory picker"
+jq -e '.server.mcp_config.env.MARKDOWN_VAULT_MCP_SOURCE_DIR == "${user_config.source_dir}"' \
+  "$work/manifest.json" > /dev/null \
+  || fail "bundle manifest env is not wired to user_config.source_dir"
+grep -qF '${DOCUMENTS}' "$work/manifest.json" \
+  || fail "\${DOCUMENTS} placeholder was expanded away in the bundle manifest"
+
+echo "project-specific pre-release checks passed (plugin manifests at v${plugin_version}, mcpb screen wired)"

--- a/scripts/gen_config_surface.py
+++ b/scripts/gen_config_surface.py
@@ -87,9 +87,12 @@ _NO_DEFAULT = object()
 # then by declaration order within each provenance.
 _PROVENANCE_ORDER = ("core", "template", "external", "domain")
 
-_CORE_FLOOR_RE = re.compile(
-    r"fastmcp-pvl-core(?:\[[^\]]*\])?\s*>=\s*([0-9]+(?:\.[0-9]+)*)"
-)
+# Captures the full version constraint (e.g. ">=4.11.0,<5"), not just the
+# floor: the bootstrap re-exec must resolve the SAME version `uv sync` will
+# resolve for the project venv, or copy-time generation and a later venv
+# regeneration disagree the moment a core release changes any help text
+# (#335). A bare `==floor` pin did exactly that.
+_CORE_CONSTRAINT_RE = re.compile(r"fastmcp-pvl-core(?:\[[^\]]*\])?\s*([><=!~][^\"']*)")
 
 
 def _clean_help(help_text: str) -> str:
@@ -183,8 +186,9 @@ def _load_domain_presentation(
 
     Unlike `load_presentation`'s template-owned file (mandatory in every
     render), this one is *seeded* — a downstream project owns and edits it.
-    Its ``vars`` feed `collect_vars` and its ``wizard_routing``/
-    ``wizard_guards`` feed `render_wizard_spec`. A missing file means
+    Its ``vars`` feed `collect_vars`, its ``wizard_routing``/
+    ``wizard_guards`` feed `render_wizard_spec`, and its ``files`` overlay
+    the template's artifact map (see `_merged_files`). A missing file means
     "nothing manually declared" rather than a configuration error.
     """
     import yaml
@@ -1729,6 +1733,9 @@ class PresentationContext:
 
     presentation: Mapping[str, Any]
     answers: Mapping[str, object]
+    # The project's config-presentation.domain.yml content; only the wizard
+    # renderer reads it today, but it is per-run input like the other two.
+    domain_presentation: Mapping[str, Any] = dataclasses.field(default_factory=dict)
 
     @property
     def required_names(self) -> Collection[str]:
@@ -1818,6 +1825,187 @@ def render_json_splice_file(
             for var in vars_
             if packaging_id in _packaging_ids(var, packaging)
         ]
+
+    text = json.dumps(data, indent=2, ensure_ascii=False)
+    return f"{text}\n"
+
+
+# mcpb `user_config` field types this generator can emit. `directory` and
+# `file` are host-picker types no Python annotation maps to — they are only
+# reachable via an explicit `type:` override in a field spec.
+_MCPB_TYPES = frozenset({"string", "boolean", "number", "directory", "file"})
+_MCPB_TYPE_BY_PYTHON = {
+    "str": "string",
+    "bool": "boolean",
+    "int": "number",
+    "float": "number",
+}
+_MCPB_FIELD_SPEC_KEYS = frozenset(
+    {"id", "title", "description", "type", "required", "default", "sensitive"}
+)
+# mcpb config ids become `${user_config.<id>}` references; keep them to the
+# conservative snake_case shape every existing manifest uses.
+_MCPB_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _mcpb_field_type(var: Var, spec: Mapping[str, Any], rel_path: str) -> str:
+    """The mcpb `type` for one field: explicit override, else from the annotation."""
+    explicit = spec.get("type")
+    if explicit is not None:
+        if explicit not in _MCPB_TYPES:
+            raise SystemExit(
+                f"ERROR: files[{rel_path!r}] field for {var.name!r} declares "
+                f"unknown mcpb type {explicit!r} — expected one of "
+                f"{sorted(_MCPB_TYPES)!r}."
+            )
+        return str(explicit)
+    return _MCPB_TYPE_BY_PYTHON.get(_normalize_type_name(var.type_name), "string")
+
+
+def _mcpb_user_config_entry(
+    var: Var, spec: Mapping[str, Any], rel_path: str
+) -> dict[str, Any]:
+    """One `user_config` object value, derived from the var + its field spec.
+
+    Everything falls back to the var's own metadata (wizard-style label,
+    `_clean_help`-cleaned help text, declared default) so a field spec only
+    states what the install screen should present *differently* — an
+    override, not a second copy of the surface.
+    """
+    entry: dict[str, Any] = {
+        "type": _mcpb_field_type(var, spec, rel_path),
+        "title": str(spec.get("title") or _wizard_label(var)),
+        "description": str(spec.get("description") or var.help),
+        "required": bool(spec.get("required", False)),
+    }
+    default = spec.get("default", var.default)
+    if default is _NO_DEFAULT:
+        default = None
+    if default is not None:
+        entry["default"] = default
+    if spec.get("sensitive"):
+        entry["sensitive"] = True
+    return entry
+
+
+def _mcpb_field_id(name: str, spec: Mapping[str, Any], rel_path: str) -> str:
+    """Validate one field spec's shape and return its snake_case id."""
+    unknown_keys = sorted(set(spec) - _MCPB_FIELD_SPEC_KEYS)
+    if unknown_keys:
+        raise SystemExit(
+            f"ERROR: files[{rel_path!r}] field for {name!r} has unknown "
+            f"keys {unknown_keys!r} — expected a subset of "
+            f"{sorted(_MCPB_FIELD_SPEC_KEYS)!r}."
+        )
+    field_id = spec.get("id")
+    if not isinstance(field_id, str) or not _MCPB_ID_RE.match(field_id):
+        raise SystemExit(
+            f"ERROR: files[{rel_path!r}] field for {name!r} needs a "
+            "snake_case `id:` — it becomes the ${user_config.<id>} "
+            "reference in mcp_config.env."
+        )
+    return field_id
+
+
+def _mcpb_screen_from_fields(
+    fields: Mapping[str, Any],
+    var_by_name: Mapping[str, Var],
+    rel_path: str,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Build the (`user_config`, `mcp_config.env`) pair from a fields map.
+
+    One pass produces both objects, which is the drift-proofing itself: a
+    screen field and its env wiring cannot disagree because neither exists
+    without the other. A `None` spec is a field a domain overlay removed.
+    """
+    user_config: dict[str, Any] = {}
+    env: dict[str, str] = {}
+    id_owner: dict[str, str] = {}
+    for name, spec in fields.items():
+        if spec is None:
+            continue
+        field_id = _mcpb_field_id(name, spec, rel_path)
+        if field_id in id_owner:
+            raise SystemExit(
+                f"ERROR: files[{rel_path!r}] declares id {field_id!r} for "
+                f"both {id_owner[field_id]!r} and {name!r}."
+            )
+        id_owner[field_id] = name
+        user_config[field_id] = _mcpb_user_config_entry(
+            var_by_name[name], spec, rel_path
+        )
+        env[name] = "${user_config." + field_id + "}"
+    return user_config, env
+
+
+def render_mcpb_user_config_file(
+    project_root: Path,
+    rel_path: str,
+    file_spec: Mapping[str, Any],
+    vars_: Sequence[Var],
+    ctx: PresentationContext,
+) -> str:
+    """Render one `kind: mcpb-user-config` artifact's full on-disk text.
+
+    Structurally splices a Claude Desktop mcpb manifest the same way
+    `kind: json-splice` splices ``server.json``: exactly two objects are
+    replaced wholesale — top-level ``user_config`` and
+    ``server.mcp_config.env`` — and every other key survives untouched,
+    including the ``${VERSION}`` placeholders the release flow substitutes
+    with ``envsubst``. Both objects derive from the same ``fields:`` map, so
+    a config field and its env wiring cannot drift apart, and a field that
+    exists nowhere else in the config surface cannot be invented here
+    (every key must name a collected var). Membership is explicit
+    curation — the install screen shows what `fields:` declares, nothing
+    more — with the project's ``config-presentation.domain.yml`` able to
+    add, override or remove fields via the domain files overlay (see
+    `_merged_files`).
+
+    The unused *ctx* keeps this renderer call-compatible with the other
+    file kinds dispatched from `write_artifacts`.
+    """
+    del ctx
+    target = project_root / rel_path
+    if not target.exists():
+        raise SystemExit(
+            f"ERROR: {target} does not exist — a `kind: mcpb-user-config` "
+            "artifact must already exist; this generator only replaces its "
+            "`user_config` and `server.mcp_config.env` objects, never the "
+            "surrounding manifest."
+        )
+    raw = target.read_text(encoding="utf-8")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"ERROR: {rel_path} is not valid JSON: {exc}.") from exc
+
+    fields: Mapping[str, Any] = file_spec.get("fields") or {}
+    if not fields:
+        raise SystemExit(
+            f"ERROR: files[{rel_path!r}] (kind: mcpb-user-config) declares no "
+            "`fields:` — an mcpb bundle with an empty install screen would "
+            "silently drop its existing user_config; remove the files entry "
+            "instead if that is really intended."
+        )
+    var_by_name = {v.name: v for v in vars_}
+    unknown = sorted(name for name in fields if name not in var_by_name)
+    if unknown:
+        raise SystemExit(
+            f"ERROR: files[{rel_path!r}] names config vars that do not exist "
+            f"(check for a typo, or a var whose gate is off): {unknown!r}."
+        )
+
+    user_config, env = _mcpb_screen_from_fields(fields, var_by_name, rel_path)
+
+    server = data.get("server")
+    mcp_config = server.get("mcp_config") if isinstance(server, dict) else None
+    if not isinstance(mcp_config, dict):
+        raise SystemExit(
+            f"ERROR: {rel_path} has no `server.mcp_config` object to hold the "
+            "generated env mapping — is this really an mcpb manifest?"
+        )
+    data["user_config"] = user_config
+    mcp_config["env"] = env
 
     text = json.dumps(data, indent=2, ensure_ascii=False)
     return f"{text}\n"
@@ -2222,8 +2410,9 @@ _ENV_KIND = "env"
 _WIZARD_KIND = "wizard"
 _SPLICE_KIND = "splice"
 _JSON_SPLICE_KIND = "json-splice"
+_MCPB_KIND = "mcpb-user-config"
 _KNOWN_FILE_KINDS = frozenset(
-    {_ENV_KIND, _WIZARD_KIND, _SPLICE_KIND, _JSON_SPLICE_KIND}
+    {_ENV_KIND, _WIZARD_KIND, _SPLICE_KIND, _JSON_SPLICE_KIND, _MCPB_KIND}
 )
 
 
@@ -2294,6 +2483,86 @@ def _assert_every_var_has_an_env_destination(
     )
 
 
+def _render_one_artifact(
+    project_root: Path,
+    rel_path: str,
+    file_spec: Mapping[str, Any],
+    vars_: Sequence[Var],
+    ctx: PresentationContext,
+) -> str:
+    """Dispatch one `files:` entry to its kind's renderer.
+
+    An unrecognised ``kind`` fails loudly instead of either silently
+    producing nothing or raising a bare `KeyError`.
+    """
+    kind = file_spec.get("kind")
+    if kind == _ENV_KIND:
+        return render_env_file(file_spec, vars_, ctx.answers)
+    if kind == _WIZARD_KIND:
+        return render_wizard_spec(
+            ctx.presentation, vars_, ctx.answers, domain_pres=ctx.domain_presentation
+        )
+    if kind == _SPLICE_KIND:
+        return render_splice_file(project_root, rel_path, file_spec, vars_, ctx)
+    if kind == _JSON_SPLICE_KIND:
+        return render_json_splice_file(project_root, rel_path, file_spec, vars_, ctx)
+    if kind == _MCPB_KIND:
+        return render_mcpb_user_config_file(
+            project_root, rel_path, file_spec, vars_, ctx
+        )
+    raise SystemExit(
+        f"ERROR: config-presentation.yml files[{rel_path!r}] has "
+        f"unknown kind {kind!r} — expected one of "
+        f"{sorted(_KNOWN_FILE_KINDS)!r}."
+    )
+
+
+def _merged_files(
+    presentation: Mapping[str, Any], domain_presentation: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Overlay the domain presentation's `files:` onto the template's.
+
+    Two distinct powers, matching what a downstream may legitimately own:
+
+    - A rel_path only the domain file declares is taken wholesale — this is
+      how a project declares an install channel the template does not ship
+      (a Claude Code plugin manifest, say) while reusing the generator's
+      kinds and the `--check` gate.
+    - A rel_path both declare merges at the `fields:` level only: a domain
+      entry adds fields, overrides a template field's spec, or removes one
+      by mapping its var name to `null`. Every other key (`kind:` above
+      all) stays template-owned — a domain overlay must curate a template
+      channel's fields, not repoint or re-kind the artifact.
+
+    Declaration order is preserved: template fields first, domain additions
+    after, so a curated screen leads with the template's baseline unless the
+    domain entry overrides those fields too.
+    """
+    merged: dict[str, Any] = dict(presentation.get("files") or {})
+    for rel_path, domain_spec in (domain_presentation.get("files") or {}).items():
+        base = merged.get(rel_path)
+        if base is None:
+            merged[rel_path] = domain_spec
+            continue
+        extra = sorted(set(domain_spec) - {"fields"})
+        if extra:
+            raise SystemExit(
+                f"ERROR: config-presentation.domain.yml files[{rel_path!r}] "
+                f"may only contribute `fields:` to a template-declared file — "
+                f"remove {extra!r}; kind and layout are template-owned."
+            )
+        fields = dict(base.get("fields") or {})
+        for name, field_spec in (domain_spec.get("fields") or {}).items():
+            if field_spec is None:
+                fields.pop(name, None)
+            else:
+                fields[name] = field_spec
+        combined = dict(base)
+        combined["fields"] = fields
+        merged[rel_path] = combined
+    return merged
+
+
 def write_artifacts(
     project_root: Path,
     *,
@@ -2306,9 +2575,12 @@ def write_artifacts(
     presentation.yml`'s ``files`` mapping — adding or removing a `files:`
     entry there changes what gets generated, with no second list to keep in
     sync (YAML mapping order is insertion order, so iterating ``files``
-    directly is as deterministic as the fixed tuple it replaces). An
-    unrecognised ``kind`` fails loudly instead of either silently producing
-    nothing or raising a bare `KeyError`.
+    directly is as deterministic as the fixed tuple it replaces). The
+    project's ``config-presentation.domain.yml`` may overlay that mapping —
+    contribute whole entries for its own artifacts, or curate a template
+    entry's ``fields:`` — see `_merged_files`. An unrecognised ``kind``
+    fails loudly instead of either silently producing nothing or raising a
+    bare `KeyError`.
 
     *vars_*, when given, is used as-is instead of calling `collect_vars`
     internally — `collect_vars` re-imports `fastmcp_pvl_core`, reloads and
@@ -2340,30 +2612,18 @@ def write_artifacts(
         vars_ = collect_vars(project_root, answers)
 
     validate_presentation_keys(presentation, vars_)
-    ctx = PresentationContext(presentation=presentation, answers=answers)
+    ctx = PresentationContext(
+        presentation=presentation,
+        answers=answers,
+        domain_presentation=domain_presentation,
+    )
 
-    artifacts: list[tuple[str, str]] = []
-    for rel_path, file_spec in presentation.get("files", {}).items():
-        kind = file_spec.get("kind")
-        if kind == _ENV_KIND:
-            text = render_env_file(file_spec, vars_, answers)
-        elif kind == _WIZARD_KIND:
-            text = render_wizard_spec(
-                presentation, vars_, answers, domain_pres=domain_presentation
-            )
-        elif kind == _SPLICE_KIND:
-            text = render_splice_file(project_root, rel_path, file_spec, vars_, ctx)
-        elif kind == _JSON_SPLICE_KIND:
-            text = render_json_splice_file(
-                project_root, rel_path, file_spec, vars_, ctx
-            )
-        else:
-            raise SystemExit(
-                f"ERROR: config-presentation.yml files[{rel_path!r}] has "
-                f"unknown kind {kind!r} — expected one of "
-                f"{sorted(_KNOWN_FILE_KINDS)!r}."
-            )
-        artifacts.append((rel_path, text))
+    artifacts: list[tuple[str, str]] = [
+        (rel_path, _render_one_artifact(project_root, rel_path, file_spec, vars_, ctx))
+        for rel_path, file_spec in _merged_files(
+            presentation, domain_presentation
+        ).items()
+    ]
 
     # Checked after every file kind is known-good (so a genuinely malformed
     # `files:` entry above still gets its own, more specific error) but
@@ -2389,24 +2649,27 @@ def write_artifacts(
 # ---------------------------------------------------------------------------
 
 
-def _core_floor(project_root: Path) -> str:
-    """Parse the `fastmcp-pvl-core>=X.Y.Z` floor from the project's pyproject.toml.
+def _core_constraint(project_root: Path) -> str:
+    """Parse the full `fastmcp-pvl-core` version constraint from pyproject.toml.
 
-    Tolerates an extras marker (`fastmcp-pvl-core[redis]>=4.5.0,<5`) and a
-    floor with fewer than three components (`>=4.5`) — both appear in real
-    rendered `pyproject.toml`s, so a strict `X.Y.Z`-only, no-extras regex
-    would raise here and kill the `_tasks` bootstrap re-exec entirely.
+    Returns the constraint exactly as the project declares it (e.g.
+    `>=4.11.0,<5`), so the bootstrap re-exec resolves the same core version
+    `uv sync` resolves for the project venv — pinning only the floor made
+    copy-time generation and check-time regeneration disagree whenever a
+    newer core changed any surface text (#335). Tolerates an extras marker
+    (`fastmcp-pvl-core[redis]>=4.5.0,<5`) and a floor with fewer than three
+    components (`>=4.5`) — both appear in real rendered `pyproject.toml`s.
     """
     pyproject_path = project_root / "pyproject.toml"
     if not pyproject_path.exists():
         raise SystemExit(f"ERROR: {pyproject_path} not found.")
     text = pyproject_path.read_text(encoding="utf-8")
-    match = _CORE_FLOOR_RE.search(text)
+    match = _CORE_CONSTRAINT_RE.search(text)
     if match is None:
         raise SystemExit(
             f"ERROR: no 'fastmcp-pvl-core>=X.Y.Z' dependency found in {pyproject_path}"
         )
-    return match.group(1)
+    return match.group(1).strip()
 
 
 def _core_importable() -> bool:
@@ -2452,9 +2715,12 @@ def ensure_core_available(
     copier's ``_tasks`` run before any virtualenv exists for the freshly
     rendered project, so this script cannot assume its dependencies are
     installed. When either import fails, re-exec the whole process under
-    ``uv run --no-project`` with the core library and PyYAML pinned ad hoc —
-    this must NOT create a persistent virtualenv, since template-ci renders
-    the template twice and diffs the results.
+    ``uv run --no-project`` with the core library constrained exactly as the
+    project's pyproject.toml declares it — the same resolution ``uv sync``
+    performs later, so copy-time generation and a venv regeneration cannot
+    disagree (#335) — and PyYAML added ad hoc. This must NOT create a
+    persistent virtualenv, since template-ci renders the template twice and
+    diffs the results.
 
     ``_GEN_CONFIG_BOOTSTRAPPED`` guards against re-exec'ing more than once:
     if the dependencies are still missing right after a re-exec, that is a
@@ -2486,7 +2752,7 @@ def ensure_core_available(
             "installed."
         )
 
-    floor = _core_floor(project_root)
+    constraint = _core_constraint(project_root)
     script = str(Path(__file__).resolve())
     extra_argv = list(sys.argv[1:] if argv is None else argv)
     args = [
@@ -2494,7 +2760,7 @@ def ensure_core_available(
         "run",
         "--no-project",
         "--with",
-        f"fastmcp-pvl-core=={floor}",
+        f"fastmcp-pvl-core{constraint}",
         "--with",
         "pyyaml",
         "python",


### PR DESCRIPTION
Closes #1041, closes #351. Part of epic #1043 — the first downstream adoption of the template mechanisms merged today (fastmcp-server-template v3.4.0: template#330/#331/#333).

## What changed

**`copier update` v3.3.0 → v3.4.0** (no conflicts). Brings: marketplace direct-push publishing with the artifact-exists guard (release no longer ends at an unmerged catalog PR), the shared `build-mcpb` composite action, the `Pre-release check` `workflow_dispatch` workflow, and `mcpb-user-config` generation. Config artifacts regenerated from the project venv (109 vars) — `.env.example`, wizard-spec, `server.json` and friends came back byte-identical, confirming update idempotency.

**Curated mcpb install screen (#1041)** — the mechanism's first consumer. `config-presentation.domain.yml` gains a `files:` overlay declaring 14 fields: vault directory (required, `${DOCUMENTS}/Vault` default, directory picker), read-only, exclude patterns, embedding provider + Ollama/FastEmbed/OpenAI settings with a `sensitive` API key, git sync URL + `sensitive` token, plus the template's server-name/log-level baseline. Replaces the hand-maintained 26-field `user_config` that had drifted in both directions — the 7 HTTP-auth fields (meaningless on a stdio bundle) are gone, and the 5 operator-tuning paths stay reachable via env vars per `docs/configuration.md`. Field **ids are preserved** so Claude Desktop keeps existing installs' stored values. Descriptions now come from the real config surface's help text, and the screen regenerates on every update, gated by `gen_config_surface.py --check` — the drift class #1041 describes is mechanically dead.

**`packaging/pre-release-checks.sh` (#351's domain half)** — plugs into the new workflow's seam: asserts the plugin manifests' version lockstep (`plugin.json` ↔ `.mcp.json` `--from` pin), the shipped `vault-workflow` skill, and inside the packed bundle: `source_dir` is a required directory picker wired to `MARKDOWN_VAULT_MCP_SOURCE_DIR`, and `${DOCUMENTS}` survived the render. Exercised locally against an emulated bundle: passes, and correctly failed while I had a wrong jq path — the assertions bite.

**Docs** — `docs/guides/claude-desktop.md`'s wizard note now describes the generated, reduced screen (Vale-clean).

## Verification (hard gates)

- `pytest -x -q`: 3278 passed, 20 skipped
- `ruff check --fix` → `ruff format` → `format --check`: clean
- `mypy src/ tests/`: clean
- `diff-quality` structural gate vs `origin/main`: 100%
- `gen_config_surface.py --check`: green (screen regeneration is idempotent)
- Patch coverage: the diff adds no Python source lines (YAML/shell/docs/generated artifacts only)
- Vale on the edited guide page: 0 errors

## Deliberately not done

- Plugin `userConfig` screen (#1040) and bootstrap skill/hook (#1042) — blocked on / superseded by template#332 (plugin-channel scaffold), which is the remaining template-side epic item.
- No change to the plugin channel's `.mcp.json` shell-expansion wiring — that gets replaced by exec-form wiring in the #332/#1040 work (verified constraint: `${user_config.*}` is rejected in shell-form since Claude Code v2.1.207).
- The `SUMMARIZE_*`/frontmatter-schema vars #1041 listed as "missing from the screen" are deliberately *not* added — the direction is a severely reduced screen; they remain env-var-configurable and wizard-documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpzfNGAaCapWDf58vswzH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzfNGAaCapWDf58vswzH3)_