### PR TITLE
chore: prepare release 4.0.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 <!-- version list -->
 
+## 4.0.0-rc.6 (2026-08-21)
+
+### Breaking Changes
+
+- replace anthropic summarizer with generic OpenAI-compatible backend (#917)
+- dual-mode background jobs via pvl-core 4.11.0 + template v3.3.0 (#1034)
+- make reindex and build_embeddings dual-mode background jobs (#1037)
+- adopt the branch-aware release model via copier update to template v4.0.0 (#1066)
+- follow redirects, report the final URL, and classify the change (#1118)
+- default READ_ONLY to false so the write surface ships enabled (#1119)
+
+### Features
+
+- add LLM-backed summarize tool gated on an API key (#869)
+- folder conventions — per-folder authoring policy for LLM clients (#877)
+- configurable title field, searchable frontmatter, and ranking weights (#867)
+- map-reduce summarization for inputs beyond one model request (#924)
+- per-call max_notes with in-result coverage hint for summarize (#926)
+- rebuild on INDEXED_FIELDS change; SEARCHABLE_FIELDS defaults to it (#928)
+- bound summarize latency with a timeout error and background jobs (#937) (#938)
+- detect OKF bundles and annotate read surfaces (#968)
+- OKF filter dimensions and graph node typing (#970)
+- okf_validate conformance audit tool (#971)
+- migration transforms (wikilink conversion, index/log generation) (#973)
+- adopt fastmcp-pvl-core transfer subsystem; retire local store (#981)
+- bundle export via an okf-bundle download ref (#982)
+- enforced write layer — provenance stamping, verification invalidation, okf_verify (#964) (#984)
+- enforced-write convention maintenance — log.md append + index.md refresh (#964) (#987)
+- ranking downweights for deprecated/stale/reserved files (#965) (#988)
+- configurable timeout (EMBED_TIMEOUT_S) + batch size (EMBEDDING_BATCH_SIZE) (#1000)
+- harden okf_verify against model self-attestation (#990) (#1004)
+- scope okf_seed_log's log.md content to the folder's subtree (#974) (#1005)
+- add append tool for end-of-note writes without a prior read (#1025)
+- ship client-side summarization recipe as summarize-subtree prompt (#1038)
+- adopt template v3.4.0 — generated mcpb screen, curated fields, pre-release checks (#1045)
+- adopt template v3.5.0 — plugin channel onto the template scaffold (#1046)
+- vault-summarize skill and vault-mapper agent for client-side summarization (#1047)
+- vault-setup skill and SessionStart doctor hook for in-session bootstrap (#1048)
+- generated userConfig configuration screen — no more shell-profile setup (#1049)
+
+### Bug Fixes
+
+- hybrid search vector channel misses folder normalization (#882)
+- recover keyword/hybrid search for hyphenated terms (#866) (#884)
+- stop reasoning models exhausting the summarize token budget (#920)
+- forbid assistant-style offers in summarize output (#923)
+- bump transitive mcp 1.28.0 → 1.28.1 (CVE-2026-59950) (#934)
+- make incremental reindex inline embedding resilient to provider timeouts (#930) (#932)
+- guard inline/converge vector mutation against dimension mismatch (#935) (#936)
+- resolve leading-slash markdown links against the vault root (#972)
+- skip malformed-frontmatter files in build_embeddings (#994)
+- retry failed deferred pushes on the periodic pull-loop tick (#997)
+- honour process umask for newly created files (#958) (#998)
+- single-agent reviewer; drop fan-out plugin + pin experiment
+- drop Task from @claude — #1499 background-subagent orphan footgun
+- allow-list Skill defensively (both claude workflows)
+- finalize pin-combo reviewer (restore CI gate, drop show_full_output)
+- close SSRF gaps by migrating to pvl-core's hardened fetch_url (#1029)
+- adopt template v3.2.2 — template-owned bump_manifests, non-mutating CI syncs (#1032)
+- drop track_progress from the notes drafting action (#1094)
+- make the notes drafting agent able to write — and safe to run (#1095)
+- rc releases get their full artifact set, and the 4.0 notes page passes its own evidence contract (#1096)
+- clear the v4.0 milestone's bug reports (#1109)
+- never send a blank string to the embedding provider (#1112)
+- raise the pvl-core floor to 4.11.2 and drop the removed read_only kwarg (#1117)
+- rebuild when the parse pipeline changes, and expose a force flag (#1125)
+- persist authoritative empty embedding rebuilds (#1115)
+- confirm FTS absence against the source tree before reclaiming vectors (#1132)
+- adopt template v5.3.1→v5.4.0, and de-fork README.md and ci.yml to pristine (#1138)
+
 ## 4.0.0-rc.5 (2026-08-20)
 
 ### Breaking Changes

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -395,7 +395,7 @@ flow.
 
 One-time upload and download links now survive a server restart: the token
 store moved from an in-memory dictionary onto `fastmcp-pvl-core`'s shared,
-KV-backed transfer subsystem, retiring roughly 350 lines of local machinery
+KV-backed transfer subsystem, retiring roughly 800 lines of local machinery
 in the process
 ([#979](https://github.com/pvliesdonk/markdown-vault-mcp/issues/979),
 [#981](https://github.com/pvliesdonk/markdown-vault-mcp/pull/981)). A

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -377,8 +377,8 @@ flow.
   ([#1130](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1130));
   a note with malformed frontmatter or an empty body no longer aborts an
   entire embedding batch
-  ([#994](https://github.com/pvliesdonk/markdown-vault-mcp/issues/994),
-  [#1112](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1112));
+  ([#994](https://github.com/pvliesdonk/markdown-vault-mcp/pull/994),
+  [#1112](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1112));
   and a single embedding-provider timeout or vector-dimension mismatch no
   longer fails a whole reindex or convergence pass
   ([#930](https://github.com/pvliesdonk/markdown-vault-mcp/issues/930),

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -1,508 +1,452 @@
 # 4.0
 
-<!-- notes-range-end: 8dc73f8cd42f2fc5cdcaa77c81fbcbaa7311b25b -->
+<!-- notes-range-end: 2651e8e65c1a24d2d5c10d52e6ec14b84fd002c5 -->
 
 <!-- RELEASE-SUMMARY v4.0.0 START -->
-4.0.0 is the first stable release since v3.1.0 (July 8, 2026), and it carries
-everything that accumulated while a planned 3.2.0 release ran seven
-release-candidate revisions without converging
-([#1054](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1054)). The
-headline additions are [Open Knowledge Format (OKF)
-support](#open-knowledge-format-okf-support) for structured agent-context
-vaults, a rebuilt [LLM summarization](#llm-backed-summarization) feature that
-now talks to any OpenAI-compatible endpoint and runs as a background job when
-it's slow, per-vault [authoring conventions and ranking
-control](#folder-conventions-custom-frontmatter-and-ranking-control), a new
-`append` tool, security fixes, and a [Claude Code plugin
-channel](#packaging-the-claude-code-plugin-channel) with guided setup. Late in
-the cycle, `MARKDOWN_VAULT_MCP_READ_ONLY` also flipped its default from `true`
-to `false`, so a freshly installed server now serves its write tools out of
-the box instead of only a search index
-([#1113](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1113)). It's
-a major version because four things break existing setups on upgrade; see
-[Upgrading](#upgrading).
+4.0 is the release where the vault stops being just a search index. It gains
+awareness of [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+(Google's Open Knowledge Format): detection, filtering, a conformance audit,
+migration and bundle-export tooling, and an operator-gated enforced-write
+layer with human-in-the-loop attestation. The `summarize` tool grows a
+map-reduce path for folders too large for one model call, dual-mode
+background jobs, and a client-side alternative for installs with no
+configured backend. Search gains configurable title fields, searchable
+frontmatter, and per-folder and per-column ranking weights. The Claude Code
+plugin and Claude Desktop bundle both switch to generated, curated
+configuration screens with an in-session repair path, replacing shell-profile
+edits. Three things change on upgrade without a config change on your part:
+the write tools ship enabled by default, `fetch` now follows redirects, and
+`from markdown_vault_mcp import ...` no longer works. Import from submodules
+instead.
 <!-- RELEASE-SUMMARY v4.0.0 END -->
 
-## Why this release covers so much
+This is the first stable release since [3.1](3.1.md). It carries five
+epics (OKF support, the summarize tool's evolution into a background-job
+platform, search ranking configuration, the plugin and Desktop install
+experience, and the release process itself moving to branch-aware,
+knope-driven release PRs), plus a security-hardening pass on the `fetch`
+tool and a long tail of correctness fixes to folder-scoped search, link
+extraction, and the vector sidecar.
 
-Between v3.1.0 and 4.0.0, `main` accumulated 125+ commits while `v3.2.0-rc.1`
-through `v3.2.0-rc.7` ran for five weeks without ever becoming a stable
-release. The rc series stalled on a mechanical problem: each `v3.2.0-rc.N`
-tag predicted the next stable would be `3.2.0`, but the release tooling
-recomputes the target from every commit since the last *stable* release, so
-each new merge kept pushing the real target past `3.2.0`. The project's own
-diagnosis, quoted directly: "no dispatch can now produce 3.2.0," because the
-finalise path emits 4.0.0 instead
-([#1054](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1054)). The
-release-engineering rebuild that fixed this is out of scope for these notes,
-since it changed how *this project* ships releases and not anything an
-operator of the MCP server needs to touch, but it's why 4.0.0 bundles six
-weeks of feature work instead of arriving in smaller pieces.
+## Upgrade notes
 
-## Open Knowledge Format (OKF) support
+Five things change behavior on upgrade. Two need no code change to notice;
+read them first.
 
-[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) is a
-standard for a bundle of markdown files with YAML frontmatter serving as
-curated agent context. The server's design already matched that shape by
-construction, it just had no OKF awareness
+### The write tools ship enabled by default
+
+`MARKDOWN_VAULT_MCP_READ_ONLY` now defaults to `false`, where it defaulted to
+`true` through 3.1
+([#1113](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1113),
+[#1119](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1119)). An
+operator who set nothing and relied on the old default gets a vault an LLM
+client can now write to, edit, and delete from. Set
+`MARKDOWN_VAULT_MCP_READ_ONLY=true` explicitly to keep a search-only
+instance.
+
+The flip exposes seven tools that were previously hidden: `write`, `edit`,
+`append`, `delete`, `rename`, `move_folder`, and `fetch`. Four more
+write-tagged tools stay behind their own separate gates regardless of this
+setting: `git_sync` (needs managed git mode), `create_upload_link` (needs an
+HTTP transport), and the `okf_*` write tools (need OKF semantics active, and
+`okf_verify` also needs `OKF_WRITE=true`). The Python library default
+is unchanged: `Vault(..., read_only=True)` remains the fail-safe default for
+code that omits the argument.
+
+### `fetch` now follows redirects
+
+Through 3.1, `fetch` refused any URL that redirected. It now follows the
+chain and returns the resolved end-of-chain URL as a new `final_url` field
+([#1116](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1116),
+[#1118](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1118)). This
+was a deliberate call, not an oversight: the SSRF guard now checks scheme,
+address, and IP pin again on every hop instead of once before the first
+request, so this per-hop check is a stronger guarantee than the old
+blanket refusal, and ordinary indirection (`http` to `https`, shortened
+links, CDN hand-offs) now resolves instead of failing. A caller that used
+the redirect refusal as a way to reject indirection now gets content
+instead; there is no opt-out.
+
+### `summarize`, `reindex`, and `build_embeddings` changed their polling shape
+
+Both `reindex`/`build_embeddings` and `summarize` moved onto a shared
+dual-mode background-job mechanism this release
+([#1033](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1033),
+[#1037](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1037),
+[#1034](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1034)). A call
+that finishes within `MARKDOWN_VAULT_MCP_JOBS_SOFT_DEADLINE_S` (default 25
+seconds) now returns its real result inline instead of a `{"status": "queued"}`
+placeholder. A call that runs longer is promoted to a background job and
+polled with the generic `get_job_result` tool, which replaces the
+summarize-specific `get_summary` tool entirely. A caller built against the
+old `queued`/`get_summary` shape needs to move to the new one.
+
+### The Anthropic-specific `summarize` backend is gone
+
+`summarize` no longer talks to the Anthropic API directly. It speaks a
+generic OpenAI-compatible chat-completions API instead: the same client
+code now serves OpenAI, Ollama, Anthropic's own OpenAI-compatible endpoint,
+vLLM, LM Studio, OpenRouter, and LiteLLM without per-provider branching
+([#915](https://github.com/pvliesdonk/markdown-vault-mcp/issues/915),
+[#917](https://github.com/pvliesdonk/markdown-vault-mcp/pull/917)). A bare
+`ANTHROPIC_API_KEY` or `MARKDOWN_VAULT_MCP_SUMMARIZE_ANTHROPIC_MODEL` is no
+longer read, and `MARKDOWN_VAULT_MCP_SUMMARIZE_PROVIDER=anthropic` now
+raises a configuration error naming the migration path: point
+`MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_BASE_URL` at Anthropic's
+`https://api.anthropic.com/v1/` endpoint instead.
+
+### Importing from the package root no longer works
+
+`from markdown_vault_mcp import Vault` (and every other name previously
+re-exported at the package root, including `ProjectConfig`, the exception
+hierarchy, the `types` dataclasses, and `GitWriteStrategy`) now raises
+`ImportError`. The
+package root shrank to a docstring and `__version__`, matching the shared
+template's minimal-skeleton convention
+([#903](https://github.com/pvliesdonk/markdown-vault-mcp/issues/903),
+[#912](https://github.com/pvliesdonk/markdown-vault-mcp/pull/912)). Import
+from the owning submodule instead: `from markdown_vault_mcp.vault import
+Vault`, `from markdown_vault_mcp.config import ProjectConfig`, and so on.
+See the [source layout](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/CLAUDE.md#project-structure)
+for which submodule owns which name.
+
+This is a breaking change to the public library interface under this
+project's own versioning policy, and issue #903 said so explicitly before
+the work started ("This is a breaking change to the library's public import
+surface"). The merged commit's title did not carry a breaking-change marker.
+This page's classification follows the issue, not the commit: MCP tool
+callers are unaffected (nothing here touches a registered tool), but a
+Python program importing this package from its root breaks and needs the
+submodule-import migration above.
+
+## Highlights
+
+### OKF (Open Knowledge Format) support
+
+Google's [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+(spec v0.2, announced June 2026) standardizes exactly the artifact this
+server already indexes: a directory of markdown files with YAML frontmatter,
+curated as context for AI agents. The server was already most of the way
+there by construction (frontmatter-aware indexing, permissive parsing,
+broken-link tolerance, a wikilink-and-markdown-link graph, git versioning),
+but had no OKF-specific semantics for the `type`/`status`/`stale_after`
+field family or the `index.md`/`log.md` reserved-file conventions
 ([#959](https://github.com/pvliesdonk/markdown-vault-mcp/issues/959)). This
-release adds a full, independently enabled layer on top:
+release adds them, end to end.
 
-- **Detection and read annotations**
-  ([#968](https://github.com/pvliesdonk/markdown-vault-mcp/pull/968)): the
-  server probes for an `okf_version` declaration in the vault's root
-  `index.md` and, once found, adds `okf` metadata to `search`, `read`, and
-  `get_context` results, an `okf` section to `stats`, and version/mode
-  reporting to the `config://vault` resource. Controlled by
-  `MARKDOWN_VAULT_MCP_OKF_MODE` (`auto` / `off` / `on`); a non-OKF vault's
-  responses are byte-identical to before.
-- **Filtering and graph typing**
-  ([#970](https://github.com/pvliesdonk/markdown-vault-mcp/pull/970)): new
-  `status`, `stale`, and `trust_tier` filters on `search`, `list_documents`,
-  and `get_similar`, and a `note_type` field on graph-neighborhood nodes.
-- **Conformance auditing**: the new `okf_validate` tool
-  ([#971](https://github.com/pvliesdonk/markdown-vault-mcp/pull/971)) reports
-  conformant/non-conformant note counts with three severities and example
-  paths, and works even before a vault has declared an `okf_version`.
-- **Migration tooling**
-  ([#973](https://github.com/pvliesdonk/markdown-vault-mcp/pull/973)): three
-  new write tools, `okf_convert_links`, `okf_generate_index`, and
-  `okf_seed_log`, turn an existing vault into an OKF-conformant one by
-  rewriting wikilinks to OKF's root-absolute markdown style, generating a
-  reserved `index.md` from the table of contents, and seeding a reserved
-  `log.md` change history from git. `okf_seed_log` was later scoped to a
-  folder's own subtree instead of the whole vault's history
-  ([#1005](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1005)).
-- **Bundle export**: `create_download_link` gained an `okf-bundle` ref
-  ([#982](https://github.com/pvliesdonk/markdown-vault-mcp/pull/982)) that
-  packages the vault (or a folder) as a self-contained OKF archive, rewriting
-  wikilinks and excluding template/`_conventions.md` files. This needed the
-  server's transfer layer to carry generated bytes rather than only
-  pass-through files, which landed first as its own adoption of
-  `fastmcp-pvl-core`'s transfer subsystem
-  ([#981](https://github.com/pvliesdonk/markdown-vault-mcp/pull/981)).
-- **Enforced writes and human verification**, opt-in via
-  `MARKDOWN_VAULT_MCP_OKF_WRITE` (default `false`): enforced writes stamp a
-  `generated: {by, at}` provenance marker and clear any `verified` marker on
-  content change
-  ([#984](https://github.com/pvliesdonk/markdown-vault-mcp/pull/984)), and a
-  companion `okf_verify` tool lets a note be attested as human-reviewed.
-  That attestation was hardened before release: an early version stamped
-  `human:<subject>` from bearer-auth identity alone, with no evidence of
-  actual review
-  ([#990](https://github.com/pvliesdonk/markdown-vault-mcp/issues/990)). The
-  shipped behavior instead defaults `MARKDOWN_VAULT_MCP_OKF_VERIFY=elicit`,
-  which asks a human via MCP elicitation and fails closed; `trust-auth`
-  (the old behavior) is available but opt-in, and `off` hides the tool
-  ([#1004](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1004)).
-  Enforced writes also keep a vault's reserved files current automatically,
-  appending a `log.md` bullet and refreshing `index.md` after every write
-  ([#987](https://github.com/pvliesdonk/markdown-vault-mcp/pull/987)).
-- **Ranking**: once OKF is active, search and listing results downweight
-  `status: deprecated` notes (×0.5), stale notes (×0.75), and reserved files
-  like `index.md`/`log.md` (×0.5) across keyword, semantic, and hybrid
-  search, so they stop crowding out current content
-  ([#988](https://github.com/pvliesdonk/markdown-vault-mcp/pull/988),
-  reported in
-  [#965](https://github.com/pvliesdonk/markdown-vault-mcp/issues/965)).
+Two independent channels control it, deliberately kept apart: a vault
+declares `okf_version` in its root `index.md` and that declaration only ever
+buys read semantics and advisory conventions; an operator's environment
+config is the only thing that can authorize write behavior. The design
+rationale, quoted directly: the vault is writable by the agent itself
+through the `write` tool, so "data that could enable byte-changing or
+write-refusing server behavior would be a self-modifying-config loop."
+Vault content may only ever advise, never authorize.
 
-Guides for getting started live at
-[`docs/guides/okf.md`](../guides/okf.md), with interop sections added to the
-[PARA](../guides/para.md) and [Zettelkasten](../guides/zettelkasten.md)
-guides and a starter `examples/okf/` pack
-([#989](https://github.com/pvliesdonk/markdown-vault-mcp/pull/989)).
+- **Detection and read-side annotation.** With `MARKDOWN_VAULT_MCP_OKF_MODE`
+  at its default `auto`, declaring `okf_version` in the vault's root
+  `index.md` switches on `okf` annotations (`type`, derived `status`,
+  staleness, trust tier) in `search`, `read`, and `get_context` results, and
+  an `okf` section in `stats`. Set `off` to disable OKF semantics entirely,
+  or `on` to force them without a declaration
+  ([#960](https://github.com/pvliesdonk/markdown-vault-mcp/issues/960),
+  [#968](https://github.com/pvliesdonk/markdown-vault-mcp/pull/968)).
+- **Filtering and graph typing.** `search`, `list_documents`, and
+  `get_similar` gain `status`, `stale`, and `trust_tier` filter dimensions,
+  and graph views color nodes by OKF type
+  ([#961](https://github.com/pvliesdonk/markdown-vault-mcp/issues/961),
+  [#970](https://github.com/pvliesdonk/markdown-vault-mcp/pull/970)).
+- **`okf_validate`**, a disk-based conformance audit that reports
+  conformance as a degree rather than a verdict: a count of conformant
+  notes out of the total, plus per-rule violation counts across three
+  severities
+  ([#962](https://github.com/pvliesdonk/markdown-vault-mcp/issues/962),
+  [#971](https://github.com/pvliesdonk/markdown-vault-mcp/pull/971)).
+- **Migration and bundle export.** `okf_convert_links` rewrites `[[wikilinks]]`
+  to OKF's recommended bundle-root-absolute markdown links without breaking
+  the link graph; `okf_generate_index` and `okf_seed_log` populate a
+  folder's `index.md` and `log.md` (the latter from git history, scoped to
+  the folder's own subtree); bundle export is a `create_download_link` call
+  with `ref="okf-bundle"` (or `"okf-bundle:<folder>"` for a subtree), not a
+  separate tool
+  ([#963](https://github.com/pvliesdonk/markdown-vault-mcp/issues/963),
+  [#973](https://github.com/pvliesdonk/markdown-vault-mcp/pull/973),
+  [#982](https://github.com/pvliesdonk/markdown-vault-mcp/pull/982)).
+- **An enforced write layer**, off by default
+  (`MARKDOWN_VAULT_MCP_OKF_WRITE=false`). Turned on for an active bundle,
+  every write stamps `generated: {by, at}` provenance and clears any prior
+  `verified` attestation when content changes, and a folder's `log.md`/
+  `index.md` stay current automatically
+  ([#964](https://github.com/pvliesdonk/markdown-vault-mcp/issues/964),
+  [#984](https://github.com/pvliesdonk/markdown-vault-mcp/pull/984),
+  [#987](https://github.com/pvliesdonk/markdown-vault-mcp/pull/987)). The
+  `okf_verify` tool that records a human review was hardened against
+  self-attestation after review found that a model holding a human's
+  auth token could stamp `verified: {by: "human:..."}` without a human ever
+  reviewing anything. `MARKDOWN_VAULT_MCP_OKF_VERIFY` now governs it: the
+  default `elicit` asks the human to confirm through an MCP elicitation and
+  writes the attestation only on an affirmative reply, failing closed on an
+  unsupported client or a decline; `trust-auth` restores the original
+  token-attribution behavior for interfaces driven directly by a human;
+  `off` hides the tool
+  ([#990](https://github.com/pvliesdonk/markdown-vault-mcp/issues/990),
+  [#1004](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1004)).
+- **Ranking downweights**, active only on a declared bundle: `status:
+  deprecated` scores at 0.5x, a stale note (past `stale_after`) at 0.75x,
+  and the reserved `index.md`/`log.md` files at 0.5x, applied across
+  keyword, semantic, and hybrid search alike
+  ([#965](https://github.com/pvliesdonk/markdown-vault-mcp/issues/965),
+  [#988](https://github.com/pvliesdonk/markdown-vault-mcp/pull/988)). Trust
+  tier deliberately does not boost ranking. It stays an annotation so the
+  agent applies that judgment visibly, rather than the ranker reshuffling
+  results silently.
 
-## LLM-backed summarization
+The [OKF guide](../guides/okf.md) covers the full migration path (audit,
+declare, enrich, convert) and interop notes for PARA and Zettelkasten
+vaults, alongside an [example pack](https://github.com/pvliesdonk/markdown-vault-mcp/tree/main/examples/okf)
+of declaration templates and prompts.
 
-The `summarize` tool is new in this release: `synthesis` or `per_note`
-summaries of a note, a set of notes, or a folder subtree, with an optional
-`focus` and source attribution, gated behind a configured provider
-([#869](https://github.com/pvliesdonk/markdown-vault-mcp/pull/869)). It
-shipped fast and was hardened just as fast against real usage:
+### Summarization becomes a platform
 
-- An early version exhausted its whole token budget on reasoning models
-  before producing output: `gpt-5-mini` returned `finish_reason=length`
-  with nothing usable, because `max_completion_tokens=2048` was consumed
-  entirely by internal reasoning tokens. The fix lowers reasoning effort for
-  the summarize call and raises the default budget to 8192
-  ([#920](https://github.com/pvliesdonk/markdown-vault-mcp/pull/920)).
-- Output stopped including assistant-style offers ("If you want I can: draw
-  a diagram…") that make no sense in a tool result, since "nobody can 'tell
-  it which,' the response is terminal"
-  ([#923](https://github.com/pvliesdonk/markdown-vault-mcp/pull/923), quoting
-  [#921](https://github.com/pvliesdonk/markdown-vault-mcp/issues/921)).
-- Summarizing a large folder used to silently truncate: a 262-note folder
-  came back `truncated: true` with only 11 notes actually read. The
-  character budget is now a per-request packing budget rather than a hard
-  coverage cap, split across a map/reduce pipeline so multi-batch summaries
-  use parallel requests instead of dropping notes
-  ([#924](https://github.com/pvliesdonk/markdown-vault-mcp/pull/924), quoting
-  [#922](https://github.com/pvliesdonk/markdown-vault-mcp/issues/922)). A new
-  per-call `max_notes` parameter and an in-result `hint` guide a caller
-  toward splitting by subfolder when notes are still omitted
-  ([#926](https://github.com/pvliesdonk/markdown-vault-mcp/pull/926)).
-- The backend switched from an Anthropic-only client to a generic
-  OpenAI-compatible one, covering OpenAI, Ollama, vLLM, and
-  Anthropic-compatible endpoints through one `base_url` / `api_key` / `model`
-  configuration
-  ([#917](https://github.com/pvliesdonk/markdown-vault-mcp/pull/917)).
-- Slow summarize calls used to mean a client-side timeout on a single serial
-  request: one reproduction hit a 180-second wall on a 17-note folder with a
-  demanding `focus`
-  ([#937](https://github.com/pvliesdonk/markdown-vault-mcp/issues/937)). The
-  tool now enforces a configurable request timeout and promotes slow calls to
-  a background job polled via a job-result tool instead of blocking the
-  caller
-  ([#938](https://github.com/pvliesdonk/markdown-vault-mcp/pull/938)). That
-  hand-rolled job store was later replaced with the shared background-task
-  mechanism used elsewhere in the server (see
-  [Search and indexing](#search-and-indexing-fixes-and-background-jobs)
-  below), consolidating on a single `get_job_result` tool
-  ([#1034](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1034)).
-- For agentic and privacy-sensitive clients that can't or don't want to
-  configure a server-side summarization backend, a new `summarize-subtree`
-  MCP prompt drives the same map/reduce recipe using the *client's* own
-  model instead
-  ([#1038](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1038)).
+`summarize` shipped two releases ago as a single LLM call over a note, a set
+of notes, or a subtree. This release turns it into something that scales to
+a folder of any size and degrades gracefully when nothing is configured.
 
-Configuration lives under `MARKDOWN_VAULT_MCP_SUMMARIZE_*` (provider,
-OpenAI-compatible base URL/key/model, max notes, max input characters, max
-tokens, timeout); see [Configuration](../configuration.md) and the [tools
-reference](../tools/index.md#summarize) for current defaults.
+The character budget that previously capped how much of a folder could be
+covered in one call now caps a single model *request* instead: notes are
+packed into batches, each batch is summarized independently with bounded
+parallelism, and, in the default `synthesis` mode, the partial summaries
+are combined into one
+([#922](https://github.com/pvliesdonk/markdown-vault-mcp/issues/922),
+[#924](https://github.com/pvliesdonk/markdown-vault-mcp/pull/924)). A
+262-note folder that previously silently covered 11 notes and reported only
+`truncated: true` now covers all of them, or reports precisely how many were
+included and omitted. A per-call `max_notes` parameter and a `hint` field
+that appears whenever notes were omitted let a caller plan a subfolder split
+itself instead of guessing
+([#925](https://github.com/pvliesdonk/markdown-vault-mcp/issues/925),
+[#926](https://github.com/pvliesdonk/markdown-vault-mcp/pull/926)).
 
-## Folder conventions, custom frontmatter, and ranking control
+Latency is now bounded rather than open-ended: each backend call is capped
+by `MARKDOWN_VAULT_MCP_SUMMARIZE_TIMEOUT` (default 120 seconds), and the
+tool call itself runs inline up to `MARKDOWN_VAULT_MCP_JOBS_SOFT_DEADLINE_S`
+(default 25 seconds) before promoting to a background job (the dual-mode
+mechanism described in [Upgrade notes](#upgrade-notes) above)
+([#937](https://github.com/pvliesdonk/markdown-vault-mcp/issues/937),
+[#1034](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1034)). Along
+the way, a reasoning model (the new default, `gpt-5-mini`) exhausting its
+entire token budget on internal reasoning before producing visible output is
+fixed by raising the default `MARKDOWN_VAULT_MCP_SUMMARIZE_MAX_TOKENS` from
+2048 to 8192 and requesting low reasoning effort
+([#919](https://github.com/pvliesdonk/markdown-vault-mcp/issues/919),
+[#920](https://github.com/pvliesdonk/markdown-vault-mcp/pull/920)), and
+output no longer ends with chat-assistant offers like "if you want I can
+draw a diagram"
+([#921](https://github.com/pvliesdonk/markdown-vault-mcp/issues/921),
+[#923](https://github.com/pvliesdonk/markdown-vault-mcp/pull/923)).
 
-Two related problems came up from real vaults: an LLM client asked to write
-a reference note produced one "polluted with auto-linked personal context"
-because it had no way to know a folder's local conventions
-([#872](https://github.com/pvliesdonk/markdown-vault-mcp/issues/872)), and a
-~1,400-document personal memory vault found that "~78% of docs are
-machine-written session summaries that crowded curated notes out of every
-search"
-([#867](https://github.com/pvliesdonk/markdown-vault-mcp/pull/867),
-reported by
-[@mikebronner](https://github.com/mikebronner)).
+For an install with no summarization backend configured at all, or a vault
+too privacy-sensitive to send content to an external API, a new
+`summarize-subtree` MCP prompt delegates the same map-reduce recipe to the
+*client's own* model instead: a planner subagent fans out parallel mapper
+subagents that each read and summarize their own batch, keeping note bodies
+out of the primary conversation's context window
+([#1035](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1035),
+[#1038](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1038)). When a
+backend is configured, the prompt recommends the single-call `summarize`
+tool first and offers itself as the fallback for scopes that don't fit in
+one call.
 
-- **Folder conventions**: a per-folder `_conventions.md` file (name
-  configurable via `MARKDOWN_VAULT_MCP_CONVENTIONS_FILE`, or `none` to
-  disable) is transported to the client root-first, CLAUDE.md-style, so an
-  LLM client can follow local authoring rules instead of guessing them
-  ([#877](https://github.com/pvliesdonk/markdown-vault-mcp/pull/877)).
-- **Custom frontmatter and ranking**: five new, default-to-no-op
-  environment variables:
-  `MARKDOWN_VAULT_MCP_TITLE_FIELD` (use a custom frontmatter key as a
-  note's title), `SEARCHABLE_FIELDS` (index chosen frontmatter fields into
-  full-text search and embeddings), `EMBED_CONTEXT` (prepend title/heading
-  context to embedding input), `FOLDER_WEIGHTS` (per-folder-prefix rank
-  multipliers), and `FTS_WEIGHTS` (per-column BM25 weights)
-  ([#867](https://github.com/pvliesdonk/markdown-vault-mcp/pull/867),
-  contributed by [@mikebronner](https://github.com/mikebronner)).
-- Changing `MARKDOWN_VAULT_MCP_INDEXED_FIELDS` used to be silently ignored by
-  incremental reindex: a real run logged `0 added, 0 modified, 0 deleted,
-  891 unchanged` after the change took no effect
-  ([#927](https://github.com/pvliesdonk/markdown-vault-mcp/issues/927)). The
-  field is now tracked in build provenance, forcing a one-time rebuild when
-  it changes, and `SEARCHABLE_FIELDS` now defaults to whatever
-  `INDEXED_FIELDS` is set to unless explicitly opted out with `none`
-  ([#928](https://github.com/pvliesdonk/markdown-vault-mcp/pull/928)). If you
-  set `INDEXED_FIELDS` in your deployment, expect one rebuild (and a
-  possible re-embed) on the first post-upgrade boot.
+### Precision search: frontmatter fields, ranking weights, consistent scoping
 
-## Search and indexing: fixes and background jobs
+A curated vault keeps its highest-signal text in frontmatter (a display
+name, a hand-written summary) that search previously never saw, because it
+only ever indexed the note body. Contributed by
+[@mikebronner](https://github.com/mikebronner) against a concrete case (a
+1,400-document memory vault where machine-written session summaries crowded
+out curated notes in every search), five new settings fix this without
+touching the corpus
+([#870](https://github.com/pvliesdonk/markdown-vault-mcp/issues/870),
+[#867](https://github.com/pvliesdonk/markdown-vault-mcp/pull/867)):
+`MARKDOWN_VAULT_MCP_TITLE_FIELD` (any frontmatter key can serve as the
+document title), `SEARCHABLE_FIELDS` (chosen frontmatter fields become
+keyword-searchable and enrich embeddings), `EMBED_CONTEXT` (prepend
+title/heading context to embedded chunk text), `FOLDER_WEIGHTS` (a
+per-folder rank multiplier, longest-prefix-wins), and `FTS_WEIGHTS`
+(per-column BM25 weights across `path`, `title`, `folder`, `heading`,
+`content`, and `summary`). All five default to an exact no-op: nothing
+changes for a vault that sets none of them.
 
-- Hybrid search's vector channel used an inline, unnormalized folder filter
-  that predated shared normalization logic, so a trailing-slash folder
-  filter (`folder="X/"`) silently dropped every vector-channel candidate in
-  hybrid mode while plain semantic search worked fine
-  ([#882](https://github.com/pvliesdonk/markdown-vault-mcp/pull/882)).
-- Hyphenated search terms like `vault-mcp` returned zero results with no
-  error, because FTS5 parses `-` as an operator and the resulting
-  `OperationalError` was silently swallowed to an empty list: "the same
-  query with the hyphen replaced by a space… returns the expected document
-  as top-1"
-  ([#866](https://github.com/pvliesdonk/markdown-vault-mcp/issues/866)). A
-  failed FTS5 query now retries once with terms quoted as phrase literals,
-  and unrecoverable queries log a warning instead of failing silently
-  ([#884](https://github.com/pvliesdonk/markdown-vault-mcp/pull/884)).
-- Incremental reindex had no per-note error guard around inline embedding,
-  unlike the cold-build and convergence paths, so a single embedding-provider
-  timeout aborted the entire reindex and left the tracker baseline stuck in
-  a repeat-failure loop
-  ([#930](https://github.com/pvliesdonk/markdown-vault-mcp/issues/930)). The
-  inline path now batches, skips just the failing note, and converges later
-  ([#932](https://github.com/pvliesdonk/markdown-vault-mcp/pull/932)); a
-  related gap let an embedding-dimension mismatch abort a reindex after
-  already deleting the old vectors for that note
-  ([#936](https://github.com/pvliesdonk/markdown-vault-mcp/pull/936)).
-  Timeouts got easier to tune, too: embedding request timeout and batch size
-  are now configurable via `MARKDOWN_VAULT_MCP_EMBED_TIMEOUT_S` (default 30
-  seconds) and `MARKDOWN_VAULT_MCP_EMBEDDING_BATCH_SIZE` (default 4), after
-  one deployment logged 61 timeout failures in an afternoon under normal
-  writing load with the old hard-coded values
-  ([#1000](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1000),
-  quoting
-  [#954](https://github.com/pvliesdonk/markdown-vault-mcp/issues/954)).
-- Building embeddings used to abort the entire run if a single file had
-  malformed YAML frontmatter, matching resilience the rest of the indexing
-  pipeline already had: "one broken file anywhere means no semantic index
-  can be built"
-  ([#955](https://github.com/pvliesdonk/markdown-vault-mcp/issues/955),
-  fixed in
-  [#994](https://github.com/pvliesdonk/markdown-vault-mcp/pull/994)).
-- A note with no body (zero-byte, frontmatter-only, or whitespace-only)
-  chunks to a single empty-string chunk, and sending that string to an
-  embedding provider gets HTTP 400 back, which used to abort the whole
-  batch rather than just the offending note: one reporter's 3-line
-  frontmatter-only note "held the index stale for ~17 hours before anyone
-  noticed"
-  ([#1087](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1087),
-  reported by
-  [@salmonumbrella](https://github.com/salmonumbrella)). A blank chunk is
-  now dropped before it reaches the provider, at both the embed call and
-  the convergence-pass signature diff (dropping it in only one place would
-  make the index re-embed the same document forever); the note stays fully
-  keyword-searchable through FTS, only its vector is skipped
-  ([#1112](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1112)).
-- `reindex` and `build_embeddings` are now **dual-mode background jobs**: a
-  fast call still returns its result inline, but a slow one now returns
-  `{"status": "working", "job_id": ...}` for polling via `get_job_result`,
-  and a backend failure that happens within the deadline now raises on the
-  call itself instead of surfacing only through `get_index_status`
-  ([#1037](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1037)).
-  This is one of the four behavior changes covered under
-  [Upgrading](#upgrading).
+Two long-standing search gaps close alongside it. Keyword and hybrid search
+previously returned nothing for a hyphenated query term (`File-back Ingest
+Lint`) because FTS5 parses an unquoted hyphen as an operator, silently
+swallowed to an empty result, reported by
+[@vomos-ua](https://github.com/vomos-ua)
+([#866](https://github.com/pvliesdonk/markdown-vault-mcp/issues/866),
+[#884](https://github.com/pvliesdonk/markdown-vault-mcp/pull/884)). And
+folder- and filter-scoped search was inconsistently honored across search
+surfaces: an empty-string folder was silently treated as no restriction on
+every vector-backed path, a trailing slash returned nothing on every
+FTS-backed one, and a narrow folder's matches could fall outside semantic
+search's candidate pool before that pool was widened; all fixed together
+this release
+([#1103](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1103),
+[#1106](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1106),
+[#1108](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1108)).
 
-## Folder-filter and link-rewrite bug sweep
+Changing `MARKDOWN_VAULT_MCP_INDEXED_FIELDS` now triggers the one-time
+rebuild it always should have, and `SEARCHABLE_FIELDS` inherits
+`INDEXED_FIELDS` when left unset, so one field list expresses one intent
+instead of two
+([#927](https://github.com/pvliesdonk/markdown-vault-mcp/issues/927),
+[#928](https://github.com/pvliesdonk/markdown-vault-mcp/pull/928)).
 
-A live 902-note vault run against `4.0.0-rc.4` turned up six bugs in one
-sitting, all filed against the v4.0 milestone and fixed together in one PR
-([#1109](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1109)):
+### A guided path onto Claude Code and Claude Desktop
 
-- **Trailing-slash folder filters returned nothing.** `folder="X/"` and
-  `folder="X"` were supposed to select the same notes, but every
-  FTS-backed surface (`search(mode="keyword")`, `list_documents`,
-  `get_recent`, `get_broken_links`) silently returned `[]` for the
-  trailing-slash form, and `mode="hybrid"` quietly dropped to
-  semantic-only results
-  ([#1103](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1103)).
-  A related fix corrected the opposite bug on the vector-row post-filter,
-  where `.strip("/") or None` collapsed an explicit `folder=""` into "no
-  restriction" and made `mode="semantic"`/`"hybrid"`/`get_similar` search
-  the whole vault instead of the documented root-level-only scope
-  ([#1106](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1106)).
-  Both are now handled by one shared `normalize_folder` helper that keeps
-  `None`, `""`, and every other value distinct.
-- **A folder-scoped semantic search needed `limit` in the thousands to
-  return anything.** The candidate pool was capped before the folder
-  filter ran, so a folder whose chunks all scored below the cap came back
-  empty
-  ([#1108](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1108)).
-  The cap now applies after scoping, not before.
-- **`rename` and `move_folder` demoted root-relative links back to
-  folder-relative ones**, silently undoing OKF's own link convention on
-  every move: a link `okf_convert_links` had just rewritten to
-  `/folder/note.md` came back as bare `note.md` after the next `rename`
-  ([#1105](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1105)).
-  `compute_new_raw_target` now recognizes the leading-slash shape as a
-  third link form rather than falling through to relative.
-- **`[[#Heading]]` wikilinks stored a literal `.md` target** because the
-  fragment was split off before `.md` was appended
-  ([#1107](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1107));
-  they're now skipped, matching how `[text](#heading)` is already
-  handled.
-- **Footnote definitions were parsed as link targets**, because footnote
-  syntax differs from reference-link syntax by one character and both
-  reference regexes matched it
-  ([#1104](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1104)).
-
-Five more regressions the fix itself introduced were caught in review
-before merge (a `limit=0` off-by-one, corrupted `okf_generate_index` /
-`okf_seed_log` output, Windows attachment paths dropping out of
-`list_documents`, and a folder-scoped `get_similar` losing its pool
-widening), all fixed in the same PR and none shipped.
-
-## New `append` tool, and other write and git fixes
-
-- **`append`**: a write tool that appends text to the end of a note without
-  requiring a prior `read`. Before this, "every time [the client] needs to
-  append content to a note, it has to invoke the edit tool instead. This
-  forces the LLM to read the entire note first, leading to excessive token
-  consumption and making modifications prone to errors"
-  ([#980](https://github.com/pvliesdonk/markdown-vault-mcp/issues/980),
-  reported by [@zbingos](https://github.com/zbingos); shipped in
-  [#1025](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1025)). It
-  supports the same optimistic-concurrency `if_match` as `write`/`edit` and
-  a `create_if_missing` flag.
-- Newly created files always came out owner-only readable (mode `0600`)
-  regardless of the process umask, breaking deployments that expect
-  group-readable state: "even when the systemd unit sets `UMask=0027`
-  expecting group-readable state"
-  ([#958](https://github.com/pvliesdonk/markdown-vault-mcp/issues/958),
-  reported by [@andreas8horvath](https://github.com/andreas8horvath); fixed
-  in [#998](https://github.com/pvliesdonk/markdown-vault-mcp/pull/998)).
-- A failed git push (non-fast-forward or a transient network error) used to
-  stop retrying until the next write or process restart; one deployment
-  measured a 20-hour window stuck this way
-  ([#957](https://github.com/pvliesdonk/markdown-vault-mcp/issues/957),
-  reported by [@andreas8horvath](https://github.com/andreas8horvath)). The
-  periodic pull-loop tick now retries a pending push
-  ([#997](https://github.com/pvliesdonk/markdown-vault-mcp/pull/997)).
-- Leading-slash markdown links (`/guides/playbook.md`) resolved to a doubled
-  slash and were reported broken; they now resolve relative to the vault
-  root, which also matters because OKF's recommended link style is
-  bundle-root-absolute
-  ([#972](https://github.com/pvliesdonk/markdown-vault-mcp/pull/972)).
-
-## Security fixes
-
-- The `fetch` tool's outbound SSRF guard had two gaps: its address deny-list
-  didn't cover CGNAT / shared address space (`100.64.0.0/10`, RFC 6598), and
-  the outbound HTTP client didn't set `trust_env=False`, so an ambient
-  `HTTP(S)_PROXY` environment variable (or a `.netrc` file) could route a
-  request around the entire resolve-validate-pin chain
-  ([#862](https://github.com/pvliesdonk/markdown-vault-mcp/issues/862)). The
-  fix retires the vault-local guard entirely in favor of
-  `fastmcp-pvl-core`'s shared hardened `fetch_url`, which structurally
-  blocks anything not globally routable and ignores ambient proxy
-  configuration
-  ([#1029](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1029)).
-- A transitive dependency, `mcp`, was bumped from 1.28.0 to 1.28.1 to pick
-  up a fix for CVE-2026-59950, flagged by the CI dependency-audit gate
-  ([#933](https://github.com/pvliesdonk/markdown-vault-mcp/issues/933),
-  fixed in
-  [#934](https://github.com/pvliesdonk/markdown-vault-mcp/pull/934)). Neither
-  the issue nor the fix describes the vulnerability's attack vector beyond
-  the audit tool's own flag; if you need more detail, check the upstream
-  `mcp` advisory directly.
-- **`fetch` now follows redirects instead of refusing them.** This is a
-  side effect of raising the `fastmcp-pvl-core` floor to 4.11.2, which
-  hardcodes `follow_redirects=True` in the shared `fetch_url` helper with
-  no opt-out
-  ([#1116](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1116)).
-  The guard is not weakened by this: it moved from a one-time pre-flight
-  check into the transport itself, so every redirect hop re-runs the
-  scheme check, the address validation, and the IP pin, and a `Location`
-  header pointing at an internal target is refused exactly as a direct
-  request would be. The response now reports where the bytes actually came
-  from in a `final_url` field, which may differ from the requested `url`
-  after a redirect; a caller enforcing its own host policy needs to check
-  that field, not just the input. A chain longer than the transport's
-  redirect limit now fails with `httpx.TooManyRedirects` instead of the
-  previous `ValueError`
-  ([#1118](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1118)).
-  See [Upgrading](#upgrading).
-
-## Packaging: the Claude Code plugin channel
-
-Configuring this server used to mean "editing a shell profile and
-restarting," with secrets traveling as plain environment variables and no
-in-product path to fix a broken setup: "a misconfigured install currently
-fails silently with no in-product path to a fix"
+Installing the Claude Code plugin previously meant exporting environment
+variables to a shell profile and restarting Claude Code (for even the one
+required setting, the vault directory), with no in-product path to a fix if
+you skipped a step or the vault later moved. The Claude Desktop bundle's
+configuration screen had drifted from reality in the other direction: 26
+hand-maintained fields including HTTP-auth settings that do nothing on a
+stdio-only bundle, while newer settings were missing entirely
 ([#1043](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1043)).
-This release adds a guided setup path, mostly through the Claude Code
-plugin channel:
 
-- The Claude Desktop `mcpb` bundle's install screen used to wire only 21 of
-  93 known configuration variables, plus several meaningless HTTP-auth
-  fields on a stdio bundle
-  ([#1041](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1041)).
-  It's now a curated, generated 14-field screen covering the settings that
-  actually matter (vault directory, read-only, exclusions, embedding
-  provider and its credentials, git sync URL/token, server name, log level)
-  ([#1045](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1045)).
-- The Claude Code plugin gained a **`vault-summarize` skill** and a
-  **`vault-mapper` agent**, so a plugin user who asks Claude Code to
-  "summarize my project folder" gets a proper plan, parallel-map, reduce
-  workflow, preferring the server's own `summarize` tool when configured
-  and falling back to `vault-mapper` subagents (restricted to `read` and
-  `get_toc`) when it isn't, instead of the agent reading note after note
-  into its own context
-  ([#1036](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1036),
-  fixed in
-  [#1047](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1047)).
-- A **`vault-setup` skill** plus a `SessionStart` "doctor" hook now speak up
-  when the plugin starts with no vault configured, or when a configured
-  vault directory has moved; previously this left "a dead `Failed to
-  connect` entry in `/mcp` with no in-product path to a fix"
-  ([#1042](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1042),
-  fixed in
-  [#1048](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1048)). The
-  skill discovers candidate vaults, validates them, and writes the
-  configuration itself.
-- Enabling the plugin now prompts through a generated configuration screen
-  (vault directory, read-only, exclusions, embedding provider, git sync,
-  server name, log level) sharing the same curated field set as the `mcpb`
-  screen, with secrets masked instead of traveling as plain environment
-  variables
-  ([#1040](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1040),
-  fixed in
-  [#1049](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1049)).
+Both channels now show a small, generated configuration screen of 14
+curated fields (vault directory, read-only toggle, exclude patterns,
+embedding provider and credentials, git sync URL and token, server name,
+log level), sharing one field map as their single source of truth, so the
+two channels cannot drift apart again
+([#1040](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1040),
+[#1041](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1041)). The
+Claude Code plugin's values now live in `userConfig` and persist across
+plugin updates instead of a shell-exported env var. When something is
+still wrong (no vault configured, or a configured vault directory that no
+longer exists), a `SessionStart` hook now speaks up only on failure and
+points the model at a `vault-setup` skill that discovers candidate vaults,
+validates one, and writes the working configuration
+([#1042](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1042)). A
+`vault-summarize` skill and `vault-mapper` subagent give the plugin its own
+client-side summarization path, built on the same recipe as the
+`summarize-subtree` prompt above
+([#1036](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1036)).
 
-See the [Claude Code plugin guide](../guides/claude-code-plugin.md) and the
-[Claude Desktop guide](../guides/claude-desktop.md) for current setup steps.
+Release-to-marketplace publishing is also now direct rather than a bump pull
+request that could sit without being merged for months. The epic that drove
+this work found fifteen such PRs open across the marketplace catalog at
+once, including this project's own. This release is also the first to
+close a narrower bug in the
+same area: because the plugin's version pin was rewritten on every release
+including release candidates, `main` could briefly point the plugin at an
+rc version that was never published to PyPI; the 4.0.0 stable cut is the
+point where that pin resolves to a real, installable version again
+([#1053](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1053)).
 
-## Upgrading
+See the [Claude Code plugin](../guides/claude-code-plugin.md) and
+[Claude Desktop](../guides/claude-desktop.md) guides for the current setup
+flow.
 
-Four changes break existing setups. Everything else in this release is
-additive: new tools, new optional environment variables, and reworks of
-features (like `summarize`) that never reached a stable release before now,
-so their internal churn had no released surface to break.
+## Other changes
 
-- **`MARKDOWN_VAULT_MCP_READ_ONLY` now defaults to `false`.** Through 3.1
-  it defaulted to `true`, so a server installed from any channel started
-  with its entire write surface hidden, which is "most of what the server
-  is for"
-  ([#1113](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1113)).
-  This is the one 4.0 change where doing nothing on upgrade silently
-  widens what a connected model may do to your data: a default install
-  now gains `write`, `edit`, `append`, `delete`, `rename`, `move_folder`,
-  and `fetch` (seven tools, not the full write-tagged set: `git_sync`,
-  `create_upload_link`, and the `okf_*` tools stay behind their own
-  gates). Set `MARKDOWN_VAULT_MCP_READ_ONLY=true` explicitly to keep a
-  read-only server
-  ([#1119](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1119)).
-  The corresponding library-level defaults
-  (`Vault.__init__`/`DocumentManager.__init__`) are unchanged at
-  `read_only=True`, since that tier is a downstream Python consumer's
-  fail-safe, not the operator default.
-- **`fetch` follows redirects instead of refusing them.** Through 3.1 the
-  tool's own docstring promised redirects were not followed; a caller
-  that relied on a refusal error to reject indirection now silently gets
-  content instead, with `final_url` reporting where it actually came from
-  ([#1116](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1116),
-  fixed in
-  [#1118](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1118)).
-  See [Security fixes](#security-fixes) for the guard-safety detail.
-- **`from markdown_vault_mcp import X` no longer works for most names.** The
-  package root used to lazily re-export `Vault`, `ProjectConfig`,
-  `GitWriteStrategy`, every exception type, and the shared dataclasses; it
-  is now a minimal skeleton holding only a docstring and `__version__`.
-  Import from the relevant submodule instead, such as
-  `from markdown_vault_mcp.git import GitWriteStrategy`. This landed as
-  part of an internal refactor that realigned the package with its upstream
-  template
-  ([#903](https://github.com/pvliesdonk/markdown-vault-mcp/issues/903)) and
-  was not marked as a breaking change at the time; it should have been, and
-  downstream Python consumers of the library (not the MCP tool surface) are
-  the ones affected.
-- **`reindex` and `build_embeddings` are no longer always-queued.** Before
-  this release, both tools always returned `{"status": "queued"}`
-  immediately and required a separate `get_index_status` poll. Now a fast
-  call can return its result inline (`status: "completed"`), a slow one
-  returns `{"status": "working", "job_id": ...}` for polling via
-  `get_job_result`, and a backend failure inside the deadline now raises on
-  the call itself. Automation that assumed "always queued, always poll
-  status" needs to handle the inline-completion and raised-error cases too
-  ([#1037](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1037)).
+### Search, indexing, and links
 
-One commit in this range carries a `!` marker that, on inspection, doesn't
-meet this project's own breaking-change bar: `chore(copier)!:` adopting the
-branch-aware release model
-([#1066](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1066))
-changed the *project's own* release workflow (a rolling Docker tag rename,
-a removed release-dispatch input), nothing an operator running the MCP
-server needs to change. It's called out here only so the `!` doesn't get
-read as a second real break.
+- A new `append` tool writes to the end of a note without a prior read,
+  contributed by [@zbingos](https://github.com/zbingos) building an
+  Obsidian workflow: every append previously had to go through `edit`,
+  which forced reading the whole note first purely to construct the diff
+  ([#980](https://github.com/pvliesdonk/markdown-vault-mcp/issues/980),
+  [#1025](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1025)).
+- `MARKDOWN_VAULT_MCP_EMBED_TIMEOUT_S` (default 30 seconds) and
+  `MARKDOWN_VAULT_MCP_EMBEDDING_BATCH_SIZE` (default 4) are now
+  configurable rather than hard-coded, after
+  [@andreas8horvath](https://github.com/andreas8horvath) reported 61 embed
+  timeouts in one afternoon running a CPU-only Ollama model where a single
+  large batch routinely took 20 to 44 seconds
+  ([#954](https://github.com/pvliesdonk/markdown-vault-mcp/issues/954),
+  [#1000](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1000)).
+- Two classes of false-positive broken links are fixed: a same-note heading
+  link (`[[#Section]]`) resolving to a literal, always-broken `.md` target,
+  and markdown footnote definitions being mis-extracted as vault links
+  entirely
+  ([#1104](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1104),
+  [#1107](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1107)).
+- The vector sidecar is more durable: embedding convergence no longer
+  reclaims vectors for sources it merely failed to see on an incomplete
+  directory walk, up to and including wiping the whole sidecar in the worst
+  case
+  ([#1130](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1130));
+  a note with malformed frontmatter or an empty body no longer aborts an
+  entire embedding batch
+  ([#994](https://github.com/pvliesdonk/markdown-vault-mcp/issues/994),
+  [#1112](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1112));
+  and a single embedding-provider timeout or vector-dimension mismatch no
+  longer fails a whole reindex or convergence pass
+  ([#930](https://github.com/pvliesdonk/markdown-vault-mcp/issues/930),
+  [#935](https://github.com/pvliesdonk/markdown-vault-mcp/issues/935)).
+- The index now tracks its own derivation logic and self-heals when it
+  changes: a future fix to link, tag, or chunk extraction now triggers an
+  automatic one-time rebuild instead of leaving stale rows behind
+  indefinitely, and the `reindex` tool and CLI gained a manual `force` flag
+  as an escape hatch that did not exist before
+  ([#1124](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1124),
+  [#1125](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1125)).
+
+### Transfer links
+
+One-time upload and download links now survive a server restart: the token
+store moved from an in-memory dictionary onto `fastmcp-pvl-core`'s shared,
+KV-backed transfer subsystem, retiring roughly 350 lines of local machinery
+in the process
+([#979](https://github.com/pvliesdonk/markdown-vault-mcp/issues/979),
+[#981](https://github.com/pvliesdonk/markdown-vault-mcp/pull/981)). A
+successful transfer no longer burns its token outright either: its
+remaining lifetime shrinks to `MARKDOWN_VAULT_MCP_TRANSFER_GRACE_TTL_S`
+(default 60 seconds) instead, so a served-but-stalled transfer can still
+retry.
+The `create_download_link`/`create_upload_link` call contract itself is
+unchanged. See the [transfer links guide](../guides/transfer-links.md) for
+the full parameter reference.
+
+### Security
+
+- The `fetch` tool's SSRF guard closed two gaps: carrier-grade NAT address
+  space (`100.64.0.0/10`) was not on its block list, and the outbound HTTP
+  client trusted ambient proxy environment variables, so an
+  `HTTP_PROXY`/`HTTPS_PROXY` set in the server's environment could route a
+  fetch around the entire address-validation chain
+  ([#1029](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1029)).
+- A transitive dependency, `mcp`, was bumped from 1.28.0 to 1.28.1 to
+  resolve CVE-2026-59950, flagged by the project's dependency-audit gate
+  ([#934](https://github.com/pvliesdonk/markdown-vault-mcp/pull/934)).
+
+## Thanks
+
+This release includes four reports from outside the repository:
+
+- [@mikebronner](https://github.com/mikebronner) contributed configurable
+  title fields, searchable frontmatter, and ranking weights directly
+  ([#867](https://github.com/pvliesdonk/markdown-vault-mcp/pull/867)).
+- [@vomos-ua](https://github.com/vomos-ua) reported the hyphenated-term
+  search gap
+  ([#866](https://github.com/pvliesdonk/markdown-vault-mcp/issues/866)).
+- [@zbingos](https://github.com/zbingos) requested the `append` tool while
+  building an Obsidian workflow
+  ([#980](https://github.com/pvliesdonk/markdown-vault-mcp/issues/980)).
+- [@andreas8horvath](https://github.com/andreas8horvath) reported the
+  embedding-timeout cascade under a CPU-only Ollama setup, with measured
+  failure counts
+  ([#954](https://github.com/pvliesdonk/markdown-vault-mcp/issues/954)).
 
 <!-- PATCH-RELEASES-START -->
+
+## Patch releases
+
+No patch releases yet.
+
 <!-- PATCH-RELEASES-END -->
+
+## All changes
+
+See [CHANGELOG.md](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/CHANGELOG.md)
+for the full commit-level list, or the
+[v3.1.0 to 4.0.0 comparison](https://github.com/pvliesdonk/markdown-vault-mcp/compare/v3.1.0...2651e8e65c1a24d2d5c10d52e6ec14b84fd002c5).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-vault-mcp"
-version = "4.0.0-rc.5"
+version = "4.0.0-rc.6"
 description = "Generic markdown vault MCP server with FTS5 + semantic search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/uv.lock
+++ b/uv.lock
@@ -1739,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "4.0.0rc5"
+version = "4.0.0rc6"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **4.0.0-rc.6** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

This PR also carries the release-notes page under `docs/releases/`,
drafted by the prepare run's notes job — review it as part of the release
(an evidence check: every causal claim must trace to its linked issue or
PR).  The PR is held as a DRAFT until the notes land; the notes job marks
it ready.  Still draft means the notes job is running or failed — check
the prepare run.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Breaking Changes

- replace anthropic summarizer with generic OpenAI-compatible backend (#917)
- dual-mode background jobs via pvl-core 4.11.0 + template v3.3.0 (#1034)
- make reindex and build_embeddings dual-mode background jobs (#1037)
- adopt the branch-aware release model via copier update to template v4.0.0 (#1066)
- follow redirects, report the final URL, and classify the change (#1118)
- default READ_ONLY to false so the write surface ships enabled (#1119)

## Features

- add LLM-backed summarize tool gated on an API key (#869)
- folder conventions — per-folder authoring policy for LLM clients (#877)
- configurable title field, searchable frontmatter, and ranking weights (#867)
- map-reduce summarization for inputs beyond one model request (#924)
- per-call max_notes with in-result coverage hint for summarize (#926)
- rebuild on INDEXED_FIELDS change; SEARCHABLE_FIELDS defaults to it (#928)
- bound summarize latency with a timeout error and background jobs (#937) (#938)
- detect OKF bundles and annotate read surfaces (#968)
- OKF filter dimensions and graph node typing (#970)
- okf_validate conformance audit tool (#971)
- migration transforms (wikilink conversion, index/log generation) (#973)
- adopt fastmcp-pvl-core transfer subsystem; retire local store (#981)
- bundle export via an okf-bundle download ref (#982)
- enforced write layer — provenance stamping, verification invalidation, okf_verify (#964) (#984)
- enforced-write convention maintenance — log.md append + index.md refresh (#964) (#987)
- ranking downweights for deprecated/stale/reserved files (#965) (#988)
- configurable timeout (EMBED_TIMEOUT_S) + batch size (EMBEDDING_BATCH_SIZE) (#1000)
- harden okf_verify against model self-attestation (#990) (#1004)
- scope okf_seed_log's log.md content to the folder's subtree (#974) (#1005)
- add append tool for end-of-note writes without a prior read (#1025)
- ship client-side summarization recipe as summarize-subtree prompt (#1038)
- adopt template v3.4.0 — generated mcpb screen, curated fields, pre-release checks (#1045)
- adopt template v3.5.0 — plugin channel onto the template scaffold (#1046)
- vault-summarize skill and vault-mapper agent for client-side summarization (#1047)
- vault-setup skill and SessionStart doctor hook for in-session bootstrap (#1048)
- generated userConfig configuration screen — no more shell-profile setup (#1049)

## Bug Fixes

- hybrid search vector channel misses folder normalization (#882)
- recover keyword/hybrid search for hyphenated terms (#866) (#884)
- stop reasoning models exhausting the summarize token budget (#920)
- forbid assistant-style offers in summarize output (#923)
- bump transitive mcp 1.28.0 → 1.28.1 (CVE-2026-59950) (#934)
- make incremental reindex inline embedding resilient to provider timeouts (#930) (#932)
- guard inline/converge vector mutation against dimension mismatch (#935) (#936)
- resolve leading-slash markdown links against the vault root (#972)
- skip malformed-frontmatter files in build_embeddings (#994)
- retry failed deferred pushes on the periodic pull-loop tick (#997)
- honour process umask for newly created files (#958) (#998)
- single-agent reviewer; drop fan-out plugin + pin experiment
- drop Task from @claude — #1499 background-subagent orphan footgun
- allow-list Skill defensively (both claude workflows)
- finalize pin-combo reviewer (restore CI gate, drop show_full_output)
- close SSRF gaps by migrating to pvl-core's hardened fetch_url (#1029)
- adopt template v3.2.2 — template-owned bump_manifests, non-mutating CI syncs (#1032)
- drop track_progress from the notes drafting action (#1094)
- make the notes drafting agent able to write — and safe to run (#1095)
- rc releases get their full artifact set, and the 4.0 notes page passes its own evidence contract (#1096)
- clear the v4.0 milestone's bug reports (#1109)
- never send a blank string to the embedding provider (#1112)
- raise the pvl-core floor to 4.11.2 and drop the removed read_only kwarg (#1117)
- rebuild when the parse pipeline changes, and expose a force flag (#1125)
- persist authoritative empty embedding rebuilds (#1115)
- confirm FTS absence against the source tree before reclaiming vectors (#1132)
- adopt template v5.3.1→v5.4.0, and de-fork README.md and ci.yml to pristine (#1138)
