### PR TITLE
docs: record release-model decision, cut criterion, and remaining map entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ src/markdown_vault_mcp/
     fs.py              -- filesystem traversal helpers: symlink-aware iteration, directory pruning (#508, #835)
     fts.py             -- fts_row_to_note_info: FTS row → NoteInfo conversion shared across managers
   managers/
+    __init__.py        -- package aggregator: re-exports DocumentManager/IndexManager/LinkManager/SearchManager
     link.py            -- LinkManager: backlinks, outlinks, broken, orphans, hubs, paths
     search.py          -- SearchManager: keyword/semantic/hybrid search, list, context, stats
     index.py           -- IndexManager: build_index, reindex, embeddings, flush
@@ -30,10 +31,12 @@ src/markdown_vault_mcp/
     _ranking.py        -- pure ranking pipeline: downweight/boost/grouping/snippets (#759)
     _vector_loader.py  -- shared load-or-self-heal routine for the vector sidecar (#736)
   indexing/
+    __init__.py        -- package aggregator: re-exports IndexWriteCoordinator, IndexWriter + writer job dataclasses, ReadinessState
     index_writer.py    -- IndexWriter: single-owner FIFO writer thread + job dataclasses/runners
     readiness.py       -- ReadinessState: build-readiness state machine (#576)
     coordinator.py     -- IndexWriteCoordinator: owns the writer + build/async orchestration (#576)
   facets/
+    __init__.py        -- package aggregator: re-exports the five facets (Reader/Writer/Graph/Index/Summarize)
     reader.py          -- ReaderFacet: search/read/list/toc/similar/context/stats/history (#604)
     writer.py          -- WriterFacet: write/edit/delete/rename/attachments (#604)
     graph.py           -- GraphFacet: backlinks/outlinks/broken/orphans/most-linked/paths (#604); neighborhood/hub graph views (#880)
@@ -67,6 +70,7 @@ src/markdown_vault_mcp/
   _write_tools.py      -- WRITE_TOOL_NAMES + write_tools_phrase: single source for the user-facing write-tool enumeration (#1009)
   config.py            -- template-owned skeleton: flat metadata-carrying ProjectConfig fields + section-view properties + from_env, all inside CONFIG-* sentinels (#900, #952)
   config_sections/
+    __init__.py          -- package aggregator: re-exports the seven section configs (Content/Embeddings/Git/Indexing/Search/Summarize/Sync)
     _assembly.py         -- domain config-assembly kept out of template-owned config.py: to_vault_kwargs, derive_max_chunk_chars, git-strategy builder, from_env value resolvers (#900, #952)
     _helpers.py          -- shared env-reading helpers for the sections' from_env classmethods (no config.py import)
     content.py           -- ContentConfig: attachment/read limits, template/prompt folders, conventions file

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3031,6 +3031,22 @@ with rcs, then finalize), or a patch to an already-shipped release while
 `X.Y.Z` when the `finalize` input is set; the `force` bump input is
 `main`-only, since a branch's target is fixed at cut time.
 
+**The cut criterion — when trunk is safe to release.** An epic that
+ships atomically makes trunk unreleasable while it is open: dispatching
+`release.yml` on `main` would ship HEAD mid-story. Whether trunk is
+quiescent is judged from a queryable signal recorded on the epic —
+preferably a **release milestone** named for the target version (`X.Y`)
+with no open issues, and the **`ships-atomically` label** as the
+fallback when no milestone names the release yet. `release.yml` carries
+an **advisory step** on every `main` dispatch that surfaces both
+signals — a release-named milestone that still has open issues, and each
+open `ships-atomically` epic (with a count of its still-open native
+sub-issues, so a cross-repo epic whose children live elsewhere stays
+visible) — and it warns without blocking, since the cut may be
+intentional. An open atomic epic with unclosed children means either
+releasing from a commit before the epic started (a `release/X.Y` branch
+cut from there) or waiting.
+
 **Stable** runs the full pipeline: semantic-release cuts a `vX.Y.Z` tag,
 PyPI receives the wheel + sdist, the Docker image publishes `:vX.Y.Z`
 plus the rolling `:latest`/`:vX`/`:vX.Y`, `.deb`/`.rpm` packages attach
@@ -3221,3 +3237,9 @@ Later decisions (2026-08-14, #1035):
 | 20 | Client-side summarization | `summarize-subtree` MCP prompt carrying the plan → map → reduce recipe, registered config-dependently with a registration-time `${route_note}` slot (prefer-the-tool note when a backend is configured, standalone recipe when not); mapper/reducer prose derived from `_SYSTEM_MAP` / `_SYSTEM_REDUCE` | Prompts are served with the server over plain HTTP-hosted MCP (unlike plugin skills); covers keyless installs after sampling's rejection (decision 18). The recipe runs with or without subagents; trade-off prose is operator-facing and lives in docs/prompts.md only. The plugin channel's `vault-summarize` skill + `vault-mapper` read-only agent wrap this same recipe rather than duplicating it (#1036, resolved) |
 | 21 | Plugin bootstrap and repair | A `vault-setup` skill (discover candidates via `.obsidian/` markers → validate → write the plugin's stored options in user-scope `~/.claude/settings.json` (originally the `env` block, moved with decision 22) → instruct restart) plus a SessionStart doctor hook (`scripts/doctor.sh`) that emits guidance only when `MARKDOWN_VAULT_MCP_SOURCE_DIR` is unset or missing, silent when healthy | The plugin container is the natural repair path (#1042): skills and hooks keep working while the MCP server is down, settings-file `env` reaches the server process and beats the shell environment, project-scope settings are wrong for a per-user vault path, and a restart is the floor because servers only start at session start. Replaces the shell-profile-and-README dead end; no server-side "setup mode" needed (epic #1043 non-goal) |
 | 22 | Plugin configuration screen | `plugin.json`'s `userConfig` and `.mcp.json`'s env wiring are generated from the config surface as a split-file pair (`claude-plugin-user-config` + `claude-plugin-env` with `fields_from`, template v3.6.0), sharing the mcpb screen's curated field set via a YAML anchor in `config-presentation.domain.yml`; `.mcp.json` env values are `${user_config.<id>}` references (exec-form only), replacing the legacy `${VAR:-default}` shell expansion; the plugin's `source_dir` ships without the mcpb `${DOCUMENTS}/Vault` default (an mcpb-host placeholder Claude Code does not substitute) | One fields map drives both files so the screen and its wiring cannot drift (#1040); values persist across plugin updates in `pluginConfigs`, sensitive fields (API key, git token) go to secure storage; the doctor hook and vault-setup skill resolve/write the plugin options surface accordingly (CLAUDE_PLUGIN_OPTION_*, `pluginConfigs[...].options`), with the env-block and shell environment demoted to legacy fallbacks |
+
+Later decisions (2026-08-16, #1054):
+
+| # | Topic | Decision | Rationale |
+|-|-|-|-|
+| 23 | Release model — how to cut an RC | Short-lived `release/X.Y` stabilisation branches cut on demand, not a long-lived `unstable` branch; prerelease-ness is a property of the branch (semantic-release branch groups: `main`→stable, `release/.*`→rc), not a dispatch flag; "run the latest code" is served by the versionless rolling `edge` channel; merge-back into `main` after any branch-cut release is mandatory | The disagreement that stalled the 4.0.0 cut. **Rejected:** a permanent `unstable` branch with cherry-picks forward to `main` — forward-porting is the expensive direction (epics are multi-commit and interleaved) and every quality gate is `main`-relative, so an unstable-first PR is measured against an ever-growing diff. **Rejected:** cutting rcs from trunk / a `prerelease` dispatch flag — a pre-release tag then asserts a next-version prediction semantic-release keeps falsifying (the `v3.2.0-rc.*` series that could no longer produce 3.2.0), and the flag can desync from the tag. **Rejected:** per-channel feature-flag defaults (preview-on in rc) — it dogfoods a configuration no user runs, whereas a release branch is bit-for-bit what ships. **Adopted** because a frozen branch's version is a decision made at cut time rather than an extrapolation, which makes the renumbering problem structurally impossible; the merge-back is a correctness requirement, since without the tag reachable from `main`, semantic-release recomputes the same version, finds it taken repo-globally, and reports "already released" forever. The channel identities, branch mechanics, and cut criterion are specified under [Release channels](#release-channels) above |

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -7,7 +7,7 @@ behind it.
 ## Available pages
 
 <!-- RELEASE-PAGES-START -->
-- [3.1](3.1.md) (released July 8, 2026)
+- [3.1](3.1.md) (released July 8, 2026). Backfilled.
 - [3.0](3.0.md) (released June 17, 2026, with patch releases through v3.0.4).
   Backfilled.
 - [1.x](1.x.md) (March 9 to May 3, 2026; the whole 1.x line on one page).


### PR DESCRIPTION
## Closes / Refs

Closes #1071, closes #1072, closes #1079
Refs #1068

## What & why

A second-order critical review of the epic #1054 cleanup pass surfaced four documentation loose ends the prior PRs (#1074/#1076) left behind. This closes them:

- **CLAUDE.md module map** — adds the four package `__init__.py` entries #1071 enumerated but #1076 left out (`managers/`, `indexing/`, `facets/`, `config_sections/`). Each is a real aggregating re-export (`__all__` present, 6–35 non-blank lines), not an empty package marker, so the "map matches the tree" claim was still false. [verified: read each file + the committed map]
- **design.md "Release channels"** — adds the cut-criterion paragraph (the release-milestone / `ships-atomically` signal and the advisory step) that landed in `CLAUDE.md` via #1075 but never reached the authoritative spec. design.md is "when in doubt, the design doc wins", so it was again lagging `CLAUDE.md`/`release.yml`.
- **design.md decision log** — records decision 23, the release-model / RC-cut decision (stabilisation branches over a long-lived unstable, prerelease as a branch property, mandatory merge-back, and the alternatives rejected). The decision previously lived only in the epic thread (#1079).
- **docs/releases/index.md** — labels 3.1 "Backfilled" for consistency with the "Reconstructed after the fact" banner #1076 gave `3.1.md` and with the 3.0/1.x list entries.

## What this PR deliberately does NOT do

- **The one-time `v3.1.0` release-body edit (the other half of #1068)** is not done here — the live body is the bare PSR default with no interim marker, so the `release-notes-publish` auto-upgrade guard can never fire for that tag, and editing a published release body is a maintainer `gh release edit` action outside this diff. #1068 stays open for it, with the exact steps in the issue comment.
- **No `docs/decisions/` ADR subtree** is created — the project's stated home for the decision log is the `design.md` appendix (CLAUDE.md: "Full decision log in `docs/design/design.md` appendix"), so decision 23 goes there rather than introducing a new subtree.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening.
- [x] No commit carries `!`; this is a docs-only change (no operator or library surface touched).

## Docs impact

- [x] `docs/` site pages (`docs/releases/index.md`)
- [x] `docs/design/` (`design.md` release channels + decision log)
- [x] `CLAUDE.md` module map

Gates run locally: Vale clean on `docs/releases/index.md`; `mkdocs build --strict` passes; doc-referencing tests green (`test_structural_gate`, `test_commit_conventions`, `test_config_wizard_spec`). No Python changed, so ruff/mypy/structural-gate/patch-coverage do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJi4Nrirfy9Tgt68bbonZD)_