### PR TITLE
fix(okf): give generated reserved files the frontmatter the index gate requires

### DIFF
--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -411,6 +411,43 @@ not ongoing enforcement) but are write tools and respect read-only mode. Each is
 registered per the Tool Registration Checklist, with `destructiveHint` /
 `idempotentHint` reflecting that they mutate the vault.
 
+### Generated reserved files and the index gate
+
+The generated `index.md` / `log.md` are subject to the same
+`required_frontmatter` gate as any other note, so a body-only reserved file is
+a deterministic `missing_frontmatter` skip on a vault that configures one — the
+server generating a file its own indexer then rejects (#1174, #1175). Two
+second-order effects follow: the bundle's change history disappears from
+`search` and `list_documents` while staying readable from disk, and a folder
+whose only indexed file would have been its generated `index.md` loses its
+pointer in the parent listing, because `generate_index` synthesises sub-folder
+pointers from index entries.
+
+`ReservedFrontmatterPolicy` (`okf.py`) is the single owner of what those files
+carry. Both generators and the `OKF_WRITE` maintainer write through it:
+
+- **Conditional, not unconditional.** With no required fields configured a
+  reserved file needs no frontmatter to be indexed, and the policy returns
+  `None` so the generators keep emitting the body-only files existing bundles
+  already have on disk. Closing the defect costs an unaffected vault no churn
+  — and, on a git vault, no commits.
+- **Existing keys win.** A hand-authored title and the root `index.md`'s
+  `okf_version` declaration survive regeneration; only genuinely absent
+  required fields are added.
+- **`title_field` gets the derived title** (the same H1 the body builders
+  emit); any other required field is seeded as `null`, since the gate tests
+  presence rather than value and the server has nothing truthful to put there.
+- **`okf_version` is never synthesized.** The audit flags it on any file but
+  the bundle root as `misplaced`, so seeding it into a folder's index would
+  trade one defect for another.
+
+The `OKF_WRITE` maintainer needs this for a second reason: `_append_log` is a
+read-modify-write and `DocumentManager.read` returns the body without
+frontmatter, so the log's frontmatter has to be carried across the rewrite
+explicitly. Since the maintainer runs after *every* content write, the
+alternative is not a one-time gap but frontmatter stripped again after each
+save — including frontmatter an operator seeded by hand.
+
 ### Export
 
 Export ships **not as a bespoke tool but as an overloaded download ref** on

--- a/docs/guides/okf.md
+++ b/docs/guides/okf.md
@@ -85,6 +85,12 @@ Three tools handle the changes you should not make by hand. They are write tools
 - **`okf_generate_index`** writes a folder's `index.md` as a listing of the notes directly in that folder, plus a pointer into each subfolder's own `index.md`. It draws the description from each note's frontmatter and lists one level at a time, so a nested bundle stays navigable rather than flattening into one long page. It preserves existing frontmatter, so regenerating the root `index.md` keeps your `okf_version` declaration.
 - **`okf_seed_log`** creates a `log.md` change history from the vault's git commits, newest first. The `folder` argument both places the log and scopes its content: seeding a folder includes only the commits that touched that subtree, while seeding the bundle root includes the whole vault's history. It refuses to overwrite an existing `log.md`, so a hand-maintained history is safe.
 
+### Reserved files on a vault with required fields
+
+If you set `MARKDOWN_VAULT_MCP_REQUIRED_FIELDS`, documents missing any listed field are excluded from the index. The generated `index.md` and `log.md` are ordinary documents to the indexer, so the generators give them the fields your vault requires. Your title field is filled in from the file's heading; any other required field is written empty, for you to complete. Without this the bundle's own listing and change history would be absent from `search` and `list_documents` while still opening through `read`.
+
+Anything already in the file wins, so a title you wrote yourself and the root `index.md`'s `okf_version` declaration are left alone. On a vault that sets no required fields nothing changes: the reserved files carry no frontmatter, exactly as before.
+
 ## The enforced write layer
 
 The steps above keep a bundle conformant by convention. The enforced write layer makes the server keep two of those fields correct on its own. Turn it on by setting `MARKDOWN_VAULT_MCP_OKF_WRITE=true`. It requires `OKF_MODE` to be `auto` or `on`; pairing it with `OKF_MODE=off` is a configuration error, since there is nothing to enforce. When the flag is off the write path is untouched, so an ordinary vault behaves exactly as before.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -482,17 +482,17 @@ Rewrite `[[wikilinks]]` as the bundle-root-absolute markdown links OKF recommend
 
 #### `okf_generate_index`
 
-Generate (or overwrite) a folder's reserved `index.md` as a progressive-disclosure listing: `- [title](/path.md) - description` for each note directly in the folder, plus a pointer into each immediate subfolder's own `index.md`. Descriptions are drawn from frontmatter. The listing is one level deep (it does not flatten the subtree). Existing frontmatter is preserved, so regenerating the bundle-root `index.md` keeps its `okf_version` declaration. Reserved files are omitted.
+Generate (or overwrite) a folder's reserved `index.md` as a progressive-disclosure listing: `- [title](/path.md) - description` for each note directly in the folder, plus a pointer into each immediate subfolder's own `index.md`. Descriptions are drawn from frontmatter. The listing is one level deep (it does not flatten the subtree). Existing frontmatter is preserved, so regenerating the bundle-root `index.md` keeps its `okf_version` declaration. Reserved files are omitted. When the vault sets `REQUIRED_FIELDS`, any required field the file lacks is added, so the generated listing is not itself excluded from the index.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `folder` | string | Folder to index; omit for the bundle root |
 
-**Returns:** `path` (string), `entries` (integer), `frontmatter_preserved` (bool).
+**Returns:** `path` (string), `entries` (integer), `frontmatter_preserved` (bool). `frontmatter_preserved` reports whether frontmatter already on the file was carried over. A file that had none can still be written with required fields added.
 
 #### `okf_seed_log`
 
-Seed a folder's reserved `log.md` change history from the vault's git commit history, newest-first `## YYYY-MM-DD` sections, one bullet per commit. The `folder` argument both places the log and scopes its content: a folder seeds only the commits that touched that subtree, while the bundle root seeds the whole vault's history. Refuses to overwrite an existing `log.md` (a change history is hand-maintained after seeding).
+Seed a folder's reserved `log.md` change history from the vault's git commit history, newest-first `## YYYY-MM-DD` sections, one bullet per commit. The `folder` argument both places the log and scopes its content: a folder seeds only the commits that touched that subtree, while the bundle root seeds the whole vault's history. Refuses to overwrite an existing `log.md` (a change history is hand-maintained after seeding). When the vault sets `REQUIRED_FIELDS`, the seeded log carries those fields, so the bundle's own history is not excluded from the index.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,6 +265,10 @@ ignore = ["E501"]
 # logic. Same gate-only mechanism as scanner.py above (PLR0913 isn't in the
 # base select, so an inline `# noqa` would be stripped as unused, RUF100).
 "src/markdown_vault_mcp/_okf_convention.py" = ["PLR0913"]
+# OkfMigrationManager is the same shape: six injected collaborators (doc/link/
+# search/git-query managers + the readiness gate + the reserved-frontmatter
+# policy), no logic. Same gate-only mechanism as _okf_convention.py above.
+"src/markdown_vault_mcp/managers/okf_migrate.py" = ["PLR0913"]
 # Test fixtures import vault/protocol types only used in annotations.
 "tests/conftest.py" = ["TC002", "TC003"]
 # _install_fake_openai's keyword-only scenario toggles (content/refusal/

--- a/src/markdown_vault_mcp/_okf_convention.py
+++ b/src/markdown_vault_mcp/_okf_convention.py
@@ -24,7 +24,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from markdown_vault_mcp._okf_write import current_okf_intent, okf_write_suppressed
-from markdown_vault_mcp.okf import OKF_RESERVED_FILENAMES, append_okf_log_entry
+from markdown_vault_mcp.okf import (
+    OKF_LOG_TITLE,
+    OKF_RESERVED_FILENAMES,
+    ReservedFrontmatterPolicy,
+    append_okf_log_entry,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -53,6 +58,7 @@ class ConventionMaintainer:
         sync_index: Callable[[], object],
         write_lock: AbstractContextManager[object] | None = None,
         today: Callable[[], date] = date.today,
+        reserved_frontmatter: ReservedFrontmatterPolicy | None = None,
     ) -> None:
         """Hold the collaborators the secondary writes delegate to.
 
@@ -73,6 +79,10 @@ class ConventionMaintainer:
                 ``None`` (tests) serialises nothing.
             today: Date provider (injectable for tests); defaults to
                 :meth:`datetime.date.today`.
+            reserved_frontmatter: Frontmatter policy for the maintained
+                ``log.md``, so the log this maintainer rewrites on every
+                enforced write satisfies the vault's own index gate (#1174).
+                Defaults to the no-required-fields policy.
         """
         self._doc_mgr = doc_mgr
         self._okf_migrate = okf_migrate
@@ -82,6 +92,7 @@ class ConventionMaintainer:
             write_lock if write_lock is not None else nullcontext()
         )
         self._today = today
