### PR TITLE
docs: establish docs/releases/ structure with the 3.1 notes page

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -245,3 +245,9 @@ Zotero
 # --- Fonts / typography ---
 Newsreader
 Plex
+
+# --- Release-notes prose vocabulary ---
+accessor
+backoff
+globbed
+subcommands

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- DOMAIN-START -->
 A generic markdown vault [MCP](https://modelcontextprotocol.io/) server with FTS5 full-text search, semantic vector search, frontmatter-aware indexing, incremental reindexing, and non-markdown attachment support.
 
-**[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[Config wizard](https://pvliesdonk.github.io/markdown-vault-mcp/latest/configuration-generator/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
+**[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[Release notes](https://pvliesdonk.github.io/markdown-vault-mcp/latest/releases/)** | **[Config wizard](https://pvliesdonk.github.io/markdown-vault-mcp/latest/configuration-generator/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
 
 Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Zettelkasten, a PARA vault) and it exposes search, read, write, and edit tools over the Model Context Protocol.
 <!-- DOMAIN-END -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,12 @@ A few flows the server enables with an LLM on top (none of these require a bespo
 
 See [MCP Prompts](prompts.md) for the codified workflows and the ambient-pattern reference.
 
+## Release notes
+
+Per-minor [release notes](releases/index.md) explain what changed in each
+release, who is affected, and what to check before upgrading. The GitHub
+release body links to the matching page.
+
 ## Quick Start
 
 ### As a library

--- a/docs/releases/3.1.md
+++ b/docs/releases/3.1.md
@@ -1,0 +1,319 @@
+# 3.1
+
+Released July 8, 2026.
+
+This is the release where other people's vaults broke it. Three outside
+reporters ran markdown-vault-mcp against a 4,400-document home directory, a
+symlink farm, and an Obsidian vault full of table navigators, and between them
+filed the issues behind most of what follows. The headline work is not a new
+feature: it is that discovery, watching and semantic recall now behave the same
+on a large real vault as they did on a small test one.
+
+Alongside that, the four in-panel MCP App views were rebuilt on a shared visual
+foundation, and two new read tools landed.
+
+## Upgrade notes
+
+Read these before upgrading. Two affect existing deployments.
+
+### `VaultConfig` is now `ProjectConfig`, with no alias
+
+The configuration dataclass was renamed from `VaultConfig` to `ProjectConfig`
+([#767](https://github.com/pvliesdonk/markdown-vault-mcp/issues/767)). No
+back-compatible alias was kept, so `from markdown_vault_mcp.config import
+VaultConfig` now raises `ImportError`. Only Python API consumers are affected.
+Environment variables, MCP tools and the CLI are unchanged.
+
+The rename was forced by an upstream template gate,
+`tests/test_config_wizard_drift.py`, which hard-imports `ProjectConfig` and
+could not collect against this repository at all. The same change taught the
+gate to see configuration reads that are delegated into `config_sections/`
+submodules, which it had previously been scanning past. Roughly 40 domain
+environment variables were unchecked before this landed.
+
+### Check `EMBEDDINGS_PATH` if it ends in `.npy`
+
+Setting `MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH` to a path with a `.npy` extension
+could destroy the vector store
+([#819](https://github.com/pvliesdonk/markdown-vault-mcp/issues/819)). The
+loader probed for the sidecar by appending `.npy` to the configured base, while
+save and load derived it with `Path.with_suffix`. The two agreed only when the
+base had no extension. With `embeddings.npy` configured, the loader looked for
+`embeddings.npy.npy`, found nothing, cold-built an empty index, and the next
+save overwrote the real store.
+
+The reporter lost a 68,796-vector store to a 604-chunk watcher delta on the
+first `serve` after building it with `index --force`. `embeddings_status`
+carried the same defect and reported `chunk_count=0` for a store that existed.
+
+Both call sites now derive with `with_suffix`. If you configured an extension
+and your store looks empty, rebuild with `index --force`.
+
+### New setting: `FILE_WATCHER_ROOT_FLOOR`
+
+`MARKDOWN_VAULT_MCP_FILE_WATCHER_ROOT_FLOOR` (default `true`) keeps the
+non-recursive watch on the vault root, so root-level `.md` changes still
+trigger a reindex. Set it to `false` to register zero watches rooted at the
+source directory, at the cost of root-level files being picked up only by
+scans.
+
+This exists for macOS. A non-recursive watchdog watch is emulated there, and
+still opens an OS-level recursive `FSEvents` stream over the whole tree, so a
+vault rooted at `$HOME` produces repeated "would like to access data from other
+apps" consent prompts naming the Python binary
+([#823](https://github.com/pvliesdonk/markdown-vault-mcp/issues/823)).
+
+## Highlights
+
+### Large vaults are no longer minutes behind
+
+File discovery globbed `**/*.md` across the whole vault and applied exclude
+patterns per file afterwards, so every excluded subtree was fully descended on
+every scan
+([#822](https://github.com/pvliesdonk/markdown-vault-mcp/issues/822)). On a
+home-directory vault with 4,400 documents and 23 exclude patterns, one
+`detect_changes` call took 5,043 seconds. A second run sat 28 minutes inside a
+single `opendir` system call before it was killed. With the watcher on, any
+churn started the scan again, so the process scanned all day and
+save-to-searchable latency was measured in minutes.
+
+Discovery now prunes a directory before descending into it, but only when the
+exclude patterns provably cover everything beneath. The per-file filter stays
+as the correctness layer. The same scan now takes 3.2 seconds across 25,263
+directories, and save-to-searchable drops to about 15 seconds.
+
+The watcher was rebuilt on the same pruning helper. Instead of one recursive
+watch on the vault root, it derives watch roots from the root's immediate
+children minus the provably excluded ones: 94 scoped watches on the reporter's
+vault, none rooted at the source directory.
+
+That re-rooting also fixes a second defect in the same issue. The watcher now
+decides whether a path is hidden relative to the watch root that delivered the
+event, rather than relative to the vault root. A vault whose content lives
+under a dot directory, such as `.claude/` beneath `$HOME`, previously never
+reindexed from its own edits.
+
+Two follow-ups landed in the same release. Watch roots are resolved to their
+real paths, because watchdog's FSEvents emitter delivers realpath-prefixed
+events that the root-relative filter was dropping silently, leaving the watcher
+live but blind on symlinked layouts
+([#849](https://github.com/pvliesdonk/markdown-vault-mcp/issues/849)). And the
+vault's own state directory and `.git` are never watch roots, after the scoped
+watch work reintroduced the self-feedback reindex loop that
+[#720](https://github.com/pvliesdonk/markdown-vault-mcp/issues/720) had fixed:
+`reindex()` writes tracker state unconditionally, that write is an event under
+the state-directory watch, and the loop sustains itself
+([#830](https://github.com/pvliesdonk/markdown-vault-mcp/issues/830)).
+
+### Semantic search recall no longer depends on `limit`
+
+Semantic search sized its candidate pool from the caller's `limit` before
+grouping chunks by document, which made the pool a recall cap
+([#820](https://github.com/pvliesdonk/markdown-vault-mcp/issues/820)). When a
+few chunk-heavy documents filled the pool, a smaller document whose best chunk
+ranked just past it disappeared from the results, even when it was the
+best-scoring document for the query.
+
+On a 6,916-chunk vault, one query's true best document scored 0.685 and was
+absent at every limit from 3 to 12, while the returned top result scored 0.495.
+It appeared only at limit 13 or higher. Scores were also not comparable across
+limits, because the pool changed what got grouped.
+
+The pool is now floored at 1,000. Because `VectorIndex.search` already scans
+and sorts the whole index anyway, a wider pool costs only the slice at the end.
+No extra distance computation happens.
+
+### Chunking gained overlap, and a ceiling
+
+Adjacent chunks now share a configurable within-section overlap, so a passage
+straddling a chunk boundary stays retrievable from either side
+([#791](https://github.com/pvliesdonk/markdown-vault-mcp/issues/791)).
+
+Separately, the derived chunk-character cap has an upper bound
+([#790](https://github.com/pvliesdonk/markdown-vault-mcp/issues/790)). It
+scaled linearly with the embedding model's context length and had no ceiling,
+so an 8,192-token model produced a roughly 22,900-character cap. That is the
+regime a previous release moved away from after the fastembed ONNX path froze
+on oversize chunks, and picking any long-context model silently re-entered it.
+Pass `-1` to opt back into unbounded behaviour.
+
+### Vault Views rebuilt as "Paper"
+
+The four in-panel MCP App views were restyled onto a shared warm, editorial
+foundation with serif headings and one accent colour, aware of light and dark
+([#809](https://github.com/pvliesdonk/markdown-vault-mcp/issues/809)). Paper
+tokens map onto the host's existing `--color-*` variables with Paper values as
+fallback, so a host that pushes its own theme still wins.
+
+Data fetching, routing and tool wiring are unchanged. This was a restyle, and
+no tool was renamed or removed.
+
+- **Foundation**: token layer, fonts and tab strip
+  ([#811](https://github.com/pvliesdonk/markdown-vault-mcp/issues/811))
+- **Context Card**: folder breadcrumb, relative timestamp, type and status
+  chips, collapsible sections with count badges, similarity scores with
+  progress bars
+  ([#812](https://github.com/pvliesdonk/markdown-vault-mcp/issues/812))
+- **Vault Browser**: restyled tree with attachment glyphs, active-row
+  highlighting, and the hybrid search field
+  ([#813](https://github.com/pvliesdonk/markdown-vault-mcp/issues/813))
+- **Note Preview**: table of contents, collapsible frontmatter and tags, copy
+  actions
+- **Graph Explorer**: level-of-detail labels
+
+As a prerequisite, the single 52 KB `app.src.html` was split into modular
+partials assembled at build time by `build_spa.py`
+([#810](https://github.com/pvliesdonk/markdown-vault-mcp/issues/810)).
+
+### Move a whole folder in one call
+
+`move_folder(old_dir, new_dir)` moves a subtree and rewrites every affected
+link across the vault in a single pass
+([#511](https://github.com/pvliesdonk/markdown-vault-mcp/issues/511)).
+
+Previously an agent had to enumerate the subtree and call `rename` per file,
+which corrupted links between documents inside the moved subtree: when file A
+moved, its backlink in still-unmoved sibling B was rewritten to A's new home,
+then B itself moved, and the intermediate rewrites interleaved badly. Computing
+the full old-to-new mapping first and rewriting once afterwards is what makes
+this correct.
+
+The directory move is all-or-nothing and validates before touching anything, so
+a target collision aborts with nothing moved. Link rewrites stay best-effort
+and report how many succeeded, matching the existing single-file behaviour.
+
+### Table of contents for a folder
+
+`get_toc` returns a heading outline for a folder or subtree, not just one note
+([#773](https://github.com/pvliesdonk/markdown-vault-mcp/issues/773)). The
+per-note outline was previously reachable only through the `toc://vault/{path}`
+resource, which left clients that surface tools but not resources with no way
+to get it at all.
+
+### Skipped notes are visible without reading container logs
+
+A note whose YAML frontmatter failed to parse was dropped from the index and
+reported only as a warning in the container log
+([#775](https://github.com/pvliesdonk/markdown-vault-mcp/issues/775)).
+`get_index_status` said `queryable` with zero dirty paths and no error, `read`
+said the document did not exist, and the note surfaced only indirectly as
+broken inbound links from elsewhere. A parse-skipped note was indistinguishable
+from one that had not synced yet.
+
+`get_index_status` now returns `skipped_files` with a category and detail per
+path. Follow-up work separates a true `internal_error` from a
+`parse_error`, so tooling built on the field can tell "this document has a data
+problem you can fix" from "the indexer itself hit a bug"
+([#802](https://github.com/pvliesdonk/markdown-vault-mcp/issues/802)).
+
+### Aliased wikilinks in tables resolve
+
+`[[path\|alias]]` parsed with the escaping backslash baked into the target, so
+the link was reported broken and its graph edge was dropped
+([#731](https://github.com/pvliesdonk/markdown-vault-mcp/issues/731)). This is
+the canonical on-disk form, because Obsidian requires the pipe to be escaped
+inside a table cell. The reporter's vault had about 190 false broken links,
+all from this.
+
+## Other changes
+
+### Indexing and watching
+
+- An already-indexed file that fails to re-hash is kept rather than purged. It
+  was dropped from the disk snapshot and then computed as deleted, which
+  removed a live document from FTS and its embedding until a later scan
+  ([#831](https://github.com/pvliesdonk/markdown-vault-mcp/issues/831)).
+- Transient descriptor exhaustion is retried with backoff while hashing during
+  a scan, instead of silently dropping the file from the scan
+  ([#821](https://github.com/pvliesdonk/markdown-vault-mcp/issues/821)).
+- Excluded files are invisible in `build_index` for file-shaped patterns such
+  as `**/*.draft.md`, matching the contract that discovery pruning already met
+  for directory-shaped ones
+  ([#832](https://github.com/pvliesdonk/markdown-vault-mcp/issues/832)).
+- An unreadable subtree is logged rather than silently skipped, and a watcher
+  that ends up with zero active watches is reported above `INFO` instead of
+  logging success
+  ([#835](https://github.com/pvliesdonk/markdown-vault-mcp/issues/835)).
+- The vector sidecar is written atomically, corrupt sidecars self-heal on
+  load, and row-count parity is enforced.
+
+### Reading and search
+
+- `read(path, section=...)` returns the whole section. Any section large enough
+  to be split across chunks returned only its first chunk, with no error or
+  truncation marker, and a section with sub-headings returned only the preamble
+  before the first one
+  ([#741](https://github.com/pvliesdonk/markdown-vault-mcp/issues/741)).
+- Whole-document `read` degrades to `None` on malformed frontmatter, and is
+  guarded against mid-read failure.
+- Git sync resolves its ref as `origin/<branch>` rather than `@{upstream}`.
+
+### Diagnostics
+
+- The `index` and `reindex` CLI commands no longer swallow internal embedding
+  failures. A blanket `except ValueError: pass`, intended to skip when
+  embeddings are not configured, also caught an internal consistency failure,
+  so a corrupt sidecar produced `Indexed N documents` and a zero exit code
+  ([#774](https://github.com/pvliesdonk/markdown-vault-mcp/issues/774)).
+- Internal semantic-search failures surface from `get_context`.
+- `httpx` per-request logs are quiet at the default level. One `INFO` line per
+  Ollama embed batch flooded the log during a build
+  ([#792](https://github.com/pvliesdonk/markdown-vault-mcp/issues/792)).
+- One malformed prompt no longer aborts registration of every prompt after it
+  ([#799](https://github.com/pvliesdonk/markdown-vault-mcp/issues/799)), and
+  prompts are built from a synthetic signature instead of `exec()`.
+
+### MCP Apps
+
+- Graph and context app tools no longer fail on a note larger than
+  `MAX_NOTE_READ_BYTES`. Four sites called the size-capped `read()` purely to
+  extract a title for a node label, so one 375 KB note failed the whole tool. A
+  metadata accessor backed by the index is used instead
+  ([#855](https://github.com/pvliesdonk/markdown-vault-mcp/issues/855)).
+- Graph canvas colours are resolved by probe, so nodes are not black on Claude
+  Desktop.
+- The Vault Explorer view honours host container dimensions on mobile.
+
+### Tooling and plumbing
+
+- Every tool carries a human-readable `title` annotation. VS Code's MCP client
+  honours only `title` and `readOnlyHint` among annotations, so tools had been
+  rendering under their raw machine names
+  ([#751](https://github.com/pvliesdonk/markdown-vault-mcp/issues/751)).
+- Eight `copier update` commits took the upstream template from v2.1.1 to
+  v2.10.1. Most of that range is developer-facing: a diff-scoped structural
+  health gate, Vale linting of user-facing docs, a configuration-wizard
+  coverage gate, and a `DOMAIN-COMMANDS` sentinel for domain CLI subcommands.
+  The in-browser configuration generator on the documentation site arrived the
+  same way.
+
+## Thanks
+
+This release leans heavily on reports from outside the repository, several
+carrying measurements, stack samples and fault-injection reproductions:
+
+- [@michael-denyer](https://github.com/michael-denyer) for
+  [#819](https://github.com/pvliesdonk/markdown-vault-mcp/issues/819),
+  [#820](https://github.com/pvliesdonk/markdown-vault-mcp/issues/820),
+  [#821](https://github.com/pvliesdonk/markdown-vault-mcp/issues/821),
+  [#822](https://github.com/pvliesdonk/markdown-vault-mcp/issues/822),
+  [#823](https://github.com/pvliesdonk/markdown-vault-mcp/issues/823) and
+  [#849](https://github.com/pvliesdonk/markdown-vault-mcp/issues/849)
+- [@Finomosec](https://github.com/Finomosec) for
+  [#720](https://github.com/pvliesdonk/markdown-vault-mcp/issues/720)
+- [@Denzilla04](https://github.com/Denzilla04) for
+  [#731](https://github.com/pvliesdonk/markdown-vault-mcp/issues/731)
+
+<!-- PATCH-RELEASES-START -->
+
+## Patch releases
+
+No patch releases yet.
+
+<!-- PATCH-RELEASES-END -->
+
+## All changes
+
+See [CHANGELOG.md](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/CHANGELOG.md)
+for the full commit-level list, or the
+[v3.0.0 to v3.1.0 comparison](https://github.com/pvliesdonk/markdown-vault-mcp/compare/v3.0.0...v3.1.0).

--- a/docs/releases/3.1.md
+++ b/docs/releases/3.1.md
@@ -10,7 +10,7 @@ feature: it is that discovery, watching and semantic recall now behave the same
 on a large real vault as they did on a small test one.
 
 Alongside that, the four in-panel MCP App views were rebuilt on a shared visual
-foundation, and two new read tools landed.
+foundation, and two new tools landed.
 
 ## Upgrade notes
 

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,39 @@
+# Release notes
+
+Human-readable notes for each minor release: what changed, who is affected,
+and what to do about it, with every claim linked to the issue or pull request
+behind it.
+
+## Available pages
+
+- [3.1](3.1.md) (released July 8, 2026)
+
+## How these pages work
+
+**One page per minor version.** Each minor release gets a single page, named
+for the minor (`3.1`, `3.2`, and so on). This matches how the documentation site is
+deployed: each minor is published as its own site version, so the notes for a
+release always travel with the documentation that describes it.
+
+**Patch releases append to the minor's page.** A patch release adds a dated
+section to its minor's page rather than getting a page of its own, so the full
+story of a minor stays in one linkable document.
+
+**The GitHub release links here.** The release body on GitHub carries a short
+summary and a link to the matching page on this site. These pages are the
+canonical narrative; the release body is the pointer.
+
+**`CHANGELOG.md` stays machine-generated.** The
+[commit-level audit trail](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/CHANGELOG.md)
+records what landed, commit by commit; these pages explain whether to upgrade
+and what to check first. The two are generated separately and neither replaces
+the other.
+
+## Coverage
+
+Pages for releases before 3.1 arrive through a one-time backfill
+([#1058](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1058)).
+Pages for future releases are drafted by a generation workflow maintained
+upstream in the project template
+([fastmcp-server-template#347](https://github.com/pvliesdonk/fastmcp-server-template/issues/347)),
+reviewed as an ordinary pull request before publication.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,9 @@ plugins:
           - api/providers.md: Embedding provider API reference
           - api/types.md: All data types returned by the Vault API
           - api/exceptions.md: All exceptions raised by the library
+        Releases:
+          - releases/index.md: Release notes overview — page-per-minor model and available pages
+          - releases/3.1.md: Release notes for 3.1 — upgrade notes, highlights, and linked evidence
         # PROJECT-LLMSTXT-SECTIONS-END
   - mkdocstrings:
       handlers:
@@ -189,4 +192,7 @@ nav:
       - Embedding Providers: api/providers.md
       - Types: api/types.md
       - Exceptions: api/exceptions.md
+  - Releases:
+      - Overview: releases/index.md
+      - "3.1": releases/3.1.md
   # PROJECT-NAV-END


### PR DESCRIPTION
## Closes / Refs

Refs #1050 (batch-5 work of epic #1054)

**Why Refs, not Closes:** this PR delivers the domain-side residual of #1050 — the `docs/releases/` pages, the nav/llmstxt lockstep, and the landing page. What remains of #1050 is the generation workflow, which was moved upstream to pvliesdonk/fastmcp-server-template#347 and arrives here mechanically via #1056's copier update. Leaving #1050 open gives the first real generation run a home: the issue closes once the workflow has produced a page here end-to-end, rather than declaring victory on structure alone.

## What & why

The repo now has a `docs/releases/` section: the bot-review-passed prototype notes page for 3.1 (ported from the deliberately-kept-alive `claude/auto-release-notes-generation-770xjo` branch, with its four Vale vocabulary terms), plus a new landing page explaining the page-per-minor model and the settled release-body contract (release body = summary + deep link; the docs page is canonical — per the 2026-08-16 decision on pvliesdonk/fastmcp-server-template#350). `mkdocs.yml` gains the Releases section in **both** the `nav:` block (inside `PROJECT-NAV-START/-END`) and the `llmstxt` `sections:` block (inside `PROJECT-LLMSTXT-SECTIONS-START/-END`), per the documented requirement that the two stay aligned as a unit.

Verification done while porting:

- `vale` clean on `docs/releases/3.1.md` against current styles (0 errors); the new landing page was iterated to Vale-clean as well (`docs/releases/` **is** linted — only `design/decisions/superpowers` are excluded).
- The prototype already carries the `PATCH-RELEASES-START` / `-END` sentinel pair, so no addition was needed.
- Factual spot-checks still hold: v3.1.0 tag date is 2026-07-08 (matches "Released July 8, 2026"), the `v3.0.0...v3.1.0` compare link resolves, no `v3.1.x` patch tags exist (so "No patch releases yet" is accurate), and `CHANGELOG.md` exists at the linked path.

## What this PR deliberately does NOT do

- (generation workflow — upstream template scope, being built by a sibling agent): pvliesdonk/fastmcp-server-template#347
- (workflow adoption here via copier update): #1056
- (backfill of 3.0 / 2.x / 1.x pages, and CHANGELOG.md reconstruction — `CHANGELOG.md` is untouched by this PR): #1058
- (release-body contract implementation in the release workflow): pvliesdonk/fastmcp-server-template#347 / #350

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening the PR.

## Docs impact

- [x] `README.md` — cross-ref check done: added a **Release notes** entry to the domain-owned link bar at the top (the bottom "Links" section is template-owned and would not survive `copier update`, so it was left alone).
- [x] `docs/` site pages — `docs/releases/{index,3.1}.md` new; `docs/index.md` cross-ref check done: added a short "Release notes" section (warranted because the per-minor `mike` deploy in `docs.yml` means each site version carries its own notes, and `docs/index.md` feeds `llms.txt`); `mkdocs.yml` nav + llmstxt in lockstep.
- [ ] `docs/design/` — checked, not needed: no runtime behavior or architecture change; the release-notes model is specified by epic #1054 and issue #1050.
- [ ] Inline docstrings — no code touched.

## Gates

- `uv run pytest -x -q` — 3271 passed, 13 skipped
- `ruff check --fix` → `ruff format` → `ruff format --check` — clean
- `uv run mypy src/ tests/` — no issues in 189 files
- `diff-quality` vs `origin/main` — no lines with quality information (docs-only diff), passes
- `uv run --group docs mkdocs build --strict` — builds clean (only pre-existing INFO notices)
- `vale` on all touched docs — 0 errors
- `uv run pre-commit run --all-files` — all hooks pass (including vale and gitleaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hGpJEsDCyPHRi6bCkEQY3

---
_Generated by [Claude Code](https://claude.ai/code/session_017hGpJEsDCyPHRi6bCkEQY3)_