### PR TITLE
chore(deps): hold numpy below 2.5 in [tool.uv] constraints, the one bound Renovate cannot rewrite

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3182,6 +3182,7 @@ mcp = ["fastmcp>=3.0,<4"]
 embeddings-api = ["httpx>=0.25", "numpy"]
 embeddings = ["fastembed>=0.3", "numpy"]
 all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy"]
+dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.1", "mypy>=1.0"]
 
 [tool.uv]
 # The single numpy bound while requires-python floors at 3.11: numpy 2.5.x
@@ -3189,7 +3190,6 @@ all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy"]
 # (#727, #1214).  Held here, not in the extras, so Renovate cannot rewrite
 # it (#1216); check_pins.py enforces the exit condition.
 constraint-dependencies = ["numpy<2.5"]  # until: fastmcp-server-template#547
-dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.1", "mypy>=1.0"]
 
 [project.scripts]
 markdown-vault-mcp = "markdown_vault_mcp.cli:main"

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3179,11 +3179,16 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = ["fastmcp>=3.0,<4"]
-# numpy <2.5 while requires-python floors at 3.11: numpy 2.5.x is 3.12-only
-# and its PEP 695 stubs abort mypy at python_version=3.11 (#727, #1214).
-embeddings-api = ["httpx>=0.25", "numpy>=1.20,<2.5"]
-embeddings = ["fastembed>=0.3", "numpy>=1.20,<2.5"]
-all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy>=1.20,<2.5"]
+embeddings-api = ["httpx>=0.25", "numpy"]
+embeddings = ["fastembed>=0.3", "numpy"]
+all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy"]
+
+[tool.uv]
+# The single numpy bound while requires-python floors at 3.11: numpy 2.5.x
+# is 3.12-only and its PEP 695 stubs abort mypy at python_version=3.11
+# (#727, #1214).  Held here, not in the extras, so Renovate cannot rewrite
+# it (#1216); check_pins.py enforces the exit condition.
+constraint-dependencies = ["numpy<2.5"]  # until: fastmcp-server-template#547
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.1", "mypy>=1.0"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,16 +79,18 @@ dependencies = [
 [project.optional-dependencies]
 # PROJECT-EXTRAS-START — add domain-specific optional-dependency groups below; kept across copier update
 mcp = ["fastmcp>=3.0,<4"]
-# numpy <2.5: 2.5.x is 3.12-only and its stubs abort mypy at
-# python_version=3.11 — see the [tool.mypy] comment below and #1214.  Lift
-# together with `requires-python`/`python_version` moving to 3.12.
-embeddings-api = ["httpx>=0.25", "numpy>=1.20,<2.5", "openai>=1.45"]
-embeddings = ["fastembed>=0.3", "numpy>=1.20,<2.5"]
+# numpy carries no bound here on purpose: the <2.5 ceiling lives in
+# [tool.uv] constraint-dependencies below (single bound per package, per
+# scripts/check_pins.py), where Renovate's range rewriting cannot reach it
+# (#1216) — an extras cap got rewritten to >=2.5 by rangeStrategy
+# update-lockfile's out-of-range fallback.
+embeddings-api = ["httpx>=0.25", "numpy", "openai>=1.45"]
+embeddings = ["fastembed>=0.3", "numpy"]
 file-watcher = ["watchdog>=4.0"]
 # LLM-backed summarize tool (OpenAI-compatible chat-completions backend:
 # OpenAI, Ollama, Anthropic's compat endpoint, vLLM, ...).
 summarize = ["openai>=1.45"]
-all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy>=1.20,<2.5", "watchdog>=4.0", "openai>=1.45"]
+all = ["fastmcp>=3.0,<4", "httpx>=0.25", "fastembed>=0.3", "numpy", "watchdog>=4.0", "openai>=1.45"]
 # Pulls debugpy transitively via fastmcp-pvl-core's [debug] extra.  The
 # version range is inherited from the [project] dependency on
 # fastmcp-pvl-core above; pip resolves a single, consistent version.
@@ -152,6 +154,21 @@ Changelog = "https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/CHANGELO
 # with a publisher that accepts whatever the new minor emits.
 requires = ["hatchling>=1.32,<1.33"]
 build-backend = "hatchling.build"
