### PR TITLE
chore(copier): update to template v4.1.0 and clear stale rc manifest pins

### DIFF
--- a/.claude-plugin/plugin/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-vault-mcp",
   "description": "MCP server for markdown vaults: FTS5 + semantic search, link graph, write/edit/git.",
-  "version": "3.2.0-rc.7",
+  "version": "3.1.0",
   "author": {
     "name": "Peter van Liesdonk"
   },

--- a/.claude-plugin/plugin/.mcp.json
+++ b/.claude-plugin/plugin/.mcp.json
@@ -3,7 +3,7 @@
     "command": "uvx",
     "args": [
       "--from",
-      "markdown-vault-mcp[all]==3.2.0-rc.7",
+      "markdown-vault-mcp[all]==3.1.0",
       "markdown-vault-mcp",
       "serve"
     ],

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v4.0.0
+_commit: v4.1.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,40 @@ jobs:
         run: bash scripts/structural_gate.sh
 
 
+  pr-title:
+    name: PR Title
+    # A squash merge takes the pull-request title as the commit subject, and
+    # python-semantic-release drops a subject it cannot parse from
+    # CHANGELOG.md silently — not under a fallback heading, absent. This is
+    # the last point at which that subject can still be corrected.
+    #
+    # PR-only by design: the writers to `main` outside a merge are PSR's own
+    # release commit and the automated merge-back, both machine-generated and
+    # already conformant. On push/dispatch the job is skipped, which the
+    # `ci-success` aggregate below treats as a pass.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check pull-request title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # Read the CURRENT title from the API rather than from
+        # `github.event.pull_request.title`. A re-run replays the original
+        # event payload, so an author who fixes the title would otherwise have
+        # to push a commit to clear a red check that a retitle already fixed.
+        run: |
+          set -euo pipefail
+          TITLE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .title)"
+          python3 scripts/check_pr_title.py "$TITLE"
+
   ci-success:
     name: CI Success
     # Single aggregate gate for branch protection / Renovate auto-merge to
@@ -446,6 +480,7 @@ jobs:
       - audit
       - secrets
       - vale
+      - pr-title
 
       - structure
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,24 +66,44 @@ jobs:
           echo "::error::Dispatch with force='' — commits on the branch advance the rc revision; check 'finalize' to cut the final stable."
           exit 1
 
-      # Advisory only: an open epic marked ships-atomically means trunk may be
-      # mid-story.  Releasing from main ships HEAD, so warn (the cut may still
-      # be intentional — or belongs on a release/X.Y branch cut from an
-      # earlier commit).  Label query per the epic-form convention; milestones
-      # are per-release and checked by the maintainer when choosing the cut.
-      - name: Warn about open ships-atomically epics
+      # Advisory only (never blocks — the cut may be intentional, or belong on
+      # a release/X.Y branch cut from an earlier commit).  Surfaces both
+      # queryable quiescence signals the epic conventions record:
+      #   * the preferred milestone — a release-named milestone (X.Y) with
+      #     open issues means that version is not yet safe to cut; and
+      #   * the ships-atomically label — for each open epic it also counts
+      #     open native sub-issues, which may live in another repo, so a
+      #     cross-repo epic whose children are elsewhere stays visible.
+      # Every gh call is guarded so a failure or an unsupported endpoint
+      # degrades to no warning rather than failing the step under pipefail.
+      - name: Warn about open ships-atomically epics and release milestones
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          open_atomic=$(gh issue list --repo "${{ github.repository }}" \
-            --label ships-atomically --state open --json number,title \
-            --jq '.[] | "#\(.number) \(.title)"' || true)
-          if [ -n "$open_atomic" ]; then
-            echo "::warning::Open ships-atomically epic(s) — releasing main ships HEAD mid-story. Consider a release/X.Y branch cut from before the epic started:"
-            printf '%s\n' "$open_atomic" | while IFS= read -r line; do
-              echo "::warning::  $line"
-            done
+          # (1) Open ships-atomically epics, each with a count of still-open
+          #     children (native sub-issues — cross-repo aware).
+          epics=$(gh issue list --repo "$REPO" --label ships-atomically \
+            --state open --json number,title \
+            --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null || true)
+          if [ -n "$epics" ]; then
+            printf '%s\n' "$epics" | while IFS="$(printf '\t')" read -r num title; do
+              [ -n "$num" ] || continue
+              kids=$(gh api "repos/$REPO/issues/$num/sub_issues" \
+                --jq '[.[] | select(.state == "open")] | length' 2>/dev/null || echo '?')
+              echo "::warning::Open ships-atomically epic #$num ($title) — $kids open child issue(s). Releasing $REPO@main ships HEAD mid-story; consider a release/X.Y branch cut from before the epic started."
+            done || true
+          fi
+          # (2) The preferred signal: a release-named milestone (X.Y) that
+          #     still has open issues — that version is not yet quiescent.
+          milestones=$(gh api "repos/$REPO/milestones?state=open&per_page=100" \
+            --jq '.[] | select(.open_issues > 0) | select(.title | test("^[0-9]+[.][0-9]+$")) | "\(.title): \(.open_issues) open issue(s)"' 2>/dev/null || true)
+          if [ -n "$milestones" ]; then
+            printf '%s\n' "$milestones" | while IFS= read -r ms; do
+              [ -n "$ms" ] || continue
+              echo "::warning::Release milestone $ms — not yet safe to cut that version from a quiescent trunk."
+            done || true
           fi
 
       # PSR's CLI can force prerelease ON (--as-prerelease) but not OFF, so
