### PR TITLE
fix(ci): let @claude review actually run a review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,11 +36,31 @@ jobs:
         with:
           fetch-depth: 1
 
+      # LOCAL WORKAROUND (#1193, upstream fastmcp-server-template#535) — see the
+      # claude_args comment below for why. Mirrors the pin the removed
+      # claude-code-review.yml carried: Claude Code >= 2.1.198 dispatches
+      # subagents as background tasks and claude-code-action breaks its query()
+      # loop on the first result, so a granted Task would be orphaned and the
+      # run would still finish green with nothing posted
+      # (claude-code-action#1499). 2.1.197 is the last synchronous-subagent
+      # release. Remove this step, path_to_claude_code_executable, and the
+      # extra grants below once a template release carries the upstream fix.
+      - name: Install pinned Claude Code (2.1.197, pre-background-subagents)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.197
+          BIN="$HOME/.local/bin/claude"
+          test -x "$BIN"
+          "$BIN" --version
+          echo "CLAUDE_BIN=$BIN" >> "$GITHUB_ENV"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the pinned 2.1.197 CLI installed above (skips the action's own).
+          path_to_claude_code_executable: ${{ env.CLAUDE_BIN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -58,13 +78,33 @@ jobs:
           # ADD to the action's defaults (Edit/Write/git stay available), but
           # `contents: read` above is what keeps this workflow from committing.
           #
-          # Task/Agent is deliberately NOT granted: under claude-code-action,
-          # Claude Code >= 2.1.198 runs subagents as background tasks and the
-          # action breaks its query() loop on the first result, so a subagent
-          # still running when @claude finishes is silently orphaned — its work
-          # is lost with no error (claude-code-action#1499, intermittent per
-          # #1515). Keeping @claude single-agent avoids that footgun. Restore
-          # Task once #1499 is fixed upstream.
+          # LOCAL WORKAROUND (#1193, upstream fastmcp-server-template#535).
+          # Everything after `Bash(gh api *)` on the grant line, and the CLI pin
+          # step above, is local — the template's rendered claude.yml has
+          # neither, and `copier update` will overwrite both. Remove them once a
+          # template release carries the upstream fix.
+          #
+          # Upstream dropped Task here in template#320 to keep @claude
+          # single-agent, on the reasoning that the heavy /code-review fan-out
+          # lived in claude-code-review.yml. Since template v6.0.0 that workflow
+          # renders only when automatic review is enabled, and it is not here —
+          # so this file is the only review path, while `Skill` (still granted)
+          # lets it launch the code-review skill whose fan-out Task denial then
+          # stalls the run: 51 denials in 6 turns, green, nothing posted.
+          #
+          # Restored to match what the removed review workflow proved:
+          #   Task ................ dispatch the skill's review subagents
+          #                         (template#312 / #313)
+          #   gh pr diff/view ..... establish the review range; the skill's
+          #   gh run view/list      first step needs a diff and no `git` read
+          #                         command is granted here
+          #   uv run pytest/mypy/ruff
+          #                       . targeted verification of a single finding
+          #                         (REVIEW.md: never the full gate). No venv
+          #                         setup step: `uv run` provisions on demand,
+          #                         so ordinary @claude mentions pay nothing.
+          # Subagents inherit this same curated set under `contents: read`, so
+          # Task grants delegation, not new capability.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           claude_args: |
-            --allowedTools "Skill,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,mcp__github_ci__*,mcp__github_inline_comment__*,Bash(gh api *)"
+            --allowedTools "Skill,Task,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,mcp__github_ci__*,mcp__github_inline_comment__*,Bash(gh api *),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"


### PR DESCRIPTION
## Closes / Refs

Closes #1193. Upstream: pvliesdonk/fastmcp-server-template#535.

Targets `main` ahead of #1192 so that PR can rebase onto it and get a real review.

## What & why

`@claude review` on #1192 finished **green and posted nothing** — 51 permission denials in 6 turns, tracking comment frozen at step 1 of 6, $9.52 spent. A green job under a "Claude finished" header is indistinguishable from a clean review, which is the dangerous part.

Template v6.0.0 makes automatic review opt-in and off by default, so `claude-code-review.yml` is no longer rendered and `claude.yml` is this repository's only review path — carrying none of the configuration that made reviewing work. Upstream dropped `Task` from `claude.yml` in fastmcp-server-template#320 to keep `@claude` single-agent, on the reasoning that the heavy `/code-review` fan-out lived in the review workflow. That workflow is now gone, while `Skill` stays granted — so the responder launches the review skill and is then denied the `Task` dispatches the skill is built on.

This restores, in `claude.yml`, what the removed review workflow had proved:

| restored | why | prior art |
|---|---|---|
| `Task` | dispatch the review skill's subagents | fastmcp-server-template#312 → #313 |
| CLI pinned to 2.1.197 | ≥ 2.1.198 runs subagents as background tasks that the action orphans, so a granted `Task` alone would still finish green with nothing posted | fastmcp-server-template#319 → #320, claude-code-action#1499 |
| `gh pr diff` / `gh pr view` / `gh run view` / `gh run list` | the skill's first step establishes its range from a diff, and no `git` read command is granted here — only the write-side `git add`/`commit`/`rm` the action adds | — |
| `uv run pytest` / `mypy` / `ruff` (scoped) | verifying a single finding; `REVIEW.md` forbids re-running the full gate | — |

The grant set is byte-for-byte the removed workflow's **minus `Bash(gh pr comment:*)`**: the responder posts through `mcp__github_comment__update_claude_comment` and the inline-comment server, so it does not need it. Subagents inherit the same curated set under `contents: read`, so `Task` grants delegation, not new capability.

## What this PR deliberately does NOT do

- **Does not add a `setup-project-env` step.** The removed review workflow had one so its `uv run` checks had a venv. Adding it here would make *every* `@claude` mention — including one-line questions — pay a dependency sync. `uv run` provisions on demand instead, so the capability is there when a review wants it and costs nothing otherwise. This is the one place this PR deviates from the configuration it is restoring.
- **Does not fix this upstream.** `claude.yml` is template-owned and `copier update` re-renders it, so this is a workaround with a shelf life, not a fix. The durable change is fastmcp-server-template#535; #1193 tracks reverting this once a template release carries it. Both the pin step and the added grants are marked `LOCAL WORKAROUND` in place so they are easy to find and drop.
- **Does not change `ci.yml` or any required check.** Nothing about the merge gate moves.
- **Does not verify the fix end to end.** A workflow change only takes effect once merged to the default branch, since `issue_comment` runs the workflow from `main`. The acceptance test is the next `@claude review` — see below.

## Verification

Static only, by nature — this cannot be exercised before it is on `main`:

- YAML parses; step order is `Checkout` → `Install pinned Claude Code` → `Run Claude Code`.
- Grant line diffed against the removed `claude-code-review.yml`: the only difference is the deliberate `gh pr comment` omission.
- `tests/test_release_flow_contract.py`, `test_structural_gate.py`, `test_template_conformance.py` (the three suites that read `.github/workflows/`): 88 passed.
- `pre-commit run --all-files`: all hooks pass, including `check yaml` and Vale.
- Nothing in `tests/` or `scripts/` asserts on `claude.yml`'s contents.

**After merge, the acceptance test is a real `@claude review` on #1192 that posts findings.** If it again finishes green and empty, this diagnosis is wrong and #1193 should stay open.

## Docs impact

- [ ] `README.md` — not affected
- [ ] `docs/` site pages — not affected
- [ ] `docs/design/` — not affected; no server behaviour changes
- [ ] Inline docstrings — no code changes

The reasoning lives in `claude.yml` itself, next to each restored grant, which is where someone removing the workaround will look.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZSRMrP8BnFjJh2xdhcZf8)_