### PR TITLE
fix(search): validate default_search_mode at the constructor boundary too

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -224,6 +224,41 @@ independently. Merged score: `1 / (k + rank)` where `k` is a constant
 
 This produces sensible merged rankings regardless of the raw score scales.
 
+**Which mode an unqualified search gets.** `mode` is optional. When the caller
+omits it, `SearchManager._resolve_mode` consults the vault's configured
+`default_mode` (`MARKDOWN_VAULT_MCP_DEFAULT_SEARCH_MODE`, shipped as `auto`):
+
+| configured default | vectors available | resolves to |
+|---|---|---|
+| `auto` | yes / no | `hybrid` / `keyword` |
+| `keyword` | either | `keyword` |
+| `hybrid` | yes / no | `hybrid` / `keyword` |
+| `semantic` | yes / no | `semantic` / `keyword` |
+
+Availability is binary: FTS is always present, so there is no semantic-only
+vault to resolve to. A vault that paid to build a vector index searches it
+without every call site having to ask, and an operator on a metered embedding
+provider pins `keyword` so unqualified searches never embed a query.
+
+Four properties hold the resolution together:
+
+- **A configured default degrades, never fails.** A pinned `semantic` or
+  `hybrid` falls back to `keyword` on a vault without embeddings, so no
+  setting can make a vault unsearchable.
+- **An explicit mode is never degraded.** `semantic` and `hybrid` passed by
+  the caller still reach `_require_vectors` and raise
+  `EmbeddingsNotConfiguredError`. Handing back keyword results under a
+  semantic label would hide the misconfiguration at the wrong layer.
+- **One predicate feeds both paths.** `_vectors_available` backs
+  `_require_vectors` and `_resolve_mode` alike, so what an unqualified search
+  lands on cannot disagree with what an explicit request may ask for.
+- **One accepted set feeds both boundaries.** `types.DEFAULT_SEARCH_MODES` is
+  validated by `SearchConfig.__post_init__` on the environment route and by
+  `SearchManager.__init__` on the library route. They diverged once (#1205):
+  the constructor stored an unrecognised value, `_resolve_mode` returned it
+  verbatim, and `search`'s dispatch — keyword, then semantic, then hybrid as
+  the fallthrough — ran hybrid under a name nobody had asked for.
+
 ### Search Ranking and Snippet Truncation
 
 Four complementary mechanisms improve result diversity and bound LLM context cost:

--- a/src/markdown_vault_mcp/config_sections/search.py
+++ b/src/markdown_vault_mcp/config_sections/search.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from markdown_vault_mcp.exceptions import ConfigurationError
+from markdown_vault_mcp.types import DEFAULT_SEARCH_MODES
 
 # FTS5 column names accepted as fts_weights keys, in notes_fts column order.
 _FTS_COLUMNS = ("path", "title", "folder", "heading", "content", "summary")
@@ -14,9 +15,9 @@ _FTS_COLUMNS = ("path", "title", "folder", "heading", "content", "summary")
 # parse_weight_map) or an already-frozen tuple of (key, weight) pairs.
 _WeightMap = Mapping[str, float] | Sequence[tuple[str, float]]
 
-# Modes accepted for default_mode: the search tool's Literal plus "auto",
-# which is resolved per-vault at search time rather than named by the caller.
-_SEARCH_MODES = frozenset({"auto", "keyword", "semantic", "hybrid"})
+# Modes accepted for default_mode, shared with the SearchManager constructor
+# so the two boundaries cannot drift (#1205).
+_SEARCH_MODES = frozenset(DEFAULT_SEARCH_MODES)
 
 
 @dataclass(frozen=True)

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -17,7 +17,10 @@ import sqlite3
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from markdown_vault_mcp.embed_text import is_embeddable
-from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
+from markdown_vault_mcp.exceptions import (
+    ConfigurationError,
+    EmbeddingsNotConfiguredError,
+)
 from markdown_vault_mcp.managers._ranking import (
     ChannelRow as _ChannelRow,
 )
@@ -54,6 +57,7 @@ from markdown_vault_mcp.okf import (
     parse_stale_filter,
 )
 from markdown_vault_mcp.types import (
+    DEFAULT_SEARCH_MODES,
     AttachmentInfo,
     BacklinkInfo,
     DocumentMeta,
@@ -203,6 +207,16 @@ class SearchManager:
         self._chunks_per_file = chunks_per_file
         self._snippet_words = snippet_words
         self._length_downweight_alpha = length_downweight_alpha
+        if default_mode not in DEFAULT_SEARCH_MODES:
+            # The configuration boundary already rejects this, but a library
+            # consumer reaches Vault/SearchManager without passing through it.
+            # Unvalidated, an unrecognised mode survives _resolve_mode's cast
+            # and lands in search()'s final dispatch branch, running hybrid
+            # under a name nobody asked for (#1205).
+            raise ConfigurationError(
+                "default_mode must be one of "
+                f"{', '.join(sorted(DEFAULT_SEARCH_MODES))}; got {default_mode!r}"
+            )
         self._default_mode = default_mode
         self._folder_weights = folder_weights
         self._embed_text_format = embed_text_format

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -18,6 +18,20 @@ SKIP_CATEGORIES: frozenset[str] = frozenset(
 )
 
 
+#: The modes ``search`` dispatches on. Every result carries one of these as
+#: its ``search_type``.
+SEARCH_MODES: tuple[str, ...] = ("keyword", "semantic", "hybrid")
+
+#: Values accepted for a vault's *configured* default mode: the dispatchable
+#: modes plus ``"auto"``, which resolves per-vault at search time rather than
+#: naming a channel. Shared so the configuration boundary
+#: (:class:`~markdown_vault_mcp.config_sections.SearchConfig`) and the
+#: constructor boundary (``SearchManager``) accept exactly the same set — the
+#: env route validated while the library route did not, and an unrecognised
+#: value reached the dispatch's final branch and ran hybrid silently (#1205).
+DEFAULT_SEARCH_MODES: tuple[str, ...] = ("auto", *SEARCH_MODES)
+
+
 @dataclass(frozen=True)
 class SkippedFile:
     """A file deliberately dropped from the index for a surfaced reason.

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -1890,3 +1890,47 @@ class TestDefaultModeResolution:
         """An explicit keyword request runs keyword search."""
         results = search_mgr.search("alpha", mode="keyword")
         assert "alpha.md" in [r.path for r in results]
+
+
+class TestDefaultModeValidation:
+    """The accepted set is the same at both boundaries (#1205).
+
+    ``SearchConfig`` rejected an unknown ``default_mode`` while
+    ``SearchManager`` — reachable through ``Vault`` without touching the
+    environment — stored it unchecked. ``_resolve_mode`` returned it verbatim
+    through its cast, and ``search`` dispatches keyword → semantic → else
+    hybrid, so an unrecognised mode ran hybrid rather than failing.
+    """
+
+    @pytest.mark.parametrize("mode", ["auto", "keyword", "semantic", "hybrid"])
+    def test_every_configurable_mode_constructs(
+        self, search_vault: Path, mode: str
+    ) -> None:
+        assert _mgr(search_vault, default_mode=mode)._default_mode == mode
+
+    @pytest.mark.parametrize("mode", ["fuzzy", "Hybrid", "", "auto "])
+    def test_an_unknown_mode_raises_at_construction(
+        self, search_vault: Path, mode: str
+    ) -> None:
+        """Fails where the value enters, not at the first search."""
+        from markdown_vault_mcp.exceptions import ConfigurationError
+
+        with pytest.raises(ConfigurationError, match="default_mode"):
+            _mgr(search_vault, default_mode=mode)
+
+    def test_the_vault_constructor_rejects_it_too(self, tmp_path: Path) -> None:
+        """The path a library consumer actually takes."""
+        from markdown_vault_mcp.exceptions import ConfigurationError
+        from markdown_vault_mcp.vault import Vault
+
+        source = tmp_path / "vault"
+        source.mkdir()
+        with pytest.raises(ConfigurationError, match="default_mode"):
+            Vault(source_dir=source, default_search_mode="fuzzy")
+
+    def test_both_boundaries_accept_the_same_set(self) -> None:
+        """One constant, so the env route and the constructor cannot drift."""
+        from markdown_vault_mcp.config_sections.search import _SEARCH_MODES
+        from markdown_vault_mcp.types import DEFAULT_SEARCH_MODES
+
+        assert frozenset(DEFAULT_SEARCH_MODES) == _SEARCH_MODES


### PR DESCRIPTION
## Closes / Refs

Closes #1205. Refs #1189, #1200.

## What & why

`MARKDOWN_VAULT_MCP_DEFAULT_SEARCH_MODE` was validated at config load, so an operator who typoed it learned immediately. A library consumer passing the same typo to `Vault(...)` got no error at all.

Reproduced on `9487d85` before the fix:

```python
Vault(source_dir=root, default_search_mode="fuzzy")   # accepted
mgr._resolve_mode(None)                               # -> "fuzzy"
mgr.search("alpha")                                   # -> search_type={"hybrid"}

os.environ["MARKDOWN_VAULT_MCP_DEFAULT_SEARCH_MODE"] = "fuzzy"
ProjectConfig.from_env()                              # -> ConfigurationError
```

Same value, two doors, opposite outcomes — and the invalid one did not fail. `SearchManager.__init__` stored it unchecked, `_resolve_mode` returned it verbatim through its `cast`, and `search` dispatches keyword → semantic → **else hybrid**, so an unrecognised mode landed in the fallthrough and ran hybrid under a name nobody asked for.

**The accepted set now has one home.** `types.DEFAULT_SEARCH_MODES` is validated by `SearchConfig.__post_init__` on the environment route and by `SearchManager.__init__` on the library route; `config_sections/search.py` derives its frozenset from it rather than redeclaring the literal. `types.py` is the right home because it is the leaf both layers can reach — `managers/search.py` already imported from it, and it carries the `Literal["keyword", "semantic", "hybrid"]` the results use.

A single-site check would have closed today's instance and left the drift that produced it, which is the same shape #1189's own mutation pass caught in its dataclass defaults: a check covering `from_env` while direct construction went around it.

After:

```
ConfigurationError: default_mode must be one of auto, hybrid, keyword, semantic; got 'fuzzy'
```

All four valid modes still construct.

## What this PR deliberately does NOT do

- **Does not narrow the parameters to `Literal[...]`.** That catches static callers, but does nothing for a mode read from a dictionary or a config file at run time — which is exactly the case that produced the silent hybrid. Worth doing as well, not instead; it is a typing change across `Vault` and `SearchManager` signatures and belongs on its own.
- **Does not touch the resolution rule.** It is correct; I traced all eight combinations of configured default against vector availability while reviewing #1189, and the table now in `docs/design/design.md` is that trace.
- **Does not revisit `auto` as a caller-passable mode.** #1189 settled that: omitting `mode` already does it.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before opening.
- [x] No commit carries `!`. Assessed against 4.0.0: `default_search_mode` did not exist there, so no operator or library consumer of the last stable release has anything to change. The new raise can only fire on a value that was already meaningless.

## Docs impact

- [ ] `README.md` — the variable's own row is unchanged; #1189 generated it.
- [ ] `docs/` site pages — no user-facing behaviour changed for a valid configuration.
- [x] `docs/design/` — `docs/design/design.md` gains the resolution rule, which was undocumented before this. The default × availability table plus the four properties holding it together: a configured default degrades, an explicit mode never does, one predicate feeds both dispatch paths, and one accepted set feeds both boundaries. Raised on #1189 before it merged and recorded in #1205 so it would not be lost.
- [x] Inline docstrings — `SEARCH_MODES` / `DEFAULT_SEARCH_MODES`, and the comment at the new raise explaining why the check sits where it does.

## Verification

| Gate | Result |
|---|---|
| `uv run pytest -q` | 3716 passed, 4 skipped |
| `uv run ruff check .` / `format --check` | clean |
| `uv run mypy src/ tests/` | no issues, 196 files |
| Patch coverage (`diff-cover` vs `origin/main`) | **100%** (0 of 7 lines missing) |
| `bash scripts/structural_gate.sh` | 100%, 0 violations on 77 diff lines |
| `uv run pre-commit run vale --all-files` | passed |
| Manifest version lockstep | untouched |

The reproduction above was executed against `9487d85` before the change and against this branch after it. The 7 new tests cover the shapes most likely to slip a naive check — `"Hybrid"` (case), `""` (empty), `"auto "` (trailing space) — plus the `Vault` constructor path a library consumer actually takes, and one asserting both boundaries accept the same set so the drift cannot return.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPyj9Rg3LU7jz6YhG3Lo19)_