### PR TITLE
test: fence writer trace-hook install before builder start in sync-rebuild test

### DIFF
--- a/tests/test_index_coordinator.py
+++ b/tests/test_index_coordinator.py
@@ -12,7 +12,7 @@ import pytest
 
 from markdown_vault_mcp.exceptions import IndexUnavailableError
 from markdown_vault_mcp.fts_index import FTSIndex
-from markdown_vault_mcp.indexing import IndexWriteCoordinator
+from markdown_vault_mcp.indexing import IndexWriteCoordinator, ProcessDirtyPaths
 from markdown_vault_mcp.managers.index import IndexManager
 from markdown_vault_mcp.scanner import HeadingChunker
 from markdown_vault_mcp.tracker import ChangeTracker
@@ -644,6 +644,15 @@ def test_build_index_clears_stale_error_during_sync_rebuild(tmp_path: Path) -> N
     try:
         coord._readiness.fail_build(RuntimeError("stale async failure"))
         assert coord.get_index_status()["status"] == "failed"
+
+        # Fence (#1091): run one no-op job through the writer so its coverage
+        # trace-hook install (triggered by its first traced events under the
+        # 3.11 settrace core) completes before the builder thread bootstraps
+        # its own. Concurrent installs trip CPython 3.11's process-global
+        # settrace reentrancy guard (python/cpython#98257), killing the
+        # builder inside threading._bootstrap_inner before the gated runner
+        # ever runs — with the fence, at most one thread installs at a time.
+        coord.writer.submit(ProcessDirtyPaths()).result(timeout=5)
 
         started = threading.Event()
         proceed = threading.Event()


### PR DESCRIPTION
## Closes / Refs

Closes #1091

## What &amp; why

`test_build_index_clears_stale_error_during_sync_rebuild` flaked four times on the Python 3.11 CI lane (most recently [job 96043820701](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/32245106305/job/96043820701)), always with the same captured unraisable: the builder thread dies inside `threading._bootstrap_inner` at `_sys.settrace(_trace_hook)` with `RuntimeError: Cannot install a trace function while another trace function is being installed`, so the gated runner never runs and `started.wait(timeout=5)` fails. The guard it trips is a **process-global** `static int reentrant` in CPython's `_PyEval_SetTrace` ([python/cpython#98257](https://github.com/python/cpython/issues/98257)), so two threads installing coverage's trace hook concurrently — the coordinator's writer thread (installing on its first traced events) and the test's freshly-bootstrapping builder thread — race, and the loser dies before running its target. Only the 3.11 lane is affected: coverage traces via `sys.monitoring` on 3.12+, which has no such guard.

The fix rounds one no-op `ProcessDirtyPaths` job through the writer before the builder thread starts. The completed round-trip proves the writer's trace-hook installation is finished, so at most one thread ever installs a trace function at a time — the race becomes structurally impossible in this test rather than merely retried. `ProcessDirtyPaths` on an empty dirty set is a pure no-op (`if not paths: return`).

Verified: full suite green locally (3343 passed), the fixed test passes repeatedly under Python 3.11 with `--cov` (the failing lane's configuration), and the fence adds ~no runtime.

## What this PR deliberately does NOT do

- Does not add a bootstrap-retry helper for the other 23 bare `threading.Thread(...)` starts across 6 other test files — the race has only ever fired in this test (4/4 occurrences), and those tests' thread-start patterns differ; the fence pattern here is the template to copy if another test ever exhibits the same `_bootstrap_inner` settrace death. Tracking stays with #1091's history if it recurs elsewhere.
- Does not touch production code — the race lives in the interaction of `threading.Thread` bootstrap with settrace-based coverage tracing, not in the coordinator under test.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening the PR.
- [x] No commit carries `!` — test-only change, no operator or library surface touched.

## Docs impact

- [x] `README.md` — n/a (test-infra only)
- [x] `docs/` site pages — n/a
- [x] `docs/design/` — n/a
- [x] Inline docstrings — the fence carries an explanatory comment with both issue references

**Rule: code without matching docs is incomplete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHH41hbWNyk57DDYree1ha

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHH41hbWNyk57DDYree1ha)_