### PR TITLE
fix(index): persist authoritative empty embedding rebuilds

### DIFF
--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -158,7 +158,9 @@ class IndexManager:
         """
         return is_path_excluded(path, self._exclude_patterns)
 
-    def _discover_indexable_candidates(self) -> list[tuple[Path, str]]:
+    def _discover_indexable_candidates(
+        self, *, on_walk_error: Callable[[OSError], None] | None = None
+    ) -> list[tuple[Path, str]]:
         """Discover markdown files eligible for indexing, with relative paths.
 
         Applies the per-file :meth:`_is_path_excluded` filter as the correctness
@@ -174,7 +176,11 @@ class IndexManager:
             files, in discovery order.
         """
         candidates: list[tuple[Path, str]] = []
-        for abs_path in iter_markdown_files(self._source_dir, self._exclude_patterns):
+        for abs_path in iter_markdown_files(
+            self._source_dir,
+            self._exclude_patterns,
+            on_error=on_walk_error,
+        ):
             if not abs_path.is_file():
                 continue
             # iter_markdown_files yields paths built as source_dir / rel, so
@@ -265,6 +271,52 @@ class IndexManager:
                 "Embeddings require both 'embedding_provider' and "
                 "'embeddings_path' to be configured."
             )
+
+    def _empty_embedding_build_is_authoritative(self, indexed_paths: set[str]) -> bool:
+        """Return whether an empty FTS-derived embedding build is complete.
+
+        A forced FTS rebuild can omit a source that failed parsing, leaving no
+        row for :meth:`build_embeddings` to re-parse. Before replacing an old
+        sidecar with an empty one, inspect only source candidates absent from
+        FTS. Deliberate required-frontmatter skips are authoritative; parse,
+        I/O, and FTS-population gaps are not.
+        """
+        walk_incomplete = False
+
+        def _record_walk_error(_exc: OSError) -> None:
+            nonlocal walk_incomplete
+            walk_incomplete = True
+
+        candidates = self._discover_indexable_candidates(
+            on_walk_error=_record_walk_error
+        )
+        if walk_incomplete:
+            logger.warning("build_embeddings_source_walk_incomplete (no vectors saved)")
+            return False
+
+        for abs_path, path in candidates:
+            if path in indexed_paths:
+                continue
+            outcome = parse_note_categorized(
+                abs_path,
+                self._source_dir,
+                self._chunk_strategy,
+                rel_path=path,
+                title_field=self._title_field,
+                required_frontmatter=self._required_frontmatter,
+                log_context="build_embeddings",
+            )
+            if (
+                isinstance(outcome, CategorizedSkip)
+                and outcome.skip.category == "missing_frontmatter"
+            ):
+                continue
+            logger.warning(
+                "build_embeddings_unindexed_source path=%s (no vectors saved)",
+                path,
+            )
+            return False
+        return True
 
     def _load_vectors(self) -> VectorIndex:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
@@ -920,8 +972,10 @@ class IndexManager:
             also transient API/network errors) is logged and the batch
             skipped, so this may be less than the total number of chunks
             attempted; if every batch is skipped, ``0`` is returned and no
-            vectors are saved.  On the convergence path this counts only the
-            newly embedded chunks — a fully converged index returns ``0``.
+            vectors are saved. A successful build with no embeddable chunks
+            persists an empty index so stale sidecar vectors cannot survive a
+            forced rebuild. On the convergence path this counts only the newly
+            embedded chunks — a fully converged index returns ``0``.
 
         Raises:
             EmbeddingsNotConfiguredError: If ``embedding_provider`` or
@@ -955,10 +1009,12 @@ class IndexManager:
             # Empty index — fall through to the full cold build.
 
         rows = self._fts.list_notes()
+        indexed_paths = {row["path"] for row in rows}
         num_notes = len(rows)
         logger.info("build_embeddings: parsing %d notes into chunks", num_notes)
         texts: list[str] = []
         meta: list[dict[str, Any]] = []
+        had_parse_failure = False
 
         for i, row in enumerate(rows, 1):
             path = row["path"]
@@ -974,6 +1030,7 @@ class IndexManager:
                 )
             except (UnicodeDecodeError, OSError, yaml.YAMLError) as exc:
                 logger.warning("build_embeddings: skipping %s — %s", path, exc)
+                had_parse_failure = True
                 continue
             note_texts, note_meta = self._embed_inputs(
                 path=path,
@@ -1057,8 +1114,17 @@ class IndexManager:
                 "build_embeddings_all_batches_failed total=%d (no vectors saved)",
                 total,
             )
+        elif had_parse_failure:
+            logger.warning(
+                "build_embeddings_parse_failures_with_no_inputs (no vectors saved)"
+            )
+        elif not self._empty_embedding_build_is_authoritative(indexed_paths):
+            logger.warning(
+                "build_embeddings_empty_not_authoritative (no vectors saved)"
+            )
         else:
-            logger.info("build_embeddings: nothing to embed")
+            vectors.save(self._embeddings_path)
+            logger.info("build_embeddings: saved empty index")
         return embedded
 
     def _converge_embeddings(self, vectors: VectorIndex) -> int:

--- a/src/markdown_vault_mcp/utils/fs.py
+++ b/src/markdown_vault_mcp/utils/fs.py
@@ -8,7 +8,7 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Sequence
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -124,6 +124,8 @@ def _should_prune_dir(
 def iter_markdown_files(
     source_dir: Path,
     exclude_patterns: Sequence[str] | None = None,
+    *,
+    on_error: Callable[[OSError], None] | None = None,
 ) -> Iterator[Path]:
     """Yield ``*.md`` files under *source_dir*, pruning excluded subtrees.
 
