### PR TITLE
docs(releases): release notes for v3.1.0

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -254,8 +254,11 @@ Plex
 # --- Release-notes prose vocabulary ---
 accessor
 backoff
+callables
 globbed
+indirected
 subcommands
+unvalidated
 
 # --- Release-notes backfill vocabulary (#1058) ---
 backfilled

--- a/docs/releases/3.1.md
+++ b/docs/releases/3.1.md
@@ -1,5 +1,7 @@
 # 3.1
 
+<!-- notes-range-end: 05ed4b5ed72a91b05a349e5e5367d530a8db8173 -->
+
 Released July 8, 2026.
 
 !!! note "Reconstructed after the fact"
@@ -179,7 +181,9 @@ no tool was renamed or removed.
   ([#813](https://github.com/pvliesdonk/markdown-vault-mcp/issues/813))
 - **Note Preview**: table of contents, collapsible frontmatter and tags, copy
   actions
+  ([#814](https://github.com/pvliesdonk/markdown-vault-mcp/issues/814))
 - **Graph Explorer**: level-of-detail labels
+  ([#815](https://github.com/pvliesdonk/markdown-vault-mcp/issues/815))
 
 As a prerequisite, the single 52 KB `app.src.html` was split into modular
 partials assembled at build time by `build_spa.py`
@@ -253,13 +257,20 @@ problem you can fix" from "the indexer itself hit a bug"
   embeddings are not configured, also caught an internal consistency failure,
   so a corrupt sidecar produced `Indexed N documents` and a zero exit code
   ([#774](https://github.com/pvliesdonk/markdown-vault-mcp/issues/774)).
-- Internal semantic-search failures surface from `get_context`.
+- Internal semantic-search failures surface from `get_context` instead of
+  being swallowed at `DEBUG`, the same class of defect as `#774` on the read
+  path
+  ([#804](https://github.com/pvliesdonk/markdown-vault-mcp/issues/804)).
 - `httpx` per-request logs are quiet at the default level. One `INFO` line per
   Ollama embed batch flooded the log during a build
   ([#792](https://github.com/pvliesdonk/markdown-vault-mcp/issues/792)).
 - One malformed prompt no longer aborts registration of every prompt after it
-  ([#799](https://github.com/pvliesdonk/markdown-vault-mcp/issues/799)), and
-  prompts are built from a synthetic signature instead of `exec()`.
+  ([#799](https://github.com/pvliesdonk/markdown-vault-mcp/issues/799)).
+- Prompt callables are built from a synthetic function signature instead of
+  `exec()`-ing an interpolated source string. User-authored prompt argument
+  names reached that source unvalidated beyond a `SyntaxError` guard, so a
+  name that parsed to more than a bare identifier was an injection surface
+  ([#788](https://github.com/pvliesdonk/markdown-vault-mcp/issues/788)).
 
 ### MCP Apps
 
@@ -268,8 +279,15 @@ problem you can fix" from "the indexer itself hit a bug"
   extract a title for a node label, so one 375 KB note failed the whole tool. A
   metadata accessor backed by the index is used instead
   ([#855](https://github.com/pvliesdonk/markdown-vault-mcp/issues/855)).
-- Graph canvas colours are resolved by probe, so nodes are not black on Claude
-  Desktop.
+- Graph canvas colours are resolved by probe instead of read directly off a
+  CSS custom property, so nodes are not black on Claude Desktop. Chromium
+  returns the literal unresolved `var(...)` string for an indirected custom
+  property, which `<canvas>` `fillStyle` cannot parse
+  ([#856](https://github.com/pvliesdonk/markdown-vault-mcp/issues/856)). The
+  graph palette is now also pinned to literal Paper colours rather than the
+  host's own theme tokens, so the focus pill and edges keep their terracotta
+  accent instead of picking up Claude's blue
+  ([#861](https://github.com/pvliesdonk/markdown-vault-mcp/issues/861)).
 - The Vault Explorer view honours host container dimensions on mobile.
 
 ### Tooling and plumbing


### PR DESCRIPTION
## Summary

Full redraft of `docs/releases/3.1.md` under the current writing-release-notes
contract, per this run's `full_redraft: true` input. The page predates the
`notes-range-end` watermark (it was hand-backfilled by #1058 in August 2026),
so this run re-researched the whole `v3.0.4...v3.1.0` range
(https://github.com/pvliesdonk/markdown-vault-mcp/compare/v3.0.4...v3.1.0)
through the GitHub API — commits → PRs → closing issues, epic body (#809), and
milestone/label checks — rather than trusting the existing prose, and now
stamps `<!-- notes-range-end: 05ed4b5ed72a91b05a349e5e5367d530a8db8173 -->` so
future runs can research incrementally.

**Verification, not rewrite.** The existing page turned out to be highly
accurate: every checked numeric claim traced verbatim to its source issue
(#822's 5,043 s / 28 min / 3.2 s / 25,263-directory figures; #819's
68,796-vector / 604-chunk figures; #820's 0.685 / 0.495 / 6,916-chunk
figures; #767's "~40 domain env vars"), the `.env.example` and
`tests/public_import_surface.txt` diffs confirmed the breaking-change
classification (only the `VaultConfig` → `ProjectConfig` rename breaks
anything, and only for Python API consumers — no operator-surface or
tool-surface break), and the Thanks section's attributions checked out
against each issue's `user.login` / `author_association`. So this pass kept
the accepted prose and made **targeted additions** where the fan-out found
real gaps:

- Added missing evidence links: Note Preview → #814, Graph Explorer → #815
  (both epic #809 children), graph canvas colors → #856, `get_context`
  internal-failure surfacing → #804.
- Added a bullet for #861 (graph view pinned to literal Paper colors instead
  of inheriting host theme tokens) — a real shipped fix in the range that the
  prior draft had not covered at all.
- Gave #788 (the `exec()`-based prompt-callable injection surface, S102) its
  own bullet instead of a trailing clause on the #799 bullet, since it is a
  security-hardening fix in its own right, not a detail of the prompt-registration
  robustness fix.
- Added the `notes-range-end` watermark so the next draft (patch or redraft)
  can research incrementally instead of re-walking the whole range.

## Breaking-change classification

Unchanged from the existing page, and independently re-confirmed: only the
Python API surface breaks (`VaultConfig` → `ProjectConfig`, no alias,
`#767`). `git diff v3.0.4..v3.1.0 -- tests/public_import_surface.txt` is
empty; `.env.example` gained one purely additive var
(`FILE_WATCHER_ROOT_FLOOR`); the tool surface only grew (`move_folder`,
`get_toc`). No disagreement with any `!`/`BREAKING CHANGE:` marker in the
range (none were used for #767 or #912-style breaks in this range — commit
`580afd09` for #772 carries a plain `feat:` subject, consistent with the
page's framing).

## Docs staleness

Checked `docs/tools/index.md`, `docs/configuration.md`, `README.md`, and
`docs/design/design.md` against the `v3.0.4..v3.1.0` diff for every
user-facing surface named in the page (`move_folder`, `get_toc`,
`FILE_WATCHER_ROOT_FLOOR`) — all current, no staleness candidates found.

## What I could not source

Nothing new landed unsourced; every commit in the range maps to either a
narrated theme, the "Shipped earlier, in the 3.0 patch line" carry-forward
section, or an internal/infra change (de-fork CLI polish, copier-update
follow-ups, doc-only corrections) that the existing page already correctly
omits from user-facing narrative.

## Evidence

Every claim in the diff carries its own inline issue link; there is no
claim in this PR without one.
