### PR TITLE
fix(release): make the notes drafting agent able to write — and safe to run

### DIFF
--- a/.claude/skills/writing-release-notes/SKILL.md
+++ b/.claude/skills/writing-release-notes/SKILL.md
@@ -180,15 +180,16 @@ A list of tools shipped is the failure mode, not the deliverable.
 
 Do **not** trust `!` markers or `BREAKING CHANGE:` footers — trials found
 them wrong in both directions. Derive the section from the actual surfaces
-between `PREV` and `RANGE_END` (`git show` accepts a SHA where the tag does
-not exist yet), classified against the breaking-change policy in
-`CLAUDE.md` (operator surface and public library interface, assessed against
-the last stable):
+between `PREV` and `RANGE_END`, read through the API — you have no local
+git (`gh api "repos/OWNER/REPO/contents/PATH?ref=REF" --jq .content |
+base64 -d`; the ref accepts a tag or a commit SHA, so the same call covers
+prepare-time drafting where the tag does not exist yet) — classified
+against the breaking-change policy in `CLAUDE.md` (operator surface and
+public library interface, assessed against the last stable):
 
-- import surface: diff `tests/public_import_surface.txt` at the two tags
-  (`git show PREV:tests/public_import_surface.txt`);
-- operator surface: diff `.env.example` / the config surface at the two tags;
-- tool surface: compare the registered-tools docs at the two tags (not
+- import surface: diff `tests/public_import_surface.txt` at the two refs;
+- operator surface: diff `.env.example` / the config surface at the two refs;
+- tool surface: compare the registered-tools docs at the two refs (not
   breaking on its own, but worth a migration note when behaviour moved).
 
 Where your classification disagrees with a commit's marker, follow the

--- a/.claude/skills/writing-release-notes/SKILL.md
+++ b/.claude/skills/writing-release-notes/SKILL.md
@@ -181,11 +181,12 @@ A list of tools shipped is the failure mode, not the deliverable.
 Do **not** trust `!` markers or `BREAKING CHANGE:` footers — trials found
 them wrong in both directions. Derive the section from the actual surfaces
 between `PREV` and `RANGE_END`, read through the API — you have no local
-git (`gh api "repos/OWNER/REPO/contents/PATH?ref=REF" --jq .content |
-base64 -d`; the ref accepts a tag or a commit SHA, so the same call covers
-prepare-time drafting where the tag does not exist yet) — classified
-against the breaking-change policy in `CLAUDE.md` (operator surface and
-public library interface, assessed against the last stable):
+git (`gh api "repos/OWNER/REPO/contents/PATH?ref=REF" -H "Accept:
+application/vnd.github.raw"` returns the file body directly, no decoding
+pipeline needed; the ref accepts a tag or a commit SHA, so the same call
+covers prepare-time drafting where the tag does not exist yet) —
+classified against the breaking-change policy in `CLAUDE.md` (operator
+surface and public library interface, assessed against the last stable):
 
 - import surface: diff `tests/public_import_surface.txt` at the two refs;
 - operator surface: diff `.env.example` / the config surface at the two refs;

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -63,14 +63,17 @@ on:
 permissions:
   contents: read
 
+# One notes run at a time, END TO END.  Serialising per job would let
+# the draft job release the lock before its landing ran, and GitHub
+# keeps only one pending entry per group — a queued newer draft could
+# replace the pending landing, stranding a finished draft unlanded.
+concurrency:
+  group: release-notes-draft
+  cancel-in-progress: false
+
 jobs:
   draft:
     runs-on: ubuntu-latest
-    # Serialise drafts: two quick successive releases would race on the same
-    # index page and branch namespace.
-    concurrency:
-      group: release-notes-draft
-      cancel-in-progress: false
     timeout-minutes: 60
     permissions:
       contents: read       # the agent only reads; the landing job pushes
@@ -415,9 +418,6 @@ jobs:
   land:
     needs: draft
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-notes-draft
-      cancel-in-progress: false
     timeout-minutes: 15
     permissions:
       contents: read       # pushes use RELEASE_TOKEN, not GITHUB_TOKEN

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -386,7 +386,7 @@ jobs:
           # Python.  The job's `contents: read` keeps the agent from
           # pushing anything.
           claude_args: |
-            --allowedTools "Skill,Task,Read,Glob,Grep,Edit(docs/releases/**),Edit(.vale/styles/config/vocabularies/**),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs build --strict)"
+            --allowedTools "Skill,Task,Read,Glob,Grep,Edit(docs/releases/**),Edit(.vale/styles/config/vocabularies/Base/accept.txt),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs build --strict)"
 
       # The agent is done; everything after this line treats this runner
       # as compromised.  The surface ships to a FRESH runner as an

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -302,10 +302,13 @@ jobs:
           # Read-only GitHub research (MCP read tools + gh api), Task for the
           # per-theme fan-out, Skill to load the contract, vale + mkdocs for
           # the quality loop, and read-only git for tag-to-tag surface diffs.
-          # Edit/Write stay available from the action's defaults; the job's
+          # The file tools are listed explicitly: in headless mode
+          # --allowedTools IS the allowlist — nothing is inherited from the
+          # action, and the first live run had every page write denied before
+          # failing the watermark gate (template#421).  The job's
           # `contents: read` keeps the agent from pushing anything.
           claude_args: |
-            --allowedTools "Skill,Task,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *),Bash(git tag *),Bash(git show *),Bash(git diff *),Bash(git log *)"
+            --allowedTools "Skill,Task,Read,Write,Edit,Glob,Grep,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *),Bash(git tag *),Bash(git show *),Bash(git diff *),Bash(git log *)"
 
       - name: Land the drafted page
         env:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -479,6 +479,13 @@ jobs:
             if cmp -s "$src" "$base"; then
               return 0    # the draft left this file as it found it
             fi
+            if [ "$base" != /dev/null ] && [ ! -f "$dst" ]; then
+              # Edit-versus-delete divergence: the draft changed a file
+              # the base deleted while it ran.  Copying would silently
+              # resurrect the deleted file; a human decides.
+              echo "::error::${dst} was deleted on the base while the draft edited it — resolve by hand and re-run the drafting job"
+              exit 1
+            fi
             if [ -f "$dst" ] && ! cmp -s "$dst" "$base"; then
               merged="$(mktemp)"
               cp "$src" "$merged"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -130,10 +130,9 @@ jobs:
           # content and belongs in that PR's diff, and the tree there (base
           # plus knope's stamps) is exactly the state the page describes.
           # Dispatch mode: the default branch, where the accumulated pages
-          # live.  Research is API-driven, but full depth supplies the tags
-          # for the previous-stable computation and the tag-to-tag surface
-          # diffs (import surface, env examples) the upgrade section
-          # derives from.
+          # live.  Research is API-driven (the agent has no local git);
+          # full depth supplies the tags for the context step's
+          # previous-stable computation.
           ref: ${{ inputs.prep_branch || steps.discover.outputs.prep_branch || github.event.repository.default_branch }}
           fetch-depth: 0
           # PAT, so the push below triggers CI on the release PR (call
@@ -312,17 +311,18 @@ jobs:
           include_fix_links: false
           # Read-only GitHub research (MCP read tools + gh api), Task for the
           # per-theme fan-out, Skill to load the contract, vale + mkdocs for
-          # the quality loop, and read-only git for tag-to-tag surface diffs.
-          # The file tools are listed explicitly: in headless mode
-          # --allowedTools IS the allowlist — nothing is inherited from the
-          # action, and the first live run had every page write denied before
-          # failing the watermark gate (template#421).  Write/Edit are scoped
-          # to the notes surface the landing step commits: an unscoped write
-          # tool would let a prompt-injected research source plant git
-          # config or hooks that the credentialed landing step executes.
-          # The job's `contents: read` keeps the agent from pushing anything.
+          # the quality loop.  The file tools are listed explicitly: in
+          # headless mode --allowedTools IS the allowlist — nothing is
+          # inherited from the action, and the first live run had every page
+          # write denied before failing the watermark gate (template#421).
+          # Write/Edit are scoped to the notes surface the landing step
+          # commits, and the agent gets NO local git: read-oriented git
+          # commands still carry arbitrary-file-write flags (git log
+          # --output=...) that would bypass the write scoping, and the skill
+          # reads tags and files-at-refs through the API instead.  The
+          # job's `contents: read` keeps the agent from pushing anything.
           claude_args: |
-            --allowedTools "Skill,Task,Read,Glob,Grep,Write(docs/releases/**),Edit(docs/releases/**),Write(.vale/styles/config/vocabularies/**),Edit(.vale/styles/config/vocabularies/**),Write(.release-notes-pr-body.md),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *),Bash(git tag *),Bash(git show *),Bash(git diff *),Bash(git log *)"
+            --allowedTools "Skill,Task,Read,Glob,Grep,Write(docs/releases/**),Edit(docs/releases/**),Write(.vale/styles/config/vocabularies/**),Edit(.vale/styles/config/vocabularies/**),Write(.release-notes-pr-body.md),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *)"
 
       - name: Land the drafted page
         env:
@@ -336,19 +336,41 @@ jobs:
           RANGE_END: ${{ steps.ctx.outputs.range_end }}
         run: |
           set -euo pipefail
+          # The drafting agent ran in THIS checkout on research-controlled
+          # input, so nothing here is trustworthy as git state: planted
+          # config (core.fsmonitor, credential helpers, hooks) would
+          # execute on the first git command a credentialed step runs.
+          # The landing therefore treats the agent's tree as DATA only —
+          # the notes surface is copied out, and every git operation runs
+          # in a fresh clone the agent never touched, with inherited
+          # credential helpers reset and gh's named per invocation.
           # Only the notes surface is ever committed: the release pages and
           # any vocabulary the Vale loop legitimately added.
           ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
+          BODY=.release-notes-pr-body.md
+          SURFACE="$RUNNER_TEMP/notes-surface"
+          rm -rf "$SURFACE"
+          mkdir -p "$SURFACE"
+          [ ! -d docs/releases ] || cp -R docs/releases "$SURFACE/releases"
+          [ ! -f "$ACCEPT" ] || cp "$ACCEPT" "$SURFACE/accept.txt"
+          [ ! -f "$BODY" ] || cp "$BODY" "$SURFACE/body.md"
+          LAND="$RUNNER_TEMP/land"
+          rm -rf "$LAND"
+          git -c credential.helper= -c 'credential.helper=!gh auth git-credential' \
+            clone --quiet --single-branch --branch "${PREP_BRANCH:-$DEFAULT}" \
+            "https://github.com/${REPO}.git" "$LAND"
+          cd "$LAND"
           git config user.name "github-actions"
           git config user.email "actions@users.noreply.github.com"
-          # This step must not trust git state the agent could have
-          # influenced: every commit and push below runs with working-tree
-          # hooks disabled, and every network call resets inherited
-          # credential helpers before naming gh's per invocation — nothing
-          # the checkout carries can execute here or see the PAT.
-          GIT_PUSH=(git -c credential.helper= \
-            -c 'credential.helper=!gh auth git-credential' \
-            -c core.hooksPath=/dev/null push)
+          if [ -d "$SURFACE/releases" ]; then
+            rm -rf docs/releases
+            mkdir -p docs
+            cp -R "$SURFACE/releases" docs/releases
+          fi
+          if [ -f "$SURFACE/accept.txt" ]; then
+            mkdir -p "$(dirname "$ACCEPT")"
+            cp "$SURFACE/accept.txt" "$ACCEPT"
+          fi
           if [ -n "$PREP_BRANCH" ]; then
             # Call mode: the page is release content — commit it onto the
             # release PR's prep branch so the release PR's diff carries it
@@ -373,13 +395,14 @@ jobs:
               accepted_head="$EXPECTED_HEAD"
             else
               git add docs/releases "$ACCEPT"
-              git -c core.hooksPath=/dev/null commit -m "docs(releases): notes for ${TAG}"
+              git commit -m "docs(releases): notes for ${TAG}"
               # Lease on the stamp head this draft was cut against: a
               # Release Prepare re-dispatch force-recreates the prep
               # branch, and a stale draft must never clobber the newer
               # prepare — the lease fails this push loudly instead; the
               # newer dispatch's own draft-notes job owns the branch.
-              "${GIT_PUSH[@]}" --force-with-lease="${PREP_BRANCH}:${EXPECTED_HEAD}" \
+              git -c credential.helper= -c 'credential.helper=!gh auth git-credential' \
+                push --force-with-lease="${PREP_BRANCH}:${EXPECTED_HEAD}" \
                 origin "HEAD:${PREP_BRANCH}"
               accepted_head="$(git rev-parse HEAD)"
             fi
@@ -411,21 +434,22 @@ jobs:
             echo "no notes changes produced — skipping PR"
             exit 0
           fi
-          BODY=.release-notes-pr-body.md
-          if [ ! -f "$BODY" ]; then
+          BODYFILE="$SURFACE/body.md"
+          if [ ! -f "$BODYFILE" ]; then
             {
               echo "Agent-drafted release notes for ${TAG} (the drafting run left no PR body; review the page against its inline evidence links)."
               echo
               echo "Refs: https://github.com/${REPO}/releases/tag/${TAG}"
-            } > "$BODY"
+            } > "$BODYFILE"
           fi
           BRANCH="release-notes/${TAG}"
           git checkout -B "$BRANCH"
           git add docs/releases "$ACCEPT"