@@ -217,8 +237,13 @@ jobs:
               echo "- All changes since ${prev}: https://github.com/${REPO}/compare/${prev}...${TAG}"
             fi
             echo "- Commit-level detail: [CHANGELOG.md](https://github.com/${REPO}/blob/${TAG}/CHANGELOG.md)"
-            echo
-            echo "Release notes will move to a versioned notes page on the documentation site; until then, the links above carry the full change record."
+            # Only a stable's body gets the notes-page promise: the Release
+            # Notes Publish workflow matches stable tags only, so an rc body
+            # would carry a pointer nothing ever fulfils.
+            if [ "$IS_PRERELEASE" != "true" ]; then
+              echo
+              echo "Release notes will move to a versioned notes page on the documentation site; until then, the links above carry the full change record."
+            fi
           } > release-body.md
           gh release edit "$TAG" --notes-file release-body.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,38 @@ This project is extracted from [`pvliesdonk/if-craft-corpus`](https://github.com
 - Python 3.11+
 - `uv` for package management, `ruff` for linting/formatting (line length 88)
 - `hatchling` build backend
-- Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+- Conventional commits, one type from `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` — optionally scoped (`feat(search): ...`) and with `!` for a breaking change. `feat` cuts a minor release, `fix` and `perf` cut a patch, the rest cut none.
 - Google-style docstrings on all public functions
 - `logging.getLogger(__name__)` throughout, no `print()`
 - Type hints everywhere
 - Tests: `pytest` with fixtures in `tests/fixtures/`
+
+**Pull-request titles are enforced, not merely encouraged.** A squash merge
+takes the PR title as the commit subject, so CI's `PR Title` job checks it
+against the type list above and fails the `CI Success` aggregate when it does
+not match. This is not style policing: python-semantic-release parses that
+subject, and a type it does not recognise is dropped from `CHANGELOG.md`
+without a warning — no fallback heading, no entry at all. A commit that never
+reaches the changelog never reaches the release notes that link into it.
+
+Retitling is enough to clear a failure — the job reads the current title from
+the API, so re-running it after a retitle needs no push.
+
+**Reverts are the one accepted title with a caveat.** `Revert "..."`, the
+shape `git revert` and GitHub's revert button generate, passes: it is the
+ecosystem's convention, and Conventional Commits deliberately leaves reverts
+unspecified. But no python-semantic-release parser reads it — `angular` and
+`conventional` both fail on it — so such a commit does **not** reach
+`CHANGELOG.md`. The job says so with a warning annotation rather than letting
+you find out at release time. `revert: ORIGINAL SUBJECT` is the form that does
+reach the changelog. Either way the revert is narrated on the
+`docs/releases/` page, whose research runs off merged pull requests and linked
+issues rather than commit subjects.
+
+The accepted set lives in `pyproject.toml` under
+`[tool.semantic_release.commit_parser_options] allowed_tags`.
+`scripts/check_pr_title.py` and the list above are checked against it by
+`tests/test_commit_conventions.py`, so no one of the three can drift alone.
 
 The automated Claude review runs **only after CI passes** — if CI is red, no
 review is posted. Fix CI and push; the review runs on the next green run.
@@ -367,7 +394,7 @@ The `Pre-release check` workflow (Actions tab, `workflow_dispatch`) builds and v
 
 **The default release path is trunk.** When a release is wanted and trunk is quiescent (no atomic epic mid-flight — the cut criterion below), dispatch Release on `main`. It cuts a stable from HEAD: no branch, no ceremony. Most releases should look like this.
 
-**The cut criterion.** An epic that ships atomically makes trunk unreleasable while it is open: releasing `main` ships HEAD, mid-story. Judge quiescence from the queryable signal the epic conventions record (see CONTRIBUTING.md's Epics section): preferably the **release milestone** — safe to cut means no open issues in the target release's milestone — with the **`ships-atomically` label** as the fallback when no milestone names a release yet. An open atomic epic with unclosed children means either release from a commit before the epic started (a `release/X.Y` branch cut from that commit) or wait. The Release workflow's advisory step ("Warn about open ships-atomically epics") surfaces open labelled epics on every `main` dispatch; it warns and never blocks, because the cut may still be intentional.
+**The cut criterion.** An epic that ships atomically makes trunk unreleasable while it is open: releasing `main` ships HEAD, mid-story. Judge quiescence from the queryable signal the epic conventions record (see CONTRIBUTING.md's Epics section): preferably the **release milestone** — safe to cut means no open issues in the target release's milestone — with the **`ships-atomically` label** as the fallback when no milestone names a release yet. An open atomic epic with unclosed children means either release from a commit before the epic started (a `release/X.Y` branch cut from that commit) or wait. The Release workflow's advisory step surfaces both signals on every `main` dispatch — a release-named milestone (`X.Y`) that still has open issues, and open `ships-atomically` epics (each with a count of its native sub-issues, so a cross-repo epic whose children live elsewhere stays visible); it warns and never blocks, because the cut may still be intentional.
 
 **The `release/X.Y` branch is the exception tool**, for exactly two cases:
 

--- a/docs/deployment/release-process.md
+++ b/docs/deployment/release-process.md
@@ -32,9 +32,11 @@ newest in the relevant series, so a patch release cut from an old
 The default release path is trunk. When trunk is quiescent (no epic that
 must ship whole is mid-flight), dispatching Release on `main` cuts a
 stable from the head commit: no branch, no ceremony. The workflow prints
-an advisory warning when open `ships-atomically` epics exist, because
-releasing `main` ships everything merged so far; the warning never
-blocks, since the cut may still be intentional.
+an advisory warning when a release-named milestone still has open issues,
+or when an open `ships-atomically` epic shows work in flight. It counts the
+epic's native sub-issues, which may live in another repository, so a
+cross-repo epic stays visible. Either way the warning never blocks, since
+the cut may still be intentional.
 
 ## Stabilisation branches
 
@@ -79,8 +81,10 @@ After every stable release, the **Release Notes** workflow drafts the
 page: an agent researches the release range through the GitHub API (the
 linked issues and pull requests, not commit subjects) and opens a pull
 request against `main`. Every causal claim in a page must cite a linked
-issue or pull request, and the draft must pass the same prose lint as the
-rest of this site before the pull request opens.
+issue or pull request. The drafting agent runs the same prose lint as the
+rest of this site while it writes, and the notes pull request's own CI
+enforces it: the `vale` job must pass before the pull request can merge,
+the same gate every change to this site clears.
 
 A maintainer merge is the publication step. Nothing lands on the site
 without review, and until the merge the release keeps the short interim

--- a/docs/deployment/repository-protection.md
+++ b/docs/deployment/repository-protection.md
@@ -56,6 +56,15 @@ rules:
 - the owner's own hotfix pushes, preserving the escape hatch the previous
   classic protection provided via its disabled admin enforcement.
 
+Two clean-up operations the release model implies depend on this bypass
+too. `protect-release-branches` blocks deleting a `release/X.Y` branch, and
+`protect-release-tags` blocks deleting a `v*` tag, yet a stabilisation
+branch is short-lived, and the `Pre-release check` workflow describes its
+`v<version>-rc` pre-release as safe to delete. Both deletions are available
+only to the admin role, through the same bypass. A `RELEASE_TOKEN` that is
+not owned by a repository admin cannot perform them, and those spent
+branches and pre-release tags then accumulate until an admin removes them.
+
 Everyone below admin, including outside collaborators, write-role
 contributors, and any workflow using the default `GITHUB_TOKEN`, goes
 through a pull request with green CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -379,5 +379,28 @@ insertion_flag = "<!-- version list -->"
 changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.commit_parser_options]
+# The accepted commit types, stated explicitly rather than left to the
+# parser's default, because this list is one half of a contract: CI's
+# `PR Title` job runs scripts/check_pr_title.py against the same set, and
+# tests/test_commit_conventions.py fails when the two halves disagree.
+#
+# Getting a type wrong is not a cosmetic problem. A subject whose type is not
+# listed here does not parse, and PSR then omits the commit from CHANGELOG.md
+# entirely — no fallback heading, no warning. `revert` is added on top of the
+# parser's own default set for exactly that reason: reverts belong in the
+# audit trail, and the default drops them.
+allowed_tags = [
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", ":dependencyDashboard"],
   "labels": ["dependencies"],
   "enabledManagers": ["pep621"],
+  "semanticCommits": "enabled",
   "rangeStrategy": "update-lockfile",
   "lockFileMaintenance": {
     "enabled": true,

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Check a pull-request title against the conventional-commit type set.
+
+A squash merge takes the pull-request title as the resulting commit subject,
+so the title is the last point at which a subject can be corrected before it
+reaches ``main``.  That matters more than style: python-semantic-release
+builds its subject regex from the types listed in ``pyproject.toml``'s
+``[tool.semantic_release.commit_parser_options] allowed_tags``, and a subject
+whose type is not among them fails to parse and is dropped from the generated
+``CHANGELOG.md`` entirely -- not filed under a fallback heading, absent.  The
+release audit trail is only as complete as the subjects feeding it.
+
+The type list below and ``allowed_tags`` are two halves of one contract.
+``tests/test_commit_conventions.py`` fails when they disagree, so neither half
+can drift alone.
+
+Usage::
+
+    python3 scripts/check_pr_title.py "feat(search): add hybrid ranking"
+    python3 scripts/check_pr_title.py --list
+
+Exits 0 when the title conforms, 1 otherwise, after printing a GitHub
+workflow error annotation naming the accepted types.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+#: Commit types this project accepts, kept in agreement with
+#: ``[tool.semantic_release.commit_parser_options] allowed_tags``.
+ALLOWED_TYPES: tuple[str, ...] = (
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+)
+
+# Mirrors python-semantic-release's angular parser: an optional
+# parenthesised scope, an optional `!` breaking marker, a colon, whitespace,
+# then a non-empty subject.  Case-sensitive, as the parser is.
+_TITLE_RE = re.compile(
+    r"^(?P<type>[A-Za-z]+)"
+    r"(?:\((?P<scope>[^()\n]+)\))?"
+    r"(?P<breaking>!)?"
+    r":[ \t]+"
+    r"(?P<subject>\S.*)$"
+)
+
+# `git revert` and GitHub's revert button both produce `Revert "<original>"`.
+# That is the wider ecosystem's shape, not a GitHub quirk, and Conventional
+# Commits deliberately leaves revert handling open -- so it is accepted rather
+# than second-guessed.  The greedy `.+` also accepts the stacked form a revert
+# of a revert produces: `Revert "Revert "feat: x""`.
+#
+# It does carry a cost, and the caller is told about it rather than left to
+# find out: python-semantic-release has no revert handling in any parser (both
+# `angular` and `conventional` return ParseError for this shape), so a commit
+# with this subject does not reach CHANGELOG.md.  The release-notes page is
+# where such a change gets narrated -- its research runs off merged pull
+# requests and linked issues, not commit subjects.
+_GIT_REVERT_RE = re.compile(r'^Revert\s+".+"\s*$')
+
+_TYPES_LINE = ", ".join(ALLOWED_TYPES)
+
+_HOW_TO_FIX = (
+    "Retitle the pull request, then re-run this job -- it reads the current "
+    "title from the API, so no push is needed."
+)
+
+
+def _example() -> str:
+    return (
+        "Accepted shape: type(optional-scope)!: subject\n"
+        "  feat(search): add hybrid ranking\n"
+        "  fix: stop the writer thread on shutdown\n"
+        "  feat(config)!: drop the deprecated env alias\n"
+        f"Accepted types: {_TYPES_LINE}"
+    )
+
+
+#: Emitted for an accepted title that the release parser still cannot read.
+REVERT_CAVEAT = (
+    'Accepted: this is the Revert "..." form git and GitHub generate. '
+    "python-semantic-release cannot parse it, though, so the commit will not "
+    "appear in CHANGELOG.md. Title it 'revert: ORIGINAL SUBJECT' instead if "
+    "you want it there; either way the release-notes page narrates it, since "
+    "that research runs off merged pull requests rather than commit subjects."
+)
+
+
+def is_git_revert(title: str) -> bool:
+    """Report whether a title is the ``Revert "..."`` form git generates.
+
+    Args:
+        title: The pull-request title, as GitHub reports it.
+
+    Returns:
+        ``True`` for the git/GitHub revert shape, including the stacked form
+        a revert of a revert produces (``Revert`` applied twice).
+    """
+    return _GIT_REVERT_RE.match(title.strip()) is not None
+
+
+def check_title(title: str) -> str | None:
+    """Validate a pull-request title.
+
+    Args:
+        title: The pull-request title, as GitHub reports it.
+
+    Returns:
+        ``None`` when the title conforms, otherwise a multi-line explanation
+        of what is wrong and how to fix it.
+    """
+    stripped = title.strip()
+    if not stripped:
+        return f"The pull-request title is empty.\n{_example()}\n{_HOW_TO_FIX}"
+
+    if is_git_revert(stripped):
+        return None
+
+    match = _TITLE_RE.match(stripped)
+    if not match:
+        return (
+            "The pull-request title is not a conventional-commit subject.\n"
+            f"{_example()}\n{_HOW_TO_FIX}"
+        )
+
+    commit_type = match.group("type")
+    if commit_type not in ALLOWED_TYPES:
+        lowered = commit_type.lower()
+        hint = ""
+        if lowered in ALLOWED_TYPES:
+            hint = f"\nTypes are case-sensitive; use {lowered!r}, not {commit_type!r}."
+        return (
+            f"{commit_type!r} is not an accepted commit type. A subject with "
+            "an unrecognised type is dropped from CHANGELOG.md without a "
+            "warning.\n"
+            f"Accepted types: {_TYPES_LINE}{hint}\n{_HOW_TO_FIX}"
+        )
+
+    return None
+
+
+def main(argv: list[str]) -> int:
+    """Run the check.
+
+    Args:
+        argv: Command-line arguments without the program name. Either
+            ``["--list"]`` or a single pull-request title.
+
+    Returns:
+        Process exit status: 0 when the title conforms, 1 otherwise.
+    """
+    if argv == ["--list"]:
+        print("\n".join(ALLOWED_TYPES))
+        return 0
+    if len(argv) != 1:
+        print("usage: check_pr_title.py [--list | TITLE]", file=sys.stderr)
+        return 2
+
+    problem = check_title(argv[0])
+    if problem is None:
+        print(f"Pull-request title OK: {argv[0]}")
+        if is_git_revert(argv[0]):
+            print(REVERT_CAVEAT)
+            print(f"::warning title=Revert title::{REVERT_CAVEAT}")
+        return 0
+
+    print(problem, file=sys.stderr)
+    summary = problem.splitlines()[0]
+    print(f"::error title=Pull-request title::{summary}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pvliesdonk/markdown-vault-mcp",
   "title": "Markdown Vault MCP",
   "description": "Markdown vault MCP server with FTS5 + semantic search and frontmatter indexing",
-  "version": "3.2.0-rc.7",
+  "version": "3.1.0",
   "websiteUrl": "https://pvliesdonk.github.io/markdown-vault-mcp/",
   "repository": {
     "url": "https://github.com/pvliesdonk/markdown-vault-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "markdown-vault-mcp",
-      "version": "3.2.0-rc.7",
+      "version": "3.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -450,7 +450,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v3.2.0-rc.7",
+      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v3.1.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{--port}/mcp"

--- a/tests/test_commit_conventions.py
+++ b/tests/test_commit_conventions.py
@@ -1,0 +1,146 @@
+"""Guards for the commit-type contract between PSR, CI, and the docs.
+
+Three places name the accepted commit types: `pyproject.toml`'s
+`[tool.semantic_release.commit_parser_options] allowed_tags` (what
+python-semantic-release will parse), `scripts/check_pr_title.py` (what CI
+rejects before a squash merge turns a title into a subject), and `CLAUDE.md`
+(what a contributor reads). Let any one drift and the failure is silent: PSR
+does not warn about a subject it cannot parse, it simply omits the commit from
+`CHANGELOG.md` — no fallback heading, no entry.
+
+That is not hypothetical. Seven commits reached one downstream project's
+`main` with `diag(review):` / `experiment(review):` / prose subjects and are
+absent from its generated changelog (see the template's #368). These tests are
+what keeps the three halves honest.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKER = REPO_ROOT / "scripts" / "check_pr_title.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+
+
+def _parser_options() -> dict[str, list[str]]:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    options = data["tool"]["semantic_release"]["commit_parser_options"]
+    return {key: [str(item) for item in value] for key, value in options.items()}
+
+
+def _run_checker(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _checker_types() -> list[str]:
+    result = _run_checker("--list")
+    assert result.returncode == 0, result.stderr
+    return result.stdout.split()
+
+
+def test_checker_and_psr_accept_the_same_types() -> None:
+    """The gate must not reject what PSR accepts, or accept what it drops."""
+    assert set(_checker_types()) == set(_parser_options()["allowed_tags"])
+
+
+def test_release_bump_types_are_parseable() -> None:
+    """A type that bumps a version but does not parse would never bump one."""
+    options = _parser_options()
+    bumping = set(options["minor_tags"]) | set(options["patch_tags"])
+    assert bumping <= set(options["allowed_tags"])
+
+
+def test_claude_md_documents_every_accepted_type() -> None:
+    """Contributors read CLAUDE.md; an undocumented type is a trap."""
+    prose = CLAUDE_MD.read_text(encoding="utf-8")
+    missing = [f"`{tag}`" for tag in _checker_types() if f"`{tag}`" not in prose]
+    assert not missing, f"CLAUDE.md does not document: {missing}"
+
+
+def test_ci_runs_the_checker_and_gates_on_it() -> None:
+    """The check is worthless unless the required aggregate depends on it."""
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "scripts/check_pr_title.py" in workflow
+    assert "\n      - pr-title\n" in workflow, (
+        "the pr-title job must be a `needs` entry of the ci-success aggregate"
+    )
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "feat: add a thing",
+        "fix(search): stop the writer thread on shutdown",
+        "feat(config)!: drop the deprecated env alias",
+        "chore(deps): update dependency ruff to v0.9.0",
+        "revert: feat(search): add hybrid ranking",
+        'Revert "feat: add a thing"',
+        'Revert "Revert "feat: add a thing""',
+        "perf: reuse the compiled pattern",
+        "docs: document the new env var",
+    ],
+)
+def test_accepted_titles(title: str) -> None:
+    result = _run_checker(title)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "diag(review): pin the reviewer action",
+        "experiment(review): show full output",
+        "Modify CI workflow to handle Renovate PRs",
+        'Reverted "feat: add a thing"',
+        "Feat: capitalised type",
+        "fix:no space after the colon",
+        "feat: ",
+        "",
+    ],
+)
+def test_rejected_titles(title: str) -> None:
+    result = _run_checker(title)
+    assert result.returncode == 1
+    assert "::error" in result.stdout
+
+
+def test_rejection_names_the_accepted_types() -> None:
+    """An actionable failure tells the author what to type instead."""
+    result = _run_checker("diag(review): pin the reviewer action")
+    assert result.returncode == 1
+    assert ", ".join(_checker_types()) in result.stderr
+
+
+def test_git_revert_titles_pass_but_warn_about_the_changelog() -> None:
+    """The git/GitHub revert form is accepted; its cost is stated, not hidden.
+
+    Neither of python-semantic-release 10.5.3's parsers reads that shape --
+    both return ParseError -- so the commit never reaches CHANGELOG.md. The
+    check accepts the title (it is what git itself generates) and annotates
+    the run rather than leaving the author to discover the gap at release
+    time.
+    """
+    result = _run_checker('Revert "feat: add a thing"')
+    assert result.returncode == 0, result.stderr
+    assert "::warning" in result.stdout
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_conventional_revert_titles_pass_without_a_warning() -> None:
+    """`revert:` is in allowed_tags, so that form does reach the changelog."""
+    result = _run_checker("revert: feat: add a thing")
+    assert result.returncode == 0, result.stderr
+    assert "::warning" not in result.stdout

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -32,12 +32,19 @@ must name the flag and `CHANGELOG.md` must carry it — a flag-less changelog is
 never written, with no error.  And `changelog_file` must sit in its supported
 location (`changelog.default_templates`), not the deprecated bare
 `changelog.changelog_file` key.  The changelog tests below pin both halves.
+
+A fourth invariant joined in template#375: the two behavioral tests above
+prove the *bumper* never writes a pre-release pin, but nothing read the
+committed manifests themselves.  The stable-pin test below does, so a bad
+pin that arrives by hand edit or a half-applied update — outside the bumper
+— still fails.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -186,6 +193,99 @@ def test_changelog_carries_the_insertion_flag() -> None:
     assert flag in changelog, (
         f"CHANGELOG.md lacks the PSR insertion flag — add this exact line "
         f"once, where version sections should be inserted: {flag}"
+    )
+
+
+_PRERELEASE_SUFFIX = re.compile(r"-(?:alpha|beta|rc|dev|pre|a|b)\b", re.IGNORECASE)
+
+
+def _published_manifest_versions() -> dict[str, str]:
+    """Version each committed published-manifest currently pins.
+
+    These are the files the "Manifest version lockstep" rule keeps at the
+    latest *stable* release: ``server.json``'s own version and its pypi
+    package versions, plus the Claude plugin pair. The oci image identifier is
+    excluded — it legitimately ends in the tag form ``:vX.Y.Z``.
+    """
+    versions: dict[str, str] = {}
+    server = json.loads((REPO_ROOT / "server.json").read_text(encoding="utf-8"))
+    versions["server.json version"] = str(server["version"])
+    for pkg in server.get("packages", []):
+        if pkg.get("registryType") == "pypi":
+            versions[f"server.json pypi {pkg.get('identifier', '')}"] = str(
+                pkg["version"]
+            )
+    plugin = json.loads((REPO_ROOT / PLUGIN_JSON).read_text(encoding="utf-8"))
+    versions["plugin.json version"] = str(plugin["version"])
+    mcp = json.loads((REPO_ROOT / MCP_JSON).read_text(encoding="utf-8"))
+    for server_cfg in mcp.values():
+        for arg in server_cfg.get("args", []):
+            if isinstance(arg, str) and "==" in arg:
+                versions[f".mcp.json pin {arg}"] = arg.split("==", 1)[1]
+    return versions
+
+
+def test_committed_manifest_pins_are_stable_versions() -> None:
+    """No committed published-manifest pins a pre-release version.
+
+    The bumper leaves these files at the last published stable on a
+    pre-release run (proven by the sandbox tests below), but a value can
+    reach the committed file another way — a hand edit, a bad merge, a
+    half-applied copier update.  A pre-release pin such as ``X.Y.Z-rc.N``
+    names a version PyPI, the MCP registry, and the marketplace never
+    publish, so ``uvx --from pkg==X.Y.Z-rc.N`` cannot resolve it (the failure
+    tracked at markdown-vault-mcp#1053).  This reads the committed files
+    themselves, which the sandbox tests never touch.
+    """
+    bad = {
+        where: ver
+        for where, ver in _published_manifest_versions().items()
+        if _PRERELEASE_SUFFIX.search(ver)
+    }
+    assert not bad, (
+        "committed manifests must pin the latest stable release, but these "
+        "carry a pre-release version: "
+        + ", ".join(f"{where} = {ver}" for where, ver in sorted(bad.items()))
+    )
+
+
+def _stable_release_tags() -> list[str] | None:
+    """Stable ``vX.Y.Z`` tags in this repo, or ``None`` when git is absent.
+
+    A freshly generated project is not yet a git repository and has no tags,
+    so the caller skips there rather than failing.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "tag", "--list"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return [t for t in completed.stdout.split() if re.fullmatch(r"v\d+\.\d+\.\d+", t)]
+
+
+def test_committed_server_version_matches_a_released_tag() -> None:
+    """When the repo has stable tags, ``server.json`` names one of them.
+
+    Best-effort and self-skipping: it asserts nothing before a project's
+    first stable, but once stables exist a committed version with no matching
+    ``vX.Y.Z`` tag means the pin drifted from what was actually released.
+    """
+    tags = _stable_release_tags()
+    if not tags:
+        pytest.skip("no stable release tags in this repository yet")
+    version = str(
+        json.loads((REPO_ROOT / "server.json").read_text(encoding="utf-8"))["version"]
+    )
+    if version in {"0.0.0", "0.1.0"}:
+        pytest.skip("initial placeholder version, before the first release")
+    assert f"v{version}" in tags, (
+        f"server.json pins {version}, but no matching stable tag v{version} "
+        "exists — the manifest must name a released stable version"
     )
 
 


### PR DESCRIPTION
## Closes / Refs

Closes #1053

## What & why

Adopt `fastmcp-server-template` **v4.1.0** via `copier update` (from v4.0.0). The update brings, with no conflicts:

- **Template PR #378** (epic #1054 release-machinery fixes): the advisory cut-criterion step now also queries the release milestone and counts cross-repo native sub-issues (still never blocks); rc release bodies no longer carry the "notes will move to a versioned page" promise; `release-process.md` / `repository-protection.md` corrected; and a new committed-manifest-pin contract test in `test_release_contract.py`.
- **Template #369**: conventional-commit-type / PR-title gating (`scripts/check_pr_title.py`, `tests/test_commit_conventions.py`, `allowed_tags` in `pyproject.toml`, renovate `semanticCommits`).

The newly adopted `test_committed_manifest_pins_are_stable_versions` fails on the stale `3.2.0-rc.7` pins — a version never published to PyPI, which made `uvx --from markdown-vault-mcp[all]==3.2.0-rc.7` unresolvable (#1053). This clears them to the latest stable, **3.1.0**:

- `server.json`: `version`, the pypi package version, and the oci image identifier
- `.claude-plugin/plugin/.claude-plugin/plugin.json`: `version`
- `.claude-plugin/plugin/.mcp.json`: the `uvx` pin

`uvx --from markdown-vault-mcp[all]==3.1.0` now resolves, and the manifest lockstep gate (latest stable) holds. When 4.0.0 is cut, PSR's bumper moves them to 4.0.0.

## What this PR deliberately does NOT do

- Does **not** hand-edit `CHANGELOG.md` or `pyproject.toml` — both correctly keep `3.2.0-rc.7` (the last pre-release's historical record and PSR's working version; the manifests, not these, carry the latest *stable*).
- Does **not** cut 4.0.0 — that is the epic's #1055, a maintainer release action.
- Does **not** fix the remaining mvm domain findings (#1068, #1069, #1070, #1071, #1073) — those land as separate domain PRs on top of this base.

## Local review

- [x] Ran a local review pass on the cumulative diff; the `copier update` changes are template-owned (already validated in template CI) and the only hand edits are the five manifest pins.
- [x] No commit carries `!`. Clearing an unresolvable pin to an existing stable release is strictly corrective, not an operator- or library-surface break (assessed against the last stable release, v3.1.0).

Full gate run locally and green: `ruff check`/`ruff format --check` clean, `mypy src/ tests/` clean (192 files), `pytest` 3316 passed / 21 skipped, structural gate clean (no `src/` Python changes), and `vale` 0 errors on the changed docs. The adopted contract test passes on the corrected pins (12 passed, the tag-existence check self-skips with no local tags).

## Docs impact

- [ ] `README.md`
- [x] `docs/` site pages
- [ ] `docs/design/`
- [ ] Inline docstrings

`docs/deployment/release-process.md` and `docs/deployment/repository-protection.md` updated (Vale-clean, adopted from the template); `CLAUDE.md` release-model text updated by the same update.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJi4Nrirfy9Tgt68bbonZD)_