### PR TITLE
fix(deps): drop the pygments pins, which held the lock on the broken release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ docs = [
     "mkdocs-material>=9.7.6",
     "mkdocstrings[python]>=0.28",
     "mkdocs-llmstxt>=0.5",
-    "pygments>=2,<2.21",
     "mike>=2.1",
 ]
 browser = [
@@ -144,9 +143,6 @@ requires = ["hatchling>=1.32,<1.33"]
 build-backend = "hatchling.build"
 
 [tool.uv]
-# Pygments 2.20.0 crashes on filename=None in HtmlFormatter (introduced in 2.20.0,
-# tracked upstream as Pygments PR #3078). Pin globally until the fix ships.
-override-dependencies = ["pygments>=2,<2.21"]
 # numpy 2.5.0's stubs use PEP 695 `type` aliases; mypy run with python_version=3.11
 # rejects them as 3.12-only syntax and aborts the type-check. Our dev/CI interpreter
 # is 3.12+, which would otherwise pull numpy 2.5.0, so cap <2.5.0 to keep the 2.4.x

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,6 @@ resolution-markers = [
 
 [manifest]
 constraints = [{ name = "numpy", specifier = "<2.5.0" }]
-overrides = [{ name = "pygments", specifier = ">=2,<2.21" }]
 
 [[package]]
 name = "aiofile"
@@ -1793,7 +1792,6 @@ docs = [
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
-    { name = "pygments" },
 ]
 
 [package.metadata]
@@ -1842,7 +1840,6 @@ docs = [
     { name = "mkdocs-llmstxt", specifier = ">=0.5" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.28" },
-    { name = "pygments", specifier = ">=2,<2.21" },
 ]
 
 [[package]]
@@ -3107,11 +3104,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Closes / Refs

Closes #1164. Supersedes #1150. Refs #1165.

## What & why

`[tool.uv] override-dependencies = ["pygments>=2,<2.21"]` was written to keep pygments 2.20.0 — the release whose `HtmlFormatter` crashes on `filename=None` — out of the resolution. `<2.21` admits 2.20.x, so the bound selected the one version it named, and `uv.lock` has resolved 2.20.0 ever since. The guard was inverted: it was the only thing holding the project on the defective release.

It was correct as `<2.20` when introduced (`de73d84`, `0ad6b7b`, 2026-03-31). `120e358` — *"chore(deps): bump pygments from 2.19.2 to 2.20.0 (#384)"* — raised it to `<2.21`, a Dependabot bump lifting the ceiling that existed to stop it, under a subject that reads as a routine upgrade. The `docs` extra carried the same bound.

**Both entries are removed rather than raised**, because nothing here needs a pygments constraint any more — the bug is fixed on both sides:

- pygments **2.21.0** accepts `filename=None` again.
- pymdown-extensions **11** normalises `title is None` → `''` before constructing the formatter (`pymdownx/highlight.py:397-398`), so even 2.20.0 is harmless in this project. The original report recorded pymdownx 10.21 passing `None` through.

No first-party code imports pygments — it was added to the `docs` extra purely as the pin, and otherwise arrives through `mkdocs-material` (`>=2.16`) and `rich` (`>=2.13,<3.0`), which now govern. Raising the bound to `<2.22` instead (what #1150 does for one of the two sites) would only need raising again on the next pygments release.

One detail worth recording: **removing the constraint does not move the lock on its own.** `uv lock` keeps an already-locked version, so this carries an explicit `uv lock --upgrade-package pygments`, taking it 2.20.0 → 2.21.0. A reviewer re-running plain `uv lock` will see no change and should not read that as the pin still binding.

## What this PR deliberately does NOT do

- **Remove `docs/hooks.py`**: #1165. It monkey-patches `HtmlFormatter.__init__` for this same bug and is now the third mitigation for it, but whether to keep it as belt-and-braces is a judgment call separate from a bound that is simply wrong. Verified unnecessary here, not removed.
- **Touch the numpy constraint** in the same `[tool.uv]` table: #727 owns that one, and it is correctly bounded.
- **Add a regression test for the bound.** There is no natural place to assert "this pin excludes what it claims to"; the failure mode is a comment disagreeing with a version specifier, which a test would restate rather than catch. Flagging rather than hiding it.

## Local review

- [x] Ran a local review pass on the diff before opening.
- [x] No `!`: no operator or library surface changes. Removing a dependency ceiling widens what may resolve; it does not require an operator to change anything to upgrade.

## Docs impact

- [ ] `README.md` — no user-facing surface changed.
- [ ] `docs/` site pages — none reference the pin.
- [ ] `docs/design/` — the pin is packaging, not architecture.
- [x] Inline comments — the `[tool.uv]` comment describing the pin is removed with it, leaving the numpy rationale intact.

## Verification

| Check | Result |
|---|---|
| `HtmlFormatter(filename=None)` across releases | 2.19.2 ok · **2.20.0 `AttributeError: 'NoneType' object has no attribute 'replace'`** · 2.21.0 ok |
| Resolved version after re-lock | pygments **2.21.0** |
| `mkdocs build --strict` (new resolution) | green |
| `mkdocs build --strict` **with `hooks:` removed** | green — 3 `class="highlight"` blocks on `api/types`, identical with and without |
| `uv run pytest -q` | 3498 passed, 15 skipped |
| `uv run ruff check .` / `format --check` | clean |
| `uv run mypy src/ tests/` | no issues, 192 files |
| `scripts/structural_gate.sh` | no Python source changes — skipped |
| Manifest version lockstep | untouched, all three at 4.0.0 |

Diff is 3 lines removed from `pyproject.toml` plus the lock entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HEqn5kPBqS8RXJnDgiqX)_