-          git -c core.hooksPath=/dev/null commit -m "docs(releases): release notes for ${TAG}"
+          git commit -m "docs(releases): release notes for ${TAG}"
           # Force: a re-dispatch for the same tag replaces the previous draft.
-          "${GIT_PUSH[@]}" --force origin "HEAD:${BRANCH}"
+          git -c credential.helper= -c 'credential.helper=!gh auth git-credential' \
+            push --force origin "HEAD:${BRANCH}"
           gh pr create --base "$DEFAULT" --head "$BRANCH" \
             --title "docs(releases): release notes for ${TAG}" \
-            --body-file "$BODY" \
+            --body-file "$BODYFILE" \
             || echo "PR for ${BRANCH} already exists — the force-push updated it"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -263,15 +263,24 @@ jobs:
           PAGE: ${{ steps.ctx.outputs.page }}
         run: |
           set -euo pipefail
-          ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
-          mkdir -p docs/releases "$(dirname "$ACCEPT")"
-          [ -f "$PAGE" ] || : > "$PAGE"
-          [ -f docs/releases/index.md ] || : > docs/releases/index.md
-          [ -f "$ACCEPT" ] || : > "$ACCEPT"
-          [ -f .release-notes-pr-body.md ] || : > .release-notes-pr-body.md
           PRE="$RUNNER_TEMP/pre-notes"
           rm -rf "$PRE"
           mkdir -p "$PRE"