+
+[tool.uv]
+# The single numpy bound (extras above are deliberately bare).  numpy 2.5+
+# is 3.12-only and its PEP 695 stubs abort mypy at this project's
+# python_version=3.11 (#727, #1214); without a ceiling, uv's forked
+# resolution locks 2.5.x for the 3.12+ interpreters CI type-checks on.  It
+# lives here rather than in the extras because Renovate does not manage
+# [tool.uv], so its update-lockfile fallback cannot rewrite the range the
+# way it did to an extras cap (#1216) — while uv itself honors the
+# constraint in every re-lock, lockFileMaintenance included.  check_pins.py
+# fails CI the moment the `until:` issue closes, so the pin cannot outlive
+# the 3.12 floor raise that removes it.
+constraint-dependencies = [
+  "numpy<2.5", # until: https://github.com/pvliesdonk/fastmcp-server-template/issues/547
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/markdown_vault_mcp"]
@@ -349,8 +366,9 @@ exclude_lines = [
 # The `requires-python = ">=3.11"` floor alone does NOT keep numpy 2.5 out:
 # uv forks the resolution on `python_full_version` markers, so a plain
 # `uv lock --upgrade` locks 2.5.x for 3.12+ interpreters — the ones CI
-# type-checks on (#1214).  The `numpy<2.5` caps in the extras above are what
-# hold the single 2.4.x resolution; lift them when this moves to "3.12".
+# type-checks on (#1214).  The `numpy<2.5` entry in [tool.uv]
+# constraint-dependencies is what holds the single 2.4.x resolution; lift
+# it when this moves to "3.12".
 # Beware when re-verifying: an incremental `uv lock` (no --upgrade) keeps the
 # already-locked 2.4.x and hides the fork — that masking is how #1168 judged
 # the previous cap redundant and removed it.  Test with --upgrade.

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,9 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[manifest]
+constraints = [{ name = "numpy", specifier = "<2.5" }]
+
 [[package]]
 name = "aiofile"
 version = "3.12.3"
@@ -1865,9 +1868,9 @@ requires-dist = [
     { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25" },
     { name = "httpx", marker = "extra == 'embeddings-api'", specifier = ">=0.25" },
-    { name = "numpy", marker = "extra == 'all'", specifier = ">=1.20,<2.5" },
-    { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.20,<2.5" },
-    { name = "numpy", marker = "extra == 'embeddings-api'", specifier = ">=1.20,<2.5" },
+    { name = "numpy", marker = "extra == 'all'" },
+    { name = "numpy", marker = "extra == 'embeddings'" },
+    { name = "numpy", marker = "extra == 'embeddings-api'" },
     { name = "openai", marker = "extra == 'all'", specifier = ">=1.45" },
     { name = "openai", marker = "extra == 'embeddings-api'", specifier = ">=1.45" },
     { name = "openai", marker = "extra == 'summarize'", specifier = ">=1.45" },


### PR DESCRIPTION
## Closes / Refs

Closes #1216. Refs #1203, #1214, #1215, pvliesdonk/fastmcp-server-template#547.

> Reworked after review feedback: the first draft countered Renovate's range rewriting with an `allowedVersions` rule in `renovate.json` — a second pin location, in a template-owned file with no domain seam. This version keeps exactly one bound, total.

## What & why

On rebasing #1203 over the merged extras cap (#1215), Renovate's `rangeStrategy: "update-lockfile"` hit its out-of-range fallback and **rewrote** `numpy>=1.20,<2.5` to `numpy>=2.5`, making the project unresolvable on the 3.11 split (#1216). Any bound in `[project]` is exposed to that rewriting. So:

- The extras go back to **bare `numpy`** (the `>=1.20` floor was practically vacuous — every resolver lands on 2.x).
- The single ceiling moves to `[tool.uv] constraint-dependencies = ["numpy<2.5"]` — the table Renovate's pep621 manager does not parse, so the #1216 failure mode is structurally impossible, while uv honors the constraint in every resolution: ordinary lock updates *and* the Monday `lockFileMaintenance` full re-lock. This is the arrangement that held for months before #1168 removed it.
- `renovate.json` stays pristine template content — no domain edit, no copier-update conflict.
- The pin's `# until:` points at the 3.12 floor raise (fastmcp-server-template#547), and `scripts/check_pins.py` **fails CI the moment that issue closes** — the pin mechanically cannot outlive its reason, and the one-bound-per-package rule guards against a second location reappearing.

Once this merges and Renovate re-runs, it rebuilds #1203's immortal grouped PR: the numpy bump no-ops against the constraint, leaving the in-range lock bumps (openai, ruff, typer); that PR has automerge.

## What this PR deliberately does NOT do

- Touch `renovate.json` (first draft reverted; the template-seam gap it exposed is reported on fastmcp-server-template#258).
- Touch #1203 — Renovate rebuilds it after this merges.
- Revisit the floor plan (fastmcp-server-template#547; parked by maintainer decision).

## Local review

- [x] Reworked from first-draft review feedback (see note above); re-ran the pass on the new diff.
- [x] No `!`: dropping the vacuous `>=1.20` extras floor and adding a resolver constraint change nothing an operator or library consumer must do against the last stable release.

## Docs impact

- [ ] `README.md` — no version prose there.
- [ ] `docs/` site pages — none name numpy bounds.
- [x] `docs/design/` — packaging snippet updated to the bare-extras + `[tool.uv]` constraint shape.
- [ ] Inline docstrings — no code changed.

## Verification

| Check | Result |
|---|---|
| `uv lock` | lock carries `[manifest] constraints = numpy<2.5`; extras `requires-dist` bare |
| `uv lock --upgrade --dry-run` | openai/ruff/typer move; numpy does not appear |
| `scripts/check_pins.py --offline` | OK (1 pin, exit condition present; `until:` issue is open) |
| `uv run mypy src/ tests/` (all extras, numpy 2.4.6) | Success, 196 files |
| `uv run pytest -x -q` | 3717 passed, 18 skipped |
| `ruff check` / `format --check` | clean |
| `scripts/structural_gate.sh` | no Python source changes — skipped |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdoRbh5ZLJjZK5QVBHimvj