### PR TITLE
docs(embeddings): document the OpenAI-compatible recipe and the preset acceptance bar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,7 +163,7 @@
 # MARKDOWN_VAULT_MCP_FOLDER_WEIGHTS=
 # Per-column BM25 weights (`column:weight` pairs, comma-separated, weights >= 0) for keyword ranking. Columns: path, title, folder, heading, content, summary.
 # MARKDOWN_VAULT_MCP_FTS_WEIGHTS=
-# Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage).
+# Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). Any OpenAI-compatible endpoint works with openai plus OPENAI_BASE_URL; see the embeddings guide.
 # MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=
 # Ollama embedding model name.
 # MARKDOWN_VAULT_MCP_OLLAMA_MODEL=nomic-embed-text

--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -145,6 +145,7 @@ ifcraftcorpus
 int
 invalid_client
 IPs
+Jina
 jpg
 keyless
 keyspace
@@ -152,12 +153,14 @@ lfs
 lifespan
 linux
 litellm
+LiteLLM
 LLM
 LLMs
 lockfile
 MCP
 mcpb
 middleware
+Mistral
 Mitigations
 MOCs
 most_linked
@@ -207,6 +210,7 @@ sdist
 SELinux
 SHAs
 show_context
+SiliconFlow
 stderr
 streamable
 subfolder

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Generic markdown vault MCP server with FTS5 + semantic search
 ## Features
 
 <!-- DOMAIN-START -->
