### PR TITLE
chore(deps): update copier template to v5.6.3

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v5.6.2
+_commit: v5.6.3
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: Generic markdown vault MCP server with FTS5 + semantic search

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,7 +26,7 @@ jobs:
         # (a bare @v46 does not resolve and fails the job before any step).
         # v46.x bundles a Renovate CLI well past the >=43.59.0 floor (fixes the
         # PEP 735 [dependency-groups] depName bug); do not pin an older renovate-version.
-        uses: renovatebot/github-action@v46.2.2
+        uses: renovatebot/github-action@v46.2.4
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- DOMAIN-START -->
+<!-- Add an optional project logo or project-specific header here. Kept across copier update. -->
+<!-- DOMAIN-END -->
+
 # Markdown Vault MCP
 
 <!-- mcp-name: io.github.pvliesdonk/markdown-vault-mcp -->


### PR DESCRIPTION
## Closes / Refs

Closes #1142

## What & why

Updates the repository from `fastmcp-server-template` v5.6.2 to v5.6.3 using `copier update --trust -A`. The generated diff advances the Copier answer, updates the Renovate action to v46.2.4, and preserves the project README domain sentinel scaffold.

## What this PR deliberately does NOT do

- No unrelated domain or application changes are deferred; this PR is limited to the generated template update.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] Any commit carrying `!` breaks an operator or library surface that existed at the **last stable release** (see the breaking-change policy in `CLAUDE.md`) — this commit carries no `!` marker.

## Docs impact

- [x] `README.md` — updated by the Copier render with the preserved domain sentinel scaffold.
- [x] `docs/` site pages — reviewed; no changes required.
- [x] `docs/design/` — reviewed; no changes required.
- [x] Inline docstrings — reviewed; no changes required.

Verification: `3483 passed, 4 skipped`; coverage `96.82%`; Ruff, mypy, and structural checks passed.

---
_Generated by [Claude Code](https://claude.ai/code)_
