### PR TITLE
fix: v4.1 bug sweep — rename staging, webhook gating, blank query, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+Machine-generated audit trail. Sections from `4.0.0-rc.1` onward are written
+by knope into each release PR from `feat` / `fix` / `!` commit subjects —
+never hand-edit those, or the flag line below.
+
+Two things to know when reading further down:
+
+- **Sections at and below `3.2.0-rc.7` were reconstructed** from commit
+  subjects in #1067, replacing a hand-maintained Keep a Changelog file whose
+  entries all lived under a single `## [Unreleased]` heading. The
+  reconstruction emitted no `Breaking Changes` heading, so pre-4.0 `!`
+  markers were flattened; #1123 restored the `3.0.0` block by hand, and
+  #1077 tracks auditing the rest of the historical markers.
+- **A stable release section can be empty** when its whole range is the
+  promotion commit — the work sits in the `-rc` sections directly beneath
+  it. `3.2.0-rc.6`, `3.1.0`, `1.27.0`, `1.25.0`, and `1.23.1` are all this
+  shape.
+
+Narrative, rationale, and upgrade guidance live in
+[`docs/releases/`](docs/releases/), not here.
+
 <!-- version list -->
 
 ## 4.0.0 (2026-08-25)
@@ -1341,6 +1361,68 @@
 
 
 ## 3.0.0 (2026-06-17)
