### PR TITLE
chore: align the project description across every carrier

### DIFF
--- a/.claude-plugin/plugin/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-vault-mcp",
-  "description": "MCP server for markdown vaults: FTS5 + semantic search, link graph, write/edit/git.",
+  "description": "Generic markdown vault MCP with hybrid search",
   "version": "4.0.0",
   "author": {
     "name": "Peter van Liesdonk"

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -2,7 +2,7 @@
 _commit: v5.6.3
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
-domain_description: Generic markdown vault MCP server with FTS5 + semantic search
+domain_description: Generic markdown vault MCP with hybrid search
 enable_authorization: false
 enable_structural_gate: true
 env_prefix: MARKDOWN_VAULT_MCP

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -603,7 +603,7 @@ jobs:
             type=raw,value=v${{ steps.version.outputs.major }},enable=${{ steps.recheck.outputs.is_latest_major == 'true' }}
           labels: |
             org.opencontainers.image.title=markdown-vault-mcp
-            org.opencontainers.image.description=Generic markdown vault MCP server with FTS5 + semantic search
+            org.opencontainers.image.description=Generic markdown vault MCP with hybrid search
             org.opencontainers.image.vendor=pvliesdonk
             io.modelcontextprotocol.server.name=io.github.pvliesdonk/markdown-vault-mcp
 
@@ -884,7 +884,7 @@ jobs:
           # Through env, not interpolated into the script: the blurb is
           # free-form prose and a quote in it would otherwise break the
           # shell rather than the entry.
-          PLUGIN_DESC: "Generic markdown vault MCP server with FTS5 + semantic search"
+          PLUGIN_DESC: "Generic markdown vault MCP with hybrid search"
           PLUGIN_HOME: "https://pvliesdonk.github.io/markdown-vault-mcp/"
         run: |
           cd catalog

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -70,7 +70,7 @@ jobs:
             type=raw,value=edge
           labels: |
             org.opencontainers.image.title=markdown-vault-mcp
-            org.opencontainers.image.description=Generic markdown vault MCP server with FTS5 + semantic search
+            org.opencontainers.image.description=Generic markdown vault MCP with hybrid search
             org.opencontainers.image.vendor=pvliesdonk
             io.modelcontextprotocol.server.name=io.github.pvliesdonk/markdown-vault-mcp
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,11 +107,6 @@ src/markdown_vault_mcp/
 ```
 <!-- DOMAIN-END -->
 
-## Reference
-<!-- DOMAIN-START -->
-This project is extracted from [`pvliesdonk/if-craft-corpus`](https://github.com/pvliesdonk/if-craft-corpus). See the design doc's Reference Code section for the mapping between source files.
-<!-- DOMAIN-END -->
-
 <!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # markdown-vault-mcp
 
-Generic markdown vault MCP server with FTS5 + semantic search, frontmatter-aware indexing, and incremental reindexing.
+Generic markdown vault MCP with hybrid search.
 
 ## Design
 <!-- DOMAIN-START -->

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![CI](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/markdown-vault-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/markdown-vault-mcp) [![PyPI](https://img.shields.io/pypi/v/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![Python](https://img.shields.io/pypi/pyversions/markdown-vault-mcp)](https://pypi.org/project/markdown-vault-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/markdown-vault-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/markdown-vault-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/markdown-vault-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/markdown-vault-mcp/latest/llms.txt) [![Template](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/pvliesdonk/markdown-vault-mcp/main/.copier-answers.yml&query=%24._commit&label=template)](https://github.com/pvliesdonk/fastmcp-server-template)
 
-Generic markdown vault MCP server with FTS5 + semantic search
+Generic markdown vault MCP with hybrid search
 
 **[Documentation](https://pvliesdonk.github.io/markdown-vault-mcp/)** | **[Config wizard](https://pvliesdonk.github.io/markdown-vault-mcp/latest/configuration-generator/)** | **[PyPI](https://pypi.org/project/markdown-vault-mcp/)** | **[Docker](https://github.com/pvliesdonk/markdown-vault-mcp/pkgs/container/markdown-vault-mcp)**
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1,8 +1,6 @@
 # markdown-vault-mcp: Design Specification v2
 
-> Generic markdown vault MCP server with FTS5 + semantic search,
-> frontmatter-aware indexing, and incremental reindexing. Extracted from
-> and replacing the search layer in `pvliesdonk/if-craft-corpus`.
+> Generic markdown vault MCP with hybrid search.
 
 ## Terminology
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: markdown-vault-mcp
 site_url: https://pvliesdonk.github.io/markdown-vault-mcp/
-site_description: Generic markdown vault MCP server with FTS5 + semantic search
+site_description: Generic markdown vault MCP with hybrid search
 repo_url: https://github.com/pvliesdonk/markdown-vault-mcp
 repo_name: pvliesdonk/markdown-vault-mcp
 edit_uri: edit/main/docs/

--- a/packaging/mcpb/manifest.json.in
+++ b/packaging/mcpb/manifest.json.in
@@ -3,7 +3,7 @@
   "name": "markdown-vault-mcp",
   "display_name": "Markdown Vault",
   "version": "${VERSION}",
-  "description": "FTS5 + semantic search over a markdown vault. Read, edit, link, and analyze notes.",
+  "description": "Generic markdown vault MCP with hybrid search",
   "long_description": "Generic markdown-vault MCP server with SQLite FTS5 full-text search, optional embedding-based semantic search, frontmatter-aware indexing, link-graph tools (backlinks, outlinks, similar notes, orphans), git write strategy, and MCP Apps views (Context Card, Graph Explorer, Vault Browser).",
   "author": {
     "name": "Peter van Liesdonk",

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -15,8 +15,7 @@ section: utils
 priority: optional
 maintainer: "Peter van Liesdonk <pvliesdonk@users.noreply.github.com>"
 description: |
-  Generic markdown vault MCP server with FTS5 + semantic search,
-  frontmatter-aware indexing, and incremental reindexing.
+  Generic markdown vault MCP with hybrid search.
 homepage: "https://pvliesdonk.github.io/markdown-vault-mcp/"
 license: "MIT"  # project-owned — keep across copier updates
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "markdown-vault-mcp"
 version = "4.0.0"
-description = "Generic markdown vault MCP server with FTS5 + semantic search"
+description = "Generic markdown vault MCP with hybrid search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.pvliesdonk/markdown-vault-mcp",
   "title": "Markdown Vault MCP",
-  "description": "Markdown vault MCP server with FTS5 + semantic search and frontmatter indexing",
+  "description": "Generic markdown vault MCP with hybrid search",
   "version": "4.0.0",
   "websiteUrl": "https://pvliesdonk.github.io/markdown-vault-mcp/",
   "repository": {

--- a/src/markdown_vault_mcp/__init__.py
+++ b/src/markdown_vault_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Markdown Vault MCP.
 
-Generic markdown vault MCP server with FTS5 + semantic search
+Generic markdown vault MCP with hybrid search
 """
 
 __version__ = "0.1.0"

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -17,7 +17,7 @@ from markdown_vault_mcp.config import _ENV_PREFIX, ProjectConfig, to_vault_kwarg
 
 app = typer.Typer(
     name="markdown-vault-mcp",
-    help="Generic markdown vault MCP server with FTS5 + semantic search",
+    help="Generic markdown vault MCP with hybrid search",
     no_args_is_help=True,
     add_completion=False,
 )

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -81,7 +81,7 @@ def make_server(
     server_name = env(_ENV_PREFIX, "SERVER_NAME", "markdown-vault-mcp")
     instructions = env(_ENV_PREFIX, "INSTRUCTIONS") or build_instructions(
         env_prefix=_ENV_PREFIX,
-        domain_line="Generic markdown vault MCP server with FTS5 + semantic search",
+        domain_line="Generic markdown vault MCP with hybrid search",
     )
 
     auth = build_auth(config.server)


### PR DESCRIPTION
## Closes / Refs

Closes #1184

Follows #1183, now merged. The branch carries a merge of `main`, so the diff below is this PR's own change only: 15 files, +16/−19.

## What & why

The description had drifted into **five** different strings. The copier answer said one thing; `CLAUDE.md`, `packaging/nfpm.yaml` and `docs/design/design.md` appended "frontmatter-aware indexing, and incremental reindexing"; and `server.json`, the Claude plugin manifest and the mcpb manifest each carried their own hand-written wording. Since the template interpolates `domain_description` verbatim into most of these, the drift stayed invisible until an update would have rewritten them.

Settled on `Generic markdown vault MCP with hybrid search` everywhere a description field appears — it names the capability rather than the implementation.

At 45 characters it also clears a constraint arriving with template v6, which renders the description into `instructions_for(mcp).identity("...")` — a line of `38 + len(description)` columns:

```
61 chars (before) -> 99 cols   EXCEEDS 88
45 chars (after)  -> 83 cols   OK
```

The old value would have forced a choice between `ruff format` and the byte-for-byte template-conformance check on `server.py`. Settling it here, ahead of the update, means the template upgrade never has to make that trade.

## What this PR deliberately does NOT do

- **Does not touch the three files under `docs/superpowers/`.** They are historical plans and specs that quote the old string as it stood when written; rewriting them would falsify a record. They are the only remaining occurrences, deliberately.
- **Does not touch `docs/index.md`.** The template renders it from `domain_description`, but this repo has intentionally drifted to its own longer prose. It renders identically before and after this change, so `copier update` sees no diff there and the drift survives the upgrade untouched.
- **Does not change any client-visible behaviour.** `server.py`'s `domain_line` feeds the `FastMCP` constructor, but `DOMAIN-WIRING` overwrites `mcp.instructions` before any client sees it — that copy is dead today. The instructions text only changes when the composed-instructions rework lands.
- **Does not run `copier update` or move any dependency floor.**

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening the PR. 16 line changes across 15 files, every one a description swap; no collateral edits.
- [x] No commit carries `!`. `chore:` is deliberate — knope counts only `feat`/`fix`/`!`, so this cuts no release. It changes published description text but adds no capability and fixes no defect.

## Docs impact

- [x] `README.md` — carries the new description
- [x] `docs/` site pages — `mkdocs.yml` `site_description`
- [x] `docs/design/` — opening blockquote normalised
- [ ] Inline docstrings — `__init__.py`'s module docstring is the package description line; no API docs changed

## Verification

- **No stale carriers**: `git grep` for the old string returns only the three `docs/superpowers/` files.
- **Machine-readable files parse**: `json.load` on `server.json`, `plugin.json`, `manifest.json.in`; `yaml.safe_load` on `mkdocs.yml`, `nfpm.yaml`, `.copier-answers.yml`.
- `gen_config_surface.py --check`: clean. The three manifest descriptions sit outside the generated `user_config` / `env` / `userConfig` objects, so the generator does not own them.
- `uv run pytest -x -q`: 3548 passed, 15 skipped locally; **3550 passed, 27 skipped in CI**, all four Python versions green.
- `ruff check`, `ruff format --check`, `mypy src/ tests/`, `mkdocs build --strict`: clean.
- Structural gate: **100%, 0 violations** — locally and in CI.

### Correction: the template-conformance gate did not verify this change

An earlier revision of this description said CI would be the authority for `test_template_conformance.py`. **That was wrong, and the correction matters more than the original claim.**

That test does not run in CI either. It loud-skips there for the same reason it does locally — copier's filtered clone cannot resolve the template tag:

```
SKIPPED tests/test_template_conformance.py:466:
  template-conformance gate: pristine render FAILED — SKIPPED, not a pass.
  rc=1 missing=['src/markdown_vault_mcp/config.py', 'src/markdown_vault_mcp/server.py',
                'src/markdown_vault_mcp/_server_deps.py', 'src/markdown_vault_mcp/_server_apps.py',
                'src/markdown_vault_mcp/__init__.py', 'src/markdown_vault_mcp/cli.py',
                'README.md', '.github/workflows/ci.yml']

Command line: git -c core.fsmonitor=false checkout -f v5.6.3
Stderr: fatal: git upload-pack: not our ref 01d76ab1679b0e6cdd93c757afdd15fca55d964b
        fatal: could not fetch 7f245c5dc4b91fe2535e39e054a15b9073a02a03 from promisor remote
```

The extra skips in CI's `27` against `15` locally are those cases. The test behaves as designed — it refuses to report a pass it did not earn — but the consequence is that **nothing currently verifies template conformance on any pull request**, and this PR moves four files inside that test's comparison set (`README.md`, `__init__.py`, `cli.py`, `server.py`).

What is verified here instead: every carrier of `domain_description` was enumerated with `git grep` against the tracked tree and each one changed, so the answer and its rendered sites are consistent by construction rather than by the gate. That is weaker evidence, and worth knowing when reviewing.

This is a pre-existing condition, not something this change introduced. It is not fixed here.