### PR TITLE
docs: add architectural studies for vault service separation and decoupling

### DIFF
--- a/docs/design/studies/README.md
+++ b/docs/design/studies/README.md
@@ -1,0 +1,43 @@
+# Architectural Studies
+
+> **Status:** long-term investigations. No implementation proposed or committed to.
+
+Two studies map the project's potential — from a single MCP server to a layered
+vault platform. They are orthogonal and compose: one asks *where* the vault runs,
+the other asks *how its internals are shaped*.
+
+## The two studies
+
+1. **[Vault service separation](vault-service-separation.md)** — *process*
+   separation: run the vault as a separate read-write service with an HTTP/JSON
+   API, the MCP server as a thin client, and the integrated mode preserved
+   alongside.
+
+2. **[Decoupling and layering](decoupling-and-layering.md)** — *internal*
+   decoupling: nine seams (versioned filestore, identity, search/index, adapter
+   layer, access policy, vault registry, dialect hooks, artifact store, document
+   parser) that collapse to a single content boundary — indexable (format +
+   dialect) vs. artifact.
+
+## The combined potential
+
+Together they describe one target: a **vault platform** — a synchronous core with
+pluggable versioning, identity, and search, driven by interchangeable adapters
+(MCP, CLI, service), running in-process or as a service, over one or many vaults,
+for one or many users, over any indexable format.
+
+| Axis | Process (study 1) | Internal (study 2) |
+|---|---|---|
+| Deployment | separate service; MCP as a thin client | — |
+| Versioning | git moves into the service | `VersionedStore` (Git/Noop/Remote) |
+| Identity | propagation across the boundary | `Principal`/`IdentitySource`/`AccessPolicy` |
+| Search | the service owns the index | `KeywordIndex`/`GraphStore`/`VectorStore` |
+| Content | — | dialect hooks + `ArtifactStore` + `DocumentParser` |
+| Scale | one service, many consumers | `VaultRegistry` + multi-user |
+
+## Framing
+
+These are investigations, not plans. The question they answer is *whether* these
+directions are worth investigating in theory — not *how* to get there. Sequencing,
+mechanics, and migration are deliberately out of scope. No short-term
+implementation is intended.

