### PR TITLE
docs(git): cover the GitHub push webhook in the git integration guide

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -300,7 +300,7 @@ The endpoint is only available on HTTP/SSE transports. To set up:
 2. In your GitHub repository, add a webhook pointing at `https://<your-host>/github-webhook` with content type `application/json` and the same secret.
 3. Select the `push` event (other events are acknowledged with 200 and ignored).
 
-The periodic pull loop (`GIT_PULL_INTERVAL_S`) remains active as a belt-and-suspenders fallback for missed webhook deliveries.
+The periodic pull loop (`GIT_PULL_INTERVAL_S`) remains active as a belt-and-suspenders fallback for missed webhook deliveries. For the same setup in context, alongside the other sync mechanisms and what each delivery outcome means, see the [git integration guide](guides/git-integration.md#push-triggered-pull-github-webhook).
 
 ## File Watcher
 

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -32,6 +32,68 @@ Behavior:
 - Writes are committed and pushed after the configured idle delay.
 - Periodic pull uses fast-forward-only updates.
 
+Two mechanisms sit alongside the periodic loop, both described below: a
+GitHub webhook that pulls the moment someone pushes, and the `git_sync`
+tool for pulling or pushing on demand from inside a conversation.
+
+## Push-Triggered Pull: GitHub Webhook
+
+The periodic loop leaves reads up to `GIT_PULL_INTERVAL_S` seconds behind
+the remote (default 600). In a multi-author vault, where a teammate or
+another instance commits from elsewhere, that window is what the webhook
+closes: GitHub delivers a `push` event, the server pulls and reindexes
+straight away, and staleness drops to delivery latency, a couple of
+seconds in practice.
+
+Generate a secret and set it:
+
+```bash
+MARKDOWN_VAULT_MCP_GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 32)
+```
+
+Setting the secret mounts `POST /github-webhook` on the HTTP and SSE
+transports. Under stdio there is no HTTP server, so nothing is mounted and
+the setting has no effect. In the GitHub repository, add a webhook pointing
+at `https://<your-host>/github-webhook` with content type
+`application/json`, the same secret, and the `push` event selected.
+
+Behavior:
+
+- Every delivery's `X-Hub-Signature-256` header is verified (HMAC-SHA256,
+  constant-time). An invalid or missing signature returns 401 and no git
+  operation runs.
+- A `push` event pulls first, then reindexes only when HEAD actually moved.
+  A push to a branch the vault does not track leaves HEAD where it was, so
+  it costs a fetch and nothing more.
+- `ping`, GitHub's handshake delivery, answers `pong`; every other event
+  returns 200 and does nothing.
+- A delivery that lands before the server has finished starting, or whose
+  pull did not apply, returns 503 so GitHub retries it instead of marking
+  it delivered. GitHub's retry budget spans roughly two minutes, so a
+  delivery during a long cold-start index build can still be lost.
+- A pull that fails permanently, such as an unresolved conflict or a
+  missing remote, exhausts those retries and waits for the next periodic
+  tick. Divergent history is not a failure: it flows through the
+  Syncthing-style sibling resolution described under
+  [`git_sync`](#manual-sync-git_sync-tool) below.
+
+The webhook is a managed-mode feature. With no `GIT_REPO_URL` configured
+there is nothing to pull from, and deliveries are acknowledged with 200
+without doing any work.
+
+Keep `GIT_PULL_INTERVAL_S` enabled. The webhook narrows the staleness
+window; the loop is what catches the deliveries the webhook loses.
+
+!!! note "The file watcher steps aside"
+    Setting `GITHUB_WEBHOOK_SECRET` disables the filesystem watcher, the
+    same way `GIT_PULL_INTERVAL_S > 0` does. Git rewrites the working tree
+    during a checkout, and a watcher firing mid-checkout would scan a
+    partial tree. Reindexing stays driven by the webhook and the periodic
+    loop. See [File Watcher](../configuration.md#file-watcher).
+
+The variable itself is listed in the
+[configuration reference](../configuration.md#github-webhook-push-triggered-pull).
+
 ## Manual sync: `git_sync` tool
 
 The periodic loops are time-based: pull every

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -67,19 +67,25 @@ Behavior:
   it costs a fetch and nothing more.
 - `ping`, GitHub's handshake delivery, answers `pong`; every other event
   returns 200 and does nothing.
-- A delivery that lands before the server has finished starting, or whose
-  pull did not apply, returns 503 so GitHub retries it instead of marking
-  it delivered. GitHub's retry budget spans roughly two minutes, so a
-  delivery during a long cold-start index build can still be lost.
-- A pull that fails permanently, such as an unresolved conflict or a
-  missing remote, exhausts those retries and waits for the next periodic
-  tick. Divergent history is not a failure: it flows through the
+- A delivery whose pull did not apply returns 503, so GitHub retries it
+  instead of marking it delivered. A pull that keeps failing, such as an
+  unresolved conflict, exhausts the retries and waits for the next
+  periodic tick. Divergent history is not a failure: it flows through the
   Syncthing-style sibling resolution described under
   [`git_sync`](#manual-sync-git_sync-tool) below.
+- A delivery arriving while the initial index build is still running is
+  handled, not dropped. The pull is a pure git operation and runs
+  regardless of index state; only the reindex is skipped, and the boot
+  reconciliation pass that follows the build picks the pulled changes up.
 
-The webhook is a managed-mode feature. With no `GIT_REPO_URL` configured
-there is nothing to pull from, and deliveries are acknowledged with 200
-without doing any work.
+!!! warning "Managed mode only"
+    Set the secret only where the server owns the remote. Outside managed
+    mode a delivery is not a quiet no-op: the pull path ignores the sync
+    switch that unmanaged mode turns off and runs `git fetch origin`
+    anyway. A checkout with no reachable `origin` fails that fetch and
+    answers 503, burning GitHub's retries on every push; against a vault
+    that is not a git repository at all, the pull raises out of the
+    handler.
 
 Keep `GIT_PULL_INTERVAL_S` enabled. The webhook narrows the staleness
 window; the loop is what catches the deliveries the webhook loses.


### PR DESCRIPTION
## Closes / Refs

Closes #1126. Refs #1128 (a defect the verification pass turned up; not fixed here).

## What & why

`docs/guides/git-integration.md` is the page an operator reads to choose and configure a git sync mode, and it never mentioned the GitHub push webhook. The feature was documented when it landed (#530), but only in the configuration reference and the README env table — so someone setting up managed mode from the guide learned about `GIT_PULL_INTERVAL_S` and `git_sync` and stopped there, without discovering push-triggered pull or the fact that enabling it turns the file watcher off.

The guide now carries a **Push-Triggered Pull: GitHub Webhook** section, placed between managed mode and `git_sync` so the three pull mechanisms read in order of cadence. It covers why the staleness window exists, the secret plus repository setup, and what each delivery outcome means: 401 on a bad or missing signature with no git operation run, reindex only when HEAD moved (so a push to an untracked branch costs a fetch and nothing more), `ping` answered with `pong`, and 503 for a delivery whose pull did not apply, so GitHub retries rather than marking it delivered. It states that a delivery arriving during the initial index build is handled rather than dropped, that the periodic loop stays enabled as the backstop, and — as a warning — what actually happens when the secret is set outside managed mode.

The configuration reference gains one sentence linking back to that section, matching how the OKF rows point at their guide.

Every behavioural claim traces to `_github_webhook.py`, `server.py`'s mount condition, `domain.py`'s startup ordering, and `git/strategy.py`'s pull pipeline, rather than being restated from the existing prose.

### Review round 1

The bot review found two factual errors in the first draft, both correct, both fixed in 8dafaad:

1. The draft claimed a delivery without `GIT_REPO_URL` is acknowledged with 200 and does nothing. It is not: `to_vault_kwargs` builds a `GitWriteStrategy` on every path, and `force_pull` never consults `enable_pull`. Running it against both non-managed shapes shows `applied=False reason=fetch_failed` (→ 503) for a checkout with no reachable `origin`, and an uncaught `CalledProcessError` from `git rev-parse HEAD` for a vault that is not a git repository. The section now warns about exactly that, and the underlying behaviour is filed as #1128.
2. The draft claimed a delivery during a long cold-start index build can be lost. The opposite is true: `set_vault_singleton()` runs before the build is even submitted, and the pull runs regardless of index state by design. The bullet now says so.

## What this PR deliberately does NOT do

- Does not fix the non-managed-mode webhook behaviour it now warns about: #1128. Changing `force_pull` or the handler's error surface is a code change with its own test surface, not something to bury in a docs PR.
- Does not audit the other guide pages for the same documentation gap. #1126 notes that as an open question (`[unverified]`); this PR fixes the one page it reports.
- Does not assert whether a delivery can reach the handler before the vault singleton is set. The branch exists, but whether the transport routes requests that early was not verified, so the guide says nothing about it.
- Does not restructure the configuration reference's webhook section. It stays the variable-level reference; the guide is now the narrative half.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening this PR, and re-verified every claim against source after round 1.
- [x] No commit carries `!`, and none could: the change is prose. `docs:` cuts no release, which is correct here.

## Docs impact

- [x] `README.md` — no change needed; its env-var row already describes the webhook, and the README does not carry the guide's narrative.
- [x] `docs/` site pages — `docs/guides/git-integration.md` (new section) and `docs/configuration.md` (reverse link).
- [x] `docs/design/` — no change; no behaviour or architecture changed.
- [x] Inline docstrings — no change; `_github_webhook.py` already documents the contract this section describes.

## Verification

- Built the site with `uv run mkdocs build` and confirmed every new anchor resolves against a real generated id: `#push-triggered-pull-github-webhook`, `#manual-sync-git_sync-tool`, `../configuration/#file-watcher`, `../configuration/#github-webhook-push-triggered-pull`.
- Ran `GitWriteStrategy.force_pull()` against a git repo with no remote and against a plain directory to establish the non-managed failure modes the warning describes, instead of inferring them.
- Vale clean on both changed pages; full `uv run pre-commit run --all-files` passes.
- `uv run pytest -q` — 3446 passed. (A local `site/` build makes the 15 config-wizard smoke tests attempt a Chromium launch this container cannot satisfy; they skip by design without a built site, which is what the CI test lane does. Removing the local build restores the clean skip.)