### PR TITLE
chore: prepare release 4.1.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ Narrative, rationale, and upgrade guidance live in
 
 <!-- version list -->
 
+## 4.1.0-rc.0 (2026-08-29)
+
+### Features
+
+- Voyage embedding provider and the WRITE_PROTECT_EXISTING guard (#1169)
+- expose note size on the enumeration surfaces (#1171)
+- adopt template v6.0.0 and compose via pvl-core 5 (#1192)
+- ✨ Resolve the default search mode from what the vault can serve. (#1189)
+
+### Bug Fixes
+
+- v4.1 bug sweep — rename staging, webhook gating, blank query, changelog (#1163)
+- drop the pygments pins, which held the lock on the broken release (#1166)
+- make the template-conformance gate actually render (#1191)
+- let @claude review actually run a review (#1194)
+- give generated reserved files the frontmatter the index gate requires (#1196)
+- declare the font origins the SPA actually loads (#1199)
+- validate default_search_mode at the constructor boundary too (#1206)
+- give the release index the marker form the promotion matches (#1212)
+
 ## 4.0.0 (2026-08-25)
 
 ### Breaking Changes

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -1,8 +1,8 @@
-# Next release
+# 4.1
 
 <!-- notes-range-end: 59cc4a8276d2ef79f311eec84149f995252bf698 -->
 
-<!-- RELEASE-SUMMARY NEXT START -->
+<!-- RELEASE-SUMMARY v4.1.0 START -->
 This release is mostly about the server making better choices on its own. A
 `search` call that omits `mode` now runs the best mode the vault can actually
 serve, so a vault with embeddings built stops answering conversational
@@ -14,7 +14,7 @@ change on upgrade with no configuration edit on your part: search results move
 on any vault with embeddings, and the server rebuilds its text index once on
 first start. A downstream library consumer that read `ProjectConfig.instructions`
 needs a change; operators do not.
-<!-- RELEASE-SUMMARY NEXT END -->
+<!-- RELEASE-SUMMARY v4.1.0 END -->
 
 This is the first release since [4.0](4.0.md). Its through-line is defaults:
 several places where the server knew enough to do the right thing but waited to
@@ -260,3 +260,6 @@ The `pygments` pins that held the lock on a broken release are gone
 ([#1166](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1166)), and the
 project moved to mypy 2.x
 ([#1168](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1168)).
+
+<!-- PATCH-RELEASES-START -->
+<!-- PATCH-RELEASES-END -->

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -9,6 +9,7 @@ behind it.
 <!-- RELEASE-PAGES-START: newest series first; one list entry per page.
      Release Prepare inserts the new series entry directly below this
      comment when it promotes the staged notes. -->
+- [4.1](4.1.md)
 - [4.0](4.0.md).
 - [3.1](3.1.md) (released July 8, 2026). Backfilled.
 - [3.0](3.0.md) (released June 17, 2026, with patch releases through v3.0.4).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-vault-mcp"
-version = "4.0.0"
+version = "4.1.0-rc.0"
 description = "Generic markdown vault MCP with hybrid search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/uv.lock
+++ b/uv.lock
@@ -1790,7 +1790,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "4.0.0"
+version = "4.1.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **4.1.0-rc.0** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

The deterministic promotion step checked that this PR carries release notes
under `docs/releases/`. Reviewers must compare the page's `notes-range-end`
with the release delta and verify that every meaningful behavior change is
covered. If meaningful behavior is missing, merge a normal notes PR into the
base branch and re-dispatch Release Prepare.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Features

- Voyage embedding provider and the WRITE_PROTECT_EXISTING guard (#1169)
- expose note size on the enumeration surfaces (#1171)
- adopt template v6.0.0 and compose via pvl-core 5 (#1192)
- ✨ Resolve the default search mode from what the vault can serve. (#1189)

## Bug Fixes

- v4.1 bug sweep — rename staging, webhook gating, blank query, changelog (#1163)
- drop the pygments pins, which held the lock on the broken release (#1166)
- make the template-conformance gate actually render (#1191)
- let @claude review actually run a review (#1194)
- give generated reserved files the frontmatter the index gate requires (#1196)
- declare the font origins the SPA actually loads (#1199)
- validate default_search_mode at the constructor boundary too (#1206)
- give the release index the marker form the promotion matches (#1212)