+        self._reserved_frontmatter = reserved_frontmatter or ReservedFrontmatterPolicy()
 
     def maintain(self, path: str, operation: WriteOperation) -> None:
         """Refresh the written note's folder ``log.md`` and ``index.md``.
@@ -119,7 +130,13 @@ class ConventionMaintainer:
         return "" if parent == "." else parent
 
     def _append_log(self, folder: str, path: str, operation: WriteOperation) -> None:
-        """Append a dated ``**Update**`` bullet to the folder's ``log.md``."""
+        """Append a dated ``**Update**`` bullet to the folder's ``log.md``.
+
+        The read-modify-write splits frontmatter from body: ``read()`` hands
+        back the body alone, so the log's frontmatter has to be carried over
+        explicitly or the rewrite would strip it — including frontmatter an
+        operator seeded by hand to satisfy ``required_frontmatter`` (#1174).
+        """
         log_path = f"{folder}/log.md" if folder else "log.md"
         verb = _OPERATION_VERB.get(operation, operation)
         summary = f"**Update**: {verb} `{path}`"
@@ -134,7 +151,15 @@ class ConventionMaintainer:
                 new_text = append_okf_log_entry(
                     text, date=self._today().isoformat(), summary=summary
                 )
-                self._doc_mgr.write(log_path, new_text, allow_overwrite=True)
+                self._doc_mgr.write(
+                    log_path,
+                    new_text,
+                    frontmatter=self._reserved_frontmatter.build(
+                        existing.frontmatter if existing is not None else None,
+                        title=OKF_LOG_TITLE,
+                    ),
+                    allow_overwrite=True,
+                )
         except Exception:
             logger.warning("okf_convention_log_failed path=%s", log_path, exc_info=True)
 

--- a/src/markdown_vault_mcp/managers/okf_migrate.py
+++ b/src/markdown_vault_mcp/managers/okf_migrate.py
@@ -13,6 +13,11 @@ dirtying, and the git-commit callback all come for free):
   frontmatter (notably the root ``okf_version`` declaration).
 - :meth:`seed_log` seeds a reserved ``log.md`` change history from git.
 
