### PR TITLE
fix(tests): make the template-conformance gate actually render

### DIFF
--- a/tests/test_template_conformance.py
+++ b/tests/test_template_conformance.py
@@ -259,16 +259,40 @@ def _answers() -> dict:
     return yaml.safe_load(ANSWERS.read_text())
 
 
+def _is_partial_clone(repo: Path) -> bool:
+    """Whether *repo* is a partial (blobless/treeless) clone.
+
+    Such a checkout cannot serve the blobs copier needs — see
+    :func:`_template_git_dir` — so it is skipped in favour of a full clone.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "config", "--get", "remote.origin.promisor"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout.strip() == "true"
+
+
 def _template_git_dir(tmp_path_factory: pytest.TempPathFactory, src_url: str) -> Path:
     """A local git checkout of the template — the sibling checkout if present
-    (offline-friendly), else a blobless clone of ``_src_path``.
+    (offline-friendly), else a full clone of ``_src_path``.
 
-    When no sibling checkout exists the clone needs network. Probe the remote
+    The clone must carry blobs. copier is pointed at whatever this returns and
+    clones *from* it before checking out the ref; cloning from a blobless
+    partial clone yields a repo with no blobs and no promisor remote to fetch
+    them from, so the checkout half-succeeds — tree entries appear, file
+    contents do not — and every watched file reads as missing (#1190). The
+    whole template is a few MB, so filtering saved nothing to begin with. For
+    the same reason a sibling checkout that is itself partial is unusable, and
+    is passed over in favour of the clone below.
+
+    When no sibling checkout is used the clone needs network. Probe the remote
     first with a short timeout so an offline environment skips in seconds
     (loudly) instead of stalling on the multi-minute clone/fetch timeouts.
     """
     local = REPO_ROOT.parent / "fastmcp-server-template"
-    if (local / ".git").is_dir():
+    if (local / ".git").is_dir() and not _is_partial_clone(local):
         return local
     dest = tmp_path_factory.mktemp("template")
     try:
@@ -280,7 +304,7 @@ def _template_git_dir(tmp_path_factory: pytest.TempPathFactory, src_url: str) ->
             timeout=15,
         )
         subprocess.run(
-            ["git", "clone", "--filter=blob:none", src_url, str(dest)],
+            ["git", "clone", src_url, str(dest)],
             check=True,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Closes / Refs

Closes #1190

Inserted before the template v6.0.0 migration, which changes all eight files in this gate's comparison set and was to use it as its principal review evidence. #1183, #1185 and #1188 are merged.

## What & why

The gate reported `pristine render FAILED — SKIPPED, not a pass` on **every** run, in CI and locally alike, listing every watched file as missing. The suite went green while nothing verified that template-owned files match the pristine render.

`_template_git_dir` cloned the template with `--filter=blob:none`. copier is then pointed at that clone and clones *from* it before checking out the ref — and cloning from a blobless partial clone yields a repository with no blobs **and no promisor remote** to fetch them from. The checkout half-succeeds: tree entries appear, file contents do not, so every watched file reads as missing.

Measured against the real remote, cloning each result a second time the way copier does and running `git checkout -f v5.6.3`:

| clone of the template | `remote.origin.promisor` | checkout | files | a known blob readable |
|---|---|---|---|---|
| `--filter=blob:none` (before) | true | **exit 1** | 157 | **no** |
| no filter (after) | absent | exit 0 | 210 | yes |

The template's entire `.git` is **3.0 MB** — the filter saved nothing and broke the gate.

**Two changes, one file:**

1. **Drop the filter.** This is the fix.
2. **Pass over a partial sibling checkout.** The same function prefers a sibling at `REPO_ROOT.parent / "fastmcp-server-template"`; one that is itself blobless reaches the identical failure through the other branch. Not hypothetical — the environment this was diagnosed in has exactly that (`remote.origin.promisor=true`, `partialclonefilter=blob:none`). A small deliberate addition rather than silent scope creep: without it the gate stays broken for anyone whose sibling checkout is partial.

## What this PR deliberately does NOT do

- **Does not change what the gate compares**, how it normalises, or its file set. The gate's semantics are untouched; only its ability to obtain a render changes.
- **Does not change the loud-skip behaviour.** Skipping rather than passing when a render genuinely cannot be produced is correct and stays — offline environments still skip loudly.
- **Nothing upstream.** `tests/test_template_conformance.py` exists in neither v5.6.3 nor v6.0.0 of the template, so it is project-owned and there is nothing to send to `fastmcp-server-template`. It also means `copier update` will not overwrite this fix, so the working gate will be live for the migration PR.

## Local review

- [x] Ran a local code-review pass on the diff before opening the PR. One file, +29/−5.
- [x] No commit carries `!`. `fix:` is deliberate: this repairs a defect in a check that silently verified nothing, and cutting a patch release is the honest description of restoring a broken gate.

## Docs impact

- [ ] `README.md` — not affected
- [ ] `docs/` site pages — not affected
- [ ] `docs/design/` — not affected; no behaviour of the server changes
- [x] Inline docstrings — `_template_git_dir`'s docstring now states why the clone must carry blobs, and the new `_is_partial_clone` helper is documented

## Verification

**The acceptance test is that the gate stops skipping and starts asserting — and can still fail.**

| state | result |
|---|---|
| before the fix | 10 passed, **9 skipped** — never asserting |
| after the fix | **19 passed, 0 skipped** |
| after the fix, with a template-owned file perturbed | **1 failed**, 18 passed |

The third row is the one that matters. Adding a line to `src/markdown_vault_mcp/cli.py` outside any sentinel makes the gate fail, naming the file and the offending line:

```
FAILED tests/test_template_conformance.py::test_template_owned_file_conforms[cli.py]
assert (1, '# deliberate perturbation to prove the gate can fail', 'app = typer.Typer(') is None
```

A gate that cannot fail is not a gate; this one now can. The perturbation was reverted.

- Full suite: **3557 passed, 6 skipped** — up from 3548 passed / 15 skipped, exactly the nine conformance skips converting to passes. The six remaining skips are all environment-gated (3.13 `recurse_symlinks`, root chmod, no domain wizard tests yet).
- `ruff check`, `ruff format --check`, `mypy src/ tests/`: clean (192 source files).
- Structural gate against `origin/main`: **100%, 0 violations** over 29 changed lines.

**Watch CI on this one specifically.** The sandbox and the runner previously failed for the same reason, so a local pass is good evidence but not proof for CI. The check to make is the conformance *skip reason* in the `Test` job log, not merely a green job — a green `Test` job is exactly what concealed this for however long it has been broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZSRMrP8BnFjJh2xdhcZf8)_