### PR TITLE
feat(fetch)!: follow redirects, report the final URL, and classify the change

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2559,11 +2559,25 @@ overrides it.
   CGNAT/shared 100.64/10, and reserved ranges are all blocked, with NAT64
   embedded-IPv4 validation), DNS-rebind pinning of the validated IP,
   `trust_env=False` (ambient `HTTP(S)_PROXY`/`.netrc` cannot divert the
-  pinned connection), redirect refusal, a streaming size cap, and
-  userinfo/query redaction in logs and errors. The tool keeps only the
-  vault-side policy: which cap applies (attachment limit vs. uncapped
-  markdown) and the operator-facing size-limit message naming
-  `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB`.
+  pinned connection), a streaming size cap, and userinfo/query redaction in
+  logs and errors. The tool keeps only the vault-side policy: which cap
+  applies (attachment limit vs. uncapped markdown) and the operator-facing
+  size-limit message naming `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB`.
+
+  **Redirects are followed, and every hop re-runs that chain** (#1116).
+  Through 3.1 the primitive refused every 3xx outright; from the 4.11.2
+  floor the guard lives in the transport httpx sends each hop through, so a
+  `Location` pointing at an internal target is refused exactly as a directly
+  supplied one is. The posture is not locally configurable — pvl-core owns
+  it — and it was adopted deliberately rather than inherited silently: per-hop
+  revalidation is a stronger guarantee than a blanket refusal, and ordinary
+  indirection (`http`→`https`, shortened links, CDN hand-offs) now resolves
+  instead of erroring. The cost is that the bytes need not come from the host
+  in `url`, so the tool returns `final_url` — the URL the bytes actually came
+  from — and a caller enforcing a host policy must check it rather than
+  trusting the URL it supplied. A chain longer than httpx's `max_redirects`
+  raises `httpx.TooManyRedirects`, which propagates uncaught like the other
+  transport-tier failures.
 
 These semantics are intentionally close to Claude Code's file tools for
 familiarity. LLMs that know how to read/write/edit files can use these tools

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -503,7 +503,7 @@ Download a file from a URL and save it to the vault as a note or attachment. Des
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `url` | string | required | Source URL to download. Only `http`/`https` schemes allowed; the host is resolved and blocked unless every address is publicly routable (private, loopback, link-local, CGNAT/shared, and reserved ranges are all refused); the validated IP is pinned for the connection; ambient `HTTP(S)_PROXY`/`.netrc` settings are ignored; redirects are not followed (SSRF protection) |
+| `url` | string | required | Source URL to download. Only `http`/`https` schemes allowed; the host is resolved and blocked unless every address is publicly routable (private, loopback, link-local, CGNAT/shared, and reserved ranges are all refused); the validated IP is pinned for the connection; ambient `HTTP(S)_PROXY`/`.netrc` settings are ignored. Redirects are followed, and each hop repeats every check above (SSRF protection) |
 | `path` | string | required | Destination path in vault. Extension determines handling: `.md` for notes, anything else for attachments |
 | `frontmatter` | object | `null` | Optional YAML frontmatter dict for `.md` files. Ignored for attachments |
 | `if_match` | string | `null` | Optional etag from a previous `read` call for optimistic concurrency |
@@ -513,13 +513,29 @@ Download a file from a URL and save it to the vault as a note or attachment. Des
 the saved file by `path` for downstream tools rather than `read()`-ing it
 back into context.
 
-**Returns:** `{"path": "notes/report.md", "created": true, "content_length": 4096, "content_type": "text/markdown"}`
+**Returns:** `{"path": "notes/report.md", "created": true, "content_length": 4096, "content_type": "text/markdown", "final_url": "https://example.com/report.md"}`
 
 For `.md` destinations, the response may also include a `conventions` list; see [`write`](#write).
 
 The download itself runs through `fastmcp-pvl-core`'s hardened `fetch_url`
 primitive, so the SSRF protections above are shared, audited code rather
 than a local copy.
+
+!!! warning "Redirects are followed (changed in 4.0)"
+
+    Through 3.1 this tool refused every redirect: a `301` or `302` produced
+    an error rather than content. It now follows the chain, so the bytes may
+    come from a host other than the one you asked for. Every hop re-runs the
+    full address check, so a redirect cannot reach an internal target — but
+    if you rely on `fetch` to reject indirection, that guarantee is gone.
+
+    `final_url` reports where the bytes came from: equal to `url` when
+    nothing redirected, otherwise the last hop. Check it when the source
+    host matters. It keeps its query string (a redirect target's query is
+    often load-bearing), so do not log it verbatim.
+
+    A chain longer than the transport's redirect limit fails with a
+    "too many redirects" error rather than saving anything.
 
 ### `git_sync`
 

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -588,8 +588,14 @@ def register(mcp: FastMCP) -> None:
                 every address is publicly routable (private, loopback,
                 link-local, CGNAT/shared, and reserved ranges are all
                 blocked), the validated IP is pinned for the connection
-                (closing DNS rebinding), ambient HTTP(S)_PROXY / .netrc
-                settings are ignored, and redirects are NOT followed.
+                (closing DNS rebinding), and ambient HTTP(S)_PROXY / .netrc
+                settings are ignored. Redirects ARE followed (changed in
+                #1116; through v3.1.0 a redirect was refused), and every hop
+                repeats the whole chain above — a ``Location`` pointing at an
+                internal target is refused exactly as a directly supplied one
+                is. Because of that, the bytes need not come from the host in
+                *url*: check the returned ``final_url`` when the source host
+                matters.
             path: Destination path in the vault (e.g. "notes/report.md"
                 or "assets/diagram.png"). Extension determines handling:
                 .md for notes, anything else for attachments.
@@ -607,6 +613,10 @@ def register(mcp: FastMCP) -> None:
             - created (bool): true if new file, false if overwrite
             - content_length (int): bytes downloaded
             - content_type (str or null): Content-Type from the response
+            - final_url (str): the URL the bytes actually came from — equal
+              to ``url`` when nothing redirected, otherwise the last hop.
+              Userinfo is stripped; the query string is not, so do not log
+              it verbatim
             - conventions (list, optional; .md only): the user's authoring
               conventions for the target folder (root-first list of
               {folder, path, content}). When present, verify the saved note
@@ -618,9 +628,15 @@ def register(mcp: FastMCP) -> None:
 
         Raises:
             ValueError: If the URL scheme is not http/https, the host is
-                blocked or cannot be resolved, a redirect is returned, the
-                download exceeds the size limit, or the response cannot be
-                decoded.
+                blocked or cannot be resolved (on the supplied URL or on any
+                redirect hop), the download exceeds the size limit, or the
+                response cannot be decoded.
+            httpx.TooManyRedirects: If the redirect chain exceeds httpx's
+                ``max_redirects``. Propagates uncaught, like the
+                ``HTTPStatusError`` of a non-2xx response and the
+                ``TransportError`` of a timeout — the vault has no better
+                answer than the transport's own. Unreachable before #1116,
+                when a redirect was refused outright.
         """
         # Attachment size cap only: markdown notes are not size-limited, and
         # a non-positive configured cap disables the limit. `capped` derives
@@ -638,19 +654,20 @@ def register(mcp: FastMCP) -> None:
         max_bytes = cap_bytes if capped else _FETCH_UNCAPPED_BYTES
 
         # All SSRF hardening (scheme allowlist, non-public-address rejection
-        # incl. CGNAT, DNS-rebind pinning, trust_env=False, redirect refusal,
-        # streaming size cap, userinfo/query redaction) lives in pvl-core's
-        # fetch_url — the shared primitive this tool's guard was lifted into
-        # (#862; pvl-core #219).
+        # incl. CGNAT, DNS-rebind pinning, trust_env=False, per-redirect-hop
+        # revalidation of all of those, streaming size cap, userinfo/query
+        # redaction) lives in pvl-core's fetch_url — the shared primitive this
+        # tool's guard was lifted into (#862; pvl-core #219).
         try:
             fetched = await fetch_url(url, max_bytes=max_bytes, timeout_s=timeout_s)
         except ValueError as exc:
             # Translate the size-cap refusal into the vault's operator-facing
             # terms (which env var raises the limit). Matches fetch_url's full
-            # terminal suffix — not a substring, which URL content could spoof
-            # (e.g. a redirect refusal whose redacted URL contains the words).
-            # Couples to fetch_url's message text, but fails safe: on a reword
-            # the original error still propagates.
+            # terminal suffix — not a substring. The size-cap message embeds
+            # the (redacted) URL, which is caller-supplied, so a substring test
+            # could be spoofed by a URL crafted to contain the phrase; the
+            # suffix is fetch_url's own text and cannot be. Couples to that
+            # text, but fails safe: on a reword the original error propagates.
             if capped and str(exc).endswith(
                 f"exceeded the size cap of {max_bytes} bytes."
             ):
@@ -666,6 +683,13 @@ def register(mcp: FastMCP) -> None:
         raw_bytes = fetched.body
         content_type = fetched.content_type
         content_length = fetched.size
+        # Where the bytes actually came from. Equal to `url` when nothing
+        # redirected; since #1116 redirects are followed, so a caller that
+        # cares which host served the content has to be told (validating the
+        # supplied URL alone is no longer sufficient). Surfaced rather than
+        # logged: fetch_url already logged the redacted source, and this
+        # string keeps its query, which may be a pre-signed token.
+        final_url = fetched.final_url
 
         # Dispatch to the appropriate write method.
         if is_markdown:
@@ -707,6 +731,7 @@ def register(mcp: FastMCP) -> None:
             **asdict(result),
             "content_length": content_length,
             "content_type": content_type,
+            "final_url": final_url,
         }
         if is_markdown:
             data = await attach_conventions(vault, data, path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1675,6 +1675,80 @@ class TestFetchTool:
         assert "title: Report" in written
         assert "source: https://example.com/report.md" in written
 
+    async def test_fetch_reports_final_url_when_nothing_redirected(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        """final_url echoes the requested URL when there was no redirect."""
+        mock_fetch = self._fetch_url_returning(
+            b"# Direct\n", "text/markdown", final_url="https://example.com/direct.md"
+        )
+
+        with patch(self._FETCH_URL_SEAM, mock_fetch):
+            server = make_server()
+            async with Client(server) as client:
+                result = await client.call_tool(
+                    "fetch",
+                    {"url": "https://example.com/direct.md", "path": "direct.md"},
+                )
+        assert result.data["final_url"] == "https://example.com/direct.md"
+
+    async def test_fetch_reports_final_url_after_a_redirect(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        """A followed redirect is reported, not refused (#1116).
+
+        Through v3.1.0 pvl-core refused every 3xx and the tool surfaced the
+        refusal as an error. Since the 4.11.2 floor the hop is followed —
+        each one re-running the SSRF chain — so the bytes can come from a
+        host other than the one asked for, and ``final_url`` is how a caller
+        enforcing a host policy finds out.
+        """
+        mock_fetch = self._fetch_url_returning(
+            b"# Moved\n", "text/markdown", final_url="https://cdn.example.net/moved.md"
+        )
+
+        with patch(self._FETCH_URL_SEAM, mock_fetch):
+            server = make_server()
+            async with Client(server) as client:
+                result = await client.call_tool(
+                    "fetch",
+                    {"url": "https://example.com/moved.md", "path": "moved.md"},
+                )
+        assert result.data["created"] is True
+        assert result.data["final_url"] == "https://cdn.example.net/moved.md"
+        assert (
+            (_mcp_env_writable_with_attachments / "moved.md")
+            .read_text(encoding="utf-8")
+            .endswith("# Moved\n")
+        )
+
+    async def test_fetch_too_many_redirects(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        """A redirect chain past httpx's max_redirects propagates (#1116).
+
+        Unreachable before the 4.11.2 floor, when a redirect was refused
+        outright with a ValueError the size-cap handler already caught. It
+        now reaches the client as a ToolError, like the sibling
+        HTTPStatusError and TimeoutException paths.
+        """
+        import httpx
+
+        async def _too_many(url: str, **_kwargs: object) -> None:
+            raise httpx.TooManyRedirects(
+                "Exceeded maximum allowed redirects.",
+                request=httpx.Request("GET", url),
+            )
+
+        with patch(self._FETCH_URL_SEAM, _too_many):
+            server = make_server()
+            async with Client(server) as client:
+                with pytest.raises(ToolError, match="redirects"):
+                    await client.call_tool(
+                        "fetch",
+                        {"url": "https://example.com/loop.md", "path": "loop.md"},
+                    )
+
     async def test_fetch_http_error_status(
         self, _mcp_env_writable_with_attachments: Path
     ) -> None:


### PR DESCRIPTION
## Closes / Refs

Closes #1116
Refs #1114

Second of three (#1114 → #1116 → #1113). **#1117 is merged and this PR now targets `main` directly**; its diff is this change alone (4 files). #1119 is stacked behind this one.

## What & why

Adopting pvl-core 4.11.2 changes what `fetch` does: it stops refusing redirects and starts following them. This PR makes that call explicitly, rather than letting a release-PR reviewer discover it.

**The posture is not locally configurable.** 4.11.2 hardcodes `follow_redirects=True` in `fetch_url` with no opt-out parameter, so the only options were to accept it or re-assert the refusal domain-side by comparing `FetchResult.final_url` against the requested URL. **Accepting it**, for two reasons:

- **Per-hop revalidation is a stronger guarantee than a blanket refusal.** The guard is not a pre-flight check any more — it lives in `_GuardedTransport`, which httpx sends *every* redirect hop through. Each hop repeats the scheme check, the address validation, and the IP pin, so a `Location` pointing at an internal target is refused exactly as a directly supplied one is.
- **Ordinary indirection now resolves instead of erroring** — `http`→`https`, shortened links, CDN hand-offs. A refusal-based tool fails on a large share of real URLs.

### Why this carries `!`

Assessed against **v3.1.0**, the last stable release (every 4.0 tag is an rc), per the policy in `CLAUDE.md`:

```
$ git show v3.1.0:src/markdown_vault_mcp/_server_tools/writer.py | grep follow_redirects
596:  httpx.AsyncClient(timeout=timeout_s, follow_redirects=False) as client,
```

The tool's own docstring promised *"redirects are NOT followed"*. That behaviour is **gone and not reachable through any parameter** — not additive, not dual-mode. The policy is explicit that an MCP-surface change where the old behaviour is gone earns the marker even though the schema re-discovers cleanly. A caller that used a fetch error as a way to reject indirection now silently receives content, with no signature change to notice.

It rides inside the **unreleased 4.0 major** rather than forcing a 5.0 — same reasoning as #1113.

## Three consequences, handled

1. **`final_url` in the response.** The bytes need not come from the host in `url`, so validating the supplied URL is no longer sufficient on its own; pvl-core's own note says a caller enforcing a host policy must re-check `final_url`. It is surfaced rather than logged — `fetch_url` already logged the redacted source, and this string keeps its query string, which may be a pre-signed token.
2. **`httpx.TooManyRedirects` was unreachable before** — a redirect was refused up front with a `ValueError` the size-cap handler already caught. It is now documented as propagating and has a test, matching its `HTTPStatusError` and `TimeoutException` siblings, which were the only propagate-uncaught paths with coverage.
3. **The bogus comment is corrected.** The size-cap suffix match justified itself with *"a redirect refusal whose redacted URL contains the words"*. No such refusal exists any more, and pvl-core's blocked-host errors carry a bare hostname (`Host '127.0.0.1.nip.io' resolves to a non-public address…`), not a redacted URL — so the example was wrong on both counts. The rationale is restated on the message that genuinely does embed a caller-influenced URL: the size-cap error itself.

## What this PR deliberately does NOT do

- **Does not re-assert the refusal, or add a knob for it.** Both were considered; see the reasoning above. A `FETCH_FOLLOW_REDIRECTS` env var would have kept the change non-breaking, at the cost of a permanent operator-surface knob, a config field, install-screen and wizard regeneration, and docs across every guide — for a mode the argument above says is the worse one.
- **Does not audit `httpx.HTTPStatusError` / `httpx.TransportError` handling**, listed `[unverified]` in #1116. Both predate 4.11.2, both already propagate, and both already have tests; nothing in this floor move changed them.
- **The floor move itself**: #1117 (merged).
- **The `READ_ONLY` default**: #1113 / #1119.

## Note on the `ci:` commit

The second commit on this branch is empty. It exists because CI genuinely never ran on the first one, and the recovery attempt made it worse:

- The branch was pushed *before* the PR was retargeted from its stacked base to `main`, so `synchronize` was filtered out by `ci.yml`'s `branches: [main, "release/**"]`; a base change fires `edited`, which is not one of `pull_request`'s default trigger types.
- A `workflow_dispatch` run then reported **`CI Success: success` while `PR Title` and `Structural Quality (diff)` were skipped** and the patch-coverage steps never ran — all three gated on `github.event_name == 'pull_request'`. A green aggregate with three required gates unexecuted is worse than no CI.

The empty commit fires `synchronize` against the correct base so the full PR-triggered set actually runs. Both previously-skipped gates now pass. The correct order — retarget first, then push — is what #1119 will use.

## Local review

- [x] Ran a local code-review pass on the cumulative diff.
- [x] The `!` breaks a surface that existed at the last stable release — verified by reading `v3.1.0`'s `writer.py`, not inferred. The `git tag --contains` sanity check does not apply inversely here: the surface being *removed* shipped in v3.1.0, so the marker is not spurious.

## Docs impact

- [ ] `README.md` — does not describe fetch's redirect behaviour
- [x] `docs/tools/index.md` — `url` parameter row corrected, `final_url` added to the return example, and a warning admonition covering the change, what replaces the guarantee, and the too-many-redirects failure
- [x] `docs/design/` — the SSRF paragraph no longer lists "redirect refusal"; a new paragraph records the posture, why it was adopted rather than inherited, and that it is pvl-core's to own
- [x] Inline docstrings — `url` argument, `Returns`, `Raises`, and both explanatory comments

## Gates

All 19 checks green on `2d8c3c2` (`deploy` correctly skipped). `claude-review`: no issues found — its passes independently confirmed the `!` justification, that `final_url` is returned and never logged, that `TooManyRedirects` falls outside the `except ValueError` handler, and that userinfo stripping in `final_url` holds against pvl-core's `_GuardedTransport`.

Locally: 3442 passed, ruff/mypy clean, 100% patch coverage, structural gate 100%, Vale clean.