### PR TITLE
feat(packaging): adopt template v3.5.0 — plugin channel onto the template scaffold

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v3.4.0
+_commit: v3.5.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search
@@ -8,6 +8,7 @@ enable_structural_gate: true
 env_prefix: MARKDOWN_VAULT_MCP
 github_org: pvliesdonk
 human_name: Markdown Vault MCP
+include_claude_plugin: true
 include_mcp_apps_scaffold: true
 project_name: markdown-vault-mcp
 pypi_name: markdown-vault-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,11 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 
 Every path bumped there must also appear in `pyproject.toml`'s `[tool.semantic_release] assets`, or PSR leaves it out of the release commit. The two are checked against each other by `tests/test_release_contract.py`, so a manifest named in one and not the other fails the gate rather than shipping a release commit with a stale file in it.
 
+
+## Claude Code plugin channel
+
+`.claude-plugin/plugin/` ships this server as a Claude Code plugin: `.claude-plugin/plugin.json` (identity + version) and an exec-form `.mcp.json` that launches the released PyPI package with `uvx --from <pkg>==<version>`. Both manifests are version-coupled to the release — `scripts/bump_manifests.py` bumps them in the release commit and `[tool.semantic_release] assets` stages them, so the marketplace entry published by the release workflow always installs the version it points at (`tests/test_release_contract.py` gates that pairing). The `env` block in `.mcp.json`, the plugin README, and any `skills/` directories are project-owned content: the files are seeded once and never re-rendered by template updates. Values in `env` may reference plugin `userConfig` entries as `${user_config.<id>}` declared in `plugin.json` — exec-form fields only; shell-form command strings reject the substitution.
+
 ## Pre-release artifact smoke test
 
 The `Pre-release check` workflow (Actions tab, `workflow_dispatch`) builds and validates the mcpb bundle from any branch at a caller-supplied version (default `0.0.0-dev`), uploads it as a workflow artifact for manual install testing, and can optionally attach it to a deletable `v<version>-rc` pre-release. It runs the exact same steps a real release runs — both call the shared `.github/actions/build-mcpb` composite — so a green pre-release check means the release path's bundle build is green too. Project-specific artifact assertions (extra bundles, plugin manifests) belong in `packaging/pre-release-checks.sh` — an executable script the workflow runs when present, with `VERSION` and `BUNDLE` exported; the file is project-owned, and template updates never touch it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,12 +327,16 @@ build_command = "python scripts/bump_manifests.py"
 # all version-coupled files.
 assets = [
     "server.json",
-    ".claude-plugin/plugin/.claude-plugin/plugin.json",
-    ".claude-plugin/plugin/.mcp.json",
     # bump_manifests.py also refreshes uv.lock's self-version entry, so the
     # release commit carries a consistent lockfile instead of leaving drift
     # for the next `uv run` to re-sync as a side effect.
     "uv.lock",
+
+    # The Claude Code plugin channel's manifests, bumped by
+    # scripts/bump_manifests.py in the same release commit.
+    ".claude-plugin/plugin/.claude-plugin/plugin.json",
+    ".claude-plugin/plugin/.mcp.json",
+
 ]
 
 [tool.semantic_release.changelog]

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -87,6 +87,31 @@ def _bump_lockfile(version: str) -> None:
     print(f"bump_manifests: uv.lock ({normalized}) → {version}")
 
 
+def _bump_claude_plugin_manifests(version: str) -> None:
+    """Bump the Claude Code plugin channel's two version-coupled manifests.
+
+    ``plugin.json``'s ``version`` and ``.mcp.json``'s ``--from`` pin move in
+    lockstep with the release, so the marketplace entry the release workflow
+    publishes always installs the version it points at. Only the version
+    part after ``==`` is rewritten; the package spec (name and extras) stays
+    whatever the project configured.
+    """
+    plugin_path = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
+    manifest = _load(plugin_path)
+    manifest["version"] = version
+    _dump(plugin_path, manifest)
+
+    mcp_path = Path(".claude-plugin/plugin/.mcp.json")
+    mcp = _load(mcp_path)
+    for server in mcp.values():
+        args = server.get("args", [])
+        for i, arg in enumerate(args):
+            if arg == "--from" and i + 1 < len(args):
+                spec = args[i + 1].split("==", 1)[0]
+                args[i + 1] = f"{spec}=={version}"
+    _dump(mcp_path, mcp)
+
+
 # DOMAIN-MANIFESTS-HELPERS-START — module-level helpers for this project's own
 # versioned manifests (a `_bump_plugin_json(version)`, a TOML rewriter, ...).
 # `_load` / `_dump` above read and write JSON in the byte format the rest of
