### PR TITLE
fix(search): resolve an unqualified search to the best mode the vault serves

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -224,6 +224,28 @@ independently. Merged score: `1 / (k + rank)` where `k` is a constant
 
 This produces sensible merged rankings regardless of the raw score scales.
 
+**Which mode an unqualified search gets.** `mode` is optional; when the caller
+omits it, `SearchManager._resolve_mode` picks the best mode this vault can
+serve — `hybrid` where embeddings are configured, `keyword` where they are not
+(#1200). Availability is binary: FTS is always present, so there is no
+semantic-only vault to resolve to.
+
+Two properties keep the resolution honest:
+
+- **Resolution never degrades an explicit mode.** `semantic` and `hybrid` still
+  reach `_require_vectors` and raise `EmbeddingsNotConfiguredError` on an
+  unconfigured vault. A caller that asked for semantic results is never handed
+  keyword results under a semantic label; that failure belongs at the call
+  site, not buried in a resolver.
+- **One predicate feeds both paths.** `_vectors_available` backs both
+  `_require_vectors` and `_resolve_mode`, so the mode an unqualified search
+  lands on cannot disagree with the mode an explicit request may ask for.
+
+The previous default was the literal `"keyword"` on the signature, which meant
+a vault with embeddings built and current still answered unqualified searches
+with BM25 — while the server instructions told callers to prefer hybrid. The
+old behaviour stays reachable as an explicit `mode="keyword"`.
+
 ### Search Ranking and Snippet Truncation
 
 Four complementary mechanisms improve result diversity and bound LLM context cost:

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -72,7 +72,7 @@ Find documents matching a query using full-text or semantic search.
 |-----------|------|---------|-------------|
 | `query` | string | required | Natural language or keyword query string |
 | `limit` | int | `10` | Maximum results to return |
-| `mode` | string | `"keyword"` | `"keyword"` (FTS5/BM25), `"semantic"` (vector similarity), or `"hybrid"` (reciprocal rank fusion) |
+| `mode` | string | auto | Omit to let the server choose: `"hybrid"` where embeddings are configured, `"keyword"` where they are not. Set explicitly to override: `"keyword"` (FTS5/BM25), `"semantic"` (vector similarity), or `"hybrid"` (reciprocal rank fusion). An explicit `"semantic"` or `"hybrid"` errors on a vault without embeddings rather than falling back |
 | `folder` | string | `null` | Restrict to documents under this folder path |
 | `filters` | object | `null` | Filter by indexed frontmatter field values (such as `{"tags": "pacing"}`), ANDed. On an OKF bundle, `status` (`stable` also matches notes without one), `stale` (`true`/`false`), and `trust_tier` carry OKF semantics; `type` filters normally |
 | `chunks_per_file` | int | server default (`2`) | Maximum number of matching sections returned per file. Overrides `MARKDOWN_VAULT_MCP_CHUNKS_PER_FILE` for this call. `0` is rejected. |

--- a/src/markdown_vault_mcp/_instructions.py
+++ b/src/markdown_vault_mcp/_instructions.py
@@ -149,7 +149,8 @@ def _domain_snippets(
         )
     snippets.append(
         Snippet(
-            "Use 'search' (mode='hybrid' preferred when available) to find documents, "
+            "Use 'search' to find documents — it picks hybrid automatically "
+            "where embeddings are configured — "
             "'read' for full content, 'list_documents' to enumerate, 'stats' to check "
             "capabilities. 'browse_vault' and 'show_context' open a visual UI for the "
             "user — do not call them to retrieve vault content; use 'search', 'read', "

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -37,7 +37,7 @@ def register(mcp: FastMCP) -> None:
     async def search(
         query: str,
         limit: int = 10,
-        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+        mode: Literal["keyword", "semantic", "hybrid"] | None = None,
         folder: str | None = None,
         filters: dict[str, str] | None = None,
         chunks_per_file: int | None = None,
@@ -47,10 +47,10 @@ def register(mcp: FastMCP) -> None:
     ) -> list[dict[str, Any]]:
         """Find documents matching a query using full-text or semantic search.
 
-        Search the vault. Default mode is "keyword" (FTS5/BM25). Pass
-        mode="hybrid" when 'stats' shows semantic_search_available=True —
-        hybrid fuses keyword and vector results for best quality. Use
-        mode="semantic" for pure vector similarity.
+        Search the vault. Omitting mode picks the best mode this vault can
+        serve: "hybrid" where embeddings are configured, "keyword" where they
+        are not. Pass mode explicitly only to override that — "keyword" to
+        force FTS5/BM25 term matching, "semantic" for pure vector similarity.
 
         The 'content' field in each result is a snippet by default, not the
         full document. Use read(path, section=heading) to retrieve the full
@@ -59,9 +59,12 @@ def register(mcp: FastMCP) -> None:
         Args:
             query: Natural language or keyword query string.
             limit: Maximum results to return (default 10).
-            mode: "keyword" uses FTS5/BM25 for exact terms. "semantic" uses
-                vector similarity (requires embeddings). "hybrid" fuses both
-                via reciprocal rank fusion — best quality when available.
+            mode: Omit to let the server choose (hybrid where embeddings
+                exist, keyword otherwise). "keyword" uses FTS5/BM25 for exact
+                terms. "semantic" uses vector similarity (requires
+                embeddings). "hybrid" fuses both via reciprocal rank fusion.
+                An explicit "semantic" or "hybrid" errors on a vault without
+                embeddings rather than falling back.
             folder: Restrict to documents under this folder path (e.g.
                 "Journal"). Must match a value from 'list_folders'.
                 Use folder="" for root-level (top-level) documents only.

--- a/src/markdown_vault_mcp/facets/reader.py
+++ b/src/markdown_vault_mcp/facets/reader.py
@@ -90,7 +90,7 @@ class ReaderFacet:
         query: str,
         *,
         limit: int = 10,
-        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+        mode: Literal["keyword", "semantic", "hybrid"] | None = None,
         filters: dict[str, str] | None = None,
         folder: str | None = None,
         chunks_per_file: int | None = None,

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -237,13 +237,57 @@ class SearchManager:
         """
         validate_path(path, self._source_dir)
 
+    def _vectors_available(self) -> bool:
+        """Whether this vault can serve semantic and hybrid search.
+
+        The single availability predicate: :meth:`_require_vectors` raises on
+        it and :meth:`_resolve_mode` resolves on it, so the mode an
+        unqualified search lands on can never disagree with the mode an
+        explicit request is allowed to ask for (#1200).
+        """
+        return (
+            self._embedding_provider is not None and self._embeddings_path is not None
+        )
+
     def _require_vectors(self) -> None:
         """Raise :class:`EmbeddingsNotConfiguredError` if semantic search is unconfigured."""
-        if self._embedding_provider is None or self._embeddings_path is None:
+        if not self._vectors_available():
             raise EmbeddingsNotConfiguredError(
                 "Semantic search requires both 'embedding_provider' and "
                 "'embeddings_path' to be configured."
             )
+
+    def _resolve_mode(
+        self, mode: Literal["keyword", "semantic", "hybrid"] | None
+    ) -> Literal["keyword", "semantic", "hybrid"]:
+        """Resolve the search mode when the caller did not name one.
+
+        An unqualified search gets the best mode this vault can actually
+        serve: ``"hybrid"`` where vectors are configured, ``"keyword"``
+        where they are not. Configuring an embedding provider and keeping
+        the sidecar current should be enough to get fused results — before
+        #1200 it also required every call site to pass ``mode`` explicitly,
+        which agent callers routinely do not, so conversational queries fell
+        to BM25 and often returned nothing.
+
+        Availability is binary: FTS is always present, so there is no
+        semantic-only vault to resolve to.
+
+        An explicit *mode* is returned untouched and is **never** degraded
+        here — ``"semantic"`` and ``"hybrid"`` still reach
+        :meth:`_require_vectors` and raise on an unconfigured vault, so a
+        caller that asked for semantic results is never handed keyword
+        results under a semantic label.
+
+        Args:
+            mode: The caller's mode, or ``None`` to resolve one.
+
+        Returns:
+            The mode to dispatch on.
+        """
+        if mode is not None:
+            return mode
+        return "hybrid" if self._vectors_available() else "keyword"
 
     def _load_vectors(self) -> VectorIndex:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
@@ -633,7 +677,7 @@ class SearchManager:
         query: str,
         *,
         limit: int = 10,
-        mode: Literal["keyword", "semantic", "hybrid"] = "keyword",
+        mode: Literal["keyword", "semantic", "hybrid"] | None = None,
         filters: dict[str, str] | None = None,
         folder: str | None = None,
         chunks_per_file: int | None = None,
@@ -646,7 +690,9 @@ class SearchManager:
             limit: Maximum number of files (not chunks) to return.
             mode: ``"keyword"`` for BM25 FTS5, ``"semantic"`` for cosine
                 similarity, or ``"hybrid"`` for Reciprocal Rank Fusion of
-                both.
+                both. ``None`` (the default) resolves to ``"hybrid"`` when
+                this vault has embeddings configured and ``"keyword"`` when
+                it does not (:meth:`_resolve_mode`, #1200).
             filters: Dict of ``{frontmatter_key: value}`` pairs (AND
                 semantics).  Only works for fields in
                 ``indexed_frontmatter_fields``.
@@ -670,6 +716,7 @@ class SearchManager:
                 ``"hybrid"`` but no embedding provider or embeddings path is
                 configured (a ``ValueError`` subclass).
         """
+        mode = self._resolve_mode(mode)
         eff_cap = (
             chunks_per_file if chunks_per_file is not None else self._chunks_per_file
         )

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -1772,3 +1772,87 @@ def test_vector_index_blank_query_returns_empty(
     vectors._provider = _RejectsBlankProvider()  # type: ignore[assignment]
 
     assert vectors.search("   ", limit=5) == []
+
+
+class TestDefaultModeResolution:
+    """An unqualified search picks the best mode the vault can serve (#1200).
+
+    Before this, ``mode`` defaulted to the literal ``"keyword"`` on the
+    signature, so a vault with embeddings built and current still answered
+    unqualified searches with BM25 — while the server's own instructions told
+    callers to prefer hybrid. Agent callers routinely omit ``mode``.
+    """
+
+    def test_resolves_to_keyword_without_embeddings(
+        self, search_mgr: SearchManager
+    ) -> None:
+        assert search_mgr._resolve_mode(None) == "keyword"
+
+    def test_resolves_to_hybrid_with_embeddings(
+        self, search_mgr_with_embeddings: SearchManager
+    ) -> None:
+        assert search_mgr_with_embeddings._resolve_mode(None) == "hybrid"
+
+    @pytest.mark.parametrize("mode", ["keyword", "semantic", "hybrid"])
+    def test_an_explicit_mode_is_returned_untouched(
+        self, search_mgr_with_embeddings: SearchManager, mode: str
+    ) -> None:
+        """Resolution only fills a gap; it never overrides the caller."""
+        assert search_mgr_with_embeddings._resolve_mode(mode) == mode  # type: ignore[arg-type]
+
+    def test_explicit_keyword_still_reaches_the_keyword_path(
+        self, search_mgr_with_embeddings: SearchManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The old default stays reachable, which is why this is not breaking."""
+        called: list[str] = []
+
+        def _spy(*_args: object, **_kwargs: object) -> list[GroupedResult]:
+            called.append("keyword")
+            return []
+
+        monkeypatch.setattr(search_mgr_with_embeddings, "_keyword_search", _spy)
+        search_mgr_with_embeddings.search("foo", mode="keyword")
+        assert called == ["keyword"]
+
+    def test_an_unqualified_search_reaches_the_hybrid_path(
+        self, search_mgr_with_embeddings: SearchManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The point of the fix, asserted end to end through ``search``."""
+        called: list[str] = []
+
+        def _spy(*_args: object, **_kwargs: object) -> list[GroupedResult]:
+            called.append("hybrid")
+            return []
+
+        monkeypatch.setattr(search_mgr_with_embeddings, "_hybrid_search", _spy)
+        search_mgr_with_embeddings.search("foo")
+        assert called == ["hybrid"]
+
+    def test_an_unqualified_search_never_raises_without_embeddings(
+        self, search_mgr: SearchManager
+    ) -> None:
+        """Degrade, never fail: enabling this cannot make a vault unsearchable."""
+        assert isinstance(search_mgr.search("foo"), list)
+
+    @pytest.mark.parametrize("mode", ["semantic", "hybrid"])
+    def test_an_explicit_vector_mode_still_raises_without_embeddings(
+        self, search_mgr: SearchManager, mode: str
+    ) -> None:
+        """A caller who asked for semantic results is never handed keyword ones."""
+        from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
+
+        with pytest.raises(EmbeddingsNotConfiguredError):
+            search_mgr.search("foo", mode=mode)  # type: ignore[arg-type]
+
+    def test_the_raise_and_resolve_paths_share_one_predicate(
+        self, search_mgr_with_embeddings: SearchManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """They cannot drift: flipping availability moves both together."""
+        monkeypatch.setattr(
+            search_mgr_with_embeddings, "_vectors_available", lambda: False
+        )
+        from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
+
+        assert search_mgr_with_embeddings._resolve_mode(None) == "keyword"
+        with pytest.raises(EmbeddingsNotConfiguredError):
+            search_mgr_with_embeddings._require_vectors()


### PR DESCRIPTION
## Closes / Refs

Closes #1200. Refs #1189.

## What & why

`search` declared `mode: Literal[...] = "keyword"` (`managers/search.py:636`), so a vault with an embedding provider configured and its sidecar current still answered every unqualified call with BM25 — while the server's own instructions told callers the opposite:

> Use 'search' (mode='hybrid' preferred when available) to find documents

(`_instructions.py:152`)

A recommendation in the instructions only reaches callers that read and follow it, and agent callers routinely omit `mode`. So an operator who configured embeddings, paid to build the sidecar, and keeps it current got keyword results anyway unless every call site opted in.

The retrieval cost is not marginal. Measured by @mikebronner on a 3,476-document vault in #1189 — two of four conversational queries returned **nothing** under keyword and five results each under hybrid, while the term query scored identically, which is what you would expect from BM25.

`mode` becomes optional. With no mode named, `_resolve_mode` picks what this vault can actually serve: hybrid where vectors are configured, keyword where they are not. Availability is binary — FTS is always present, so there is no semantic-only vault to resolve to.

Two properties keep the resolution honest, both carried over from #1189, which got them right:

- **Resolution never degrades an explicit mode.** `semantic` and `hybrid` still reach `_require_vectors` and raise `EmbeddingsNotConfiguredError` on an unconfigured vault. A caller that asked for semantic results is never handed keyword results under a semantic label; that failure belongs at the call site, not buried in a resolver.
- **One predicate feeds both paths.** `_vectors_available` backs `_require_vectors` and `_resolve_mode` alike, so the mode an unqualified search lands on cannot drift from the mode an explicit request is allowed to ask for.

The tool description and the server instructions are reworded: both stated the keyword default as a fact, and the instructions' advice to pass `mode='hybrid'` is what the default now does on the caller's behalf.

## What this PR deliberately does NOT do

- **Add a configuration knob.** #1189 proposes `MARKDOWN_VAULT_MCP_DEFAULT_SEARCH_MODE` defaulting to `keyword`, which makes the better behaviour opt-in; [the decision on that PR](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1189#issuecomment-5460862638) was to fix the resolution instead of shipping a switch that starts in the wrong position. **One consequence worth naming:** an operator who *wants* keyword-by-default on an embeddings-configured vault now has no deployment-level way to get it, only per-call `mode="keyword"` — which they do not control if an agent is calling. If that is a real deployment, a knob with an `auto` default is additive and I will add it.
- **Change ranking, fusion, or the RRF constant.** Only which mode an unqualified call dispatches to.
- **Measure latency.** #1189 measured result quality; whether hybrid makes an unqualified search noticeably slower on a large vault is recorded as unverified in #1200.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening.
- [x] No commit carries `!`. Assessed against **4.0.0**: no operator surface changes (nothing must be set to upgrade into this), and the MCP surface keeps its shape with the previous behaviour still reachable as an explicit `mode="keyword"`. Per `AGENTS.md`, a semantics change whose old behaviour stays reachable is not breaking. Typed `fix` rather than `feat` because the defect is the default contradicting the server's own advice.

## Docs impact

- [ ] `README.md` — does not document search modes.
- [x] `docs/` site pages — `docs/tools/index.md`, the `mode` row (default is now "auto", with the override and raise-vs-degrade semantics spelled out).
- [x] `docs/design/` — `docs/design/design.md` gains "Which mode an unqualified search gets" under the RRF section: the resolution, the two honesty properties, and what the old default was.
- [x] Inline docstrings — `_vectors_available`, `_resolve_mode`, `SearchManager.search`'s `mode` argument, and the `search` tool description.

## Verification

| Gate | Result |
|---|---|
| `uv run pytest -q` | **3699 passed**, 4 skipped (3686 before; +11 new tests, +2 parametrised) |
| `uv run ruff check .` / `format --check` | clean |
| `uv run mypy src/ tests/` | no issues, 196 files |
| Patch coverage (`diff-cover` vs `origin/main`) | **100%** (0 of 8 source lines missing) |
| `bash scripts/structural_gate.sh` | 100%, 0 violations on 148 diff lines |
| `uv run pre-commit run --all-files` | all 13 hooks pass |
| Manifest version lockstep | untouched |

**The 11 new tests were mutation-checked.** Reverting `_resolve_mode` to a hardcoded `"keyword"` fails exactly the two that assert the new behaviour (`test_resolves_to_hybrid_with_embeddings`, `test_an_unqualified_search_reaches_the_hybrid_path`); the other nine pass either way, which is correct — they guard invariants this PR preserves rather than introduces (explicit modes untouched, degrade-never-fail, explicit vector modes still raising, and the shared predicate moving both paths together).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPyj9Rg3LU7jz6YhG3Lo19)_