### PR TITLE
fix(apps): declare the font origins the SPA actually loads

### DIFF
--- a/docs/guides/mcp-apps.md
+++ b/docs/guides/mcp-apps.md
@@ -109,7 +109,10 @@ code, property keys, and tags. (As each view is restyled, these families also
 reach the remaining mono metadata such as paths and scores.) The fonts are the
 one runtime network dependency the app keeps (the vendored libraries are embedded);
 if they fail to load, the app falls back to system fonts with no loss of
-function.
+function. Because a host may build the app frame's Content Security Policy from
+the origins the resource declares, `fonts.googleapis.com` and `fonts.gstatic.com`
+are named in that declaration. A host that enforces the policy strictly would
+otherwise drop the request silently and show the fallback fonts.
 
 ### Source layout and build
 

--- a/src/markdown_vault_mcp/_vault_apps.py
+++ b/src/markdown_vault_mcp/_vault_apps.py
@@ -22,9 +22,18 @@ from markdown_vault_mcp.config import _ENV_PREFIX
 if TYPE_CHECKING:
     from markdown_vault_mcp.types import GraphView
 
-# All SPA dependencies are vendored inline (see scripts/vendor_spa.py).
-# No external CDN domains needed at runtime.
-_CDN_RESOURCE_DOMAINS: list[str] = []
+#: Origins the served SPA loads sub-resources from, declared so a host that
+#: builds its iframe CSP from ``resourceDomains`` permits them (#1181). Every
+#: script dependency is vendored inline (see scripts/vendor_spa.py), but the
+#: three typefaces are still fetched: the stylesheet from ``fonts.googleapis``
+#: and the font files it references from ``fonts.gstatic``. Keep this list and
+#: what ``static/app.html`` actually requests in step — a declaration that
+#: omits an origin fails silently, with the host simply dropping the request.
+#: ``tests/test_apps_vendoring.py`` asserts the two agree in both directions.
+_CDN_RESOURCE_DOMAINS: list[str] = [
+    "https://fonts.googleapis.com",
+    "https://fonts.gstatic.com",
+]
 
 
 def _compute_claude_app_domain() -> str | None:

--- a/tests/test_apps_vendoring.py
+++ b/tests/test_apps_vendoring.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import markdown_vault_mcp._server_apps as apps
+import markdown_vault_mcp._vault_apps as vault_apps
 
 
 def test_app_html_is_served_with_tools_rewritten() -> None:
@@ -111,3 +113,46 @@ def test_vendor_check_detects_drift(tmp_path: Path) -> None:
     assert "<!-- drift -->" not in (static_src / "app.src.html").read_text(
         encoding="utf-8"
     )
+
+
+def _spa_external_resource_origins(html: str) -> set[str]:
+    """Origins the served HTML loads sub-resources from.
+
+    Only resource-loading attributes count: ``href`` / ``src`` on ``link``,
+    ``script`` and ``img``, plus CSS ``url()`` references. Bare URLs in
+    vendored-library comments and attribution banners are not requests and
+    need no CSP grant, so matching them would make the assertion below
+    demand grants for origins the page never contacts.
+    """
+    refs = re.findall(
+        r"""<(?:link|script|img)\b[^>]*?\b(?:href|src)\s*=\s*["'](https?://[^"']+)""",
+        html,
+        re.IGNORECASE,
+    )
+    refs += re.findall(r"""url\(\s*["']?(https?://[^)"']+)""", html, re.IGNORECASE)
+    return {match.group(0) for r in refs if (match := re.match(r"https?://[^/]+", r))}
+
+
+def test_declared_csp_origins_match_what_the_spa_actually_loads() -> None:
+    """The declared ``resourceDomains`` and the served HTML cannot drift (#1181).
+
+    The defect this guards was a silent one in both directions: the SPA
+    fetched Google Fonts while the declaration was empty, so a host building
+    its iframe policy from ``resourceDomains`` had no origin permitting the
+    stylesheet — and a blocked font request produces no error, just fallback
+    type. Asserting equality rather than containment also catches the reverse,
+    a stale grant left behind after an asset is vendored away.
+    """
+    requested = _spa_external_resource_origins(apps._SPA_SHELL_HTML)
+    declared = set(vault_apps._CDN_RESOURCE_DOMAINS)
+
+    assert requested == declared, (
+        f"SPA requests {sorted(requested - declared)} without a CSP grant; "
+        f"declares {sorted(declared - requested)} it never requests"
+    )
+
+
+def test_declared_csp_origins_reach_the_app_resource() -> None:
+    """The constant is what register_apps actually hands to the host."""
+    assert apps._CDN_RESOURCE_DOMAINS is vault_apps._CDN_RESOURCE_DOMAINS
+    assert "https://fonts.googleapis.com" in apps._CDN_RESOURCE_DOMAINS

