### PR TITLE
fix(docs): give the release index the marker form the promotion matches

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -6,7 +6,9 @@ behind it.
 
 ## Available pages
 
-<!-- RELEASE-PAGES-START -->
+<!-- RELEASE-PAGES-START: newest series first; one list entry per page.
+     Release Prepare inserts the new series entry directly below this
+     comment when it promotes the staged notes. -->
 - [4.0](4.0.md).
 - [3.1](3.1.md) (released July 8, 2026). Backfilled.
 - [3.0](3.0.md) (released June 17, 2026, with patch releases through v3.0.4).


### PR DESCRIPTION
## Closes / Refs

Closes #1211. Follows #1210, which cleared the previous blocker on the same step.

## What & why

Release Prepare got past the rc.0 refusal and failed again on the next line:

```
promote_release_notes: REFUSING: release pages start must occur exactly once; found 0
```

`docs/releases/index.md` carries a `RELEASE-PAGES-START` marker exactly once, so "found 0" does not describe the file. The cause is the form, not the count: `INDEX_START_RE` is `<!-- RELEASE-PAGES-START:[\s\S]*?-->` and requires a **colon** plus a trailing note. This page had the bare `<!-- RELEASE-PAGES-START -->`, which the pattern does not match at all.

This is a one-file, comment-only change. No prose, no list entries, no code.

## Why no update would have fixed it

The bare marker is present in the very first commit that created this page — it predates the template's promotion machinery entirely. And `docs/releases/**` is in the template's `_skip_if_exists`, so the page is seeded once and never re-rendered: neither #1192 (which adopted the machinery) nor #1210 could have corrected it. The template's own starter page and the fixtures in `tests/test_promote_release_notes.py` both use the colon form, so the contract was clear — this page just never met it.

The note after the colon is written for this page rather than copied from the starter, whose wording describes replacing a placeholder line this page has not had since 3.0.

## Why the tests did not catch it

`tests/test_promote_release_notes.py` exercises the script against its own fixture strings, never against the committed `docs/releases/index.md`. So the contract between this repository's real index page and the promotion script is evaluated only at release time — which is exactly when it failed, twice in a row now, one gap per dispatch.

Worth a follow-up so the next release does not find a third gap this way: a test that runs `plan_promotion` against the real `docs/releases/` tree would have caught both this and #1209 before either dispatch. I have not filed it — say the word and I will, or I can add it here if you would rather it ship with the fix.

## Verification

Rather than fix the one error and re-dispatch, I ran the promotion end to end against a copy of the tree, so a third latent gap would surface here rather than in another CI cycle:

```
$ python3 scripts/promote_release_notes.py 4.1.0-rc.0
promote_release_notes: promoted 4.1.0-rc.0
EXIT=0
```

It produces exactly what the release needs:

- `docs/releases/4.1.md` — `# 4.1`, the watermark, the summary renamed to `<!-- RELEASE-SUMMARY v4.1.0 START -->`, headings shifted under the page title, and an empty `PATCH-RELEASES` block appended
- `- [4.1](4.1.md)` inserted at the top of the list, directly below the marker
- `docs/releases/next.md` consumed

| Gate | Result |
|---|---|
| `uv run vale docs/releases/index.md` | 0 errors, 0 warnings, 0 suggestions |
| `uv run pytest tests/test_promote_release_notes.py tests/test_release_flow_contract.py -q` | 148 passed |
| `uv run mkdocs build --strict` | built, no warnings |
| promotion rehearsal | exit 0, output as above |

I did not run the full suite: the change is a comment inside one Markdown file, with no importable surface. The two release-contract modules are the ones that could possibly be affected, and both pass.

## What this PR deliberately does NOT do

- **Does not touch the list entries or prose.** Only the marker comment changes; the existing 4.0 / 3.1 / 3.0 / 1.x entries and every paragraph are untouched.
- **Does not loosen the upstream regex to accept a bare marker.** The misleading "found 0" diagnostic is a real upstream wart — the marker *is* there once — but it is the template's to fix and does not block this release. Recorded as the open question on #1211; I can file it against `fastmcp-server-template` if you want it chased.
- **Does not add the real-tree promotion test.** Flagged above rather than smuggled into a release-unblocking fix.

## Docs impact

- [x] `docs/` site pages — `docs/releases/index.md` is the changed file; the change is an HTML comment, invisible in the rendered page. Vale clean, strict build clean.
- [ ] `README.md` / `docs/design/` / inline docstrings — no user-facing behaviour or source changed.

## Note on the branch

`claude/triage-4.1-release-hdhy09` was force-pushed again. Its previous tip (`ced5080`, #1210) was squash-merged into `main` as `0b908e1`; verified before pushing that the content diff between the old remote branch and `main` was empty, so it held only already-merged history.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPyj9Rg3LU7jz6YhG3Lo19)_