### PR TITLE
fix(deps): raise the pvl-core floor to 4.11.2 and drop the removed read_only kwarg

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v5.2.1
+_commit: v5.3.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,16 +31,24 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    # >=4.11.1 for the usable-/data probe in build_kv_store's unset-URL
-    # default: server.py wires build_jobs unconditionally, and on 4.11.0
-    # that crashed make_server with PermissionError on hosts without a
-    # writable /data (bare-metal/uvx installs, CI).  4.11.0 brought
-    # configure_task_backend + ServerConfig.tasks_url (the background-task
-    # backend surface, ADR 0002 §4) and moved fastmcp[tasks] into
-    # pvl-core's BASE dependencies, so pydocket arrives transitively — no
-    # extra to declare here, and no packaging plumbing.  (The
-    # config-surface generator pins the floor exactly, so the floor must
-    # name a version that exists on PyPI.)
+    # >=4.11.2 because the code cannot run against anything older: that
+    # release removed the `read_only` keyword from build_instructions, which
+    # both call sites passed (server.py's skeleton body and _instructions.py's
+    # domain composition), so 4.11.1 and 4.11.2 are mutually exclusive — one
+    # requires the argument, the other rejects it with a TypeError before
+    # make_server finishes.  It also made FetchResult.final_url mandatory.
+    # The floor and the call sites had to move together (#1114).
+    #
+    # Earlier floors, kept for the rationale: >=4.11.1 for the usable-/data
+    # probe in build_kv_store's unset-URL default (server.py wires build_jobs
+    # unconditionally, and on 4.11.0 that crashed make_server with
+    # PermissionError on hosts without a writable /data — bare-metal/uvx
+    # installs, CI); >=4.11.0 for configure_task_backend +
+    # ServerConfig.tasks_url (the background-task backend surface, ADR 0002
+    # §4), which also moved fastmcp[tasks] into pvl-core's BASE dependencies,
+    # so pydocket arrives transitively — no extra to declare here, and no
+    # packaging plumbing.  (The config-surface generator pins the floor
+    # exactly, so the floor must name a version that exists on PyPI.)
     "fastmcp-pvl-core>=4.11.2,<5",
     "typer>=0.12",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     # extra to declare here, and no packaging plumbing.  (The
     # config-surface generator pins the floor exactly, so the floor must
     # name a version that exists on PyPI.)
-    "fastmcp-pvl-core>=4.11.1,<5",
+    "fastmcp-pvl-core>=4.11.2,<5",
     "typer>=0.12",
 
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update

