### PR TITLE
refactor: consolidate the duplicated path-traversal guard into utils

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The authoritative design specification lives at [`docs/design/design.md`](docs/d
 src/markdown_vault_mcp/
   __init__.py        -- minimal template-skeleton root (docstring + __version__); import from submodules, not the root (#665, #903)
   utils/
-    __init__.py        -- path-traversal guard (validate_path) + attachment/exclusion helpers re-exported for managers and facets
+    __init__.py        -- shared path-traversal guard (resolve_inside + validate_path variants) + attachment/exclusion helpers re-exported for managers and facets (#876)
     text.py            -- text normalization, position mapping, fuzzy matching
     links.py           -- link target computation and replacement
     serialization.py   -- toc_payload: TocEntry/SubtreeToc → JSON-able dicts

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1407,6 +1407,15 @@ All public **write** methods accepting a `path` parameter call
 This applies to `write()`, `edit()`, `delete()`, `rename()`, and all
 attachment write operations.
 
+The resolve-then-contain-then-raise sequence itself lives in one shared
+helper, `utils.resolve_inside(path, base)` (#876): every raising validator —
+`validate_path`, `validate_history_path`, `validate_history_dir`, the
+attachment/folder validators in `DocumentManager`, the conventions folder
+normalizer, and the transfer-sink upload/download/bundle checks — delegates
+containment to it. Site-specific policy stays local: extension allowlists,
+`_validate_dir_path` additionally rejecting the vault root, and read paths
+that return `None` instead of raising.
+
 `read()` validates the path inline rather than via `_validate_path()`: if the
 resolved path escapes `source_dir`, it returns `None` instead of raising.
 

--- a/src/markdown_vault_mcp/_transfer_sink.py
+++ b/src/markdown_vault_mcp/_transfer_sink.py
@@ -33,7 +33,11 @@ from fastmcp_pvl_core import (
 
 from markdown_vault_mcp.domain import get_vault_singleton
 from markdown_vault_mcp.okf_bundle import build_okf_bundle
-from markdown_vault_mcp.utils import effective_attachment_extensions, validate_path
+from markdown_vault_mcp.utils import (
+    effective_attachment_extensions,
+    resolve_inside,
+    validate_path,
+)
 from markdown_vault_mcp.utils.text import decode_utf8
 
 logger = logging.getLogger(__name__)
@@ -89,9 +93,7 @@ def _validate_destination(
     if path.endswith(".md"):
         validate_path(path, source_dir)
         return
-    resolved = (source_dir / path).resolve()
-    if not resolved.is_relative_to(source_dir.resolve()):
-        raise ValueError(f"Path traversal detected: {path}")
+    resolved = resolve_inside(path, source_dir)
     exts = effective_attachment_extensions(attachment_extensions)
     ext = resolved.suffix.lstrip(".").lower()
     if "*" not in exts and ext not in exts:
@@ -121,9 +123,7 @@ def _validate_source(
     if not is_attachment:
         resolved = validate_path(path, source_dir)
     else:
-        resolved = (source_dir / path).resolve()
-        if not resolved.is_relative_to(source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {path}")
+        resolved = resolve_inside(path, source_dir)
     try:
         exists = resolved.is_file()
     except OSError as exc:  # pragma: no cover - defensive: stat fault on is_file()
@@ -211,9 +211,7 @@ class VaultTransferSink:
         if not scope:
             return
         source_dir = self._config.source_dir
-        folder = (source_dir / scope).resolve()
-        if not folder.is_relative_to(source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {scope}")
+        folder = resolve_inside(scope, source_dir)
         if not folder.is_dir():
             raise ValueError(f"Bundle folder not found: {scope}")
 

--- a/src/markdown_vault_mcp/conventions.py
+++ b/src/markdown_vault_mcp/conventions.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 import frontmatter as fm
 import yaml
 
-from markdown_vault_mcp.utils import is_path_excluded
+from markdown_vault_mcp.utils import is_path_excluded, resolve_inside
 from markdown_vault_mcp.utils.fs import iter_markdown_files
 
 if TYPE_CHECKING:
@@ -172,9 +172,7 @@ class ConventionsResolver:
             cleaned = cleaned.rsplit("/", 1)[0] if "/" in cleaned else ""
         if not cleaned:
             return ""
-        abs_path = (self._source_dir / cleaned).resolve()
-        if not abs_path.is_relative_to(self._source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {path}")
+        abs_path = resolve_inside(cleaned, self._source_dir, original=path)
         return abs_path.relative_to(self._source_dir.resolve()).as_posix()
 
     def _load(self, folder: str) -> ConventionEntry | None:

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -53,6 +53,7 @@ from markdown_vault_mcp.types import (
 from markdown_vault_mcp.utils import (
     effective_attachment_extensions,
     is_path_excluded,
+    resolve_inside,
     validate_path,
 )
 from markdown_vault_mcp.utils.links import (
@@ -323,10 +324,7 @@ class DocumentManager:
                 "Set MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS=* to allow "
                 "all non-.md files."
             )
-        abs_path = (self._source_dir / path).resolve()
-        if not abs_path.is_relative_to(self._source_dir.resolve()):
-            raise ValueError(f"Path traversal detected: {path}")
-        return abs_path
+        return resolve_inside(path, self._source_dir)
 
     def _validate_dir_path(self, path: str) -> Path:
         """Resolve a relative folder path and validate it is inside the vault.
@@ -346,9 +344,9 @@ class DocumentManager:
         """
         if not path or path in (".", "/"):
             raise ValueError(f"Invalid folder path: {path!r}")
-        abs_path = (self._source_dir / path).resolve()
-        source_root = self._source_dir.resolve()
-        if abs_path == source_root or not abs_path.is_relative_to(source_root):
+        abs_path = resolve_inside(path, self._source_dir)
+        if abs_path == self._source_dir.resolve():
+            # A folder scope must be a strict subtree, never the vault root.
             raise ValueError(f"Path traversal detected: {path}")
         return abs_path
 

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -103,6 +103,36 @@ def effective_attachment_extensions(
     return frozenset(attachment_extensions)
 
 
+def resolve_inside(path: str, base: Path, *, original: str | None = None) -> Path:
+    """Resolve *path* against *base* and verify the result stays inside it.
+
+    The single path-traversal guard shared by every validator: resolve the
+    joined path, then reject it unless it is *base* itself or one of its
+    descendants. Callers that must also reject *base* itself (e.g. a folder
+    scope that may not be the vault root) add that check locally.
+
+    Args:
+        path: Relative path to resolve (may contain ``..`` segments —
+            that is exactly what the guard catches).
+        base: Absolute base directory the result must stay inside.
+        original: Spelling of the path to name in the error message, for
+            callers that normalized *path* before resolving. Defaults to
+            *path* itself.
+
+    Returns:
+        The resolved absolute path.
+
+    Raises:
+        ValueError: If the resolved path escapes *base*.
+    """
+    abs_path = (base / path).resolve()
+    if not abs_path.is_relative_to(base.resolve()):
+        raise ValueError(
+            f"Path traversal detected: {path if original is None else original}"
+        )
+    return abs_path
+
+
 def validate_path(path: str, source_dir: Path) -> Path:
     """Resolve a relative path and validate it is inside *source_dir*.
 
@@ -119,10 +149,7 @@ def validate_path(path: str, source_dir: Path) -> Path:
     """
     if not path.endswith(".md"):
         raise ValueError(f"Path must end with '.md': {path}")
-    abs_path = (source_dir / path).resolve()
-    if not abs_path.is_relative_to(source_dir.resolve()):
-        raise ValueError(f"Path traversal detected: {path}")
-    return abs_path
+    return resolve_inside(path, source_dir)
 
 
 def validate_history_path(
@@ -160,10 +187,7 @@ def validate_history_path(
         raise ValueError(
             f"Path must be a .md note or a configured attachment type: {path}"
         )
-    abs_path = (source_dir / path).resolve()
-    if not abs_path.is_relative_to(source_dir.resolve()):
-        raise ValueError(f"Path traversal detected: {path}")
-    return abs_path
+    return resolve_inside(path, source_dir)
 
 
 def validate_history_dir(path: str, source_dir: Path) -> Path:
@@ -192,10 +216,7 @@ def validate_history_dir(path: str, source_dir: Path) -> Path:
             "A directory history scope must name a folder; pass None for "
             "whole-vault history."
         )
-    abs_path = (source_dir / path).resolve()
-    if not abs_path.is_relative_to(source_dir.resolve()):
-        raise ValueError(f"Path traversal detected: {path}")
-    return abs_path
+    return resolve_inside(path, source_dir)
 
 
 __all__ = [
@@ -208,6 +229,7 @@ __all__ = [
     "fts_row_to_note_info",
     "is_path_excluded",
     "normalize_text",
+    "resolve_inside",
     "validate_history_dir",
     "validate_history_path",
     "validate_path",

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -725,6 +725,13 @@ class TestValidation:
         with pytest.raises(ValueError, match="Invalid folder path"):
             doc_mgr.get_toc(".")
 
+    def test_get_toc_folder_resolving_to_root_raises(
+        self, doc_mgr: DocumentManager
+    ) -> None:
+        """A folder path that resolves to the vault root itself is rejected."""
+        with pytest.raises(ValueError, match="Path traversal"):
+            doc_mgr.get_toc("sub/..")
+
     def test_is_path_excluded(self, doc_vault: Path) -> None:
         fts = FTSIndex(db_path=":memory:")
         mgr = DocumentManager(

--- a/tests/test_utils_resolve_inside.py
+++ b/tests/test_utils_resolve_inside.py
@@ -1,0 +1,28 @@
+import pytest
+
+from markdown_vault_mcp.utils import resolve_inside
+
+
+def test_resolves_relative_path_inside_base(tmp_path):
+    assert resolve_inside("notes/a.md", tmp_path) == (tmp_path / "notes/a.md").resolve()
+
+
+def test_accepts_base_itself(tmp_path):
+    """Containment includes the base directory itself (callers that must
+    reject the base add that check locally)."""
+    assert resolve_inside(".", tmp_path) == tmp_path.resolve()
+
+
+def test_resolves_internal_dotdot_that_stays_inside(tmp_path):
+    assert resolve_inside("a/../b.md", tmp_path) == (tmp_path / "b.md").resolve()
+
+
+def test_rejects_traversal_with_default_message(tmp_path):
+    with pytest.raises(ValueError, match=r"Path traversal detected: \.\./escape\.md"):
+        resolve_inside("../escape.md", tmp_path)
+
+
+def test_rejects_traversal_naming_original_spelling(tmp_path):
+    """The *original* override names the caller's pre-normalization spelling."""
+    with pytest.raises(ValueError, match=r"Path traversal detected: /\.\./raw/"):
+        resolve_inside("../raw", tmp_path, original="/../raw/")


### PR DESCRIPTION
## Closes / Refs

Closes #876. Refs #1161 (future-proofing epic)

## What & why

Extracts a single shared guard, `markdown_vault_mcp.utils.resolve_inside(path, base, *, original=None)`, implementing the resolve → containment-check → raise `ValueError("Path traversal detected: ...")` pattern, and migrates all nine duplicated sites to it (the duplication had grown since the issue was filed — nine sites, not six):

- `utils/__init__.py`: `validate_path`, `validate_history_path`, `validate_history_dir`
- `managers/document.py`: the attachment validator and `_validate_dir_path` — the latter keeps its additional vault-root rejection local, as that is site policy rather than containment
- `conventions.py`: `_normalize_folder`, using the helper's `original=` override so the error still names the caller's raw spelling
- `_transfer_sink.py`: `_validate_destination`, `_validate_source`, `_validate_bundle_scope`

Behaviour-preserving: every site raises the same exception class and message as before; the existing suite passes unchanged. A future hardening fix (symlink-escape handling, BOM handling, message change under test) now lands in one place.

## What this PR deliberately does NOT do

- The frontmatter-strip half of #876 is stale and intentionally untouched: `scanner.py`'s two `frontmatter.loads(text).content` calls are bare, with skip-with-category error handling living elsewhere; only `conventions.py` has the YAML-fallback helper — there is no longer a shared pattern to extract.
- Near-miss variants stay as they are, deliberately: `okf_bundle.py` (different message, "Path escapes the vault"), `DocumentManager.read()`'s return-`None` guard, and the `is_relative_to` nesting checks in `document.py` / `_file_watcher.py` — different semantics, not the guard.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before creating the PR (charters: rules, diff, comments, history; range `90f95f2..5f18f97`; no findings — verified message/class preservation at every migrated site, including the raw-spelling message in `conventions.py` and the strict-subtree policy in `_validate_dir_path`).
- [x] No commit carries `!` — behaviour-preserving internal refactor.

## Docs impact

- [ ] `README.md` — no operator-facing change
- [ ] `docs/` site pages — no tool-visible change
- [x] `docs/design/` — path-traversal-protection section now names `resolve_inside` as the single shared guard
- [x] Inline docstrings — Google-style docstring on the new helper; AGENTS.md tree line updated

New direct tests for the helper (`tests/test_utils_resolve_inside.py`) plus a test for the now-isolated root-equality branch; touched modules at 99–100% coverage, structural gate 100%.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Q12LpD5yLESRHUX7Lpyi8)_