### PR TITLE
fix(index): confirm FTS absence against the source tree before reclaiming vectors

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -753,8 +753,18 @@ reconciles:
   boundaries) are re-embedded in full. The multiset is the chunk identity
   (`VectorIndex` has no per-chunk keys, only a parallel metadata list
   with path-level deletion).
-- Vectors for documents no longer in the FTS index (deleted, or newly
-  excluded) are removed.
+- Vectors for documents no longer in the FTS index are removed — but only
+  when the absence is **authoritative** (#1130). FTS row absence alone also
+  covers a source the producing build failed to parse or a walk failed to
+  see (#1129), so a sidecar path with no FTS rows at all is first confirmed
+  against the source tree: an incomplete walk (unreadable or missing vault
+  directory) confirms nothing and removes nothing, and a source still
+  present on disk keeps its vectors — logged as
+  `build_embeddings_converge_kept` — unless re-parsing shows a state the
+  current build would also decline to embed (a deliberate
+  `missing_frontmatter` skip, or a note with no embeddable chunk text,
+  #930/#1087). Deletions and exclusions reclaim as before; a body-less note
+  that still has FTS chunk rows reclaims without touching the disk.
 - Unchanged documents are untouched; the sidecar is saved only when
   something actually changed, and the run is summarised in a single
   `build_embeddings_converged added=N removed=M up_to_date=K` log line.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -293,7 +293,7 @@ Change detection is hash-based, so an unchanged file is never re-parsed, and the
 
 Build vector embeddings to enable semantic and hybrid search. This can be slow for large vaults.
 
-Without `force`, an existing vector index is **converged** to the FTS chunk set (#665). The operation embeds missing documents, re-embeds those whose indexed content changed, and drops vectors for deleted or excluded documents. Work scales with the size of the drift, not the size of the vault; an already-converged index does no embedding work.
+Without `force`, an existing vector index is **converged** to the FTS chunk set (#665). The operation embeds missing documents, re-embeds those whose indexed content changed, and drops vectors for deleted or excluded documents. A document whose source file still exists but is missing from the search index (such as one that failed to parse) keeps its vectors until the index sees it again (#1130). Work scales with the size of the drift, not the size of the vault; an already-converged index does no embedding work.
 
 **Parameters:**
 

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -318,6 +318,98 @@ class IndexManager:
             return False
         return True
 
+    def _confirm_stale_vector_paths(self, stale_paths: list[str]) -> list[str]:
+        """Return the stale sidecar paths whose FTS absence is authoritative.
+
+        A path present in the vector sidecar but absent from the FTS index is
+        reclaimable only when the absence means "deleted or deliberately not
+        indexed". Absence equally covers a source the producing build failed
+        to parse or a walk failed to see (#1129), and deleting those vectors
+        turns a transient build gap into semantic-search loss that no later
+        pass repairs while the gap persists (#1130).
+
+        The convergence-side mirror of
+        :meth:`_empty_embedding_build_is_authoritative`: an incomplete source
+        walk confirms nothing, and a source still present on disk keeps its
+        vectors unless re-parsing shows a state the current build would also
+        decline to embed — a deliberate ``missing_frontmatter`` skip, or a
+        note whose chunks yield no embeddable text (#930/#1087) — so
+        reclaiming those is convergent rather than lossy.
+
+        Args:
+            stale_paths: Sidecar paths absent from the FTS chunk listing.
+
+        Returns:
+            The subset safe to reclaim, in input order.
+        """
+        walk_incomplete = False
+
+        def _record_walk_error(_exc: OSError) -> None:
+            nonlocal walk_incomplete
+            walk_incomplete = True
+
+        candidates = self._discover_indexable_candidates(
+            on_walk_error=_record_walk_error
+        )
+        if walk_incomplete:
+            logger.warning(
+                "build_embeddings_converge_walk_incomplete kept=%d "
+                "(no vectors removed)",
+                len(stale_paths),
+            )
+            return []
+        present = {rel: abs_path for abs_path, rel in candidates}
+        confirmed: list[str] = []
+        for path in stale_paths:
+            abs_path = present.get(path)
+            if abs_path is None:
+                # Deleted or excluded — the reclaim convergence exists for.
+                confirmed.append(path)
+                continue
+            outcome = parse_note_categorized(
+                abs_path,
+                self._source_dir,
+                self._chunk_strategy,
+                rel_path=path,
+                title_field=self._title_field,
+                required_frontmatter=self._required_frontmatter,
+                log_context="build_embeddings",
+            )
+            if self._stale_source_is_reclaimable(path, outcome):
+                confirmed.append(path)
+            else:
+                logger.warning(
+                    "build_embeddings_converge_kept path=%s "
+                    "(source present but absent from FTS; vectors kept)",
+                    path,
+                )
+        return confirmed
+
+    def _stale_source_is_reclaimable(
+        self, path: str, outcome: ParsedNote | CategorizedSkip | None
+    ) -> bool:
+        """Return whether a still-on-disk stale source's vectors may go.
+
+        ``True`` only for the two states the current build would also decline
+        to embed: a deliberate ``missing_frontmatter`` skip, or a note that
+        parses but yields no embeddable chunk text (#930/#1087). A transient
+        ``OSError`` (``None``), any other skip category, or a note that would
+        embed today all keep their vectors — the FTS gap, not the source, is
+        the anomaly there (#1130).
+        """
+        if isinstance(outcome, CategorizedSkip):
+            return outcome.skip.category == "missing_frontmatter"
+        if isinstance(outcome, ParsedNote):
+            texts, _meta = self._embed_inputs(
+                path=path,
+                title=outcome.title,
+                folder=_derive_folder(outcome.path),
+                frontmatter=outcome.frontmatter,
+                chunks=outcome.chunks,
+            )
+            return not texts
+        return False
+
     def _load_vectors(self) -> VectorIndex:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
 
@@ -1139,11 +1231,18 @@ class IndexManager:
         are reclaimed through the stale-path branch.  A sidecar written by a
         provider that *did* accept an empty input sees one re-embed of the
         affected documents and converges after it.  Documents present only
-        in the vector index (deleted or newly excluded while no server
-        ran) lose their vectors; documents missing from it are embedded;
-        documents whose chunk multiset differs in any way (modified
-        content, changed title, re-chunked boundaries) are re-embedded in
-        full.  The sidecar is saved only when something actually changed.
+        in the vector index lose their vectors when that absence is
+        authoritative — deleted, newly excluded, or deliberately skipped
+        while no server ran.  FTS absence alone does not establish that: it
+        equally covers a source the producing build failed to parse or a
+        walk failed to see (#1129), so paths FTS has no rows for at all are
+        first confirmed against the source tree via
+        :meth:`_confirm_stale_vector_paths`, and an unconfirmed path keeps
+        its vectors for the pass that next sees its source (#1130).
+        Documents missing from the vector index are embedded; documents
+        whose chunk multiset differs in any way (modified content, changed
+        title, re-chunked boundaries) are re-embedded in full.  The sidecar
+        is saved only when something actually changed.
 
         A provider failure while embedding one document's chunks skips
         that document — its existing vectors are left intact — and the
@@ -1205,7 +1304,13 @@ class IndexManager:
         # (first chunk only) so the signature diff detects offline
         # summary-only edits; the vector side stores it per row.
         fts_by_path: dict[str, list[dict[str, Any]]] = {}
+        # Every path FTS has chunk rows for, *before* the embeddable filter:
+        # a path present here but absent from fts_by_path is indexed with
+        # nothing embeddable (body-less, #1087), which reclaims without the
+        # source-side confirmation genuine FTS absence needs (#1130).
+        fts_chunk_paths: set[str] = set()
         for row in self._fts.list_chunks():
+            fts_chunk_paths.add(row["path"])
             row["preamble"] = (
                 self._embed_builder.fields_text(row.get("frontmatter_json"))
                 if row.get("is_first_chunk")
@@ -1237,6 +1342,14 @@ class IndexManager:
         vec_by_path = vectors.chunks_by_path()
 
         stale_paths = [p for p in vec_by_path if p not in fts_by_path]
+        # Sidecar paths FTS does not know at all cannot be reclaimed on row
+        # absence alone — that also covers parse failures and discovery gaps
+        # (#1129) — so they need source-side confirmation first (#1130).
+        unconfirmed = [p for p in stale_paths if p not in fts_chunk_paths]
+        if unconfirmed:
+            kept = set(unconfirmed) - set(self._confirm_stale_vector_paths(unconfirmed))
+            if kept:
+                stale_paths = [p for p in stale_paths if p not in kept]
         missing_paths: list[str] = []
         refresh_paths: list[str] = []
         up_to_date = 0

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1156,6 +1156,239 @@ class TestBuildEmbeddings:
 
 
 # ---------------------------------------------------------------------------
+# Convergence reclaims stale vectors only on authoritative FTS absence (#1130)
+# ---------------------------------------------------------------------------
+
+
+class TestConvergeStaleConfirmation:
+    """FTS row absence alone must not delete a still-existing source's vectors.
+
+    ``_converge_embeddings`` reclaims vectors for paths absent from FTS.
+    Absence also covers sources a build could not parse or a walk could not
+    see (#1129), so an unconfirmed absence must keep the vectors (#1130)
+    while genuine deletions, exclusions, deliberate ``missing_frontmatter``
+    skips, and body-less notes (#930/#1087) still reclaim.
+    """
+
+    @staticmethod
+    def _embedded_pair(tmp_path: Path):
+        """Vault with good.md + bad.md indexed and embedded; returns wiring."""
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text(
+            "---\ntitle: Good\n---\n# Good\n\nGood body.\n", encoding="utf-8"
+        )
+        (vault / "bad.md").write_text(
+            "---\ntitle: Bad\n---\n# Bad\n\nBad body.\n", encoding="utf-8"
+        )
+        embeddings_path = tmp_path / "embeddings"
+        provider = MockEmbeddingProvider()
+        mgr, _fts, _holder = _make_index_mgr(
+            vault,
+            tmp_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=provider,
+        )
+        mgr.build_index()
+        assert mgr.build_embeddings() == 2
+        assert set(VectorIndex.load(embeddings_path, provider).chunks_by_path()) == {
+            "good.md",
+            "bad.md",
+        }
+        return vault, embeddings_path, provider, mgr
+
+    @staticmethod
+    def _sidecar_paths(embeddings_path: Path, provider) -> set[str]:
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        return set(VectorIndex.load(embeddings_path, provider).chunks_by_path())
+
+    def test_unparseable_source_keeps_vectors(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Shape A of #1130: parse failure + forced FTS rebuild loses nothing."""
+        vault, embeddings_path, provider, mgr = self._embedded_pair(tmp_path)
+
+        # Corrupt bad.md; a forced FTS rebuild drops its row while the file
+        # is still on disk.
+        (vault / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
+        )
+        mgr.build_index(force=True)
+        assert {row["path"] for row in mgr._fts.list_notes()} == {"good.md"}
+
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            mgr.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {
+            "good.md",
+            "bad.md",
+        }
+        assert any(
+            "build_embeddings_converge_kept" in r.getMessage()
+            and "bad.md" in r.getMessage()
+            for r in caplog.records
+        )
+
+        # A second pass does not erode the guarantee.
+        mgr.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {
+            "good.md",
+            "bad.md",
+        }
+
+        # Once the source is valid again but FTS has not yet caught up, the
+        # gap is FTS-side, so the vectors still stay.
+        (vault / "bad.md").write_text(
+            "---\ntitle: Bad\n---\n# Bad\n\nRepaired body.\n", encoding="utf-8"
+        )
+        mgr.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {
+            "good.md",
+            "bad.md",
+        }
+
+        # After reindexing picks the repaired file back up, convergence heals.
+        mgr.build_index()
+        mgr.build_embeddings()
+        assert {row["path"] for row in mgr._fts.list_notes()} == {
+            "good.md",
+            "bad.md",
+        }
+        assert self._sidecar_paths(embeddings_path, provider) == {
+            "good.md",
+            "bad.md",
+        }
+
+    def test_unavailable_source_tree_keeps_all_vectors(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Shape B of #1130: a cold index over a vanished vault wipes nothing."""
+        import shutil
+
+        vault, embeddings_path, provider, _mgr = self._embedded_pair(tmp_path)
+
+        # Cold boot against the same sidecar with the source tree unavailable
+        # (unmounted volume / not-yet-populated checkout): the walk is
+        # incomplete, so nothing is authoritative and nothing is removed.
+        shutil.rmtree(vault)
+        state2 = tmp_path / "state2"
+        state2.mkdir()
+        mgr2, _fts2, _holder2 = _make_index_mgr(
+            vault,
+            state2,
+            embeddings_path=embeddings_path,
+            embedding_provider=provider,
+        )
+        mgr2.build_index()
+        assert mgr2._fts.list_notes() == []
+        with caplog.at_level(
+            logging.WARNING, logger="markdown_vault_mcp.managers.index"
+        ):
+            mgr2.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {
+            "good.md",
+            "bad.md",
+        }
+        assert any(
+            "build_embeddings_converge_walk_incomplete" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_deleted_source_still_reclaims(self, tmp_path: Path) -> None:
+        """A genuinely deleted note still loses its vectors — the reclaim
+        convergence exists for."""
+        vault, embeddings_path, provider, mgr = self._embedded_pair(tmp_path)
+
+        (vault / "bad.md").unlink()
+        mgr.build_index(force=True)
+        mgr.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {"good.md"}
+
+    def test_newly_excluded_source_still_reclaims(self, tmp_path: Path) -> None:
+        """A note newly covered by an exclude pattern loses its vectors."""
+        vault, embeddings_path, provider, _mgr = self._embedded_pair(tmp_path)
+
+        state2 = tmp_path / "state2"
+        state2.mkdir()
+        mgr2, _fts2, _holder2 = _make_index_mgr(
+            vault,
+            state2,
+            embeddings_path=embeddings_path,
+            embedding_provider=provider,
+            exclude_patterns=["bad.md"],
+        )
+        mgr2.build_index()
+        mgr2.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {"good.md"}
+
+    def test_missing_frontmatter_skip_still_reclaims(self, tmp_path: Path) -> None:
+        """A deliberate required-frontmatter skip is authoritative."""
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text(
+            "---\ntitle: Good\n---\n# Good\n\nGood body.\n", encoding="utf-8"
+        )
+        (vault / "bad.md").write_text(
+            "---\ntitle: Bad\n---\n# Bad\n\nBad body.\n", encoding="utf-8"
+        )
+        embeddings_path = tmp_path / "embeddings"
+        provider = MockEmbeddingProvider()
+        mgr, _fts, _holder = _make_index_mgr(
+            vault,
+            tmp_path,
+            embeddings_path=embeddings_path,
+            embedding_provider=provider,
+            required_frontmatter=["title"],
+        )
+        mgr.build_index()
+        assert mgr.build_embeddings() == 2
+
+        # Drop the required key: the note is now deliberately unindexed.
+        (vault / "bad.md").write_text("# Bad\n\nBad body.\n", encoding="utf-8")
+        mgr.build_index(force=True)
+        mgr.build_embeddings()
+        assert set(VectorIndex.load(embeddings_path, provider).chunks_by_path()) == {
+            "good.md"
+        }
+
+    def test_note_without_embeddable_text_still_reclaims(self, tmp_path: Path) -> None:
+        """A note that parses to no embeddable text loses its vectors (#930/#1087)."""
+        vault, embeddings_path, provider, mgr = self._embedded_pair(tmp_path)
+
+        (vault / "bad.md").write_text("---\ntitle: Bad\n---\n", encoding="utf-8")
+        mgr.build_index(force=True)
+        mgr.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {"good.md"}
+
+    def test_transient_oserror_keeps_vectors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A possibly-transient read failure confirms nothing."""
+        from markdown_vault_mcp.managers import index as index_module
+
+        vault, embeddings_path, provider, mgr = self._embedded_pair(tmp_path)
+
+        (vault / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
+        )
+        mgr.build_index(force=True)
+        monkeypatch.setattr(
+            index_module, "parse_note_categorized", lambda *_a, **_kw: None
+        )
+        mgr.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {
+            "good.md",
+            "bad.md",
+        }
+
+
+# ---------------------------------------------------------------------------
 # _load_vectors self-heal of a corrupt/incomplete sidecar
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Closes / Refs

Closes #1130. Refs #1129.

## What & why

`_converge_embeddings` deleted vectors for every sidecar path absent from FTS, which also covers sources the producing build failed to parse or a walk failed to see — shape A of #1130 (an unparseable note loses its vectors after a forced FTS rebuild and never gets them back) and shape B (a cold boot over an unavailable vault wipes the whole sidecar). Stale paths that FTS has no rows for at all are now confirmed against the source tree first, mirroring #1115's `_empty_embedding_build_is_authoritative` on the convergence side:

- An incomplete source walk (unreadable or missing vault directory) confirms nothing — no vectors are removed, logged as `build_embeddings_converge_walk_incomplete`.
- A source still present on disk keeps its vectors (`build_embeddings_converge_kept`) unless re-parsing shows a state the current build would also decline to embed: a deliberate `missing_frontmatter` skip, or a note whose chunks yield no embeddable text (#930/#1087).
- Genuine deletions and exclusions reclaim exactly as before, and a body-less note that still has FTS chunk rows reclaims through a pre-filter path set without touching the disk (preserving #1087's fast path).

The walk runs only when a sidecar path is entirely unknown to FTS, so a drift-free converge does no extra work.

## What this PR deliberately does NOT do

- (deferral): the structural refactor making FTS row absence unambiguous (tombstone rows for skipped files) — #1129
- (deferral): the empty-*build* persistence decision, already addressed by #1115 and untouched here
- (deferral): a genuinely empty, readable source directory with a clean walk remains an authoritative empty vault (consistent with #1115) and still reclaims — only *incomplete/unavailable* views and still-present sources are protected

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] Any commit carrying `!` breaks an operator or library surface that
      existed at the **last stable release** (see the breaking-change policy
      in `CLAUDE.md`) — MCP tool-surface changes alone do not earn a `!`. (No `!` carried: behavior fix, no surface change.)

## Docs impact

- [ ] `README.md` — no user-facing config/tool surface change
- [x] `docs/` site pages — `docs/tools/index.md` build-embeddings convergence paragraph
- [x] `docs/design/` — Embedding Convergence section (#665) updated with the authoritative-absence rule
- [x] Inline docstrings — `_converge_embeddings`, new `_confirm_stale_vector_paths` / `_stale_source_is_reclaimable`

**Rule: code without matching docs is incomplete.**

Gates run locally: full suite (3454 passed), ruff check+format, mypy, structural gate (100%), diff coverage (all new branches exercised by `TestConvergeStaleConfirmation`), Vale clean on the touched docs line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rYgqee5aGcdNDNvYumfsj

---
_Generated by [Claude Code](https://claude.ai/code/session_018rYgqee5aGcdNDNvYumfsj)_