--- a/src/markdown_vault_mcp/_instructions.py
+++ b/src/markdown_vault_mcp/_instructions.py
@@ -25,7 +25,16 @@ def build_default_instructions(
 
     Composes MV's domain-specific guidance into a ``domain_line`` and
     delegates to :func:`fastmcp_pvl_core.build_instructions` for the
-    read-only/read-write line and operator override hint.
+    operator override hint.
+
+    The read-only/read-write announcement is composed here rather than by
+    pvl-core, which dropped it in 4.11.2 (pvl-core #222) because nothing in
+    the library enforced it — a server could be told to announce read-only
+    while every write tool stayed listable and callable. This server does
+    enforce it: write-tagged components are never registered when
+    ``read_only`` is set, and ``DocumentManager`` raises ``ReadOnlyError``
+    underneath. The sentence is therefore true here, so it is kept and owned
+    domain-side (#1114).
 
     The folder-conventions sentence is emitted whenever *conventions_file*
     is configured, not gated on convention files existing on disk: in
@@ -35,7 +44,8 @@ def build_default_instructions(
 
     Args:
         read_only: Whether write tools are disabled; selects the write-guidance
-            sentence and the read-only/read-write line.
+            sentence and the read-only/read-write announcement, both of which
+            this function owns.
         conventions_file: The configured per-folder conventions filename, or
             ``None`` when conventions are not configured.
         summarize_note_limit: The configured summarize note limit, surfaced so
@@ -119,12 +129,20 @@ def build_default_instructions(
             "markdown links for new cross-references."
         )
     )
+    # Enforced here, so announced here — see the docstring. Placed last in
+    # ``domain_line`` so the composed text keeps the word order pvl-core
+    # produced before 4.11.2: domain prose, then the mode line, then the
+    # operator hint the core still appends.
+    write_line = (
+        " This instance is READ-ONLY — write tools are not available."
+        if read_only
+        else " This instance is READ-WRITE — write tools are available."
+    )
     domain_line = (
         f"{prelude}{write_guidance}{search_guidance}"
-        f"{summarize_guidance}{conventions_guidance}{okf_guidance}"
+        f"{summarize_guidance}{conventions_guidance}{okf_guidance}{write_line}"
     )
     return _core_build_instructions(
-        read_only=read_only,
         env_prefix=_ENV_PREFIX,
         domain_line=domain_line,
     )

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -80,7 +80,6 @@ def make_server(
     # build_instructions' hint advertises). Both fall back when unset/empty.
     server_name = env(_ENV_PREFIX, "SERVER_NAME", "markdown-vault-mcp")
     instructions = env(_ENV_PREFIX, "INSTRUCTIONS") or build_instructions(
-        read_only=True,
         env_prefix=_ENV_PREFIX,
         domain_line="Generic markdown vault MCP server with FTS5 + semantic search",
     )

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -565,7 +565,9 @@ class TestFetchThreadsActor:
             "markdown_vault_mcp._server_tools.writer.fetch_url",
             AsyncMock(
                 return_value=FetchResult(
-                    body=b"# Fetched\n\nBody.\n", content_type="text/plain"
+                    body=b"# Fetched\n\nBody.\n",
+                    content_type="text/plain",
+                    final_url="https://example.com/report.md",
                 )
             ),
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -114,6 +114,31 @@ class TestServerIdentity:
         assert "MARKDOWN_VAULT_MCP_INSTRUCTIONS" in server.instructions
         assert "Operators:" in server.instructions
 
+    def test_mode_line_is_composed_domain_side(self) -> None:
+        """The READ-ONLY/READ-WRITE line is ours, not pvl-core's (#1114).
+
+        pvl-core 4.11.2 dropped the announcement (and the ``read_only``
+        keyword that selected it) because nothing in the library enforced
+        it. This server does enforce it, so the sentence is composed in
+        ``build_default_instructions`` — after the domain prose and before
+        the operator-override hint the core still appends.
+        """
+        import inspect
+
+        from fastmcp_pvl_core import build_instructions as core_build_instructions
+
+        from markdown_vault_mcp._instructions import build_default_instructions
+
+        assert "read_only" not in inspect.signature(core_build_instructions).parameters
+
+        text = build_default_instructions(read_only=True)
+        assert "READ-ONLY" in text
+        assert text.index("READ-ONLY") < text.index("Operators:")
+
+        text = build_default_instructions(read_only=False)
+        assert "READ-WRITE" in text
+        assert text.index("READ-WRITE") < text.index("Operators:")
+
     @pytest.mark.usefixtures("_mcp_env")
     def test_custom_server_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_SERVER_NAME", "my-vault")
@@ -1474,11 +1499,24 @@ class TestFetchTool:
     _UNCAPPED = 2**63 - 1
 
     @staticmethod
-    def _fetch_url_returning(body: bytes, content_type: str | None) -> AsyncMock:
-        """Stub ``fetch_url`` returning a real ``FetchResult``."""
+    def _fetch_url_returning(
+        body: bytes,
+        content_type: str | None,
+        final_url: str = "https://example.com/note.md",
+    ) -> AsyncMock:
+        """Stub ``fetch_url`` returning a real ``FetchResult``.
+
+        ``final_url`` is the URL the bytes came from — equal to the requested
+        URL when nothing redirected, which is what every caller here wants
+        (pvl-core 4.11.2 made the field mandatory, #1114).
+        """
         from fastmcp_pvl_core import FetchResult
 
-        return AsyncMock(return_value=FetchResult(body=body, content_type=content_type))
+        return AsyncMock(
+            return_value=FetchResult(
+                body=body, content_type=content_type, final_url=final_url
+            )
+        )
 
     async def test_fetch_markdown_note(
         self, _mcp_env_writable_with_attachments: Path

--- a/uv.lock
+++ b/uv.lock
@@ -967,15 +967,15 @@ tasks = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "4.11.1"
+version = "4.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp", extra = ["tasks"] },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/85/dd0ab85a340793f0d0bfeb0cffa76c2cdcc98e60789a0d54cf815937e76f/fastmcp_pvl_core-4.11.1.tar.gz", hash = "sha256:dd392b0e1ecfd748c2fac788b3af8ee8b25b55e310d19d507c9301374f745175", size = 508723, upload-time = "2026-08-13T18:56:26.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/4e/6b445b0ebd6aad389e763b58ffb46b578e86abc6a517b454a4b55784f802/fastmcp_pvl_core-4.11.2.tar.gz", hash = "sha256:06625a0d93cdc48f2272eb1a23f42c19d95010ee030413927557473da9b78d16", size = 511153, upload-time = "2026-08-19T19:15:20.395Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/64/7d96c0420c1e463f4a20cd874586c34d347745b1fe0b871d6760e27ca7d0/fastmcp_pvl_core-4.11.1-py3-none-any.whl", hash = "sha256:7914d58c36f26a4b9225b0043e191382b81017c959ce5341e1e39184816746d7", size = 120183, upload-time = "2026-08-13T18:56:25.056Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/60/64f0a4bb79787b327e1c391c4fbd690f44b013ede3146741e419490f7b39/fastmcp_pvl_core-4.11.2-py3-none-any.whl", hash = "sha256:82eb18761612977b418f36ce27b46599757df1c1e54f9d0c6105725410ae6a88", size = 121355, upload-time = "2026-08-19T19:15:18.682Z" },
 ]
 
 [package.optional-dependencies]
@@ -1322,7 +1322,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1810,7 +1810,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.3" },
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=3.0,<4" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
-    { name = "fastmcp-pvl-core", specifier = ">=4.11.1,<5" },
+    { name = "fastmcp-pvl-core", specifier = ">=4.11.2,<5" },
     { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25" },
     { name = "httpx", marker = "extra == 'embeddings-api'", specifier = ">=0.25" },


### PR DESCRIPTION
## Closes / Refs

Closes #1114
Refs #1116

First of three stacked PRs (#1114 → #1116 → #1113); see **Sequencing** below.

## What & why

`pyproject.toml` declared `fastmcp-pvl-core>=4.11.1,<5`, but 4.11.2 removes the `read_only` keyword `build_instructions` still received. Any re-resolution of the lockfile produced a server that raised `TypeError` before it finished starting.

**Two call sites passed it, not one** — this is the correction #1114's comment recorded, and it is why template v5.3.0 alone is not sufficient:

- `server.py:83` is template-owned. Fixed by `copier update` to **template v5.3.0**, which drops the argument *and* moves the floor to `>=4.11.2` in one commit — they cannot land independently. The update is exactly that one change plus the `_commit` bump; nothing else in the tree moved.
- `_instructions.py:126` is domain-owned and carries a decision rather than a mechanical edit. pvl-core dropped the read-only announcement (pvl-core #222) because nothing in the library enforced it — a server could be told to announce read-only while every write tool stayed listable. **This server does enforce it**: write-tagged components are never registered in read-only mode and `DocumentManager` raises `ReadOnlyError` underneath. The sentence is true here, so it is kept by composing it domain-side instead of deleted.

The rendered instructions text is **unchanged, byte for byte**, in both modes: the mode line is appended to `domain_line` so it still lands between the domain prose and the operator-override hint the core appends. `tests/test_server.py::TestServerIdentity` covers both directions already; a new `test_mode_line_is_composed_domain_side` pins the ownership and asserts the core no longer takes the keyword, so a future re-add fails loudly.

`FetchResult` also gained a mandatory `final_url` in 4.11.2. The two test fakes that construct one are updated so the suite stays green; nothing reads the field yet.

## What this PR deliberately does NOT do

- **The fetch redirect posture**: #1116. Raising the floor also flips `fetch` from refusing redirects to following them — a semantic change to a tool whose behaviour shipped in the last stable release. It is classified and handled in the next PR in the stack, deliberately not reviewed as part of a dependency bump. This PR only makes the mandatory `final_url` constructible; it does not surface it, handle `httpx.TooManyRedirects`, or touch the tool's docstring.
- **The `READ_ONLY` operator default**: #1113. Independent of this change.
- **Library-tier `read_only` defaults** (`Vault.__init__`, `DocumentManager.__init__`): unchanged at `True`, per #1113's open question.

### Sequencing

The floor move causes both #1114 and #1116, so the two cannot ship independently even though the work is separable. This PR merging alone leaves `main` briefly carrying an unclassified posture change — acceptable because a merge to `main` releases nothing (it feeds `edge` only), and the #1116 PR follows immediately. Both land inside the unreleased 4.0 range, so no tagged release ever carries only half.

## Local review

- [x] Ran a local code-review pass on the cumulative diff.
- [x] No commit carries `!`. Assessed against `v3.1.0`: the operator surface is untouched, the public library interface is untouched, and the rendered instructions text is byte-identical. The floor move's user-visible consequence is the fetch posture, which is #1116's to classify.

## Docs impact

- [ ] `README.md` — no user-facing change in this PR
- [ ] `docs/` site pages — no user-facing change in this PR
- [ ] `docs/design/` — no spec change; the enforcement claim the new docstring makes is already the documented behaviour
- [x] Inline docstrings — `build_default_instructions` records why the announcement is now composed domain-side

## Gates

| Gate | Result |
|---|---|
| `pytest` | 3439 passed, 1 pre-existing failure |
| `ruff check --fix` / `format --check` | clean |
| `mypy src/ tests/` | clean, 192 files |
| Patch coverage | 100% |
| `scripts/structural_gate.sh` | 100%, 0 violations |

The one failure is `test_release_flow_contract.py::test_release_tags_are_visible_when_the_changelog_records_releases`, which asserts `v*` tags are visible in the checkout. It fails identically on `origin/main` in this environment — the clone has no tags — and is unrelated to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfffPyEJieVyZ7DyzobwrZ)_