@@ -94,38 +119,6 @@ def _bump_lockfile(version: str) -> None:
 # scripts/gen_config_surface.py asserts that format, so prefer them over a
 # bare `json.dump`.  Call what you define from the DOMAIN-MANIFESTS block in
 # `main()` below.  Kept across copier update.
-def _bump_plugin_manifests(version: str) -> None:
-    """Bump the two Claude Code plugin manifests to ``version``.
-
-    Both move in lockstep with the released package version (gate #7):
-
-    - ``.claude-plugin/plugin/.claude-plugin/plugin.json`` — plugin ``version``
-    - ``.claude-plugin/plugin/.mcp.json`` — the
-      ``uvx --from markdown-vault-mcp[all]==<ver>`` pin in the server's
-      launch args.
-
-    Args:
-        version: The new release version string from PSR's ``NEW_VERSION``.
-    """
-    plugin_path = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
-    plugin = _load(plugin_path)
-    plugin["version"] = version
-    _dump(plugin_path, plugin)
-
-    mcp_path = Path(".claude-plugin/plugin/.mcp.json")
-    mcp = _load(mcp_path)
-    mcp["markdown-vault-mcp"]["args"] = [
-        "--from",
-        f"markdown-vault-mcp[all]=={version}",
-        "markdown-vault-mcp",
-        "serve",
-    ]
-    _dump(mcp_path, mcp)
-
-    print(f"bump_manifests: {plugin_path} → {version}")
-    print(f"bump_manifests: {mcp_path} → markdown-vault-mcp[all]=={version}")
-
-
 # DOMAIN-MANIFESTS-HELPERS-END
 
 
@@ -192,6 +185,7 @@ def main() -> int:
 
     print(f"bump_manifests: server.json → {version}")
     _bump_lockfile(version)
+    _bump_claude_plugin_manifests(version)
     # DOMAIN-MANIFESTS-START — bump this project's extra versioned manifests
     # here; `version` is the new version string, and the repo root is the cwd.
     # Every path touched here must also be listed in `pyproject.toml`
@@ -199,7 +193,9 @@ def main() -> int:
     # commit.  Kept across copier update; everything outside these markers is
     # template-owned and re-rendered, which is what keeps the bumpers above in
     # lockstep with the `assets` list they are declared against.
-    _bump_plugin_manifests(version)
+    # (The Claude Code plugin manifests are template-owned since v3.5.0's
+    # include_claude_plugin scaffold — see _bump_claude_plugin_manifests
+    # above — so nothing project-specific remains here.)
     # DOMAIN-MANIFESTS-END
     return 0
 


### PR DESCRIPTION
Refs #1043, #1040. Second downstream adoption in the epic: template v3.5.0 (fastmcp-server-template#332) with `include_claude_plugin: true`.

## What changed

**`copier update` v3.4.0 → v3.5.0, flag on.** The existing `.claude-plugin/plugin/` content — manifests, README, `vault-workflow` skill, current `.mcp.json` env wiring — is untouched (`.claude-plugin/**` is seeded-once), and generation confirmed all config artifacts already current. What changes hands is the *machinery*:

- **Version lockstep is now template-owned**: the template's `_bump_claude_plugin_manifests` (which rewrites only the version after `==`, preserving the package spec) replaces the hand-built `_bump_plugin_manifests` — removed from the `DOMAIN-MANIFESTS` blocks along with its helper. This is the same lockstep gap that left scholar-mcp's plugin self-reporting 1.6.0 at tag v1.9.0; it's now structurally impossible to fork per-project.
- **Assets deduped**: the update's three-way merge left the two plugin-manifest paths in `[tool.semantic_release] assets` twice (the old domain-added pair plus the template's flag-gated pair); the domain pair is removed.
- New flag-gated "Claude Code plugin channel" section lands in `CLAUDE.md`.

## Verification

- The bumper exercised end-to-end at a test version: `server.json`, `uv.lock`, `plugin.json`, and `.mcp.json`'s `--from` pin all move together (then reverted).
- `tests/test_release_contract.py` (assets ↔ bumper lockstep) and `tests/test_packaging_mcpb.py`: 12 passed.
- Full gates: 3278 tests passed, ruff check/format clean, mypy clean, structural diff-gate 100%.
- No `.rej` conflicts; regenerated artifacts byte-identical.

## Deliberately not done

- `.mcp.json` still uses its current `${VAR:-default}` env expansion — replacing it with `${user_config.*}` wiring is exactly #1040's scope (the generated plugin `userConfig` screen), which builds on this adoption.
- #1042's setup skill / doctor hook and #1036's summarize skill are separate follow-ups on this scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpzfNGAaCapWDf58vswzH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzfNGAaCapWDf58vswzH3)_