+          # Record every file seeded into being: a seeded placeholder that
+          # is absent from the landing clone is the first release of its
+          # series, not a concurrent deletion.
+          : > "$PRE/seeded.txt"
+          seed() {
+            [ -f "$1" ] && return 0
+            mkdir -p "$(dirname "$1")"
+            : > "$1"
+            echo "$1" >> "$PRE/seeded.txt"
+          }
+          ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
+          seed "$PAGE"
+          seed docs/releases/index.md
+          seed "$ACCEPT"
+          seed .release-notes-pr-body.md
           cp -R docs/releases "$PRE/releases"
           cp "$ACCEPT" "$PRE/accept.txt"
 
@@ -474,15 +483,18 @@ jobs:
           # three-way merged, failing loudly on overlap — a silent
           # clobber would revert the concurrent change.
           overlay() {
-            src="$1"; base="$2"; dst="$3"
+            src="$1"; base="$2"; dst="$3"; relpath="$4"
             [ -f "$base" ] || base=/dev/null
             if cmp -s "$src" "$base"; then
               return 0    # the draft left this file as it found it
             fi
-            if [ "$base" != /dev/null ] && [ ! -f "$dst" ]; then
+            if [ "$base" != /dev/null ] && [ ! -f "$dst" ] \
+              && ! grep -qxF "$relpath" "$PRE/seeded.txt"; then
               # Edit-versus-delete divergence: the draft changed a file
               # the base deleted while it ran.  Copying would silently
-              # resurrect the deleted file; a human decides.
+              # resurrect the deleted file; a human decides.  A SEEDED
+              # baseline is exempt — its absence from the clone means the
+              # first release of its series, not a deletion.
               echo "::error::${dst} was deleted on the base while the draft edited it — resolve by hand and re-run the drafting job"
               exit 1
             fi
@@ -502,11 +514,12 @@ jobs:
           if [ -d "$SURFACE/releases" ]; then
             while IFS= read -r -d '' f; do
               rel="${f#"$SURFACE"/releases/}"
-              overlay "$f" "$PRE/releases/$rel" "$LAND/docs/releases/$rel"
+              overlay "$f" "$PRE/releases/$rel" "$LAND/docs/releases/$rel" \
+                "docs/releases/$rel"
             done < <(find "$SURFACE/releases" -type f -print0)
           fi
           if [ -f "$SURFACE/accept.txt" ]; then
-            overlay "$SURFACE/accept.txt" "$PRE/accept.txt" "$LAND/$ACCEPT"
+            overlay "$SURFACE/accept.txt" "$PRE/accept.txt" "$LAND/$ACCEPT" "$ACCEPT"
           fi
           if [ -n "$PREP_BRANCH" ]; then
             # Call mode: the page is release content — commit it onto the

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -144,10 +144,11 @@ jobs:
           # into the working tree.  The drafting agent has unrestricted
           # Read, and a prompt-injected research source must never be able
           # to lift a persisted credential out of .git/config into content
-          # the landing step publishes.  Steps that need network git
-          # authenticate per-step via `gh auth setup-git`, whose helper
-          # holds no secret on disk and only works where GH_TOKEN is in
-          # that step's env — which the agent step's is not.
+          # the landing step publishes.  Steps that need network git name
+          # gh's credential helper per invocation (with inherited helpers
+          # reset), so no credential state ever lives on disk and the
+          # helper resolves only where GH_TOKEN is in that step's env —
+          # which the agent step's is not.
           persist-credentials: false
 
       - name: Resolve release context
@@ -159,9 +160,6 @@ jobs:
           SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
-          # Credentials are not persisted by the checkout; the fetch
-          # fallback below authenticates through gh's credential helper.
-          gh auth setup-git
           TAG="$INPUT_TAG"
           if [ -n "$TARGET_VERSION" ]; then
             # Prepare-time mode: the tag does not exist yet.  Key everything
@@ -186,7 +184,7 @@ jobs:
             # commands could not resolve the ref NAME later.
             if git rev-parse -q --verify "${SOURCE_REF}^{commit}" > /dev/null; then
               RANGE_END="$(git rev-parse "${SOURCE_REF}^{commit}")"
-            elif git fetch -q origin "$SOURCE_REF"; then
+            elif git -c credential.helper= -c 'credential.helper=!gh auth git-credential' fetch -q origin "$SOURCE_REF"; then
               RANGE_END="$(git rev-parse FETCH_HEAD)"
             else
               echo "::error::source_ref '${SOURCE_REF}' is neither a known commit nor fetchable from origin"
@@ -318,10 +316,13 @@ jobs:
           # The file tools are listed explicitly: in headless mode
           # --allowedTools IS the allowlist — nothing is inherited from the
           # action, and the first live run had every page write denied before
-          # failing the watermark gate (template#421).  The job's
-          # `contents: read` keeps the agent from pushing anything.
+          # failing the watermark gate (template#421).  Write/Edit are scoped
+          # to the notes surface the landing step commits: an unscoped write
+          # tool would let a prompt-injected research source plant git
+          # config or hooks that the credentialed landing step executes.
+          # The job's `contents: read` keeps the agent from pushing anything.
           claude_args: |
-            --allowedTools "Skill,Task,Read,Write,Edit,Glob,Grep,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *),Bash(git tag *),Bash(git show *),Bash(git diff *),Bash(git log *)"
+            --allowedTools "Skill,Task,Read,Glob,Grep,Write(docs/releases/**),Edit(docs/releases/**),Write(.vale/styles/config/vocabularies/**),Edit(.vale/styles/config/vocabularies/**),Write(.release-notes-pr-body.md),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *),Bash(git tag *),Bash(git show *),Bash(git diff *),Bash(git log *)"
 
       - name: Land the drafted page
         env:
@@ -340,10 +341,14 @@ jobs:
           ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
           git config user.name "github-actions"
           git config user.email "actions@users.noreply.github.com"
-          # The checkout did not persist credentials (the agent step must
-          # not see them); this step's pushes authenticate through gh's
-          # credential helper with the PAT from this step's env.
-          gh auth setup-git
+          # This step must not trust git state the agent could have
+          # influenced: every commit and push below runs with working-tree
+          # hooks disabled, and every network call resets inherited
+          # credential helpers before naming gh's per invocation — nothing
+          # the checkout carries can execute here or see the PAT.
+          GIT_PUSH=(git -c credential.helper= \
+            -c 'credential.helper=!gh auth git-credential' \
+            -c core.hooksPath=/dev/null push)
           if [ -n "$PREP_BRANCH" ]; then
             # Call mode: the page is release content — commit it onto the
             # release PR's prep branch so the release PR's diff carries it
@@ -368,13 +373,13 @@ jobs:
               accepted_head="$EXPECTED_HEAD"
             else
               git add docs/releases "$ACCEPT"
-              git commit -m "docs(releases): notes for ${TAG}"
+              git -c core.hooksPath=/dev/null commit -m "docs(releases): notes for ${TAG}"
               # Lease on the stamp head this draft was cut against: a
               # Release Prepare re-dispatch force-recreates the prep
               # branch, and a stale draft must never clobber the newer
               # prepare — the lease fails this push loudly instead; the
               # newer dispatch's own draft-notes job owns the branch.
-              git push --force-with-lease="${PREP_BRANCH}:${EXPECTED_HEAD}" \
+              "${GIT_PUSH[@]}" --force-with-lease="${PREP_BRANCH}:${EXPECTED_HEAD}" \
                 origin "HEAD:${PREP_BRANCH}"
               accepted_head="$(git rev-parse HEAD)"
             fi
@@ -417,9 +422,9 @@ jobs:
           BRANCH="release-notes/${TAG}"
           git checkout -B "$BRANCH"
           git add docs/releases "$ACCEPT"
-          git commit -m "docs(releases): release notes for ${TAG}"
+          git -c core.hooksPath=/dev/null commit -m "docs(releases): release notes for ${TAG}"
           # Force: a re-dispatch for the same tag replaces the previous draft.
-          git push --force origin "HEAD:${BRANCH}"
+          "${GIT_PUSH[@]}" --force origin "HEAD:${BRANCH}"
           gh pr create --base "$DEFAULT" --head "$BRANCH" \
             --title "docs(releases): release notes for ${TAG}" \
             --body-file "$BODY" \

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -238,6 +238,33 @@ jobs:
             echo "mode=$mode"
           } >> "$GITHUB_OUTPUT"
 
