### PR TITLE
feat(plugin): vault-summarize skill and vault-mapper agent for client-side summarization

### DIFF
--- a/.claude-plugin/plugin/README.md
+++ b/.claude-plugin/plugin/README.md
@@ -50,9 +50,14 @@ For the full list of env vars, see the
 - **Tools:** `search`, `read`, `get_context`, `get_backlinks`, `get_outlinks`,
   `get_similar`, `get_connection_path`, `get_recent`, `list_documents`, and
   (in write mode) `write`, `edit`, `rename`, `delete`.
-- **Skill:** `vault-workflow` tells Claude Code when to use hybrid vs.
+- **Skills:** `vault-workflow` tells Claude Code when to use hybrid vs.
   keyword search, when to call `get_context` before `read`, and how to use
-  `rename(update_links=True)` correctly.
+  `rename(update_links=True)` correctly; `vault-summarize` triggers on
+  folder/multi-note summarization requests and runs the server's batched
+  map-reduce recipe with parallel `vault-mapper` subagents, keeping note
+  bodies out of the retained conversation context.
+- **Agent:** `vault-mapper` — the summarize skill's map-phase worker,
+  restricted to the vault read tools.
 - **Prompts:** `summarize`, `summarize-subtree`, `research`, `discuss`,
   `related`, `compare` (available as slash commands via MCP prompt surfacing).
 

--- a/.claude-plugin/plugin/agents/vault-mapper.md
+++ b/.claude-plugin/plugin/agents/vault-mapper.md
@@ -1,0 +1,22 @@
+---
+name: vault-mapper
+description: Reads one assigned batch of markdown-vault notes and returns a faithful partial summary with per-note path attribution. Used by the vault-summarize skill's map phase; not for general vault questions.
+tools: mcp__markdown-vault-mcp__read, mcp__markdown-vault-mcp__get_toc
+---
+
+You summarize notes from a markdown vault. Call `read(path=...)` for each
+path assigned to you. The notes provided are one part of a larger
+collection; other parts are summarized separately by other mappers.
+
+Produce a detailed partial summary of your assigned notes that preserves
+concrete specifics — names, dates, numbers, decisions, open questions — and
+reference each note by its path (e.g. `folder/note.md`) so the partial
+summaries can be combined without losing attribution. Be faithful to the
+notes and do not invent details. If a note is unreadable, skip it and name
+it at the end.
+
+You may `read` one directly referenced note beyond your batch when needed to
+resolve an otherwise-unclear reference, but summarize only your assigned
+batch. If a focus was given, steer the summary toward it.
+
+Output only the partial summary — no meta-commentary, no preamble.