@@ -155,6 +157,8 @@ def iter_markdown_files(
         exclude_patterns: Exclude glob patterns. Used only to derive directory
             prune rules; ``None`` or empty prunes nothing (the walk still runs
             and yields every ``*.md`` file).
+        on_error: Optional callback invoked after an unreadable-directory error
+            is logged. The walk continues after the callback returns.
 
     Yields:
         Absolute paths to ``*.md`` files, anchored at the unresolved
@@ -169,6 +173,8 @@ def iter_markdown_files(
         # permission-denied or broken-link subtree does not silently disappear
         # from discovery/indexing (#835).
         logger.warning("markdown_walk_dir_unreadable path=%s: %s", exc.filename, exc)
+        if on_error is not None:
+            on_error(exc)
 
     for dirpath, dirnames, filenames in os.walk(
         source_str, onerror=_on_walk_error, followlinks=_WALK_FOLLOWLINKS

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1065,6 +1065,62 @@ class TestBuildEmbeddings:
             for r in caplog.records
         )
 
+    def test_force_rebuild_persists_empty_only_after_successful_parse(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An authoritative empty rebuild replaces stale on-disk vectors."""
+        from markdown_vault_mcp.managers import index as index_module
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        note = vault / "note.md"
+        note.write_text("# Note\n\nBody.\n", encoding="utf-8")
+        embeddings_path = tmp_path / "embeddings"
+        provider = MockEmbeddingProvider()
+        holder: dict = {"vectors": None}
+        mgr, _fts, _ = _make_index_mgr(
+            vault,
+            tmp_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=provider,
+            get_vectors=lambda: holder["vectors"],
+            set_vectors=lambda vectors: holder.__setitem__("vectors", vectors),
+        )
+        mgr.build_index()
+        assert mgr.build_embeddings() == 1
+        assert VectorIndex.load(embeddings_path, provider).count == 1
+
+        # An unreadable source is not authoritative: keep its last good vector.
+        note.write_text("---\ntitle: [unclosed\n---\nbody", encoding="utf-8")
+        assert mgr.build_embeddings(force=True) == 0
+        assert VectorIndex.load(embeddings_path, provider).count == 1
+
+        # The same guarantee must hold after a forced FTS rebuild has skipped
+        # the malformed source and therefore no longer exposes its old row.
+        mgr.build_index(force=True)
+        assert mgr.build_embeddings(force=True) == 0
+        assert VectorIndex.load(embeddings_path, provider).count == 1
+
+        # An incomplete directory walk is equally non-authoritative, even
+        # when the unreadable subtree leaves discovery with no candidates.
+        def incomplete_walk(_source, _excludes, *, on_error=None):
+            if on_error is not None:
+                on_error(PermissionError("unreadable subtree"))
+            return iter(())
+
+        with monkeypatch.context() as patch:
+            patch.setattr(index_module, "iter_markdown_files", incomplete_walk)
+            assert mgr.build_embeddings(force=True) == 0
+            assert VectorIndex.load(embeddings_path, provider).count == 1
+
+        # A successful parse with no embeddable text is authoritative: the
+        # empty index must reach disk so a restart cannot revive stale vectors.
+        note.write_text("---\ntitle: Note\n---\n", encoding="utf-8")
+        mgr.build_index(force=True)
+        assert mgr.build_embeddings(force=True) == 0
+        assert VectorIndex.load(embeddings_path, provider).count == 0
+
     def test_build_embeddings_all_batches_fail_escalates(self, tmp_path, caplog):
         """Every batch failing returns 0, saves nothing, warns loudly (#649)."""
         import logging


### PR DESCRIPTION
## Closes / Refs

Refs #1087 and #1112.

## What & why

#1112 stopped sending blank note bodies to embedding providers, but a forced
rebuild containing only those notes replaced the in-memory vector index without
writing the empty result to disk. A restart could therefore reload stale
vectors from the previous sidecar.

An empty rebuild is now persisted only when it is authoritative. Parse failures,
valid source files missing from FTS, and incomplete directory walks keep the
last good sidecar; intentional required-frontmatter exclusions do not block the
empty save. The regression test covers the direct parse-failure path, the same
failure after a forced FTS rebuild, an unreadable subtree, and the successful
all-body-less rebuild.

## What this PR deliberately does NOT do

- Change the blank-input filtering or keyword-index behavior from #1112.
- Change provider-wide failure handling; an all-failed provider run still saves
  nothing.
- Add `docs/` changes. #1112 already documents the body-less-note behavior;
  this PR narrows the persistence contract and updates its inline docstrings.

## Local review

- [x] Ran independent review and Roborev on the cumulative diff. Roborev found
  the forced-FTS-rebuild and incomplete-directory-walk cases; both now have
  regression coverage, and the final Roborev pass found no issues.
- [x] No commit carries `!`; no operator, library, CLI, configuration, or
  sidecar-format surface changes.

## Docs impact

- [ ] `README.md`
- [ ] `docs/` site pages
- [ ] `docs/design/`
- [x] Inline docstrings

**Rule: code without matching docs is incomplete.**

## Gates

| Gate | Result |
|---|---|
| `pytest -q` | 3436 passed, 25 skipped |
| Ruff check + format | clean |
| `mypy src/ tests/` | no issues in 192 source files |
| Structural gate | 100%, 0 violations over 134 changed lines |