+      # Two jobs before the agent runs, while the tree is still trusted.
+      # SEED: pre-create the files a draft may need to bring into being
+      # (the target page, the PR-body file, the vocabulary, a first-ever
+      # index) so the agent works entirely through Edit — Edit(path)
+      # rules are the only path-scoped file gate Claude Code consults.
+      # Seeding runs after mode resolution: an empty page must not flip
+      # the mode away from `new`.  SNAPSHOT: copy the pre-draft notes
+      # surface aside so the landing step can overlay ONLY files this
+      # draft changed — an hour-long agent run must never revert notes
+      # changes that merged concurrently on the base.
+      - name: Seed and snapshot the notes surface
+        env:
+          PAGE: ${{ steps.ctx.outputs.page }}
+        run: |
+          set -euo pipefail
+          ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
+          mkdir -p docs/releases "$(dirname "$ACCEPT")"
+          [ -f "$PAGE" ] || : > "$PAGE"
+          [ -f docs/releases/index.md ] || : > docs/releases/index.md
+          [ -f "$ACCEPT" ] || : > "$ACCEPT"
+          [ -f .release-notes-pr-body.md ] || : > .release-notes-pr-body.md
+          PRE="$RUNNER_TEMP/pre-notes"
+          rm -rf "$PRE"
+          mkdir -p "$PRE"
+          cp -R docs/releases "$PRE/releases"
+          cp "$ACCEPT" "$PRE/accept.txt"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -315,17 +342,22 @@ jobs:
           # headless mode --allowedTools IS the allowlist — nothing is
           # inherited from the action, and the first live run had every page
           # write denied before failing the watermark gate (template#421).
-          # Write/Edit are scoped to the notes surface the landing step
-          # commits, and the agent gets NO local git: read-oriented git
-          # commands still carry arbitrary-file-write flags (git log
-          # --output=...) that would bypass the write scoping, and the skill
-          # reads tags and files-at-refs through the API instead.  mkdocs is
-          # pinned to the exact quality-gate invocation — with a wildcard,
-          # `-f` would build an agent-written config whose `hooks:` execute
-          # arbitrary Python.  The job's `contents: read` keeps the agent
-          # from pushing anything.
+          # File mutation is scoped to the notes surface the landing step
+          # commits, via Edit(path) rules — the only path-scoped file gate
+          # Claude Code consults, covering the Write tool as well (a
+          # Write(path) rule is accepted but never matched).  The seed step
+          # above pre-creates the files a draft may need, so Edit suffices
+          # even where Write-tool creation is unavailable.  The agent gets
+          # NO local git: read-oriented git commands still carry
+          # arbitrary-file-write flags (git log --output=...) that would
+          # bypass the write scoping, and the skill reads tags and
+          # files-at-refs through the API instead.  mkdocs is pinned to the
+          # exact quality-gate invocation — with a wildcard, `-f` would
+          # build an agent-written config whose `hooks:` execute arbitrary
+          # Python.  The job's `contents: read` keeps the agent from
+          # pushing anything.
           claude_args: |
-            --allowedTools "Skill,Task,Read,Glob,Grep,Write(docs/releases/**),Edit(docs/releases/**),Write(.vale/styles/config/vocabularies/**),Edit(.vale/styles/config/vocabularies/**),Write(.release-notes-pr-body.md),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs build --strict)"
+            --allowedTools "Skill,Task,Read,Glob,Grep,Edit(docs/releases/**),Edit(.vale/styles/config/vocabularies/**),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs build --strict)"
 
       - name: Land the drafted page
         env:
@@ -371,12 +403,24 @@ jobs:
           cd "$LAND"
           git config user.name "github-actions"
           git config user.email "actions@users.noreply.github.com"
+          # Overlay ONLY files this draft changed, judged against the
+          # pre-draft snapshot — the checkout is an hour old, and pages
+          # it never touched must keep the fresh clone's state so notes
+          # changes that merged concurrently are not reverted.
+          PRE="$RUNNER_TEMP/pre-notes"
           if [ -d "$SURFACE/releases" ]; then
-            rm -rf docs/releases
-            mkdir -p docs
-            cp -R "$SURFACE/releases" docs/releases
+            (cd "$SURFACE/releases" && find . -type f -print0) \
+              | while IFS= read -r -d '' f; do
+              rel="${f#./}"
+              if [ ! -f "$PRE/releases/$rel" ] \
+                || ! cmp -s "$SURFACE/releases/$rel" "$PRE/releases/$rel"; then
+                mkdir -p "docs/releases/$(dirname "$rel")"
+                cp "$SURFACE/releases/$rel" "docs/releases/$rel"
+              fi
+            done
           fi
-          if [ -f "$SURFACE/accept.txt" ]; then
+          if [ -f "$SURFACE/accept.txt" ] \
+            && ! cmp -s "$SURFACE/accept.txt" "$PRE/accept.txt"; then
             mkdir -p "$(dirname "$ACCEPT")"
             cp "$SURFACE/accept.txt" "$ACCEPT"
           fi
@@ -444,7 +488,9 @@ jobs:
             exit 0
           fi
           BODYFILE="$SURFACE/body.md"
