### PR TITLE
fix(index): never send a blank string to the embedding provider

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -781,6 +781,41 @@ FTS/`document_tags` refresh half-applied while the tracker never advanced,
 so every retry re-detected the same diff and failed identically until a
 cold-boot rebuild ran the resilient batch path instead.
 
+### Blank Embedding Inputs (#1087)
+
+A note with no body — zero-byte, frontmatter-only, or whitespace-only —
+chunks to a single chunk whose `content` is `""`. Under the default (v1)
+embedding format `EmbedTextBuilder.build()` returns that content verbatim,
+so the empty string would be submitted to the provider. Every
+OpenAI-compatible endpoint rejects an empty input string with HTTP 400
+(Voyage: `Input cannot contain empty strings or empty lists`), **and the
+rejection fails the whole request batch, not just the offending element** —
+so on the cold build, which batches across documents, one body-less note
+takes up to `_EMBEDDING_BATCH_SIZE` unrelated chunks down with it.
+
+`embed_text.is_embeddable()` is the single predicate for "may be sent to a
+provider" (non-whitespace text), and every embedding site filters through
+it:
+
+- `IndexManager._embed_inputs()` — the shared builder for the cold build,
+  the inline reindex, and the deferred flush — drops blank entries from
+  both the `texts` and `metadata` lists. Callers already treat an empty
+  result as "no vectors for this path", so a wholly body-less note reaches
+  the existing `delete_by_path` branch.
+- The convergence pass filters the FTS rows **at the source**, before the
+  signature diff, rather than at its embed call. This is load-bearing: the
+  diff compares the FTS row multiset against the sidecar's, so a blank
+  chunk excluded only at embed time would leave the two permanently
+  unequal and re-embed that document on *every* pass.
+
+A body-less note stays fully keyword-searchable through FTS; only its
+vector is skipped, which costs nothing — there is no content to match
+semantically. Under the v2 format the same note builds a non-empty text
+(title, heading, first-chunk preamble) and is embedded as before, so
+enrichment behaviour is unchanged. A sidecar written by a provider that
+did accept empty inputs converges after one re-embed of the affected
+documents.
+
 ### Error Handling
 
 Two-layer model:

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -241,6 +241,26 @@ Regardless of which provider you choose:
 
     For very large vaults (thousands of notes), the first startup may take several minutes. If the process is interrupted mid-build, it will rebuild from scratch on the next startup — partial indices are never persisted.
 