--- a/tests/test_apps_vendoring.py
+++ b/tests/test_apps_vendoring.py
@@ -153,6 +153,19 @@ def test_declared_csp_origins_match_what_the_spa_actually_loads() -> None:
 
 
 def test_declared_csp_origins_reach_the_app_resource() -> None:
-    """The constant is what register_apps actually hands to the host."""
+    """The constant is what register_apps actually hands to the host.
+
+    The test above compares the SPA against ``_vault_apps``; this one pins the
+    re-export ``_server_apps`` actually passes to ``AppConfig``, so importing
+    or shadowing a different constant there cannot pass unnoticed.
+
+    Asserted as whole-list equality rather than membership: an
+    ``"https://…" in <list>`` check is exact in Python, but it is
+    indistinguishable from URL substring matching to a static analyzer, and
+    equality pins every entry instead of one.
+    """
     assert apps._CDN_RESOURCE_DOMAINS is vault_apps._CDN_RESOURCE_DOMAINS
-    assert "https://fonts.googleapis.com" in apps._CDN_RESOURCE_DOMAINS
+    assert sorted(apps._CDN_RESOURCE_DOMAINS) == [
+        "https://fonts.googleapis.com",
+        "https://fonts.gstatic.com",
+    ]


### PR DESCRIPTION
## Closes / Refs

Closes #1181. Refs #1198 (the vendoring alternative, filed while weighing this fix).

## What & why

The app-shell resource advertised `resourceDomains: []` while the served SPA loads a stylesheet from `fonts.googleapis.com` and the font files it references from `fonts.gstatic.com`. A host that builds its iframe Content Security Policy from the declaration therefore had no origin permitting either request — and a blocked font produces no error, just fallback type, so the mismatch was invisible from both sides.

The empty list was a stale truth rather than an oversight: every script dependency really is vendored inline, and the comment above the constant said so. The three typefaces are the exception the vendoring never covered, so the comment is corrected here too — it was asserting something the font links falsify.

I verified these are the only external origins the page requests, by extracting resource-loading attributes and CSS `url()` references from the served HTML: exactly the two font hosts, no CSS references, no anchors. The `github.com` and `visjs.github.io` strings elsewhere in the file are vendored-library attribution comments, not requests.

### Why declare rather than vendor

`resourceDomains` is the narrower fix and matches what the issue is actually about: the declaration disagreed with the content. Vendoring the faces instead would make the app genuinely self-contained and let the `preconnect` tags go, but it adds three base64 families to an already ~630KB file and reaches into the SPA build pipeline. That is #1198, with the two constraints I hit while weighing it: the size needs measuring before committing to the approach, and the OFL requires the license text to travel with the binaries.

### The regression test

Drift between the declaration and the content is what caused this, so the test binds the two **in both directions** and asserts set equality rather than containment:

- a newly added external asset fails until it is granted;
- a stale grant fails once its asset is vendored away — which is exactly the state #1198 would leave behind.

It matches only resource-loading attributes (`href`/`src` on `link`/`script`/`img`) plus CSS `url()`, so attribution comments don't demand phantom grants. Both new tests were confirmed to fail against the old empty list before being kept.

## What this PR deliberately does NOT do

- **Vendor the fonts** — #1198.
- **Remove the `preconnect` tags.** They are correct while the fonts are remote; they go with the vendoring, not with this.
- **Touch #1176.** I picked it up alongside this one and stopped: the `status` collision is documented in four places, all present at `134b1c1` (the commit that issue reports reading), and the shipped PARA templates keeping `status` is a decision recorded in #1080 rather than an oversight. Evidence and a recommendation to close are [on the issue](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1176#issuecomment-5462307826); re-keying the templates would reverse that decision, so it is not folded in here.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening.
- [x] No commit carries `!`. The MCP resource's `_meta` gains two origins — an additive change to a declaration the client re-reads on connect, with no operator or library surface touched. Assessed against 4.0.0.

## Docs impact

- [ ] `README.md` — does not document the app's CSP.
- [x] `docs/` site pages — `docs/guides/mcp-apps.md`, where the fonts are already described as the app's one runtime network dependency; it now also says the two origins are named in the resource declaration and what a strict host would otherwise do.
- [ ] `docs/design/` — `design.md` names `_CDN_RESOURCE_DOMAINS` in the module layout only, and makes no claim about its contents.
- [x] Inline docstrings — the constant's comment, which previously asserted no external domains were needed.

## Verification

All hard gates run locally on the final tree:

| Gate | Result |
|---|---|
| `uv run pytest -q` | 3688 passed, 4 skipped (baseline 3686, plus the two new tests) |
| `uv run ruff check .` / `format --check` | clean |
| `uv run mypy src/ tests/` | no issues, 196 files |
| `bash scripts/structural_gate.sh` | 100%, 0 violations on 57 diff lines |
| `uv run pre-commit run vale --all-files` | passed |
| Manifest version lockstep | untouched, all three at 4.0.0 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPyj9Rg3LU7jz6YhG3Lo19)_