+Both generators write through the vault's
+:class:`~markdown_vault_mcp.okf.ReservedFrontmatterPolicy`, so the reserved
+files they produce carry the frontmatter the vault's own index gate requires
+(#1174, #1175).
+
 These are write tools gated on read-only mode only, not on a future
 ``OKF_WRITE`` flag (design §7): they are deliberate migrations, not ongoing
 enforcement.
@@ -24,10 +29,13 @@ import logging
 from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.okf import (
+    OKF_LOG_TITLE,
     OKF_RESERVED_FILENAMES,
+    OKF_ROOT_INDEX_TITLE,
     OkfConvertResult,
     OkfIndexResult,
     OkfLogResult,
+    ReservedFrontmatterPolicy,
     build_index_markdown,
     build_log_markdown,
     convert_wikilinks_to_markdown,
@@ -56,6 +64,7 @@ class OkfMigrationManager:
         search_mgr: SearchManager,
         git_query_mgr: GitQueryManager,
         require_built: Callable[[], None],
+        reserved_frontmatter: ReservedFrontmatterPolicy | None = None,
     ) -> None:
         """Hold the collaborators the transforms delegate to.
 
@@ -68,12 +77,17 @@ class OkfMigrationManager:
             git_query_mgr: Vault-wide history for the log seeder.
             require_built: Index-readiness gate; the link/TOC-dependent
                 transforms call it first.
+            reserved_frontmatter: Frontmatter policy for the generated
+                reserved files, so they satisfy the vault's own index gate
+                (#1174, #1175). Defaults to the no-required-fields policy,
+                which writes frontmatter only where one already exists.
         """
         self._doc_mgr = doc_mgr
         self._link_mgr = link_mgr
         self._search_mgr = search_mgr
         self._git_query_mgr = git_query_mgr
         self._require_built = require_built
+        self._reserved_frontmatter = reserved_frontmatter or ReservedFrontmatterPolicy()
 
     def convert_links(self, *, folder: str | None = None) -> OkfConvertResult:
         """Rewrite resolvable wikilinks as root-absolute markdown links.
@@ -128,7 +142,9 @@ class OkfMigrationManager:
         subfolder's own ``index.md`` — it does not flatten the whole
         subtree, so each level defers depth to the level below. Existing
         frontmatter is preserved (the root ``index.md``'s ``okf_version``
-        declaration must survive regeneration).
+        declaration must survive regeneration), and any field the vault
+        requires but the file lacks is seeded, so a freshly generated index
+        is not itself excluded from the index that produced it (#1175).
 
         Args:
             folder: Vault-relative folder (``""`` for the bundle root).
@@ -179,12 +195,14 @@ class OkfMigrationManager:
         existing = self._doc_mgr.read(index_path)
         existing_fm = existing.frontmatter if existing is not None else None
         preserved = bool(existing_fm)
-        heading = folder.rsplit("/", 1)[-1] if folder else "Index"
+        heading = folder.rsplit("/", 1)[-1] if folder else OKF_ROOT_INDEX_TITLE
         body = build_index_markdown(heading, entries)
         self._doc_mgr.write(
             index_path,
             body,
-            frontmatter=existing_fm if preserved else None,
+            frontmatter=self._reserved_frontmatter.build(
+                existing_fm if preserved else None, title=heading
+            ),
             allow_overwrite=True,
         )
         return OkfIndexResult(
@@ -202,6 +220,10 @@ class OkfMigrationManager:
         content: a folder seeds only the commits that touched that subtree,
         while the bundle root (``folder=""``) seeds the whole bundle's history
         (#974).
+
+        The seeded file carries whatever frontmatter the vault requires, so
+        the bundle's own change history is not excluded from ``search`` and
+        ``list_documents`` by the gate this server enforces (#1174).
 
         Args:
             folder: Vault-relative folder (``""`` for the bundle root).
@@ -228,5 +250,9 @@ class OkfMigrationManager:
         # falls back to whole-vault history via path=None.
         history = self._git_query_mgr.get_history(path=folder or None, limit=limit)
         body, commits, dates = build_log_markdown(history)
-        self._doc_mgr.write(log_path, body)
+        self._doc_mgr.write(
+            log_path,
+            body,
+            frontmatter=self._reserved_frontmatter.build(None, title=OKF_LOG_TITLE),
+        )
         return OkfLogResult(path=log_path, commits=commits, dates=dates)

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -29,6 +29,7 @@ import frontmatter as fm
 import yaml
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,15 @@ _HUMAN_ACTOR_PREFIX = "human:"
 #: phase 1 — staged for the conformance audit (#962: reserved files are
 #: exempt from the ``type`` rule) and ranking downweights (#965).
 OKF_RESERVED_FILENAMES: tuple[str, ...] = ("index.md", "log.md")
+
+#: H1 heading, and title, of a generated ``log.md``. Shared by the two body
+#: builders and the reserved-frontmatter policy so the heading a reader sees
+#: and the title the index resolves cannot drift apart.
+OKF_LOG_TITLE = "Log"
+
+#: H1 heading, and title, of a generated bundle-root ``index.md``. A folder's
+#: index uses the folder name instead.
+OKF_ROOT_INDEX_TITLE = "Index"
 
 #: Ranking downweight factors (design §5, #965), applied only under detection.
 #: Multiplicative on a hit's score and composed so the ordering
@@ -625,7 +635,16 @@ class OkfConvertResult:
 
 @dataclass(frozen=True)
 class OkfIndexResult:
-    """Result of generating a reserved ``index.md`` listing (#963)."""
+    """Result of generating a reserved ``index.md`` listing (#963).
+
+    Attributes:
+        path: Vault-relative path of the generated listing.
+        entries: Notes and sub-folder pointers listed.
+        frontmatter_preserved: Whether frontmatter already on the file was
+            carried over. Not "the file has frontmatter": a file that had
+            none is still written with the vault's required fields seeded
+            (#1175), which reports ``False`` here.
+    """
 
     path: str
     entries: int
@@ -697,6 +716,69 @@ def convert_wikilinks_to_markdown(content: str, outlinks: Any) -> tuple[str, int
     return content, converted, skipped
 
 
+@dataclass(frozen=True)
+class ReservedFrontmatterPolicy:
+    """Frontmatter the server's own generated reserved files must carry.
+
+    ``index.md`` and ``log.md`` are written by the server, but the index gate
+    is configured by the operator: with ``required_frontmatter`` set, a
+    generated file carrying no frontmatter is a deterministic
+    ``missing_frontmatter`` skip, so the bundle's own navigation and change
+    history disappear from ``search`` and ``list_documents`` while staying
+    readable from disk (#1174, #1175). The generators consult this policy so
+    what they write satisfies the gate the same server enforces.
+
+    The policy is deliberately *conditional*. With no required fields
+    configured a reserved file needs no frontmatter to be indexed, and
+    :meth:`build` returns ``None`` so the generators keep emitting the
+    body-only files every existing vault already has on disk — closing the
+    defect costs an unconfigured vault no churn.
+
+    Attributes:
+        title_field: The frontmatter key the indexer resolves titles from.
+            The one required field given a derived value rather than a
+            placeholder, since the server knows the title it just wrote.
+        required_fields: The vault's configured ``required_frontmatter``.
+    """
+
+    title_field: str = "title"
+    required_fields: tuple[str, ...] = ()
+
+    def build(
+        self, existing: Mapping[str, Any] | None, *, title: str
+    ) -> dict[str, Any] | None:
+        """Build the frontmatter for a generated reserved file.
+
+        Existing keys always win, so a hand-authored title and the root
+        ``index.md``'s ``okf_version`` declaration survive regeneration
+        untouched and only genuinely absent required fields are added. A
+        required field other than *title_field* is seeded as ``None``: the
+        gate tests presence rather than value
+        (:func:`~markdown_vault_mcp.scanner.parse_note_categorized`), and the
+        server has nothing truthful to put there.
+
+        ``okf_version`` is never synthesized. The conformance audit flags it
+        on any file but the bundle root as ``misplaced``, so seeding it into
+        a folder's generated index would trade one defect for another.
+
+        Args:
+            existing: The file's current frontmatter, or ``None`` when the
+                file does not exist yet or carries none.
+            title: Title for *title_field*, matching the H1 heading the body
+                builders emit for the same file.
+
+        Returns:
+            The frontmatter mapping to write, or ``None`` when the file needs
+            no frontmatter at all.
+        """
+        merged: dict[str, Any] = dict(existing or {})
+        for field in self.required_fields:
+            if field in merged:
+                continue
+            merged[field] = title if field == self.title_field else None
+        return merged or None
+
+
 def build_index_markdown(
     heading: str, entries: list[tuple[str, str, str | None]]
 ) -> str:
@@ -743,7 +825,8 @@ def build_log_markdown(entries: Any) -> tuple[str, int, int]:
         block = [f"## {date}", ""]
         block.extend(f"- **{c.message}** ({c.short_sha})" for c in by_date[date])
         sections.append("\n".join(block))
-    body = "# Log\n\n" + "\n\n".join(sections) + "\n" if sections else "# Log\n"
+    header = f"# {OKF_LOG_TITLE}"
+    body = f"{header}\n\n" + "\n\n".join(sections) + "\n" if sections else f"{header}\n"
     return body, sum(len(v) for v in by_date.values()), len(order)
 
 
@@ -776,7 +859,7 @@ def append_okf_log_entry(text: str | None, *, date: str, summary: str) -> str:
     heading = f"## {date}"
     bullet = f"- {summary}"
     if not text or not text.strip():
-        return f"# Log\n\n{heading}\n\n{bullet}\n"
+        return f"# {OKF_LOG_TITLE}\n\n{heading}\n\n{bullet}\n"
     lines = text.splitlines()
     first = next((i for i, line in enumerate(lines) if line.startswith("## ")), None)
     if first is not None and lines[first].strip() == heading:

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -26,6 +26,7 @@ from markdown_vault_mcp.okf import (
     OKF_INDEXED_FIELDS,
     OkfAuditReport,
     OkfDetector,
+    ReservedFrontmatterPolicy,
     audit_bundle,
 )
 from markdown_vault_mcp.scanner import (
@@ -531,12 +532,20 @@ class Vault:
             require_built=self._require_built,
             okf_audit=self._okf_audit,
         )
+        # The reserved files the OKF generators write are subject to this
+        # vault's own required-frontmatter gate, so the generators need the
+        # gate's terms to produce files that survive it (#1174, #1175).
+        reserved_frontmatter = ReservedFrontmatterPolicy(
+            title_field=self._title_field,
+            required_fields=tuple(self._required_frontmatter or ()),
+        )
         self._okf_migrate = OkfMigrationManager(
             doc_mgr=self._doc_mgr,
             link_mgr=self._link_mgr,
             search_mgr=self._search_mgr,
             git_query_mgr=self._git_query_mgr,
             require_built=self._require_built,
+            reserved_frontmatter=reserved_frontmatter,
         )
         # OKF enforced-write convention maintenance (#964, phase 5b): built only
         # under OKF_WRITE (mirroring the enricher gating). On a successful
@@ -554,6 +563,7 @@ class Vault:
                     timeout=_CONVENTION_DRAIN_TIMEOUT
                 ),
                 write_lock=self._file_write_lock,
+                reserved_frontmatter=reserved_frontmatter,
             )
         self._writer_facet = WriterFacet(
             self._doc_mgr,

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -19,6 +19,7 @@ from markdown_vault_mcp.okf import (
     TRUST_MACHINE,
     TRUST_UNVERIFIED,
     OkfDetector,
+    ReservedFrontmatterPolicy,
     derive_annotation,
     derive_stale,
     derive_trust_tier,
@@ -880,3 +881,68 @@ class TestAppendOkfLogEntry:
 
         out = append_okf_log_entry("# Log\n", date="2026-08-09", summary="x")
         assert out == "# Log\n\n## 2026-08-09\n\n- x\n"
+
+
+class TestReservedFrontmatterPolicy:
+    """The gate the generated reserved files must survive (#1174, #1175).
+
+    ``index.md`` and ``log.md`` are written by the server, but
+    ``required_frontmatter`` is set by the operator — so without this policy
+    the server generates files its own indexer then skips as
+    ``missing_frontmatter``.
+    """
+
+    def test_unconfigured_vault_gets_no_frontmatter(self) -> None:
+        """No required fields → body-only files, exactly as before the fix.
+
+        Closing the defect must cost a vault that never had it any churn: a
+        frontmatter block on every generated file would rewrite (and, on a
+        git vault, commit) the reserved files of every existing bundle.
+        """
+        assert ReservedFrontmatterPolicy().build(None, title="Log") is None
+
+    def test_existing_frontmatter_is_preserved_unconfigured(self) -> None:
+        """Preservation does not depend on a required field being configured."""
+        policy = ReservedFrontmatterPolicy()
+        assert policy.build({"okf_version": "0.2"}, title="Index") == {
+            "okf_version": "0.2"
+        }
+
+    def test_title_field_is_seeded_with_the_derived_title(self) -> None:
+        policy = ReservedFrontmatterPolicy(required_fields=("title",))
+        assert policy.build(None, title="Log") == {"title": "Log"}
+
+    def test_other_required_fields_are_seeded_as_null(self) -> None:
+        """The gate tests presence, not value, and the server knows no value."""
+        policy = ReservedFrontmatterPolicy(required_fields=("title", "type"))
+        assert policy.build(None, title="guides") == {"title": "guides", "type": None}
+
+    def test_existing_values_win_over_seeded_ones(self) -> None:
+        """A hand-authored title survives regeneration untouched."""
+        policy = ReservedFrontmatterPolicy(required_fields=("title",))
+        assert policy.build({"title": "Change history"}, title="Log") == {
+            "title": "Change history"
+        }
+
+    def test_root_declaration_survives_alongside_a_seeded_field(self) -> None:
+        policy = ReservedFrontmatterPolicy(required_fields=("title",))
+        assert policy.build({"okf_version": "0.2"}, title="Index") == {
+            "okf_version": "0.2",
+            "title": "Index",
+        }
+
+    def test_okf_version_is_never_synthesized(self) -> None:
+        """A folder index carrying ``okf_version`` audits as ``misplaced``.
+
+        Only the bundle root may declare it, so seeding it would trade the
+        missing-frontmatter defect for a conformance one.
+        """
+        policy = ReservedFrontmatterPolicy(required_fields=("title",))
+        assert "okf_version" not in policy.build(None, title="guides")
+
+    def test_custom_title_field_is_honoured(self) -> None:
+        """The seeded key follows the vault's configured ``title_field``."""
+        policy = ReservedFrontmatterPolicy(
+            title_field="heading", required_fields=("heading",)
+        )
+        assert policy.build(None, title="Log") == {"heading": "Log"}

--- a/tests/test_okf_convention.py
+++ b/tests/test_okf_convention.py
@@ -20,6 +20,7 @@ import pytest
 
 from markdown_vault_mcp._okf_convention import ConventionMaintainer
 from markdown_vault_mcp._okf_write import okf_write_suppressed
+from markdown_vault_mcp.okf import ReservedFrontmatterPolicy
 from markdown_vault_mcp.vault import Vault
 from tests.conftest import wait_for_writer_drain
 
@@ -57,19 +58,28 @@ class _FakeMigrate:
 class _FakeDoc:
     def __init__(self) -> None:
         self.writes: list[tuple[str, str]] = []
+        self.write_kwargs: list[dict[str, object]] = []
         self.raise_on_write = False
+        #: Stands in for an existing log.md: ``(body, frontmatter)`` or None.
+        self.existing: tuple[str, dict[str, Any]] | None = None
 
-    def read(self, _path: str) -> None:
-        return None
+    def read(self, _path: str) -> Any:
+        if self.existing is None:
+            return None
+        body, metadata = self.existing
+        return type("N", (), {"content": body, "frontmatter": metadata})()
 
-    def write(self, path: str, content: str, **_kw: object) -> None:
+    def write(self, path: str, content: str, **kw: object) -> None:
         if self.raise_on_write:
             raise RuntimeError("disk full")
         self.writes.append((path, content))
+        self.write_kwargs.append(kw)
 
 
 def _maintainer(
-    *, active: bool = True
+    *,
+    active: bool = True,
+    reserved_frontmatter: ReservedFrontmatterPolicy | None = None,
 ) -> tuple[ConventionMaintainer, _FakeDoc, _FakeMigrate]:
     doc, migrate = _FakeDoc(), _FakeMigrate()
     m = ConventionMaintainer(
@@ -78,6 +88,7 @@ def _maintainer(
         detector=_FakeDetector(active),  # type: ignore[arg-type]
         sync_index=lambda: None,
         today=lambda: _FIXED,
+        reserved_frontmatter=reserved_frontmatter,
     )
     return m, doc, migrate
 
@@ -141,6 +152,37 @@ class TestMaintainerFailureIsolation:
         assert migrate.index_calls == [""]
 
 
+class TestMaintainedLogFrontmatter:
+    """The maintained ``log.md`` keeps satisfying the vault's index gate (#1174).
+
+    ``_append_log`` is a read-modify-write and ``read()`` returns the body
+    without frontmatter, so the log's frontmatter has to be carried across
+    the rewrite explicitly — the maintainer runs on *every* enforced write,
+    so getting this wrong strips it again after each save.
+    """
+
+    def test_unconfigured_vault_writes_no_frontmatter(self) -> None:
+        m, doc, _ = _maintainer()
+        m.maintain("note.md", "write")
+        assert doc.write_kwargs[0]["frontmatter"] is None
+
+    def test_hand_authored_frontmatter_survives_the_rewrite(self) -> None:
+        m, doc, _ = _maintainer()
+        doc.existing = ("# Log\n", {"title": "Change history", "type": "log"})
+        m.maintain("note.md", "write")
+        assert doc.write_kwargs[0]["frontmatter"] == {
+            "title": "Change history",
+            "type": "log",
+        }
+
+    def test_required_field_is_seeded_on_a_fresh_log(self) -> None:
+        m, doc, _ = _maintainer(
+            reserved_frontmatter=ReservedFrontmatterPolicy(required_fields=("title",))
+        )
+        m.maintain("note.md", "write")
+        assert doc.write_kwargs[0]["frontmatter"] == {"title": "Log"}
+
+
 # ---------------------------------------------------------------------------
 # Integration through a writable, OKF-active vault
 # ---------------------------------------------------------------------------
@@ -148,9 +190,19 @@ class TestMaintainerFailureIsolation:
 _ROOT_INDEX = '---\nokf_version: "0.2"\ntitle: Root\n---\n# Root\n'
 
 
-def _build_vault(source: Path, *, okf_write: bool, okf_mode: str = "on") -> Vault:
+def _build_vault(
+    source: Path,
+    *,
+    okf_write: bool,
+    okf_mode: str = "on",
+    required_frontmatter: list[str] | None = None,
+) -> Vault:
     col = Vault(
-        source_dir=source, read_only=False, okf_mode=okf_mode, okf_write=okf_write
+        source_dir=source,
+        read_only=False,
+        okf_mode=okf_mode,
+        okf_write=okf_write,
+        required_frontmatter=required_frontmatter,
     )
     col.index.build_index()
     return col
@@ -290,5 +342,55 @@ class TestConventionMaintenanceIntegration:
             col.writer.write("guides/note.md", "# N\n")
             wait_for_writer_drain(col)
             assert col.reader.read("guides/log.md") is None
+        finally:
+            col.close()
+
+
+class TestUpkeepUnderRequiredFrontmatter:
+    """End-to-end for #1174 on the path that runs on every save.
+
+    The one-shot ``okf_seed_log`` is not the only generator of a reserved
+    ``log.md``: with ``OKF_WRITE`` on, the maintainer creates and rewrites it
+    after every content write. Under a required-field gate that made the
+    bundle's own history and navigation permanently unlistable, and repairing
+    the files by hand did not survive the next save.
+    """
+
+    def test_maintained_reserved_files_are_indexed(self, tmp_path: Path) -> None:
+        root = tmp_path / "gated_vault"
+        (root / "guides").mkdir(parents=True)
+        (root / "index.md").write_text(_ROOT_INDEX, encoding="utf-8")
+        col = _build_vault(root, okf_write=True, required_frontmatter=["title"])
+        try:
+            col.writer.write("guides/playbook.md", "---\ntitle: P\n---\n# P\n")
+            wait_for_writer_drain(col)
+
+            assert col.reader.read("guides/log.md").frontmatter["title"] == "Log"
+            indexed = {note.path for note in col.reader.list_documents()}
+            assert {"guides/log.md", "guides/index.md"} <= indexed
+        finally:
+            col.close()
+
+    def test_a_second_write_does_not_strip_the_log_frontmatter(
+        self, tmp_path: Path
+    ) -> None:
+        """The rewrite is the regression: one save seeded it, the next dropped it."""
+        root = tmp_path / "gated_vault_twice"
+        (root / "guides").mkdir(parents=True)
+        (root / "index.md").write_text(_ROOT_INDEX, encoding="utf-8")
+        col = _build_vault(root, okf_write=True, required_frontmatter=["title"])
+        try:
+            col.writer.write("guides/a.md", "---\ntitle: A\n---\n# A\n")
+            wait_for_writer_drain(col)
+            col.writer.write("guides/b.md", "---\ntitle: B\n---\n# B\n")
+            wait_for_writer_drain(col)
+
+            log = col.reader.read("guides/log.md")
+            assert log.frontmatter["title"] == "Log"
+            # Both bullets are still there — carrying frontmatter across the
+            # rewrite must not cost the append its accumulated body.
+            assert "wrote `guides/a.md`" in log.content
+            assert "wrote `guides/b.md`" in log.content
+            assert "guides/log.md" in {n.path for n in col.reader.list_documents()}
         finally:
             col.close()

--- a/tests/test_okf_migrate.py
+++ b/tests/test_okf_migrate.py
@@ -316,3 +316,94 @@ def test_facet_without_migration_manager_raises(vault: Vault) -> None:
         facet.okf_generate_index()
     with pytest.raises(RuntimeError, match="migration manager"):
         facet.okf_seed_log()
+
+
+@pytest.fixture
+def gated_vault(source_dir: Path) -> Iterator[Vault]:
+    """A vault whose index gate excludes notes without a ``title`` (#1174)."""
+    col = Vault(source_dir=source_dir, read_only=False, required_frontmatter=["title"])
+    try:
+        col.index.build_index()
+        yield col
+    finally:
+        col.close()
+
+
+def _indexed_paths(vault: Vault) -> set[str]:
+    return {note.path for note in vault.reader.list_documents()}
+
+
+class TestReservedFilesUnderRequiredFrontmatter:
+    """The generators' output survives the vault's own index gate.
+
+    Each of these fails before #1174 / #1175: the generated file carries no
+    frontmatter, so the scanner classifies it as a ``missing_frontmatter``
+    skip and the bundle's own navigation and history vanish from the
+    enumeration surfaces while staying readable from disk.
+    """
+
+    def test_seeded_log_is_indexed(self, gated_vault: Vault) -> None:
+        gated_vault.writer.okf_seed_log()
+        wait_for_writer_drain(gated_vault)
+
+        assert gated_vault.reader.read("log.md").frontmatter["title"] == "Log"
+        assert "log.md" in _indexed_paths(gated_vault)
+
+    def test_generated_index_is_indexed(self, gated_vault: Vault) -> None:
+        _write(gated_vault, "note.md", "---\ntitle: A Note\n---\n# A Note\n")
+
+        gated_vault.writer.okf_generate_index()
+        wait_for_writer_drain(gated_vault)
+
+        assert gated_vault.reader.read("index.md").frontmatter["title"] == "Index"
+        assert "index.md" in _indexed_paths(gated_vault)
+
+    def test_folder_index_takes_the_folder_name_as_its_title(
+        self, gated_vault: Vault
+    ) -> None:
+        _write(gated_vault, "guides/one.md", "---\ntitle: One\n---\n# One\n")
+
+        result = gated_vault.writer.okf_generate_index(folder="guides")
+        wait_for_writer_drain(gated_vault)
+
+        index = gated_vault.reader.read("guides/index.md")
+        assert result.frontmatter_preserved is False
+        assert index.frontmatter["title"] == "guides"
+        # Only the bundle root may declare okf_version; a folder index
+        # carrying it audits as misplaced.
+        assert "okf_version" not in index.frontmatter
+
+    def test_root_declaration_survives_regeneration(self, gated_vault: Vault) -> None:
+        _write(gated_vault, "index.md", '---\nokf_version: "0.2"\n---\n# Old\n')
+
+        result = gated_vault.writer.okf_generate_index()
+        wait_for_writer_drain(gated_vault)
+
+        index = gated_vault.reader.read("index.md")
+        assert result.frontmatter_preserved is True
+        assert index.frontmatter["okf_version"] == "0.2"
+        assert index.frontmatter["title"] == "Index"
+
+    def test_subfolder_stays_reachable_from_the_parent_listing(
+        self, gated_vault: Vault
+    ) -> None:
+        """The second-order effect in #1175: a folder falling out of navigation.
+
+        The parent's listing synthesises a sub-folder pointer only from
+        entries the *index* returns. A folder whose notes are all skipped by
+        the gate contributes nothing, so before the fix its generated
+        ``index.md`` was skipped too and the folder became unreachable by
+        navigation from the bundle root.
+        """
+        # Skipped by the gate: no title, so nothing under archive/ is indexed.
+        _write(gated_vault, "archive/draft.md", "# Draft\n")
+        gated_vault.writer.okf_generate_index(folder="archive")
+        wait_for_writer_drain(gated_vault)
+
+        gated_vault.writer.okf_generate_index()
+        wait_for_writer_drain(gated_vault)
+
+        assert (
+            "- [archive/](/archive/index.md)"
+            in gated_vault.reader.read("index.md").content
+        )


### PR DESCRIPTION
## Closes / Refs

Closes #1174, closes #1175.

## What & why

`index.md` and `log.md` are written by the server, but `required_frontmatter` is configured by the operator. A body-only reserved file is a deterministic `missing_frontmatter` skip (`scanner.py:1240`), so on a vault that sets one the server generated files its own indexer then rejected: the bundle's navigation and change history vanished from `search` and `list_documents` while staying readable from disk.

**Both issues scope this to the one-shot migration tools; the same two call sites also run on the live write path.** With `OKF_WRITE` on, `ConventionMaintainer` creates and rewrites `log.md` (`_okf_convention.py:137`) and regenerates `index.md` (`:146`) after every content write, so the gap recurred on every save rather than once at migration. `_append_log` was worse than merely missing: it is a read-modify-write and `read()` returns the body without frontmatter, so it **stripped** frontmatter an operator had seeded by hand — undoing exactly the workaround #1177 sets out to document.

`ReservedFrontmatterPolicy` (`okf.py`) is now the single owner of what those files carry, shared by both generators and the maintainer:

- **Conditional.** With no required fields configured the policy returns `None` and the generators emit the body-only files existing bundles already have on disk — an unaffected vault sees no churn and, on a git vault, no extra commits. The 244 pre-existing OKF tests pass untouched, which is the evidence for that.
- **Existing keys win**, so a hand-authored title and the root `okf_version` declaration survive regeneration.
- **`title_field` gets the H1** the body builders emit; any other required field is seeded as `null`, since the gate tests presence rather than value and the server has nothing truthful to put there. A null value produces no `document_tags` row (`fts_index.py:737`), so this cannot pollute `list_tags` or the `status` filter.
- **`okf_version` is never synthesized** — the audit flags it outside the bundle root as `misplaced` (`okf.py:_audit_file`), which would trade one defect for another. This settles the open question raised in the #1175 triage comment: a nested folder's generated index must not carry it.

Also fixes the second-order effect in #1175: `generate_index` synthesises sub-folder pointers from index entries, so a folder whose only indexable file was its own skipped `index.md` disappeared from its parent's listing.

Verified end to end on a real vault (`OKF_WRITE=true`, `REQUIRED_FIELDS=title,type`): both reserved files land well-formed, are indexed, and `okf_validate` reports zero findings against them — no `misplaced_okf_version`, no `log_heading_shape`.

## What this PR deliberately does NOT do

- **Exempt reserved files from the required-frontmatter gate in the scanner.** Both issues leave this open. It would change which documents the index contains for every vault, needs an `INDEX_SEMANTICS_VERSION` bump, and alters documented `REQUIRED_FIELDS` behaviour for a problem solvable inside the OKF generators. Not filed — the issues already record it as undecided.
- **Add a `frontmatter_seeded` field to `OkfIndexResult`.** `frontmatter_preserved: false` alongside a file that now has frontmatter is a wrinkle; it is answered with a precise `Attributes` docstring and a tool-reference sentence rather than a new result field.
- **Migrate reserved files already on disk.** Existing vaults keep their frontmatter-less `log.md` / `index.md` until something rewrites them. Under `OKF_WRITE` the next write into a folder fixes it; otherwise re-run the generators. Worth a line on the 4.1 release-notes page.
- **Touch #1176 / #1177 / #1178**, the other v4.1-and-later OKF issues.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening. Report below.
- [x] No commit carries `!`. Both constructors gained a defaulted keyword argument (additive); the new `okf.py` symbols are additive; no operator surface changes — the fix needs no action to upgrade into. Assessed against 4.0.0.
- [x] No `INDEX_SEMANTICS_VERSION` bump: this changes the bytes written to reserved files, not how stored rows are derived from a note's bytes.

### Self-review 17adb92..b678261

Charters: rules, diff, comments, history, conformance. Coverage: full; past-PR charter skipped (no prior review history on these files).

No blocker or important findings survived refutation. Four candidates struck, with what settled each:

- *`type: null` reads as junk in a user's file* — satisfies the presence-only gate (`scanner.py:1240`) and produces no tag row (`fts_index.py:737`, `if value is None: continue`, confirmed by inspecting a generated vault). The alternative reintroduces the defect.
- *An omitted policy argument silently restores the bug* — the default exists so a downstream consumer constructing `OkfMigrationManager` directly is not broken; the vault wiring is covered by integration tests that go through `vault.writer`, which fail if it is dropped.
- *Extra churn on unconfigured vaults* — `build()` returns `None` there, so the written bytes are identical; the pre-existing OKF suite passes unchanged.
- *Contradicted adjacent commitments* — `build_index_markdown` / `build_log_markdown` still return "the markdown body (no frontmatter)", which stays true: frontmatter is applied at the write, not in the builder.

Every new test was confirmed to fail against a neutered policy before being kept, so all nine are genuine regression tests rather than restatements of current behaviour.

## Docs impact

- [ ] `README.md` — does not document the OKF tools or their behaviour.
- [x] `docs/` site pages — `docs/guides/okf.md` (new "Reserved files on a vault with required fields" section), `docs/tools/index.md` (both generator entries + what `frontmatter_preserved` actually reports).
- [x] `docs/design/` — `docs/design/okf.md` §7 gains "Generated reserved files and the index gate": the defect, the policy's four rules, and why the maintainer needs it for the second reason (frontmatter carried across a read-modify-write).
- [x] Inline docstrings — `ReservedFrontmatterPolicy` and `build`, `OkfIndexResult`, `OkfMigrationManager.__init__` / `generate_index` / `seed_log`, `ConventionMaintainer.__init__` / `_append_log`, plus the `okf_migrate` module docstring.

## Verification

All hard gates run locally on the final tree:

| Gate | Result |
|---|---|
| `uv run pytest -q` | 3686 passed, 4 skipped |
| `uv run ruff check .` / `format --check` | clean |
| `uv run mypy src/ tests/` | no issues, 196 files |
| Patch coverage (`diff-cover` vs `origin/main`) | **100%** (0 of 23 lines missing) |
| `bash scripts/structural_gate.sh` | 100%, 0 violations on 419 diff lines |
| `uv run pre-commit run --all-files` | all hooks pass |
| Manifest version lockstep | untouched, all three at 4.0.0 |

One note on the suite: `test_release_tags_are_visible_when_the_changelog_records_releases` fails on a tag-less checkout, which is what this session started with. `git fetch --tags` clears it; the run above is post-fetch. CI fetches tags, so it does not arise there.

`pyproject.toml` gains a `PLR0913` per-file ignore for `managers/okf_migrate.py`, matching the existing entries for `_okf_convention.py` and `git/query.py`: the constructor is six injected collaborators and no logic, and `PLR0913` is gate-only, so an inline `# noqa` would be stripped as unused (RUF100).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPyj9Rg3LU7jz6YhG3Lo19)_