### PR TITLE
docs: remove the dead Reference section from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,11 +107,6 @@ src/markdown_vault_mcp/
 ```
 <!-- DOMAIN-END -->
 
-## Reference
-<!-- DOMAIN-START -->
-This project is extracted from [`pvliesdonk/if-craft-corpus`](https://github.com/pvliesdonk/if-craft-corpus). See the design doc's Reference Code section for the mapping between source files.
-<!-- DOMAIN-END -->
-
 <!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
 
 ## Conventions


### PR DESCRIPTION
## Closes / Refs

Closes #1182

## What & why

`CLAUDE.md`'s `## Reference` section pointed at `pvliesdonk/if-craft-corpus`, a repository that has since been deleted, so the sentence directed readers somewhere they cannot go.

It also gave this repo a **fourth** filled `DOMAIN` block against the **three** slots in the template's `AGENTS.md`. Template v6.0.0's migration splices those blocks by ordinal, so at four-into-three the Reference content would land under `## Key Design Decisions` and the real Key Design Decisions block would be dropped — with the script reporting success.

Five lines deleted, nothing else. After the change the three surviving blocks map one-to-one onto the template's slots, and the leading heading order matches it exactly:

```
repo:     ## Design | ## Project Structure | ## Conventions
template: ## Design | ## Project Structure | ## Conventions
```

This is the first of four stacked PRs for the template v6.0.0 / fastmcp-pvl-core 5 migration. It goes first because the loss it prevents is silent and irreversible once the update has run.

## What this PR deliberately does NOT do

- **Does not touch `docs/design/design.md`.** Its `## Reference Code` section, the `## Problem` narrative, Use Case 2 and the architecture block all still mention `if-craft-corpus`. Scoping to `CLAUDE.md` was a deliberate call; note it leaves that `## Reference Code` section orphaned, since the sentence pointing at it is what goes away. Untracked — raise an issue if the wider cleanup is wanted.
- **Does not run `copier update` or change any dependency floor.** That is the fourth PR in the stack.
- **Does not rename or restructure the surviving DOMAIN blocks.** Their content is untouched; only the count changes.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening the PR.
- [x] No commit carries `!` — nothing here touches an operator or library surface. `docs:` is deliberate: knope counts only `feat`/`fix`/`!`, so this cuts no release and reaches no changelog entry, which is right for dead-content removal.

## Docs impact

- [ ] `README.md` — not affected
- [ ] `docs/` site pages — not affected (`CLAUDE.md` is not part of the published site)
- [ ] `docs/design/` — deliberately out of scope, see above
- [ ] Inline docstrings — no code changed

## Verification

- Block count 4 → 3, surviving blocks Design / Project Structure / Key Design Decisions in that order.
- `uv run pytest -x -q`: **3548 passed, 15 skipped**. `test_structural_gate.py` and `test_commit_conventions.py` both read `CLAUDE.md`; both pass.
- `ruff check` and `ruff format --check`: clean.
- Structural gate: self-skips, *"No Python source changes — skipping structural diff gate"*.
- `pre-commit run --all-files`: every hook passes **except the two Vale hooks**, which fail at the `vale sync` step — this sandbox cannot download the style packages, so Vale never ran. Not a prose failure, and Vale's scope is `^(docs/|README\.md$)`, which this diff does not touch at all. CI will run it properly.
- `test_template_conformance.py`: 10 passed, **9 skipped** — its documented loud skip, because copier cannot fetch the template tag through this sandbox's proxy. `CLAUDE.md` is not in that test's comparison set, so it is not a gate for this change; CI covers it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZSRMrP8BnFjJh2xdhcZf8)_