### PR TITLE
chore: prepare release 4.0.0-rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,77 @@
 
 <!-- version list -->
 
+## 4.0.0-rc.8 (2026-08-24)
+
+### Breaking Changes
+
+- replace anthropic summarizer with generic OpenAI-compatible backend (#917)
+- dual-mode background jobs via pvl-core 4.11.0 + template v3.3.0 (#1034)
+- make reindex and build_embeddings dual-mode background jobs (#1037)
+- adopt the branch-aware release model via copier update to template v4.0.0 (#1066)
+- follow redirects, report the final URL, and classify the change (#1118)
+- default READ_ONLY to false so the write surface ships enabled (#1119)
+
+### Features
+
+- add LLM-backed summarize tool gated on an API key (#869)
+- folder conventions — per-folder authoring policy for LLM clients (#877)
+- configurable title field, searchable frontmatter, and ranking weights (#867)
+- map-reduce summarization for inputs beyond one model request (#924)
+- per-call max_notes with in-result coverage hint for summarize (#926)
+- rebuild on INDEXED_FIELDS change; SEARCHABLE_FIELDS defaults to it (#928)
+- bound summarize latency with a timeout error and background jobs (#937) (#938)
+- detect OKF bundles and annotate read surfaces (#968)
+- OKF filter dimensions and graph node typing (#970)
+- okf_validate conformance audit tool (#971)
+- migration transforms (wikilink conversion, index/log generation) (#973)
+- adopt fastmcp-pvl-core transfer subsystem; retire local store (#981)
+- bundle export via an okf-bundle download ref (#982)
+- enforced write layer — provenance stamping, verification invalidation, okf_verify (#964) (#984)
+- enforced-write convention maintenance — log.md append + index.md refresh (#964) (#987)
+- ranking downweights for deprecated/stale/reserved files (#965) (#988)
+- configurable timeout (EMBED_TIMEOUT_S) + batch size (EMBEDDING_BATCH_SIZE) (#1000)
+- harden okf_verify against model self-attestation (#990) (#1004)
+- scope okf_seed_log's log.md content to the folder's subtree (#974) (#1005)
+- add append tool for end-of-note writes without a prior read (#1025)
+- ship client-side summarization recipe as summarize-subtree prompt (#1038)
+- adopt template v3.4.0 — generated mcpb screen, curated fields, pre-release checks (#1045)
+- adopt template v3.5.0 — plugin channel onto the template scaffold (#1046)
+- vault-summarize skill and vault-mapper agent for client-side summarization (#1047)
+- vault-setup skill and SessionStart doctor hook for in-session bootstrap (#1048)
+- generated userConfig configuration screen — no more shell-profile setup (#1049)
+
+### Bug Fixes
+
+- hybrid search vector channel misses folder normalization (#882)
+- recover keyword/hybrid search for hyphenated terms (#866) (#884)
+- stop reasoning models exhausting the summarize token budget (#920)
+- forbid assistant-style offers in summarize output (#923)
+- bump transitive mcp 1.28.0 → 1.28.1 (CVE-2026-59950) (#934)
+- make incremental reindex inline embedding resilient to provider timeouts (#930) (#932)
+- guard inline/converge vector mutation against dimension mismatch (#935) (#936)
+- resolve leading-slash markdown links against the vault root (#972)
+- skip malformed-frontmatter files in build_embeddings (#994)
+- retry failed deferred pushes on the periodic pull-loop tick (#997)
+- honour process umask for newly created files (#958) (#998)
+- single-agent reviewer; drop fan-out plugin + pin experiment
+- drop Task from @claude — #1499 background-subagent orphan footgun
+- allow-list Skill defensively (both claude workflows)
+- finalize pin-combo reviewer (restore CI gate, drop show_full_output)
+- close SSRF gaps by migrating to pvl-core's hardened fetch_url (#1029)
+- adopt template v3.2.2 — template-owned bump_manifests, non-mutating CI syncs (#1032)
+- drop track_progress from the notes drafting action (#1094)
+- make the notes drafting agent able to write — and safe to run (#1095)
+- rc releases get their full artifact set, and the 4.0 notes page passes its own evidence contract (#1096)
+- clear the v4.0 milestone's bug reports (#1109)
+- never send a blank string to the embedding provider (#1112)
+- raise the pvl-core floor to 4.11.2 and drop the removed read_only kwarg (#1117)
+- rebuild when the parse pipeline changes, and expose a force flag (#1125)
+- persist authoritative empty embedding rebuilds (#1115)
+- confirm FTS absence against the source tree before reclaiming vectors (#1132)
+- adopt template v5.3.1→v5.4.0, and de-fork README.md and ci.yml to pristine (#1138)
+- adopt template v5.6.2, and reconcile the seeded scaffolds copier update never rewrites (#1144)
+
 ## 4.0.0-rc.7 (2026-08-22)
 
 ### Breaking Changes

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -1,6 +1,6 @@
 # 4.0
 
-<!-- notes-range-end: d3ef6ec5f5c12ab5872bcfd7f856623e5910f217 -->
+<!-- notes-range-end: 32ffbd0f7295fc42fb478953d8fae20afe942658 -->
 
 <!-- RELEASE-SUMMARY v4.0.0 START -->
 4.0 is the release where the vault stops being just a search index. It gains
@@ -449,4 +449,4 @@ No patch releases yet.
 
 See [CHANGELOG.md](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/CHANGELOG.md)
 for the full commit-level list, or the
-[v3.1.0 to 4.0.0 comparison](https://github.com/pvliesdonk/markdown-vault-mcp/compare/v3.1.0...d3ef6ec5f5c12ab5872bcfd7f856623e5910f217).
+[v3.1.0 to 4.0.0 comparison](https://github.com/pvliesdonk/markdown-vault-mcp/compare/v3.1.0...32ffbd0f7295fc42fb478953d8fae20afe942658).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-vault-mcp"
-version = "4.0.0-rc.7"
+version = "4.0.0-rc.8"
 description = "Generic markdown vault MCP server with FTS5 + semantic search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/uv.lock
+++ b/uv.lock
@@ -1739,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "4.0.0rc7"
+version = "4.0.0rc8"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **4.0.0-rc.8** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

This PR also carries the release-notes page under `docs/releases/`,
drafted by the prepare run's notes job — review it as part of the release
(an evidence check: every causal claim must trace to its linked issue or
PR).  The PR is held as a DRAFT until the notes land; the notes job marks
it ready.  Still draft means the notes job is running or failed — check
the prepare run.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Breaking Changes

- replace anthropic summarizer with generic OpenAI-compatible backend (#917)
- dual-mode background jobs via pvl-core 4.11.0 + template v3.3.0 (#1034)
- make reindex and build_embeddings dual-mode background jobs (#1037)
- adopt the branch-aware release model via copier update to template v4.0.0 (#1066)
- follow redirects, report the final URL, and classify the change (#1118)
- default READ_ONLY to false so the write surface ships enabled (#1119)

## Features

- add LLM-backed summarize tool gated on an API key (#869)
- folder conventions — per-folder authoring policy for LLM clients (#877)
- configurable title field, searchable frontmatter, and ranking weights (#867)
- map-reduce summarization for inputs beyond one model request (#924)
- per-call max_notes with in-result coverage hint for summarize (#926)
- rebuild on INDEXED_FIELDS change; SEARCHABLE_FIELDS defaults to it (#928)
- bound summarize latency with a timeout error and background jobs (#937) (#938)
- detect OKF bundles and annotate read surfaces (#968)
- OKF filter dimensions and graph node typing (#970)
- okf_validate conformance audit tool (#971)
- migration transforms (wikilink conversion, index/log generation) (#973)
- adopt fastmcp-pvl-core transfer subsystem; retire local store (#981)
- bundle export via an okf-bundle download ref (#982)
- enforced write layer — provenance stamping, verification invalidation, okf_verify (#964) (#984)
- enforced-write convention maintenance — log.md append + index.md refresh (#964) (#987)
- ranking downweights for deprecated/stale/reserved files (#965) (#988)
- configurable timeout (EMBED_TIMEOUT_S) + batch size (EMBEDDING_BATCH_SIZE) (#1000)
- harden okf_verify against model self-attestation (#990) (#1004)
- scope okf_seed_log's log.md content to the folder's subtree (#974) (#1005)
- add append tool for end-of-note writes without a prior read (#1025)
- ship client-side summarization recipe as summarize-subtree prompt (#1038)
- adopt template v3.4.0 — generated mcpb screen, curated fields, pre-release checks (#1045)
- adopt template v3.5.0 — plugin channel onto the template scaffold (#1046)
- vault-summarize skill and vault-mapper agent for client-side summarization (#1047)
- vault-setup skill and SessionStart doctor hook for in-session bootstrap (#1048)
- generated userConfig configuration screen — no more shell-profile setup (#1049)

## Bug Fixes

- hybrid search vector channel misses folder normalization (#882)
- recover keyword/hybrid search for hyphenated terms (#866) (#884)
- stop reasoning models exhausting the summarize token budget (#920)
- forbid assistant-style offers in summarize output (#923)
- bump transitive mcp 1.28.0 → 1.28.1 (CVE-2026-59950) (#934)
- make incremental reindex inline embedding resilient to provider timeouts (#930) (#932)
- guard inline/converge vector mutation against dimension mismatch (#935) (#936)
- resolve leading-slash markdown links against the vault root (#972)
- skip malformed-frontmatter files in build_embeddings (#994)
- retry failed deferred pushes on the periodic pull-loop tick (#997)
- honour process umask for newly created files (#958) (#998)
- single-agent reviewer; drop fan-out plugin + pin experiment
- drop Task from @claude — #1499 background-subagent orphan footgun
- allow-list Skill defensively (both claude workflows)
- finalize pin-combo reviewer (restore CI gate, drop show_full_output)
- close SSRF gaps by migrating to pvl-core's hardened fetch_url (#1029)
- adopt template v3.2.2 — template-owned bump_manifests, non-mutating CI syncs (#1032)
- drop track_progress from the notes drafting action (#1094)
- make the notes drafting agent able to write — and safe to run (#1095)
- rc releases get their full artifact set, and the 4.0 notes page passes its own evidence contract (#1096)
- clear the v4.0 milestone's bug reports (#1109)
- never send a blank string to the embedding provider (#1112)
- raise the pvl-core floor to 4.11.2 and drop the removed read_only kwarg (#1117)
- rebuild when the parse pipeline changes, and expose a force flag (#1125)
- persist authoritative empty embedding rebuilds (#1115)
- confirm FTS absence against the source tree before reclaiming vectors (#1132)
- adopt template v5.3.1→v5.4.0, and de-fork README.md and ci.yml to pristine (#1138)
- adopt template v5.6.2, and reconcile the seeded scaffolds copier update never rewrites (#1144)