--- a/docs/design/studies/decoupling-and-layering.md
+++ b/docs/design/studies/decoupling-and-layering.md
@@ -1,0 +1,511 @@
+# Decoupling and Layering — Architectural Investigation
+
+> **Status:** investigation (long-term). No implementation proposed.
+> **Date:** 2026-08-23
+> **Related:** [`vault-service-separation.md`](vault-service-separation.md) — the
+> orthogonal *process-separation* study; [`README.md`](README.md) ties the two
+> together.
+
+## Purpose
+
+Two framings, one investigation:
+
+- **Maintainability.** The vault's internals have grown a few god classes and a
+  few scattered concerns. Decoupling them into single-purpose components behind
+  interfaces is the long-term maintainability play.
+- **Potential.** Combined with the process-separation study, this maps what the
+  project *could* become: not a single MCP server, but a layered vault platform
+  with pluggable versioning, identity, and search backends, usable in-process, as
+  a service, from a CLI, and from a web frontend.
+
+The question this study answers is **whether these directions are worth
+investigating in theory** — not *how* to get there. Sequencing, mechanics, and
+migration are deliberately out of scope.
+
+## 1. The current coupling
+
+### 1.1 Identity is scattered and MCP-coupled
+
+"Who is acting" is four aspects, each resolved from a different place, two of
+them reaching into the MCP auth context:
+
+| Aspect | Today | Source |
+|---|---|---|
+| Subject (who) | `_okf_write.resolve_write_actor` | `fastmcp_pvl_core.get_subject` → `human:<subject>` or a tool actor |
+| Credentials (tokens) | `GitWriteStrategy._token` / `._username` | config (`GIT_TOKEN`/`GIT_USERNAME`) |
+| Committer identity (name/email) | `GitWriteStrategy._check_identity` / `_extract_claim` | config (`GIT_COMMIT_NAME`/`EMAIL`) **or** OIDC claims read from the MCP access token (`fastmcp.server.dependencies.get_access_token`) |
+| Permissions (what) | implicit — `read_only` flag, no per-user model | config |
+
+There is no `Principal` object; identity is a set of ad-hoc reads scattered
+across the write path, and two of them (`get_subject`, `get_access_token`) bind
+the vault's write semantics to the MCP request context.
+
+### 1.2 The git strategy is a god class
+
+`GitWriteStrategy` (`git/strategy.py`, ~1,930 lines) carries at least five
+responsibilities, which map cleanly onto three concerns plus credentials:
+
+| Concern | Methods |
+|---|---|
+| **Versioning** (commit/checkout) | `__call__` (the `on_write` commit), `_stage_and_commit`, `_ensure_write_init`, `_check_identity`, and the conflict-resolution family (`_resolve_rebase_conflicts`, `_abort_in_progress_rebase`, `_restore_upstream_paths`, `_write_conflict_files`) |
+| **History** (log/diff) | `get_file_history`, `get_file_diff`, `_resolve_path_at_ref` |
+| **Syncing** (pull/push) | `force_pull`, `_pull_pipeline`, `force_push`, `sync_once`, `_pull_loop`, `_schedule_push`, `_do_push`, `_push_if_unpushed`, `_lfs_pull` |
+| **Credentials/identity** | `_git_env`, `_redact`, `_extract_claim`, `_check_identity`, `_ensure_managed_repo`, `_check_remote_protocol` |
+
+`Vault` depends on it **concretely** (`git_strategy: GitWriteStrategy | None`),
+and `_build_git_strategy` in `config_sections/_assembly.py` always constructs a
+`GitWriteStrategy` and wires it as *both* `git_strategy` and `on_write`. There is
+no seam to substitute a different versioning backend.
+
+### 1.3 The index/search stack is concrete
+
+Three concrete classes, no backend seam:
+
+- **`FTSIndex`** (`fts_index.py`, ~2,150 lines) — SQLite FTS5, but also the
+  relational store (`documents`/`sections`/`tags`/`links`), the graph queries
+  (backlinks/outlinks/broken/orphans/most-linked/connection-path), TOC, listing,
+  and counting. One class, one backend, many concerns.
+- **`VectorIndex`** (`vector_index.py`, ~530 lines) — numpy embeddings + cosine
+  similarity, with a sidecar metadata list.
+- **`SearchManager`** / **`IndexManager`** — the search pipeline (RRF, ranking,
+  grouping, snippets) and the build/reindex/embeddings lifecycle, both depending
+  on `FTSIndex` and `VectorIndex` concretely.
+
+The design doc's own risk note — *"If tens of thousands, evaluate Qdrant"* — is
+exactly this gap: there is no interface to swap the backend behind.
+
+### 1.4 The async orchestration is tied to FastMCP
+
+The vault core is synchronous (a deliberate, documented decision). The async
+layer is ~50 `asyncio.to_thread` calls, all in the MCP layer: the tool handlers
+(`_server_tools/*`), resources, MCP Apps, the transfer sink, the webhook, the
+`needs_queryable` readiness wait, and `domain.py`'s `Service.start`. The
+lifespan, the dual-mode jobs (`register_long_running_tool`), and the readiness
+gate are FastMCP concepts. A CLI or a service would need its own orchestration —
+there is no reusable "adapter" layer between the sync core and any given driver.
+
+### 1.5 The single-vault assumption
+
+`domain.py` holds one `Service` owning one `Vault`, plus a module-level
+`_vault_singleton`. `Vault` takes one `source_dir`. Multi-vault means either N
+`Vault` instances or a `Vault` serving N roots — neither exists today.
+
+## 2. The decoupled target
+
+### 2.1 Identity component
+
+A `Principal` value object carrying subject, credentials, and committer
+name/email, resolved once by an `IdentitySource` and passed down, instead of each
+layer reading the MCP context itself. Permissions are a separate concern
+(authorization over a `Principal`, not part of the value object).
+
+- **In-process:** `IdentitySource` reads the MCP auth context (the current
+  `get_subject` / `get_access_token` reads, moved behind one interface).
+- **Across a service boundary:** the caller supplies the `Principal` (the
+  "identity propagation" finding from the first study, made concrete).
+
+The git strategy and the OKF write layer stop reading the MCP context and take a
+`Principal` instead. This is also the foundation for multi-user: a `Principal`
+is what a permission check is *about*.
+
+### 2.2 Versioned filestore — one interface or three?
+
+The git strategy's five responsibilities collapse into three concerns:
+**versioning** (commit/checkout), **history** (log/diff), and **syncing**
+(pull/push). The open question is whether these are one interface with three
+facets, or three interfaces.
+
+**Interpretation A — one `VersionedStore` with three facets.**
+
+- *Pro:* one dependency, one construction point, one lifecycle for the vault; a
+  git-backed vault always needs all three, so a single interface matches the
+  current usage; it mirrors the existing `Vault` shape (four facets:
+  reader/writer/graph/index); `NoopStore`/`RemoteStore` no-op or delegate the
+  facets they don't have; fewer interfaces to maintain, document, and test.
+- *Con:* a fat interface with three reasons to change (versioning semantics,
+  history query shape, sync protocol); a consumer that only wants history is
+  coupled to the versioning/syncing surface it never uses; it risks becoming a
+  god interface mirroring the god class it replaced; harder to evolve one concern
+  independently without touching the shared interface.
+
+**Interpretation B — three interfaces (`Versioner`, `HistorySource`, `Syncer`).**
+
+- *Pro:* each interface has one reason to change; consumers depend on only what
+  they need; consistent with the "distinct concepts" principle (see §2.3 — the
+  graph is distinct from search, and by the same logic versioning/history/syncing
+  are distinct); independent evolution of each concern.
+- *Con:* more interfaces to maintain, document, test, and wire; the vault holds
+  three references instead of one; risk of over-abstraction if no consumer ever
+  wants one without the others; the three concerns operate on the same repo, so
+  splitting can create artificial seams that leak (e.g. `Syncer` needs to know
+  about `Versioner`'s commits to push them).
+
+**Resolution: three narrow interfaces, one implementation.** The deciding
+evidence is that the consumers already want different subsets — `GitQueryManager`
+uses only `get_file_history`/`get_file_diff` (history), the webhook uses only
+`force_pull` (syncing), and the write path uses commit + pull/push (versioning +
+syncing). The current code already has this split implicitly; the interfaces make
+it explicit. A single `GitStore` class implements all three and is passed as one
+object, while each consumer depends on the specific interface it needs — interface
+segregation without forcing three separate objects.
+
+### 2.3 Search/index abstraction — three distinct concepts
+
+The `FTSIndex`'s many concerns are three distinct concepts, each its own
+interface:
+
+- **`KeywordIndex`** — the relational document store + full-text search
+  (`search`, `get_note`, `list_*`, `get_toc`, …). `FTS5Index` (SQLite) is the
+  current implementation.
+- **`GraphStore`** — the link graph (`get_backlinks`, `get_outlinks`,
+  `get_broken_links`, `get_orphan_notes`, `get_most_linked`,
+  `get_connection_path`, neighborhood/hub views). Distinct from search: the graph
+  is about *structure* (what links to what), not *relevance* (what matches a
+  query). The current `FTS5Index` implements both over the same SQLite DB; a
+  future backend could split them (e.g. a graph store alongside a search index).
+- **`VectorStore`** — the semantic surface (`add`, `search`, `search_by_path`,
+  `delete_by_path`). `NumpyVectorStore` is the current implementation.
+
+`SearchManager` and `IndexManager` depend on the interfaces, not the classes. The
+embedding *provider* is already abstracted (`EmbeddingProvider`); this extends the
+same move to the *storage* it feeds.
+
+### 2.4 Async orchestration as an adapter layer
+
+The sync vault core stays sync. The async orchestration becomes a thin, reusable
+**adapter** per driver: an MCP adapter (lifespan, `to_thread`, jobs, readiness),
+a CLI adapter, a service adapter. Each adapter owns its own concurrency model and
+wraps the same sync core. This is what makes the core usable from FastMCP, a CLI,
+and a service without any of them leaking into the core.
+
+### 2.5 Multi-vault registry
+
+A `VaultRegistry` owning N `Vault` instances (one per `source_dir`), replacing the
+single `Service`/singleton. Consumers resolve a vault by name/path; the registry
+owns construction, lifecycle, and the per-vault index/writer.
+
+### 2.6 Multi-user — a modeling question
+
+The architecture should *enable* both per-user vaults and shared vaults with
+per-user permissions, without committing to either. That is a modeling decision,
+not an implementation one: the model keeps three concepts distinct, and both
+deployment patterns fall out of how they are combined.
+
+- **`Vault`** — the data, one per `source_dir`. Deliberately user-agnostic: it
+  knows nothing about who is reading or writing.
+- **`Principal`** — the identity (who is acting).
+- **`AccessPolicy`** — the mapping `Principal × Vault → permission`
+  (read/write/none).
+
+Per-user vaults are the case where each `Principal` maps to its own `Vault` with
+write permission; shared vaults are the case where many `Principal`s map to the
+same `Vault` with different permissions. The `Vault` never changes between the
+two — only the `AccessPolicy` does. Whether the implementation ever supports
+multi-user is a separate question; the model does not foreclose it.
+
+### 2.7 Dialects and artifacts — optional layers on the core
+
+The core vault is dialect-agnostic by design: the spec's non-goal is that the
+server "treats all `.md` files structurally identically" and imposes no
+frontmatter convention. But three optional layers add semantics on top, and one
+kind of content is a different thing entirely:
+
+- **OKF** — the heaviest dialect: detection (`okf_version` in `index.md`), read
+  annotations (`type`/`status`/`stale`/`trust_tier`), write provenance
+  (`generated` stamp, `verified` clear), reserved-file maintenance (`log.md`/
+  `index.md`), migration tools (`okf_convert_links`/`okf_generate_index`/
+  `okf_seed_log`), and bundle export. Today it is woven through the index (OKF
+  keys join `indexed_frontmatter_fields`), the read path (annotations), and the
+  write path (provenance) — gated by `OKF_MODE`, but not *pluggable*.
+- **Conventions** — a lighter dialect: transport of `_conventions.md` text.
+  Already the cleanest of the three (pure disk I/O, zero index coupling).
+- **Indexed labels** — a configurable schema: which frontmatter fields are
+  promoted to `document_tags`. Baked into the index and the chunking provenance.
+
+- **Artifacts** — non-md files (attachments): binary, no frontmatter, not
+  indexed, path-based CRUD. A different kind of content from markdown documents,
+  currently overloaded onto the document tools via extension dispatch.
+
+The decoupling: the core vault stays dialect-agnostic, and the dialects become
+**pluggable extensions** that hook into the core at well-defined points — detect,
+annotate-read, stamp-write, promote-fields, maintain-reserved-files. The core
+invokes the hooks; the dialects implement them. Artifacts become a separate
+`ArtifactStore` with its own interface, not overloaded onto the document tools.
+
+### 2.8 Content format — the core is format-agnostic
+
+The concepts — documents, index, search, graph, versioning, identity — are
+format-agnostic, but the implementation is markdown-specific at every layer: YAML
+frontmatter parsing, heading-based chunking (H1–H6), markdown/wikilink link
+extraction, and the `.md` extension baked into document identity. A docx, pdf,
+txt, or tex file is still a document that can be indexed, searched, linked, and
+versioned — but the markdown parser makes no sense for it.
+
+The abstraction: a **`DocumentParser`** (or `ContentFormat`) interface that takes
+a file and produces the normalized `ParsedNote` — the document model the core
+already operates on (`path`, `title`, `chunks`, `links`, `metadata`, hash). The
+core is format-agnostic because it consumes `ParsedNote`s, not markdown. The
+markdown parser is the current implementation; docx/pdf/txt/tex parsers are
+future ones.
+
+The `ParsedNote`/`Chunk` model is already close to format-agnostic; the
+markdown-specific residue is `heading`/`heading_level` (H1–H6) and `frontmatter`
+(YAML). Generalizing these to a "section" concept and a "metadata" dict is the
+only change the model needs. `ChunkStrategy` is already a partial abstraction
+(chunking); `DocumentParser` extends it to parsing + link extraction + metadata.
+
+The dialects (§2.7) are also markdown-specific in their current form — they read
+frontmatter, which is a markdown convention. A format-agnostic core would need
+the dialects to read the normalized `metadata` instead, so the two abstractions
+compose: `DocumentParser` normalizes the format, the dialect hooks interpret the
+normalized document.
+
+### 2.9 The indexable boundary
+
+§2.7 and §2.8 collapse to a single seam. A file is either:
+
+- **Indexable** — it goes through `DocumentParser` (format) and the dialect hooks
+  (interpretation) to become a document in the model: searched, graphed,
+  versioned, interpreted.
+- **Artifact** — everything else: path CRUD only, no index, no dialect.
+
+The current code already draws this boundary (`.md` vs. non-md), but hard-codes
+"indexable" to "markdown." The abstraction generalizes "indexable" to "format +
+dialect": any format a `DocumentParser` can parse, and any dialect that can
+interpret the result, is indexable. Everything else is an artifact.
+
+## 3. The decoupled component diagram
+
+### Current (coupled)
+
+```mermaid
+flowchart LR
+    subgraph MCP["MCP layer"]
+        Tools["tools / resources / prompts"]
+        Auth["auth context<br/>get_subject · get_access_token"]
+    end
+    subgraph Vault["Vault (single source_dir)"]
+        Facets["facets"]
+        Managers["managers"]
+        Index["FTSIndex (SQLite)<br/>FTS + graph + relational<br/>+ VectorIndex (numpy)"]
+    end
+    subgraph Git["git/"]
+        Strategy["GitWriteStrategy<br/>versioning · history · syncing · creds"]
+    end
+    OKF["_okf_write<br/>provenance"]
+
+    Tools --> Facets
+    Facets --> Managers --> Index
+    Vault --> Strategy
+    Strategy --> Auth
+    OKF --> Auth
+```
+
+### Target (decoupled)
+
+```mermaid
+flowchart TB
+    subgraph Consumers["Consumers"]
+        MCP["MCP client"]
+        CLI["CLI"]
+        Web["Web / other services"]
+    end
+
+    subgraph Adapters["Adapters (async orchestration)"]
+        MCPAdapter["MCP adapter<br/>lifespan · to_thread · jobs · readiness"]
+        CLIAdapter["CLI adapter"]
+        SvcAdapter["service adapter"]
+    end
+
+    subgraph Registry["Multi-vault"]
+        VR["VaultRegistry<br/>(N × Vault)"]
+    end
+
+    subgraph Core["Vault core (sync)"]
+        Vault["Vault"]
+        Facets["facets: reader / writer / graph / index"]
+        Managers["managers: search / index / document / link"]
+    end
+
+    subgraph Identity["Identity"]
+        P["Principal<br/>subject · credentials · committer"]
+        IS["IdentitySource<br/>MCP auth ctx | caller-supplied"]
+        AP["AccessPolicy<br/>Principal × Vault → permission"]
+    end
+
+    subgraph Versioning["Versioned filestore"]
+        VS["VersionedStore<br/>versioning · history · syncing"]
+        Git["GitStore"]
+        Noop["NoopStore"]
+        Remote["RemoteStore"]
+    end
+
+    subgraph Search["Search / index"]
+        KI["KeywordIndex<br/>relational + FTS"]
+        GS["GraphStore<br/>links / graph"]
+        Vec["VectorStore<br/>semantic"]
+        FTS["FTS5 (SQLite)"]
+        Qdrant["Qdrant / pgvector"]
+        Numpy["numpy + cosine"]
+    end
+
+    subgraph Dialects["Dialects (optional)"]
+        OKF["OKF dialect<br/>detect · annotate · stamp · migrate"]
+        Conv["Conventions<br/>transport"]
+        Labels["Indexed labels<br/>frontmatter schema"]
+    end
+
+    subgraph Artifacts["Artifacts"]
+        Art["ArtifactStore<br/>non-md · path CRUD · no index"]
+    end
+
+    subgraph Formats["Content formats"]
+        Parser["DocumentParser<br/>parse · chunk · link-extract"]
+        MD["MarkdownParser"]
+        Docx["DocxParser"]
+        Pdf["PdfParser"]
+        Txt["TxtParser"]
+    end
+
+    MCP --> MCPAdapter
+    CLI --> CLIAdapter
+    Web --> SvcAdapter
+    MCPAdapter --> Vault
+    CLIAdapter --> Vault
+    SvcAdapter --> Vault
+    VR --> Vault
+
+    Vault --> Facets
+    Facets --> Managers
+    Managers --> VS
+    Managers --> KI
+    Managers --> GS
+    Managers --> Vec
+    Managers --> P
+
+    VS -.-> Git
+    VS -.-> Noop
+    VS -.-> Remote
+
+    KI -.-> FTS
+    KI -.-> Qdrant
+    GS -.-> FTS
+    Vec -.-> Numpy
+    Vec -.-> Qdrant
+
+    IS --> P
+    AP --> P
+    AP --> VR
+    Git --> P
+
+    OKF -.-> Managers
+    Conv -.-> Managers
+    Labels -.-> KI
+    Managers --> Art
+
+    Parser -.-> MD
+    Parser -.-> Docx
+    Parser -.-> Pdf
+    Parser -.-> Txt
+    Parser --> Managers
+```
+
+Nine seams, each an interface or extension point the core depends on instead of
+a concrete class or a global context: **`VersionedStore`**,
+**`Principal`/`IdentitySource`**, **`KeywordIndex`/`GraphStore`/`VectorStore`**,
+the **adapter layer**, **`AccessPolicy`**, **`VaultRegistry`**, the **dialect
+hooks** (OKF/conventions/indexed-labels as pluggable extensions),
+**`ArtifactStore`** (non-md content as a separate store), and **`DocumentParser`**
+(the content format, so the core consumes `ParsedNote`s, not markdown).
+
+## 4. The combined potential
+
+The two studies are orthogonal and compose. The first (process separation) asks
+*where* the vault runs; this one asks *how its internals are shaped*. Together
+they describe one target:
+
+| Axis | First study (process) | This study (internal) |
+|---|---|---|
+| Deployment | vault as a separate service; MCP as a thin client | — |
+| Versioning | git moves into the service | `VersionedStore` with `GitStore`/`NoopStore`/`RemoteStore` |
+| Identity | identity propagation across the boundary | `Principal`/`IdentitySource`/`AccessPolicy` |
+| Search | the service owns the index | `KeywordIndex`/`GraphStore`/`VectorStore` with swappable backends |
+| Content model | — | dialect hooks (OKF/conventions/indexed-labels) + `ArtifactStore` |
+| Content format | — | `DocumentParser` (markdown/docx/pdf/txt/tex → `ParsedNote`) |
+| Scale | one service, many consumers | `VaultRegistry` (multi-vault) + multi-user |
+
+The end-state is a **vault platform**: a sync core with pluggable versioning,
+identity, and search, driven by interchangeable adapters (MCP, CLI, service),
+running in-process or as a service, over one or many vaults, for one or many
+users. The current single MCP server is the *integrated* corner of that space —
+the first study's "separated lives next to integrated" and this study's
+"decoupled lives next to concrete" are the same principle at two scales.
+
+## 5. What is already abstracted (patterns to follow)
+
+The codebase already applies this pattern in four places, which is the strongest
+argument that the git strategy, identity, and index are the *exceptions*, not the
+rule:
+
+| Abstraction | Where | Shape |
+|---|---|---|
+| `EmbeddingProvider` | `providers.py` | ABC + implementations (Ollama/OpenAI/FastEmbed) |
+| `Summarizer` | `summarizer.py` | ABC + OpenAI-compatible backend |
+| `ChunkStrategy` | `scanner.py` | `Protocol` + `HeadingChunker`/`WholeDocumentChunker` |
+| `TransferSink` | pvl-core | `Protocol` + `VaultTransferSink` |
+
+`VersionedStore`, `Principal`, and `KeywordIndex`/`GraphStore`/`VectorStore` are
+the same move applied to the three places that have not yet received it.
+
+## 6. Worth investigating
+
+All six seams are worth investigating in theory; the question this study answers
+is *whether*, not *how*. For completeness, the relative weight if the work is
+ever picked up (not a plan, not a sequence):
+
+- **`VersionedStore`** — highest leverage: it is the largest god class, the
+  consumers already want different subsets, and it unblocks the `RemoteStore` the
+  first study's separated mode needs.
+- **`Principal`/`IdentitySource`** — small but touches write-path semantics
+  (provenance, committer identity); prerequisite for multi-user.
+- **`KeywordIndex`/`GraphStore`/`VectorStore`** — the largest behavioural surface
+  (every query flows through it), but the interfaces are already implied by the
+  manager boundaries; the Qdrant risk note is the forcing function.
+- **Dialect hooks + `ArtifactStore`** — the dialects (OKF especially) are the most
+  woven-in of the optional layers; extracting them into pluggable extensions is
+  the clearest "optional aspect" win, and `ArtifactStore` removes the
+  extension-dispatch overload on the document tools.
+- **`DocumentParser`** — the format abstraction. The `ParsedNote` model is already
+  close to format-agnostic, so this is mostly generalizing `heading`/`frontmatter`
+  and moving the markdown-specific parse/chunk/link code behind an interface. The
+  lowest *immediate* value (no non-markdown consumer exists), but the highest
+  *conceptual* leverage — it is what makes "vault" mean "documents" rather than
+  "markdown files."
+- **Adapter layer** — the sync core is already there; extracting the async
+  orchestration is mostly mechanical.
+- **`AccessPolicy`** and **`VaultRegistry`** — the largest behavioural change
+  (lifecycle, per-vault index/writer, consumer resolution), and the most
+  product-shaped.
+
+**Risks:** the `VersionedStore` split is a large refactor of a bug-magnet file
+(`git/strategy.py` — 23 bug fixes in its history); the `Principal` change alters
+provenance semantics (a behavioural change, not just structure); the
+`KeywordIndex`/`GraphStore`/`VectorStore` split touches every query path; and
+multi-vault/multi-user is a *product* decision the code can only enable, not
+settle.
+
+## 7. Open questions
+
+Resolved in this revision: the graph is a distinct concept (`GraphStore`, §2.3);
+multi-user is modeled to enable both per-user and shared vaults (§2.6); and
+`VersionedStore` is three narrow interfaces with one implementation (§2.2).
+
+Still open:
+
+- **Does `KeywordIndex` need a separate relational `DocumentStore`?** The
+  relational store (`documents`/`sections`/`tags`) currently rides inside
+  `FTSIndex` alongside FTS and graph. Whether it is its own interface is a finer
+  decomposition than this study needs to settle.
+- **Does the `AccessPolicy` live in the vault core or in the adapter?** The model
+  keeps it distinct; where it is *enforced* (core vs. adapter) is an
+  implementation question this study deliberately leaves open.

--- a/docs/design/studies/vault-service-separation.md
+++ b/docs/design/studies/vault-service-separation.md
@@ -1,0 +1,355 @@
+# Vault Service Separation — Architectural Study
+
+> **Status:** study (investigation only). No implementation is proposed or
+> committed to in the short term.
+> **Date:** 2026-08-22
+> **Related:** [`decoupling-and-layering.md`](decoupling-and-layering.md) — the
+> orthogonal *internal-decoupling* study; [`README.md`](README.md) ties the two
+> together.
+
+## Purpose
+
+`markdown-vault-mcp` is one package containing two things: a **vault** (writing,
+indexing, and searching a directory of markdown) and an **MCP layer** around it.
+The vault is more generically useful than the MCP surface — a CLI, a web
+interface, or another service could all want to search and edit the same running
+index. This study investigates disentangling the two so the vault can run as a
+**separate read-write service with an API**, with the MCP server as a thin
+client, while the current **integrated** mode (one plugin / one container)
+continues to exist alongside.
+
+The study is deliberately not a plan. It maps the current boundary, identifies
+the hard problems, and recommends a direction. Nothing here is a commitment.
+
+## 1. Baseline — the split that already exists
+
+The disentanglement is not primarily a code refactor, because the code-level
+split already exists. The design spec is explicit: `Vault` is the primary
+interface and *"MCP is one consumer, not the only one"* (Use Cases #3).
+Concretely:
+
+- **The library is synchronous.** `Vault` is a thin façade over four facets —
+  `reader`, `writer`, `graph`, `index` — plus lifecycle (`start`/`stop`/`close`).
+  Managers are injected; no manager holds a back-reference to `Vault`.
+- **The MCP layer wraps the library.** Tool handlers call the facets through
+  `asyncio.to_thread(...)`. The MCP layer is a protocol adapter: it owns the tool
+  surface, resources, prompts, auth, MCP Apps, and instructions.
+- **One process owns the state.** The index (SQLite FTS5 + numpy sidecar +
+  `state.json`) and the single-writer `IndexWriter` (all index mutations through
+  one FIFO thread) live inside the `Vault` instance. The write-side orchestration
+  — git sync (pull loop, deferred push, conflict resolution), the file watcher,
+  the webhook, OKF write tools, transfer links, summarize — all assume this
+  in-process ownership.
+
+So the question is not "how do we untangle the code" but "how do we move a clean
+in-process library boundary to a service boundary" — a process/deployment
+separation, not a code separation.
+
+### How clean is the library boundary, exactly?
+
+A grep for `fastmcp` / `fastmcp_pvl_core` imports across `src/` shows the split
+is already nearly complete:
+
+- **The core library is clean.** `vault.py`, `managers/`, `facets/`,
+  `indexing/`, `scanner.py`, `fts_index.py`, `vector_index.py`, `tracker.py`,
+  `providers.py`, `types.py`, and `utils/` import nothing from FastMCP or
+  pvl-core.
+- **One deliberate exception.** `exceptions.py` re-exports pvl-core's
+  `ConfigurationError` as the canonical config error (#638), so
+  `markdown_vault_mcp.exceptions.ConfigurationError` *is* the pvl-core class.
+- **Two auth-context couplings in the orchestration layer.** `git/strategy.py`
+  reads the MCP access token (`fastmcp.server.dependencies.get_access_token`) to
+  authenticate git operations, and `_okf_write.py` reads the current subject
+  (`fastmcp_pvl_core.get_subject`) for OKF provenance stamping. Both are "who is
+  acting" identity that flows from the MCP auth context into the write path.
+
+This is the single most useful fact for the study: the vault library is already
+~99% decoupled from MCP, and the residual couplings are (a) one re-export and
+(b) two identity reads. The hard work is not untangling code; it is moving the
+*identity* and *state-ownership* assumptions across a process boundary.
+
+## 2. Target — the disentangled architecture
+
+```
+                    ┌──────────────────────────────┐
+   MCP client ────▶ │  markdown-vault-mcp (thin)    │  auth, prompts, apps, instructions
+                    │  = protocol adapter           │
+                    └──────────────┬───────────────┘
+                                   │ VaultClient (HTTP/JSON)
+                    ┌──────────────▼───────────────┐
+   CLI ───────────▶ │  vault service (separate      │  owns files + index + writer
+   web ───────────▶ │  process / container)          │  + git + watcher + webhook
+   other svc ─────▶ │  = Vault library + API        │  + OKF + summarize + transfer
+                    └──────────────────────────────┘
+```
+
+- The **vault service** is the `Vault` library plus its orchestration, behind an
+  API. It owns the files, the index, the single writer, git sync, the file
+  watcher, the webhook, OKF, summarize, and transfer links.
+- The **MCP server** becomes a thin client: it keeps auth, prompts, MCP Apps, and
+  instructions, but every tool is a call to the vault service's API.
+- **Other consumers** (CLI, web, other services) talk to the same API and share
+  the same running index.
+- The **integrated mode** is preserved: when no vault service is configured, the
+  MCP server constructs the `Vault` in-process exactly as today.
+
+## 3. The hard problems
+
+### 3.1 The API surface and wire format
+
+The facet surface is rich and typed: `search` returns `list[GroupedResult]`
+(nested `SectionHit`s), `read` returns `NoteContent`, `get_context` returns a
+`NoteContext` dossier, graph tools return `BacklinkInfo`/`OutlinkInfo`/
+`BrokenLinkInfo`, index tools return `IndexStats`/`ReindexResult`, and so on.
+Today these are Python dataclasses; the MCP layer already serializes them to JSON
+for the MCP wire.
+
+The vault service needs a **wire format** for the first time. The good news: the
+JSON shapes already exist (the MCP tools are the de-facto schema). The work is to
+formalize them — a typed schema (OpenAPI/JSON Schema) that the service serves and
+the client validates — rather than invent a new one. The dataclasses become the
+single source of truth, with the JSON schema generated from them (or
+hand-maintained alongside, as the MCP tool schemas are today).
+
+### 3.2 Transport
+
+Three candidates:
+
+| Transport | For | Against |
+|---|---|---|
+| **HTTP/JSON** | Universal; CLI/web/other-services are all HTTP-native; the MCP layer already speaks JSON; pvl-core already has HTTP infrastructure (transfer routes, auth) | No streaming/typed contract out of the box (mitigated by a JSON schema) |
+| **gRPC** | Typed contracts, streaming, codegen | Heavier tooling; poor fit for CLI/web; the MCP layer is JSON-native, so it buys little |
+| **MCP-as-service** | Reuses MCP tooling; the vault service's tools *are* the API | CLI/web clients need an MCP client (heavy); couples the vault to the MCP protocol — the exact coupling being removed; the "thin wrapper" degenerates to a proxy |
+
+**Recommendation: HTTP/JSON with a typed schema.** The consumers are
+CLI/web/other-services, and the MCP layer is already JSON. MCP-as-service is
+tempting but wrong: it re-couples the vault to MCP and makes non-MCP consumers
+heavier. gRPC buys nothing the consumers need.
+
+### 3.3 Write-side orchestration across the boundary
+
+This is the hard part the read-write choice commits to. Everything that assumes
+in-process ownership of files + index moves into the service:
+
+- **Git sync** (pull loop, deferred push, conflict resolution, history/diff) —
+  the service owns the working tree, so it owns git.
+- **File watcher** and **webhook** — these are *triggers* on the files; they live
+  in the service.
+- **OKF write tools** and **transfer links** — write paths; they live in the
+  service.
+- **Summarize** — vault-adjacent (reads note content, references paths); it lives
+  in the service.
+
+The **single-writer model survives**, and in one sense improves: the service is
+now the *only* owner of the index, so the "one writer" invariant is enforced by
+the process boundary rather than by convention. But the boundary introduces new
+concerns:
+
+- **Idempotency and retries.** A write that succeeds server-side but whose
+  response is lost must be retryable without double-applying. The existing
+  `if_match`/etag mechanism is the concurrency guard (it prevents *conflicting*
+  writes), but it does not dedupe *duplicate* writes; a client-generated request
+  ID is needed on top for true idempotency.
+- **Long-running operations.** `reindex`/`build_embeddings`/`summarize` are
+  already dual-mode (inline or promoted to a pollable job). Across the boundary
+  they become service-side jobs with handles; the MCP server's `get_job_result`
+  proxies them.
+- **Concurrent writers.** Multiple clients (MCP + CLI + web) now write through
+  one service. The service's single writer serializes them; `if_match` gives
+  optimistic concurrency at the client level.
+
+### 3.4 Identity propagation
+
+The two auth-context couplings (§1) are the subtlest part of the boundary. Today
+the write path reads the acting identity *in-process*: git needs the MCP access
+token to authenticate the remote, and OKF write needs the current subject to
+stamp provenance. Across the boundary, the client must pass the acting identity,
+and the service must map it to git credentials and provenance.
+
+This is a real design decision, not a mechanical one:
+
+- **Git credentials.** The vault service needs its own git credential (a token
+  or deploy key), independent of any MCP client's token. The MCP server's access
+  token is the wrong credential for the service to use — it is scoped to the MCP
+  session, not to the vault's remote.
+- **OKF provenance.** The "who wrote this" stamp must survive the boundary. The
+  client passes a subject (or the service derives one from its own auth), and the
+  service stamps it. This is a small but load-bearing semantic: provenance is
+  currently tied to the MCP auth subject.
+
+The clean resolution is to give the vault service its own identity model — a
+service credential for git, and a caller-supplied subject for provenance — rather
+than trying to forward the MCP auth context.
+
+### 3.5 MCP-layer signals across the boundary
+
+Three MCP-layer mechanisms today reach into the index in-process. Each becomes an
+API concern:
+
+| Today (in-process) | Across the boundary |
+|---|---|
+| `needs_queryable` decorator blocks on `IndexFacet.wait_until_queryable(timeout)` | The service exposes a readiness/status endpoint; the client polls it with the same timeout semantics |
+| `_meta.index_stale` (OR of wait-timeout, write-generation advance, non-idle writer) | The service exposes a monotonic write-generation counter (it already has one internally); the client maps it to `_meta.index_stale` |
+| Dual-mode jobs (`reindex`/`build_embeddings`/`summarize`) via pvl-core jobs | The service owns the job store; the MCP server's `get_job_result` proxies the service's job endpoint |
+
+The semantics get *fuzzier* across a network boundary (eventual consistency; a
+stale read is now "the service's last-known state" rather than "the writer's
+in-flight state"), but the shape is the same.
+
+### 3.6 Auth and exposure
+
+The vault service needs its own access control. Two positions:
+
+- **Public service** — the vault service is exposed and does its own auth
+  (reusing pvl-core's bearer/OIDC builders, or a simpler token). This makes the
+  vault service a first-class public API.
+- **Private service** — the vault service is on a private network; the MCP server
+  is the only public entry point and forwards a service credential (shared secret
+  or mTLS). The vault service's auth is "network isolation + a shared secret."
+
+**Recommendation: private service.** The MCP server already does the real auth
+(OIDC/bearer) and is the public surface. Making the vault service public
+duplicates that and expands the attack surface. A private service with a shared
+secret keeps the vault service simple; the MCP server (and any other trusted
+consumer) holds the credential. This also matches the current deployment (single
+container, private network).
+
+### 3.7 Coexistence — one codebase, two backends
+
+The key design move that keeps the integrated mode alive: **define the facet
+interface as the seam, and implement it twice.**
+
+- **In-process `Vault`** — the current implementation. The MCP layer calls the
+  facets directly via `asyncio.to_thread`.
+- **Remote `VaultClient`** — implements the same facet interface but calls the
+  vault service's HTTP API.
+
+The MCP layer is written against the facet interface and selects the backend at
+startup: `VAULT_SERVICE_URL` unset → in-process; set → remote. This is the
+"separated lives next to integrated" requirement, satisfied by one codebase.
+
+Two sub-decisions:
+
+- **Sync vs async client.** The facet interface is sync. The simplest
+  `VaultClient` is a sync HTTP client, so the MCP layer keeps its
+  `asyncio.to_thread` shape unchanged. An async-native MCP layer (async HTTP
+  client, no `to_thread`) is cleaner for a network backend but a larger change;
+  it can come later.
+- **Where the interface lives.** If the vault splits into its own package (§4),
+  the facet interface and the dataclasses live there, and both `Vault` and
+  `VaultClient` implement it. The MCP package depends on the vault package and is
+  agnostic to which backend it got.
+
+## 4. The template and pvl-core
+
+### 4.1 pvl-core — mostly unaffected
+
+pvl-core serves the MCP side: `ServerConfig`, auth builders, middleware, logging,
+transfer routes, jobs, CLI helpers. That side is unchanged — the MCP server still
+uses all of it. The vault service is *not* an MCP server, so it doesn't need the
+MCP-specific parts (OIDCProxy, MCP Apps, prompts). It might reuse pvl-core's
+HTTP/auth primitives if it is exposed, but under the private-service
+recommendation it needs little more than a shared-secret check. **Conclusion:
+pvl-core is not a constraint on this design.**
+
+### 4.2 The template — four options
+
+The template (`fastmcp-server-template`) is built for "one MCP server package." A
+second deployable (the vault service) and a second package (the vault library)
+are outside its model. The four options:
+
+| Option | What it means | Cost | Benefit |
+|---|---|---|---|
+| **Change the template** | The template gains a generic "additional service" capability | Large, speculative template change; the template's consumers are all MCP servers, so a generic "vault service" doesn't generalize cleanly | All consumers get the capability |
+| **Fork the template** | The project forks and diverges | Loses `copier update`; manual reconciliation of CI/release/Dockerfile/packaging forever | Full control |
+| **Absorb** | Stop using copier; own everything | Loses all template updates (CI/release/packaging improvements) | Maximum freedom |
+| **Separate package (subrepo direction)** | The vault library + service become their own package/repo; the MCP server stays template-managed and depends on it | A package split (breaking change to the import surface; a second release stream) | The template stays as-is; the vault is a normal dependency; cleanest long-term |
+
+**Recommendation: separate package.** The disentanglement's natural end-state is
+a package split: `markdown-vault` (the library + service, no MCP dependency) and
+`markdown-vault-mcp` (the thin MCP server, template-managed, depending on
+`markdown-vault`). This is the "subrepo" direction, framed as "the vault becomes
+a standalone package the MCP server consumes" rather than "the template is
+applied to a subdirectory."
+
+The reasons:
+
+- **The template stays as-is.** No speculative generic multi-service change; no
+  fork's maintenance cost; no absorb's loss of updates. The template keeps
+  managing exactly what it is good at — the MCP server.
+- **The vault's consumers get a clean dependency.** A CLI or web interface
+  depends on `markdown-vault` (or its service), not on an MCP server package.
+- **The MCP dependency is removed from the vault package.** The core library is
+  already clean (§1); the split makes the *package* clean too, so the vault no
+  longer ships MCP-adjacent concerns (config sentinels, server wiring) to
+  consumers who only want the vault.
+
+The costs are real and should be named:
+
+- **Breaking change.** The public import surface (`markdown_vault_mcp.vault`,
+  `.types`, `.config`, …) moves to `markdown_vault.*`. This is a major-version
+  event for library consumers.
+- **Config splits.** `ProjectConfig` today mixes vault settings (`source_dir`,
+  `index_path`, embeddings) with MCP settings (auth, `base_url`, apps). The split
+  moves vault config into the vault package and leaves MCP config in the MCP
+  package.
+- **Two release streams.** Two packages to version, release, and publish. The
+  template's release machinery (knope, `stamp_manifests`) manages the MCP
+  package; the vault package needs its own (simpler) release flow.
+- **The sentinel structure.** The template's sentinels (config fields, domain
+  wiring, apps) currently hold vault-specific code. Splitting moves that code out
+  of the sentinels into the vault package, shrinking the MCP package's domain
+  surface to "the protocol adapter."
+
+## 5. Recommendation, summarized
+
+1. **Split the package** into `markdown-vault` (library + service) and
+   `markdown-vault-mcp` (thin MCP server). This is the enabling move; everything
+   else follows from it.
+2. **HTTP/JSON API** with a typed schema, mirroring the facet surface. Not
+   MCP-as-service, not gRPC.
+3. **Backend abstraction at the facet seam** — in-process `Vault` and remote
+   `VaultClient` implement the same interface; the MCP layer selects at startup.
+   This is what keeps the integrated mode alive.
+4. **The vault service owns the write-side orchestration** (git, watcher,
+   webhook, OKF, summarize, transfer); the single-writer model survives as a
+   service-internal invariant.
+5. **The vault service gets its own identity model** — a service credential for
+   git and a caller-supplied subject for OKF provenance — rather than forwarding
+   the MCP auth context.
+6. **The MCP-layer signals become API concerns** (readiness endpoint, generation
+   counter, job handles), mapped back to `needs_queryable` / `_meta.index_stale`
+   / `get_job_result`.
+7. **Private service** with a shared secret; the MCP server remains the public,
+   authenticated entry point.
+8. **pvl-core is unaffected**; the template stays as-is and manages only the MCP
+   package.
+
+## 6. Risks and open questions
+
+**Risks**
+
+- **The wire format becomes a public API** with a stability burden. The
+  dataclasses and their JSON shapes must be versioned and evolved deliberately.
+- **Two backends to maintain** (in-process + remote) — drift risk between `Vault`
+  and `VaultClient`. Mitigated by a shared interface and a conformance test that
+  runs the same suite against both.
+- **The single-writer model under network concurrency** — idempotency, retries,
+  and `if_match` across the wire need care; the existing etag mechanism is the
+  foundation but was designed for in-process use.
+- **Readiness/staleness semantics get fuzzier** across a network boundary
+  (eventual consistency).
+- **The package split is a breaking change** to the public import surface and the
+  release model.
+
+**Open questions**
+
+- **One vault or many per service?** Recommend one vault per service instance
+  (matches today); multi-vault is a separate concern.
+- **Async-native MCP layer?** Recommend sync-client + `to_thread` first;
+  async-native later.
+- **Where does summarize's LLM call live?** In the service (it owns the content);
+  the MCP server just proxies.
+- **Does the vault service reuse pvl-core's HTTP/auth primitives, or stay
+  dependency-free?** Under the private-service recommendation it needs little;
+  decide when the service is actually built.


### PR DESCRIPTION
## Closes / Refs

Closes #1151

## What & why

Adds two architectural studies under `docs/design/studies/` — process separation (running the vault as a separate read-write service) and internal decoupling (identity, versioned filestore, search/index, dialects, content formats) — plus a README tying them together. They map the project's potential from a single MCP server to a layered vault platform, framed as long-term investigations rather than implementation plans.

## What this PR deliberately does NOT do

- No code changes — the studies are documentation only.
- No implementation of any decoupling direction; the studies are "worth investigating in theory", not plans.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create` (preflight circus: 11 lenses, clean).
- [x] No commit carries `!` — nothing breaks an operator or library surface at the last stable release.

## Docs impact

- [ ] `README.md`
- [ ] `docs/` site pages
- [x] `docs/design/`
- [ ] Inline docstrings

**Rule: code without matching docs is incomplete.**

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._