### PR TITLE
docs(readme): add project logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!-- DOMAIN-START -->
+<p align="center">
+  <img src="assets/icon.svg" alt="Markdown Vault MCP logo" width="128" height="128">
+</p>
+<!-- DOMAIN-END -->
+
 # Markdown Vault MCP
 
 <!-- mcp-name: io.github.pvliesdonk/markdown-vault-mcp -->

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-labelledby="title desc">
+  <title id="title">VaultMCP matrix Markdown icon, extra-wide iteration</title>
+  <desc id="desc">An extra-wide heavy Markdown M and a compact far-spaced down arrow enclosed by matrix brackets.</desc>
+  <rect width="512" height="512" rx="112" fill="#F4F1E8"/>
+  <rect x="12" y="12" width="488" height="488" rx="100" fill="none" stroke="#DDD8CB" stroke-width="24"/>
+  <path d="M136 134H96V378H136" fill="none" stroke="#25241F" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M376 134H416V378H376" fill="none" stroke="#25241F" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- The broadest, heaviest interpretation: low, stable, and unmistakably Markdown. -->
+  <path d="M136 320V190H174L213 237L252 190H290V320H252V246L213 292L174 246V320Z" fill="#25241F"/>
+
+  <!-- Compact arrow held farther away from the M. -->
+  <path d="M333 194H363V263H386L348 305L310 263H333Z" fill="#2F6659"/>
+</svg>


### PR DESCRIPTION
## Closes / Refs

Closes #1147. Refs pvliesdonk/fastmcp-server-template#488.

<img width="512" height="512" alt="01c-extra-wide" src="https://github.com/user-attachments/assets/b8391a7c-a47a-47c0-bc6a-6bcedcfd8da8" />

## What & why

Adds a self-contained SVG logo and displays it above the README title. The repository now has one canonical project-owned asset that the README and downstream packages can reuse without external image hosting.

## What this PR deliberately does NOT do

- Does not change the product UI or the existing MCP tool icons. This is repository branding only.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening.
- [x] No commit carries `!`. This changes documentation and adds an asset; no operator or library surface changes.

## Docs impact

- [x] `README.md` — displays the logo above the title.
- [ ] `docs/` site pages — unchanged.
- [ ] `docs/design/` — no design change.
- [ ] Inline docstrings — no code change.

## Verification

- SVG parses cleanly with `xmllint`.
- The committed SVG is byte-identical to the selected source asset.
- `git diff --check` passes.
- The current README template-conformance gate needs pvliesdonk/fastmcp-server-template#488 before it accepts a preserved header block.