-          if [ ! -f "$BODYFILE" ]; then
+          # -s: the seed step pre-creates the body file empty; an empty
+          # body means the agent left none.
+          if [ ! -s "$BODYFILE" ]; then
             {
               echo "Agent-drafted release notes for ${TAG} (the drafting run left no PR body; review the page against its inline evidence links)."
               echo

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -140,15 +140,28 @@ jobs:
           # mode) or on the standalone notes PR (dispatch mode) —
           # GITHUB_TOKEN pushes trigger no workflows.
           token: ${{ secrets.RELEASE_TOKEN }}
+          # The PAT authenticates the checkout ONLY — it must not survive
+          # into the working tree.  The drafting agent has unrestricted
+          # Read, and a prompt-injected research source must never be able
+          # to lift a persisted credential out of .git/config into content
+          # the landing step publishes.  Steps that need network git
+          # authenticate per-step via `gh auth setup-git`, whose helper
+          # holds no secret on disk and only works where GH_TOKEN is in
+          # that step's env — which the agent step's is not.
+          persist-credentials: false
 
       - name: Resolve release context
         id: ctx
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           INPUT_TAG: ${{ inputs.tag }}
           TARGET_VERSION: ${{ inputs.target_version }}
           SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
+          # Credentials are not persisted by the checkout; the fetch
+          # fallback below authenticates through gh's credential helper.
+          gh auth setup-git
           TAG="$INPUT_TAG"
           if [ -n "$TARGET_VERSION" ]; then
             # Prepare-time mode: the tag does not exist yet.  Key everything
@@ -327,6 +340,10 @@ jobs:
           ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
           git config user.name "github-actions"
           git config user.email "actions@users.noreply.github.com"
+          # The checkout did not persist credentials (the agent step must
+          # not see them); this step's pushes authenticate through gh's
+          # credential helper with the PAT from this step's env.
+          gh auth setup-git
           if [ -n "$PREP_BRANCH" ]; then
             # Call mode: the page is release content — commit it onto the
             # release PR's prep branch so the release PR's diff carries it

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -73,10 +73,19 @@ jobs:
       cancel-in-progress: false
     timeout-minutes: 60
     permissions:
-      contents: read       # the agent only reads; the PR push uses RELEASE_TOKEN
+      contents: read       # the agent only reads; the landing job pushes
       issues: read
       pull-requests: read
       id-token: write
+    # Everything the landing job needs, resolved BEFORE the agent ran:
+    # job outputs are captured from each step's completion, so nothing
+    # the agent later does on this runner can alter them.
+    outputs:
+      tag: ${{ steps.ctx.outputs.tag }}
+      page: ${{ steps.ctx.outputs.page }}
+      range_end: ${{ steps.ctx.outputs.range_end }}
+      prep_branch: ${{ inputs.prep_branch || steps.discover.outputs.prep_branch }}
+      expected_head: ${{ inputs.expected_head || steps.discover.outputs.expected_head }}
     steps:
       # Manual target_version re-drafts land on the open release PR's prep
       # branch, exactly like the prepare-time run — a re-draft that opened
@@ -135,25 +144,23 @@ jobs:
           # previous-stable computation.
           ref: ${{ inputs.prep_branch || steps.discover.outputs.prep_branch || github.event.repository.default_branch }}
           fetch-depth: 0
-          # PAT, so the push below triggers CI on the release PR (call
-          # mode) or on the standalone notes PR (dispatch mode) —
-          # GITHUB_TOKEN pushes trigger no workflows.
-          token: ${{ secrets.RELEASE_TOKEN }}
-          # The PAT authenticates the checkout ONLY — it must not survive
-          # into the working tree.  The drafting agent has unrestricted
-          # Read, and a prompt-injected research source must never be able
-          # to lift a persisted credential out of .git/config into content
-          # the landing step publishes.  Steps that need network git name
-          # gh's credential helper per invocation (with inherited helpers
-          # reset), so no credential state ever lives on disk and the
-          # helper resolves only where GH_TOKEN is in that step's env —
-          # which the agent step's is not.
+          # The release PAT never touches this job's runner — the default
+          # GITHUB_TOKEN authenticates the checkout, and even it is not
+          # persisted: the drafting agent has unrestricted Read, and a
+          # prompt-injected research source must never be able to lift a
+          # credential out of .git/config into content the landing job
+          # publishes.  The context step's fetch fallback names gh's
+          # credential helper per invocation with GH_TOKEN in that step's
+          # env; the PAT-credentialed pushes live in the separate landing
+          # job.
           persist-credentials: false
 
       - name: Resolve release context
         id: ctx
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          # Read-only fetch fallback — GITHUB_TOKEN, never the PAT: the
+          # release PAT must not exist anywhere in this job.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_TAG: ${{ inputs.tag }}
           TARGET_VERSION: ${{ inputs.target_version }}
           SOURCE_REF: ${{ inputs.source_ref }}
@@ -265,6 +272,16 @@ jobs:
           cp -R docs/releases "$PRE/releases"
           cp "$ACCEPT" "$PRE/accept.txt"
 
+      # Uploaded BEFORE the agent runs — the landing job's trusted
+      # baseline for "what did this draft actually change".
+      - name: Upload the pre-draft snapshot
+        uses: actions/upload-artifact@v7
+        with:
+          name: notes-pre
+          path: ${{ runner.temp }}/pre-notes
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -359,34 +376,16 @@ jobs:
           claude_args: |
             --allowedTools "Skill,Task,Read,Glob,Grep,Edit(docs/releases/**),Edit(.vale/styles/config/vocabularies/**),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs build --strict)"
 
-      - name: Land the drafted page
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          # No global or system git config in the credentialed step: a
-          # gadget that reached $HOME (or injected env via GITHUB_ENV —
-          # explicit step env overrides it) must not hand git a
-          # core.fsmonitor or credential helper to execute here.
-          GIT_CONFIG_GLOBAL: /dev/null
-          GIT_CONFIG_SYSTEM: /dev/null
-          TAG: ${{ steps.ctx.outputs.tag }}
-          DEFAULT: ${{ github.event.repository.default_branch }}
-          REPO: ${{ github.repository }}
-          PREP_BRANCH: ${{ inputs.prep_branch || steps.discover.outputs.prep_branch }}
-          EXPECTED_HEAD: ${{ inputs.expected_head || steps.discover.outputs.expected_head }}
-          PAGE: ${{ steps.ctx.outputs.page }}
-          RANGE_END: ${{ steps.ctx.outputs.range_end }}
+      # The agent is done; everything after this line treats this runner
+      # as compromised.  The surface ships to a FRESH runner as an
+      # artifact — data, not environment — because an agent able to run
+      # any output-producing command could have poisoned this runner
+      # beyond the tree: $GITHUB_PATH prepends, $GITHUB_ENV injections,
+      # overwritten executables under $RUNNER_TEMP.  No credentialed
+      # step runs here.
+      - name: Collect the drafted surface
         run: |
           set -euo pipefail
-          # The drafting agent ran in THIS checkout on research-controlled
-          # input, so nothing here is trustworthy as git state: planted
-          # config (core.fsmonitor, credential helpers, hooks) would
-          # execute on the first git command a credentialed step runs.
-          # The landing therefore treats the agent's tree as DATA only —
-          # the notes surface is copied out, and every git operation runs
-          # in a fresh clone the agent never touched, with inherited
-          # credential helpers reset and gh's named per invocation.
-          # Only the notes surface is ever committed: the release pages and
-          # any vocabulary the Vale loop legitimately added.
           ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
           BODY=.release-notes-pr-body.md
           SURFACE="$RUNNER_TEMP/notes-surface"
@@ -395,6 +394,71 @@ jobs:
           [ ! -d docs/releases ] || cp -R docs/releases "$SURFACE/releases"
           [ ! -f "$ACCEPT" ] || cp "$ACCEPT" "$SURFACE/accept.txt"
           [ ! -f "$BODY" ] || cp "$BODY" "$SURFACE/body.md"
+
+      - name: Upload the drafted surface
+        uses: actions/upload-artifact@v7
+        with:
+          name: notes-surface
+          path: ${{ runner.temp }}/notes-surface
+          if-no-files-found: error
+          retention-days: 1
+
+  # The landing runs on a FRESH runner: the drafting agent executes
+  # research-controlled input, and an allowlisted command with shell
+  # output redirection could poison the drafting runner for its later
+  # steps — $GITHUB_PATH prepends, $GITHUB_ENV injections (LD_PRELOAD,
+  # GIT_*), executables overwritten under $RUNNER_TEMP and re-run by a
+  # later allowlisted call.  A separate job discards all of it; only
+  # the two artifacts (treated as data) and the draft job's outputs
+  # (finalized before the agent ran) cross over.  The PAT exists only
+  # in this job.
+  land:
+    needs: draft
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-notes-draft
+      cancel-in-progress: false
+    timeout-minutes: 15
+    permissions:
+      contents: read       # pushes use RELEASE_TOKEN, not GITHUB_TOKEN
+    steps:
+      - name: Download the drafted surface
+        uses: actions/download-artifact@v8
+        with:
+          name: notes-surface
+          path: ${{ runner.temp }}/notes-surface
+
+      - name: Download the pre-draft snapshot
+        uses: actions/download-artifact@v8
+        with:
+          name: notes-pre
+          path: ${{ runner.temp }}/pre-notes
+
+      - name: Land the drafted page
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          # No global or system git config in the credentialed step —
+          # nothing may hand git a core.fsmonitor or credential helper
+          # to execute here.
+          GIT_CONFIG_GLOBAL: /dev/null
+          GIT_CONFIG_SYSTEM: /dev/null
+          TAG: ${{ needs.draft.outputs.tag }}
+          DEFAULT: ${{ github.event.repository.default_branch }}
+          REPO: ${{ github.repository }}
+          PREP_BRANCH: ${{ needs.draft.outputs.prep_branch }}
+          EXPECTED_HEAD: ${{ needs.draft.outputs.expected_head }}
+          PAGE: ${{ needs.draft.outputs.page }}
+          RANGE_END: ${{ needs.draft.outputs.range_end }}
+        run: |
+          set -euo pipefail
+          # The artifacts are DATA from an untrusted producer; all git
+          # runs in this job's own fresh clone, with inherited credential
+          # helpers reset and gh's named per invocation.  Only the notes
+          # surface is ever committed: the release pages and any
+          # vocabulary the Vale loop legitimately added.
+          ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
+          SURFACE="$RUNNER_TEMP/notes-surface"
+          PRE="$RUNNER_TEMP/pre-notes"
           LAND="$RUNNER_TEMP/land"
           rm -rf "$LAND"
           git -c credential.helper= -c 'credential.helper=!gh auth git-credential' \
@@ -404,25 +468,38 @@ jobs:
           git config user.name "github-actions"
           git config user.email "actions@users.noreply.github.com"
           # Overlay ONLY files this draft changed, judged against the
-          # pre-draft snapshot — the checkout is an hour old, and pages
-          # it never touched must keep the fresh clone's state so notes
-          # changes that merged concurrently are not reverted.
-          PRE="$RUNNER_TEMP/pre-notes"
-          if [ -d "$SURFACE/releases" ]; then
-            (cd "$SURFACE/releases" && find . -type f -print0) \
-              | while IFS= read -r -d '' f; do
-              rel="${f#./}"
-              if [ ! -f "$PRE/releases/$rel" ] \
-                || ! cmp -s "$SURFACE/releases/$rel" "$PRE/releases/$rel"; then
-                mkdir -p "docs/releases/$(dirname "$rel")"
-                cp "$SURFACE/releases/$rel" "docs/releases/$rel"
+          # pre-draft snapshot — the draft is an hour old, and files it
+          # never touched keep the fresh clone's state.  A file BOTH the
+          # draft and the base changed (index entries, vocabulary) is
+          # three-way merged, failing loudly on overlap — a silent
+          # clobber would revert the concurrent change.
+          overlay() {
+            src="$1"; base="$2"; dst="$3"
+            [ -f "$base" ] || base=/dev/null
+            if cmp -s "$src" "$base"; then
+              return 0    # the draft left this file as it found it
+            fi
+            if [ -f "$dst" ] && ! cmp -s "$dst" "$base"; then
+              merged="$(mktemp)"
+              cp "$src" "$merged"
+              if ! git merge-file "$merged" "$base" "$dst"; then
+                echo "::error::concurrent change to ${dst} conflicts with the draft — re-run the drafting job against the current base"
+                exit 1
               fi
-            done
+              mv "$merged" "$dst"
+              return 0
+            fi
+            mkdir -p "$(dirname "$dst")"
+            cp "$src" "$dst"
+          }
+          if [ -d "$SURFACE/releases" ]; then
+            while IFS= read -r -d '' f; do
+              rel="${f#"$SURFACE"/releases/}"
+              overlay "$f" "$PRE/releases/$rel" "$LAND/docs/releases/$rel"
+            done < <(find "$SURFACE/releases" -type f -print0)
           fi
-          if [ -f "$SURFACE/accept.txt" ] \
-            && ! cmp -s "$SURFACE/accept.txt" "$PRE/accept.txt"; then
-            mkdir -p "$(dirname "$ACCEPT")"
-            cp "$SURFACE/accept.txt" "$ACCEPT"
+          if [ -f "$SURFACE/accept.txt" ]; then
+            overlay "$SURFACE/accept.txt" "$PRE/accept.txt" "$LAND/$ACCEPT"
           fi
           if [ -n "$PREP_BRANCH" ]; then
             # Call mode: the page is release content — commit it onto the

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -319,14 +319,23 @@ jobs:
           # commits, and the agent gets NO local git: read-oriented git
           # commands still carry arbitrary-file-write flags (git log
           # --output=...) that would bypass the write scoping, and the skill
-          # reads tags and files-at-refs through the API instead.  The
-          # job's `contents: read` keeps the agent from pushing anything.
+          # reads tags and files-at-refs through the API instead.  mkdocs is
+          # pinned to the exact quality-gate invocation — with a wildcard,
+          # `-f` would build an agent-written config whose `hooks:` execute
+          # arbitrary Python.  The job's `contents: read` keeps the agent
+          # from pushing anything.
           claude_args: |
-            --allowedTools "Skill,Task,Read,Glob,Grep,Write(docs/releases/**),Edit(docs/releases/**),Write(.vale/styles/config/vocabularies/**),Edit(.vale/styles/config/vocabularies/**),Write(.release-notes-pr-body.md),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *)"
+            --allowedTools "Skill,Task,Read,Glob,Grep,Write(docs/releases/**),Edit(docs/releases/**),Write(.vale/styles/config/vocabularies/**),Edit(.vale/styles/config/vocabularies/**),Write(.release-notes-pr-body.md),Edit(.release-notes-pr-body.md),mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs build --strict)"
 
       - name: Land the drafted page
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          # No global or system git config in the credentialed step: a
+          # gadget that reached $HOME (or injected env via GITHUB_ENV —
+          # explicit step env overrides it) must not hand git a
+          # core.fsmonitor or credential helper to execute here.
+          GIT_CONFIG_GLOBAL: /dev/null
+          GIT_CONFIG_SYSTEM: /dev/null
           TAG: ${{ steps.ctx.outputs.tag }}
           DEFAULT: ${{ github.event.repository.default_branch }}
           REPO: ${{ github.repository }}

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -536,6 +536,26 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "and copy only files the draft changed — never revert concurrent "
         "notes changes with an hour-old checkout"
     )
