### PR TITLE
fix(index): rebuild when the parse pipeline changes, and expose a force flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,5 +501,6 @@ If a conflict marker appears in a copier-update bot PR, the conflict itself ofte
 - Hybrid search: Reciprocal Rank Fusion (RRF)
 - Tool semantics: mirror Claude Code Read/Write/Edit patterns
 - Library is sync; MCP layer uses `asyncio.to_thread()`
+- Indexing is hash-based, so an unchanged file is never re-parsed: any change to how a note's stored rows are derived from its bytes (link extraction, chunking, tag/alias/heading derivation) must bump `INDEX_SEMANTICS_VERSION` in `fts_index.py` in the same commit, or deployed vaults keep serving the rows the old code produced (#1124)
 - Full decision log in `docs/design/design.md` appendix
 <!-- DOMAIN-END -->

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Point it at a directory of Markdown files (an Obsidian vault, a docs folder, a Z
 > **Upgrading.** As of this release, `search` returns query-relevant snippets in the `content` field by default (approximately 200 words). Pass `snippet_words=0` to recover the prior full-chunk behaviour, or use `read(path, section=heading)` to fetch the full section after seeing a snippet. Documents are also re-chunked on next `reindex` to honour the adaptive `MARKDOWN_VAULT_MCP_MAX_CHUNK_WORDS` threshold (default 400).
 - **Frontmatter-aware**: indexes YAML frontmatter fields, supports required field enforcement
 - **OKF-aware**: recognizes [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog) bundles (an `okf_version` declaration in the root `index.md`) and annotates search/read results with each note's type, lifecycle status, staleness, and trust tier. Those dimensions are filterable and also nudge ranking on a detected bundle (deprecated and stale notes rank lower, and the reserved `index.md` / `log.md` navigation files are demoted below real notes), and the server adds an `okf_validate` conformance audit plus one-shot migration transforms (`okf_convert_links`, `okf_generate_index`, `okf_seed_log`) for moving a vault into the format, plus a downloadable bundle export served through `create_download_link` with an `okf-bundle` reference. Read semantics are controlled by `MARKDOWN_VAULT_MCP_OKF_MODE`
-- **Incremental reindexing**: hash-based change detection, only re-processes modified files; an automatic boot-time reconciliation pass picks up changes made while no server was running, and the vector index converges to the reconciled chunk set (embedding exactly the delta)
+- **Incremental reindexing**: hash-based change detection, only re-processes modified files; an automatic boot-time reconciliation pass picks up changes made while no server was running, and the vector index converges to the reconciled chunk set (embedding exactly the delta). Each build records the version of the parse pipeline that produced it, so an upgrade that changes what is extracted from a note rebuilds the index once instead of serving rows the current server would no longer produce
 - **Write operations**: create, edit, append to, delete, rename documents, and move entire folder subtrees with automatic index updates
 - **Folder conventions**: per-folder `_conventions.md` files carry your authoring rules, such as "reference notes stay self-contained"; the server surfaces them to LLM clients at write time via the `get_conventions` tool and in `write`/`edit` results, without interpreting them
 - **Attachment support**: read, write, delete, and list non-markdown files (PDFs, images, etc.)
@@ -418,8 +418,10 @@ markdown-vault-mcp search <query> [-n LIMIT] [-m {keyword|semantic|hybrid}] [--f
 Incrementally reindex the vault (only processes changed files). When semantic search is configured, the vector index is converged to the updated chunk set: exactly the changed documents are re-embedded and orphaned vectors dropped, never the whole corpus.
 
 ```bash
-markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
+markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH] [--force]
 ```
+
+`--force` drops the index and re-parses every file, ignoring change detection. An upgrade that changes how notes are parsed rebuilds the index by itself on the next run, so this is a manual repair for an index you have reason to distrust, not routine maintenance.
 
 ## MCP Tools
 
@@ -436,7 +438,7 @@ markdown-vault-mcp reindex [--source-dir PATH] [--index-path PATH]
 | `list_documents` | List indexed documents; pass `include_attachments=true` to also list non-markdown files |
 | `list_folders` | List all folder paths in the vault |
 | `list_tags` | List all unique frontmatter tag values |
-| `reindex` | Incrementally reindex files changed outside the server; fast runs answer inline with real counts, slow runs promote to a job (`get_job_result`) |
+| `reindex` | Incrementally reindex files changed outside the server (`force=true` re-parses everything); fast runs answer inline with real counts, slow runs promote to a job (`get_job_result`) |
 | `stats` | Get vault statistics (document count, chunk count, link health metrics, etc.) |
 | `build_embeddings` | Build or rebuild vector embeddings for semantic search; fast convergence answers inline, slow builds promote to a job (`get_job_result`) |
 | `embeddings_status` | Check embedding provider and index status |

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -604,6 +604,28 @@ Two methods manage the index:
   unreachable at startup, so its context length reads as `None` and the cap
   falls back to a conservative default) changes neither key and so does
   not force a rebuild, avoiding flap.
+
+  **Derived-content invalidation (issue #1124)**: the same `meta` row set
+  carries one key that records no operator input —
+  `index_semantics_version`, written from the source constant
+  `INDEX_SEMANTICS_VERSION` in `fts_index.py`. Change detection is
+  hash-based, so an unchanged file is never re-parsed; the rows derived
+  from its bytes (links, chunks, tags, aliases, headings) therefore survive
+  every upgrade that fixes how those rows are derived. That is what #1124
+  observed after the link-extraction fixes in #1104 / #1107: new notes got
+  the corrected extraction, every pre-existing note kept its wrong link
+  rows, and no tool exposed a way to force the re-parse. The constant is
+  bumped in the same commit as any change that makes unchanged bytes yield
+  different stored rows; `_chunking_meta_matches` compares it like every
+  other key, so the first start after such an upgrade rejects the
+  short-circuit and cold-rebuilds once. An index written before the key
+  existed reads back as `0` and rebuilds on the same rule; a corrupted or
+  unparseable row also reads as `0`, because serving stale derived rows is
+  the worse failure. Changes that only affect how stored rows are queried
+  or rendered (ranking, snippets, response shaping) need no bump.
+  `reindex(force=True)` is the manual counterpart, surfacing the
+  already-existing `build_index(force=True)` for an index an operator has
+  reason to distrust.
 - **`reindex()`**: incremental update. Uses `ChangeTracker` to detect
   adds/modifies/deletes since the last scan and applies only the delta.
   Applies `exclude_patterns` filtering and purges stale excluded documents.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -39,7 +39,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`get_job_result`](#get_job_result) | Get Job Result | AI | Retrieve the outcome of a background job started by a long-running tool |
 | [`get_history`](#get_history) | Note History | Read (git) | List commits that touched a note, attachment, folder, or the whole vault |
 | [`get_diff`](#get_diff) | Note Diff | Read (git) | Return a diff of a note or attachment between two points in history |
-| [`reindex`](#reindex) | Reindex Vault | Admin | Incremental reindex; inline result when fast, job promotion when slow |
+| [`reindex`](#reindex) | Reindex Vault | Admin | Incremental reindex (`force=true` re-parses everything); inline result when fast, job promotion when slow |
 | [`build_embeddings`](#build_embeddings) | Build Embeddings | Admin | Build or rebuild vector embeddings; inline result when fast, job promotion when slow |
 | [`write`](#write) | Write Note | Write | Create or overwrite a document or attachment |
 | [`edit`](#edit) | Edit Note | Write | Replace a unique text span in a document |
@@ -279,7 +279,15 @@ If semantic search is configured, the reindex job re-embeds the changed document
 !!! note "Boot reconciliation"
     The server lifespan automatically queues one incremental reindex at every startup (#665), so files added, modified, or deleted while no server was running are reconciled without a manual `reindex` call. Reads served before that job completes report `index_stale: true` in `_meta`.
 
-**Returns:** The tool is dual-mode. A fast reindex (the common case, since work scales with the drift, not the vault) completes inline with `"status": "completed"` and its real counts: `added`, `modified`, `deleted`, `unchanged`, and `skipped`. A reindex still running at the jobs soft deadline (`JOBS_SOFT_DEADLINE_S`, default 25 s) continues on the single-owner :class:`IndexWriter` thread (#559) and returns `{"status": "working", "job_id": ...}` immediately; fetch the outcome with [`get_job_result`](#get_job_result). A failure within the deadline raises immediately; after promotion it is reported through `get_job_result` (and mirrored in `get_index_status`'s `last_reindex_error`). `get_index_status` remains the non-blocking observability view (`queue_depth`, `in_flight`, `dirty_paths`, `dirty_embeddings`), covering boot-time and file-watcher work no client call initiated.
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `force` | bool | `false` | When true, drops every indexed document and re-parses the whole vault instead of applying the hash-detected delta. The index is not queryable while the rebuild runs |
+
+Change detection is hash-based, so an unchanged file is never re-parsed, and the rows derived from it (links, chunks, tags) persist as first extracted. A server upgrade that changes extraction needs the index rebuilt, and the server does that for itself: each build records the version of its parse pipeline, and a start that finds an older version rebuilds once before serving (#1124). `force=true` is the manual form of the same repair, for an index you have reason to distrust; it is not routine maintenance. An ordinary reindex re-embeds the documents it touches, but a forced rebuild does not, so follow one with [`build_embeddings`](#build_embeddings) (without `force`) when semantic search is configured.
+
+**Returns:** The tool is dual-mode. A fast reindex (the common case, since work scales with the drift, not the vault) completes inline with `"status": "completed"` and its real counts: `added`, `modified`, `deleted`, `unchanged`, and `skipped`, plus `full_rebuild` (true only for a `force=true` run, whose counts report every document under `added` because the rebuild dropped and re-added them all). A reindex still running at the jobs soft deadline (`JOBS_SOFT_DEADLINE_S`, default 25 s) continues on the single-owner :class:`IndexWriter` thread (#559) and returns `{"status": "working", "job_id": ...}` immediately; fetch the outcome with [`get_job_result`](#get_job_result). A failure within the deadline raises immediately; after promotion it is reported through `get_job_result` (and mirrored in `get_index_status`'s `last_reindex_error`). `get_index_status` remains the non-blocking observability view (`queue_depth`, `in_flight`, `dirty_paths`, `dirty_embeddings`), covering boot-time and file-watcher work no client call initiated.
 
 ### `build_embeddings`
 

--- a/src/markdown_vault_mcp/_server_tools/index.py
+++ b/src/markdown_vault_mcp/_server_tools/index.py
@@ -144,6 +144,7 @@ def register_index_jobs(mcp: FastMCP, jobs: Jobs) -> None:
     )
     @needs_queryable()
     async def reindex(
+        force: bool = False,
         vault: Vault = Depends(get_vault),
     ) -> dict[str, Any]:
         """Run an incremental reindex on the writer thread.
@@ -153,6 +154,16 @@ def register_index_jobs(mcp: FastMCP, jobs: Jobs) -> None:
         the vault directory. Do NOT call this after using 'write', 'edit',
         'delete', or 'rename' — those tools update the index immediately as
         part of the operation.
+
+        Change detection is hash-based, so an unchanged file is never
+        re-parsed. Use force=True to drop the index and re-parse every file
+        regardless of hashes — the repair for index content that no longer
+        matches what the current server would extract. A version upgrade that
+        changes extraction does this by itself on the next start (#1124), so
+        force=True is a manual escape hatch, not routine maintenance. When
+        semantic search is configured, follow a force=True run with
+        'build_embeddings' (without force) so the vector index converges to
+        the rebuilt chunk set; an ordinary reindex re-embeds as it goes.
 
         To rebuild all embeddings from scratch (e.g. after changing the
         embedding model), use 'build_embeddings' with force=True.
@@ -165,16 +176,29 @@ def register_index_jobs(mcp: FastMCP, jobs: Jobs) -> None:
         observability view of the index (it also covers boot-time builds and
         file-watcher reindexes no client call initiated).
 
+        Args:
+            force: When True, drop every indexed document and re-parse the
+                whole vault instead of applying the hash-detected delta.
+                The index is not queryable while the rebuild runs, and the
+                cost scales with the vault rather than the drift, so prefer
+                the default.
+
         Returns:
             On inline completion, a dict with ``"status": "completed"`` plus
             the reindex counts:
 
-            - added (int): Documents added since the last index.
-            - modified (int): Documents that changed since the last index.
-            - deleted (int): Documents removed since the last index.
-            - unchanged (int): Documents with no changes.
+            - added (int): Documents added since the last index. On a
+              force=True rebuild every indexed document is counted here,
+              because the rebuild dropped and re-added them all.
+            - modified (int): Documents that changed since the last index
+              (always 0 on a force=True rebuild).
+            - deleted (int): Documents removed since the last index (always
+              0 on a force=True rebuild — the drop is not a vault change).
+            - unchanged (int): Documents with no changes (always 0 on a
+              force=True rebuild).
             - skipped (int): Files deliberately not indexed (missing required
               frontmatter, exclude patterns, unparseable).
+            - full_rebuild (bool): True when force=True re-parsed everything.
 
             When promoted, a dict with ``"status": "working"``, a ``job_id``,
             and a ``poll_with`` field naming ``get_job_result``.
@@ -191,8 +215,19 @@ def register_index_jobs(mcp: FastMCP, jobs: Jobs) -> None:
                 fails with a job-limit error and the queued reindex is
                 cancelled — retry after fetching pending job results.
         """
+        if force:
+            stats = await asyncio.wrap_future(vault.index.build_index_async(force=True))
+            return {
+                "status": "completed",
+                "added": stats.documents_indexed,
+                "modified": 0,
+                "deleted": 0,
+                "unchanged": 0,
+                "skipped": stats.skipped,
+                "full_rebuild": True,
+            }
         result = await asyncio.wrap_future(vault.index.reindex_async())
-        return {**asdict(result), "status": "completed"}
+        return {**asdict(result), "status": "completed", "full_rebuild": False}
 
     @register_long_running_tool(
         mcp,

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -232,6 +232,15 @@ def reindex(
     index_path: str | None = typer.Option(
         None, help=f"Path to SQLite index file (overrides ${_ENV_PREFIX}_INDEX_PATH)."
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help=(
+            "Drop the index and re-parse every file, ignoring change detection. "
+            "An upgrade that changes extraction rebuilds by itself on the next "
+            "run; use this only for an index you have reason to distrust."
+        ),
+    ),
 ) -> None:
     """Incrementally reindex the vault."""
     from markdown_vault_mcp._http_logging import quiet_http_loggers
@@ -240,8 +249,9 @@ def reindex(
     quiet_http_loggers()
     vault = _build_vault(source_dir, index_path)
     # reindex() needs a built index (#525); build_index() is a cheap no-op when
-    # the index is already populated (a SQL row-count check, no filesystem scan).
-    vault.index.build_index()
+    # the index is already populated (a SQL row-count check, no filesystem scan)
+    # and the recorded build provenance still matches this process (#1124).
+    vault.index.build_index(force=force)
     result = vault.index.reindex()
     typer.echo(
         f"Reindex: {result.added} added, {result.modified} modified, "

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -189,6 +189,29 @@ _META_SEARCHABLE_FIELDS_KEY = "searchable_fields"
 # left to default to INDEXED_FIELDS).
 _META_INDEXED_FIELDS_KEY = "indexed_frontmatter_fields"
 
+# Derived-content provenance: the version of this server's own parse-to-row
+# pipeline (#1124). Unlike every key above it, this records no operator input
+# at all — it is a source constant, bumped whenever a code change alters the
+# rows derived from unchanged file bytes. Indexing is hash-based, so an
+# unchanged file is never re-parsed after an upgrade and its stale rows would
+# be served indefinitely; recording the version lets the warm-restart
+# short-circuit reject an index built by an older pipeline and cold-rebuild
+# it once. An index written before this key existed reads back as 0, so the
+# first start after the upgrade rebuilds — which is the repair #1124 found
+# missing after the link-extraction fixes in #1104 / #1107.
+_META_INDEX_SEMANTICS_KEY = "index_semantics_version"
+
+#: Current version of the parse-to-row pipeline whose output is stored in the
+#: index (link extraction, chunk boundaries, tag/alias/heading derivation).
+#:
+#: **Bump this in the same commit** as any change that makes an unchanged file
+#: yield different stored rows. The bump is what converts such a fix into a
+#: fix operators actually receive: on the next start, the warm-restart
+#: short-circuit is rejected and every file is re-parsed once. Changes that
+#: only affect how stored rows are *queried* or *rendered* (ranking, snippets,
+#: response shaping) need no bump — nothing on disk went stale.
+INDEX_SEMANTICS_VERSION = 1
+
 
 class ChunkingMeta(NamedTuple):
     """Embedding/indexing provenance recorded with an FTS build (#649).
@@ -207,6 +230,8 @@ class ChunkingMeta(NamedTuple):
         indexed_frontmatter_fields: Comma-joined canonical form of the
             frontmatter fields promoted to ``document_tags`` for structured
             filtering (default ``""`` — none configured).
+        semantics_version: :data:`INDEX_SEMANTICS_VERSION` in force when the
+            build ran (``0`` for an index written before the key existed).
     """
 
     model: str | None
@@ -214,6 +239,7 @@ class ChunkingMeta(NamedTuple):
     title_field: str = "title"
     searchable_fields: str = ""
     indexed_frontmatter_fields: str = ""
+    semantics_version: int = 0
 
 
 def _escape_like(value: str) -> str:
@@ -1041,6 +1067,12 @@ class FTSIndex:
         detect a genuine option change and reject the short-circuit,
         triggering a cold rebuild (#649, #927).
 
+        :data:`INDEX_SEMANTICS_VERSION` is written alongside them and is
+        deliberately not a parameter: it records this build's *code*
+        provenance rather than an operator input, so a pipeline change that
+        alters derived rows invalidates the index the same way an option
+        change does (#1124).
+
         Args:
             model: Embedding model name, or ``None`` when no provider is
                 configured. ``None`` is stored as the empty string.
@@ -1072,6 +1104,7 @@ class FTSIndex:
                 (_META_TITLE_FIELD_KEY, title_value),
                 (_META_SEARCHABLE_FIELDS_KEY, searchable_fields),
                 (_META_INDEXED_FIELDS_KEY, indexed_frontmatter_fields),
+                (_META_INDEX_SEMANTICS_KEY, str(INDEX_SEMANTICS_VERSION)),
             ):
                 conn.execute(
                     "INSERT OR REPLACE INTO meta(key, value) VALUES(?, ?)",
@@ -1088,18 +1121,22 @@ class FTSIndex:
             ``max_chunk_chars_override``, ``"title"`` for ``title_field``,
             ``""`` for ``searchable_fields`` and
             ``indexed_frontmatter_fields``);
-            ``max_chunk_chars_override`` reads back as ``int``.
+            ``max_chunk_chars_override`` reads back as ``int``, and
+            ``semantics_version`` as ``int`` (``0`` when absent or
+            unparseable — either way the index predates the pipeline
+            version it claims and must be rebuilt).
         """
         conn = self._conn()
         with conn:
             rows = conn.execute(
-                "SELECT key, value FROM meta WHERE key IN (?, ?, ?, ?, ?)",
+                "SELECT key, value FROM meta WHERE key IN (?, ?, ?, ?, ?, ?)",
                 (
                     _META_EMBED_MODEL_KEY,
                     _META_MAX_CHUNK_CHARS_OVERRIDE_KEY,
                     _META_TITLE_FIELD_KEY,
                     _META_SEARCHABLE_FIELDS_KEY,
                     _META_INDEXED_FIELDS_KEY,
+                    _META_INDEX_SEMANTICS_KEY,
                 ),
             ).fetchall()
         stored = {row[0]: row[1] for row in rows}
@@ -1109,12 +1146,19 @@ class FTSIndex:
         # An empty string (a stored ``None``) is falsy → reads back as None;
         # config rejects a 0 override so truthiness is safe here.
         override: int | None = int(override_raw) if override_raw else None
+        try:
+            semantics_version = int(stored.get(_META_INDEX_SEMANTICS_KEY) or 0)
+        except ValueError:
+            # A hand-edited or corrupted row is not a reason to serve stale
+            # derived rows: read it as "older than anything" and rebuild.
+            semantics_version = 0
         return ChunkingMeta(
             model=model,
             max_chunk_chars_override=override,
             title_field=stored.get(_META_TITLE_FIELD_KEY) or "title",
             searchable_fields=stored.get(_META_SEARCHABLE_FIELDS_KEY) or "",
             indexed_frontmatter_fields=stored.get(_META_INDEXED_FIELDS_KEY) or "",
+            semantics_version=semantics_version,
         )
 
     @_retry_on_locked

--- a/src/markdown_vault_mcp/indexing/coordinator.py
+++ b/src/markdown_vault_mcp/indexing/coordinator.py
@@ -19,6 +19,7 @@ from concurrent.futures import CancelledError, Future
 from typing import TYPE_CHECKING, Any
 
 from markdown_vault_mcp.exceptions import IndexUnavailableError
+from markdown_vault_mcp.fts_index import INDEX_SEMANTICS_VERSION
 from markdown_vault_mcp.indexing.index_writer import (
     BuildEmbeddings,
     BuildIndex,
@@ -212,7 +213,7 @@ class IndexWriteCoordinator:
     # ------------------------------------------------------------------
 
     def _chunking_meta_matches(self) -> bool:
-        """True when the stored build provenance matches the current config.
+        """True when the stored build provenance matches this process.
 
         Compares the STABLE inputs to the FTS build's contents — the model
         name and the explicit ``MAX_CHUNK_CHARS`` override (the shared
@@ -224,15 +225,51 @@ class IndexWriteCoordinator:
         warm-restart short-circuit (cold rebuild); a derived cap that merely
         differs because the model context was read transiently differently
         (e.g. an Ollama instance briefly unreachable) changes no input, so
-        it does NOT force a rebuild (avoid flapping)."""
+        it does NOT force a rebuild (avoid flapping).
+
+        The recorded :data:`~markdown_vault_mcp.fts_index.INDEX_SEMANTICS_VERSION`
+        is compared on the same footing (#1124). It is the one key that is
+        not an operator input: it invalidates an index whose derived rows
+        (links, chunks, tags) were produced by an older parse pipeline, which
+        hash-based reindexing would otherwise never re-parse.
+
+        Returns:
+            ``True`` when every recorded key matches; ``False`` after logging
+            the first mismatching key at INFO, so the rebuild an operator
+            sees in the log names its own cause.
+        """
         stored = self._fts.get_chunking_meta()
-        return (
-            stored.model == self._embed_model_name
-            and stored.max_chunk_chars_override == self._max_chunk_chars_override
-            and stored.title_field == self._title_field
-            and stored.searchable_fields == self._searchable_fields
-            and stored.indexed_frontmatter_fields == self._indexed_frontmatter_fields
+        checks: tuple[tuple[str, object, object], ...] = (
+            ("embed_model_name", stored.model, self._embed_model_name),
+            (
+                "max_chunk_chars_override",
+                stored.max_chunk_chars_override,
+                self._max_chunk_chars_override,
+            ),
+            ("title_field", stored.title_field, self._title_field),
+            ("searchable_fields", stored.searchable_fields, self._searchable_fields),
+            (
+                "indexed_frontmatter_fields",
+                stored.indexed_frontmatter_fields,
+                self._indexed_frontmatter_fields,
+            ),
+            (
+                "index_semantics_version",
+                stored.semantics_version,
+                INDEX_SEMANTICS_VERSION,
+            ),
         )
+        for key, stored_value, current_value in checks:
+            if stored_value != current_value:
+                logger.info(
+                    "index_provenance_changed key=%s stored=%s current=%s "
+                    "action=rebuild",
+                    key,
+                    stored_value,
+                    current_value,
+                )
+                return False
+        return True
 
     def build_index(self, *, force: bool = False) -> IndexStats:
         """Scan source_dir and build the FTS index (warm restart is O(1))."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -726,6 +726,36 @@ def test_reindex_calls_build_index_first() -> None:
     assert call_names.index("build_index") < call_names.index("reindex")
 
 
+def test_reindex_force_drops_and_rebuilds() -> None:
+    """``--force`` passes force through to build_index (#1124 escape hatch)."""
+    mock_vault = MagicMock()
+    mock_result = MagicMock()
+    mock_result.added = mock_result.modified = mock_result.deleted = 0
+    mock_result.unchanged = mock_result.skipped = 0
+    mock_vault.index.reindex.return_value = mock_result
+
+    with patch("markdown_vault_mcp.cli._build_vault", return_value=mock_vault):
+        result = runner.invoke(app, ["reindex", "--force"])
+
+    assert result.exit_code == 0, result.output
+    mock_vault.index.build_index.assert_called_once_with(force=True)
+
+
+def test_reindex_without_force_keeps_warm_restart() -> None:
+    """Without ``--force`` the build stays the cheap warm-restart no-op."""
+    mock_vault = MagicMock()
+    mock_result = MagicMock()
+    mock_result.added = mock_result.modified = mock_result.deleted = 0
+    mock_result.unchanged = mock_result.skipped = 0
+    mock_vault.index.reindex.return_value = mock_result
+
+    with patch("markdown_vault_mcp.cli._build_vault", return_value=mock_vault):
+        result = runner.invoke(app, ["reindex"])
+
+    assert result.exit_code == 0, result.output
+    mock_vault.index.build_index.assert_called_once_with(force=False)
+
+
 def test_reindex_builds_embeddings_when_configured() -> None:
     """``reindex`` calls build_embeddings() (no force) when configured."""
     mock_vault = MagicMock()

--- a/tests/test_fts_index.py
+++ b/tests/test_fts_index.py
@@ -1144,33 +1144,52 @@ class TestGetRecent:
 
 
 def test_chunking_meta_roundtrip(tmp_path):
-    from markdown_vault_mcp.fts_index import ChunkingMeta, FTSIndex
+    from markdown_vault_mcp.fts_index import (
+        INDEX_SEMANTICS_VERSION,
+        ChunkingMeta,
+        FTSIndex,
+    )
 
     idx = FTSIndex(db_path=str(tmp_path / "i.db"))
     idx.set_chunking_meta(model="bge-m3:latest", max_chunk_chars_override=5000)
     assert idx.get_chunking_meta() == ChunkingMeta(
-        model="bge-m3:latest", max_chunk_chars_override=5000
+        model="bge-m3:latest",
+        max_chunk_chars_override=5000,
+        semantics_version=INDEX_SEMANTICS_VERSION,
     )
     idx2 = FTSIndex(db_path=str(tmp_path / "j.db"))
+    # A never-built index reads back the all-defaults meta, semantics
+    # version included (0 = "older than any recorded pipeline", #1124).
     assert idx2.get_chunking_meta() == ChunkingMeta(
         model=None, max_chunk_chars_override=None
     )
+    assert idx2.get_chunking_meta().semantics_version == 0
 
 
 def test_chunking_meta_stores_none_as_empty(tmp_path):
     """``None`` model + override round-trip back as ``None`` (stored empty)."""
-    from markdown_vault_mcp.fts_index import ChunkingMeta, FTSIndex
+    from markdown_vault_mcp.fts_index import (
+        INDEX_SEMANTICS_VERSION,
+        ChunkingMeta,
+        FTSIndex,
+    )
 
     idx = FTSIndex(db_path=str(tmp_path / "k.db"))
     idx.set_chunking_meta(model=None, max_chunk_chars_override=None)
     assert idx.get_chunking_meta() == ChunkingMeta(
-        model=None, max_chunk_chars_override=None
+        model=None,
+        max_chunk_chars_override=None,
+        semantics_version=INDEX_SEMANTICS_VERSION,
     )
 
 
 def test_chunking_meta_indexed_frontmatter_fields_roundtrip(tmp_path):
     """indexed_frontmatter_fields persists and defaults to ``""``."""
-    from markdown_vault_mcp.fts_index import ChunkingMeta, FTSIndex
+    from markdown_vault_mcp.fts_index import (
+        INDEX_SEMANTICS_VERSION,
+        ChunkingMeta,
+        FTSIndex,
+    )
 
     idx = FTSIndex(db_path=str(tmp_path / "i.db"))
     idx.set_chunking_meta(
@@ -1182,6 +1201,7 @@ def test_chunking_meta_indexed_frontmatter_fields_roundtrip(tmp_path):
         model=None,
         max_chunk_chars_override=None,
         indexed_frontmatter_fields="tags,category",
+        semantics_version=INDEX_SEMANTICS_VERSION,
     )
     idx2 = FTSIndex(db_path=str(tmp_path / "j.db"))
     assert idx2.get_chunking_meta().indexed_frontmatter_fields == ""

--- a/tests/test_index_coordinator.py
+++ b/tests/test_index_coordinator.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from markdown_vault_mcp.exceptions import IndexUnavailableError
-from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.fts_index import INDEX_SEMANTICS_VERSION, FTSIndex
 from markdown_vault_mcp.indexing import IndexWriteCoordinator, ProcessDirtyPaths
 from markdown_vault_mcp.managers.index import IndexManager
 from markdown_vault_mcp.scanner import HeadingChunker
@@ -234,6 +234,173 @@ def test_transient_context_read_does_not_flap(tmp_path: Path) -> None:
         assert coord2._chunking_meta_matches() is True
         stats = coord2.build_index()
         assert stats.chunks_indexed == 0  # warm O(1)
+    finally:
+        coord2.close(timeout=5)
+
+
+# --- #1124: an older parse pipeline rejects the warm restart ---------------
+
+
+def _stored_semantics_version(db: Path) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        row = conn.execute(
+            "SELECT value FROM meta WHERE key = 'index_semantics_version'"
+        ).fetchone()
+    finally:
+        conn.close()
+    return 0 if row is None else int(row[0])
+
+
+def _set_semantics_version(db: Path, value: str) -> None:
+    conn = sqlite3.connect(db)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES('index_semantics_version', ?)",
+                (value,),
+            )
+    finally:
+        conn.close()
+
+
+def _link_targets(db: Path) -> list[str]:
+    conn = sqlite3.connect(db)
+    try:
+        return [row[0] for row in conn.execute("SELECT target_path FROM links")]
+    finally:
+        conn.close()
+
+
+def test_build_records_current_semantics_version(tmp_path: Path) -> None:
+    """A clean build stamps the running pipeline version into ``meta``."""
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, db=db)
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+    assert _stored_semantics_version(db) == INDEX_SEMANTICS_VERSION
+
+
+def test_older_semantics_version_rejects_warm_restart(tmp_path: Path) -> None:
+    """An index built by an older parse pipeline is rebuilt, not short-circuited.
+
+    Hash-based reindexing never re-parses an unchanged file, so rows derived
+    from its bytes by a since-fixed extractor would be served forever. The
+    stale link row planted here stands in for the wrong link rows #1124
+    reported surviving an upgrade: only a real re-parse clears it.
+    """
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, db=db)
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+
+    conn = sqlite3.connect(db)
+    try:
+        with conn:
+            doc_id = conn.execute("SELECT id FROM documents LIMIT 1").fetchone()[0]
+            conn.execute(
+                "INSERT INTO links(source_id, target_path, link_text, link_type) "
+                "VALUES(?, 'stale-extractor-row.md', '#Stale', 'wikilink')",
+                (doc_id,),
+            )
+    finally:
+        conn.close()
+    assert "stale-extractor-row.md" in _link_targets(db)
+    _set_semantics_version(db, str(INDEX_SEMANTICS_VERSION - 1))
+
+    coord2 = make_coordinator(tmp_path, db=db)
+    try:
+        assert coord2._chunking_meta_matches() is False
+        stats = coord2.build_index()
+        assert stats.chunks_indexed > 0  # full re-parse ran, not warm O(1)
+    finally:
+        coord2.close(timeout=5)
+
+    assert "stale-extractor-row.md" not in _link_targets(db)
+    assert _stored_semantics_version(db) == INDEX_SEMANTICS_VERSION
+
+
+def test_absent_semantics_version_rejects_warm_restart(tmp_path: Path) -> None:
+    """An index written before the key existed reads as 0 and rebuilds once."""
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, db=db)
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+
+    conn = sqlite3.connect(db)
+    try:
+        with conn:
+            conn.execute("DELETE FROM meta WHERE key = 'index_semantics_version'")
+    finally:
+        conn.close()
+
+    coord2 = make_coordinator(tmp_path, db=db)
+    try:
+        assert coord2._chunking_meta_matches() is False
+        assert coord2.build_index().chunks_indexed > 0
+    finally:
+        coord2.close(timeout=5)
+
+
+def test_unparseable_semantics_version_rejects_warm_restart(tmp_path: Path) -> None:
+    """A corrupted version row rebuilds rather than trusting the index."""
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, db=db)
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+    _set_semantics_version(db, "not-a-version")
+
+    coord2 = make_coordinator(tmp_path, db=db)
+    try:
+        assert coord2._chunking_meta_matches() is False
+    finally:
+        coord2.close(timeout=5)
+
+
+def test_async_warm_restart_also_rejects_older_semantics(tmp_path: Path) -> None:
+    """The async boot path applies the same invalidation as the sync one."""
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, db=db)
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+    _set_semantics_version(db, str(INDEX_SEMANTICS_VERSION - 1))
+
+    coord2 = make_coordinator(tmp_path, db=db)
+    try:
+        stats = coord2.build_index_async().result(timeout=30)
+        assert stats.chunks_indexed > 0  # a real BuildIndex job ran
+    finally:
+        coord2.close(timeout=5)
+
+
+def test_provenance_mismatch_is_logged_with_its_key(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The rebuild an operator sees in the log names the key that caused it."""
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, embed_model_name="A", db=db)
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+
+    coord2 = make_coordinator(tmp_path, embed_model_name="B", db=db)
+    try:
+        with caplog.at_level(
+            logging.INFO, logger="markdown_vault_mcp.indexing.coordinator"
+        ):
+            assert coord2._chunking_meta_matches() is False
+        assert "index_provenance_changed key=embed_model_name" in caplog.text
     finally:
         coord2.close(timeout=5)
 

--- a/tests/test_tools_index.py
+++ b/tests/test_tools_index.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for the get_index_status tool skipped_files field (#775)."""
+"""End-to-end tests for the index-management tools (#775, #1124)."""
 
 from __future__ import annotations
 
@@ -61,3 +61,49 @@ async def test_get_index_status_exposes_skipped_files(
     paths = {e["path"]: e for e in data["skipped_files"]}
     assert "bad.md" in paths
     assert paths["bad.md"]["category"] == "parse_error"
+
+
+async def test_reindex_reports_incremental_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plain reindex applies the delta and says it was not a full rebuild."""
+    (tmp_path / "a.md").write_text("# A\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
+    server = make_server()
+    async with Client(server) as client:
+        await wait_for_mcp_writer_drain(client)
+        data = (await client.call_tool("reindex", {})).data
+    assert data["status"] == "completed"
+    assert data["full_rebuild"] is False
+
+
+async def test_reindex_force_reparses_every_document(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """force=True re-parses the whole vault, not the hash-detected delta (#1124).
+
+    Change detection would report every unchanged file as ``unchanged``; the
+    forced rebuild drops the index instead, so each document comes back as an
+    add. That is the operator-facing repair for rows derived by an older
+    extractor.
+    """
+    (tmp_path / "a.md").write_text("# A\n\nbody\n", encoding="utf-8")
+    (tmp_path / "b.md").write_text("# B\n\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
+    server = make_server()
+    async with Client(server) as client:
+        await wait_for_mcp_writer_drain(client)
+        data = (await client.call_tool("reindex", {"force": True})).data
+        await wait_for_mcp_writer_drain(client)
+        status = (await client.call_tool("get_index_status", {})).data
+    assert data["status"] == "completed"
+    assert data["full_rebuild"] is True
+    assert data["added"] == 2
+    assert data["modified"] == data["deleted"] == data["unchanged"] == 0
+    assert status["documents_indexed"] == 2


### PR DESCRIPTION
## Closes / Refs

Closes #1124

## What & why

Indexing is hash-based, so an unchanged file is never re-parsed and the rows derived from its bytes (links, chunks, tags, aliases) survive an upgrade that fixes how those rows are derived. #1124 observed exactly that after the link-extraction fixes in #1104 / #1107: notes written after the upgrade got the corrected extraction, every pre-existing note kept its wrong link rows, `stats.broken_link_count` stayed at its pre-upgrade figure, and no tool could force the re-parse.

Each clean build now records `INDEX_SEMANTICS_VERSION` — a source constant naming the version of the parse-to-row pipeline — into the FTS `meta` table alongside the existing provenance keys (`embed_model_name`, `max_chunk_chars_override`, `title_field`, `searchable_fields`, `indexed_frontmatter_fields`). `IndexWriteCoordinator._chunking_meta_matches` compares it on the same footing, so a start that finds an older version rejects the warm-restart short-circuit and cold-rebuilds once, through the existing #513 background-build path. It is the one recorded key that is not an operator input: the mechanism the design doc already had for option changes now covers code changes too.

The already-deployed indexes the issue reports are repaired by the same rule — an index written before the key existed reads back as `0`, and so does a corrupted row, because serving stale derived rows is the worse failure. A mismatch on any provenance key is now logged at INFO with the key that caused it, so the rebuild an operator sees in the log names its own cause rather than being unexplained.

The `reindex` tool gains `force=True` and the CLI `reindex` a `--force` flag, surfacing the already-existing `build_index(force=True)` as the manual repair for an index an operator has reason to distrust. Its result carries `full_rebuild` and reports every document under `added`, since the rebuild dropped and re-added them all.

Keeping the mechanism working depends on a convention no test can enforce — a pipeline change must bump the constant — so that rule is recorded in `CLAUDE.md` next to the other key design decisions.

## What this PR deliberately does NOT do

- Does not re-verify the #1104 / #1107 extraction fixes themselves; the issue confirms they are correct on new content, and this PR only changes whether existing content is re-parsed.
- Does not add a mechanical guard that a pipeline change bumped the constant. A test cannot tell a derivation change from a refactor; the convention is documented in `CLAUDE.md` and in the constant's own docstring instead.
- Does not converge embeddings from inside the forced `reindex` path. The boot flow already runs `build_embeddings` after a build, and the tool docstring plus the docs page point manual callers at it.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening this PR.
- [x] No commit carries `!`. The library surface only gains names (`INDEX_SEMANTICS_VERSION`, a defaulted `ChunkingMeta.semantics_version`), the `reindex` tool and CLI changes are additive, and no operator action is required to upgrade — the one-time rebuild is what the fix is.

## Docs impact

- [x] `README.md` — the incremental-reindexing bullet states the recorded pipeline version; the CLI `reindex` section documents `--force`; the tool table row mentions it.
- [x] `docs/` site pages — `docs/tools/index.md` gains the `reindex` parameter table, the hash-based-staleness explanation, and the `full_rebuild` return key.
- [x] `docs/design/design.md` — new "Derived-content invalidation (issue #1124)" subsection under Index Lifecycle, alongside the chunking-provenance one it extends.
- [x] Inline docstrings — `INDEX_SEMANTICS_VERSION`, `ChunkingMeta`, `set_chunking_meta` / `get_chunking_meta`, `_chunking_meta_matches`, and both `reindex` surfaces.

## Verification

- `uv run pytest -x -q` — 3452 passed, 21 skipped (the one failure in an earlier run was `test_release_tags_are_visible_when_the_changelog_records_releases` on a tagless fresh clone; it passes after `git fetch --tags`).
- `uv run ruff check --fix .` → `uv run ruff format .` → `uv run ruff format --check .` clean; `uv run mypy src/ tests/` clean.
- `bash scripts/structural_gate.sh` — 413 diff lines, 0 violations.
- `uv run pre-commit run --all-files` — all hooks pass, Vale included.
- New tests: the stale-link-row regression (a planted row survives a hash-based reindex and is cleared by the version-triggered rebuild), absent / unparseable version rows, the async boot path, the mismatch log line, both `reindex` force paths at the MCP layer, and the CLI flag.

---
_Generated by [Claude Code](https://claude.ai/code/session_019TbSHK8p1L1M6hgyc4qhEB)_