+### Notes with no body
+
+A note with no body is indexed for keyword search but is not embedded. This
+covers zero-byte files, notes that are nothing but frontmatter, and notes
+whose body is only whitespace. These notes hold no text to embed, so they
+carry no semantic signal either way.
+
+The server skips these notes deliberately. Embedding providers reject an empty
+input string with HTTP 400 (Voyage reports `Input cannot contain empty strings
+or empty lists`), and the rejection fails the whole request, so a single
+body-less note used to stop a batch of unrelated notes from being embedded as
+well. On version 3.1.0 it could hold the entire index stale until the file was
+excluded. See issue [#1087](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1087).
+
+Nothing is required of you. The notes still appear in keyword search and in
+`list_documents`, and they gain vectors as soon as they get a body. If you set
+`MARKDOWN_VAULT_MCP_EMBED_CONTEXT` or `MARKDOWN_VAULT_MCP_SEARCHABLE_FIELDS`,
+the enriched input carries the title and frontmatter values, so those notes are
+embedded as before.
+
 ### Slow or CPU-only backends
 
 Each embedding request has a wall-clock budget, `MARKDOWN_VAULT_MCP_EMBED_TIMEOUT_S` (default `30.0` seconds). It applies to the network providers, OpenAI and Ollama. FastEmbed runs in-process with no network call and ignores it.

--- a/src/markdown_vault_mcp/embed_text.py
+++ b/src/markdown_vault_mcp/embed_text.py
@@ -37,6 +37,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def is_embeddable(text: str) -> bool:
+    """Return whether *text* is safe to submit to an embedding provider.
+
+    A note with no body — zero-byte, frontmatter-only, or whitespace-only —
+    chunks to a single chunk whose content is ``""``, and under the default
+    v1 format :meth:`EmbedTextBuilder.build` returns that content verbatim.
+    Every OpenAI-compatible provider rejects an empty input string with a
+    hard HTTP 400 (Voyage: ``Input cannot contain empty strings or empty
+    lists``), and the rejection fails the whole *batch*, not just the
+    offending element (#1087).
+
+    Whitespace-only text is treated the same way: it carries no signal, and
+    providers differ on whether they accept it.
+
+    Args:
+        text: A candidate embedding input, as returned by
+            :meth:`EmbedTextBuilder.build`.
+
+    Returns:
+        ``True`` when *text* has non-whitespace content.
+    """
+    return bool(text.strip())
+
+
 def fields_text(
     frontmatter_or_json: Mapping[str, Any] | str | None,
     fields: Sequence[str],

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from markdown_vault_mcp.embed_text import EmbedTextBuilder
+from markdown_vault_mcp.embed_text import EmbedTextBuilder, is_embeddable
 from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
 from markdown_vault_mcp.fts_index import _derive_folder, should_optimize
 from markdown_vault_mcp.hashing import compute_file_hash
@@ -213,22 +213,38 @@ class IndexManager:
             chunks: The document's chunks, in document order.
 
         Returns:
-            ``(texts, metadata)`` lists of equal length, one entry per chunk.
+            ``(texts, metadata)`` lists of equal length, one entry per
+            *embeddable* chunk. Chunks whose built text is blank are
+            omitted (#1087), so both lists may be shorter than *chunks* —
+            and empty for a body-less note, which every caller already
+            handles as "no vectors for this path".
         """
         fields_text = self._embed_builder.fields_text(frontmatter)
         texts: list[str] = []
         meta: list[dict[str, Any]] = []
         for i, chunk in enumerate(chunks):
             is_first = i == 0
-            texts.append(
-                self._embed_builder.build(
-                    title=title,
-                    heading=chunk.heading,
-                    content=chunk.content,
-                    fields_text=fields_text,
-                    is_first_chunk=is_first,
-                )
+            text = self._embed_builder.build(
+                title=title,
+                heading=chunk.heading,
+                content=chunk.content,
+                fields_text=fields_text,
+                is_first_chunk=is_first,
             )
+            if not is_embeddable(text):
+                # Nothing to embed, and sending it is actively harmful: an
+                # empty input string is a hard HTTP 400 that fails the whole
+                # batch (#1087). The cold build batches across documents, so
+                # one body-less note would take up to _embedding_batch_size
+                # unrelated chunks down with it. The chunk stays keyword-
+                # searchable through FTS; only its vector is skipped.
+                #
+                # ``is_first`` deliberately stays bound to the document's
+                # real chunk 0 rather than shifting to the first *surviving*
+                # chunk: the preamble belongs to chunk 0, and a chunk 0 that
+                # carries a preamble is never blank in the first place.
+                continue
+            texts.append(text)
             meta.append(
                 {
                     "path": path,
@@ -1050,7 +1066,13 @@ class IndexManager:
 
         Chunk identity is the ``(title, heading, content)`` multiset per
         document path — exactly the metadata stored alongside each vector
-        row, so the diff needs no file re-parsing.  Documents present only
+        row, so the diff needs no file re-parsing.  Chunks whose embedding
+        input is blank are excluded from that multiset before the diff runs
+        (#1087), so a body-less note is simply a path with no embeddable
+        chunks: it never enters the comparison, and any vectors it still has
+        are reclaimed through the stale-path branch.  A sidecar written by a
+        provider that *did* accept an empty input sees one re-embed of the
+        affected documents and converges after it.  Documents present only
         in the vector index (deleted or newly excluded while no server
         ran) lose their vectors; documents missing from it are embedded;
         documents whose chunk multiset differs in any way (modified
@@ -1123,6 +1145,28 @@ class IndexManager:
                 if row.get("is_first_chunk")
                 else ""
             )
+            text = self._embed_builder.build(
+                title=row["title"],
+                heading=row["heading"],
+                content=row["content"],
+                fields_text=row["preamble"],
+                is_first_chunk=bool(row.get("is_first_chunk")),
+            )
+            if not is_embeddable(text):
+                # Same filter as _embed_inputs (#1087), but it has to be
+                # applied *here* rather than at the embed call below.
+                # _signature() compares this row set against the sidecar's
+                # rows, so a blank chunk dropped only at embed time would
+                # leave the two multisets permanently unequal and re-embed
+                # the whole document on every convergence pass. Filtering at
+                # the source keeps the comparison, the embed inputs, the
+                # metadata and the up_to_date tally on one row set.
+                continue
+            # Carried on the row so the embed loop below does not rebuild it.
+            # Safe to attach: the sidecar metadata is assembled from named
+            # keys, and _signature() reads only the identity keys, so this
+            # never leaks into a vector row or perturbs the diff.
+            row["embed_text"] = text
             fts_by_path.setdefault(row["path"], []).append(row)
         vec_by_path = vectors.chunks_by_path()
 
@@ -1148,16 +1192,7 @@ class IndexManager:
         # untouched and every other document still converges.
         for path in missing_paths + refresh_paths:
             rows = fts_by_path[path]
-            texts = [
-                self._embed_builder.build(
-                    title=r["title"],
-                    heading=r["heading"],
-                    content=r["content"],
-                    fields_text=r["preamble"],
-                    is_first_chunk=bool(r.get("is_first_chunk")),
-                )
-                for r in rows
-            ]
+            texts = [r["embed_text"] for r in rows]
             # Vector metadata keeps the canonical row shape (plus preamble);
             # the list_chunks-only keys (frontmatter_json, is_first_chunk)
             # must not leak into the sidecar.

--- a/tests/test_embed_text.py
+++ b/tests/test_embed_text.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
 
-from markdown_vault_mcp.embed_text import EmbedTextBuilder, fields_text
+import pytest
 
-if TYPE_CHECKING:
-    import pytest
+from markdown_vault_mcp.embed_text import (
+    EmbedTextBuilder,
+    fields_text,
+    is_embeddable,
+)
 
 # ---------------------------------------------------------------------------
 # fields_text (module-level, shared with the FTS summary column)
@@ -191,3 +193,42 @@ class TestBuildV2:
             is_first_chunk=True,
         )
         assert out == "T\n\nc"
+
+
+class TestIsEmbeddable:
+    """`is_embeddable` gates what may reach an embedding provider (#1087)."""
+
+    @pytest.mark.parametrize(
+        "text",
+        ["", "   ", "\n", "\t\n  \n", "\u00a0"],
+    )
+    def test_blank_text_is_not_embeddable(self, text: str) -> None:
+        assert is_embeddable(text) is False
+
+    @pytest.mark.parametrize(
+        "text",
+        ["a", "# Title", "  body  ", "0", "\n\ncontent\n\n"],
+    )
+    def test_text_with_content_is_embeddable(self, text: str) -> None:
+        assert is_embeddable(text) is True
+
+    def test_v1_build_of_a_body_less_note_is_rejected(self) -> None:
+        """The exact shape that produced the reported HTTP 400 (#1087)."""
+        builder = EmbedTextBuilder()
+        text = builder.build(
+            title="Empty", heading=None, content="", fields_text="", is_first_chunk=True
+        )
+        assert text == ""
+        assert is_embeddable(text) is False
+
+    def test_v2_build_of_a_body_less_note_still_embeds(self) -> None:
+        """Enrichment gives a body-less note real text, so it is kept."""
+        builder = EmbedTextBuilder(embed_context=True, searchable_fields=("summary",))
+        text = builder.build(
+            title="Empty",
+            heading=None,
+            content="",
+            fields_text="A summary.",
+            is_first_chunk=True,
+        )
+        assert is_embeddable(text) is True

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -2104,3 +2104,131 @@ class TestEmbeddingBatchSize:
 
         assert failed == 0
         assert provider.calls == [2, 2, 1]
+
+
+# ---------------------------------------------------------------------------
+# Body-less notes never reach the embedding provider (#1087)
+# ---------------------------------------------------------------------------
+
+
+class _StrictProvider(MockEmbeddingProvider):
+    """Provider that rejects blank input the way a real endpoint does.
+
+    Mirrors the reported failure: OpenAI-compatible endpoints answer an
+    empty input string with HTTP 400 and fail the *whole batch*, not just
+    the offending element (#1087).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Every attempt, including the ones that raise — asserting on
+        # attempts rather than successes is what distinguishes "never sent"
+        # from "sent and rejected".
+        self.calls: list[list[str]] = []
+        self.texts: list[str] = []
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        if any(not t.strip() for t in texts):
+            raise RuntimeError(
+                "OpenAI API error 400: Error for argument 'input': Value error, "
+                "Input cannot contain empty strings or empty lists"
+            )
+        self.texts.extend(texts)
+        return super().embed(texts)
+
+
+def _body_less_vault(tmp_path: Path) -> Path:
+    """A vault holding each reported empty-body shape plus one real note."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "zero.md").write_bytes(b"")
+    (vault / "fm_only.md").write_text(
+        "---\nlast_edited: 2026-08-17\n---\n", encoding="utf-8"
+    )
+    (vault / "whitespace.md").write_text("   \n\n", encoding="utf-8")
+    (vault / "real.md").write_text("# Real\n\nActual body text.\n", encoding="utf-8")
+    return vault
+
+
+class TestBodyLessNotesAreNotEmbedded:
+    """A note with no body must never produce an empty provider input."""
+
+    def _mgr(self, vault: Path, tmp_path: Path, provider: _StrictProvider):
+        return _make_index_mgr(
+            vault,
+            tmp_path,
+            embeddings_path=tmp_path / "embeddings",
+            embedding_provider=provider,
+        )
+
+    def test_cold_build_skips_them_and_embeds_the_rest(self, tmp_path: Path) -> None:
+        provider = _StrictProvider()
+        vault = _body_less_vault(tmp_path)
+        mgr, fts, _holder = self._mgr(vault, tmp_path, provider)
+        mgr.build_index()
+
+        # Would raise from _StrictProvider before the fix: the cold build
+        # batches across documents, so one blank input takes the whole
+        # batch — including real.md — down with it.
+        assert mgr.build_embeddings() == 1
+        assert provider.texts == ["# Real\n\nActual body text."]
+
+        # The body-less notes are still keyword-indexed; only their vectors
+        # are skipped.
+        indexed = {row["path"] for row in fts.list_chunks()}
+        assert {"zero.md", "fm_only.md", "whitespace.md", "real.md"} <= indexed
+
+    def test_hot_reindex_skips_a_note_that_becomes_empty(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        provider = _StrictProvider()
+        vault = _body_less_vault(tmp_path)
+        mgr, _fts, holder = self._mgr(vault, tmp_path, provider)
+        mgr.build_index()
+        mgr.build_embeddings()
+        provider.calls.clear()
+        provider.texts.clear()
+
+        # The failure mode from the report: a note is emptied while the
+        # server runs, and the file watcher's reindex picks it up.
+        (vault / "real.md").write_text("---\ntitle: Real\n---\n", encoding="utf-8")
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            mgr.reindex()
+
+        # Nothing was *sent*, which is the point: before the fix the blank
+        # input went out and came back 400, and the same 400 recurred on
+        # every later reindex of the same file.
+        assert provider.calls == []
+        assert not [
+            r
+            for r in caplog.records
+            if "reindex_inline_embed_failed_docs" in r.getMessage()
+        ]
+        # Its now-stale vectors are dropped rather than left behind.
+        assert "real.md" not in holder["vectors"].chunks_by_path()
+
+    def test_repeated_convergence_does_no_work(self, tmp_path: Path) -> None:
+        """The signature-drift regression guard.
+
+        Blank chunks are filtered out of the FTS row set *before* the
+        convergence diff, not at the embed call. Filtering only at embed
+        time would leave the FTS and sidecar multisets permanently unequal,
+        re-embedding every body-less note's document on every single pass.
+        """
+        provider = _StrictProvider()
+        vault = _body_less_vault(tmp_path)
+        mgr, _fts, _holder = self._mgr(vault, tmp_path, provider)
+        mgr.build_index()
+        mgr.build_embeddings()
+        provider.calls.clear()
+
+        # A converged index must be a genuine no-op, twice over: not one
+        # provider call, not one retried document. Asserting on the return
+        # value alone would not discriminate — a failed re-embed also
+        # reports 0 newly embedded chunks.
+        assert mgr.build_embeddings() == 0
+        assert mgr.build_embeddings() == 0
+        assert provider.calls == []

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -2888,8 +2888,10 @@ class TestEmbeddingsStatus:
         status = semantic_vault.index.embeddings_status()
 
         assert status["available"] is True
-        # 9 documents, each one chunk — chunk_count must match.
-        assert status["chunk_count"] == 9
+        # 9 documents, each one chunk, minus the zero-byte ``empty.md``
+        # fixture: a note with no body is keyword-indexed but never
+        # embedded, because an empty provider input is a hard 400 (#1087).
+        assert status["chunk_count"] == 8
 
     def test_status_reads_json_when_vectors_not_loaded(
         self,
@@ -2943,9 +2945,11 @@ class TestBuildEmbeddings:
     ) -> None:
         """build_embeddings(force=False) converges, not rebuilds, when chunks exist.
 
-        The first call embeds 9 chunks and saves to disk.  The second call (no
-        force) diffs the vector index against the FTS chunk set (#665), finds
-        no drift, embeds nothing, and reports zero newly embedded chunks.
+        The first call embeds 8 chunks and saves to disk (9 documents less
+        the body-less ``empty.md``, which is never embedded — #1087).  The
+        second call (no force) diffs the vector index against the FTS chunk
+        set (#665), finds no drift, embeds nothing, and reports zero newly
+        embedded chunks.
         """
         embeddings_path = tmp_path / "embeddings"
         col = Vault(
@@ -2955,7 +2959,7 @@ class TestBuildEmbeddings:
         )
         col.index.build_index()
         count1 = col.index.build_embeddings()
-        assert count1 == 9
+        assert count1 == 8
 
         # Track embed calls to prove no re-embedding happens.
         original_embed = mock_provider.embed
@@ -3003,7 +3007,8 @@ class TestBuildEmbeddings:
 
         # Re-embedding must have occurred.
         assert len(embed_calls) > 0
-        assert count == 9
+        # 8, not 9: the body-less ``empty.md`` fixture is never embedded (#1087).
+        assert count == 8
 
     def test_build_embeddings_uses_bounded_batches(
         self,
@@ -3032,7 +3037,8 @@ class TestBuildEmbeddings:
         mock_provider.embed = tracking_embed  # type: ignore[method-assign]
 
         count = col.index.build_embeddings(force=True)
-        assert count == 9
+        # 8, not 9: the body-less ``empty.md`` fixture is never embedded (#1087).
+        assert count == 8
 
         # embed() must have been called, and every batch at most _EMBEDDING_BATCH_SIZE.
         assert len(batch_sizes) > 0, "embed() should have been called"


### PR DESCRIPTION
## Closes / Refs

Closes #1087. Refs #1111 (the read-side sibling, filed from this work, not fixed here).

## What &amp; why

A note with no body — zero-byte, frontmatter-only, or whitespace-only — chunks
to a single chunk whose `content` is `""`. Under the default v1 embedding
format `EmbedTextBuilder.build()` returns that content verbatim, so the empty
string went to the provider, which answers HTTP 400 and fails **the whole
request batch**, not just the offending element.

`embed_text.is_embeddable()` is now the single predicate for "may be sent to a
provider", applied at both places embedding inputs are produced:

- **`_embed_inputs()`** drops blank entries from the `texts` and `metadata`
  lists. This covers three of the four embed sites (cold build, inline
  reindex, deferred flush); each already treats an empty result as "no vectors
  for this path", so a wholly body-less note lands on the existing
  `delete_by_path` branch.
- **`_converge_embeddings()`** filters the FTS rows *at the source*, before the
  signature diff. That placement is load-bearing rather than stylistic: the
  diff compares the FTS row multiset against the sidecar's, so a blank chunk
  excluded only at the embed call would leave the two permanently unequal and
  re-embed the document on every pass. The regression test pins exactly this —
  without the source-level filter it observes every document being re-embedded
  on an already-converged index.

A body-less note stays fully keyword-searchable through FTS; only its vector is
skipped. Under the v2 format (`EMBED_CONTEXT` / `SEARCHABLE_FIELDS`) the same
note builds a non-empty text and is embedded exactly as before.

### On the four changed expectations in `test_vault.py`

`tests/fixtures/empty.md` is a zero-byte file, so the shared fixture vault has
carried the trigger for this bug all along; the permissive
`MockEmbeddingProvider` embedded `""` without complaint, which is why no test
ever saw it. Four chunk-count assertions move from 9 to 8. That is the fix
working, not a regression, and each site says so inline.

## What this PR deliberately does NOT do

- **The read-side twin.** `VectorIndex.search` embeds `[query]` unguarded, so
  an empty or whitespace-only `mode="semantic"` query hits the same 400.
  Reproduced and filed as #1111 rather than folded in: it is a read path
  (the call fails, nothing persists, nothing recurs), so it shares neither the
  severity nor the fix location.
- **Suggestion (2) from the issue** — tolerating a per-note provider 4xx in
  `reindex_all` the way #930/#932 tolerates a timeout. That is the deeper
  hardening for *any* provider rejection; this PR removes the specific input
  that provokes the common one. Not separately tracked; say the word and I
  will file it.
- **Changing v2 behaviour.** A body-less note under enrichment still embeds its
  title/preamble text. Suppressing that would be a retrieval-quality decision,
  not a defect fix.
- **Re-attaching the preamble when chunk 0 is filtered.** `is_first` stays
  bound to the document's real chunk 0. The case cannot arise: a chunk 0
  carrying a preamble is never blank.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening. It
      surfaced two things that changed the patch: the convergence-pass
      signature-drift trap (fixing only the embed call would have caused a
      permanent re-embed loop), and #1111. It also caught that two of my three
      new tests passed *without* the source change — they asserted on
      successful embeds rather than on attempts, so they discriminated
      nothing. Both were rewritten to assert on provider calls, and all three
      were then confirmed red against a stashed `src/`.
- [x] No commit carries `!`. No env var, CLI flag, config file, deployment
      layout, or on-disk format changes; the package root's import surface is
      untouched (`is_embeddable` is a submodule name). The vector sidecar
      format is unchanged — an existing sidecar containing vectors for
      body-less notes converges after one re-embed of those documents.

## Docs impact

- [ ] `README.md` — no env var, CLI flag, or install change.
- [x] `docs/` site pages — `docs/guides/embeddings.md` gains a "Notes with no
      body" section explaining that such notes are keyword-indexed but not
      embedded, and why. Vale-clean.
- [x] `docs/design/` — new "Blank Embedding Inputs (#1087)" section recording
      the predicate, both filter sites, and why the convergence filter must sit
      at the source.
- [x] Inline docstrings — `is_embeddable`, `_embed_inputs`'s `Returns` clause,
      and `_converge_embeddings`'s chunk-identity paragraph.

**Rule: code without matching docs is incomplete.**

## Gates

| Gate | Result |
|---|---|
| `pytest -q` | 3439 passed, 21 skipped |
| `ruff check --fix .` → `ruff format .` → `--check` | clean |
| `mypy src/ tests/` | no issues in 192 source files |
| `diff-cover --compare-branch=origin/main` | 100% (12/12 lines) |
| `scripts/structural_gate.sh` | 100%, 0 violations over 267 lines |
| `vale docs README.md` | 0 errors in 42 files |

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMw2pE6dXQJKU617JFZL2Y)_