### PR TITLE
chore: prepare release 4.1.0

### DIFF
--- a/.claude-plugin/plugin/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-vault-mcp",
   "description": "Generic markdown vault MCP with hybrid search",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "Peter van Liesdonk"
   },

--- a/.claude-plugin/plugin/.mcp.json
+++ b/.claude-plugin/plugin/.mcp.json
@@ -3,7 +3,7 @@
     "command": "uvx",
     "args": [
       "--from",
-      "markdown-vault-mcp[all]==4.0.0",
+      "markdown-vault-mcp[all]==4.1.0",
       "markdown-vault-mcp",
       "serve"
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ Narrative, rationale, and upgrade guidance live in
 
 <!-- version list -->
 
+## 4.1.0 (2026-08-30)
+
+### Features
+
+- Voyage embedding provider and the WRITE_PROTECT_EXISTING guard (#1169)
+- expose note size on the enumeration surfaces (#1171)
+- adopt template v6.0.0 and compose via pvl-core 5 (#1192)
+- ✨ Resolve the default search mode from what the vault can serve. (#1189)
+
+### Bug Fixes
+
+- v4.1 bug sweep — rename staging, webhook gating, blank query, changelog (#1163)
+- drop the pygments pins, which held the lock on the broken release (#1166)
+- make the template-conformance gate actually render (#1191)
+- let @claude review actually run a review (#1194)
+- give generated reserved files the frontmatter the index gate requires (#1196)
+- declare the font origins the SPA actually loads (#1199)
+- validate default_search_mode at the constructor boundary too (#1206)
+- give the release index the marker form the promotion matches (#1212)
+
 ## 4.1.0-rc.0 (2026-08-29)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-vault-mcp"
-version = "4.1.0-rc.0"
+version = "4.1.0"
 description = "Generic markdown vault MCP with hybrid search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pvliesdonk/markdown-vault-mcp",
   "title": "Markdown Vault MCP",
   "description": "Generic markdown vault MCP with hybrid search",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "websiteUrl": "https://pvliesdonk.github.io/markdown-vault-mcp/",
   "repository": {
     "url": "https://github.com/pvliesdonk/markdown-vault-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "markdown-vault-mcp",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -475,7 +475,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v4.0.0",
+      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v4.1.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{--port}/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -1790,7 +1790,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "4.1.0rc0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **4.1.0** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

The deterministic promotion step checked that this PR carries release notes
under `docs/releases/`. Reviewers must compare the page's `notes-range-end`
with the release delta and verify that every meaningful behavior change is
covered. If meaningful behavior is missing, merge a normal notes PR into the
base branch and re-dispatch Release Prepare.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Features

- Voyage embedding provider and the WRITE_PROTECT_EXISTING guard (#1169)
- expose note size on the enumeration surfaces (#1171)
- adopt template v6.0.0 and compose via pvl-core 5 (#1192)
- ✨ Resolve the default search mode from what the vault can serve. (#1189)

## Bug Fixes

- v4.1 bug sweep — rename staging, webhook gating, blank query, changelog (#1163)
- drop the pygments pins, which held the lock on the broken release (#1166)
- make the template-conformance gate actually render (#1191)
- let @claude review actually run a review (#1194)
- give generated reserved files the frontmatter the index gate requires (#1196)
- declare the font origins the SPA actually loads (#1199)
- validate default_search_mode at the constructor boundary too (#1206)
- give the release index the marker form the promotion matches (#1212)