+    assert "git merge-file" in text, (
+        "a file both the draft and the base changed must be three-way "
+        "merged, failing loudly on overlap — a silent clobber reverts "
+        "the concurrent change"
+    )
+    assert "\n  land:\n    needs: draft" in text, (
+        "the landing must run in a SEPARATE job on a fresh runner — the "
+        "drafting runner may be poisoned beyond the tree (GITHUB_PATH, "
+        "GITHUB_ENV, overwritten executables) and the PAT must never "
+        "exist on it"
+    )
+    draft_half = text[: text.index("\n  land:")]
+    assert "RELEASE_TOKEN" not in draft_half, (
+        "no step of the draft job may carry the release PAT — it exists "
+        "only in the landing job"
+    )
+    assert "notes-surface" in text and "notes-pre" in text, (
+        "the surface and the pre-draft snapshot must cross jobs as "
+        "artifacts — data, not environment"
+    )
     assert "persist-credentials: false" in text, (
         "the checkout must not persist the release PAT — the agent's "
         "unrestricted Read would let a prompt-injected research source "

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -541,6 +541,10 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "merged, failing loudly on overlap — a silent clobber reverts "
         "the concurrent change"
     )
+    assert "deleted on the base" in text, (
+        "an edit-versus-delete divergence must fail loudly — copying "
+        "would silently resurrect the file the base deleted"
+    )
     assert "\n  land:\n    needs: draft" in text, (
         "the landing must run in a SEPARATE job on a fresh runner — the "
         "drafting runner may be poisoned beyond the tree (GITHUB_PATH, "

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -516,6 +516,16 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "explicitly — in headless mode the flag IS the allowlist, nothing "
         "is inherited, and without them every page write is denied"
     )
