### PR TITLE
docs: bring the CLAUDE.md module map in sync with the source tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,16 @@ src/markdown_vault_mcp/
     text.py            -- text normalization, position mapping, fuzzy matching
     links.py           -- link target computation and replacement
     serialization.py   -- toc_payload: TocEntry/SubtreeToc → JSON-able dicts
+    fs.py              -- filesystem traversal helpers: symlink-aware iteration, directory pruning (#508, #835)
+    fts.py             -- fts_row_to_note_info: FTS row → NoteInfo conversion shared across managers
   managers/
     link.py            -- LinkManager: backlinks, outlinks, broken, orphans, hubs, paths
     search.py          -- SearchManager: keyword/semantic/hybrid search, list, context, stats
     index.py           -- IndexManager: build_index, reindex, embeddings, flush
     document.py        -- DocumentManager: CRUD, attachments, path validation, backlinks
     git_query.py       -- GitQueryManager: git history/diff reads (#610)
+    summarize.py       -- SummarizeManager: LLM-backed note/subtree summarization, map-reduce batching (#922)
+    okf_migrate.py     -- OkfMigrationManager: one-shot OKF transforms — link conversion, index generation, log seeding (#963)
     _ranking.py        -- pure ranking pipeline: downweight/boost/grouping/snippets (#759)
     _vector_loader.py  -- shared load-or-self-heal routine for the vector sidecar (#736)
   indexing/
@@ -33,25 +37,66 @@ src/markdown_vault_mcp/
     writer.py          -- WriterFacet: write/edit/delete/rename/attachments (#604)
     graph.py           -- GraphFacet: backlinks/outlinks/broken/orphans/most-linked/paths (#604); neighborhood/hub graph views (#880)
     index.py           -- IndexFacet: build/reindex/embeddings, readiness, writer + embeddings status (#604)
-  transfer/
-    store.py           -- TransferStore: in-memory one-time transfer-token state machine (#622)
-    routes.py          -- ASGI handler for the /transfer/{token} download/upload route (#622)
+    summarize.py       -- SummarizeFacet: readiness-gated summarization surface; present only when a backend is configured (#925)
+  git/
+    __init__.py        -- package facade preserving the historical single-module import surface (incl. test patch targets)
+    _run.py            -- low-level git subprocess + credential plumbing
+    strategy.py        -- GitWriteStrategy: auto-commit per write, deferred background push
+    conflict.py        -- rebase-conflict resolution mechanics (caller holds the strategy lock)
+    query.py           -- read-only git history/diff queries; lock-free pure functions
+    types.py           -- PullResult/PushResult + pull/push reason-code constants
   scanner.py           -- file discovery, frontmatter parsing, chunking
   fts_index.py         -- SQLite FTS5 schema, BM25 search
   _fts_connection.py   -- per-thread sqlite connection registry + SQLITE_LOCKED retry (#760)
   vector_index.py      -- numpy embeddings, cosine similarity
+  embed_text.py        -- EmbedTextBuilder: single shared builder for (context-enriched) embedding input text
   providers.py         -- embedding provider ABC + implementations
   tracker.py           -- hash-based change detection
+  hashing.py           -- compute_etag / compute_file_hash: shared SHA-256 helpers
+  types.py             -- shared dataclasses and result types (NoteInfo, SkippedFile, SKIP_CATEGORIES, ...)
+  exceptions.py        -- exception hierarchy; re-exports pvl-core's ConfigurationError as the canonical config error (#638)
+  conventions.py       -- ConventionsResolver: per-folder _conventions.md authoring policy, accumulated root-first
+  okf.py               -- OKF detection probe + pure read-side annotations: type/status/staleness/trust (#961)
+  okf_bundle.py        -- OKF bundle-zip export from live vault state, served via an okf-bundle download ref (#963)
+  _okf_convention.py   -- OKF reserved-file maintenance after enforced writes: log.md bullet + index.md refresh (#964)
+  _okf_write.py        -- OKF enforced-write runtime: contextvar actor + provenance stamp / verified clear (#964)
+  summarizer.py        -- Summarizer ABC + OpenAI-compatible chat-completions backend (#915)
   vault.py             -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
   write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
   _write_tools.py      -- WRITE_TOOL_NAMES + write_tools_phrase: single source for the user-facing write-tool enumeration (#1009)
   config.py            -- template-owned skeleton: flat metadata-carrying ProjectConfig fields + section-view properties + from_env, all inside CONFIG-* sentinels (#900, #952)
   config_sections/
     _assembly.py         -- domain config-assembly kept out of template-owned config.py: to_vault_kwargs, derive_max_chunk_chars, git-strategy builder, from_env value resolvers (#900, #952)
+    _helpers.py          -- shared env-reading helpers for the sections' from_env classmethods (no config.py import)
+    content.py           -- ContentConfig: attachment/read limits, template/prompt folders, conventions file
+    embeddings.py        -- EmbeddingsConfig: provider selection + per-provider and shared embedding knobs
+    git.py               -- GitConfig: git auth, identity, sync cadence
+    indexing.py          -- IndexingConfig: paths, frontmatter, exclusions
+    search.py            -- SearchConfig: ranking weights + snippet-truncation knobs
+    summarize.py         -- SummarizeConfig: OpenAI-compatible summarization backend settings
+    sync.py              -- SyncConfig: file-watcher + GitHub-webhook settings
   domain.py            -- Service: owns the Vault lifecycle (build, boot index/reindex/embeddings jobs, file watcher); get_vault/get_config DI + vault singleton (#902)
   _instructions.py     -- build_default_instructions: domain server-instructions prose, applied in server.py's DOMAIN-WIRING (#901)
   _server_apps.py      -- template-owned MCP Apps scaffold; vault SPA + app-tools confined to DOMAIN-APP-TOOL-NAMES/DOMAIN-APP-RESOURCE/DOMAIN-APP-TOOLS sentinels (#905)
   _vault_apps.py       -- domain helpers backing _server_apps sentinels: Claude sandbox-domain compute + CDN CSP + GraphView→SPA wire serializer (#905)
+  _server_deps.py      -- server_lifespan + LifespanState: Service lifecycle and vault DI for request handlers
+  _server_tools/
+    __init__.py        -- register_tools: single entry point delegating to the per-facet groups (#578)
+    _common.py         -- shared tool plumbing: staleness-annotated results, drain waits
+    reader.py          -- read-side tool registrations (search/read/list/toc/context/...)
+    writer.py          -- write-side tool registrations (write/edit/delete/rename/attachments)
+    graph.py           -- link-graph tool registrations
+    index.py           -- index/reindex/embeddings-status tool registrations
+    git.py             -- git sync/history/diff tool registrations
+    summarize.py       -- dual-mode summarize job tool; registered from make_server's DOMAIN-WIRING (#1033)
+  _server_resources.py -- register_resources: MCP resource registrations
+  _server_prompts.py   -- register_prompts: MCP prompt registrations from static/prompts templates (#609)
+  _server_queryable.py -- needs_queryable decorator: MCP-layer wait/block on index readiness (#513)
+  _transfer_sink.py    -- VaultTransferSink: domain sink + validator hooks for pvl-core's transfer routes (#979)
+  _file_watcher.py     -- watchdog external-change watcher with debounce; used when git pull and webhook are off (#558)
+  _github_webhook.py   -- GitHub push-webhook route: HMAC verify → force_pull + reindex (#530)
+  _http_logging.py     -- quiet_http_loggers: pin httpx/httpcore to WARNING unless root level is DEBUG (#792)
+  _icons.py            -- Lucide SVG tool icons from static/icons/ as data URIs
   server.py            -- generic FastMCP server factory (make_server); template-owned, domain customization confined to DOMAIN-UPSTREAM/DOMAIN-WIRING (#901)
   cli.py               -- CLI entry point
 ```


### PR DESCRIPTION
Refs #1057 (batch-1 work of epic #1054).

## What this PR does

Fixes the stale `CLAUDE.md` Project Structure map — the wider pass called for in the 2026-08-15 review comment on #1057, not just the deleted-`transfer/` correction in the issue body:

- **Removed (2 entries):** `transfer/store.py`, `transfer/routes.py` — the directory was retired by #981 (pvl-core transfer subsystem adoption); verified absent from `src/`.
- **Added (46 entries):** every existing module the map was missing, including the OKF family (`okf.py`, `okf_bundle.py`, `_okf_convention.py`, `_okf_write.py`, `managers/okf_migrate.py`), the summarize stack (`summarizer.py`, `managers/summarize.py`, `facets/summarize.py`, `config_sections/summarize.py`, `_server_tools/summarize.py`), the `git/` package (6 modules), the server-registration layer (`_server_deps.py`, `_server_tools/` with 8 modules, `_server_resources.py`, `_server_prompts.py`, `_server_queryable.py`), the sync layer (`_file_watcher.py`, `_github_webhook.py`, `_transfer_sink.py`), the `config_sections/` files (8 modules), and the small shared modules (`types.py`, `exceptions.py`, `hashing.py`, `embed_text.py`, `conventions.py`, `_http_logging.py`, `_icons.py`, `utils/fs.py`, `utils/fts.py`).

Every one-liner was written from the module's actual docstring/head (not guessed), in the map's existing terse style with issue refs where the module carries them. Mapped-but-unchanged entries were spot-checked against their modules (`managers/git_query.py`, `vault.py`, the facets) and found still accurate. A scripted cross-check confirms the map now lists exactly the set of modules on disk (subpackage `__init__.py` files listed only where load-bearing: `git/`, `_server_tools/`).

## Why `Refs`, not `Closes`

#1057 has two halves. This PR completes the module-map half. The commit-types half needs a maintainer decision ("a decision on commit-type hygiene, and the gate if one is wanted") — a comment on #1057 recommends the routing (see below) but does not make that decision, so closing the issue from this PR would be premature. Recommend closing #1057 after deciding on the gate question, or once a template issue is filed.

## Commit-types routing recommendation (half 1 of #1057)

Posted on #1057: a commit-lint / PR-title gate is CI-workflow machinery, which is template-owned — per CONTRIBUTING's three-tier rule it belongs as an issue on `pvliesdonk/fastmcp-server-template` (with the seven observed subjects as evidence), not as a repo-local gate that `copier update` would overwrite. Meanwhile, no new convention is needed in this repo: CI-debugging commits fit the already-allowed `chore(ci): ...` form, and agent-authored commits should follow the conventional set already in CLAUDE.md.

## Documentation impact check

Per Documentation Discipline: this change is confined to the internal `CLAUDE.md` module map. `docs/design/design.md`, `README.md`, and the `docs/` site pages describe behaviour/configuration, not the CLAUDE.md file map, and carry no stale `transfer/store.py` / `transfer/routes.py` references (verified by grep; #1061 already corrected the docs-side transfer links). No other docs need updating.

## Gates

- `uv run pytest -x -q` — 3278 passed, 6 skipped
- `uv run ruff check --fix .` → `ruff format .` → `ruff format --check .` — clean, no changes
- `uv run mypy src/ tests/` — no issues in 189 files
- `diff-quality` structural gate vs `origin/main` — no lines with quality information (docs-only diff), passes
- Docs updated in the same commit — n/a beyond CLAUDE.md itself (see check above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hGpJEsDCyPHRi6bCkEQY3

---
_Generated by [Claude Code](https://claude.ai/code/session_017hGpJEsDCyPHRi6bCkEQY3)_