+
+### Breaking Changes
+
+Restored by hand in #1123. The 2026-08-16 reconstruction (#1067) generated
+this file's pre-4.0 sections from commit subjects using only Features / Bug
+Fixes / Chores headings, so every `!` marker in the 1.28.0 → 3.0.0 range was
+flattened away and the hand-written migration instructions that shipped in
+the tagged changelogs were lost with them. The entries below are the sixteen
+`!`-marked commits in that range, with the operator-facing detail recovered
+from `git show v3.2.0-rc.7:CHANGELOG.md`.
+
+**Readiness vocabulary (#538, #542, #554)**
+
+- `Collection.get_index_status` `status` value renamed from `"ready"` to
+  `"queryable"`. MCP clients pattern-matching on the old value silently
+  treat the new value as unknown until updated.
+- `Collection.get_index_status` priority order flipped: a built index with a
+  captured background error from a prior attempt now reports
+  `status="queryable"` (with the diagnostic in `error`), not
+  `status="failed"`. `"failed"` now means "preconditions do not hold AND a
+  captured error exists" — the index is not readable.
+- `Collection.is_index_ready()` renamed to `Collection.is_queryable()`.
+- `Collection.wait_for_index_ready()` renamed to
+  `Collection.wait_until_queryable()`.
+- `Collection._require_index_ready()` (private) renamed to
+  `Collection._require_built()`.
+- MCP decorator `needs_index_ready` renamed to `needs_queryable`; module
+  `_server_readiness.py` renamed to `_server_queryable.py`.
+- Public exception `IndexNotReadyError` renamed to `IndexUnavailableError`,
+  which gained a required `reason` field typed by a new
+  `IndexUnavailableReason` literal.
+- Environment variable `MARKDOWN_VAULT_MCP_READY_TIMEOUT_S` renamed to
+  `MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S`. **Running deployments that set the
+  old variable silently fall back to the 60-second default after upgrading;
+  update operator configs (compose files, systemd units, `.env` files)
+  accordingly.**
+
+External consumers that imported `IndexNotReadyError`, called
+`is_index_ready()` / `wait_for_index_ready()`, or set the old env var must
+rename their references. No deprecation shims ship.
+
+**`Collection` renamed to `Vault` (#629, #630)**
+
+- The public class is `Vault`. Downstream code importing `Collection` must
+  rename its references.
+
+**Field-collapsed search results (#469, #471)**
+
+- `search` returns one entry per file with up to `chunks_per_file` nested
+  sections (`GroupedResult`) instead of one entry per chunk. Callers reading
+  a flat chunk list must iterate `sections`.
+- `get_similar` and `get_context.similar` return `GroupedResult` as well;
+  the `SimilarItem` type is removed.
+- The MCP tool surface gained `chunks_per_file` and the `GroupedResult`
+  shape, and the Vault Explorer SPA was adapted to it.
+
+**Attachment size default (#442)**
+
+- `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB` default lowered from `10` to
+  `1` — a 10 MB base64-encoded attachment blows up most LLM contexts. Any
+  deployment relying on the old ceiling must set
+  `MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB=10` explicitly.
 
 
 ## 2.0.0-rc.5 (2026-06-17)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -300,6 +300,8 @@ The endpoint is only available on HTTP/SSE transports. To set up:
 2. In your GitHub repository, add a webhook pointing at `https://<your-host>/github-webhook` with content type `application/json` and the same secret.
 3. Select the `push` event (other events are acknowledged with 200 and ignored).
 
+Set the secret only on a deployment that owns its remote (`GIT_REPO_URL`). Elsewhere the endpoint mounts but is inert. With no remote to pull from, every delivery is acknowledged with 200 and logged as a warning. The server logs the same warning once at startup.
+
 The periodic pull loop (`GIT_PULL_INTERVAL_S`) remains active as a belt-and-suspenders fallback for missed webhook deliveries. For the same setup in context, alongside the other sync mechanisms and what each delivery outcome means, see the [git integration guide](guides/git-integration.md#push-triggered-pull-github-webhook).
 
 ## File Watcher

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -848,6 +848,19 @@ enrichment behaviour is unchanged. A sidecar written by a provider that
 did accept empty inputs converges after one re-embed of the affected
 documents.
 
+The read side has the same hazard (#1111): `search(query, mode="semantic")`
+embeds the query verbatim, so a blank or whitespace-only query would reach
+the provider as `[""]` and return a vendor-shaped HTTP 400 rather than a
+statement about the caller's own input. `SearchManager.search()` applies
+`is_embeddable()` to the query on both the semantic and the hybrid channel
+— at the manager boundary rather than only inside `VectorIndex`, because
+hybrid reaches the provider through its own vector-channel call site — and
+returns `[]`, matching the posture of the adjacent `limit <= 0` guard.
+`VectorIndex.search()` carries the same guard as a backstop for a library
+consumer calling it directly. The guard runs *after* `_require_vectors()`,
+so a server with no embedding provider still raises
+`EmbeddingsNotConfiguredError` instead of silently answering `[]`.
+
 ### Error Handling
 
 Two-layer model:
@@ -2206,6 +2219,30 @@ unhandled exceptions are logged at `ERROR` but not propagated to the caller.
 Default: `None` (no callback). Built-in option: `GitWriteStrategy` (or the
 legacy factory `git_write_strategy(token=...)`) that auto-commits and pushes.
 
+**Per-operation staging guarantee (#894).** One MCP write operation produces
+one auto-commit containing *only* the paths that operation touched. A rename
+is the case where this is not free: it has two sides — the vanished old path
+and the new one — while the callback signature carries a single path, so the
+git strategy used to stage the old side with a pathspec-less `git add -u`.
+That stages every tracked modification in the repository, so a concurrent
+edit the server never saw (Obsidian writing straight into the vault) was
+swept into the rename's commit and pushed, and an old path git had never
+tracked had its deletion recorded not at all.
+
+The rename dispatch therefore carries the old path as well. Because
+`WriteCallback` is a public type a downstream consumer implements, the extra
+argument is an **opt-in rather than a signature change**: a callback sets the
+`accepts_old_path` attribute (`types.ACCEPTS_OLD_PATH_ATTR`) to `True`, and
+`WriteCallbackDispatcher` reads it once at construction and passes
+`old_path=` only to callbacks that advertise it. A three-argument
+third-party callback is unaffected, at type-check time and at run time.
+`GitWriteStrategy` opts in and stages with
+`git add -A -- <old_path> <new_path>`: `-A` (not `-u`) so an untracked old
+path is covered, and an explicit pathspec so nothing else in the working tree
+is. An old path git does not track is dropped from the pathspec rather than
+passed — `git add` fails the whole invocation on a pathspec matching nothing,
+which would leave the new path unstaged too.
+
 **Deprecation note**: `git_write_strategy()` factory function is preserved for
 backward compatibility. Prefer constructing `GitWriteStrategy` directly for
 access to `flush()` and `close()` methods.
@@ -3115,6 +3152,29 @@ contract. Unifying the two paths fixed the loop's diverged conflict handling:
 its post-abort upstream restore previously ran per-file `git checkout` with no
 failure handling, whereas the pipeline's `_restore_upstream_paths` drops paths
 whose restore failed instead of committing stale local content over them.
+
+**`enable_pull` gates every pull, not just the loop (#1128)**: the flag is
+`False` in unmanaged / commit-only mode, where the strategy exists only to
+auto-commit locally and there is no remote to reach. It gated `sync_once`
+alone, so `force_pull` ran the pipeline regardless — `git fetch origin`
+against a checkout with no `origin` (reporting the retryable-looking
+`fetch_failed`), and `CalledProcessError` out of `_head_sha` against a vault
+that is not a git repository at all. `force_pull` now returns
+`applied=False, reason="pull_disabled"` before running any git command. The
+reason is terminal by construction: retrying cannot change it without
+reconfiguring the deployment.
+
+The webhook handler treats it as such, answering 200 so GitHub records the
+delivery rather than spending its full retry budget on every push, and logs a
+warning naming the misconfiguration; `server.py` logs the same warning once at
+startup, when `GITHUB_WEBHOOK_SECRET` is set with neither `GIT_REPO_URL` nor
+`GIT_TOKEN`. The handler also wraps `force_pull` so no exception escapes as an
+unhandled 500 — its documented outcome set is 401 / 200 / 503. The
+`git_sync` tool cannot reach any of this: `_resolve_managed_strategy` refuses
+outside managed mode, and managed mode always has `enable_pull=True`. The
+handler's `pull_result is None` branch is likewise not dead code — a library
+consumer constructing `Vault(git_strategy=None)` reaches it, though a
+config-driven server never does.
 
 **Tracking-independent remote ref**: all sync operations (startup unpushed
 check, periodic `sync_once`, interactive `force_pull`/`force_push`, and the

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -73,6 +73,10 @@ Behavior:
   periodic tick. Divergent history is not a failure: it flows through the
   Syncthing-style sibling resolution described under
   [`git_sync`](#manual-sync-git_sync-tool) below.
+- A delivery to a server with no managed remote returns 200, not 503. There
+  is nothing to pull and a retry cannot change that, so the delivery is
+  recorded rather than retried. Each one logs a warning naming the
+  problem, and the server logs the same warning once at startup.
 - A delivery arriving while the initial index build is still running is
   handled, not dropped. The pull is a pure git operation and runs
   regardless of index state; only the reindex is skipped, and the boot
@@ -80,12 +84,17 @@ Behavior:
 
 !!! warning "Managed mode only"
     Set the secret only where the server owns the remote. Outside managed
-    mode a delivery is not a quiet no-op: the pull path ignores the sync
-    switch that unmanaged mode turns off and runs `git fetch origin`
-    anyway. A checkout with no reachable `origin` fails that fetch and
-    answers 503, burning GitHub's retries on every push; against a vault
-    that is not a git repository at all, the pull raises out of the
-    handler.
+    mode the endpoint is inert: it verifies signatures and answers 200, but
+    there is no remote to pull from, so every delivery is a no-op. The
+    server says so at startup and on each delivery, because a webhook that
+    is quietly doing nothing looks the same as one that is working.
+
+    This is a no-op rather than a failure as of 4.1. Before that the pull
+    path ignored the sync switch unmanaged mode turns off and ran
+    `git fetch origin` anyway: a checkout with no reachable `origin`
+    failed that fetch and answered 503, burning GitHub's retries on every
+    push, and against a vault that was not a git repository at all the
+    pull raised out of the handler.
 
 Keep `GIT_PULL_INTERVAL_S` enabled. The webhook narrows the staleness
 window; the loop is what catches the deliveries the webhook loses.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -94,6 +94,8 @@ Find documents matching a query using full-text or semantic search.
 
     Keyword and hybrid modes accept FTS5 operators (`AND`, `OR`, `NEAR`, `"exact phrase"`, `prefix*`). A natural-language query whose terms contain characters FTS5 reserves (a hyphenated slug such as `vault-mcp`, or a colon) is matched literally rather than failing, so plain queries do not need escaping.
 
+    An empty or whitespace-only `query` returns an empty list in `semantic` and `hybrid` modes. Such a query carries no signal, and answering it locally avoids a round-trip that embedding providers reject with a raw HTTP 400.
+
 **Example usage:**
 
 ```json

--- a/src/markdown_vault_mcp/_github_webhook.py
+++ b/src/markdown_vault_mcp/_github_webhook.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 from starlette.responses import JSONResponse
 
 from markdown_vault_mcp.domain import get_vault_singleton
+from markdown_vault_mcp.git.types import PULL_REASON_PULL_DISABLED
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -103,9 +104,15 @@ def make_webhook_handler(secret: str) -> Callable[[Request], Any]:
     - On ``push`` events: calls ``Vault.force_pull()`` unconditionally
       (it is a pure git operation with no FTS dependency), then reindexes when
       HEAD moved and the vault is queryable.
+    - Returns 200 when the deployment has no remote to pull from — no git
+      strategy at all, or a strategy built without remote sync (reason
+      ``"pull_disabled"``). Both are configuration states, not failures:
+      retrying cannot change the answer, so a 503 would only burn GitHub's
+      retry budget on every push (#1128).
     - Returns 503 when the server has not yet initialised (singleton not set),
-      or when ``force_pull`` fails (``applied=False``), so GitHub retries the
-      delivery rather than permanently marking it as delivered.
+      or when ``force_pull`` fails for a reason a retry might clear
+      (``applied=False``), so GitHub retries the delivery rather than
+      permanently marking it as delivered.
 
     Args:
         secret: HMAC secret configured via
@@ -159,14 +166,40 @@ def make_webhook_handler(secret: str) -> Callable[[Request], Any]:
             )
             return JSONResponse({"error": "vault not initialised"}, status_code=503)
 
-        pull_result = await asyncio.to_thread(vault.force_pull)
+        try:
+            pull_result = await asyncio.to_thread(vault.force_pull)
+        except Exception:
+            # The handler's contract is 401 / 200 / 503; an exception escaping
+            # here would surface as an unhandled 500 with a traceback (#1128).
+            # A retry may still succeed, so 503 rather than 200.
+            logger.error(
+                "github_webhook: force_pull raised delivery_id=%s",
+                delivery_id,
+                exc_info=True,
+            )
+            return JSONResponse({"error": "pull failed"}, status_code=503)
 
         if pull_result is None:
+            # Reachable for a library consumer that constructed Vault with
+            # git_strategy=None; a config-driven server always has one.
             logger.info(
                 "github_webhook: no git strategy configured delivery_id=%s",
                 delivery_id,
             )
             return JSONResponse({"ok": True, "message": "no git strategy"})
+
+        if pull_result.reason == PULL_REASON_PULL_DISABLED:
+            # A webhook secret set on a deployment with no managed remote
+            # (#1128). Nothing was fetched and nothing can be: answer 200 so
+            # GitHub records the delivery instead of retrying every push.
+            logger.warning(
+                "github_webhook: delivery received but this deployment has no "
+                "managed git remote, so there is nothing to pull — set "
+                "MARKDOWN_VAULT_MCP_GIT_REPO_URL (or unset "
+                "MARKDOWN_VAULT_MCP_GITHUB_WEBHOOK_SECRET) delivery_id=%s",
+                delivery_id,
+            )
+            return JSONResponse({"ok": True, "message": "pull disabled"})
 
         if not pull_result.applied:
             # Transient failures (network, expired token) benefit from retry.

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -42,6 +42,7 @@ from markdown_vault_mcp.git.types import (
     PULL_REASON_FETCH_FAILED,
     PULL_REASON_NO_REMOTE,
     PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS,
+    PULL_REASON_PULL_DISABLED,
     PULL_REASON_REBASED,
     PUSH_REASON_DRY_RUN_UNSUPPORTED,
     PUSH_REASON_NO_REMOTE,
@@ -355,13 +356,30 @@ class GitWriteStrategy:
                     self._cleanup_git_env(env)
             self._write_init_done = True
 
+    #: Opt into the dispatcher's ``old_path=`` keyword on renames (#894), so
+    #: the rename commit stages exactly the two paths the rename touched.
+    #: See :data:`~markdown_vault_mcp.types.ACCEPTS_OLD_PATH_ATTR`.
+    accepts_old_path: bool = True
+
     def __call__(
         self,
         path: Path,
         content: str,  # noqa: ARG002
         operation: WriteOperation,
+        *,
+        old_path: Path | None = None,
     ) -> None:
-        """WriteCallback interface: stage + commit, then schedule push."""
+        """WriteCallback interface: stage + commit, then schedule push.
+
+        Args:
+            path: Absolute path of the file the operation landed on. For a
+                rename this is the *new* path.
+            content: File content at write time; unused here, since staging
+                reads the working tree.
+            operation: The kind of write that occurred.
+            old_path: For a rename, the absolute path the file moved from,
+                so staging can be scoped to it and *path* (#894).
+        """
         if self._closed:
             return
 
@@ -398,6 +416,7 @@ class GitWriteStrategy:
                     self._git_root,
                     path,
                     operation,
+                    old_path=old_path,
                     commit_name=self._commit_name,
                     commit_email=self._commit_email,
                     author_name=effective_name
@@ -919,6 +938,16 @@ class GitWriteStrategy:
         new commits are materialised before the caller sees the working
         tree.
 
+        A strategy built without remote sync — unmanaged / commit-only
+        mode, where ``enable_pull`` is ``False`` — has no remote to pull
+        from, so this returns ``applied=False`` with reason
+        ``"pull_disabled"`` **before running any git command** (#1128).
+        Without that gate the pipeline ran ``git fetch origin`` on a
+        remoteless checkout (answering ``"fetch_failed"``, which reads as
+        retryable) and raised ``CalledProcessError`` out of ``_head_sha``
+        on a vault that is not a git repository at all. ``enable_pull``
+        gated only the periodic loop before; it now gates every pull.
+
         Args:
             dry_run: When ``True``, runs ``git fetch`` and computes the
                 would-be pull without modifying HEAD.  Returns
@@ -933,6 +962,19 @@ class GitWriteStrategy:
             RuntimeError: When the strategy was constructed without
                 ``repo_path``.
         """
+        if not self._enable_pull:
+            logger.info(
+                "Git force_pull: pull is disabled for this strategy "
+                "(no managed remote); skipping git entirely"
+            )
+            return PullResult(
+                applied=False,
+                fast_forward=False,
+                commits_pulled=0,
+                from_sha="",
+                to_sha="",
+                reason=PULL_REASON_PULL_DISABLED,
+            )
         git_root = self._resolve_force_repo()
         return self._pull_pipeline(git_root, dry_run=dry_run)
 
@@ -1786,10 +1828,86 @@ def _sanitize_git_identity(value: str) -> str:
     return _GIT_IDENTITY_UNSAFE.sub("", value)
 
 
+def _is_tracked(root: str, path: Path) -> bool:
+    """Return whether git tracks *path* in the repository at *root*.
+
+    ``git ls-files`` lists the index, so a file staged or committed earlier
+    answers ``True`` even once it has been removed from the working tree —
+    which is exactly the state the old side of a rename is in by the time
+    staging runs.
+
+    Args:
+        root: Git repository root, as a string.
+        path: Absolute path to probe.
+
+    Returns:
+        ``True`` when the path is in the index.
+    """
+    result = subprocess.run(
+        ["git", "-C", root, "ls-files", "--", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return bool(result.stdout.strip())
+
+
+def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
+    """Stage both sides of a rename without touching anything else (#894).
+
+    ``git add -A`` over an explicit pathspec records the old path's
+    disappearance and the new path's arrival while leaving every other
+    working-tree change alone, so a concurrent edit elsewhere in the vault is
+    not swept into this commit. ``-A`` rather than ``-u`` because ``-u``
+    would record no deletion for an old path git never tracked.
+
+    An untracked old path is omitted from the pathspec rather than passed and
+    tolerated: ``git add`` fails the *whole* invocation on a pathspec that
+    matches nothing, which would leave the new path unstaged too.
+
+    Args:
+        root: Git repository root, as a string.
+        path: Absolute path the file was renamed *to*.
+        old_path: Absolute path the file was renamed *from*, or ``None`` from
+            a caller predating #894 — which falls back to the historical
+            repository-wide staging, imprecise in exactly the two ways this
+            function fixes.
+    """
+    if old_path is None:
+        logger.debug("git_stage_rename_unscoped path=%s", path)
+        subprocess.run(
+            ["git", "-C", root, "add", "-u"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", root, "add", "--", str(path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return
+
+    pathspec = [str(path)]
+    if _is_tracked(root, old_path):
+        pathspec.insert(0, str(old_path))
+    else:
+        logger.debug("git_stage_rename_old_untracked old_path=%s", old_path)
+    subprocess.run(
+        ["git", "-C", root, "add", "-A", "--", *pathspec],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
 def _stage_and_commit(
     git_root: Path,
     path: Path,
     operation: WriteOperation,
+    *,
+    old_path: Path | None = None,
     commit_name: str = GitWriteStrategy.DEFAULT_COMMIT_NAME,
     commit_email: str = GitWriteStrategy.DEFAULT_COMMIT_EMAIL,
     author_name: str | None = None,
@@ -1799,8 +1917,14 @@ def _stage_and_commit(
 
     Args:
         git_root: Git repository root.
-        path: Absolute path to the changed file.
+        path: Absolute path to the changed file.  For a rename, the *new*
+            path.
         operation: The write operation type.
+        old_path: For a rename, the absolute path the file moved from.
+            Staging is then scoped to exactly *old_path* and *path* (#894).
+            ``None`` falls back to a repository-wide ``git add -u``, which
+            sweeps unrelated tracked modifications into the commit — see the
+            comment on that branch.
         commit_name: Git committer name (overrides git config).
         commit_email: Git committer email (overrides git config).
         author_name: Git author name override.  Falls back to *commit_name*
@@ -1824,30 +1948,7 @@ def _stage_and_commit(
             check=True,
         )
     elif operation == "rename":
-        # For rename, the old file has been moved on disk.  Stage tracked
-        # deletions (-u) to capture the old path removal, then add the new
-        # file explicitly.
-        # NOTE: ``git add -u`` without a pathspec stages ALL tracked
-        # modifications/deletions repo-wide.  In a vault with other
-        # uncommitted edits, this may sweep unrelated changes into the
-        # auto-commit.  Additionally, if the old file was never committed
-        # to git (e.g. written directly by Obsidian and not via this
-        # callback), ``git add -u`` will not record its deletion at all —
-        # the commit will only add the new path.
-        # A future improvement would extend the callback signature to
-        # pass both old and new paths, enabling scoped staging.
-        subprocess.run(
-            ["git", "-C", root, "add", "-u"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "-C", root, "add", "--", str(path)],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        _stage_rename(root, path, old_path)
     else:
         subprocess.run(
             ["git", "-C", root, "add", "--", str(path)],

--- a/src/markdown_vault_mcp/git/types.py
+++ b/src/markdown_vault_mcp/git/types.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 # :class:`PushResult.reason`.  Defined as module-level constants so callers
 # (and tests) can refer to them by name rather than re-typing string literals.
 PULL_REASON_FETCH_FAILED = "fetch_failed"
+PULL_REASON_PULL_DISABLED = "pull_disabled"
 PULL_REASON_NO_REMOTE = "no_remote"
 PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS = "non_fast_forward_with_conflicts"
 PULL_REASON_REBASED = "rebased"
@@ -57,6 +58,10 @@ class PullResult:
 
             * ``"fetch_failed"`` — ``git fetch origin`` exited non-zero
               (network error, auth failure, etc.); HEAD did not move.
+            * ``"pull_disabled"`` — the strategy was built without remote
+              sync (unmanaged / commit-only mode), so no git command was
+              run at all. Terminal: a caller that retries will get the
+              same answer until the deployment is reconfigured (#1128).
             * ``"no_remote"`` — no remote-tracking ref
               (``origin/<branch>``, or ``origin/HEAD`` for a detached
               checkout) could be resolved on the local clone.

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -18,7 +18,7 @@ import threading
 from collections import defaultdict
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import frontmatter as fm
 import yaml
@@ -37,6 +37,7 @@ from markdown_vault_mcp.scanner import (
     parse_note,
 )
 from markdown_vault_mcp.types import (
+    ACCEPTS_OLD_PATH_ATTR,
     AttachmentContent,
     DeleteResult,
     EditResult,
@@ -45,6 +46,7 @@ from markdown_vault_mcp.types import (
     RenameResult,
     SubtreeToc,
     TocEntry,
+    WriteCallback,
     WriteOperation,
     WriteResult,
 )
@@ -79,6 +81,28 @@ if TYPE_CHECKING:
     from markdown_vault_mcp.scanner import ChunkStrategy
 
 logger = logging.getLogger(__name__)
+
+
+class _OnWriteCallback(Protocol):
+    """The write-callback shape DocumentManager dispatches to.
+
+    Widens :data:`~markdown_vault_mcp.types.WriteCallback` with the optional
+    ``old_path`` keyword the rename sites pass (#894).  The dispatcher this
+    is wired to — :meth:`WriteCallbackDispatcher.fire` — accepts it
+    unconditionally and forwards it only to callbacks that opted in, so a
+    three-argument ``on_write`` remains valid at the ``Vault`` boundary.
+    """
+
+    def __call__(
+        self,
+        path: Path,
+        content: str,
+        operation: WriteOperation,
+        /,
+        old_path: Path | None = None,
+    ) -> None:
+        """Record one completed write."""
+        ...
 
 
 _UMASK_LOCK = threading.Lock()
@@ -134,7 +158,10 @@ class DocumentManager:
         max_note_read_bytes: Maximum bytes returned by full-document reads.
             ``0`` disables the limit (default ``262144``, i.e. 256 KB).
         on_write_callback: Fires after a successful write to enqueue a
-            git commit.  Signature: ``(abs_path, content, operation)``.
+            git commit.  Signature:
+            ``(abs_path, content, operation, old_path=None)``, where
+            *old_path* is set only on ``rename`` and lets the commit stage
+            exactly the two paths the rename touched (#894).
         mark_paths_dirty: Routes FTS-affecting write operations through
             the single-owner :class:`IndexWriter` (#559).  Called with an
             iterable of vault-relative paths after each successful
@@ -158,7 +185,7 @@ class DocumentManager:
         exclude_patterns: list[str] | None = None,
         attachment_extensions: list[str] | None = None,
         max_note_read_bytes: int = 262144,
-        on_write_callback: Callable[[Path, str, WriteOperation], None] | None = None,
+        on_write_callback: _OnWriteCallback | WriteCallback | None = None,
         mark_paths_dirty: Callable[[Iterable[str]], None] | None = None,
         title_field: str = "title",
         okf_write_enrich: Callable[[str, WriteOperation], str] | None = None,
@@ -171,7 +198,15 @@ class DocumentManager:
         self._exclude_patterns = exclude_patterns
         self._attachment_extensions = attachment_extensions
         self._max_note_read_bytes = max_note_read_bytes
-        self._on_write_callback = on_write_callback or (lambda *_a: None)
+        self._on_write_callback = on_write_callback or (lambda *_a, **_kw: None)
+        # Same opt-in probe the dispatcher uses (#894): a callback wired
+        # straight into this manager — the isolation tests, and any consumer
+        # constructing DocumentManager directly — may still be the published
+        # three-argument shape, which must not be handed a keyword it cannot
+        # take.
+        self._callback_takes_old_path = bool(
+            getattr(on_write_callback, ACCEPTS_OLD_PATH_ATTR, False)
+        )
         self._mark_paths_dirty = mark_paths_dirty
         self._title_field = title_field
         # OKF enforced-write hook (#964): transforms the final note text
@@ -1253,7 +1288,7 @@ class DocumentManager:
 
                 callback_content = ""
 
-            self._on_write_callback(new_abs, callback_content, "rename")
+            self._fire_rename(new_abs, callback_content, old_abs)
             for src_abs, src_content in backlink_callbacks:
                 self._on_write_callback(src_abs, src_content, "edit")
 
@@ -1425,7 +1460,7 @@ class DocumentManager:
 
     def _plan_folder_move(
         self, old_abs: Path, old_dir: str, new_dir: str
-    ) -> tuple[list[tuple[Path, Path]], dict[str, str], list[tuple[Path, str]]]:
+    ) -> tuple[list[tuple[Path, Path]], dict[str, str], list[tuple[Path, str, Path]]]:
         """Enumerate the subtree under *old_abs* and gate on collisions.
 
         Pure planning: walks the filesystem (not the index — attachments and
@@ -1443,7 +1478,7 @@ class DocumentManager:
 
             * ``moves`` — ``(src_abs, dst_abs)`` for every file to move.
             * ``md_map`` — old→new vault-relative path map (``.md`` only).
-            * ``attachment_moves`` — ``(dst_abs, new_rel_path)`` for
+            * ``attachment_moves`` — ``(dst_abs, new_rel_path, src_abs)`` for
               allowlisted attachments.
 
         Raises:
@@ -1455,7 +1490,9 @@ class DocumentManager:
         attachment_exts = self._effective_attachment_extensions()
         moves: list[tuple[Path, Path]] = []  # (src_abs, dst_abs)
         md_map: dict[str, str] = {}  # old_rel_path -> new_rel_path (.md only)
-        attachment_moves: list[tuple[Path, str]] = []  # (dst_abs, new_rel)
+        # (dst_abs, new_rel, src_abs) — src_abs so the rename callback can
+        # scope its git staging to both sides of the move (#894).
+        attachment_moves: list[tuple[Path, str, Path]] = []
         for src_abs in sorted(old_abs.rglob("*")):
             if not src_abs.is_file():
                 continue
@@ -1469,7 +1506,7 @@ class DocumentManager:
             else:
                 suffix = src_abs.suffix.lstrip(".").lower()
                 if "*" in attachment_exts or suffix in attachment_exts:
-                    attachment_moves.append((dst_abs, new_path))
+                    attachment_moves.append((dst_abs, new_path, src_abs))
 
         if not moves:
             raise DocumentNotFoundError(f"Folder is empty: {old_dir}")
@@ -1482,10 +1519,26 @@ class DocumentManager:
 
         return moves, md_map, attachment_moves
 
+    def _fire_rename(self, new_abs: Path, content: str, old_abs: Path) -> None:
+        """Fire the write callback for a rename, passing both sides when it can.
+
+        Args:
+            new_abs: Absolute path the file now lives at.
+            content: File content at the new path (``""`` for attachments).
+            old_abs: Absolute path the file moved from, so a callback that
+                opted in can scope its git staging to the two paths the
+                rename touched instead of staging the whole repository (#894).
+        """
+        if self._callback_takes_old_path:
+            rename_aware = cast("_OnWriteCallback", self._on_write_callback)
+            rename_aware(new_abs, content, "rename", old_path=old_abs)
+        else:
+            self._on_write_callback(new_abs, content, "rename")
+
     def _dispatch_move_callbacks(
         self,
         md_map: dict[str, str],
-        attachment_moves: list[tuple[Path, str]],
+        attachment_moves: list[tuple[Path, str, Path]],
         pending_callbacks: list[tuple[Path, str]],
     ) -> None:
         """Fire write callbacks for a completed folder move.
@@ -1497,20 +1550,22 @@ class DocumentManager:
 
         Args:
             md_map: Old→new vault-relative path map for moved notes.
-            attachment_moves: ``(dst_abs, new_rel_path)`` for moved
+            attachment_moves: ``(dst_abs, new_rel_path, src_abs)`` for moved
                 allowlisted attachments.
             pending_callbacks: ``(abs_path, new_content)`` for rewritten
                 link sources.
         """
         moved_note_paths = set(md_map.values())
         source_root = self._source_dir.resolve()
-        for _old_path, new_path in md_map.items():
+        for old_path, new_path in md_map.items():
             new_note_abs = (self._source_dir / new_path).resolve()
-            self._on_write_callback(
-                new_note_abs, _read_text_utf8(new_note_abs), "rename"
+            self._fire_rename(
+                new_note_abs,
+                _read_text_utf8(new_note_abs),
+                (self._source_dir / old_path).resolve(),
             )
-        for dst_abs, _new_rel in attachment_moves:
-            self._on_write_callback(dst_abs, "", "rename")
+        for dst_abs, _new_rel, src_abs_moved in attachment_moves:
+            self._fire_rename(dst_abs, "", src_abs_moved)
         for src_abs, src_content in pending_callbacks:
             src_rel = src_abs.relative_to(source_root).as_posix()
             if src_rel in moved_note_paths:

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -16,6 +16,7 @@ import mimetypes
 import sqlite3
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
+from markdown_vault_mcp.embed_text import is_embeddable
 from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
 from markdown_vault_mcp.managers._ranking import (
     ChannelRow as _ChannelRow,
@@ -689,6 +690,8 @@ class SearchManager:
 
         if mode == "semantic":
             self._require_vectors()
+            if not is_embeddable(query):
+                return self._no_embeddable_query(mode)
             return self._semantic_search(
                 query,
                 limit=limit,
@@ -701,6 +704,8 @@ class SearchManager:
 
         # hybrid
         self._require_vectors()
+        if not is_embeddable(query):
+            return self._no_embeddable_query(mode)
         return self._hybrid_search(
             query,
             limit=limit,
@@ -710,6 +715,29 @@ class SearchManager:
             snippet_words=eff_snip,
             okf_filters=okf_filters,
         )
+
+    @staticmethod
+    def _no_embeddable_query(mode: str) -> builtins.list[GroupedResult]:
+        """Return the empty result for a query with nothing to embed.
+
+        An empty or whitespace-only query carries no signal, and every
+        OpenAI-compatible provider rejects ``[""]`` with a hard HTTP 400
+        (#1111) — the read-side twin of the indexing failure in #1087. The
+        guard sits here rather than only in :class:`VectorIndex` so the
+        hybrid channel, which would otherwise reach the provider through its
+        own call site, takes the same path.
+
+        Returning ``[]`` matches the posture of the adjacent ``limit <= 0``
+        guard in :meth:`VectorIndex.search`.
+
+        Args:
+            mode: The requested search mode, for the log line only.
+
+        Returns:
+            An empty result list.
+        """
+        logger.debug("search_blank_query mode=%s", mode)
+        return []
 
     def _adapt_semantic_rows(
         self, rows: builtins.list[dict[str, Any]]

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -215,6 +215,17 @@ def make_server(
     if config.sync.github_webhook_secret and transport != "stdio":
         from markdown_vault_mcp._github_webhook import make_webhook_handler
 
+        if config.git.repo_url is None and config.git.token is None:
+            # The route still mounts and answers 200, but every delivery is a
+            # no-op: this deployment has no managed remote to pull from.  Say
+            # so at startup rather than leaving the operator to infer it from
+            # per-delivery logs (#1128).
+            logger.warning(
+                "github_webhook_inert: GITHUB_WEBHOOK_SECRET is set but no "
+                "managed git remote is configured, so push deliveries have "
+                "nothing to pull — set GIT_REPO_URL to enable sync, or unset "
+                "GITHUB_WEBHOOK_SECRET to drop the endpoint"
+            )
         mcp.custom_route("/github-webhook", methods=["POST"])(
             make_webhook_handler(config.sync.github_webhook_secret)
         )

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 # The four deterministic, non-excluded skip categories surfaced via
 # get_index_status.skipped_files. A plain frozenset (not an enum) keeps the
@@ -799,6 +799,45 @@ class SummaryResult:
 WriteOperation = Literal["write", "edit", "delete", "rename"]
 
 WriteCallback = Callable[[Path, str, WriteOperation], None]
+
+#: Attribute name a :data:`WriteCallback` sets to ``True`` to opt into
+#: receiving the ``old_path=`` keyword on ``rename`` dispatches (#894).
+#:
+#: A rename has two sides — the vanished old path and the new one — but the
+#: callback signature carries a single path, which left the git strategy
+#: staging the old side with a pathspec-less ``git add -u`` that swept every
+#: unrelated tracked modification in the repository into the auto-commit.
+#: The extra argument is an opt-in rather than a signature change so a
+#: third-party three-argument callback keeps working untouched:
+#: :class:`~markdown_vault_mcp.write_callback.WriteCallbackDispatcher` reads
+#: this attribute once and passes ``old_path`` only to callbacks that
+#: advertise it.
+ACCEPTS_OLD_PATH_ATTR = "accepts_old_path"
+
+
+class RenameAwareWriteCallback(Protocol):
+    """A :data:`WriteCallback` that also accepts a rename's old path.
+
+    Structural type for the opt-in described at
+    :data:`ACCEPTS_OLD_PATH_ATTR`. It exists so the dispatcher can express
+    the widened call in the type system instead of reaching for ``Any``;
+    ``WriteCallback`` itself deliberately stays three-argument so an
+    existing third-party callback is neither a type error nor a runtime one.
+    """
+
+    accepts_old_path: bool
+
+    def __call__(
+        self,
+        path: Path,
+        content: str,
+        operation: WriteOperation,
+        *,
+        old_path: Path | None = None,
+    ) -> None:
+        """Handle one write, optionally told where a rename moved from."""
+        ...
+
 
 # Default set of allowed attachment extensions (without leading dot, lower-case).
 # .md is always excluded — it is always handled as a markdown note.

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -9,6 +9,8 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from markdown_vault_mcp.embed_text import is_embeddable
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -379,6 +381,15 @@ class VectorIndex:
             # after appending, so a non-positive cap has to be refused here
             # or it would yield one row.
             logger.debug("VectorIndex.search: limit=%d, returning []", limit)
+            return []
+
+        if not is_embeddable(query):
+            # A blank or whitespace-only query would reach the provider as
+            # [""], which every OpenAI-compatible endpoint rejects with a
+            # hard HTTP 400 (#1111).  SearchManager guards its own channels
+            # so hybrid takes the same path; this backstops a library
+            # consumer calling VectorIndex directly.
+            logger.debug("VectorIndex.search: blank query, returning []")
             return []
 
         logger.debug(

--- a/src/markdown_vault_mcp/write_callback.py
+++ b/src/markdown_vault_mcp/write_callback.py
@@ -14,12 +14,18 @@ from __future__ import annotations
 import logging
 import queue
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
+
+from markdown_vault_mcp.types import ACCEPTS_OLD_PATH_ATTR
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from markdown_vault_mcp.types import WriteCallback, WriteOperation
+    from markdown_vault_mcp.types import (
+        RenameAwareWriteCallback,
+        WriteCallback,
+        WriteOperation,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +59,18 @@ class WriteCallbackDispatcher:
         Args:
             on_write: Invoked as ``on_write(abs_path, content, operation)`` for
                 each fired write, or ``None`` to disable dispatch entirely.
+                A callback that sets the
+                :data:`~markdown_vault_mcp.types.ACCEPTS_OLD_PATH_ATTR`
+                attribute to ``True`` also receives ``old_path=`` on
+                ``rename`` dispatches (#894).
         """
         self._on_write = on_write
+        # Read the opt-in once, here, rather than per dispatch: the callback
+        # is fixed for the dispatcher's lifetime, and the worker loop is on
+        # the write path.
+        self._accepts_old_path = bool(getattr(on_write, ACCEPTS_OLD_PATH_ATTR, False))
         self._queue: queue.Queue[
-            tuple[Path, str, WriteOperation] | _DrainMarker | None
+            tuple[Path, str, WriteOperation, Path | None] | _DrainMarker | None
         ] = queue.Queue()
         self._worker: threading.Thread | None = None
         # Guards every read/write of ``_worker`` and ``_closed`` AND the
@@ -66,7 +80,13 @@ class WriteCallbackDispatcher:
         self._worker_lock = threading.Lock()
         self._closed = False
 
-    def fire(self, abs_path: Path, content: str, operation: WriteOperation) -> None:
+    def fire(
+        self,
+        abs_path: Path,
+        content: str,
+        operation: WriteOperation,
+        old_path: Path | None = None,
+    ) -> None:
         """Queue a callback invocation, starting the worker if needed.
 
         No-op when no callback is configured. After :meth:`close`, this is a
@@ -77,6 +97,12 @@ class WriteCallbackDispatcher:
             abs_path: Absolute path of the written file.
             content: File content at write time (empty for deletes).
             operation: The kind of write that occurred.
+            old_path: For ``rename``, the absolute path the file moved *from*,
+                so the callback can scope its staging to the two paths the
+                rename actually touched (#894). Forwarded only to a callback
+                that opted in via
+                :data:`~markdown_vault_mcp.types.ACCEPTS_OLD_PATH_ATTR`;
+                ignored otherwise, and unused for every other operation.
         """
         if self._on_write is None:
             return
@@ -91,7 +117,7 @@ class WriteCallbackDispatcher:
             self._ensure_worker_locked()
             # Enqueue under the lock so close() cannot slip the sentinel in
             # ahead of this item (which would leave it permanently undrained).
-            self._queue.put((abs_path, content, operation))
+            self._queue.put((abs_path, content, operation, old_path))
 
     def _ensure_worker_locked(self) -> None:
         """Start the background worker if it is not running.
@@ -120,9 +146,13 @@ class WriteCallbackDispatcher:
                 if isinstance(item, _DrainMarker):
                     item.event.set()
                     continue
-                abs_path, content, operation = item
+                abs_path, content, operation, old_path = item
                 try:
-                    on_write(abs_path, content, operation)
+                    if old_path is not None and self._accepts_old_path:
+                        rename_aware = cast("RenameAwareWriteCallback", on_write)
+                        rename_aware(abs_path, content, operation, old_path=old_path)
+                    else:
+                        on_write(abs_path, content, operation)
                 except Exception:
                     logger.error(
                         "Write callback failed for %s (%s)",
@@ -232,3 +262,11 @@ class WriteCallbackDispatcher:
                     timeout,
                     self._queue.qsize(),
                 )
+
+
+# ``fire`` takes ``old_path`` itself, so the probe works one seam further in:
+# DocumentManager is handed this bound method and asks the same question of it
+# that this dispatcher asks of the callback underneath (#894).  Set on the
+# function rather than the instance because a bound method proxies attribute
+# lookup to its underlying function.
+setattr(WriteCallbackDispatcher.fire, ACCEPTS_OLD_PATH_ATTR, True)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -5854,3 +5854,239 @@ class TestDrainBeforePull:
             assert calls == {"pause": 0, "drain": 0}
         finally:
             strategy.close()
+
+
+# ---------------------------------------------------------------------------
+# scoped rename staging (#894)
+# ---------------------------------------------------------------------------
+
+
+def _commit_files(repo: Path, ref: str = "HEAD") -> set[str]:
+    """Return the repo-relative paths touched by *ref*."""
+    import subprocess
+
+    out = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "show",
+            "--name-only",
+            "--no-renames",
+            "--format=",
+            ref,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line for line in out.stdout.splitlines() if line.strip()}
+
+
+def _worktree_status(repo: Path) -> set[str]:
+    """Return ``git status --porcelain`` lines for *repo*."""
+    import subprocess
+
+    out = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line for line in out.stdout.splitlines() if line.strip()}
+
+
+class TestRenameStagingIsScoped:
+    """A rename auto-commit contains only the two paths it renamed (#894)."""
+
+    @staticmethod
+    def _seed(repo: Path) -> None:
+        """Commit a note and an unrelated bystander file."""
+        import subprocess
+
+        (repo / "note.md").write_text("# Note\n", encoding="utf-8")
+        (repo / "bystander.md").write_text("# Bystander\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "seed"],
+            capture_output=True,
+            check=True,
+        )
+
+    def test_unrelated_dirty_file_stays_out_of_the_rename_commit(
+        self, git_repo: Path
+    ) -> None:
+        """The reported failure: a concurrent edit must not be swept in.
+
+        A vault edited outside the server (Obsidian writing straight to disk)
+        leaves tracked modifications the server never touched. Before #894 the
+        rename path staged them with a pathspec-less ``git add -u``, pushing
+        content the user had not chosen to commit.
+        """
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+
+        # A concurrent, unrelated edit the server never saw.
+        (git_repo / "bystander.md").write_text("# Edited elsewhere\n", encoding="utf-8")
+
+        old_abs = git_repo / "note.md"
+        new_abs = git_repo / "renamed.md"
+        old_abs.rename(new_abs)
+
+        _stage_and_commit(git_repo, new_abs, "rename", old_path=old_abs)
+
+        assert _commit_files(git_repo) == {"note.md", "renamed.md"}
+        # The bystander's edit is still uncommitted, exactly as the user left it.
+        assert _worktree_status(git_repo) == {" M bystander.md"}
+
+    def test_never_committed_old_path_still_records_the_move(
+        self, git_repo: Path
+    ) -> None:
+        """``add -A`` covers an old path git never tracked.
+
+        ``git add -u`` recorded no deletion for a file written straight into
+        the vault by another tool, so the commit only added the new path.
+        """
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+
+        old_abs = git_repo / "untracked.md"
+        old_abs.write_text("# Never committed\n", encoding="utf-8")
+        new_abs = git_repo / "now-tracked.md"
+        old_abs.rename(new_abs)
+
+        _stage_and_commit(git_repo, new_abs, "rename", old_path=old_abs)
+
+        # Nothing to delete (the old path was never tracked), so the commit
+        # carries the new path — and the working tree is clean afterwards.
+        assert _commit_files(git_repo) == {"now-tracked.md"}
+        assert _worktree_status(git_repo) == set()
+
+    def test_rename_into_a_subfolder_is_scoped(self, git_repo: Path) -> None:
+        """Scoping holds when the destination is a new directory."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+        (git_repo / "bystander.md").write_text("# Dirty\n", encoding="utf-8")
+
+        old_abs = git_repo / "note.md"
+        new_abs = git_repo / "archive" / "note.md"
+        new_abs.parent.mkdir()
+        old_abs.rename(new_abs)
+
+        _stage_and_commit(git_repo, new_abs, "rename", old_path=old_abs)
+
+        assert _commit_files(git_repo) == {"note.md", "archive/note.md"}
+        assert _worktree_status(git_repo) == {" M bystander.md"}
+
+    def test_strategy_forwards_old_path(self, git_repo: Path) -> None:
+        """GitWriteStrategy threads ``old_path`` into the staging helper."""
+        from markdown_vault_mcp.git.strategy import GitWriteStrategy
+
+        self._seed(git_repo)
+        (git_repo / "bystander.md").write_text("# Dirty\n", encoding="utf-8")
+
+        old_abs = git_repo / "note.md"
+        new_abs = git_repo / "renamed.md"
+        old_abs.rename(new_abs)
+
+        strategy = GitWriteStrategy(
+            token=None,
+            repo_url=None,
+            managed=False,
+            enable_pull=False,
+            enable_push=False,
+            repo_path=git_repo,
+        )
+        try:
+            strategy(new_abs, "", "rename", old_path=old_abs)
+        finally:
+            strategy.close()
+
+        assert _commit_files(git_repo) == {"note.md", "renamed.md"}
+        assert _worktree_status(git_repo) == {" M bystander.md"}
+
+    def test_strategy_advertises_the_opt_in(self) -> None:
+        """The dispatcher's capability probe finds the strategy's opt-in."""
+        from markdown_vault_mcp.git.strategy import GitWriteStrategy
+        from markdown_vault_mcp.types import ACCEPTS_OLD_PATH_ATTR
+
+        assert getattr(GitWriteStrategy, ACCEPTS_OLD_PATH_ATTR) is True
+
+
+class TestRenameCommitEndToEnd:
+    """The scoped staging survives the full Vault → dispatcher → git path."""
+
+    @staticmethod
+    def _vault_repo(tmp_path: Path) -> Path:
+        """A git repo holding two committed notes."""
+        import subprocess
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        for cmd in (
+            ["git", "-C", str(vault), "init"],
+            ["git", "-C", str(vault), "config", "user.email", "t@t.com"],
+            ["git", "-C", str(vault), "config", "user.name", "T"],
+        ):
+            subprocess.run(cmd, capture_output=True, check=True)
+        (vault / "note.md").write_text("# Note\n", encoding="utf-8")
+        (vault / "bystander.md").write_text("# Bystander\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(vault), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(vault), "commit", "-m", "seed"],
+            capture_output=True,
+            check=True,
+        )
+        return vault
+
+    def test_vault_rename_does_not_commit_a_concurrent_edit(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end shape of the #894 report.
+
+        An external tool edits one note while the server renames another.
+        The rename's auto-commit must carry only the renamed paths, and the
+        external edit must still be sitting uncommitted afterwards.
+        """
+        from markdown_vault_mcp.git.strategy import GitWriteStrategy
+        from markdown_vault_mcp.vault import Vault
+
+        vault = self._vault_repo(tmp_path)
+        strategy = GitWriteStrategy(
+            token=None,
+            repo_url=None,
+            managed=False,
+            enable_pull=False,
+            enable_push=False,
+            repo_path=vault,
+        )
+        col = Vault(
+            source_dir=vault,
+            git_strategy=strategy,
+            on_write=strategy,
+            read_only=False,
+        )
+        try:
+            col.index.build_index()
+            # The concurrent, server-invisible edit.
+            (vault / "bystander.md").write_text("# Edited in Obsidian\n", "utf-8")
+
+            col.writer.rename("note.md", "renamed.md")
+            col._write_callback.drain()
+        finally:
+            col.close()
+
+        assert _commit_files(vault) == {"note.md", "renamed.md"}
+        # The external edit is still uncommitted, and so is the index state
+        # directory the Vault created — neither was the server's to commit.
+        assert _worktree_status(vault) == {
+            " M bystander.md",
+            "?? .markdown_vault_mcp/",
+        }

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -435,3 +435,137 @@ def test_vault_wires_pause_writes_into_git_strategy(tmp_path: Path) -> None:
     mock_strategy.force_pull.assert_called_once_with()
 
     col.close()
+
+
+# ---------------------------------------------------------------------------
+# no managed remote (#1128)
+# ---------------------------------------------------------------------------
+
+
+def _post_push(client: TestClient) -> object:
+    """POST a correctly-signed push delivery."""
+    body = _push_body()
+    return client.post(
+        "/github-webhook",
+        content=body,
+        headers={
+            "X-Hub-Signature-256": _sign(body),
+            "X-GitHub-Event": "push",
+            "Content-Type": "application/json",
+        },
+    )
+
+
+def test_force_pull_is_inert_without_remote_sync(tmp_path: Path) -> None:
+    """An unmanaged strategy answers without running git at all (#1128).
+
+    Before the fix ``enable_pull`` gated only the periodic loop, so
+    ``force_pull`` ran ``git fetch origin`` on a remoteless checkout and
+    reported the retryable-looking ``fetch_failed``.
+    """
+    from markdown_vault_mcp.git.strategy import GitWriteStrategy
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    strategy = GitWriteStrategy(
+        token=None,
+        repo_url=None,
+        managed=False,
+        enable_pull=False,
+        enable_push=False,
+        repo_path=repo,
+    )
+    try:
+        with patch("subprocess.run") as run:
+            result = strategy.force_pull()
+        run.assert_not_called()
+    finally:
+        strategy.close()
+
+    assert result.applied is False
+    assert result.reason == "pull_disabled"
+
+
+def test_force_pull_on_a_non_git_directory_does_not_raise(tmp_path: Path) -> None:
+    """The second reported shape: a plain directory, not a git repo (#1128).
+
+    ``_pull_pipeline``'s ``_head_sha`` raised ``CalledProcessError`` here,
+    which escaped the webhook handler as an unhandled 500.
+    """
+    from markdown_vault_mcp.git.strategy import GitWriteStrategy
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    strategy = GitWriteStrategy(
+        token=None,
+        repo_url=None,
+        managed=False,
+        enable_pull=False,
+        enable_push=False,
+        repo_path=plain,
+    )
+    try:
+        result = strategy.force_pull()
+    finally:
+        strategy.close()
+
+    assert result.reason == "pull_disabled"
+
+
+def test_webhook_push_returns_200_when_pull_is_disabled() -> None:
+    """A delivery with no remote to pull from is recorded, not retried (#1128).
+
+    ``applied=False`` used to answer 503, so every push to the repository
+    burned GitHub's full retry budget and then failed.
+    """
+    col = _mock_vault()
+    col.force_pull.return_value = PullResult(
+        applied=False,
+        fast_forward=False,
+        commits_pulled=0,
+        from_sha="",
+        to_sha="",
+        reason="pull_disabled",
+    )
+    client = _make_client()
+    with patch(
+        "markdown_vault_mcp._github_webhook.get_vault_singleton", return_value=col
+    ):
+        resp = _post_push(client)
+
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "pull disabled"
+    col.index.reindex.assert_not_called()
+
+
+def test_webhook_push_returns_503_when_force_pull_raises() -> None:
+    """An exception out of force_pull becomes a 503, never an unhandled 500."""
+    import subprocess
+
+    col = _mock_vault()
+    col.force_pull.side_effect = subprocess.CalledProcessError(128, ["git"])
+    client = _make_client()
+    with patch(
+        "markdown_vault_mcp._github_webhook.get_vault_singleton", return_value=col
+    ):
+        resp = _post_push(client)
+
+    assert resp.status_code == 503
+    col.index.reindex.assert_not_called()
+
+
+def test_webhook_still_returns_503_for_retryable_pull_failures() -> None:
+    """The #1128 carve-out is narrow: fetch_failed still asks for a retry."""
+    col = _mock_vault(
+        pull_result=_pull_result(from_sha="aaa", to_sha="aaa", applied=False)
+    )
+    client = _make_client()
+    with patch(
+        "markdown_vault_mcp._github_webhook.get_vault_singleton", return_value=col
+    ):
+        resp = _post_push(client)
+
+    assert resp.status_code == 503
+    assert resp.json()["reason"] == "fetch_failed"

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -1705,3 +1705,70 @@ class TestFolderWeightsEndToEnd:
         results = mgr.search("magnetberry", mode="keyword")
         assert results[0].path == "sessions/log.md"
         assert results[0].score == pytest.approx(results[1].score * 3.0)
+
+
+# ---------------------------------------------------------------------------
+# blank-query guard (#1111)
+# ---------------------------------------------------------------------------
+
+
+class _RejectsBlankProvider:
+    """Provider that rejects blank input the way a real endpoint does.
+
+    Every OpenAI-compatible endpoint answers ``[""]`` with a hard HTTP 400
+    (#1087 on the index side, #1111 on the read side). The stub raises so a
+    query that reaches it fails the test loudly instead of silently
+    succeeding.
+    """
+
+    dimension = 4
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        for text in texts:
+            if not text.strip():
+                msg = "OpenAI API error 400: Input cannot contain empty strings"
+                raise RuntimeError(msg)
+        return [[1.0, 0.0, 0.0, 0.0] for _ in texts]
+
+
+@pytest.mark.parametrize("mode", ["semantic", "hybrid"])
+@pytest.mark.parametrize("query", ["", "   ", "\t\n"])
+def test_blank_query_returns_empty_without_reaching_provider(
+    search_mgr_with_embeddings: SearchManager,
+    mode: str,
+    query: str,
+) -> None:
+    """A blank query resolves to [] without a provider round-trip (#1111).
+
+    The guard lives at the manager boundary so hybrid — which reaches the
+    provider through its own vector-channel call site — takes the same path
+    as semantic.
+    """
+    search_mgr_with_embeddings._vectors._provider = _RejectsBlankProvider()  # type: ignore[assignment]
+
+    assert search_mgr_with_embeddings.search(query, mode=mode) == []  # type: ignore[arg-type]
+
+
+def test_blank_query_still_raises_when_embeddings_unconfigured(
+    search_mgr: SearchManager,
+) -> None:
+    """The blank-query guard does not mask the unconfigured-provider error.
+
+    ``_require_vectors`` runs first, so a caller with no embedding provider
+    learns about the missing configuration rather than getting a silent ``[]``.
+    """
+    from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
+
+    with pytest.raises(EmbeddingsNotConfiguredError):
+        search_mgr.search("", mode="semantic")
+
+
+def test_vector_index_blank_query_returns_empty(
+    search_mgr_with_embeddings: SearchManager,
+) -> None:
+    """VectorIndex.search backstops a direct library consumer (#1111)."""
+    vectors = search_mgr_with_embeddings._vectors
+    assert vectors is not None
+    vectors._provider = _RejectsBlankProvider()  # type: ignore[assignment]
+
+    assert vectors.search("   ", limit=5) == []

--- a/tests/test_mcp_apps_browser.py
+++ b/tests/test_mcp_apps_browser.py
@@ -195,6 +195,7 @@ class TestBrowserDataTools:
     async def test_vault_search_respects_limit(self) -> None:
         server = make_server()
         async with Client(server) as client:
+            await wait_for_mcp_writer_drain(client)
             result = await client.call_tool(
                 _hashed("vault_search"),
                 {"query": "document", "mode": "keyword", "limit": 2},

--- a/tests/test_release_flow_contract.py
+++ b/tests/test_release_flow_contract.py
@@ -1821,3 +1821,74 @@ def test_release_tags_are_visible_when_the_changelog_records_releases() -> None:
         "checkout was made without tags (add fetch-tags: true, template#387), "
         "or the repository lost its release tags"
     )
+
+
+# ---------------------------------------------------------------------------
+# historical breaking-change content (#1123)
+# ---------------------------------------------------------------------------
+
+
+def _changelog_sections() -> list[tuple[str, str]]:
+    """Return ``(heading, body)`` for every ``## <version>`` section."""
+    text = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    parts = re.split(r"^## (?=\d)", text, flags=re.MULTILINE)[1:]
+    out = []
+    for part in parts:
+        head, _, body = part.partition("\n")
+        out.append((head.strip(), body))
+    return out
+
+
+def test_changelog_keeps_the_3_0_0_breaking_block() -> None:
+    """The 3.0.0 section still carries its restored breaking changes (#1123).
+
+    The 2026-08-16 reconstruction (#1067) generated pre-4.0 sections with
+    only Features / Bug Fixes / Chores headings, flattening sixteen `!`
+    markers and dropping the operator migration instructions that had
+    shipped in the tagged changelogs — leaving 3.0.0, a major release,
+    presenting an empty section. A support question then arrived from
+    someone who had set the renamed env var and found it inert, which is
+    exactly the failure the deleted entry predicted.
+
+    This pins the recovered content rather than the whole file: knope never
+    rewrites a historical section, so nothing but a hand edit can remove it.
+    """
+    sections = dict(_changelog_sections())
+    body = sections.get("3.0.0 (2026-06-17)")
+    assert body is not None, "the 3.0.0 section disappeared from CHANGELOG.md"
+
+    assert "### Breaking Changes" in body
+    for marker in (
+        "MARKDOWN_VAULT_MCP_READY_TIMEOUT_S",
+        "MARKDOWN_VAULT_MCP_BUILD_TIMEOUT_S",
+        "IndexNotReadyError",
+        "IndexUnavailableError",
+        "is_index_ready",
+        "wait_for_index_ready",
+        "needs_queryable",
+        "GroupedResult",
+        "MAX_ATTACHMENT_SIZE_MB",
+    ):
+        assert marker in body, f"3.0.0 breaking block lost {marker}"
+
+
+def test_changelog_preamble_explains_the_empty_promotion_sections() -> None:
+    """Empty sections are documented, not mysterious (#1123).
+
+    A stable release whose whole range is the promotion commit has nothing
+    for knope to count — its work sits in the ``-rc`` sections beneath it.
+    That is by design, but a reader hitting a blank heading cannot tell it
+    apart from lost content, so the preamble above the insertion flag names
+    the shape and lists the sections that have it.
+    """
+    text = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    preamble, flag, _ = text.partition("<!-- version list -->")
+    assert flag, "insertion flag missing"
+
+    empty = [head for head, body in _changelog_sections() if not body.strip()]
+    for head in empty:
+        version = head.split(" ", 1)[0]
+        assert version in preamble, (
+            f"release section {version} is empty and unexplained — either give "
+            f"it content or name it in the CHANGELOG.md preamble"
+        )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -380,6 +380,42 @@ class TestGithubWebhookWiring:
         server = make_server(transport="http")
         assert "/github-webhook" not in self._route_paths(server)
 
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_webhook_without_a_remote_warns_at_startup(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A secret with no managed remote is announced, not silently inert.
+
+        The route still mounts and answers 200, but every delivery is a
+        no-op — there is nothing to pull (#1128). An operator should learn
+        that at startup rather than from per-delivery logs.
+        """
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GITHUB_WEBHOOK_SECRET", "s3cret")
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_REPO_URL", raising=False)
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_GIT_TOKEN", raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.server"):
+            server = make_server(transport="http")
+
+        assert "/github-webhook" in self._route_paths(server)
+        assert "github_webhook_inert" in caplog.text
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_webhook_with_a_managed_remote_does_not_warn(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The inert warning is scoped to deployments with no remote."""
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_GITHUB_WEBHOOK_SECRET", "s3cret")
+        monkeypatch.setenv(
+            "MARKDOWN_VAULT_MCP_GIT_REPO_URL",
+            "https://github.com/example/vault.git",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.server"):
+            make_server(transport="http")
+
+        assert "github_webhook_inert" not in caplog.text
+
 
 class TestToolManifest:
     """Pin the exact set of tools register_tools() registers.

--- a/tests/test_write_callback.py
+++ b/tests/test_write_callback.py
@@ -274,3 +274,67 @@ class TestDrain:
             messages
         )
         dispatcher.close()
+
+
+# ---------------------------------------------------------------------------
+# old_path forwarding on renames (#894)
+# ---------------------------------------------------------------------------
+
+
+class TestOldPathForwarding:
+    """``old_path`` reaches opted-in callbacks and nothing else (#894)."""
+
+    def test_three_arg_callback_is_never_passed_old_path(self) -> None:
+        """A pre-#894 third-party callback keeps working untouched.
+
+        The widened argument is an opt-in precisely so a callback matching
+        the published ``WriteCallback`` signature does not start receiving a
+        keyword it cannot accept.
+        """
+        calls, cb = _recorder()
+        d = WriteCallbackDispatcher(cb)  # type: ignore[arg-type]
+        d.fire(Path("/new.md"), "x", "rename", old_path=Path("/old.md"))
+        d.close()
+
+        assert calls == [(Path("/new.md"), "x", "rename")]
+
+    def test_opted_in_callback_receives_old_path(self) -> None:
+        """A callback advertising the opt-in gets the keyword."""
+        from markdown_vault_mcp.types import ACCEPTS_OLD_PATH_ATTR
+
+        seen: list[Path | None] = []
+
+        def cb(
+            abs_path: Path,  # noqa: ARG001
+            content: str,  # noqa: ARG001
+            operation: str,  # noqa: ARG001
+            old_path: Path | None = None,
+        ) -> None:
+            seen.append(old_path)
+
+        setattr(cb, ACCEPTS_OLD_PATH_ATTR, True)
+
+        d = WriteCallbackDispatcher(cb)  # type: ignore[arg-type]
+        d.fire(Path("/new.md"), "x", "rename", old_path=Path("/old.md"))
+        d.fire(Path("/other.md"), "y", "write")
+        d.close()
+
+        # Only the rename carries an old path; the plain write does not.
+        assert seen == [Path("/old.md"), None]
+
+    def test_opt_in_is_read_once_at_construction(self) -> None:
+        """Flipping the attribute after construction does not take effect.
+
+        The probe is deliberately not re-read per dispatch — the callback is
+        fixed for the dispatcher's lifetime and the worker loop is on the
+        write path.
+        """
+        from markdown_vault_mcp.types import ACCEPTS_OLD_PATH_ATTR
+
+        calls, cb = _recorder()
+        d = WriteCallbackDispatcher(cb)  # type: ignore[arg-type]
+        setattr(cb, ACCEPTS_OLD_PATH_ATTR, True)
+        d.fire(Path("/new.md"), "x", "rename", old_path=Path("/old.md"))
+        d.close()
+
+        assert calls == [(Path("/new.md"), "x", "rename")]

--- a/uv.lock
+++ b/uv.lock
@@ -792,7 +792,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.22.5"
+version = "4.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -800,9 +800,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/05/689617b7e86503417c172f577d791524cb13b9697303d5d44409a971ba10/cyclopts-4.22.5.tar.gz", hash = "sha256:94044506317462cad90fb01a917dadce1f48a0915ba3605dc8d178dea1229e24", size = 195144, upload-time = "2026-08-04T13:53:00.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/db/becc1331b1eefe8e3370281a2fd7b9685ae6a10dbdd54c7e44ea05bf2ed6/cyclopts-4.23.2.tar.gz", hash = "sha256:1c9de7f245394d3ef9344fc6c976fc373fe1f2ce929b27f08ad4ea8499c13461", size = 196127, upload-time = "2026-08-22T19:20:49.534Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/58/bcab9c33fb7a25a1f5970f357c5b19729bc81d50615d2f737b20c4255909/cyclopts-4.22.5-py3-none-any.whl", hash = "sha256:cf9ce285836053d156730ea4ea0ad0c75cf63beb3f3d8edf222a795bc57666ab", size = 234557, upload-time = "2026-08-04T13:52:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/35/40/c17d731af4ddbf6dede1f1acb09e6335c2587e8b73b3d4742f3f9c6996d3/cyclopts-4.23.2-py3-none-any.whl", hash = "sha256:eb95b6f221ec8e62ba64f879beb27dff779408a320db730fc184427c463a3695", size = 236258, upload-time = "2026-08-22T19:20:48.106Z" },
 ]
 
 [[package]]
@@ -861,15 +861,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
-]
-
-[[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -1039,11 +1030,11 @@ tasks = [
 
 [[package]]
 name = "filelock"
-version = "3.32.3"
+version = "3.32.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/64/a02e6765de08964ed371eca577870593245afc9dfac16d037de7c10d18e6/filelock-3.32.3.tar.gz", hash = "sha256:0ffa185a3540854c95caa7fa76b76cb219d907415e2c5dc9af25fd970563487f", size = 218135, upload-time = "2026-08-13T16:00:05.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/30/03b03951873a1a0ffc7e8ca0e10c15597b59e8d0e39260704cd2ea087bc4/filelock-3.32.4.tar.gz", hash = "sha256:2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30", size = 222126, upload-time = "2026-08-23T17:37:55.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl", hash = "sha256:7f0ca4bcc0e181c60dbbd8aa9ab5b120ebb99e4e064e83636340056f833a1f09", size = 98901, upload-time = "2026-08-13T16:00:03.974Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a4/9b63d595d748e3aff8812b65eacc1a2c4bd90b7c2012e08e72373b4835eb/filelock-3.32.4-py3-none-any.whl", hash = "sha256:22e58ca3b1ae3b98993b762d7338367ae64fe50252bf78d59da3bfebcdf1cedd", size = 99864, upload-time = "2026-08-23T17:37:53.913Z" },
 ]
 
 [[package]]
@@ -1218,15 +1209,15 @@ wheels = [
 
 [[package]]
 name = "httpcore2"
-version = "2.10.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
@@ -1255,7 +1246,7 @@ wheels = [
 
 [[package]]
 name = "httpx2"
-version = "2.10.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "sys_platform != 'emscripten'" },
@@ -1265,9 +1256,9 @@ dependencies = [
     { name = "truststore", marker = "sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
 ]
 
 [[package]]
@@ -1281,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.27.0"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1294,9 +1285,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/9b/ddf3d02a8681f1b9ce52fda03d755dad6b74c4f8172304c4c8d2975450f9/huggingface_hub-1.27.0.tar.gz", hash = "sha256:c1fed40ea82a6b41b477f5243546549b792ae0a93abcea608cff66089bf8f8df", size = 942668, upload-time = "2026-08-07T12:48:05.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ae/222a91937ebee7f62c0ca8f5ee0afd97577caf24c0abb927d1f5c7e9f6d2/huggingface_hub-1.28.0.tar.gz", hash = "sha256:46a2e950c09234de54093d587d1675382f0d08dbd600d9fb599b5932f5b2c6cb", size = 959609, upload-time = "2026-08-18T12:27:15.101Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/d8/95b735e183957c1f26d94c52977f09d466d55119cbbc1558ea4975e4c216/huggingface_hub-1.27.0-py3-none-any.whl", hash = "sha256:7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d", size = 784926, upload-time = "2026-08-07T12:48:02.905Z" },
+    { url = "https://files.pythonhosted.org/packages/51/0e/eafef18f1a75e125e68395db21131db0cf868a128ecd2fce69b4df6c584b/huggingface_hub-1.28.0-py3-none-any.whl", hash = "sha256:58a8bacb03072edfc38067065e9dc24bbb34805410fcd36a1632de0b329660bb", size = 793202, upload-time = "2026-08-18T12:27:12.719Z" },
 ]
 
 [[package]]
@@ -1310,11 +1301,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.18"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -1322,7 +1313,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1943,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "1.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1961,9 +1952,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
 ]
 
 [[package]]
@@ -2148,16 +2139,16 @@ python = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.6"
+version = "2.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/02/97c98a64de554251956d6584b61aea995c8fc3b2b2ca3e791209bcde071f/mkdocstrings_python-2.0.6.tar.gz", hash = "sha256:472a97ec73b40298970ec5db3eed7a5500361e5d76f67b528c5f4acce2fb74bd", size = 200642, upload-time = "2026-08-16T13:52:06.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/5d/1be1c7a49d8fa13dc80f66a85f53333d52cf5206911412006ffdff8fb9a0/mkdocstrings_python-2.0.7.tar.gz", hash = "sha256:8c49faf66d243072d7590a1b5dea028d9d7425fac191f54f096123a4a9c1a783", size = 201598, upload-time = "2026-08-17T16:56:18.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/37/ee6de2bde70f4f0fa279a4bb05fc8de723cb64d12f36be11d05f575dfaa7/mkdocstrings_python-2.0.6-py3-none-any.whl", hash = "sha256:0cb3d1f16c1a9131c0d88ec9e6047f343332b457f5c5b9d3a3203a4f93e65e48", size = 105268, upload-time = "2026-08-16T13:52:05.017Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6d/77546d8c26f038fce314a507106954f76270f6c182488bcf9ac9721175df/mkdocstrings_python-2.0.7-py3-none-any.whl", hash = "sha256:1fce5fbfe4ffa6e8136a35351cdc97c3bf55219c7efbd3f92a82260f93235d60", size = 105387, upload-time = "2026-08-17T16:56:16.813Z" },
 ]
 
 [[package]]
@@ -2479,7 +2470,7 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.28.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flatbuffers" },
@@ -2488,49 +2479,47 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/4d/5014667e2a3a77d6e1b74cc3d88948d06163b8e0a33a84c85073322b5dec/onnxruntime-1.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f5c5daabd28aad610f83fdcf32acec8fb57e6adc6c6a39fe2a3c755db957b410", size = 19130506, upload-time = "2026-07-25T01:22:34.489Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/97/b7ce1bc8bb6048b5fe9129f55d6506dc19499068ef2e0a0af1ae3c8aa4e7/onnxruntime-1.28.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8d66f9ceb29909c70839e4e4fb3435c7b490050d8f162bd5f3aba4ca01ee517f", size = 17039880, upload-time = "2026-07-25T01:21:37.538Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/17/4e5ecd8764f87573c495d834ce79e61ecca47f7a01d1e444a606e570edcb/onnxruntime-1.28.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a166b78ee04f3a37fa1ef82034b6a3ce96d9684e582d4d30b296de83e9998bb5", size = 19193162, upload-time = "2026-07-25T01:21:59.151Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/10/3d946d5d5f2cdcc3c8da36cae63190c516d16349edaffd944bda60ca4c3e/onnxruntime-1.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d650aeee29368414367b65529e90afe4bf1bab76254789063b8b2f7ea3013c8", size = 13752539, upload-time = "2026-07-25T01:22:24.524Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/74/1c440be7af1e026280b139caa1be5d11bd4dc368011ddbe8f5362b58e12f/onnxruntime-1.28.0-cp311-cp311-win_arm64.whl", hash = "sha256:0faf85fb447a663c9cdadc39bd6b19bdf7bedded6699e45731b9b36c46fd993d", size = 13449940, upload-time = "2026-07-25T01:22:14.97Z" },
-    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
-    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
-    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/12/3807e2b17d9eb71d3cb78ed2ba76869b05c637c9b9d6112e636098b0c97a/onnxruntime-1.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:31410f544674f534c2f27348af52ef81682ca9c8719154bf4d48f0ef23823b1e", size = 19141759, upload-time = "2026-07-25T01:21:53.765Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/23/b46045c3bf67a9cf54c12f5df0f018a422c65fbb9d6072b10071bebfaae2/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f649dd6f6452d12a8059888aa489fe519e062e18793dac72b9efa0f9fdb64135", size = 17049339, upload-time = "2026-07-25T01:21:43.005Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b6/8c5396e7894e77c5a7d1e026f3acb9dd39c4b5644e412e37a0055eaa3bc5/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fa221d669282bd8f582708ce4c96010a7e9fb0661f9006b37fe2fedafb73fe", size = 19214329, upload-time = "2026-07-25T01:22:04.133Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f1/51225c202edba4dfc94e1ea03f3d78f1aaf307da75fd792c0ce1946b2514/onnxruntime-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:1a1a19175464665c9b8d50bc916f216cc0b569110045b7bbca8f9f290b186f58", size = 13755033, upload-time = "2026-07-25T01:22:29.302Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/db/f59f715edfdd96a051f32b5ef0e680a20a8755d4ecd75f63090e960e347a/onnxruntime-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:cfab507abe09d6ffeb817eee07944d452fdc0b00fdcef34cab4db10a45e378c7", size = 13454175, upload-time = "2026-07-25T01:22:19.912Z" },
-    { url = "https://files.pythonhosted.org/packages/47/28/810314fa88647af9f4cdaf438a30ad1cfebebb53ded55499232d7a0094e6/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac301f53b1930402fc46c368e268acfed02f3207272aaff05070d7e09f96f031", size = 17057307, upload-time = "2026-07-25T01:21:45.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/cc/9e9f193cc0f29f263a8f09ec08487aed6c96ee856d5fd77da32a425c1949/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7f022a1103cae591c75fc4565589a515f2ddd14a6ac8e8a05812dfeda142e28", size = 19222954, upload-time = "2026-07-25T01:22:06.952Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/eb/952314c451d9463e5c9aed9978eec76cf32930d407d9ab8700dd0f4ea1ea/onnxruntime-1.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:8adff67a3f28257b37cfe945a7e952e4122666aa8c91a0380862e9fd4c2ed19f", size = 19143748, upload-time = "2026-07-25T01:21:56.297Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/139180b4dd810329aaa42c238b4e6383c906202d98609ae29d66eb7c32b1/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc2565e487b4896fb988d6383577d875d958e071fc5f6c3550bd5d02ae98264b", size = 17051950, upload-time = "2026-07-25T01:21:48.606Z" },
-    { url = "https://files.pythonhosted.org/packages/03/88/9432428273356ad3c8aa01f52c1b3e7f53c4c0192748f41ad983872b436b/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6afdc83f1317c136e92fc29f5ee9f058de59d87c0b22cee3fdbfbaa0ccc2098a", size = 19214924, upload-time = "2026-07-25T01:22:09.727Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/e2/6feb3a43517aaf2b1bf7e46897ba5eb81a29717f7d7901420614d5ee4653/onnxruntime-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:f2a3b9e30ce880d4ca54999cb313569e36da4f62eefe25f87be18f43e9a3a4d5", size = 14093738, upload-time = "2026-07-25T01:22:31.629Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/8f/83974a1e201dc2e58e5e7111bcaeb1ca2413e9c41f505d26419ee9e3dddf/onnxruntime-1.28.0-cp314-cp314-win_arm64.whl", hash = "sha256:07fb3cbe990d6bf0ab3c22bfbbfb0e314151266046ea6edb4a07f556b4258c5f", size = 13821117, upload-time = "2026-07-25T01:22:22.387Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/83/00e606bc25c756d76a267370c39b7516ad52f9cf134d7ff2bff8b6108bc4/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e562d6e36a749f6764481c0ddb0f2af3d0b5a3c164291361d08803c557f369af", size = 17055518, upload-time = "2026-07-25T01:21:51.08Z" },
-    { url = "https://files.pythonhosted.org/packages/94/a9/68707e1ce345cbdbcd4df65932ebc82a673e917d63eda0007ebcff948691/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f6e92367ddce1e4d33cf295024f40192be6c6171a09208f515ba169ced06c8e", size = 19222976, upload-time = "2026-07-25T01:22:12.474Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a8/0520890321b8ff40b908cf165a93eb58fbc8f85c14db637277ea866c9544/onnxruntime-1.29.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:07c5907474dec4a2792fd7626b753dc66707808385a6d9eecf993db0066a9d0f", size = 21420890, upload-time = "2026-08-17T22:53:33.429Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/8bd3e0008ff8d386305351109a7329ea57e51a3ab57bc92340f29c4a5b5d/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:16925ef8497e2c07e4b5ae15b504079b3ab3f65e22c58efd10dde0f3caea969a", size = 20803602, upload-time = "2026-08-17T22:53:36.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/91/a66cd77f28379ede419672edda3184f1eb286db215dce1e7b976fae2d63b/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:85f8e8406c52658735fe5c7fbfd3ebaa1ed340768324f6252e4274e374580a23", size = 23113193, upload-time = "2026-08-17T22:53:39.732Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/82/2da968405c42340f03de0bcdb63be09ae1004f820b2295590d48951b5cf2/onnxruntime-1.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d4f427afac434b0070fe992b540ddf20a7aff2265f760f314d91331935b6b98", size = 13999253, upload-time = "2026-08-17T22:53:43.184Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/70c9c893bf732ee66124c2d8de6a21fc9361ec62cf378f857043efcbf0eb/onnxruntime-1.29.0-cp311-cp311-win_arm64.whl", hash = "sha256:4eae472cf7dc3107dec1bb53cd6d142d1964616d08aae48654cd4254b2363c4b", size = 13741410, upload-time = "2026-08-17T22:53:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/80/381c1e9efed9cc32d00aa7cab0547dc84116cec906c3ffe3613686d6963a/onnxruntime-1.29.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3a3814c041251d6a77fdf513fb282056538ee826d2f1178a0df3c549d3fff6ba", size = 21430049, upload-time = "2026-08-17T22:53:48.286Z" },
+    { url = "https://files.pythonhosted.org/packages/30/12/4be0e345d38fe707a701ca07e8f63c05b152a2e6285d1e43a7faf63fedd2/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d2fb19e848f7c33ed8d3182b52504aaa11c5e8da438bbb47296f85b133cbcf6b", size = 20816870, upload-time = "2026-08-17T22:53:51.169Z" },
+    { url = "https://files.pythonhosted.org/packages/96/eb/e6968f5e41aac3125f2ff5708855f09cb0b70d85ed3115b625b0b58305ba/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2b80d8c7ec2cc7438e4da3760b88c24568cba72c9ace96d668800a6c79419acb", size = 23136745, upload-time = "2026-08-17T22:53:53.92Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/80/5b28f1f1111210fc4a336ddbc6950f468ebf9a6a265420568f4f43fa33ce/onnxruntime-1.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:4acf2b4948b7ede87221ca6332344b8facdc8059d6ac751a7d367d04532b02dd", size = 14001407, upload-time = "2026-08-17T22:53:56.486Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d6/6883f89ea4b044e6e8447ebfaf9bcecdf457b7d80a683635e130b25498e0/onnxruntime-1.29.0-cp312-cp312-win_arm64.whl", hash = "sha256:dc61a79cb39afd66ab3f01fd2c23591a7f01de89c1668e1fb6315067fc279164", size = 13746981, upload-time = "2026-08-17T22:53:58.977Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/d375facf60edaf41f5732f9f689c98a800fcc52df5cf6ddfb406703eb5a1/onnxruntime-1.29.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:be0f8ed688cfb1d4d5765a137193b7bfab0c8ea214eed99260b380bb525a3a7f", size = 21429708, upload-time = "2026-08-17T22:54:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/b9ad04051a8c4f504852ce0e8e10f9a6b2f1a331eedcdcc503df776dd0ea/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d67673c5367727860922c5262d724472f1b5539fb7ccf4c81a638f9b71719803", size = 20816263, upload-time = "2026-08-17T22:54:04.088Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2c/d8eb945d2a372149df9705a8d5c8d7c6c46c987c5446dbcea9e1ea7f6556/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e2128f31f449e922c62dbe5d8b6b7b079f0bcaf2d56a102fa203cb6e5bb5ab19", size = 23136817, upload-time = "2026-08-17T22:54:06.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3b/66b424c63fa92dfaa48d1719efaae66fc8c256b9426a832eda51d8dfe1e9/onnxruntime-1.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:2945e1f82f81f27e88decea88c7861f45baea23818950d467bf3909aa303119e", size = 14001310, upload-time = "2026-08-17T22:54:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/83/22/d6a700e3a6322fa3d56fbe7cee9ffc53f35e77ffcd6b7e97f4b7722a27ab/onnxruntime-1.29.0-cp313-cp313-win_arm64.whl", hash = "sha256:4b940b0d777590c7e20bf298f5c16af1ea6ad1b400a1c822a6be192f64f4d954", size = 13747112, upload-time = "2026-08-17T22:54:11.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/89/c4af146de3d60a32c89fea48d5d34bfd044faaf8957270043a03bd1b462b/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:533f8370ce124304e5cb08ab961836cf755631e3dd77adc5f3bbdab70c2b7d99", size = 20826136, upload-time = "2026-08-17T22:54:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f2/e6bbacd11dfe8d070613261a758795ea128b9fc9bea391a2a7da2e4c7a08/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c1ad3f437153fe77f9d01a08fbaac0beb030e09b8a80ace1603bcf69b6c95481", size = 23138951, upload-time = "2026-08-17T22:54:17.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a3/718e1b83096a1bc7b0fc8014c23d4cf795559fe666961cfac4fc038a4871/onnxruntime-1.29.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e74b278af1d949876f5d91d1268fd6c680e79f2bac194967394eaba9fdf69e7e", size = 21431104, upload-time = "2026-08-17T22:54:20.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/17/c75e78ddc1fe69b6ebaef7fe88ac83f29bfe10955e3a0d2436d93473c91c/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:939e5d65f332e6d399774b2bd0d3559fd8fa629c1e77833db29d968d2384f23d", size = 20818488, upload-time = "2026-08-17T22:54:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/54/9f197c578d3d3d7bea16971e233e5483981228eec73748585cf7b5933403/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6c0c37b92f67ed68dd36221ce0403e1d9bd4f7efce724439978a2597848530e5", size = 23136994, upload-time = "2026-08-17T22:54:26.321Z" },
+    { url = "https://files.pythonhosted.org/packages/24/53/4616a55d2495679cfd0195f968feb3d74fe30e26467d168ee243ac97c089/onnxruntime-1.29.0-cp314-cp314-win_amd64.whl", hash = "sha256:4a3129ae56e70d2618ff773920166916310370a7e3cacb60b9e0e8910092725f", size = 14350643, upload-time = "2026-08-17T22:54:28.794Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0f/c338cb5500a522c7e671a3bb1276f4562404fbecce8a0e274565aa968484/onnxruntime-1.29.0-cp314-cp314-win_arm64.whl", hash = "sha256:e417ef8628dcce310d2d53023e750ea298ec14d4341ae6dc3a572bfd9bc7fa97", size = 14124294, upload-time = "2026-08-17T22:54:31.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e7/61064289a9a1301b25c1f0f574fe98aba31c2d388db3c1dbec664f78621f/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:11264bb58f7b7cf6af835ab10d36838d73680580820fd6f51d90124a1ca8f449", size = 20826174, upload-time = "2026-08-17T22:54:34.283Z" },
+    { url = "https://files.pythonhosted.org/packages/60/21/d0c04b561b46e9bff89b5f500fb7415b8ca0669f7902204f76ab06bb0c7e/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1ea91cef3b971506e51ae9c37c16d027774ec64994a524ec1bdfb027d68a9832", size = 23138547, upload-time = "2026-08-17T22:54:37.491Z" },
 ]
 
 [[package]]
 name = "openai"
-version = "3.1.0"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
-    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/9b/d45911bf9abfc5a754d800d79fe56e4dcf6e7b679d6ff4b7e9689b56bc02/openai-3.1.0.tar.gz", hash = "sha256:3ae7190da63f718727f9c525740d3f713e85553d2bf1d0cc9247346bd9063a4d", size = 1131016, upload-time = "2026-08-14T23:49:46.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/9c/ba0c292b4032ede74c249ca314ad64eb1bb5a03a843f6e01facb02f80cd8/openai-3.3.1.tar.gz", hash = "sha256:6f22807de1a976c932cecda620e8172a8c3fdbaeed29c7f21564e0c2410edf56", size = 1282113, upload-time = "2026-08-19T16:31:35.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/45/84b9e909968c0f4c3112a828bba9aa8be6a5ee322fcb3d781145ee53d88e/openai-3.1.0-py3-none-any.whl", hash = "sha256:f06d5a5c8d06a0aead3a67d33fe5a3c3c31540a0f7a8017b02ba8cd99bc5c736", size = 1670762, upload-time = "2026-08-14T23:49:43.998Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/db/2b7a1b3de659bb82aef979116c74e809982b13e42c057759767552b5155f/openai-3.3.1-py3-none-any.whl", hash = "sha256:9652df7fdf8ee6f5bd58e0a12f2b1d414a18e0f06bb7a9a57c8643a5f5469bd3", size = 1690337, upload-time = "2026-08-19T16:31:32.812Z" },
 ]
 
 [[package]]
@@ -2744,11 +2733,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.3"
+version = "4.11.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz", hash = "sha256:f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d", size = 34079, upload-time = "2026-08-24T14:53:49.676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
+    { url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl", hash = "sha256:e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586", size = 23741, upload-time = "2026-08-24T14:53:48.406Z" },
 ]
 
 [[package]]
@@ -2830,17 +2819,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "7.35.1"
+version = "7.36.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/e7/0553e21d25ca4d9f573135775348a372c3ec34a93a71d5f297c3bac38341/protobuf-7.36.0.tar.gz", hash = "sha256:e8e09cb0d794c6687926fa558a8a6e72aa10edb997d5ca61da0765f12a3e00ea", size = 510034, upload-time = "2026-08-20T16:34:01.071Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
-    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
-    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ae/58e3ca96cb2e118cc546b677359b3c6659f79a140935c08dec94c7998585/protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:9103532dffd80c6fab7e50c65a31007680a06eb57537d437bb1b35812c138a37", size = 453256, upload-time = "2026-08-20T16:33:53.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/15/5162230af4912697f0fe406f6800f80760945babcff0e2c2fe6c84ef2d5d/protobuf-7.36.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:bf94a5917c71058262de683669bc0a797a7669d3de71f0b36d058e3194f47b44", size = 341436, upload-time = "2026-08-20T16:33:55.134Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/09/1670b2bfc9a45e807e520c3e9be36524db9ccc7dc05ea17af7681cabdc61/protobuf-7.36.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:3297e60abdff301e5f74393d87f6cc59dacab5f024a89548a6e8de1d26576b16", size = 354440, upload-time = "2026-08-20T16:33:56.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b", size = 340439, upload-time = "2026-08-20T16:33:56.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/acd02338235a3e7d03168c4303478347b7624fc8189ff4e7f0d2654bbe86/protobuf-7.36.0-cp310-abi3-win32.whl", hash = "sha256:7326fd717bdc419162a735938d89d4032332bcc3408804012b24ff3a37086071", size = 440216, upload-time = "2026-08-20T16:33:57.99Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4e/12cb93270967a2affff5b3f720694700d4d87712a67afd05c8cb3f6fa52c/protobuf-7.36.0-cp310-abi3-win_amd64.whl", hash = "sha256:1781cc1de61249b750848029bca452c0a8b7e990080316b9bbc2518b2117b488", size = 453731, upload-time = "2026-08-20T16:33:58.951Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/629999e78d46c1115c11886d51c6bd68c17ce4a944f1ea3e153a91316a33/protobuf-7.36.0-py3-none-any.whl", hash = "sha256:53374d53fc29a67f7dbbf0ade47d7526a0f0137bf0f9c90e48d8a60790ef748c", size = 177024, upload-time = "2026-08-20T16:34:00.053Z" },
 ]
 
 [[package]]
@@ -3141,15 +3130,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0.1"
+version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/17/2db4b414de89659144488e0d9c6c0bf0c8395841dc12d81d0532cc6ef310/pymdown_extensions-11.0.2.tar.gz", hash = "sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d", size = 855419, upload-time = "2026-08-22T19:28:47.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/9f45ec4d14e596efc32c925a78104934790438b0c0628b70d741016734ad/pymdown_extensions-11.0.2-py3-none-any.whl", hash = "sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5", size = 269929, upload-time = "2026-08-22T19:28:45.389Z" },
 ]
 
 [[package]]
@@ -3255,14 +3244,14 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.5.2"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/b7/ac44da2cf0e53ada0e419033c2d058219c95dc1403126f163304c9e814b1/python_discovery-1.5.2.tar.gz", hash = "sha256:45fd4f20a4e3f9b7bf2e0817870bc8e3b320a19658da177af800768c82dbf354", size = 82350, upload-time = "2026-08-12T14:05:26.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/8f/3c92c45737f654f2488ab3662b7604a55d3d35146d37c9ce80f5c95b95a6/python_discovery-1.5.3.tar.gz", hash = "sha256:e500eb24025fb7c4876c1fdcfbafd9028a10c71b661aee38cb6fb0de594518c1", size = 82477, upload-time = "2026-08-24T14:48:46.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/45/689603d04b3bb8d7faa00f25c24acef993aab7813b3dbbfc472a459ab0b5/python_discovery-1.5.2-py3-none-any.whl", hash = "sha256:3e338c2d0f15dfaeea57493f4c2c6caebe0e998ea815c30ae8bf8ee21f1112d3", size = 38350, upload-time = "2026-08-12T14:05:25.113Z" },
+    { url = "https://files.pythonhosted.org/packages/30/12/823d9a321904ccfd2969a24b84fdfd1e6614c707ec569c62879bf1dbc6c5/python_discovery-1.5.3-py3-none-any.whl", hash = "sha256:8305296358f1aa2ed302a25b84be7df84fef8ca47c7dce2da63cb7325333044e", size = 38290, upload-time = "2026-08-24T14:48:45.305Z" },
 ]
 
 [[package]]
@@ -3618,27 +3607,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.3"
+version = "0.16.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
-    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
-    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
-    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
-    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
-    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
-    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
-    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
-    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
-    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
+    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
 ]
 
 [[package]]
@@ -3910,15 +3899,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.3"
+version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c", size = 79859, upload-time = "2026-08-13T16:50:01.323Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]
 
 [[package]]
@@ -3932,7 +3921,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.7.4"
+version = "21.7.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -3940,9 +3929,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/dc/a6eb1ddfa7f1e390fa599b078453c97edb3f6f846b34fb4eac3e8ea16401/virtualenv-21.7.4.tar.gz", hash = "sha256:c9d960c95fa458171e58222a5ccab7465298e4b6559977865e627c4719f1e825", size = 5345511, upload-time = "2026-08-10T22:54:33.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/60/fc54e876e34f94dd0cf0185aaecfd4bfa906653f003d9b2fb21428642fca/virtualenv-21.7.5.tar.gz", hash = "sha256:a73c4246fba3c8901ff9717399f466e00eeca5a3834981f1a6ebb4f1e94de2f8", size = 5346743, upload-time = "2026-08-25T05:39:16.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/4c/eb2f52aeeaf30dbd073d315a251a63ae2b8263171ec4428c135140cb0802/virtualenv-21.7.4-py3-none-any.whl", hash = "sha256:376ec93cd6aab3044fa395d7db226db38043b7b5748948044b2a87168525e843", size = 5324444, upload-time = "2026-08-10T22:54:31.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d8/401141bf45637be916c86d325bd821c5838c7eff83294b934cd94e774e4f/virtualenv-21.7.5-py3-none-any.whl", hash = "sha256:e36ca889510ab6cb0b1dca93c59e5431dd4422a3c88f487358d470c90af8c07a", size = 5324697, upload-time = "2026-08-25T05:39:14.229Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Closes / Refs

Closes #894, closes #1128, closes #1111, closes #1110, closes #1123.

## What & why

The five `bug`-labelled issues on the **v4.1** milestone, plus a `uv.lock` refresh.

**#894 — the rename auto-commit swept unrelated changes.** The rename branch of `_stage_and_commit` staged with a pathspec-less `git add -u`, so every tracked modification in the repository landed in the rename's commit: a concurrent Obsidian edit the server never saw was committed and pushed. `-u` also recorded no deletion for an old path git had never tracked, leaving the commit with only the new path.

A rename has two sides but `WriteCallback` carries one path, so the old path is now threaded through. Because `WriteCallback` is a public type a downstream consumer implements, the extra argument is an **opt-in rather than a signature change**: a callback sets `accepts_old_path` (`types.ACCEPTS_OLD_PATH_ATTR`), and both dispatch seams — `WriteCallbackDispatcher` and `DocumentManager` — read it once and pass `old_path=` only to callbacks that advertise it. A three-argument callback is unaffected at type-check time and at run time. `GitWriteStrategy` opts in and stages `git add -A -- <old> <new>`; an untracked old path is dropped from the pathspec, because `git add` fails the whole invocation on a pathspec matching nothing, which would leave the new path unstaged too.

**#1128 — a webhook delivery outside managed git mode ran git anyway.** `enable_pull` gated only the periodic loop, so `force_pull` ran the pipeline in unmanaged / commit-only mode: `git fetch origin` against a remoteless checkout (answering the retryable-looking `fetch_failed`, so every push burned GitHub's full retry budget on a 503), and an unhandled `CalledProcessError` out of `_head_sha` against a vault that is not a git repository at all. `force_pull` now returns `pull_disabled` before running any git command. The handler answers 200 for it — a configuration state, not a failure — wraps `force_pull` so nothing escapes as a 500, and the server warns once at startup when the secret is set with no remote.

Both open questions in the issue are answered: `git_sync` cannot reach these outcomes (`_resolve_managed_strategy` refuses outside managed mode, and managed mode always has `enable_pull=True`), and the `pull_result is None` branch is not dead code — a library consumer constructing `Vault(git_strategy=None)` reaches it.

**#1111 — a blank semantic query reached the embedding provider.** An empty or whitespace-only query was embedded verbatim as `[""]`, which every OpenAI-compatible endpoint rejects with a raw HTTP 400. The guard sits at the manager boundary so hybrid takes the same path as semantic, with a backstop in `VectorIndex.search` for direct library consumers. It runs *after* `_require_vectors()`, so an unconfigured provider still raises rather than silently answering `[]`. Took the issue's option 1 (return `[]`), matching the adjacent `limit <= 0` guard.

**#1110 — flaky `test_vault_search_respects_limit`.** Added the `wait_for_mcp_writer_drain(client)` its neighbours in `TestBrowserDataTools` already call.

**#1123 — the changelog lost every breaking-change block.** The 2026-08-16 reconstruction generated pre-4.0 sections with only Features / Bug Fixes / Chores headings, flattening sixteen `!` markers in the 1.28.0 → 3.0.0 range and dropping the operator migration instructions that had shipped in the tagged changelogs — so 3.0.0, a major release, presented an empty section and `grep READY_TIMEOUT_S CHANGELOG.md` returned nothing. Restored 3.0.0's block from the `!` commits in its range plus prose recovered from `v3.2.0-rc.7:CHANGELOG.md`.

The five sections still empty (`3.2.0-rc.6`, `3.1.0`, `1.27.0`, `1.25.0`, `1.23.1`) are **promotion-only ranges** — their whole diff is the release commit and the work sits in the `-rc` sections beneath them, so there is nothing lost to restore. The preamble now names that shape, and a test fails if an empty section is ever left unexplained. This is a one-time repair of historical sections; knope only ever writes new sections below the flag, so it does not fight the tooling.

**`uv.lock` refresh** — a single `uv lock --upgrade`, which subsumes #1027 (openai 3.3.1) and #1021 (ruff 0.16.4) plus transitive bumps, and drops `distro`. Deliberately unmoved: numpy (`constraint-dependencies`, #727), pygments (`override-dependencies`), mypy (#727).

## What this PR deliberately does NOT do

- **Auditing the remaining historical `!` markers**: #1077. This PR restores 3.0.0's block; the systematic pre-3.1.0 sweep is that issue's scope.
- **Backfilling the other five empty changelog sections with content**: they are promotion-only ranges with nothing to backfill. Documented in the preamble instead.
- **Refusing at configuration time when a webhook secret is set with no remote**: #1128 offered that as an alternative. A startup failure for a config that boots today is a bigger operator-facing change than the defect warrants; the endpoint stays mounted, answers 200, and warns.
- **Lifting the numpy / pygments / mypy pins**: #727 and the `override-dependencies` comment own those.
- **Touching the other open dependency PRs.** Triage in the comment below — several are no-ops or already-applied and want closing, which is the maintainer's call.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening.
- [x] No commit carries `!`. `WriteCallback`'s three-argument shape is unchanged and a downstream callback keeps working untouched; `PullResult.reason` gained a value, which is additive.

## Docs impact

- [ ] `README.md` — no user-facing surface changed that it documents.
- [x] `docs/` site pages — `docs/configuration.md` and `docs/guides/git-integration.md` (webhook outside managed mode; the guide's existing "Managed mode only" warning described the bug as a known limitation and now describes the fixed behaviour), `docs/tools/index.md` (blank-query result).
- [x] `docs/design/` — per-operation staging guarantee (#894), `enable_pull` gating every pull (#1128), the read-side blank-input guard alongside the existing #1087 section (#1111).
- [x] Inline docstrings — `_stage_and_commit`, new `_stage_rename` / `_is_tracked` / `_fire_rename`, `force_pull`, `make_webhook_handler`, `WriteCallbackDispatcher.__init__` / `fire`, `PullResult.reason`.

## Verification

All hard gates run locally on the final tree:

| Gate | Result |
|---|---|
| `uv run pytest -q` | 3498 passed, 15 skipped |
| `uv run ruff check .` / `format --check` | clean |
| `uv run mypy src/ tests/` | no issues, 192 files |
| Patch coverage (`diff-cover` vs `origin/main`) | **97%** (2 missed lines are `Protocol` `...` bodies) |
| `bash scripts/structural_gate.sh` | 100%, 0 violations on 983 diff lines |
| `uv run pre-commit run vale --all-files` | passed |
| Manifest version lockstep | untouched, all three at 4.0.0 |

The test suite was also run in full on the upgraded lock resolution before it was committed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HEqn5kPBqS8RXJnDgiqX)_