+    assert "persist-credentials: false" in text, (
+        "the checkout must not persist the release PAT — the agent's "
+        "unrestricted Read would let a prompt-injected research source "
+        "lift it out of .git/config into published content"
+    )
+    assert text.count("gh auth setup-git") >= 2, (
+        "with no persisted credentials, the context step's fetch fallback "
+        "and the landing step's pushes must each authenticate per-step "
+        "via gh's credential helper"
+    )
     call_half = text[text.index('if [ -n "$PREP_BRANCH" ]') :]
     call_half = call_half[: call_half.index("# Dispatch mode")]
     assert "::error::" in call_half and "skip_notes" in call_half, (

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -556,6 +556,11 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "the surface and the pre-draft snapshot must cross jobs as "
         "artifacts — data, not environment"
     )
+    assert text.count("concurrency:") == 1 and "\nconcurrency:\n" in text, (
+        "concurrency must be workflow-level, covering draft and landing "
+        "end to end — with per-job groups a queued newer draft can "
+        "replace the pending landing, stranding a finished draft"
+    )
     assert "persist-credentials: false" in text, (
         "the checkout must not persist the release PAT — the agent's "
         "unrestricted Read would let a prompt-injected research source "

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -511,6 +511,11 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "events; this workflow runs on workflow_dispatch/workflow_call, "
         "where passing it is a hard error before the agent starts"
     )
+    assert "Read,Write,Edit,Glob,Grep" in text, (
+        "the drafting agent's --allowedTools must list the file tools "
+        "explicitly — in headless mode the flag IS the allowlist, nothing "
+        "is inherited, and without them every page write is denied"
+    )
     call_half = text[text.index('if [ -n "$PREP_BRANCH" ]') :]
     call_half = call_half[: call_half.index("# Dispatch mode")]
     assert "::error::" in call_half and "skip_notes" in call_half, (

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -545,6 +545,12 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "an edit-versus-delete divergence must fail loudly — copying "
         "would silently resurrect the file the base deleted"
     )
+    assert "seeded.txt" in text, (
+        "the seed step must record which files it created, and the "
+        "divergence check must exempt them — a seeded placeholder absent "
+        "from the landing clone is the first release of its series, not "
+        "a concurrent deletion"
+    )
     assert "\n  land:\n    needs: draft" in text, (
         "the landing must run in a SEPARATE job on a fresh runner — the "
         "drafting runner may be poisoned beyond the tree (GITHUB_PATH, "

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -511,14 +511,30 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "events; this workflow runs on workflow_dispatch/workflow_call, "
         "where passing it is a hard error before the agent starts"
     )
