### PR TITLE
refactor: extract RepoBootstrap and PushScheduler from GitWriteStrategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,9 @@ src/markdown_vault_mcp/
   git/
     __init__.py        -- package facade preserving the historical single-module import surface (incl. test patch targets)
     _run.py            -- low-level git subprocess + credential plumbing
-    strategy.py        -- GitWriteStrategy: auto-commit per write, deferred background push
+    strategy.py        -- GitWriteStrategy: auto-commit per write; composes RepoBootstrap + PushScheduler over one shared lock (#893)
+    bootstrap.py       -- RepoBootstrap: managed-clone bootstrap, remote-protocol validation, memoised git-root discovery (#893)
+    push_scheduler.py  -- PushScheduler: deferred-push timer + pending-flag mechanics and push execution (#893)
     conflict.py        -- rebase-conflict resolution mechanics (caller holds the strategy lock)
     query.py           -- read-only git history/diff queries; lock-free pure functions
     types.py           -- PullResult/PushResult + pull/push reason-code constants

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3250,11 +3250,32 @@ Startup recovery: `GitWriteStrategy` checks for unpushed local commits
 (`git log origin/<branch>..HEAD`) on first invocation and pushes them before
 accepting new writes.
 
-**Deferred push mechanics**: `GitWriteStrategy` uses a `threading.Timer` that
-resets on each write. After `push_delay_s` seconds of idle, all accumulated
-local commits are pushed in a single `git push`. `flush()` cancels the timer
-and pushes synchronously. `close()` calls `flush()` and marks the strategy as
-closed (subsequent writes are ignored).
+**Deferred push mechanics**: the timer and pending-flag state live in a
+composed `PushScheduler` collaborator (`git/push_scheduler.py`, #893). It
+holds a `threading.Timer` that resets on each write; after `push_delay_s`
+seconds of idle, all accumulated local commits are pushed in a single
+`git push`. The strategy's public `flush()` delegates to
+`PushScheduler.flush()` (cancel timer + synchronous push); `close()` marks
+the strategy closed (subsequent writes are ignored), stops the pull thread,
+then calls `flush()`. The pull loop retries a failed deferred push via
+`PushScheduler.do_push_safe()` after each tick (#957).
+
+**Strategy collaborators (#893)**: `GitWriteStrategy` composes two
+collaborators extracted from the class, following the Versioner/Syncer
+seams of the decoupling-and-layering study (#879):
+
+- `RepoBootstrap` (`git/bootstrap.py`) — managed-repo clone/validation
+  (`ensure_managed_repo`), the SSH-vs-HTTPS remote-protocol check for token
+  auth (`check_remote_protocol`), startup validation (`validate_startup`),
+  and the memoised git-root discovery (`ensure_git_root`). It owns the
+  single copy of the discovered `git_root`, which the strategy and the
+  scheduler read through it.
+- `PushScheduler` (`git/push_scheduler.py`) — see above.
+
+Both collaborators receive the strategy-wide lock — the SAME object; no new
+locks were introduced — so the documented lock-ordering contracts of the
+pull/write paths (`_force_pull_rebase_fallback` requires the lock held;
+`_quiesce_writes` drains before the lock is taken) are unchanged.
 
 For private repos, HTTPS token auth uses:
 
@@ -3277,8 +3298,9 @@ with `***`).
 
 **Git LFS support**: when `MARKDOWN_VAULT_MCP_GIT_LFS=true` (default),
 `GitWriteStrategy` calls `_lfs_pull()` once during lazy initialisation, after
-startup recovery (`_push_if_unpushed()`) and outside the init lock, to resolve
-LFS pointer files before the first write is committed. `_lfs_pull()` runs
+startup recovery (`PushScheduler.push_if_unpushed()`) and outside the init
+lock, to resolve LFS pointer files before the first write is committed.
+`_lfs_pull()` runs
 `git lfs pull` in the vault root; failures (including `git lfs` not installed
 or any non-zero exit) are logged at ERROR and never propagated to the caller.
 Set `MARKDOWN_VAULT_MCP_GIT_LFS=false` for repos that do not use LFS, or when

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3298,8 +3298,9 @@ with `***`).
 
 **Git LFS support**: when `MARKDOWN_VAULT_MCP_GIT_LFS=true` (default),
 `GitWriteStrategy` calls `_lfs_pull()` once during lazy initialisation, after
-startup recovery (`PushScheduler.push_if_unpushed()`) and outside the init
-lock, to resolve LFS pointer files before the first write is committed.
+startup recovery (`PushScheduler.push_if_unpushed()`) and under the strategy
+lock (the one-time write init holds it, so no other git operation overlaps),
+to resolve LFS pointer files before the first write is committed.
 `_lfs_pull()` runs
 `git lfs pull` in the vault root; failures (including `git lfs` not installed
 or any non-zero exit) are logged at ERROR and never propagated to the caller.

--- a/src/markdown_vault_mcp/git/__init__.py
+++ b/src/markdown_vault_mcp/git/__init__.py
@@ -13,10 +13,10 @@ applies globally, so calls from any submodule that does ``import subprocess`` ar
 still intercepted. Keeping the attribute here preserves those patch targets.
 
 Symbols that a submodule looks up via its own module globals (e.g.
-``_stage_and_commit`` / ``_push`` / ``_get_access_token`` in ``strategy``;
-``frontmatter`` in ``conflict``) are patched by tests at their real home --
-``markdown_vault_mcp.git.<submodule>.<name>`` -- not via this package namespace.
-"Patch where the name is used."
+``_stage_and_commit`` / ``_get_access_token`` in ``strategy``; ``_push`` in
+``push_scheduler`` since #893; ``frontmatter`` in ``conflict``) are patched by
+tests at their real home -- ``markdown_vault_mcp.git.<submodule>.<name>`` --
+not via this package namespace.  "Patch where the name is used."
 """
 
 from __future__ import annotations
@@ -26,6 +26,8 @@ import subprocess  # noqa: F401 -- preserves the `markdown_vault_mcp.git.subproc
 from markdown_vault_mcp.git._run import (
     _find_git_root,  # noqa: F401 -- re-exported for the historic import surface
 )
+from markdown_vault_mcp.git.bootstrap import RepoBootstrap
+from markdown_vault_mcp.git.push_scheduler import PushScheduler
 from markdown_vault_mcp.git.strategy import (  # noqa: F401 -- re-exported for the historic import surface
     GitWriteStrategy,
     _extract_claim,
@@ -61,5 +63,7 @@ __all__ = [
     "GitWriteStrategy",
     "PullResult",
     "PushResult",
+    "PushScheduler",
+    "RepoBootstrap",
     "git_write_strategy",
 ]

--- a/src/markdown_vault_mcp/git/bootstrap.py
+++ b/src/markdown_vault_mcp/git/bootstrap.py
@@ -1,0 +1,239 @@
+"""Repository bootstrap and startup validation for the git write strategy.
+
+Extracted verbatim from :mod:`markdown_vault_mcp.git.strategy` (#893):
+:class:`RepoBootstrap` owns managed-repo cloning/validation, the
+remote-protocol (SSH vs HTTPS) check for token auth, and the memoised
+git-root discovery that :class:`~markdown_vault_mcp.git.strategy.GitWriteStrategy`
+and :class:`~markdown_vault_mcp.git.push_scheduler.PushScheduler` share.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import threading
+
+from markdown_vault_mcp.exceptions import ConfigurationError
+from markdown_vault_mcp.git._run import (
+    _find_git_root,
+    _is_ssh_remote,
+    _normalize_remote,
+    cleanup_git_env,
+    git_env,
+)
+
+
+class RepoBootstrap:
+    """Repository discovery, managed-clone bootstrap, and startup validation.
+
+    A collaborator composed into
+    :class:`~markdown_vault_mcp.git.strategy.GitWriteStrategy` (#893).  It
+    owns the shared repository identity: the memoised working-tree root
+    (:attr:`git_root`) plus the credentials used for clone-time auth.  The
+    strategy and :class:`~markdown_vault_mcp.git.push_scheduler.PushScheduler`
+    read :attr:`git_root` through this object, so there is exactly one copy
+    of that state.
+
+    Args:
+        lock: The strategy-wide lock, shared with the strategy's pull/write
+            paths and the push scheduler.  The SAME object must be passed to
+            every collaborator; this class introduces no lock of its own.
+        token: PAT for HTTPS auth via ``GIT_ASKPASS``; also gates the
+            SSH-remote rejection in :meth:`check_remote_protocol`.
+        username: Username used with token auth.
+        repo_url: Remote URL expected in managed mode (``None`` outside
+            managed mode).
+    """
+
+    def __init__(
+        self,
+        *,
+        lock: threading.Lock,
+        token: str | None,
+        username: str,
+        repo_url: str | None,
+    ) -> None:
+        self._lock = lock
+        self.token = token
+        self.username = username
+        self._repo_url = repo_url
+        #: Memoised working-tree root; ``None`` until discovered (or when
+        #: the source dir is not a git repository).
+        self.git_root: Path | None = None
+        #: Whether root discovery has run (so a ``None`` root is not retried).
+        self.git_root_checked = False
+
+    def _git_env(self) -> dict[str, str] | None:
+        """Build the GIT_ASKPASS environment for clone-time subprocess calls."""
+        return git_env(self.token, self.username)
+
+    def ensure_git_root(self, repo_path: Path) -> Path | None:
+        """Discover and memoise the git root containing *repo_path*.
+
+        Thread-safe double-checked discovery under the shared strategy lock;
+        after the first call the cached result is returned without locking.
+
+        Args:
+            repo_path: Any path inside the candidate working tree.
+
+        Returns:
+            The working-tree root, or ``None`` when *repo_path* is not
+            inside a git repository.
+        """
+        if self.git_root_checked:
+            return self.git_root
+        with self._lock:
+            if not self.git_root_checked:
+                self.git_root = _find_git_root(repo_path)
+                self.git_root_checked = True
+        return self.git_root
+
+    def get_origin_url(self, git_root: Path) -> str | None:
+        """Return the ``origin`` remote URL of *git_root*, or ``None``.
+
+        ``None`` covers every failure shape: git missing from PATH, no
+        ``origin`` remote configured, or an empty URL.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(git_root), "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            return None
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() or None
+
+    def ensure_managed_repo(self, repo_path: Path) -> None:
+        """Ensure a managed repository exists at *repo_path* (clone or validate).
+
+        Clones ``repo_url`` into an empty (or absent) *repo_path*; for an
+        existing checkout, verifies the ``origin`` remote matches the
+        configured URL.  On success, memoises the discovered git root.
+
+        Args:
+            repo_path: The configured ``SOURCE_DIR``.
+
+        Raises:
+            ConfigurationError: When no ``repo_url`` is configured, the URL
+                uses SSH transport while token auth is enabled, *repo_path*
+                is not a directory, the clone fails, the result is not a git
+                repository, ``origin`` is missing, or the remote URL does
+                not match ``repo_url``.
+        """
+        if self._repo_url is None:
+            raise ConfigurationError("Managed git mode requires a repo_url.")
+
+        if self.token and _is_ssh_remote(self._repo_url):
+            raise ConfigurationError(
+                f"Managed mode repo URL {self._repo_url!r} uses SSH transport, but "
+                "GIT_TOKEN auth requires HTTPS."
+            )
+
+        path = Path(repo_path)
+        if path.exists():
+            if not path.is_dir():
+                raise ConfigurationError(
+                    f"Managed mode requires SOURCE_DIR to be a directory: {path}"
+                )
+            is_empty = not any(path.iterdir())
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            is_empty = True
+
+        if is_empty:
+            self._clone_into(path)
+
+        git_root = _find_git_root(path)
+        if git_root is None:
+            raise ConfigurationError(
+                f"Managed mode requires SOURCE_DIR to be empty or a git repository: {path}"
+            )
+        origin_url = self.get_origin_url(git_root)
+        if origin_url is None:
+            raise ConfigurationError(
+                f"Managed mode requires an 'origin' remote in repository {git_root}."
+            )
+        if _normalize_remote(origin_url) != _normalize_remote(self._repo_url):
+            raise ConfigurationError(
+                "Managed mode remote mismatch: existing origin is "
+                f"{origin_url!r}, expected {self._repo_url!r}."
+            )
+        self.git_root = git_root
+        self.git_root_checked = True
+        self.check_remote_protocol(git_root)
+
+    def _clone_into(self, path: Path) -> None:
+        """Clone ``repo_url`` into *path* with GIT_ASKPASS credentials.
+
+        Raises:
+            ConfigurationError: When git is missing from PATH or the clone
+                itself fails (stderr is included in the message).
+        """
+        # Only reachable from ensure_managed_repo, after its repo_url guard;
+        # re-checked here (not asserted) so mypy narrows without S101.
+        if self._repo_url is None:
+            raise ConfigurationError("Managed git mode requires a repo_url.")
+        env = self._git_env()
+        try:
+            subprocess.run(
+                ["git", "clone", self._repo_url, str(path)],
+                capture_output=True,
+                text=True,
+                check=True,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise ConfigurationError("git is not installed or not on PATH.") from exc
+        except subprocess.CalledProcessError as exc:
+            raise ConfigurationError(
+                f"Failed to clone managed git repo {self._repo_url!r} into {path}: "
+                f"{(exc.stderr or '').strip()}"
+            ) from exc
+        finally:
+            cleanup_git_env(env)
+
+    def check_remote_protocol(self, git_root: Path) -> None:
+        """Raise ConfigurationError if origin uses SSH while token auth is enabled."""
+        if not self.token:
+            return
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(git_root), "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            return
+        if result.returncode != 0:
+            # No remote configured; ignore here.
+            return
+
+        url = result.stdout.strip()
+        if not _is_ssh_remote(url):
+            return
+
+        if url.startswith("ssh://git@"):
+            https_url = "https://" + url[len("ssh://git@") :]
+        elif url.startswith("ssh://"):
+            https_url = "https://" + url[len("ssh://") :]
+        else:
+            without_prefix = url[len("git@") :]
+            https_url = "https://" + without_prefix.replace(":", "/", 1)
+
+        raise ConfigurationError(
+            f"Remote URL {url!r} uses SSH transport, but GIT_TOKEN requires HTTPS.\n"
+            f"Run: git -C {git_root} remote set-url origin {https_url}"
+        )
+
+    def validate_startup(self, repo_path: Path) -> None:
+        """Validate startup git settings for token-authenticated workflows."""
+        git_root = self.ensure_git_root(repo_path)
+        if git_root is None:
+            return
+        self.check_remote_protocol(git_root)

--- a/src/markdown_vault_mcp/git/conflict.py
+++ b/src/markdown_vault_mcp/git/conflict.py
@@ -153,10 +153,10 @@ def resolve_conflicts_safely(
             has consistent ``from_sha == to_sha`` semantics.
         token: PAT used for redacting sensitive text in log messages.
         resolve_fn: Optional override for the conflict-resolution
-            callable.  Defaults to :func:`resolve_rebase_conflicts`.
-            ``GitWriteStrategy`` passes ``self._resolve_rebase_conflicts``
-            so that tests which monkeypatch ``_resolve_rebase_conflicts`` on
-            the strategy instance are still honoured.
+            callable.  Defaults to :func:`resolve_rebase_conflicts`
+            (resolved from this module's globals at call time, so tests
+            monkeypatch ``conflict.resolve_rebase_conflicts`` directly;
+            #893 removed the strategy-level delegation shims).
 
     Returns:
         ``(saved, None)`` on success — ``saved`` is the list of

--- a/src/markdown_vault_mcp/git/push_scheduler.py
+++ b/src/markdown_vault_mcp/git/push_scheduler.py
@@ -1,0 +1,246 @@
+"""Deferred-push scheduling for the git write strategy.
+
+Extracted verbatim from :mod:`markdown_vault_mcp.git.strategy` (#893):
+:class:`PushScheduler` owns the idle push timer and the pending-push flag,
+plus the push execution paths (:meth:`PushScheduler.do_push_safe`,
+:meth:`PushScheduler.do_push`, :meth:`PushScheduler.push_if_unpushed`,
+:meth:`PushScheduler.flush`).  It shares the strategy-wide lock with
+:class:`~markdown_vault_mcp.git.strategy.GitWriteStrategy` — the same object,
+so the documented lock-ordering contracts of the pull/write paths still hold.
+
+The module-level :func:`_push` helper (GIT_ASKPASS-authenticated
+``git push origin``) also lives here; tests patch it as
+``markdown_vault_mcp.git.push_scheduler._push``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import subprocess
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.git._run import (
+    _build_askpass_env,
+    redact,
+    resolve_tracking_ref,
+)
+
+if TYPE_CHECKING:
+    from markdown_vault_mcp.git.bootstrap import RepoBootstrap
+
+logger = logging.getLogger(__name__)
+
+
+class PushScheduler:
+    """Idle-timer push deferral and push execution for GitWriteStrategy.
+
+    A collaborator composed into
+    :class:`~markdown_vault_mcp.git.strategy.GitWriteStrategy` (#893).  It
+    owns the shared push state — the idle :class:`threading.Timer` and the
+    ``push_pending`` flag — and executes pushes under the strategy-wide
+    lock.  The strategy's pull loop retries a failed deferred push through
+    :meth:`do_push_safe` (#957), and the strategy's public ``flush`` /
+    ``close`` delegate their timer/pending mechanics to :meth:`flush`.
+
+    Args:
+        lock: The strategy-wide lock, shared with the strategy's pull/write
+            paths and :class:`~markdown_vault_mcp.git.bootstrap.RepoBootstrap`.
+            The SAME object must be passed to every collaborator; this class
+            introduces no lock of its own.
+        bootstrap: The repo-bootstrap collaborator; supplies the memoised
+            git root and the token/username credentials for push auth.
+        enable_push: Whether deferred push behaviour is enabled at all.
+        push_delay_s: Seconds of idle before the timer pushes.  ``0``
+            disables the timer (push only on ``flush``/``close``).
+    """
+
+    def __init__(
+        self,
+        *,
+        lock: threading.Lock,
+        bootstrap: RepoBootstrap,
+        enable_push: bool,
+        push_delay_s: float,
+    ) -> None:
+        self._lock = lock
+        self._bootstrap = bootstrap
+        self._enable_push = enable_push
+        self._push_delay_s = push_delay_s
+        self._push_pending = False
+        self._timer: threading.Timer | None = None
+
+    @property
+    def _git_root(self) -> Path | None:
+        """The memoised working-tree root, read from the bootstrap."""
+        return self._bootstrap.git_root
+
+    @property
+    def _token(self) -> str | None:
+        """PAT for HTTPS push auth, read from the bootstrap."""
+        return self._bootstrap.token
+
+    @property
+    def _username(self) -> str:
+        """Username used with token auth, read from the bootstrap."""
+        return self._bootstrap.username
+
+    def _redact(self, text: str) -> str:
+        """Replace the configured PAT with ``***`` so it never reaches logs."""
+        return redact(text, self._token)
+
+    def schedule_push(self) -> None:
+        """Reset the idle push timer."""
+        with self._lock:
+            self._push_pending = True
+            if self._timer is not None:
+                self._timer.cancel()
+            if self._push_delay_s > 0:
+                self._timer = threading.Timer(self._push_delay_s, self.do_push_safe)
+                self._timer.daemon = True
+                self._timer.start()
+
+    def do_push_safe(self) -> None:
+        """Push wrapper that catches and logs errors."""
+        try:
+            self.do_push()
+        except subprocess.CalledProcessError as exc:
+            sanitized_stderr = self._redact(exc.stderr or "")
+            logger.error(
+                "Git push failed: command %s returned %d\n%s",
+                exc.cmd,
+                exc.returncode,
+                sanitized_stderr,
+            )
+        except Exception:
+            logger.error("Git push failed", exc_info=True)
+
+    def do_push(self) -> None:
+        """Execute git push and clear the pending flag on success.
+
+        ``_push_pending`` is cleared *after* ``_push()`` returns without
+        raising. On failure the flag stays set so the periodic pull loop
+        retries the push after its rebase step resolves any non-fast-forward
+        divergence (#957); previously the flag was cleared before the push,
+        so a failed deferred push left commits local with no retry until the
+        next write or startup.
+        """
+        with self._lock:
+            git_root = self._git_root
+            if not self._enable_push or not self._push_pending or git_root is None:
+                return
+            _push(git_root, self._token, self._username)
+            self._push_pending = False
+            logger.info("Git: pushed to remote")
+
+    def push_if_unpushed(self) -> None:
+        """On startup, push any local commits ahead of the remote.
+
+        Runs WITHOUT taking the lock — the strategy's one-time write init
+        calls it while already holding the shared lock.
+        """
+        git_root = self._git_root
+        if git_root is None or not self._enable_push:
+            return
+
+        try:
+            ref = resolve_tracking_ref(git_root)
+            if ref is None:
+                # No remote-tracking ref resolvable — not an error at startup.
+                logger.debug("Git: no remote ref to check for unpushed commits")
+                return
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(git_root),
+                    "log",
+                    "--oneline",
+                    f"{ref}..HEAD",
+                ],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            logger.debug("Git: git not found, skipping unpushed check")
+            return
+
+        if result.returncode != 0:
+            # No remote-tracking ref or no remote — not an error at startup.
+            logger.debug("Git: no remote ref to check for unpushed commits")
+            return
+
+        if result.stdout.strip():
+            logger.info("Git: found unpushed commits on startup, pushing now")
+            try:
+                _push(git_root, self._token, self._username)
+            except subprocess.CalledProcessError as exc:
+                sanitized_stderr = self._redact(exc.stderr or "")
+                logger.error(
+                    "Git startup push failed: command %s returned %d\n%s",
+                    exc.cmd,
+                    exc.returncode,
+                    sanitized_stderr,
+                )
+
+    def flush(self) -> None:
+        """Block until any pending push completes.
+
+        Cancels the idle timer and pushes immediately if there are
+        pending local commits.
+        """
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+            pending = self._push_pending
+
+        if pending and self._git_root is not None:
+            self.do_push_safe()
+
+
+def _push(git_root: Path, token: str | None, username: str = "x-access-token") -> None:
+    """Push to the default remote, using GIT_ASKPASS for token auth.
+
+    When a token is supplied a temporary helper script is written to a
+    private temporary file (mode 0o700).  Git reads credentials from this
+    script via ``GIT_ASKPASS`` so the token is never present in any
+    process's command-line arguments and is therefore not visible in
+    ``/proc/<pid>/cmdline``.  The script is deleted in a ``finally`` block
+    regardless of push outcome.
+
+    Args:
+        git_root: Git repository root.
+        token: Optional PAT for HTTPS push.  If ``None``, relies on SSH
+            keys or pre-configured git credentials.
+        username: Username used for HTTPS auth prompts when *token* is set.
+    """
+    root = str(git_root)
+
+    # Always push to "origin".  If the remote is named differently,
+    # configure a git remote alias or adjust this constant.
+    if not token:
+        subprocess.run(
+            ["git", "-C", root, "push", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return
+
+    env = _build_askpass_env(token, username)
+    script_path_str = env["GIT_ASKPASS"]
+    script_path = Path(script_path_str)
+    try:
+        subprocess.run(
+            ["git", "-C", root, "push", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            script_path.unlink()

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -3,6 +3,15 @@
 Provides :class:`GitWriteStrategy`, a stateful callback that commits
 per-write and defers pushes to a background timer.  Also retains the
 legacy :func:`git_write_strategy` factory for backward compatibility.
+
+Two collaborators are composed in (#893): repository discovery, managed
+cloning, and startup validation live in
+:class:`~markdown_vault_mcp.git.bootstrap.RepoBootstrap`; the deferred-push
+timer, pending-flag, and push execution live in
+:class:`~markdown_vault_mcp.git.push_scheduler.PushScheduler`.  Both share
+the strategy-wide lock — the SAME object — so the lock-ordering contracts
+documented on :meth:`GitWriteStrategy._force_pull_rebase_fallback` and
+:meth:`GitWriteStrategy._quiesce_writes` are unchanged.
 """
 
 from __future__ import annotations
@@ -12,23 +21,18 @@ import logging
 import re
 import subprocess
 import threading
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from pathlib import Path
 
     from markdown_vault_mcp.types import CommitDiff, HistoryEntry, WriteOperation
 
 from fastmcp.server.dependencies import get_access_token as _get_access_token
 
-from markdown_vault_mcp.exceptions import ConfigurationError
 from markdown_vault_mcp.git import conflict, query
 from markdown_vault_mcp.git._run import (
-    _build_askpass_env,
-    _find_git_root,
-    _is_ssh_remote,
-    _normalize_remote,
     cleanup_git_env,
     git_env,
     redact,
@@ -36,6 +40,8 @@ from markdown_vault_mcp.git._run import (
     run_git,
     run_git_capturing,
 )
+from markdown_vault_mcp.git.bootstrap import RepoBootstrap
+from markdown_vault_mcp.git.push_scheduler import PushScheduler
 from markdown_vault_mcp.git.types import (
     PULL_REASON_CONFLICT_RESOLUTION_FAILED,
     PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS,
@@ -163,12 +169,21 @@ class GitWriteStrategy:
         # the caller re-passing it.  Distinct from ``_pull_repo_path`` which
         # is only set when the periodic pull loop is started via ``start()``.
         self._repo_path: Path | None = repo_path
-        self._git_root: Path | None = None
-        self._git_root_checked = False
         self._write_init_done = False
-        self._push_pending = False
-        self._timer: threading.Timer | None = None
+        # ONE strategy-wide lock, shared with both collaborators below.
         self._lock = threading.Lock()
+        self._bootstrap = RepoBootstrap(
+            lock=self._lock,
+            token=token,
+            username=username,
+            repo_url=repo_url,
+        )
+        self._push_scheduler = PushScheduler(
+            lock=self._lock,
+            bootstrap=self._bootstrap,
+            enable_push=enable_push,
+            push_delay_s=push_delay_s,
+        )
         self._closed = False
         self._pull_stop = threading.Event()
         self._pull_thread: threading.Thread | None = None
@@ -181,7 +196,7 @@ class GitWriteStrategy:
         self._on_pull: Callable[[], object] | None = None
         if repo_path is not None:
             if self._managed:
-                self._ensure_managed_repo(repo_path)
+                self._bootstrap.ensure_managed_repo(repo_path)
             else:
                 self.validate_startup(repo_path)
 
@@ -210,129 +225,36 @@ class GitWriteStrategy:
         """
         return redact(text, self._token)
 
+    @property
+    def _git_root(self) -> Path | None:
+        """The memoised working-tree root, owned by :class:`RepoBootstrap`."""
+        return self._bootstrap.git_root
+
+    @_git_root.setter
+    def _git_root(self, value: Path | None) -> None:
+        self._bootstrap.git_root = value
+
+    @property
+    def _push_pending(self) -> bool:
+        """The pending-push flag, owned by :class:`PushScheduler`."""
+        return self._push_scheduler._push_pending
+
+    @_push_pending.setter
+    def _push_pending(self, value: bool) -> None:
+        self._push_scheduler._push_pending = value
+
+    @property
+    def _timer(self) -> threading.Timer | None:
+        """The idle push timer, owned by :class:`PushScheduler`."""
+        return self._push_scheduler._timer
+
     def _ensure_git_root(self, repo_path: Path) -> Path | None:
-        if self._git_root_checked:
-            return self._git_root
-        with self._lock:
-            if not self._git_root_checked:
-                self._git_root = _find_git_root(repo_path)
-                self._git_root_checked = True
-        return self._git_root
-
-    def _get_origin_url(self, git_root: Path) -> str | None:
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(git_root), "remote", "get-url", "origin"],
-                capture_output=True,
-                text=True,
-            )
-        except FileNotFoundError:
-            return None
-        if result.returncode != 0:
-            return None
-        return result.stdout.strip() or None
-
-    def _ensure_managed_repo(self, repo_path: Path) -> None:
-        if self._repo_url is None:
-            raise ConfigurationError("Managed git mode requires a repo_url.")
-
-        if self._token and _is_ssh_remote(self._repo_url):
-            raise ConfigurationError(
-                f"Managed mode repo URL {self._repo_url!r} uses SSH transport, but "
-                "GIT_TOKEN auth requires HTTPS."
-            )
-
-        path = Path(repo_path)
-        if path.exists():
-            if not path.is_dir():
-                raise ConfigurationError(
-                    f"Managed mode requires SOURCE_DIR to be a directory: {path}"
-                )
-            is_empty = not any(path.iterdir())
-        else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            is_empty = True
-
-        if is_empty:
-            env = self._git_env()
-            try:
-                subprocess.run(
-                    ["git", "clone", self._repo_url, str(path)],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=env,
-                )
-            except FileNotFoundError as exc:
-                raise ConfigurationError(
-                    "git is not installed or not on PATH."
-                ) from exc
-            except subprocess.CalledProcessError as exc:
-                raise ConfigurationError(
-                    f"Failed to clone managed git repo {self._repo_url!r} into {path}: "
-                    f"{(exc.stderr or '').strip()}"
-                ) from exc
-            finally:
-                self._cleanup_git_env(env)
-
-        git_root = _find_git_root(path)
-        if git_root is None:
-            raise ConfigurationError(
-                f"Managed mode requires SOURCE_DIR to be empty or a git repository: {path}"
-            )
-        origin_url = self._get_origin_url(git_root)
-        if origin_url is None:
-            raise ConfigurationError(
-                f"Managed mode requires an 'origin' remote in repository {git_root}."
-            )
-        if _normalize_remote(origin_url) != _normalize_remote(self._repo_url):
-            raise ConfigurationError(
-                "Managed mode remote mismatch: existing origin is "
-                f"{origin_url!r}, expected {self._repo_url!r}."
-            )
-        self._git_root = git_root
-        self._git_root_checked = True
-        self._check_remote_protocol(git_root)
-
-    def _check_remote_protocol(self, git_root: Path) -> None:
-        """Raise ConfigurationError if origin uses SSH while token auth is enabled."""
-        if not self._token:
-            return
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(git_root), "remote", "get-url", "origin"],
-                capture_output=True,
-                text=True,
-            )
-        except FileNotFoundError:
-            return
-        if result.returncode != 0:
-            # No remote configured; ignore here.
-            return
-
-        url = result.stdout.strip()
-        if not _is_ssh_remote(url):
-            return
-
-        if url.startswith("ssh://git@"):
-            https_url = "https://" + url[len("ssh://git@") :]
-        elif url.startswith("ssh://"):
-            https_url = "https://" + url[len("ssh://") :]
-        else:
-            without_prefix = url[len("git@") :]
-            https_url = "https://" + without_prefix.replace(":", "/", 1)
-
-        raise ConfigurationError(
-            f"Remote URL {url!r} uses SSH transport, but GIT_TOKEN requires HTTPS.\n"
-            f"Run: git -C {git_root} remote set-url origin {https_url}"
-        )
+        """Discover and memoise the git root via :class:`RepoBootstrap`."""
+        return self._bootstrap.ensure_git_root(repo_path)
 
     def validate_startup(self, repo_path: Path) -> None:
         """Validate startup git settings for token-authenticated workflows."""
-        git_root = self._ensure_git_root(repo_path)
-        if git_root is None:
-            return
-        self._check_remote_protocol(git_root)
+        self._bootstrap.validate_startup(repo_path)
 
     def _ensure_write_init(self) -> None:
         """One-time initialisation for the write path (identity/push/LFS)."""
@@ -341,10 +263,10 @@ class GitWriteStrategy:
         with self._lock:
             if self._write_init_done or self._git_root is None:
                 return
-            self._check_remote_protocol(self._git_root)
+            self._bootstrap.check_remote_protocol(self._git_root)
             self._check_identity()
             if self._enable_push:
-                self._push_if_unpushed()
+                self._push_scheduler.push_if_unpushed()
             # LFS pull runs under the git lock to avoid overlapping git ops.
             # Forward auth credentials so token-protected LFS backends
             # authenticate with the same GIT_ASKPASS mechanism used for push.
@@ -427,7 +349,7 @@ class GitWriteStrategy:
                     else None,
                 )
             if self._enable_push:
-                self._schedule_push()
+                self._push_scheduler.schedule_push()
         except subprocess.CalledProcessError as exc:
             sanitized_stderr = self._redact(exc.stderr or "")
             logger.error(
@@ -445,53 +367,6 @@ class GitWriteStrategy:
                 operation,
                 exc_info=True,
             )
-
-    def _schedule_push(self) -> None:
-        """Reset the idle push timer."""
-        with self._lock:
-            self._push_pending = True
-            if self._timer is not None:
-                self._timer.cancel()
-            if self._push_delay_s > 0:
-                self._timer = threading.Timer(self._push_delay_s, self._do_push_safe)
-                self._timer.daemon = True
-                self._timer.start()
-
-    def _do_push_safe(self) -> None:
-        """Push wrapper that catches and logs errors."""
-        try:
-            self._do_push()
-        except subprocess.CalledProcessError as exc:
-            sanitized_stderr = self._redact(exc.stderr or "")
-            logger.error(
-                "Git push failed: command %s returned %d\n%s",
-                exc.cmd,
-                exc.returncode,
-                sanitized_stderr,
-            )
-        except Exception:
-            logger.error("Git push failed", exc_info=True)
-
-    def _do_push(self) -> None:
-        """Execute git push and clear the pending flag on success.
-
-        ``_push_pending`` is cleared *after* ``_push()`` returns without
-        raising. On failure the flag stays set so the periodic pull loop
-        retries the push after its rebase step resolves any non-fast-forward
-        divergence (#957); previously the flag was cleared before the push,
-        so a failed deferred push left commits local with no retry until the
-        next write or startup.
-        """
-        with self._lock:
-            if (
-                not self._enable_push
-                or not self._push_pending
-                or self._git_root is None
-            ):
-                return
-            _push(self._git_root, self._token, self._username)
-            self._push_pending = False
-            logger.info("Git: pushed to remote")
 
     def _check_identity(self) -> None:
         """Warn once at startup if no git committer identity is configured.
@@ -523,51 +398,6 @@ class GitWriteStrategy:
                 self._commit_name,
                 self._commit_email,
             )
-
-    def _push_if_unpushed(self) -> None:
-        """On startup, push any local commits ahead of the remote."""
-        if self._git_root is None or not self._enable_push:
-            return
-
-        try:
-            ref = self._tracking_ref(self._git_root)
-            if ref is None:
-                # No remote-tracking ref resolvable — not an error at startup.
-                logger.debug("Git: no remote ref to check for unpushed commits")
-                return
-            result = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(self._git_root),
-                    "log",
-                    "--oneline",
-                    f"{ref}..HEAD",
-                ],
-                capture_output=True,
-                text=True,
-            )
-        except FileNotFoundError:
-            logger.debug("Git: git not found, skipping unpushed check")
-            return
-
-        if result.returncode != 0:
-            # No remote-tracking ref or no remote — not an error at startup.
-            logger.debug("Git: no remote ref to check for unpushed commits")
-            return
-
-        if result.stdout.strip():
-            logger.info("Git: found unpushed commits on startup, pushing now")
-            try:
-                _push(self._git_root, self._token, self._username)
-            except subprocess.CalledProcessError as exc:
-                sanitized_stderr = self._redact(exc.stderr or "")
-                logger.error(
-                    "Git startup push failed: command %s returned %d\n%s",
-                    exc.cmd,
-                    exc.returncode,
-                    sanitized_stderr,
-                )
 
     def _lfs_pull(self, env: dict[str, str] | None = None) -> None:
         """Run ``git lfs pull`` to resolve LFS pointers, if LFS is enabled.
@@ -602,144 +432,6 @@ class GitWriteStrategy:
                 "Git LFS pull failed: git not found on PATH. "
                 "Install git or set MARKDOWN_VAULT_MCP_GIT_LFS=false to suppress this error."
             )
-
-    def _resolve_rebase_conflicts(
-        self,
-        git_root: Path,
-        env: dict[str, str] | None,
-    ) -> list[tuple[str, str]]:
-        """Resolve rebase conflicts by accepting theirs and saving ours.
-
-        Called when ``git rebase <ref>`` (the resolved ``origin/<branch>``
-        remote-tracking ref) has stopped at a conflict.
-        For each conflicting file, saves the MCP version from
-        ``REBASE_HEAD``, then accepts the upstream version via
-        ``git checkout --ours``.  Continues the rebase, looping if
-        multiple commits conflict.
-
-        Returns:
-            A list of ``(relative_path, saved_content)`` tuples for the
-            files that had conflicts.  May be partial (not all commits
-            resolved) if the iteration limit is hit; the caller is
-            responsible for aborting any in-progress rebase before
-            writing the conflict files.
-        """
-        return conflict.resolve_rebase_conflicts(git_root, env)
-
-    def _resolve_conflicts_safely(
-        self,
-        git_root: Path,
-        env: dict[str, str] | None,
-        from_sha: str,
-    ) -> tuple[list[tuple[str, str]] | None, PullResult | None]:
-        """Delegate to :func:`conflict.resolve_conflicts_safely`.
-
-        Passes ``self._resolve_rebase_conflicts`` as ``resolve_fn`` so
-        instance-level monkeypatches of it in tests are still honoured.
-
-        Returns:
-            ``(saved, None)`` on success, or ``(None, PullResult)`` on
-            failure — in which case the caller should return the
-            ``PullResult`` immediately.
-        """
-        return conflict.resolve_conflicts_safely(
-            git_root,
-            env,
-            from_sha,
-            token=self._token,
-            resolve_fn=self._resolve_rebase_conflicts,
-        )
-
-    def _rebase_in_progress(
-        self,
-        git_root: Path,
-        env: dict[str, str] | None,
-    ) -> bool:
-        """Return True if a rebase is in progress in this working tree.
-
-        Reliable signal: the existence of ``.git/rebase-merge`` or
-        ``.git/rebase-apply`` directories.  ``REBASE_HEAD`` ref is NOT
-        reliable — git keeps it around after a successful ``rebase
-        --continue`` for use as a backup reference, so its mere existence
-        does not mean a rebase is in flight.  Resolves ``GIT_DIR`` via
-        ``rev-parse`` so this works inside worktrees and submodules where
-        the directory is not the repo's literal ``.git``.
-
-        On ``rev-parse --git-dir`` failure (which means we genuinely cannot
-        tell), this conservatively returns ``True`` so the caller's abort
-        runs — abort on a clean tree fails loudly (and is logged), but
-        failing to abort a real in-progress rebase would leave the repo
-        wedged for every subsequent ``force_pull``.  The underlying
-        rev-parse failure is logged at ERROR with token-redacted stderr.
-
-        Args:
-            git_root: Working-tree root.
-            env: Optional GIT_ASKPASS environment.
-
-        Returns:
-            ``True`` if a rebase appears to be in progress (or if we cannot
-            tell); ``False`` only when ``rev-parse --git-dir`` succeeded
-            AND no ``rebase-merge`` / ``rebase-apply`` directory exists.
-        """
-        return conflict.rebase_in_progress(git_root, env, token=self._token)
-
-    def _abort_in_progress_rebase(
-        self,
-        git_root: Path,
-        env: dict[str, str] | None,
-    ) -> bool:
-        """Run ``git rebase --abort`` synchronously.
-
-        Args:
-            git_root: Working-tree root.
-            env: Optional GIT_ASKPASS environment.
-
-        Returns:
-            ``True`` if abort succeeded; ``False`` if abort itself failed
-            (in which case the caller should bail out — the working tree
-            may be inconsistent).  Failure is logged at ERROR with
-            token-redacted stderr.
-        """
-        return conflict.abort_in_progress_rebase(git_root, env, token=self._token)
-
-    def _restore_upstream_paths(
-        self,
-        git_root: Path,
-        env: dict[str, str] | None,
-        saved: list[tuple[str, str]],
-        ref: str,
-    ) -> list[tuple[str, str]]:
-        """Restore upstream content for each conflict path after rebase abort.
-
-        After ``git rebase --abort`` the working tree reverts to the
-        pre-rebase MCP state — every file in ``saved`` again contains the
-        MCP version, not the upstream version.  For each path we run
-        ``git checkout <ref> -- <path>`` to bring back the upstream
-        bytes so :meth:`_write_conflict_files` reads the right side
-        (canonical = upstream, sibling = MCP).
-
-        On per-path checkout failure (file deleted upstream, permission
-        error, etc.), the path is DROPPED from the returned list — writing
-        a sibling that contains the same MCP bytes as the canonical path
-        would defeat the "remote wins, local preserved" invariant.  Each
-        drop is logged at ERROR with the path name and token-redacted
-        stderr so an operator can investigate.
-
-        Args:
-            git_root: Working-tree root.
-            env: Optional GIT_ASKPASS environment.
-            saved: List of ``(rel_path, mcp_content)`` tuples returned by
-                :meth:`_resolve_conflicts_safely`.
-            ref: Remote-tracking ref to restore from (``origin/<branch>``),
-                resolved by :meth:`_tracking_ref`.
-
-        Returns:
-            Subset of ``saved`` whose upstream restore succeeded.  May be
-            empty if every checkout failed.
-        """
-        return conflict.restore_upstream_paths(
-            git_root, env, saved, ref, token=self._token
-        )
 
     def _build_pull_result_advanced(
         self,
@@ -784,41 +476,6 @@ class GitWriteStrategy:
             to_sha=new_head,
             reason=reason,
             conflict_files=conflict_files,
-        )
-
-    def _write_conflict_files(
-        self,
-        git_root: Path,
-        saved: list[tuple[str, str]],
-        env: dict[str, str] | None,
-    ) -> list[str] | None:
-        """Write conflict files and add ``conflict_with`` frontmatter to both sides.
-
-        For each ``(relative_path, content)`` in *saved*:
-
-        1. Write the MCP version as ``<stem>.conflict-mcp-<timestamp><ext>``
-           with ``conflict_with`` and ``conflict_date`` frontmatter.
-        2. Merge ``conflict_with`` and ``conflict_date`` into the original
-           file's existing frontmatter.  If the original cannot be read or
-           rewritten (removed/inaccessible after the existence check, or not
-           valid UTF-8), its update is skipped with a logged warning — the
-           conflict sibling is still written and counted.
-
-        Returns:
-            List of conflict file relative paths that were written and
-            committed.  Returns ``None`` when the final ``git commit`` step
-            failed (nothing-to-commit, hook failure, signing failure, etc.)
-            so callers can surface ``conflict_resolution_failed`` instead of
-            implying a successful conflict-resolution commit.  Returns an
-            empty list when *saved* is empty (nothing to do).
-        """
-        return conflict.write_conflict_files(
-            git_root,
-            saved,
-            env,
-            commit_name=self._commit_name,
-            commit_email=self._commit_email,
-            token=self._token,
         )
 
     # ------------------------------------------------------------------
@@ -926,8 +583,10 @@ class GitWriteStrategy:
 
         On ``ff-only`` failure (divergent history) the implementation
         falls through to the same rebase + Syncthing-style sibling write
-        path used by :meth:`sync_once` (see :meth:`_resolve_rebase_conflicts`
-        and :meth:`_write_conflict_files`).  When the conflict-resolution
+        path used by :meth:`sync_once` (see
+        :func:`~markdown_vault_mcp.git.conflict.resolve_rebase_conflicts` and
+        :func:`~markdown_vault_mcp.git.conflict.write_conflict_files`).  When
+        the conflict-resolution
         path produces sibling files HEAD has advanced to the remote and
         :attr:`PullResult.applied` is ``True`` with
         :attr:`PullResult.reason` set to
@@ -1017,7 +676,8 @@ class GitWriteStrategy:
                     # network-touching subprocess in this method, and git
                     # error messages can echo the URL with credentials
                     # back at the user.  Mirrors the redaction pattern
-                    # already used in ``_do_push_safe`` and ``force_push``.
+                    # already used in ``PushScheduler.do_push_safe`` and
+                    # ``force_push``.
                     stderr = self._redact((exc.stderr or "").strip())
                     logger.warning(
                         "%s: fetch failed: %s",
@@ -1177,16 +837,18 @@ class GitWriteStrategy:
             # Real conflicts during rebase — resolve by accepting upstream
             # and saving the local MCP versions as Syncthing-style siblings.
             #
-            # ``_resolve_rebase_conflicts`` runs ``git checkout --ours`` and
-            # ``git add`` with ``check=True``; if either raises mid-loop the
+            # ``conflict.resolve_rebase_conflicts`` runs ``git checkout --ours``
+            # and ``git add`` with ``check=True``; if either raises mid-loop the
             # repository is left in a half-rebased state.
-            # ``_resolve_conflicts_safely`` wraps that in a defensive abort
-            # so a subsequent ``force_pull`` (or any per-write commit path)
-            # does not trip over the leftover ``rebase-merge`` directory.
-            saved, early_exit = self._resolve_conflicts_safely(git_root, env, from_sha)
+            # ``conflict.resolve_conflicts_safely`` wraps that in a defensive
+            # abort so a subsequent ``force_pull`` (or any per-write commit
+            # path) does not trip over the leftover ``rebase-merge`` directory.
+            saved, early_exit = conflict.resolve_conflicts_safely(
+                git_root, env, from_sha, token=self._token
+            )
             if early_exit is not None:
                 return early_exit
-            # ``_resolve_conflicts_safely`` returns ``(saved, None)`` on
+            # ``resolve_conflicts_safely`` returns ``(saved, None)`` on
             # success and ``(None, PullResult)`` on failure — exactly one
             # is non-None.  After the early-exit guard above, ``saved`` is
             # guaranteed non-None; assert so mypy can narrow.
@@ -1196,14 +858,20 @@ class GitWriteStrategy:
             # limit, or exited via ``break`` without completing), abort
             # cleanly so the working tree is consistent before we write
             # conflict files.
-            rebase_in_progress = self._rebase_in_progress(git_root, env)
+            rebase_in_progress = conflict.rebase_in_progress(
+                git_root, env, token=self._token
+            )
 
             if rebase_in_progress:
-                if not self._abort_in_progress_rebase(git_root, env):
+                if not conflict.abort_in_progress_rebase(
+                    git_root, env, token=self._token
+                ):
                     return PullResult.head_unchanged_failure(
                         from_sha, PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS
                     )
-                saved = self._restore_upstream_paths(git_root, env, saved, ref)
+                saved = conflict.restore_upstream_paths(
+                    git_root, env, saved, ref, token=self._token
+                )
 
             if not saved:
                 logger.warning(
@@ -1217,7 +885,14 @@ class GitWriteStrategy:
             # Rebase has already completed via ``git rebase --continue`` — HEAD
             # has advanced even if the sibling-files commit below fails.
             actual_head = self._head_sha(git_root)
-            written = self._write_conflict_files(git_root, saved, env)
+            written = conflict.write_conflict_files(
+                git_root,
+                saved,
+                env,
+                commit_name=self._commit_name,
+                commit_email=self._commit_email,
+                token=self._token,
+            )
             if written is None:
                 logger.warning("%s: conflict commit failed, skipping", log_prefix)
                 return PullResult(
@@ -1611,9 +1286,10 @@ class GitWriteStrategy:
                             self._on_pull()
                 # Retry a pending push after the pull reconciled any
                 # non-fast-forward divergence via its rebase step (#957).
-                # _do_push's guard makes this a no-op when nothing is pending.
+                # PushScheduler.do_push's guard makes this a no-op when
+                # nothing is pending.
                 if self._enable_push:
-                    self._do_push_safe()
+                    self._push_scheduler.do_push_safe()
             except Exception:
                 logger.exception("Git pull loop tick failed")
             # Wait until the next interval, or stop early.
@@ -1637,19 +1313,19 @@ class GitWriteStrategy:
         """Block until any pending push completes.
 
         Cancels the idle timer and pushes immediately if there are
-        pending local commits.
+        pending local commits.  Thin delegation to
+        :meth:`PushScheduler.flush`, which owns the timer/pending-flag
+        mechanics (#893).
         """
-        with self._lock:
-            if self._timer is not None:
-                self._timer.cancel()
-                self._timer = None
-            pending = self._push_pending
-
-        if pending and self._git_root is not None:
-            self._do_push_safe()
+        self._push_scheduler.flush()
 
     def close(self) -> None:
-        """Cancel timer, flush pending push, mark strategy as closed."""
+        """Cancel timer, flush pending push, mark strategy as closed.
+
+        Sequencing: mark closed first (new writes become no-ops), stop the
+        periodic pull thread, then flush the push scheduler so the final
+        push happens with no pull tick racing it.
+        """
         self._closed = True
         self.stop()
         self.flush()
@@ -2025,48 +1701,3 @@ def _stage_and_commit(
     )
 
     logger.info("Git: committed %s (%s)", rel_path, operation)
-
-
-def _push(git_root: Path, token: str | None, username: str = "x-access-token") -> None:
-    """Push to the default remote, using GIT_ASKPASS for token auth.
-
-    When a token is supplied a temporary helper script is written to a
-    private temporary file (mode 0o700).  Git reads credentials from this
-    script via ``GIT_ASKPASS`` so the token is never present in any
-    process's command-line arguments and is therefore not visible in
-    ``/proc/<pid>/cmdline``.  The script is deleted in a ``finally`` block
-    regardless of push outcome.
-
-    Args:
-        git_root: Git repository root.
-        token: Optional PAT for HTTPS push.  If ``None``, relies on SSH
-            keys or pre-configured git credentials.
-        username: Username used for HTTPS auth prompts when *token* is set.
-    """
-    root = str(git_root)
-
-    # Always push to "origin".  If the remote is named differently,
-    # configure a git remote alias or adjust this constant.
-    if not token:
-        subprocess.run(
-            ["git", "-C", root, "push", "origin"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return
-
-    env = _build_askpass_env(token, username)
-    script_path_str = env["GIT_ASKPASS"]
-    script_path = Path(script_path_str)
-    try:
-        subprocess.run(
-            ["git", "-C", root, "push", "origin"],
-            capture_output=True,
-            text=True,
-            check=True,
-            env=env,
-        )
-    finally:
-        with contextlib.suppress(OSError):
-            script_path.unlink()

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -18,8 +18,30 @@ from markdown_vault_mcp.config import to_vault_kwargs
 from markdown_vault_mcp.git import (
     GitWriteStrategy,
     _find_git_root,
+    conflict,
     git_write_strategy,
 )
+
+
+def _write_conflict_files(
+    git_root: Path,
+    saved: list[tuple[str, str]],
+    env: dict[str, str] | None = None,
+    token: str | None = None,
+) -> list[str] | None:
+    """Call ``conflict.write_conflict_files`` with the strategy's default identity.
+
+    Replaces the removed ``GitWriteStrategy._write_conflict_files`` delegation
+    shim (#893) so the assertions in the tests below stay unchanged.
+    """
+    return conflict.write_conflict_files(
+        git_root,
+        saved,
+        env,
+        commit_name=GitWriteStrategy.DEFAULT_COMMIT_NAME,
+        commit_email=GitWriteStrategy.DEFAULT_COMMIT_EMAIL,
+        token=token,
+    )
 
 
 @pytest.fixture
@@ -422,18 +444,18 @@ class TestGitWriteStrategyClass:
         calls. (The earlier "assert not-yet-in-the-bare-log right after the
         writes" approach raced the 0.3 s timer and was flaky on Python 3.14.)
         """
-        import markdown_vault_mcp.git.strategy as git_strategy
+        import markdown_vault_mcp.git.push_scheduler as git_push_scheduler
 
         work, bare = git_repo_with_remote
 
         push_calls: list[tuple[object, ...]] = []
-        real_push = git_strategy._push
+        real_push = git_push_scheduler._push
 
         def counting_push(*args: object, **kwargs: object) -> None:
             push_calls.append(args)
             real_push(*args, **kwargs)  # type: ignore[arg-type]
 
-        monkeypatch.setattr(git_strategy, "_push", counting_push)
+        monkeypatch.setattr(git_push_scheduler, "_push", counting_push)
 
         # 30 s delay: the idle timer cannot fire during the writes below, so
         # there is no timer race to lose.
@@ -793,9 +815,9 @@ class TestGitWriteStrategyClass:
             cmd=["git", "push", "origin"],
             stderr="non-fast-forward",
         )
-        with patch("markdown_vault_mcp.git.strategy._push", side_effect=fake_exc):
+        with patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=fake_exc):
             # _do_push_safe swallows the error; the flag must stay set.
-            strategy._do_push_safe()
+            strategy._push_scheduler.do_push_safe()
 
         assert strategy._push_pending is True
 
@@ -807,8 +829,8 @@ class TestGitWriteStrategyClass:
         strategy._git_root = tmp_path
         strategy._push_pending = True
 
-        with patch("markdown_vault_mcp.git.strategy._push") as mock_push:
-            strategy._do_push()
+        with patch("markdown_vault_mcp.git.push_scheduler._push") as mock_push:
+            strategy._push_scheduler.do_push()
 
         assert mock_push.called
         assert strategy._push_pending is False
@@ -1091,10 +1113,10 @@ class TestTokenRedactionInLogs:
         )
 
         with (
-            patch("markdown_vault_mcp.git.strategy._push", side_effect=fake_exc),
+            patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=fake_exc),
             caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
         ):
-            strategy._do_push_safe()
+            strategy._push_scheduler.do_push_safe()
 
         log_text = " ".join(r.message for r in caplog.records)
         assert secret not in log_text
@@ -1113,13 +1135,13 @@ class TestTokenRedactionInLogs:
 
         with (
             patch(
-                "markdown_vault_mcp.git.strategy._push",
+                "markdown_vault_mcp.git.push_scheduler._push",
                 side_effect=RuntimeError("network down"),
             ),
             caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
         ):
             # Must not raise.
-            strategy._do_push_safe()
+            strategy._push_scheduler.do_push_safe()
 
         assert any("Git push failed" in r.message for r in caplog.records)
 
@@ -1157,10 +1179,10 @@ class TestTokenRedactionInLogs:
         )
 
         with (
-            patch("markdown_vault_mcp.git.strategy._push", side_effect=fake_exc),
+            patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=fake_exc),
             caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
         ):
-            strategy._push_if_unpushed()
+            strategy._push_scheduler.push_if_unpushed()
 
         log_text = " ".join(r.message for r in caplog.records)
         assert secret not in log_text
@@ -1307,7 +1329,9 @@ class TestGitLfsSupport:
 
         with (
             patch.object(strategy, "_lfs_pull", lfs_pull_mock),
-            patch.object(strategy, "_push_if_unpushed", push_if_unpushed_mock),
+            patch.object(
+                strategy._push_scheduler, "push_if_unpushed", push_if_unpushed_mock
+            ),
             patch("markdown_vault_mcp.git.strategy._stage_and_commit", commit_mock),
         ):
             # First call — triggers lazy init including _lfs_pull.
@@ -2014,8 +2038,6 @@ class TestGitSyncOnce:
         """_resolve_rebase_conflicts returns saved content when iteration limit hit."""
         from types import SimpleNamespace
 
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
-
         call_count = 0
 
         def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
@@ -2042,7 +2064,7 @@ class TestGitSyncOnce:
 
         monkeypatch.setattr("markdown_vault_mcp.git.subprocess.run", fake_run)
 
-        result = strategy._resolve_rebase_conflicts(tmp_path, env=None)
+        result = conflict.resolve_rebase_conflicts(tmp_path, env=None)
 
         # The same file conflicted in all 50 iterations; deduplication keeps only
         # the last version, so the result is a single unique entry.
@@ -2055,7 +2077,6 @@ class TestGitSyncOnce:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """_write_conflict_files returns None and logs ERROR when git commit fails."""
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
 
         # Create a real file for the original path.
         (git_repo / "note.md").write_text("# Original\n")
@@ -2084,7 +2105,7 @@ class TestGitSyncOnce:
             ),
             caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
         ):
-            written = strategy._write_conflict_files(git_repo, saved, env=None)
+            written = _write_conflict_files(git_repo, saved)
 
         # Commit failed: helper signals failure to its caller via None.
         assert written is None
@@ -2097,7 +2118,6 @@ class TestGitSyncOnce:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Commit-failure stderr passes through _redact before being logged."""
-        strategy = GitWriteStrategy(token="secret-pat-xyz", push_delay_s=0)
 
         (git_repo / "note.md").write_text("# Original\n")
         saved = [("note.md", "# MCP version\n")]
@@ -2125,7 +2145,7 @@ class TestGitSyncOnce:
             ),
             caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
         ):
-            strategy._write_conflict_files(git_repo, saved, env=None)
+            _write_conflict_files(git_repo, saved, token="secret-pat-xyz")
 
         joined = " ".join(r.getMessage() for r in caplog.records)
         assert "secret-pat-xyz" not in joined
@@ -2137,7 +2157,6 @@ class TestGitSyncOnce:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """_write_conflict_files logs WARNING for unparseable frontmatter but still writes files."""
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
 
         # Write an original file with invalid YAML frontmatter.
         (git_repo / "broken.md").write_text("---\n{invalid: yaml: [\n---\n# Body\n")
@@ -2154,7 +2173,7 @@ class TestGitSyncOnce:
             ),
             caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
         ):
-            written = strategy._write_conflict_files(git_repo, saved, env=None)
+            written = _write_conflict_files(git_repo, saved)
 
         # Conflict file was still written despite parse errors.
         assert len(written) == 1
@@ -2175,7 +2194,6 @@ class TestGitSyncOnce:
         even if the parse fails — no double read_text (#662)."""
         from pathlib import Path
 
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
         (git_repo / "note.md").write_text("# original body\n")
         saved = [("note.md", "# mcp body\n")]
 
@@ -2195,7 +2213,7 @@ class TestGitSyncOnce:
         # the old code re-read the file in that branch.
         monkeypatch.setattr("markdown_vault_mcp.git.conflict.frontmatter.loads", _raise)
 
-        written = strategy._write_conflict_files(git_repo, saved, env=None)
+        written = _write_conflict_files(git_repo, saved)
 
         assert len(written) == 1
         assert reads["n"] == 1, f"original file read {reads['n']} times, expected 1"
@@ -2211,7 +2229,6 @@ class TestGitSyncOnce:
         than crashing, and the conflict sibling is still written (#662)."""
         from pathlib import Path
 
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
         (git_repo / "note.md").write_text("# original body\n")
         saved = [("note.md", "# mcp body\n")]
 
@@ -2228,7 +2245,7 @@ class TestGitSyncOnce:
         monkeypatch.setattr(Path, "read_text", failing_read_text)
 
         with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"):
-            written = strategy._write_conflict_files(git_repo, saved, env=None)
+            written = _write_conflict_files(git_repo, saved)
 
         # No crash; the conflict sibling was still written.
         assert len(written) == 1
@@ -2251,12 +2268,11 @@ class TestGitSyncOnce:
         otherwise it bypasses the handler and crashes the whole pull. Uses a real
         non-UTF-8 file (no mocking), exercising the actual decode path.
         """
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
         (git_repo / "note.md").write_bytes(b"\xff\xfe not valid utf-8 \x80\n")
         saved = [("note.md", "# mcp body\n")]
 
         with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"):
-            written = strategy._write_conflict_files(git_repo, saved, env=None)
+            written = _write_conflict_files(git_repo, saved)
 
         # No crash; the conflict sibling was still written.
         assert len(written) == 1
@@ -2284,11 +2300,10 @@ class TestGitSyncOnce:
         """A skipped original (non-UTF-8) must NOT be staged into the conflict
         commit — only its sibling is (#675). Staging it would commit a spurious
         change (or a deletion, for a TOCTOU-removed original)."""
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
         (git_repo / "note.md").write_bytes(b"\xff\xfe not valid utf-8 \x80\n")
         saved = [("note.md", "# mcp body\n")]
 
-        written = strategy._write_conflict_files(git_repo, saved, env=None)
+        written = _write_conflict_files(git_repo, saved)
 
         assert len(written) == 1
         files = self._head_commit_files(git_repo)
@@ -2299,11 +2314,10 @@ class TestGitSyncOnce:
         """A successfully-updated original (conflict_with frontmatter written) IS
         staged into the conflict commit alongside its sibling (#675 regression
         guard — the fix must not stop staging originals it actually rewrote)."""
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
         (git_repo / "note.md").write_text("# original\n", encoding="utf-8")
         saved = [("note.md", "# mcp body\n")]
 
-        written = strategy._write_conflict_files(git_repo, saved, env=None)
+        written = _write_conflict_files(git_repo, saved)
 
         assert len(written) == 1
         files = self._head_commit_files(git_repo)
@@ -2320,12 +2334,11 @@ class TestGitSyncOnce:
         all-or-nothing (#675). This pins the selective-staging contract that the
         single-original tests cannot (a 'stage every saved original' regression
         would still pass those)."""
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
         (git_repo / "good.md").write_text("# good original\n", encoding="utf-8")
         (git_repo / "bad.md").write_bytes(b"\xff\xfe not valid utf-8 \x80\n")
         saved = [("good.md", "# good mcp\n"), ("bad.md", "# bad mcp\n")]
 
-        written = strategy._write_conflict_files(git_repo, saved, env=None)
+        written = _write_conflict_files(git_repo, saved)
 
         assert len(written) == 2
         files = self._head_commit_files(git_repo)
@@ -2341,7 +2354,6 @@ class TestGitSyncOnce:
         must NOT be staged — otherwise the conflict commit records a *deletion* of
         the upstream file (the motivating data-loss shape in #675), distinct from
         the non-UTF-8 spurious-change case."""
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
         note = git_repo / "note.md"
         note.write_text("# tracked original\n", encoding="utf-8")
         subprocess.run(["git", "-C", str(git_repo), "add", "note.md"], check=True)
@@ -2353,7 +2365,7 @@ class TestGitSyncOnce:
         note.unlink()  # removed after it was committed/tracked
         saved = [("note.md", "# mcp body\n")]
 
-        written = strategy._write_conflict_files(git_repo, saved, env=None)
+        written = _write_conflict_files(git_repo, saved)
 
         assert len(written) == 1
         files = self._head_commit_files(git_repo)
@@ -2366,18 +2378,15 @@ class TestRebaseInProgress:
     """Tests for the _rebase_in_progress helper (refs #466)."""
 
     def test_returns_false_on_clean_repo(self, git_repo: Path) -> None:
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
-        assert strategy._rebase_in_progress(git_repo, env=None) is False
+        assert conflict.rebase_in_progress(git_repo, env=None, token=None) is False
 
     def test_detects_rebase_merge_directory(self, git_repo: Path) -> None:
         (git_repo / ".git" / "rebase-merge").mkdir()
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
-        assert strategy._rebase_in_progress(git_repo, env=None) is True
+        assert conflict.rebase_in_progress(git_repo, env=None, token=None) is True
 
     def test_detects_rebase_apply_directory(self, git_repo: Path) -> None:
         (git_repo / ".git" / "rebase-apply").mkdir()
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
-        assert strategy._rebase_in_progress(git_repo, env=None) is True
+        assert conflict.rebase_in_progress(git_repo, env=None, token=None) is True
 
     def test_ignores_stale_rebase_head_ref(self, git_repo: Path) -> None:
         """Stale REBASE_HEAD ref must not trip the in-progress check (refs #466)."""
@@ -2389,8 +2398,7 @@ class TestRebaseInProgress:
         ).stdout.strip()
         (git_repo / ".git" / "REBASE_HEAD").write_text(head_sha + "\n")
 
-        strategy = GitWriteStrategy(token=None, push_delay_s=0)
-        assert strategy._rebase_in_progress(git_repo, env=None) is False
+        assert conflict.rebase_in_progress(git_repo, env=None, token=None) is False
 
 
 class TestGitPullLoop:
@@ -2562,7 +2570,7 @@ class TestGitPullLoop:
 
         push_calls: list[int] = []
         with patch(
-            "markdown_vault_mcp.git.strategy._push",
+            "markdown_vault_mcp.git.push_scheduler._push",
             side_effect=lambda *_a, **_k: push_calls.append(1),
         ):
             strategy.start(repo_path=tmp_path, pull_interval_s=3600)
@@ -2606,7 +2614,7 @@ class TestGitPullLoop:
         _run_git(local, "add", "local.md")
         _run_git(local, "commit", "-m", "local commit")
         strategy._push_pending = True
-        strategy._do_push_safe()
+        strategy._push_scheduler.do_push_safe()
         assert strategy._push_pending is True
 
         # Start the pull loop with a long interval so exactly one tick fires.
@@ -2656,7 +2664,7 @@ class TestGitPullLoop:
         strategy._push_pending = True
         safe_calls: list[str] = []
         monkeypatch.setattr(
-            strategy, "_do_push_safe", lambda: safe_calls.append("push")
+            strategy._push_scheduler, "do_push_safe", lambda: safe_calls.append("push")
         )
 
         strategy.start(repo_path=tmp_path, pull_interval_s=3600)
@@ -2870,7 +2878,7 @@ class TestCheckRemoteProtocol:
         )
 
         with pytest.raises(ConfigurationError) as exc_info:
-            strategy._check_remote_protocol(tmp_path)
+            strategy._bootstrap.check_remote_protocol(tmp_path)
 
         msg = str(exc_info.value)
         assert "SSH transport" in msg
@@ -2887,7 +2895,7 @@ class TestCheckRemoteProtocol:
             self._make_run("https://github.com/owner/repo.git"),
         )
 
-        strategy._check_remote_protocol(tmp_path)
+        strategy._bootstrap.check_remote_protocol(tmp_path)
 
     def test_no_token_does_not_raise_for_ssh_remote(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2900,7 +2908,7 @@ class TestCheckRemoteProtocol:
             self._make_run("git@github.com:owner/repo.git"),
         )
 
-        strategy._check_remote_protocol(tmp_path)
+        strategy._bootstrap.check_remote_protocol(tmp_path)
 
     def test_startup_validation_raises_in_constructor(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2908,7 +2916,7 @@ class TestCheckRemoteProtocol:
         from markdown_vault_mcp.exceptions import ConfigurationError
 
         monkeypatch.setattr(
-            "markdown_vault_mcp.git.strategy._find_git_root",
+            "markdown_vault_mcp.git.bootstrap._find_git_root",
             lambda _repo_path: tmp_path,
         )
         monkeypatch.setattr(

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from markdown_vault_mcp.git import conflict
 from tests.fixtures.git import _run_git
 
 if TYPE_CHECKING:
@@ -486,7 +487,7 @@ class TestForceMethodsErrorBranches:
         def _raising_resolve(*_args: object, **_kwargs: object) -> object:
             raise RuntimeError("simulated conflict resolution failure")
 
-        monkeypatch.setattr(strategy, "_resolve_rebase_conflicts", _raising_resolve)
+        monkeypatch.setattr(conflict, "resolve_rebase_conflicts", _raising_resolve)
 
         result = strategy.force_pull()
 
@@ -559,7 +560,7 @@ class TestForceMethodsErrorBranches:
         def _stub_resolve(*_args: object, **_kwargs: object) -> list[tuple[str, str]]:
             return [("README.md", "# local\n")]
 
-        monkeypatch.setattr(strategy, "_resolve_rebase_conflicts", _stub_resolve)
+        monkeypatch.setattr(conflict, "resolve_rebase_conflicts", _stub_resolve)
 
         # Patch subprocess.run on the git module to fail the
         # ``checkout origin/main -- <path>`` restore call.  All other
@@ -662,18 +663,11 @@ class TestForceMethodsErrorBranches:
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """_resolve_rebase_conflicts cap exhaustion logs ERROR + returns partial saved (#468)."""
+        """resolve_rebase_conflicts cap exhaustion logs ERROR + returns partial saved (#468)."""
         import logging
         import subprocess as _real_subprocess
 
-        from markdown_vault_mcp.git import GitWriteStrategy
         from markdown_vault_mcp.git import subprocess as git_subprocess
-
-        strategy = GitWriteStrategy(
-            enable_pull=True,
-            enable_push=False,
-            repo_path=git_repo_pair.local_path,
-        )
 
         real_run = _real_subprocess.run
 
@@ -710,7 +704,7 @@ class TestForceMethodsErrorBranches:
         monkeypatch.setattr(git_subprocess, "run", _patched_run)
 
         with caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"):
-            saved = strategy._resolve_rebase_conflicts(
+            saved = conflict.resolve_rebase_conflicts(
                 git_repo_pair.local_path, env=None
             )
 
@@ -754,7 +748,7 @@ class TestForceMethodsErrorBranches:
         def _stub_resolve(*_args: object, **_kwargs: object) -> list[tuple[str, str]]:
             return [("README.md", "# local\n")]
 
-        monkeypatch.setattr(strategy, "_resolve_rebase_conflicts", _stub_resolve)
+        monkeypatch.setattr(conflict, "resolve_rebase_conflicts", _stub_resolve)
 
         real_run = _real_subprocess.run
 


### PR DESCRIPTION
## Closes / Refs

Closes #893. Refs #879, refs #892, refs #1161 (future-proofing epic)

## What & why

Behaviour-preserving extraction of two composed collaborators from the 2072-line `GitWriteStrategy`, following the Versioner/Syncer seams of the decoupling-and-layering study (#879) and the verbatim-move discipline of #892:

- **`git/bootstrap.py` — `RepoBootstrap`**: managed-repo clone/validation, SSH-vs-HTTPS remote-protocol check, startup validation, and the memoised git-root discovery. Owns the single copy of `git_root`.
- **`git/push_scheduler.py` — `PushScheduler`**: the deferred-push timer, pending-flag, and push execution (`schedule_push`/`do_push`/`do_push_safe`/`push_if_unpushed`/`flush`), plus the module-level `_push` helper (tests patch `markdown_vault_mcp.git.push_scheduler._push`).

Both collaborators receive the strategy-wide lock — the same object; no new locks — so the documented pull/write lock-ordering contracts (`_force_pull_rebase_fallback` under lock, `_quiesce_writes` drains first) are unchanged. The strategy keeps thin public `flush`/`close` (close still sequences the pull thread) and delegating `_git_root`/`_push_pending`/`_timer` properties so shared state has exactly one home. The pull loop's failed-push retry (#957) now goes through `PushScheduler.do_push_safe()` and is covered by the existing two-clone non-fast-forward test.

The six test-only delegation shims to `git.conflict` (`_resolve_rebase_conflicts`, `_resolve_conflicts_safely`, `_rebase_in_progress`, `_abort_in_progress_rebase`, `_restore_upstream_paths`, `_write_conflict_files`) are removed; tests now patch the `conflict` module functions directly, assertions unchanged (`conflict.resolve_conflicts_safely` late-binds its default resolver, so module-level monkeypatches are honored). The `git.query` delegations (`get_file_history`, `get_file_diff`, `_resolve_path_at_ref`) stay — they are public API used by `GitQueryManager`.

## What this PR deliberately does NOT do

- No identity changes: `_extract_claim` / `_check_identity` and the fastmcp import stay exactly where they were — #1160 owns that seam (see also the standalone bug #1218 it surfaced).
- No behaviour changes to push cadence, conflict policy, or clone semantics — verbatim moves only, with two diff-gate-forced local adjustments in `bootstrap.py` (`_clone_into` extraction; an `if`-guard replacing an `assert`).
- No further decomposition of the strategy (pull loop, quiesce, force methods) — out of #893's stated scope.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before creating the PR (charters: rules, diff, comments, history; range `90f95f2..6524634`; no findings — verified the tracking-ref substitution is equivalent, the conflict-resolver default late-binds for the re-pointed monkeypatches, `push_if_unpushed` keeps its lock-free contract under `_ensure_write_init`'s lock, and no test assertions were weakened).
- [x] No commit carries `!` — behaviour-preserving internal refactor; `GitWriteStrategy`'s public surface is unchanged.

## Docs impact

- [ ] `README.md` — no operator-facing change
- [ ] `docs/` site pages — no tool-visible change
- [x] `docs/design/` — deferred-push mechanics rewritten + new "Strategy collaborators (#893)" section
- [x] Inline docstrings — Google-style docstrings on both new classes and all public methods; stale `conflict.resolve_conflicts_safely` docstring updated

---
_Generated by [Claude Code](https://claude.ai/code/session_015Q12LpD5yLESRHUX7Lpyi8)_