### PR TITLE
fix(release): drop track_progress from the notes drafting action

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -293,7 +293,10 @@ jobs:
             - mode: ${{ steps.ctx.outputs.mode }} (new = write the whole page and add it to docs/releases/index.md; patch = append one dated section inside the patch sentinels; redraft = the minor's page already exists — e.g. drafted at prepare time — so update/extend it in place and never append a duplicate section for this release)
 
             The vale binary (packs synced) and `uv run mkdocs build --strict` are available for the skill's quality gates. Write your proposed pull-request body to .release-notes-pr-body.md at the repository root (used only when this run opens a standalone notes PR; ignored when the draft lands on a release PR's branch). Do not commit, push, or open a PR yourself — the workflow's next step lands your working tree mechanically.
-          track_progress: true
+          # No progress-tracking input: the action supports it only on
+          # PR/issue events, and this workflow only ever runs on
+          # workflow_dispatch / workflow_call — passing it is a hard error
+          # before the agent starts (template#421, first live drafting run).
           display_report: true
           include_fix_links: false
           # Read-only GitHub research (MCP read tools + gh api), Task for the

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -506,6 +506,11 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
     assert "--force-with-lease=" in text, (
         "the prep-branch commit must be leased on the expected stamp head"
     )
+    assert "track_progress" not in text, (
+        "claude-code-action's track_progress is only supported on PR/issue "
+        "events; this workflow runs on workflow_dispatch/workflow_call, "
+        "where passing it is a hard error before the agent starts"
+    )
     call_half = text[text.index('if [ -n "$PREP_BRANCH" ]') :]
     call_half = call_half[: call_half.index("# Dispatch mode")]
     assert "::error::" in call_half and "skip_notes" in call_half, (


### PR DESCRIPTION
## Closes / Refs

Refs #1055 (Phase 4). Refs fastmcp-server-template#421 (fixed template-first on fastmcp-server-template#422, commit `0aab303`; mirrored here).

## What & why

The first live `draft-notes` run ([Release Prepare run 32172425941](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/32172425941), 4.0.0-rc.2) failed before the drafting agent started:

```
Action failed with error: track_progress is only supported for events: pull_request, issues, issue_comment, pull_request_review_comment, pull_request_review. Current event: workflow_dispatch
```

`claude-code-action` supports `track_progress` only on PR/issue events, and `release-notes.yml` only ever runs on `workflow_dispatch` / `workflow_call` — so every drafting run was doomed at step start (the old `release: published` trigger would have hit the same wall; this was latent, never exercised live). This PR removes the input (`display_report` stays) and adds a contract-test assertion pinning its absence.

The failure itself validated the merge gate: the prepare run failed loudly and release PR #1092 stayed draft, exactly as designed.

## After merge

Re-dispatch Release Prepare (`channel: rc`) on `main` — it recreates the prep branch (still 4.0.0-rc.2) and the notes job runs on the fixed workflow.

## Local review

- [x] Contract suite 36 passed; ruff + format clean; YAML parses.
- [x] No `!` — CI/workflow-only change, no operator or library surface.

## Docs impact

- [x] None — workflow-internal input removal; the documented notes flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHH41hbWNyk57DDYree1ha

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHH41hbWNyk57DDYree1ha)_