### PR TITLE
ci: bound, cache and decouple the docs workflow's Chromium install

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
     # Validation only: strict docs build. Never deploys; publishing happens
     # in `deploy` on release:published.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -50,7 +51,34 @@ jobs:
       - name: Install browser test deps
         run: uv sync --no-default-groups --all-extras --group docs --group browser --frozen
 
+      # `playwright install --with-deps` shells out to
+      #   sudo -- sh -c "apt-get update && apt-get install -y --no-install-recommends <libs>"
+      # with stdio inherited, no timeout and no retry, so an apt that blocks
+      # blocks the step for as long as the job is allowed to live.  Two of the
+      # things that make apt block on a hosted runner are configurable, but not
+      # through this step's `env:` — playwright elevates with plain `sudo`, and
+      # sudo resets the environment.  Both are therefore set as config files
+      # apt and needrestart read for themselves.
+      - name: Make apt non-blocking for the Playwright dependency install
+        run: |
+          # The image's periodic-upgrade units hold the dpkg lock; apt waits on
+          # it forever unless told otherwise.  Stop them, then bound the wait.
+          sudo systemctl stop apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
+          sudo systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service 2>/dev/null || true
+          printf 'DPkg::Lock::Timeout "120";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99-lock-timeout >/dev/null
+          # Never stop for a conffile prompt on a stdin that will not answer.
+          printf 'DPkg::Options { "--force-confdef"; "--force-confold"; };\n' \
+            | sudo tee /etc/apt/apt.conf.d/99-noninteractive >/dev/null
+          sudo mkdir -p /etc/needrestart/conf.d
+          printf '$nrconf{restart} = "a";\n$nrconf{kernelhints} = 0;\n' \
+            | sudo tee /etc/needrestart/conf.d/99-noninteractive.conf >/dev/null
+
       - name: Install Chromium
+        # Backstop for anything the hardening above does not cover: fail in
+        # bounded time so the run is re-runnable, rather than occupying a
+        # runner until the job timeout.
+        timeout-minutes: 8
         run: uv run playwright install --with-deps chromium
 
       - name: Run config-wizard browser tests
@@ -88,6 +116,7 @@ jobs:
       group: ${{ github.workflow }}-deploy-${{ github.event_name }}
       cancel-in-progress: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,35 +51,37 @@ jobs:
       - name: Install browser test deps
         run: uv sync --no-default-groups --all-extras --group docs --group browser --frozen
 
-      # `playwright install --with-deps` shells out to
-      #   sudo -- sh -c "apt-get update && apt-get install -y --no-install-recommends <libs>"
-      # with stdio inherited, no timeout and no retry, so an apt that blocks
-      # blocks the step for as long as the job is allowed to live.  Two of the
-      # things that make apt block on a hosted runner are configurable, but not
-      # through this step's `env:` — playwright elevates with plain `sudo`, and
-      # sudo resets the environment.  Both are therefore set as config files
-      # apt and needrestart read for themselves.
-      - name: Make apt non-blocking for the Playwright dependency install
-        run: |
-          # The image's periodic-upgrade units hold the dpkg lock; apt waits on
-          # it forever unless told otherwise.  Stop them, then bound the wait.
-          sudo systemctl stop apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
-          sudo systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service 2>/dev/null || true
-          printf 'DPkg::Lock::Timeout "120";\n' \
-            | sudo tee /etc/apt/apt.conf.d/99-lock-timeout >/dev/null
-          # Never stop for a conffile prompt on a stdin that will not answer.
-          printf 'DPkg::Options { "--force-confdef"; "--force-confold"; };\n' \
-            | sudo tee /etc/apt/apt.conf.d/99-noninteractive >/dev/null
-          sudo mkdir -p /etc/needrestart/conf.d
-          printf '$nrconf{restart} = "a";\n$nrconf{kernelhints} = 0;\n' \
-            | sudo tee /etc/needrestart/conf.d/99-noninteractive.conf >/dev/null
+      # Playwright's browser archives only change when the pinned version
+      # does, so cache them rather than pulling ~300 MB from the CDN each run.
+      # `playwright install` checks this directory itself and skips the
+      # download when it is populated, so no cache-hit conditional is needed.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: playwright-${{ runner.os }}-
 
+      # Split from the dependency install below, which is the unreliable half.
+      # This half only talks to Playwright's CDN, so the browser the tests need
+      # no longer depends on apt being reachable.
       - name: Install Chromium
-        # Backstop for anything the hardening above does not cover: fail in
-        # bounded time so the run is re-runnable, rather than occupying a
-        # runner until the job timeout.
         timeout-minutes: 8
-        run: uv run playwright install --with-deps chromium
+        run: uv run playwright install chromium
+
+      # apt on the hosted runners intermittently stalls (template#430, and
+      # upstream actions/runner-images#11347 / microsoft/playwright#34297, both
+      # unresolved).  On ubuntu-latest this step installs font packages only —
+      # the Chromium shared libraries already ship on the image — so a mirror
+      # outage should cost glyph coverage for CJK/Cyrillic/Thai text, not the
+      # whole job.  The failure stays visible in the log rather than silent.
+      #
+      # Projects doing visual or screenshot comparison, where fallback glyphs
+      # would be a real regression, should drop `continue-on-error` here.
+      - name: Install Chromium system dependencies (fonts)
+        timeout-minutes: 5
+        continue-on-error: true
+        run: uv run playwright install-deps chromium
 
       - name: Run config-wizard browser tests
         # Both the template-owned smoke suite and the project-owned domain suite