-    assert "Write(docs/releases/" in text and "Edit(docs/releases/" in text, (
+    assert "Edit(docs/releases/" in text, (
         "the drafting agent needs the file tools explicitly (in headless "
-        "mode --allowedTools IS the allowlist), scoped to the notes surface"
+        "mode --allowedTools IS the allowlist), scoped to the notes "
+        "surface via Edit(path) — the only path-scoped file gate Claude "
+        "Code consults, covering the Write tool as well"
+    )
+    allowlist = next(line for line in text.splitlines() if '--allowedTools "' in line)
+    assert "Write(" not in allowlist, (
+        "Write(path) rules are accepted but never matched — a dead rule "
+        "in the allowlist would suggest scoping that does not exist"
     )
     assert ",Write," not in text and ",Edit," not in text, (
         "no unscoped Write/Edit may appear in the allowlist — an unscoped "
         "write tool lets a prompt-injected research source plant git "
         "config or hooks that the credentialed landing step executes"
+    )
+    assert "Seed and snapshot the notes surface" in text and "pre-notes" in text, (
+        "the trusted pre-agent step must seed the files a draft may "
+        "create (so Edit suffices) and snapshot the pre-draft surface"
+    )
+    assert "cmp -s" in text, (
+        "the landing overlay must compare against the pre-draft snapshot "
+        "and copy only files the draft changed — never revert concurrent "
+        "notes changes with an hour-old checkout"
     )
     assert "persist-credentials: false" in text, (
         "the checkout must not persist the release PAT — the agent's "

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -549,6 +549,16 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
     assert "gh auth setup-git" not in text, (
         "no global credential-helper setup — auth is per-invocation only"
     )
+    assert "Bash(uv run mkdocs build --strict)" in text, (
+        "mkdocs must be pinned to the exact quality-gate invocation — a "
+        "wildcard admits -f with an agent-written config whose hooks "
+        "execute arbitrary Python"
+    )
+    assert "mkdocs *" not in text, "no mkdocs wildcard may reappear in the allowlist"
+    assert "GIT_CONFIG_GLOBAL: /dev/null" in text, (
+        "the credentialed landing step must read no global git config — "
+        "a gadget reaching $HOME must not hand git code to execute there"
+    )
     call_half = text[text.index('if [ -n "$PREP_BRANCH" ]') :]
     call_half = call_half[: call_half.index("# Dispatch mode")]
     assert "::error::" in call_half and "skip_notes" in call_half, (

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -511,20 +511,34 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "events; this workflow runs on workflow_dispatch/workflow_call, "
         "where passing it is a hard error before the agent starts"
     )
-    assert "Read,Write,Edit,Glob,Grep" in text, (
-        "the drafting agent's --allowedTools must list the file tools "
-        "explicitly — in headless mode the flag IS the allowlist, nothing "
-        "is inherited, and without them every page write is denied"
+    assert "Write(docs/releases/" in text and "Edit(docs/releases/" in text, (
+        "the drafting agent needs the file tools explicitly (in headless "
+        "mode --allowedTools IS the allowlist), scoped to the notes surface"
+    )
+    assert ",Write," not in text and ",Edit," not in text, (
+        "no unscoped Write/Edit may appear in the allowlist — an unscoped "
+        "write tool lets a prompt-injected research source plant git "
+        "config or hooks that the credentialed landing step executes"
     )
     assert "persist-credentials: false" in text, (
         "the checkout must not persist the release PAT — the agent's "
         "unrestricted Read would let a prompt-injected research source "
         "lift it out of .git/config into published content"
     )
-    assert text.count("gh auth setup-git") >= 2, (
-        "with no persisted credentials, the context step's fetch fallback "
-        "and the landing step's pushes must each authenticate per-step "
-        "via gh's credential helper"
+    assert "-c credential.helper= " in text.replace("\\\n", " ") and (
+        "credential.helper=!gh auth git-credential" in text
+    ), (
+        "network git must reset inherited credential helpers and name "
+        "gh's per invocation — a helper planted in the checkout must "
+        "never run with the PAT in scope"
+    )
+    assert "core.hooksPath=/dev/null" in text, (
+        "the landing step's commits and pushes must ignore working-tree "
+        "hooks — agent-influenced state must not execute in the "
+        "credentialed step"
+    )
+    assert "gh auth setup-git" not in text, (
+        "no global credential-helper setup — auth is per-invocation only"
     )
     call_half = text[text.index('if [ -n "$PREP_BRANCH" ]') :]
     call_half = call_half[: call_half.index("# Dispatch mode")]

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -532,10 +532,19 @@ def test_notes_workflow_is_callable_and_not_release_triggered() -> None:
         "gh's per invocation — a helper planted in the checkout must "
         "never run with the PAT in scope"
     )
-    assert "core.hooksPath=/dev/null" in text, (
-        "the landing step's commits and pushes must ignore working-tree "
-        "hooks — agent-influenced state must not execute in the "
-        "credentialed step"
+    assert "Bash(git" not in text, (
+        "the drafting agent gets no local git — read-oriented git "
+        "commands still carry arbitrary-file-write flags (git log "
+        "--output=...) that bypass the write-tool scoping; the skill "
+        "reads tags and files-at-refs through the API instead"
+    )
+    assert 'clone --quiet --single-branch --branch "${PREP_BRANCH:-$DEFAULT}"' in (
+        text
+    ), (
+        "the landing step must run git only in a fresh clone — the "
+        "agent's checkout is data, not git state, and planted config "
+        "(core.fsmonitor, helpers, hooks) would execute on the first "
+        "git command there"
     )
     assert "gh auth setup-git" not in text, (
         "no global credential-helper setup — auth is per-invocation only"


### PR DESCRIPTION
## Closes / Refs

Refs #1055 (Phase 4). Refs fastmcp-server-template#421 (all fixes template-first on fastmcp-server-template#422; mirrored here commit-for-commit).

## What & why

The second live `draft-notes` run ([Release Prepare run 32177731228](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/32177731228)) got past the action start (#1094), researched for 13 minutes — then had **every page write denied** (34 permission denials): in headless mode `--allowedTools` **is** the allowlist, nothing is inherited, and the file tools weren't in it. The watermark gate correctly refused the empty result and kept release PR #1092 draft.

Fixing that opened a security review chain (five Codex P1/P2 rounds plus claude-review findings), each verified and fixed. The end state, by construction rather than enumeration:

**The drafting job is fully untrusted and fully boxed:**
- File mutation scoped via `Edit(path)` rules — the only path-scoped file gate Claude Code consults (dead `Write(path)` rules removed); a trusted pre-agent step **seeds** every file a draft may need to create and records what it seeded, so `Edit` suffices regardless of Write-tool semantics on the pinned CLI.
- **No local git** (read-oriented git commands carry arbitrary-write flags like `git log --output=…`); the skill reads tags and files-at-refs through the API's raw media type — no decoder pipeline.
- **mkdocs pinned to the exact invocation** — a wildcard admitted `-f` with an agent-written config whose `hooks:` execute arbitrary Python.
- **No credentials anywhere in the job**: checkout on the unpersisted `GITHUB_TOKEN`; the release PAT never touches this runner.

**The landing runs as a separate job on a fresh runner** — because an agent able to run any output-producing command could poison the drafting runner beyond the tree (`$GITHUB_PATH` prepends, `$GITHUB_ENV` injections, overwritten executables):
- Only the drafted surface and a pre-draft snapshot cross over, as artifacts treated strictly as data; the draft job's outputs were finalized before the agent ran. The PAT exists only here.
- The overlay copies **only files the draft changed**; a file both the draft and the base changed is **three-way merged** (loud failure on overlap), an edit-versus-delete divergence fails loudly, and seeded placeholders are exempt so a new minor's first release lands.
- Fresh clone, per-invocation credential helper with inherited helpers reset, `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pinned to `/dev/null`.
- One workflow-level `concurrency` group covers draft and landing end to end, so a queued newer run can never displace a pending landing.

Contract tests pin every property.

## After merge

Re-dispatch Release Prepare (`channel: rc`) on `main` — the third live notes run then has everything it needs: the action starts, the agent can write the page (and only the page), and the landing is safe.

## Local review

- [x] Contract suite 36 passed; ruff + format clean; YAML structure and bash syntax checked on every edited step; two-job split validated structurally.
- [x] No `!` — CI/workflow-only change, no operator or library surface.

## Docs impact

- [x] `writing-release-notes` skill updated in the same commits (API-based file-at-ref reads replace `git show`) — the notes flow's operator docs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHH41hbWNyk57DDYree1ha