### PR TITLE
chore: prepare release 4.0.0-rc.5

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -275,8 +275,10 @@ upstreams
 # --- 4.0 release notes vocabulary ---
 CI
 dataclasses
+hardcodes
 interop
 OKF
+regexes
 severities
 umask
 unnormalized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 <!-- version list -->
 
+## 4.0.0-rc.5 (2026-08-20)
+
+### Breaking Changes
+
+- replace anthropic summarizer with generic OpenAI-compatible backend (#917)
+- dual-mode background jobs via pvl-core 4.11.0 + template v3.3.0 (#1034)
+- make reindex and build_embeddings dual-mode background jobs (#1037)
+- adopt the branch-aware release model via copier update to template v4.0.0 (#1066)
+- follow redirects, report the final URL, and classify the change (#1118)
+- default READ_ONLY to false so the write surface ships enabled (#1119)
+
+### Features
+
+- add LLM-backed summarize tool gated on an API key (#869)
+- folder conventions — per-folder authoring policy for LLM clients (#877)
+- configurable title field, searchable frontmatter, and ranking weights (#867)
+- map-reduce summarization for inputs beyond one model request (#924)
+- per-call max_notes with in-result coverage hint for summarize (#926)
+- rebuild on INDEXED_FIELDS change; SEARCHABLE_FIELDS defaults to it (#928)
+- bound summarize latency with a timeout error and background jobs (#937) (#938)
+- detect OKF bundles and annotate read surfaces (#968)
+- OKF filter dimensions and graph node typing (#970)
+- okf_validate conformance audit tool (#971)
+- migration transforms (wikilink conversion, index/log generation) (#973)
+- adopt fastmcp-pvl-core transfer subsystem; retire local store (#981)
+- bundle export via an okf-bundle download ref (#982)
+- enforced write layer — provenance stamping, verification invalidation, okf_verify (#964) (#984)
+- enforced-write convention maintenance — log.md append + index.md refresh (#964) (#987)
+- ranking downweights for deprecated/stale/reserved files (#965) (#988)
+- configurable timeout (EMBED_TIMEOUT_S) + batch size (EMBEDDING_BATCH_SIZE) (#1000)
+- harden okf_verify against model self-attestation (#990) (#1004)
+- scope okf_seed_log's log.md content to the folder's subtree (#974) (#1005)
+- add append tool for end-of-note writes without a prior read (#1025)
+- ship client-side summarization recipe as summarize-subtree prompt (#1038)
+- adopt template v3.4.0 — generated mcpb screen, curated fields, pre-release checks (#1045)
+- adopt template v3.5.0 — plugin channel onto the template scaffold (#1046)
+- vault-summarize skill and vault-mapper agent for client-side summarization (#1047)
+- vault-setup skill and SessionStart doctor hook for in-session bootstrap (#1048)
+- generated userConfig configuration screen — no more shell-profile setup (#1049)
+
+### Bug Fixes
+
+- hybrid search vector channel misses folder normalization (#882)
+- recover keyword/hybrid search for hyphenated terms (#866) (#884)
+- stop reasoning models exhausting the summarize token budget (#920)
+- forbid assistant-style offers in summarize output (#923)
+- bump transitive mcp 1.28.0 → 1.28.1 (CVE-2026-59950) (#934)
+- make incremental reindex inline embedding resilient to provider timeouts (#930) (#932)
+- guard inline/converge vector mutation against dimension mismatch (#935) (#936)
+- resolve leading-slash markdown links against the vault root (#972)
+- skip malformed-frontmatter files in build_embeddings (#994)
+- retry failed deferred pushes on the periodic pull-loop tick (#997)
+- honour process umask for newly created files (#958) (#998)
+- single-agent reviewer; drop fan-out plugin + pin experiment
+- drop Task from @claude — #1499 background-subagent orphan footgun
+- allow-list Skill defensively (both claude workflows)
+- finalize pin-combo reviewer (restore CI gate, drop show_full_output)
+- close SSRF gaps by migrating to pvl-core's hardened fetch_url (#1029)
+- adopt template v3.2.2 — template-owned bump_manifests, non-mutating CI syncs (#1032)
+- drop track_progress from the notes drafting action (#1094)
+- make the notes drafting agent able to write — and safe to run (#1095)
+- rc releases get their full artifact set, and the 4.0 notes page passes its own evidence contract (#1096)
+- clear the v4.0 milestone's bug reports (#1109)
+- never send a blank string to the embedding provider (#1112)
+- raise the pvl-core floor to 4.11.2 and drop the removed read_only kwarg (#1117)
+
 ## 4.0.0-rc.4 (2026-08-19)
 
 ### Breaking Changes

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -1,6 +1,6 @@
 # 4.0
 
-<!-- notes-range-end: 70024c22274d4825c65799ce4c6b58630ed52864 -->
+<!-- notes-range-end: 8dc73f8cd42f2fc5cdcaa77c81fbcbaa7311b25b -->
 
 <!-- RELEASE-SUMMARY v4.0.0 START -->
 4.0.0 is the first stable release since v3.1.0 (July 8, 2026), and it carries
@@ -13,15 +13,19 @@ vaults, a rebuilt [LLM summarization](#llm-backed-summarization) feature that
 now talks to any OpenAI-compatible endpoint and runs as a background job when
 it's slow, per-vault [authoring conventions and ranking
 control](#folder-conventions-custom-frontmatter-and-ranking-control), a new
-`append` tool, two security fixes, and a [Claude Code plugin
-channel](#packaging-the-claude-code-plugin-channel) with guided setup. It's a
-major version because two things break existing setups on upgrade; see
+`append` tool, security fixes, and a [Claude Code plugin
+channel](#packaging-the-claude-code-plugin-channel) with guided setup. Late in
+the cycle, `MARKDOWN_VAULT_MCP_READ_ONLY` also flipped its default from `true`
+to `false`, so a freshly installed server now serves its write tools out of
+the box instead of only a search index
+([#1113](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1113)). It's
+a major version because four things break existing setups on upgrade; see
 [Upgrading](#upgrading).
 <!-- RELEASE-SUMMARY v4.0.0 END -->
 
 ## Why this release covers so much
 
-Between v3.1.0 and 4.0.0, `main` accumulated 95+ commits while `v3.2.0-rc.1`
+Between v3.1.0 and 4.0.0, `main` accumulated 125+ commits while `v3.2.0-rc.1`
 through `v3.2.0-rc.7` ran for five weeks without ever becoming a stable
 release. The rc series stalled on a mechanical problem: each `v3.2.0-rc.N`
 tag predicted the next stable would be `3.2.0`, but the release tooling
@@ -245,14 +249,77 @@ reported by
   ([#955](https://github.com/pvliesdonk/markdown-vault-mcp/issues/955),
   fixed in
   [#994](https://github.com/pvliesdonk/markdown-vault-mcp/pull/994)).
+- A note with no body (zero-byte, frontmatter-only, or whitespace-only)
+  chunks to a single empty-string chunk, and sending that string to an
+  embedding provider gets HTTP 400 back, which used to abort the whole
+  batch rather than just the offending note: one reporter's 3-line
+  frontmatter-only note "held the index stale for ~17 hours before anyone
+  noticed"
+  ([#1087](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1087),
+  reported by
+  [@salmonumbrella](https://github.com/salmonumbrella)). A blank chunk is
+  now dropped before it reaches the provider, at both the embed call and
+  the convergence-pass signature diff (dropping it in only one place would
+  make the index re-embed the same document forever); the note stays fully
+  keyword-searchable through FTS, only its vector is skipped
+  ([#1112](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1112)).
 - `reindex` and `build_embeddings` are now **dual-mode background jobs**: a
   fast call still returns its result inline, but a slow one now returns
   `{"status": "working", "job_id": ...}` for polling via `get_job_result`,
   and a backend failure that happens within the deadline now raises on the
   call itself instead of surfacing only through `get_index_status`
   ([#1037](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1037)).
-  This is one of the two behavior changes covered under
+  This is one of the four behavior changes covered under
   [Upgrading](#upgrading).
+
+## Folder-filter and link-rewrite bug sweep
+
+A live 902-note vault run against `4.0.0-rc.4` turned up six bugs in one
+sitting, all filed against the v4.0 milestone and fixed together in one PR
+([#1109](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1109)):
+
+- **Trailing-slash folder filters returned nothing.** `folder="X/"` and
+  `folder="X"` were supposed to select the same notes, but every
+  FTS-backed surface (`search(mode="keyword")`, `list_documents`,
+  `get_recent`, `get_broken_links`) silently returned `[]` for the
+  trailing-slash form, and `mode="hybrid"` quietly dropped to
+  semantic-only results
+  ([#1103](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1103)).
+  A related fix corrected the opposite bug on the vector-row post-filter,
+  where `.strip("/") or None` collapsed an explicit `folder=""` into "no
+  restriction" and made `mode="semantic"`/`"hybrid"`/`get_similar` search
+  the whole vault instead of the documented root-level-only scope
+  ([#1106](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1106)).
+  Both are now handled by one shared `normalize_folder` helper that keeps
+  `None`, `""`, and every other value distinct.
+- **A folder-scoped semantic search needed `limit` in the thousands to
+  return anything.** The candidate pool was capped before the folder
+  filter ran, so a folder whose chunks all scored below the cap came back
+  empty
+  ([#1108](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1108)).
+  The cap now applies after scoping, not before.
+- **`rename` and `move_folder` demoted root-relative links back to
+  folder-relative ones**, silently undoing OKF's own link convention on
+  every move: a link `okf_convert_links` had just rewritten to
+  `/folder/note.md` came back as bare `note.md` after the next `rename`
+  ([#1105](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1105)).
+  `compute_new_raw_target` now recognizes the leading-slash shape as a
+  third link form rather than falling through to relative.
+- **`[[#Heading]]` wikilinks stored a literal `.md` target** because the
+  fragment was split off before `.md` was appended
+  ([#1107](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1107));
+  they're now skipped, matching how `[text](#heading)` is already
+  handled.
+- **Footnote definitions were parsed as link targets**, because footnote
+  syntax differs from reference-link syntax by one character and both
+  reference regexes matched it
+  ([#1104](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1104)).
+
+Five more regressions the fix itself introduced were caught in review
+before merge (a `limit=0` off-by-one, corrupted `okf_generate_index` /
+`okf_seed_log` output, Windows attachment paths dropping out of
+`list_documents`, and a folder-scoped `get_similar` losing its pool
+widening), all fixed in the same PR and none shipped.
 
 ## New `append` tool, and other write and git fixes
 
@@ -307,6 +374,23 @@ reported by
   the issue nor the fix describes the vulnerability's attack vector beyond
   the audit tool's own flag; if you need more detail, check the upstream
   `mcp` advisory directly.
+- **`fetch` now follows redirects instead of refusing them.** This is a
+  side effect of raising the `fastmcp-pvl-core` floor to 4.11.2, which
+  hardcodes `follow_redirects=True` in the shared `fetch_url` helper with
+  no opt-out
+  ([#1116](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1116)).
+  The guard is not weakened by this: it moved from a one-time pre-flight
+  check into the transport itself, so every redirect hop re-runs the
+  scheme check, the address validation, and the IP pin, and a `Location`
+  header pointing at an internal target is refused exactly as a direct
+  request would be. The response now reports where the bytes actually came
+  from in a `final_url` field, which may differ from the requested `url`
+  after a redirect; a caller enforcing its own host policy needs to check
+  that field, not just the input. A chain longer than the transport's
+  redirect limit now fails with `httpx.TooManyRedirects` instead of the
+  previous `ValueError`
+  ([#1118](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1118)).
+  See [Upgrading](#upgrading).
 
 ## Packaging: the Claude Code plugin channel
 
@@ -359,11 +443,36 @@ See the [Claude Code plugin guide](../guides/claude-code-plugin.md) and the
 
 ## Upgrading
 
-Two changes break existing setups. Everything else in this release is
+Four changes break existing setups. Everything else in this release is
 additive: new tools, new optional environment variables, and reworks of
 features (like `summarize`) that never reached a stable release before now,
 so their internal churn had no released surface to break.
 
+- **`MARKDOWN_VAULT_MCP_READ_ONLY` now defaults to `false`.** Through 3.1
+  it defaulted to `true`, so a server installed from any channel started
+  with its entire write surface hidden, which is "most of what the server
+  is for"
+  ([#1113](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1113)).
+  This is the one 4.0 change where doing nothing on upgrade silently
+  widens what a connected model may do to your data: a default install
+  now gains `write`, `edit`, `append`, `delete`, `rename`, `move_folder`,
+  and `fetch` (seven tools, not the full write-tagged set: `git_sync`,
+  `create_upload_link`, and the `okf_*` tools stay behind their own
+  gates). Set `MARKDOWN_VAULT_MCP_READ_ONLY=true` explicitly to keep a
+  read-only server
+  ([#1119](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1119)).
+  The corresponding library-level defaults
+  (`Vault.__init__`/`DocumentManager.__init__`) are unchanged at
+  `read_only=True`, since that tier is a downstream Python consumer's
+  fail-safe, not the operator default.
+- **`fetch` follows redirects instead of refusing them.** Through 3.1 the
+  tool's own docstring promised redirects were not followed; a caller
+  that relied on a refusal error to reject indirection now silently gets
+  content instead, with `final_url` reporting where it actually came from
+  ([#1116](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1116),
+  fixed in
+  [#1118](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1118)).
+  See [Security fixes](#security-fixes) for the guard-safety detail.
 - **`from markdown_vault_mcp import X` no longer works for most names.** The
   package root used to lazily re-export `Vault`, `ProjectConfig`,
   `GitWriteStrategy`, every exception type, and the shared dataclasses; it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-vault-mcp"
-version = "4.0.0-rc.4"
+version = "4.0.0-rc.5"
 description = "Generic markdown vault MCP server with FTS5 + semantic search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/uv.lock
+++ b/uv.lock
@@ -1739,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "4.0.0rc4"
+version = "4.0.0rc5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **4.0.0-rc.5** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

This PR also carries the release-notes page under `docs/releases/`,
drafted by the prepare run's notes job — review it as part of the release
(an evidence check: every causal claim must trace to its linked issue or
PR).  The PR is held as a DRAFT until the notes land; the notes job marks
it ready.  Still draft means the notes job is running or failed — check
the prepare run.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Breaking Changes

- replace anthropic summarizer with generic OpenAI-compatible backend (#917)
- dual-mode background jobs via pvl-core 4.11.0 + template v3.3.0 (#1034)
- make reindex and build_embeddings dual-mode background jobs (#1037)
- adopt the branch-aware release model via copier update to template v4.0.0 (#1066)
- follow redirects, report the final URL, and classify the change (#1118)
- default READ_ONLY to false so the write surface ships enabled (#1119)

## Features

- add LLM-backed summarize tool gated on an API key (#869)
- folder conventions — per-folder authoring policy for LLM clients (#877)
- configurable title field, searchable frontmatter, and ranking weights (#867)
- map-reduce summarization for inputs beyond one model request (#924)
- per-call max_notes with in-result coverage hint for summarize (#926)
- rebuild on INDEXED_FIELDS change; SEARCHABLE_FIELDS defaults to it (#928)
- bound summarize latency with a timeout error and background jobs (#937) (#938)
- detect OKF bundles and annotate read surfaces (#968)
- OKF filter dimensions and graph node typing (#970)
- okf_validate conformance audit tool (#971)
- migration transforms (wikilink conversion, index/log generation) (#973)
- adopt fastmcp-pvl-core transfer subsystem; retire local store (#981)
- bundle export via an okf-bundle download ref (#982)
- enforced write layer — provenance stamping, verification invalidation, okf_verify (#964) (#984)
- enforced-write convention maintenance — log.md append + index.md refresh (#964) (#987)
- ranking downweights for deprecated/stale/reserved files (#965) (#988)
- configurable timeout (EMBED_TIMEOUT_S) + batch size (EMBEDDING_BATCH_SIZE) (#1000)
- harden okf_verify against model self-attestation (#990) (#1004)
- scope okf_seed_log's log.md content to the folder's subtree (#974) (#1005)
- add append tool for end-of-note writes without a prior read (#1025)
- ship client-side summarization recipe as summarize-subtree prompt (#1038)
- adopt template v3.4.0 — generated mcpb screen, curated fields, pre-release checks (#1045)
- adopt template v3.5.0 — plugin channel onto the template scaffold (#1046)
- vault-summarize skill and vault-mapper agent for client-side summarization (#1047)
- vault-setup skill and SessionStart doctor hook for in-session bootstrap (#1048)
- generated userConfig configuration screen — no more shell-profile setup (#1049)

## Bug Fixes

- hybrid search vector channel misses folder normalization (#882)
- recover keyword/hybrid search for hyphenated terms (#866) (#884)
- stop reasoning models exhausting the summarize token budget (#920)
- forbid assistant-style offers in summarize output (#923)
- bump transitive mcp 1.28.0 → 1.28.1 (CVE-2026-59950) (#934)
- make incremental reindex inline embedding resilient to provider timeouts (#930) (#932)
- guard inline/converge vector mutation against dimension mismatch (#935) (#936)
- resolve leading-slash markdown links against the vault root (#972)
- skip malformed-frontmatter files in build_embeddings (#994)
- retry failed deferred pushes on the periodic pull-loop tick (#997)
- honour process umask for newly created files (#958) (#998)
- single-agent reviewer; drop fan-out plugin + pin experiment
- drop Task from @claude — #1499 background-subagent orphan footgun
- allow-list Skill defensively (both claude workflows)
- finalize pin-combo reviewer (restore CI gate, drop show_full_output)
- close SSRF gaps by migrating to pvl-core's hardened fetch_url (#1029)
- adopt template v3.2.2 — template-owned bump_manifests, non-mutating CI syncs (#1032)
- drop track_progress from the notes drafting action (#1094)
- make the notes drafting agent able to write — and safe to run (#1095)
- rc releases get their full artifact set, and the 4.0 notes page passes its own evidence contract (#1096)
- clear the v4.0 milestone's bug reports (#1109)
- never send a blank string to the embedding provider (#1112)
- raise the pvl-core floor to 4.11.2 and drop the removed read_only kwarg (#1117)