### PR DESCRIPTION
## Closes / Refs

Closes #1097. Upstream companions: pvliesdonk/fastmcp-server-template#425
(merged) and pvliesdonk/fastmcp-server-template#431 (open).

## What & why

Two `Documentation` runs were observed wedged on `Install Chromium` for 43 and
27 minutes — [#1719](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/32216914248)
on `main`, and [#1721](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/32217900100/job/95962739692),
which was release PR #1092's check — while run #1720, started between them,
finished in two minutes. Neither job in `docs.yml` declared `timeout-minutes`,
so a stalled `apt-get update` inside `playwright install --with-deps` held a
runner toward GitHub's 6-hour default.

Two commits, in the order the evidence arrived.

**`44bf22e` — bound it.** `timeout-minutes: 15` on both jobs (`docs.yml` was the
only workflow here with no bound) and a step-level bound on the install. This
fired on its first real encounter, turning a would-be six-hour wedge into an
eight-minute failure — and because the job terminated instead of hanging, its
log became retrievable, which is what produced the diagnosis below.

**`ba9fe54` — cache and decouple it.** The log showed `apt-get update` going
silent for 7m34s after falling back from the runner mirrorlist's
`azure.archive.ubuntu.com` to `archive.ubuntu.com`. That is a known, unresolved
condition of the hosted runners, not something this repo can fix:
[actions/runner-images#11347](https://github.com/actions/runner-images/issues/11347)
and [microsoft/playwright#34297](https://github.com/microsoft/playwright/issues/34297)
report this exact command hanging, against a long tail of mirror-instability
reports. So this commit stops the workflow depending on it:

- **Cache `~/.cache/ms-playwright`** on a `uv.lock` hash. ~300 MB of Chrome for
  Testing (184.3 MiB), headless shell (114.7 MiB) and FFmpeg came off the CDN
  every run, for archives that change only when the pinned Playwright version
  does. No cache-hit conditional is needed — `playwright install` inspects that
  directory itself.
- **Split `--with-deps`.** `[verified: read the apt output of a successful
  run]` on `ubuntu-latest` it installs nine font packages and no Chromium
  shared libraries — those already ship on the image. The CDN-only browser
  download now gates the job; the font install is bounded and allowed to fail
  visibly. A mirror outage costs CJK/Cyrillic/Thai glyph coverage on that run
  instead of costing the run.

An intermediate commit adding `Acquire::*::Timeout` / `Acquire::Retries` bounds
was dropped, not squashed: it was tested here and the stall recurred unchanged,
so it is not in this branch.

## The judgement call

`continue-on-error: true` on the font step is the one debatable line — right
for DOM-assertion browser tests like the config-wizard suite, wrong for visual
or screenshot comparison where fallback glyphs would be a silent regression.
The comment at the change site says so and names the remedy.

## Why this repo and not only the template

`docs.yml` is template-owned and re-rendered by `copier update`, so the durable
fix belongs upstream and is filed there. This applies it now rather than waiting
for the next template bump, because the wedge was parking a release PR's check.
The file is byte-identical to
pvliesdonk/fastmcp-server-template#431's render — verified by diffing against
`docs.yml.jinja` with the `{% raw %}` markers stripped — so the update carrying
it is a no-op here, with no conflict to resolve.

## What this PR deliberately does NOT do

- **Does not fix the apt stall.** Established as upstream and unresolved; this
  removes its ability to fail the job rather than curing it.
- **Does not explain why `Acquire::*::Timeout` failed to fire.** Per
  `apt.conf(5)` that value covers the data transfer, so it should have bounded
  a stalled fetch. It did not, and I could not determine why — recorded on
  pvliesdonk/fastmcp-server-template#430 rather than guessed at.
- **Does not add a guard that every workflow job declares `timeout-minutes`.**
  Deferred upstream where the workflows are owned:
  pvliesdonk/fastmcp-server-template#426.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening.
- [x] No commit carries `!`. One CI workflow file: no env var, config file,
      CLI flag, deployment layout, on-disk state format, or importable name.

## Docs impact

- [ ] `README.md`
- [ ] `docs/` site pages
- [ ] `docs/design/`
- [ ] Inline docstrings

None apply: workflow-internal, no documented behaviour or interface changed.

## Verification

The diff touches no Python, so the gates that can be affected are the contract
tests that read workflow files:

```
uv run pytest tests/test_release_flow_contract.py tests/test_commit_conventions.py \
              tests/test_structural_gate.py -q   -> 70 passed, 1 skipped
```

`yaml.safe_load` confirms the step shape: `build` 15m, `deploy` 15m,
`Install Chromium` 8m, `Install Chromium system dependencies (fonts)` 5m with
`continue-on-error: true`.