-- **Hybrid search**: SQLite FTS5 keyword search (BM25, porter stemming) and semantic search (FastEmbed, Ollama, or OpenAI embeddings), fused with Reciprocal Rank Fusion; diversity-aware ranking returns sentence-scale snippets with full-section recovery via `read(path, section=heading)`. See the [Embeddings guide](https://pvliesdonk.github.io/markdown-vault-mcp/latest/guides/embeddings/).
+- **Hybrid search**: SQLite FTS5 keyword search (BM25, porter stemming) and semantic search (FastEmbed, Ollama, OpenAI, or Voyage AI embeddings, plus any OpenAI-compatible endpoint via `OPENAI_BASE_URL`), fused with Reciprocal Rank Fusion; diversity-aware ranking returns sentence-scale snippets with full-section recovery via `read(path, section=heading)`. See the [Embeddings guide](https://pvliesdonk.github.io/markdown-vault-mcp/latest/guides/embeddings/), including the [recipe for OpenAI-compatible endpoints](https://pvliesdonk.github.io/markdown-vault-mcp/latest/guides/embeddings/#openai-compatible-endpoints).
 - **Frontmatter-aware indexing**: YAML frontmatter fields become filterable and searchable, with optional required-field enforcement and adaptive heading-level chunking for long documents.
 - **Write operations**: the write tools (`write`, `edit`, `append`, `delete`, `rename`, `move_folder`, `fetch`, `git_sync`, the `okf_*` tools, `create_upload_link`) are registered by default and hidden when `MARKDOWN_VAULT_MCP_READ_ONLY=true`; writes update the index automatically, per-folder `_conventions.md` authoring rules are surfaced to LLM clients at write time, and attachments (PDFs, images, and other non-markdown files) are read/write too.
 - **Incremental reindexing**: hash-based change detection with boot-time reconciliation; the vector index converges to the reconciled chunk set, and parse-pipeline upgrades rebuild the index once automatically.
@@ -269,7 +269,7 @@ Domain environment variables use the `MARKDOWN_VAULT_MCP_` prefix:
 | `MARKDOWN_VAULT_MCP_CHUNK_OVERLAP_WORDS` | `40` | No | Words of overlap between adjacent budget-split fragments of the same heading section (0 disables). A reindex applies a new value. |
 | `MARKDOWN_VAULT_MCP_FOLDER_WEIGHTS` | (none) | No | Folder-prefix score multipliers (`prefix:weight` pairs, comma-separated, weights > 0) applied to all search modes; the deepest matching prefix wins (sessions:0.5 demotes sessions/**). |
 | `MARKDOWN_VAULT_MCP_FTS_WEIGHTS` | (none) | No | Per-column BM25 weights (`column:weight` pairs, comma-separated, weights >= 0) for keyword ranking. Columns: path, title, folder, heading, content, summary. |
-| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | (none) | No | Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). |
+| `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` | (none) | No | Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). Any OpenAI-compatible endpoint works with openai plus OPENAI_BASE_URL; see the embeddings guide. |
 | `MARKDOWN_VAULT_MCP_OLLAMA_MODEL` | `nomic-embed-text` | No | Ollama embedding model name. |
 | `MARKDOWN_VAULT_MCP_OLLAMA_CPU_ONLY` | `false` | No | Force Ollama to embed on CPU only. |
 | `MARKDOWN_VAULT_MCP_VOYAGE_MODEL` | `voyage-4` | No | Voyage AI embedding model name. |

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2393,6 +2393,26 @@ sidecar records ``voyage`` as its provider identity. Unlike the other three,
 for an unrelated tool must not silently take over an index and force a
 re-embed.
 
+**Acceptance bar for named provider presets (#1134)**: a named
+``EMBEDDING_PROVIDER`` value is reserved for a vendor whose API has behavior the
+generic OpenAI-compatible transport cannot express. Voyage clears it on two
+counts — the strict request-shape rejections above, and the query/document
+``input_type`` asymmetry that needs a per-call ABC parameter (#1135); Ollama
+clears it as a local runtime with no API key, a CPU-only mode, and native
+context-length and reachability probes. Every other OpenAI-compatible endpoint
+(Jina, Mistral, SiliconFlow, LiteLLM, vLLM, Text Embeddings Inference, gateway
+proxies) is served by ``EMBEDDING_PROVIDER=openai`` plus ``OPENAI_BASE_URL``,
+documented as a recipe in the embeddings guide, and adding a preset for one buys
+only discoverability at the cost of another config surface to maintain. The bar
+is written down here so each "add provider X" proposal is measured against it
+rather than against precedent.
+
+A preset that does clear the bar stays a preset: a thin subclass over
+``_OpenAICompatEmbeddings`` with a pinned base URL, its own key and model
+variables, and a distinct ``provider_name`` for the sidecar identity — not a new
+HTTP client. A new transport needs a vendor whose wire protocol is not
+OpenAI-shaped at all.
+
 ### `tracker.py`: Change Detection
 
 ```python

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -323,8 +323,8 @@ have no named provider.
 Each request carries only `model` and `input`. The server never sends
 `dimensions` or `user`, and it leaves `encoding_format` to the `openai` SDK,
 whose base64 default is widely accepted. This narrow request shape is why
-strict endpoints work: Voyage, for instance, answers HTTP 400 to `dimensions`,
-to `user`, and to `encoding_format="float"`. An endpoint that *requires* a
+strict endpoints work: Voyage answers HTTP 400 to `dimensions`, to `user`,
+and to `encoding_format="float"`. An endpoint that requires a
 field outside `model` and `input` cannot be driven this way.
 
 ### Caveats worth knowing
@@ -333,8 +333,8 @@ field outside `model` and `input` cannot be driven this way.
     The vector sidecar records the provider name and the model name, and a
     mismatch on startup re-embeds the vault automatically. Both values stay
     `openai` and your configured model string no matter which vendor serves
-    them, so repointing `OPENAI_BASE_URL` at a different vendor while keeping
-    the same model name is **not** detected: vectors from two different models
+    them, so aiming `OPENAI_BASE_URL` at a different vendor while keeping
+    the same model name goes undetected: vectors from two different models
     end up in one index, and search quality degrades quietly. Force the rebuild
     yourself by deleting the two sidecar files beside `EMBEDDINGS_PATH`
     (the `.npy` matrix and the `.json` metadata) and restarting.
@@ -349,7 +349,7 @@ field outside `model` and `input` cannot be driven this way.
 
 !!! note "Auto-detection reacts to the key alone"
     With `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` unset, an `OPENAI_API_KEY` in
-    the environment selects the `openai` provider — including a key you
+    the environment selects the `openai` provider, including a key you
     exported for something else. Set the provider explicitly when a vault's
     backend matters.
 
@@ -360,8 +360,9 @@ field outside `model` and `input` cannot be driven this way.
 ### When an endpoint deserves its own provider name
 
 Named presets are reserved for vendors whose API has behavior the generic
-transport cannot express — Voyage for its strict request-shape rejections and
-its query/document asymmetry, Ollama for being a local runtime with no key.
+transport cannot express. Voyage qualifies on its strict request-shape
+rejections and its query/document asymmetry, Ollama on being a local runtime
+with no key.
 For every other OpenAI-compatible endpoint the recipe above is the supported
 answer, and it costs nothing to run. If you think an endpoint clears that
 bar, open an issue describing the specific behavior the generic client cannot

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -173,7 +173,7 @@ OPENAI_API_KEY=sk-your-api-key-here
 MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH=/path/to/store/embeddings
 ```
 
-For OpenAI-compatible providers, override the base URL and model:
+For any other OpenAI-compatible endpoint, override the base URL and model:
 
 ```bash
 MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai
@@ -182,6 +182,9 @@ OPENAI_BASE_URL=https://api.siliconflow.cn/v1
 OPENAI_EMBEDDING_MODEL=BAAI/bge-m3
 MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH=/path/to/store/embeddings
 ```
+
+See [OpenAI-compatible endpoints](#openai-compatible-endpoints) for the caveats
+that come with pointing this provider at a third-party service.
 
 !!! warning "Privacy"
     Document content (titles, headings, body text) is sent to the configured OpenAI-compatible provider for embedding. Do not use this provider if your vault contains sensitive data you don't want to share with that provider. Use Ollama or FastEmbed for fully local, private embeddings.
@@ -260,6 +263,109 @@ curl https://api.voyageai.com/v1/embeddings \
 ```
 
 You should get a JSON response with an embedding array.
+
+---
+
+## OpenAI-compatible endpoints
+
+`MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai` is a generic client, not a
+binding to OpenAI the company. Any service that serves `POST /v1/embeddings` in
+the OpenAI request and response shape works by pointing `OPENAI_BASE_URL` at it.
+Jina, Mistral, SiliconFlow, LiteLLM, vLLM, and Text Embeddings Inference all
+serve that shape, as do self-hosted gateways in front of another model.
+
+### The recipe
+
+```bash
+MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai
+OPENAI_API_KEY=your-provider-api-key
+OPENAI_BASE_URL=https://api.example-vendor.com/v1
+OPENAI_EMBEDDING_MODEL=the-vendor-model-name
+MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH=/path/to/store/embeddings
+```
+
+The base URL includes the version prefix and omits the trailing `/embeddings`:
+the SDK appends the path. Both `OPENAI_BASE_URL` and `OPENAI_EMBEDDING_MODEL`
+also accept the `MARKDOWN_VAULT_MCP_`-prefixed spelling, which wins over the
+bare one when both are set.
+
+Confirm the endpoint answers before starting the server:
+
+```bash
+curl "$OPENAI_BASE_URL/embeddings" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": \"test\", \"model\": \"$OPENAI_EMBEDDING_MODEL\"}"
+```
+
+A JSON response carrying an embedding array means the configuration will work.
+
+### A worked example
+
+Voyage AI is the endpoint this pattern was verified against end to end
+([#949](https://github.com/pvliesdonk/markdown-vault-mcp/issues/949)):
+
+```bash
+MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=openai
+OPENAI_API_KEY=pa-your-voyage-key     # a Voyage key in the OpenAI variable
+OPENAI_BASE_URL=https://api.voyageai.com/v1
+OPENAI_EMBEDDING_MODEL=voyage-4
+```
+
+That still works, and it is what the [`voyage`](#voyage-ai) provider does
+internally. Prefer the named provider for Voyage: it pins the base URL, gives
+the key its own variable, supplies a model default, and records `voyage` as the
+index identity. The example is here because it shows the shape for vendors that
+have no named provider.
+
+### What the server sends
+
+Each request carries only `model` and `input`. The server never sends
+`dimensions` or `user`, and it leaves `encoding_format` to the `openai` SDK,
+whose base64 default is widely accepted. This narrow request shape is why
+strict endpoints work: Voyage, for instance, answers HTTP 400 to `dimensions`,
+to `user`, and to `encoding_format="float"`. An endpoint that *requires* a
+field outside `model` and `input` cannot be driven this way.
+
+### Caveats worth knowing
+
+!!! warning "Changing only the base URL is invisible to the index"
+    The vector sidecar records the provider name and the model name, and a
+    mismatch on startup re-embeds the vault automatically. Both values stay
+    `openai` and your configured model string no matter which vendor serves
+    them, so repointing `OPENAI_BASE_URL` at a different vendor while keeping
+    the same model name is **not** detected: vectors from two different models
+    end up in one index, and search quality degrades quietly. Force the rebuild
+    yourself by deleting the two sidecar files beside `EMBEDDINGS_PATH`
+    (the `.npy` matrix and the `.json` metadata) and restarting.
+
+!!! note "Unknown context length falls back to a 1500-character chunk cap"
+    The chunk cap derives from the model's context length. That is known only
+    for the models the server ships a table for, so a third-party model falls
+    back to 1500 characters. If your model's context is smaller than roughly
+    536 tokens, set `MARKDOWN_VAULT_MCP_MAX_CHUNK_CHARS` explicitly, or the
+    endpoint will reject or truncate oversize chunks. See
+    [`MAX_CHUNK_CHARS`](../configuration.md).
+
+!!! note "Auto-detection reacts to the key alone"
+    With `MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER` unset, an `OPENAI_API_KEY` in
+    the environment selects the `openai` provider — including a key you
+    exported for something else. Set the provider explicitly when a vault's
+    backend matters.
+
+!!! warning "Privacy"
+    Document content (titles, headings, body text) is sent to whichever
+    endpoint you configure. Use Ollama or FastEmbed for fully local embeddings.
+
+### When an endpoint deserves its own provider name
+
+Named presets are reserved for vendors whose API has behavior the generic
+transport cannot express — Voyage for its strict request-shape rejections and
+its query/document asymmetry, Ollama for being a local runtime with no key.
+For every other OpenAI-compatible endpoint the recipe above is the supported
+answer, and it costs nothing to run. If you think an endpoint clears that
+bar, open an issue describing the specific behavior the generic client cannot
+reach.
 
 ---
 

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -683,7 +683,7 @@
       "label": "Embedding Provider",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER",
-      "help": "Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage).",
+      "help": "Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). Any OpenAI-compatible endpoint works with openai plus OPENAI_BASE_URL; see the embeddings guide.",
       "advancedGroup": "Embeddings"
     },
     {

--- a/examples/bearer-auth.env
+++ b/examples/bearer-auth.env
@@ -77,7 +77,7 @@ MARKDOWN_VAULT_MCP_CHUNK_OVERLAP_WORDS=40
 MARKDOWN_VAULT_MCP_FOLDER_WEIGHTS=
 # Per-column BM25 weights (`column:weight` pairs, comma-separated, weights >= 0) for keyword ranking. Columns: path, title, folder, heading, content, summary.
 MARKDOWN_VAULT_MCP_FTS_WEIGHTS=
-# Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage).
+# Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). Any OpenAI-compatible endpoint works with openai plus OPENAI_BASE_URL; see the embeddings guide.
 MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=
 # Ollama embedding model name.
 MARKDOWN_VAULT_MCP_OLLAMA_MODEL=nomic-embed-text

--- a/examples/oidc.env
+++ b/examples/oidc.env
@@ -91,7 +91,7 @@ MARKDOWN_VAULT_MCP_CHUNK_OVERLAP_WORDS=40
 MARKDOWN_VAULT_MCP_FOLDER_WEIGHTS=
 # Per-column BM25 weights (`column:weight` pairs, comma-separated, weights >= 0) for keyword ranking. Columns: path, title, folder, heading, content, summary.
 MARKDOWN_VAULT_MCP_FTS_WEIGHTS=
-# Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage).
+# Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). Any OpenAI-compatible endpoint works with openai plus OPENAI_BASE_URL; see the embeddings guide.
 MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=
 # Ollama embedding model name.
 MARKDOWN_VAULT_MCP_OLLAMA_MODEL=nomic-embed-text

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -89,7 +89,7 @@ MARKDOWN_VAULT_MCP_CHUNK_OVERLAP_WORDS=40
 MARKDOWN_VAULT_MCP_FOLDER_WEIGHTS=
 # Per-column BM25 weights (`column:weight` pairs, comma-separated, weights >= 0) for keyword ranking. Columns: path, title, folder, heading, content, summary.
 MARKDOWN_VAULT_MCP_FTS_WEIGHTS=
-# Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage).
+# Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). Any OpenAI-compatible endpoint works with openai plus OPENAI_BASE_URL; see the embeddings guide.
 MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER=
 # Ollama embedding model name.
 MARKDOWN_VAULT_MCP_OLLAMA_MODEL=nomic-embed-text

--- a/server.json
+++ b/server.json
@@ -244,7 +244,7 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER",
-          "description": "Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage)."
+          "description": "Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). Any OpenAI-compatible endpoint works with openai plus OPENAI_BASE_URL; see the embeddings guide."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_OLLAMA_MODEL",
@@ -795,7 +795,7 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER",
-          "description": "Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage)."
+          "description": "Embedding provider: openai, voyage, ollama, or fastembed. Unset auto-detects from the environment (never voyage). Any OpenAI-compatible endpoint works with openai plus OPENAI_BASE_URL; see the embeddings guide."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_OLLAMA_MODEL",

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -441,7 +441,9 @@ class ProjectConfig:
         metadata={
             "help": (
                 "Embedding provider: openai, voyage, ollama, or fastembed. "
-                "Unset auto-detects from the environment (never voyage)."
+                "Unset auto-detects from the environment (never voyage). Any "
+                "OpenAI-compatible endpoint works with openai plus "
+                "OPENAI_BASE_URL; see the embeddings guide."
             ),
             "tags": ("embeddings",),
             "wizard": {"group": "Embeddings"},


### PR DESCRIPTION
## Closes / Refs

Closes #1134. Refs #949, #950 (the verified configuration this documents), #1135
(the `input_type` follow-up that partly motivates the bar).

## What &amp; why

The `openai` provider with `OPENAI_BASE_URL` already reaches any OpenAI-shaped
embeddings endpoint, but nothing said so. An operator had to know the vendor's
base URL, know a valid model name, and put a third-party key in a variable
named for OpenAI. Separately, the decision made while accepting #950 — that
named provider presets are reserved for vendors the generic transport cannot
express — had no written home, so each future "add provider X" proposal would
re-litigate it from precedent.

**`docs/guides/embeddings.md`** gains an **OpenAI-compatible endpoints**
section: the recipe, the base-URL shape (version prefix included, `/embeddings`
omitted), a `curl` check, a worked example, what the server actually puts on the
wire, and the caveats. The short "For OpenAI-compatible providers" snippet in
the OpenAI section now cross-links it instead of standing alone.

**`docs/design/design.md`** records the acceptance bar next to the provider
architecture, including what a qualifying preset may be (a thin subclass over
`_OpenAICompatEmbeddings`) versus what needs a genuinely non-OpenAI wire
protocol.

**`README.md`** points at the recipe from both the feature bullet and the
generated `EMBEDDING_PROVIDER` env-table row. The bullet was also stale — it
listed three providers and omitted Voyage.

### The worked example is the verified one

The example is the Voyage configuration verified end to end in #949, with a
pointer that Voyage now has a named provider that does exactly this and should
be preferred. The other endpoints named in the section (Jina, Mistral,
SiliconFlow, LiteLLM, vLLM, Text Embeddings Inference) are presented as serving
the same shape — which is the issue's own list — and are **not** claimed to
have been tested here.

### Two caveats worth a reviewer's eye

Both are silent failures rather than errors, which is why they are called out
rather than left to be discovered:

- **Aiming `OPENAI_BASE_URL` elsewhere is invisible to the index.** The sidecar
  identity check compares only `provider` and `model` (`vector_index.py`), and
  both stay `openai` plus your model string whichever vendor serves them. A
  mismatch normally triggers an automatic re-embed; this case produces none, so
  vectors from two different models accumulate in one index. The section says to
  delete the sidecar by hand.
- **Unknown context length falls back to a 1500-character chunk cap**, which is
  too generous for a model with a context below roughly 536 tokens.

## What this PR deliberately does NOT do

- No code behaviour change. The only `src/` edit is the `EMBEDDING_PROVIDER`
  `help` string, which is the source the generated README row, `.env.example`,
  `server.json`, and the wizard spec all render from — regenerated with
  `scripts/gen_config_surface.py`, not hand-edited.
- Per-call `input_type`: #1135, unchanged.
- No new provider preset. The bar this PR writes down is the reason.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening.
- [x] No commit carries `!`. Nothing in the operator or library surface changes;
      the help string is prose.

## Docs impact

- [x] `README.md`
- [x] `docs/` site pages — `guides/embeddings.md`
- [x] `docs/design/` — the acceptance bar in the providers section
- [ ] Inline docstrings — not applicable, no API change

## Gates

`pytest -x -q` 3535 passed / 29 skipped · `ruff check` + `format --check` clean ·
`mypy src/ tests/` clean · `structural_gate.sh` 100%, 0 violations ·
`mkdocs build --strict` exit 0, and the `#openai-compatible-endpoints` anchor
the README links resolves in the built site ·
`gen_config_surface.py --check` up to date ·
**Vale 0 errors** across `docs/` + `README.md`.

On that last one: the first push of this branch had no local Vale, and CI
caught six violations in the new prose (`Vale.Spelling` on "repointing",
`ai-tells.EmphaticCopula` on emphasised "not" and "requires", `Google.EmDash`
and `ai-tells.EmDashUsage` on two em dashes, `ai-tells.FormalTransitions` on
"for instance"). Rather than guess a second time, a Vale binary was installed
and run against this project's own `.vale.ini` with its styles synced, using the
same invocation and glob as CI. All six are fixed and the run is clean. Worth
knowing for anyone editing these docs: reviewdog reports only on the diff, so
the em dashes already present elsewhere in the guide are grandfathered while new
ones are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)