--- a/.claude-plugin/plugin/skills/vault-summarize/SKILL.md
+++ b/.claude-plugin/plugin/skills/vault-summarize/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: vault-summarize
+description: Use when the user asks to summarize, digest, or get an overview of a folder, project, or set of notes in their markdown vault — runs the vault's batched map-reduce recipe so note bodies stay out of the retained conversation context.
+---
+
+# Summarizing vault folders and note sets
+
+When the user asks for a summary, digest, or overview spanning more than one
+vault note ("summarize my projects folder", "what's in my meeting notes from
+March"), do not read note after note into the conversation — long vaults
+overflow the context and the summary degrades. Route the request instead:
+
+## 1. Check scope
+
+Call `get_toc(path=<folder>)` first. It returns paths, titles, and headings —
+never bodies — so it is always safe. A single short note needs no workflow:
+just `read` it and summarize directly.
+
+## 2. Prefer the server's one-call route when it is available
+
+If the `summarize` tool is registered, it produces the whole summary
+server-side in one call: `summarize(paths=[...], focus=...)`. Use it unless
+the user asks to keep note content away from external providers (the tool
+sends note text to its configured backend).
+
+## 3. Otherwise run the canonical client-side recipe
+
+The server ships the full recipe as its `summarize-subtree` MCP prompt — that
+prompt is the single source of truth for the workflow (plan from the toc,
+map in batches of ~8 notes, reduce, deliver with a coverage note). Follow it
+with this host's strengths:
+
+- Fan out the map phase as **parallel subagents**, one per batch, using the
+  `vault-mapper` agent this plugin ships — it carries the map-phase
+  instructions and only the vault read tools. Pass each mapper its batch's
+  path list (plus the user's focus, if any).
+- Subagents cannot spawn subagents: do the planning and the reduce step in
+  the main conversation, keeping only partial summaries — never note
+  bodies — in the retained context.
+
+## Do not
+
+- Do not `read` more than one batch of notes in the main conversation.
+- Do not re-summarize notes a mapper already covered; merge the partials.
+- Do not write anything to the vault while summarizing.

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2356,8 +2356,16 @@ link-following) is operator-facing and lives in docs/prompts.md only, never
 on model-facing surfaces. MCP sampling as the "use the client's model"
 mechanism was rejected (decision 18). A prompt is the delivery vehicle
 (not a plugin skill) because prompts travel with the server over plain
-HTTP-hosted MCP; a Claude Code plugin skill wrapping the same recipe is
-follow-up work (#1036).
+HTTP-hosted MCP; the Claude Code plugin channel additionally ships a
+`vault-summarize` skill wrapping the same recipe (#1036) — a thin
+host-specific layer that triggers on summarization intent, prefers the
+server-side `summarize` tool where configured, and otherwise defers to
+this prompt as the single canonical recipe while adding what a generic
+prompt cannot express: parallel map-phase fan-out through the plugin's
+`vault-mapper` agent (a subagent restricted to the vault read tools),
+with the plan and reduce steps kept in the main conversation under the
+same retained-context rule (partial summaries survive; note bodies
+never do).
 
 **Latency containment (#937).** An LLM summary is a long, unbounded
 operation; left unguarded it outruns the MCP client's request timeout and
@@ -3162,4 +3170,4 @@ Later decisions (2026-08-14, #1035):
 
 | # | Topic | Decision | Rationale |
 |-|-|-|-|
-| 20 | Client-side summarization | `summarize-subtree` MCP prompt carrying the plan → map → reduce recipe, registered config-dependently with a registration-time `${route_note}` slot (prefer-the-tool note when a backend is configured, standalone recipe when not); mapper/reducer prose derived from `_SYSTEM_MAP` / `_SYSTEM_REDUCE` | Prompts are served with the server over plain HTTP-hosted MCP (unlike plugin skills); covers keyless installs after sampling's rejection (decision 18). The recipe runs with or without subagents; trade-off prose is operator-facing and lives in docs/prompts.md only. A plugin-channel skill wrapping the same recipe is #1036 |
+| 20 | Client-side summarization | `summarize-subtree` MCP prompt carrying the plan → map → reduce recipe, registered config-dependently with a registration-time `${route_note}` slot (prefer-the-tool note when a backend is configured, standalone recipe when not); mapper/reducer prose derived from `_SYSTEM_MAP` / `_SYSTEM_REDUCE` | Prompts are served with the server over plain HTTP-hosted MCP (unlike plugin skills); covers keyless installs after sampling's rejection (decision 18). The recipe runs with or without subagents; trade-off prose is operator-facing and lives in docs/prompts.md only. The plugin channel's `vault-summarize` skill + `vault-mapper` read-only agent wrap this same recipe rather than duplicating it (#1036, resolved) |

--- a/docs/guides/claude-code-plugin.md
+++ b/docs/guides/claude-code-plugin.md
@@ -72,6 +72,8 @@ The plugin also installs the **`vault-workflow` skill**, which gives Claude guid
 - **Link tools**: `get_backlinks`, `get_outlinks`, `get_connection_path`, and the graph tools
 - **Write semantics**: creating, editing, renaming, and deleting notes safely
 
+A second skill, **`vault-summarize`**, triggers when you ask for a summary or overview spanning more than one note. It checks scope with `get_toc`, prefers the server-side `summarize` tool when your deployment configured one, and otherwise runs the server's `summarize-subtree` recipe with parallel **`vault-mapper`** subagents (a restricted read-only agent the plugin ships), so note bodies stay confined to the subagents instead of filling the main conversation.
+
 ## Update
 
 To update the plugin to the latest version:

--- a/packaging/pre-release-checks.sh
+++ b/packaging/pre-release-checks.sh
@@ -19,6 +19,10 @@ test -f "$PLUGIN_JSON" || fail "$PLUGIN_JSON missing"
 test -f "$MCP_JSON" || fail "$MCP_JSON missing"
 test -f ".claude-plugin/plugin/skills/vault-workflow/SKILL.md" \
   || fail "vault-workflow skill missing from plugin"
+test -f ".claude-plugin/plugin/skills/vault-summarize/SKILL.md" \
+  || fail "vault-summarize skill missing from plugin"
+test -f ".claude-plugin/plugin/agents/vault-mapper.md" \
+  || fail "vault-mapper agent missing from plugin"
 
 jq -e '.name == "markdown-vault-mcp" and (.version | length > 0)' "$PLUGIN_JSON" > /dev/null \
   || fail "$PLUGIN_JSON missing name/version"


### PR DESCRIPTION
Closes #1036. Part of epic #1043 — the plugin channel's summarization surface, built on the scaffold #1046 adopted.

## What changed

- **`skills/vault-summarize/SKILL.md`** — triggers on folder/multi-note summary intent (no slash-command knowledge needed). It checks scope with `get_toc`, prefers the server-side `summarize` tool where a backend is configured (with the privacy caveat stated), and otherwise defers to the server's `summarize-subtree` MCP prompt as the **single canonical recipe** — the skill adds only the host-specific affordances a generic prompt can't express: parallel map-phase fan-out via subagents, and the plan/reduce steps kept in the main conversation (subagents can't spawn subagents). The retained-context rule — partial summaries survive, note bodies never — is stated as the core constraint, matching the prompt.
- **`agents/vault-mapper.md`** — the map-phase worker with plugin-defined identity: the tuned map instructions (preserve specifics, per-note path attribution, no meta-commentary, skip-and-name unreadable notes) and a tool allowlist of just `read` + `get_toc`. This is the "mapper subagents run with plugin-defined identity and only the vault tools they need" piece from the issue.
- **`packaging/pre-release-checks.sh`** — now asserts both skills and the agent are present in the shipped artifact, so the pre-release smoke test catches a packaging regression.
- **Docs** — plugin README's surface list and `docs/guides/claude-code-plugin.md` (Vale-clean) describe the new skill/agent.

## Verification

- Full gates: 3271 tests passed, ruff check/format clean, mypy clean, diff-quality (no Python in diff), Vale 0 errors on the edited guide.
- `bash -n` on the extended checks script; the skill/agent frontmatter follows the existing `vault-workflow` conventions.

## Deliberately not done

- No bundled multi-agent workflow file (the issue's "optional" third artifact) — the skill + agent cover the delegation shape; a workflow can follow if real usage wants a one-shot command.
- The recipe itself is not duplicated into the skill — one canonical copy lives in the server's `summarize-subtree` prompt (#1035/#1038), exactly as the issue's "thin wrapper" option proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpzfNGAaCapWDf58vswzH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzfNGAaCapWDf58vswzH3)_