### PR TITLE
feat(vault): add VaultSettings so Vault construction is settings-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,13 +68,14 @@ src/markdown_vault_mcp/
   _okf_convention.py   -- OKF reserved-file maintenance after enforced writes: log.md bullet + index.md refresh (#964)
   _okf_write.py        -- OKF enforced-write runtime: contextvar actor + provenance stamp / verified clear (#964)
   summarizer.py        -- Summarizer ABC + OpenAI-compatible chat-completions backend (#915)
-  vault.py             -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
+  vault.py             -- thin composition root: settings-first dual-mode construction (#1158), lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
   write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
   _write_tools.py      -- WRITE_TOOL_NAMES + write_tools_phrase: single source for the user-facing write-tool enumeration (#1009)
   config.py            -- template-owned skeleton: flat metadata-carrying ProjectConfig fields + section-view properties + from_env, all inside CONFIG-* sentinels (#900, #952)
   config_sections/
-    __init__.py          -- package aggregator: re-exports the seven section configs (Content/Embeddings/Git/Indexing/Search/Summarize/Sync)
-    _assembly.py         -- domain config-assembly kept out of template-owned config.py: to_vault_kwargs, derive_max_chunk_chars, git-strategy builder, from_env value resolvers (#900, #952)
+    __init__.py          -- package aggregator: re-exports the seven section configs (Content/Embeddings/Git/Indexing/Search/Summarize/Sync) + VaultSettings
+    _assembly.py         -- domain config-assembly kept out of template-owned config.py: to_vault_settings/to_vault_instances (+ deprecated to_vault_kwargs bridge, #1158), derive_max_chunk_chars, git-strategy builder, from_env value resolvers (#900, #952)
+    vault_settings.py    -- VaultSettings: frozen config-derived Vault construction settings + pure effective_* derivations (#1158)
     _helpers.py          -- shared env-reading helpers for the sections' from_env classmethods (no config.py import)
     content.py           -- ContentConfig: attachment/read limits, template/prompt folders, conventions file
     embeddings.py        -- EmbeddingsConfig: provider selection + per-provider and shared embedding knobs

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -4,16 +4,34 @@ The `config` module loads configuration from environment variables and provides 
 
 ## Quick Start
 
+`to_vault_settings` maps a loaded configuration onto a `VaultSettings`, and `to_vault_instances` resolves the constructed collaborators (embedding provider, summarizer, git strategy). Together they feed settings-first `Vault` construction:
+
 ```python
 import os
 from markdown_vault_mcp.config import ProjectConfig
+from markdown_vault_mcp.config_sections._assembly import (
+    to_vault_instances,
+    to_vault_settings,
+)
 from markdown_vault_mcp.vault import Vault
-from markdown_vault_mcp.config import to_vault_kwargs
 
 os.environ["MARKDOWN_VAULT_MCP_SOURCE_DIR"] = "/path/to/vault"
 config = ProjectConfig.from_env()
-vault = Vault(**to_vault_kwargs(config))
+instances = to_vault_instances(config)
+settings = to_vault_settings(config, instances=instances)
+vault = Vault(
+    source_dir=config.source_dir,
+    settings=settings,
+    embedding_provider=instances.embedding_provider,
+    summarizer=instances.summarizer,
+    git_strategy=instances.git_strategy,
+    on_write=instances.on_write,
+)
 ```
+
+## Deprecated: `to_vault_kwargs`
+
+The historical bridge `to_vault_kwargs(config)` returns a flat keyword dict for `Vault(**kwargs)`. It now delegates to `to_vault_settings` and `to_vault_instances` while keeping its historical dict shape for existing callers. It is scheduled for removal in the next major release, so prefer the settings-first construction above.
 
 ## API Reference
 

--- a/docs/api/git.md
+++ b/docs/api/git.md
@@ -10,7 +10,7 @@ The `git` module provides:
 ```python
 from pathlib import Path
 from markdown_vault_mcp.git import GitWriteStrategy
-from markdown_vault_mcp.vault import Vault
+from markdown_vault_mcp.vault import Vault, VaultSettings
 
 strategy = GitWriteStrategy(
     token="ghp_your_token",
@@ -19,7 +19,7 @@ strategy = GitWriteStrategy(
 
 vault = Vault(
     source_dir=Path("/path/to/vault"),
-    read_only=False,
+    settings=VaultSettings(read_only=False),
     on_write=strategy,
 )
 

--- a/docs/api/vault.md
+++ b/docs/api/vault.md
@@ -4,14 +4,26 @@ The `Vault` class is the primary public API for the library. MCP tools, CLI comm
 
 ## Quick Start
 
+Construction is *settings-first*: pass `source_dir` plus a `VaultSettings` carrying the configuration knobs. Collaborator objects that are never derived from configuration (`embedding_provider`, `summarizer`, `git_strategy`, `on_write`, and `chunk_strategy`) stay explicit keywords.
+
 ```python
 from pathlib import Path
-from markdown_vault_mcp.vault import Vault
+from markdown_vault_mcp.vault import Vault, VaultSettings
 
-# Basic read-only vault
+# Basic read-only vault (all settings at their defaults)
 vault = Vault(source_dir=Path("/path/to/vault"))
 stats = vault.index.build_index()
 print(f"Indexed {stats.documents_indexed} documents")
+
+# Configured vault: knobs travel on VaultSettings
+vault = Vault(
+    source_dir=Path("/path/to/vault"),
+    settings=VaultSettings(
+        read_only=False,
+        index_path=Path("/path/to/index.db"),
+        exclude_patterns=[".obsidian/**"],
+    ),
+)
 
 # Search (reader facet)
 results = vault.reader.search("query text", limit=10)
@@ -23,8 +35,14 @@ note = vault.reader.read("Journal/note.md")
 print(note.content)
 ```
 
+## Deprecated: per-knob keyword arguments
+
+Before `VaultSettings`, every configuration knob was its own `Vault(...)` keyword (`Vault(source_dir=..., read_only=False, index_path=...)`). Those keywords still work unchanged, but they are deprecated in favor of the same-named `VaultSettings` fields and scheduled for removal in the next major release. Passing `settings=` together with a non-default legacy keyword raises `ValueError`: pick one mode per construction. `source_dir` and the five collaborator keywords are not deprecated.
+
 ## API Reference
 
 <!-- vale off -->
+::: markdown_vault_mcp.config_sections.vault_settings.VaultSettings
+
 ::: markdown_vault_mcp.vault.Vault
 <!-- vale on -->

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -62,11 +62,12 @@ markdown-vault-mcp (new package)
 +-- vector_index.py   -- numpy embeddings, cosine similarity
 +-- providers.py      -- Ollama / OpenAI / Voyage / SentenceTransformers
 +-- tracker.py        -- hash-based change detection
-+-- vault.py          -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
++-- vault.py          -- thin composition root: settings-first dual-mode construction (#1158), lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
 +-- write_callback.py -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)
 +-- config.py         -- template-owned skeleton: flat metadata-carrying ProjectConfig fields + section-view properties + from_env, in CONFIG-* sentinels (#900, #952)
 +-- config_sections/  -- domain-grouped sub-config VIEWS (git/indexing/embeddings/search/sync/content), assembled by ProjectConfig properties; no from_env of their own (#952)
-|   +-- _assembly.py   -- domain config-assembly kept out of template-owned config.py: to_vault_kwargs, derive_max_chunk_chars, git-strategy builder, from_env value resolvers (#900, #952)
+|   +-- _assembly.py   -- domain config-assembly kept out of template-owned config.py: to_vault_settings/to_vault_instances (+ deprecated to_vault_kwargs bridge, #1158), derive_max_chunk_chars, git-strategy builder, from_env value resolvers (#900, #952)
+|   +-- vault_settings.py -- VaultSettings: frozen config-derived Vault construction settings + pure effective_* derivations (#1158)
 +-- server.py         -- template-owned skeleton; domain wiring in DOMAIN-UPSTREAM/DOMAIN-WIRING (#901)
 +-- _instructions.py  -- contribute_instructions: domain snippets for pvl-core's instructions builder (#901)
 +-- domain.py         -- Service: owns Vault lifecycle + get_vault/set_pending_config singleton (#902)
@@ -2104,22 +2105,56 @@ directly. ``Vault`` itself now exposes only construction, the four facet
 accessors, and lifecycle; the per-facet method surface is the Facets table
 above.
 
+#### Settings-first construction (#1158)
+
+Construction is dual-mode. The preferred mode passes ``source_dir`` plus a
+frozen ``VaultSettings`` (``config_sections/vault_settings.py``) carrying the
+31 config-derived knobs; the five collaborators that are never config-derived
+— ``embedding_provider``, ``summarizer``, ``git_strategy``, ``on_write``,
+``chunk_strategy`` — stay explicit keywords. The legacy per-knob keywords
+keep working (they are folded into a ``VaultSettings`` via the module-level
+``_settings_from_legacy`` seam), are docstring-deprecated, and are scheduled
+for removal in the next major; mixing ``settings=`` with a non-default
+config-derived keyword raises ``ValueError``. Either way exactly ONE wiring
+path consumes ``settings`` + the collaborators. A signature drift-guard test
+(``tests/test_vault_settings.py``) pins field names and defaults against the
+legacy keywords, including the two deliberate default drifts
+(``chunk_overlap_words=0`` vs ``SearchConfig``'s 40; the ``read_only=True``
+library fail-safe vs the server env default).
+
+``VaultSettings`` also owns the construction-time pure derivations that the
+constructor used to inline: ``effective_indexed_fields(okf_active=...)`` (OKF
+scalar-key extension), ``effective_exclude_patterns()`` (conventions-file
+fnmatch forms + metacharacter validation), and
+``effective_state_path(source_dir)``.
+
+On the served path, ``config_sections/_assembly.py`` resolves the two halves:
+``to_vault_instances(config)`` builds the collaborators (embedding-provider /
+summarizer resolution with the explicit-vs-auto error posture, the three-mode
+git-strategy construction, and the *resolved* pull interval), and
+``to_vault_settings(config, instances=...)`` maps the config onto
+``VaultSettings`` (threading the provider's token context into the
+``max_chunk_chars`` derivation). ``domain.Service.start`` and the CLI's
+``_build_vault`` construct settings-first from those two; the historical
+``to_vault_kwargs(config)`` remains as a deprecated bridge that delegates to
+them and reproduces the legacy kwargs-dict shape byte-for-byte.
+
 ```python
 class Vault:
     def __init__(
         self,
         *,
         source_dir: Path,
-        index_path: Path | None = None,       # None = in-memory SQLite
-        embeddings_path: Path | None = None,  # None = semantic search disabled
+        settings: VaultSettings | None = None,  # None = built from legacy kwargs
+        # Collaborators (never config-derived):
         embedding_provider: EmbeddingProvider | None = None,
-        read_only: bool = True,
-        state_path: Path | None = None,       # None = {source_dir}/.markdown_vault_mcp/state.json
-        indexed_frontmatter_fields: list[str] | None = None,
-        required_frontmatter: list[str] | None = None,
-        chunk_strategy: str | ChunkStrategy = "heading",
+        summarizer: Summarizer | None = None,
+        git_strategy: GitWriteStrategy | None = None,
         on_write: WriteCallback | None = None,
-        exclude_patterns: list[str] | None = None,
+        chunk_strategy: str | ChunkStrategy = "heading",
+        # ... plus the deprecated config-derived legacy kwargs
+        # (index_path, embeddings_path, read_only, exclude_patterns, ...),
+        # one per VaultSettings field, same names and defaults.
     ): ...
 
     # --- Facet accessors (the public operation surface) ---
@@ -2145,7 +2180,8 @@ class Vault:
     def sync_from_remote_before_index(self) -> None: ...
 ```
 
-**Constructor defaults**:
+**Constructor defaults** (identical on `VaultSettings` and the legacy
+kwargs):
 - `index_path=None`: index is created in-memory (`:memory:` SQLite). If
   provided, persisted to disk.
 - `embeddings_path=None`: semantic search is disabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,11 @@ ignore = ["E501"]
 [tool.ruff.lint.per-file-ignores]
 # Phase 1 write stubs: method signatures define the public API but bodies are
 # not yet implemented. ARG002 fires because parameters are unused.
-"src/markdown_vault_mcp/vault.py" = ["ARG002"]
+# PLR0913: transitional dual-mode constructor (#1158) — the config-derived
+# kwargs are docstring-deprecated in favour of VaultSettings, and their
+# removal (which shrinks the signature under the ceiling) is scheduled for
+# the next major. Gate-only rule, so a `# noqa` would be stripped (RUF100).
+"src/markdown_vault_mcp/vault.py" = ["ARG002", "PLR0913"]
 # Depends() and CurrentContext() calls in argument defaults are the standard
 # FastMCP dependency injection pattern — B008 is a false positive here.
 # Context/FastMCP/Vault imports must stay runtime (not TYPE_CHECKING) for

--- a/src/markdown_vault_mcp/_file_watcher.py
+++ b/src/markdown_vault_mcp/_file_watcher.py
@@ -364,7 +364,7 @@ def should_start_file_watcher(
             run.  This is *not* ``GIT_PULL_INTERVAL_S > 0`` alone — the
             interval defaults to 600 even on non-git vaults, but the pull
             loop only runs when a git strategy is configured.  Pass the
-            resolved ``git_pull_interval_s`` from ``to_vault_kwargs()``
+            resolved ``git_pull_interval_s`` from ``to_vault_instances()``
             (which is 0 unless ``git_repo_url``/``git_token`` is set),
             compared ``> 0``.
         github_webhook_secret: Value of ``GITHUB_WEBHOOK_SECRET`` config field.

--- a/src/markdown_vault_mcp/cli.py
+++ b/src/markdown_vault_mcp/cli.py
@@ -13,7 +13,7 @@ from fastmcp_pvl_core import (
     normalise_http_path,
 )
 
-from markdown_vault_mcp.config import _ENV_PREFIX, ProjectConfig, to_vault_kwargs
+from markdown_vault_mcp.config import _ENV_PREFIX, ProjectConfig
 
 app = typer.Typer(
     name="markdown-vault-mcp",
@@ -129,9 +129,10 @@ if TYPE_CHECKING:
 def _build_vault(source_dir: str | None = None, index_path: str | None = None) -> Vault:
     """Build a synchronous Vault from env vars + optional CLI overrides.
 
-    Uses the same ``to_vault_kwargs(config)`` bridge as the server path,
-    but constructs a bare Vault (no background tasks, file watcher, or index
-    writer — those belong to the server's lifespan).
+    Uses the same settings-first ``to_vault_settings`` / ``to_vault_instances``
+    assembly as the server path (#1158), but constructs a bare Vault (no
+    background tasks, file watcher, or index writer — those belong to the
+    server's lifespan).
 
     Args:
         source_dir: Overrides ``{PREFIX}_SOURCE_DIR`` when given (set into the
@@ -141,9 +142,14 @@ def _build_vault(source_dir: str | None = None, index_path: str | None = None) -
     Returns:
         A constructed :class:`~markdown_vault_mcp.vault.Vault` (index not built).
     """
+    import dataclasses
     import os
     from pathlib import Path
 
+    from markdown_vault_mcp.config_sections._assembly import (
+        to_vault_instances,
+        to_vault_settings,
+    )
     from markdown_vault_mcp.vault import Vault
 
     # --source-dir overrides the env var: set it before from_env() reads it.
@@ -151,10 +157,18 @@ def _build_vault(source_dir: str | None = None, index_path: str | None = None) -
     if source_dir:
         os.environ[f"{_ENV_PREFIX}_SOURCE_DIR"] = source_dir
     config = ProjectConfig.from_env()
-    kwargs = to_vault_kwargs(config)
+    instances = to_vault_instances(config)
+    settings = to_vault_settings(config, instances=instances)
     if index_path:
-        kwargs["index_path"] = Path(index_path)
-    return Vault(**kwargs)
+        settings = dataclasses.replace(settings, index_path=Path(index_path))
+    return Vault(
+        source_dir=config.source_dir,
+        settings=settings,
+        embedding_provider=instances.embedding_provider,
+        summarizer=instances.summarizer,
+        git_strategy=instances.git_strategy,
+        on_write=instances.on_write,
+    )
 
 
 @app.command()

--- a/src/markdown_vault_mcp/config_sections/__init__.py
+++ b/src/markdown_vault_mcp/config_sections/__init__.py
@@ -9,6 +9,7 @@ from markdown_vault_mcp.config_sections.indexing import IndexingConfig
 from markdown_vault_mcp.config_sections.search import SearchConfig
 from markdown_vault_mcp.config_sections.summarize import SummarizeConfig
 from markdown_vault_mcp.config_sections.sync import SyncConfig
+from markdown_vault_mcp.config_sections.vault_settings import VaultSettings
 
 __all__ = [
     "ContentConfig",
@@ -18,4 +19,5 @@ __all__ = [
     "SearchConfig",
     "SummarizeConfig",
     "SyncConfig",
+    "VaultSettings",
 ]

--- a/src/markdown_vault_mcp/config_sections/_assembly.py
+++ b/src/markdown_vault_mcp/config_sections/_assembly.py
@@ -3,9 +3,11 @@
 ``config.py`` is a copier-template-owned file: it must stay at the skeleton shape
 (module docstring, ``ProjectConfig`` dataclass, ``from_env`` scaffold) with domain
 content confined to the ``CONFIG-FIELDS`` / ``CONFIG-FROM-ENV`` sentinels. All the
-domain assembly logic that used to live in its body — the ``Vault(**kwargs)``
-builder, the git-strategy construction, the chunk-cap heuristic, and the
-``from_env`` field validators — lives here instead (#900, epic #898).
+domain assembly logic that used to live in its body — the settings-first vault
+assembly (``to_vault_settings`` / ``to_vault_instances``, #1158) with its
+deprecated ``Vault(**kwargs)`` bridge, the git-strategy construction, the
+chunk-cap heuristic, and the ``from_env`` field validators — lives here instead
+(#900, epic #898).
 
 Imports only fastmcp_pvl_core, stdlib, and sibling domain modules (never
 ``config`` at runtime) so ``config.py`` can import these without a cycle.
@@ -13,17 +15,22 @@ Imports only fastmcp_pvl_core, stdlib, and sibling domain modules (never
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fastmcp_pvl_core import parse_bool as _parse_bool
 
+from markdown_vault_mcp.config_sections.vault_settings import VaultSettings
 from markdown_vault_mcp.exceptions import ConfigurationError
 from markdown_vault_mcp.git import GitWriteStrategy
 
 if TYPE_CHECKING:
     from markdown_vault_mcp.config import ProjectConfig
+    from markdown_vault_mcp.providers import EmbeddingProvider
+    from markdown_vault_mcp.summarizer import Summarizer
+    from markdown_vault_mcp.types import WriteCallback
 
 logger = logging.getLogger(__name__)
 
@@ -137,11 +144,244 @@ def _build_git_strategy(
     )
 
 
+@dataclasses.dataclass(frozen=True)
+class VaultInstances:
+    """The never-config-derived ``Vault`` collaborators, resolved from config.
+
+    Carries the constructed instances that stay explicit ``Vault`` keywords
+    in settings-first construction (#1158), plus the *resolved* pull
+    interval, which is a property of the git assembly (only sync-enabled
+    modes run the pull loop) rather than a raw config read — the config
+    default is 600 even on non-git vaults.
+
+    Attributes:
+        embedding_provider: Resolved embedding provider, or ``None`` when
+            semantic search is unconfigured or auto-detection failed.
+        summarizer: Resolved summarization backend, or ``None`` when
+            unconfigured or auto-detection failed.
+        git_strategy: The git write strategy (always constructed; commit-only
+            mode when no remote is configured).
+        on_write: Write callback for the vault — the git strategy, so writes
+            auto-commit.
+        git_pull_interval_s: Resolved periodic-pull interval; ``0`` when no
+            remote is configured.
+    """
+
+    embedding_provider: EmbeddingProvider | None
+    summarizer: Summarizer | None
+    git_strategy: GitWriteStrategy
+    on_write: WriteCallback | None
+    git_pull_interval_s: int
+
+
+def _resolve_embedding_provider(config: ProjectConfig) -> EmbeddingProvider | None:
+    """Resolve the embedding provider, honouring the explicit-vs-auto posture.
+
+    Semantic search is gated by the storage path in ``config.indexing``,
+    while the provider lives in ``config.embeddings`` (cross-section
+    coupling).  An unrecognised provider name raises ConfigurationError from
+    the resolver and propagates unchanged.
+
+    Args:
+        config: The served project configuration.
+
+    Returns:
+        The provider, or ``None`` (unconfigured, or auto-detection failed).
+
+    Raises:
+        ConfigurationError: If an explicitly configured provider fails to
+            load.
+    """
+    if config.indexing.embeddings_path is None:
+        return None
+    explicit_provider = (config.embeddings.provider or "").strip()
+    try:
+        from markdown_vault_mcp import providers as _providers
+
+        return _providers.get_embedding_provider(config)
+    except (ImportError, RuntimeError) as exc:
+        if explicit_provider:
+            # The operator explicitly chose a backend; a load failure is
+            # a configuration error that must surface, not silently fall
+            # back to keyword-only search.
+            raise ConfigurationError(
+                f"Embedding provider {explicit_provider!r} was explicitly "
+                "configured (MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER) but "
+                f"could not be loaded: {exc}. Fix the configuration, or "
+                "unset the variable to fall back to auto-detection."
+            ) from exc
+        logger.warning(
+            "Could not auto-detect an embedding provider; semantic "
+            "search disabled. Set MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER "
+            "to require a specific backend.",
+            exc_info=True,
+        )
+        return None
+
+
+def _resolve_summarizer(config: ProjectConfig) -> Summarizer | None:
+    """Resolve the summarization backend when one is configured.
+
+    LLM summarization is gated on a backend being configured (an API key or
+    an explicit OpenAI-compatible base URL).  Same posture as embeddings: an
+    explicit provider that fails to load is a configuration error;
+    auto-detect failure warns and disables.
+
+    Args:
+        config: The served project configuration.
+
+    Returns:
+        The backend, or ``None`` (unconfigured, or auto-detection failed).
+
+    Raises:
+        ConfigurationError: If an explicitly configured backend fails to
+            load.
+    """
+    if not config.summarize.has_provider():
+        return None
+    explicit_summarizer = (config.summarize.provider or "").strip()
+    try:
+        from markdown_vault_mcp import summarizer as _summarizer
+
+        return _summarizer.get_summarizer(config)
+    except (ImportError, RuntimeError) as exc:
+        if explicit_summarizer:
+            raise ConfigurationError(
+                f"Summarize provider {explicit_summarizer!r} was "
+                "explicitly configured "
+                "(MARKDOWN_VAULT_MCP_SUMMARIZE_PROVIDER) but could not "
+                f"be loaded: {exc}. Fix the configuration, or unset the "
+                "variable to fall back to auto-detection."
+            ) from exc
+        logger.warning(
+            "Could not load a summarization backend; the summarize "
+            "tool is disabled. Install the SDK with "
+            "pip install 'markdown-vault-mcp[summarize]'.",
+            exc_info=True,
+        )
+        return None
+
+
+def _resolve_git(config: ProjectConfig) -> tuple[GitWriteStrategy, int]:
+    """Build the git strategy for the configured mode, with the pull interval.
+
+    Args:
+        config: The served project configuration.
+
+    Returns:
+        ``(strategy, pull_interval_s)`` — the interval is ``0`` in
+        commit-only mode (no remote configured).
+    """
+    if config.git.repo_url is not None:
+        strategy = _build_git_strategy(
+            config,
+            token=config.git.token,
+            repo_url=config.git.repo_url,
+            managed=True,
+            enable_sync=True,
+        )
+        return strategy, config.git.pull_interval_s
+
+    # Backward compatibility mode: token without explicit repo URL keeps
+    # pull+push semantics, using the existing local checkout's origin.
+    if config.git.token is not None:
+        strategy = _build_git_strategy(
+            config,
+            token=config.git.token,
+            managed=False,
+            enable_sync=True,
+        )
+        return strategy, config.git.pull_interval_s
+
+    # Unmanaged / commit-only mode: commit locally if repo exists, never pull/push.
+    strategy = _build_git_strategy(
+        config,
+        token=None,
+        managed=False,
+        enable_sync=False,
+    )
+    return strategy, 0
+
+
+def to_vault_instances(config: ProjectConfig) -> VaultInstances:
+    """Resolve the constructed ``Vault`` collaborators from config.
+
+    Absorbs the three conditional builds that historically lived in
+    ``to_vault_kwargs``: embedding-provider resolution, summarizer
+    resolution, and the three-mode git-strategy construction.
+
+    Args:
+        config: The :class:`~markdown_vault_mcp.config.ProjectConfig` to
+            build from.
+
+    Returns:
+        The resolved :class:`VaultInstances`.
+
+    Raises:
+        ConfigurationError: If an explicitly configured embedding or
+            summarize provider fails to load.
+    """
+    provider = _resolve_embedding_provider(config)
+    summarizer = _resolve_summarizer(config)
+    git_strategy, git_pull_interval_s = _resolve_git(config)
+    return VaultInstances(
+        embedding_provider=provider,
+        summarizer=summarizer,
+        git_strategy=git_strategy,
+        on_write=git_strategy,
+        git_pull_interval_s=git_pull_interval_s,
+    )
+
+
+def to_vault_settings(
+    config: ProjectConfig, *, instances: VaultInstances | None = None
+) -> VaultSettings:
+    """Map config onto :class:`VaultSettings` for settings-first construction.
+
+    Thin composition over
+    :meth:`~markdown_vault_mcp.config_sections.vault_settings.VaultSettings.from_project_config`
+    that threads the resolved embedding provider's token context into the
+    ``max_chunk_chars`` derivation (a token-dense chunk that fits
+    ``max_chunk_words`` can still exceed the model context; a positive
+    override wins verbatim, ``-1`` opts into unbounded context-scaling
+    (#790), otherwise the cap is bounded by the ceiling, which is also the
+    fallback when the context is unknown).
+
+    Args:
+        config: The :class:`~markdown_vault_mcp.config.ProjectConfig` to
+            build from.
+        instances: Already-resolved collaborators from
+            :func:`to_vault_instances`; pass them to avoid resolving the
+            embedding provider a second time.  ``None`` resolves a throwaway
+            set internally.
+
+    Returns:
+        The mapped :class:`VaultSettings`.
+    """
+    if instances is None:
+        instances = to_vault_instances(config)
+    provider = instances.embedding_provider
+    return VaultSettings.from_project_config(
+        config,
+        embedding_context_length=(
+            provider.context_length if provider is not None else None
+        ),
+    )
+
+
 def to_vault_kwargs(config: ProjectConfig) -> dict[str, Any]:
     """Return keyword arguments suitable for ``Vault(**kwargs)``.
 
     Resolves the embedding provider (when ``indexing.embeddings_path``
     is set) and creates a :class:`~markdown_vault_mcp.git.GitWriteStrategy`.
+
+    .. deprecated::
+        Kwargs-explosion construction is superseded by settings-first
+        construction (#1158): build a :class:`VaultSettings` via
+        :func:`to_vault_settings` and the collaborators via
+        :func:`to_vault_instances`, then pass both to ``Vault(...)``.  This
+        bridge delegates to those two and keeps the historical dict shape
+        for existing callers; removal is scheduled for the next major.
 
     Args:
         config: The :class:`~markdown_vault_mcp.config.ProjectConfig` to build from.
@@ -150,155 +390,27 @@ def to_vault_kwargs(config: ProjectConfig) -> dict[str, Any]:
         Dict of keyword arguments accepted by
         :class:`~markdown_vault_mcp.vault.Vault.__init__`.
     """
-    kwargs: dict[str, Any] = {
-        "source_dir": config.source_dir,
-        "read_only": config.read_only,
-        "write_protect_existing": config.write_protect_existing,
-        "index_path": config.indexing.index_path,
-        "embeddings_path": config.indexing.embeddings_path,
-        "state_path": config.indexing.state_path,
-        "indexed_frontmatter_fields": config.indexing.indexed_frontmatter_fields,
-        "required_frontmatter": config.indexing.required_frontmatter,
-        "exclude_patterns": config.indexing.exclude_patterns,
-        "title_field": config.indexing.title_field,
-        "searchable_frontmatter_fields": config.indexing.searchable_frontmatter,
-        "embed_context": config.embeddings.embed_context,
-        "embedding_batch_size": config.embeddings.embedding_batch_size,
-        "conventions_file": config.content.conventions_file,
-        "okf_mode": config.content.okf_mode,
-        "okf_write": config.content.okf_write,
-        "attachment_extensions": config.content.attachment_extensions,
-        "max_attachment_size_mb": config.content.max_attachment_size_mb,
-        "max_note_read_bytes": config.content.max_note_read_bytes,
-        "git_pull_interval_s": 0,
-        "default_search_mode": config.search.default_mode,
-        "chunks_per_file": config.search.chunks_per_file,
-        "snippet_words": config.search.snippet_words,
-        "length_downweight_alpha": config.search.length_downweight_alpha,
-        "max_chunk_words": config.search.max_chunk_words,
-        "chunk_overlap_words": config.search.chunk_overlap_words,
-        # Weight maps are stored as frozen sorted tuples on the config
-        # (#639); the Vault API takes plain dicts.
-        "folder_weights": (
-            dict(config.search.folder_weights)
-            if config.search.folder_weights is not None
-            else None
-        ),
-        "fts_weights": (
-            dict(config.search.fts_weights)
-            if config.search.fts_weights is not None
-            else None
-        ),
-    }
-
-    # Semantic search is gated by the storage path in config.indexing,
-    # while the provider lives in config.embeddings (cross-section coupling).
-    # An unrecognised provider name raises ConfigurationError from the
-    # resolver and propagates here unchanged.
-    provider = None
-    if config.indexing.embeddings_path is not None:
-        explicit_provider = (config.embeddings.provider or "").strip()
-        try:
-            from markdown_vault_mcp import providers as _providers
-
-            provider = _providers.get_embedding_provider(config)
-            kwargs["embedding_provider"] = provider
-        except (ImportError, RuntimeError) as exc:
-            if explicit_provider:
-                # The operator explicitly chose a backend; a load failure is
-                # a configuration error that must surface, not silently fall
-                # back to keyword-only search.
-                raise ConfigurationError(
-                    f"Embedding provider {explicit_provider!r} was explicitly "
-                    "configured (MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER) but "
-                    f"could not be loaded: {exc}. Fix the configuration, or "
-                    "unset the variable to fall back to auto-detection."
-                ) from exc
-            logger.warning(
-                "Could not auto-detect an embedding provider; semantic "
-                "search disabled. Set MARKDOWN_VAULT_MCP_EMBEDDING_PROVIDER "
-                "to require a specific backend.",
-                exc_info=True,
-            )
-
-    # Derive the chunker char cap from the embedding model's token context
-    # (a token-dense chunk that fits max_chunk_words can still exceed the
-    # model context). A positive override wins verbatim; -1 opts into
-    # unbounded context-scaling (#790); otherwise the default is bounded by
-    # the ceiling, which is also the fallback when the context is unknown.
-    kwargs["max_chunk_chars"] = derive_max_chunk_chars(
-        context_length=(provider.context_length if provider is not None else None),
-        override=config.search.max_chunk_chars_override,
+    instances = to_vault_instances(config)
+    settings = to_vault_settings(config, instances=instances)
+    kwargs: dict[str, Any] = {"source_dir": config.source_dir}
+    kwargs.update(
+        (field.name, getattr(settings, field.name))
+        for field in dataclasses.fields(VaultSettings)
     )
-    # The explicit override is also threaded straight through as the stable
-    # warm-restart key (#649): the coordinator compares it (not the derived
-    # cap) so a transient model-context read cannot trigger a rebuild.
-    kwargs["max_chunk_chars_override"] = config.search.max_chunk_chars_override
-
-    # LLM summarization is gated on a backend being configured (an API key
-    # or an explicit OpenAI-compatible base URL).
-    # Same posture as embeddings: an explicit provider that fails to load is
-    # a configuration error; auto-detect failure warns and disables.
-    if config.summarize.has_provider():
-        explicit_summarizer = (config.summarize.provider or "").strip()
-        try:
-            from markdown_vault_mcp import summarizer as _summarizer
-
-            kwargs["summarizer"] = _summarizer.get_summarizer(config)
-            kwargs["summarize_max_notes"] = config.summarize.max_notes
-            kwargs["summarize_max_input_chars"] = config.summarize.max_input_chars
-        except (ImportError, RuntimeError) as exc:
-            if explicit_summarizer:
-                raise ConfigurationError(
-                    f"Summarize provider {explicit_summarizer!r} was "
-                    "explicitly configured "
-                    "(MARKDOWN_VAULT_MCP_SUMMARIZE_PROVIDER) but could not "
-                    f"be loaded: {exc}. Fix the configuration, or unset the "
-                    "variable to fall back to auto-detection."
-                ) from exc
-            logger.warning(
-                "Could not load a summarization backend; the summarize "
-                "tool is disabled. Install the SDK with "
-                "pip install 'markdown-vault-mcp[summarize]'.",
-                exc_info=True,
-            )
-
-    if config.git.repo_url is not None:
-        git_strategy = _build_git_strategy(
-            config,
-            token=config.git.token,
-            repo_url=config.git.repo_url,
-            managed=True,
-            enable_sync=True,
-        )
-        kwargs["git_pull_interval_s"] = config.git.pull_interval_s
-        kwargs["git_strategy"] = git_strategy
-        kwargs["on_write"] = git_strategy
-        return kwargs
-
-    # Backward compatibility mode: token without explicit repo URL keeps
-    # pull+push semantics, using the existing local checkout's origin.
-    if config.git.token is not None:
-        git_strategy = _build_git_strategy(
-            config,
-            token=config.git.token,
-            managed=False,
-            enable_sync=True,
-        )
-        kwargs["git_pull_interval_s"] = config.git.pull_interval_s
-        kwargs["git_strategy"] = git_strategy
-        kwargs["on_write"] = git_strategy
-        return kwargs
-
-    # Unmanaged / commit-only mode: commit locally if repo exists, never pull/push.
-    git_strategy = _build_git_strategy(
-        config,
-        token=None,
-        managed=False,
-        enable_sync=False,
-    )
-    kwargs["git_strategy"] = git_strategy
-    kwargs["on_write"] = git_strategy
+    if instances.embedding_provider is not None:
+        kwargs["embedding_provider"] = instances.embedding_provider
+    if instances.summarizer is not None:
+        kwargs["summarizer"] = instances.summarizer
+    else:
+        # Historical dict shape: the summarize caps ride along only when a
+        # backend actually resolved.
+        del kwargs["summarize_max_notes"]
+        del kwargs["summarize_max_input_chars"]
+    kwargs["git_strategy"] = instances.git_strategy
+    kwargs["on_write"] = instances.on_write
+    # The git assembly is authoritative for the resolved interval (settings
+    # carries the same value; the equivalence is test-pinned).
+    kwargs["git_pull_interval_s"] = instances.git_pull_interval_s
     return kwargs
 
 

--- a/src/markdown_vault_mcp/config_sections/vault_settings.py
+++ b/src/markdown_vault_mcp/config_sections/vault_settings.py
@@ -1,0 +1,271 @@
+"""Settings object for :class:`~markdown_vault_mcp.vault.Vault` construction.
+
+:class:`VaultSettings` groups every *config-derived* ``Vault.__init__``
+parameter into one frozen dataclass so the constructor no longer needs one
+keyword per knob (#1158).  The never-config-derived collaborators —
+``embedding_provider``, ``summarizer``, ``git_strategy``, ``on_write``, and
+``chunk_strategy`` — stay explicit ``Vault`` keywords; the server path carries
+them in :class:`~markdown_vault_mcp.config_sections._assembly.VaultInstances`.
+
+Field defaults deliberately mirror the *library* defaults of the legacy
+``Vault.__init__`` keywords (pinned by a signature drift-guard test), which is
+why ``chunk_overlap_words`` defaults to ``0`` here while
+:class:`~markdown_vault_mcp.config_sections.search.SearchConfig` defaults to
+``40``, and ``read_only`` defaults to ``True`` while the server env default is
+``False`` — the two tiers are distinct on purpose (see the ``read_only``
+rationale in the ``Vault`` docstring).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.okf import OKF_INDEXED_FIELDS
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from markdown_vault_mcp.config import ProjectConfig
+
+#: Default state-file location under the vault root, shared with
+#: ``markdown_vault_mcp.vault`` (which re-exports both names).
+_DEFAULT_STATE_SUBDIR = ".markdown_vault_mcp"
+_DEFAULT_STATE_FILENAME = "state.json"
+
+
+@dataclasses.dataclass(frozen=True)
+class VaultSettings:
+    """Config-derived construction settings for a :class:`~markdown_vault_mcp.vault.Vault`.
+
+    One field per config-derived ``Vault`` parameter, carrying the same name,
+    type, and default as the corresponding (docstring-deprecated) legacy
+    keyword — see the ``Vault`` docstring for per-knob semantics.  Construct
+    directly for library use, or from a served config via
+    :meth:`from_project_config` /
+    :func:`~markdown_vault_mcp.config_sections._assembly.to_vault_settings`.
+
+    Attributes:
+        index_path: Path to the SQLite index file (``None`` = in-memory).
+        embeddings_path: Base path for the vector sidecar files (``None``
+            disables semantic search).
+        read_only: When ``True`` (library default), write operations raise.
+        write_protect_existing: Require an ``if_match`` etag to overwrite.
+        state_path: Hash-state JSON path (``None`` = derived default, see
+            :meth:`effective_state_path`).
+        indexed_frontmatter_fields: Frontmatter keys promoted to
+            ``document_tags`` for structured filtering.
+        required_frontmatter: Fields a document must carry to be indexed.
+        git_pull_interval_s: Periodic-pull interval; ``0`` disables the loop.
+        exclude_patterns: Configured glob patterns excluded from indexing
+            (before the conventions-file derivation, see
+            :meth:`effective_exclude_patterns`).
+        attachment_extensions: Attachment extension allowlist.
+        max_attachment_size_mb: Attachment context-size cap (``0`` = off).
+        max_note_read_bytes: Full-document read cap in bytes (``0`` = off).
+        chunks_per_file: Search results kept per file before grouping.
+        snippet_words: Snippet truncation length in words.
+        length_downweight_alpha: Length-downweight exponent for ranking.
+        default_search_mode: Mode used when ``search`` gets no ``mode``.
+        max_chunk_words: Word cap for the default heading chunker.
+        max_chunk_chars: Character cap for the default heading chunker.
+        max_chunk_chars_override: Explicit operator char-cap override — the
+            stable warm-restart key (#649).
+        chunk_overlap_words: Overlap carried between split chunks.
+        summarize_max_notes: Cap on notes per ``summarize`` call.
+        summarize_max_input_chars: Char budget per summarization request.
+        title_field: Frontmatter key consulted first for document titles.
+        searchable_frontmatter_fields: Frontmatter keys made keyword-searchable
+            (activates embed-text format v2).
+        embed_context: Force context-enriched (v2) embedding text.
+        embedding_batch_size: Chunk texts per embedding-provider call.
+        folder_weights: Folder-prefix score multipliers for search results.
+        fts_weights: Per-column BM25 weights for the FTS5 rank config.
+        conventions_file: Per-folder conventions filename (``None`` disables).
+        okf_mode: OKF read-semantics mode (``auto`` / ``off`` / ``on``).
+        okf_write: Enable the OKF enforced-write layer.
+    """
+
+    index_path: Path | None = None
+    embeddings_path: Path | None = None
+    read_only: bool = True
+    write_protect_existing: bool = False
+    state_path: Path | None = None
+    indexed_frontmatter_fields: Sequence[str] | None = None
+    required_frontmatter: Sequence[str] | None = None
+    git_pull_interval_s: int = 0
+    exclude_patterns: Sequence[str] | None = None
+    attachment_extensions: Sequence[str] | None = None
+    max_attachment_size_mb: float = 1.0
+    max_note_read_bytes: int = 262144
+    chunks_per_file: int = 2
+    snippet_words: int = 200
+    length_downweight_alpha: float = 0.25
+    default_search_mode: str = "auto"
+    max_chunk_words: int = 400
+    max_chunk_chars: int | None = None
+    max_chunk_chars_override: int | None = None
+    chunk_overlap_words: int = 0
+    summarize_max_notes: int = 50
+    summarize_max_input_chars: int = 200_000
+    title_field: str = "title"
+    searchable_frontmatter_fields: Sequence[str] | None = None
+    embed_context: bool = False
+    embedding_batch_size: int = 4
+    folder_weights: dict[str, float] | None = None
+    fts_weights: dict[str, float] | None = None
+    conventions_file: str | None = "_conventions.md"
+    okf_mode: str = "auto"
+    okf_write: bool = False
+
+    @classmethod
+    def from_project_config(
+        cls,
+        config: ProjectConfig,
+        *,
+        embedding_context_length: int | None = None,
+    ) -> VaultSettings:
+        """Map a served :class:`ProjectConfig` onto vault settings.
+
+        Absorbs the historical ``to_vault_kwargs`` renames
+        (``searchable_frontmatter`` → ``searchable_frontmatter_fields``,
+        ``default_mode`` → ``default_search_mode``) and the weight-map
+        tuple → dict conversions (#639).  The git pull interval resolves the
+        same way the git-strategy assembly does: ``config.git.pull_interval_s``
+        only when a remote is configured (repo URL or token), else ``0``.
+
+        Args:
+            config: The served project configuration.
+            embedding_context_length: Token context length of the resolved
+                embedding provider, used to derive ``max_chunk_chars``
+                (``None`` — no provider — falls back to the bounded ceiling).
+                Prefer
+                :func:`~markdown_vault_mcp.config_sections._assembly.to_vault_settings`,
+                which resolves the provider and threads this automatically.
+
+        Returns:
+            The mapped :class:`VaultSettings`.
+        """
+        # Function-local import: _assembly imports the git package at module
+        # level; keep this module import-light and cycle-free.
+        from markdown_vault_mcp.config_sections._assembly import derive_max_chunk_chars
+
+        git = config.git
+        return cls(
+            index_path=config.indexing.index_path,
+            embeddings_path=config.indexing.embeddings_path,
+            read_only=config.read_only,
+            write_protect_existing=config.write_protect_existing,
+            state_path=config.indexing.state_path,
+            indexed_frontmatter_fields=config.indexing.indexed_frontmatter_fields,
+            required_frontmatter=config.indexing.required_frontmatter,
+            # Mirrors the git-strategy assembly: only the managed and
+            # token-compat modes run the pull loop; commit-only mode never
+            # pulls, whatever the (defaulted) configured interval says.
+            git_pull_interval_s=(
+                git.pull_interval_s
+                if (git.repo_url is not None or git.token is not None)
+                else 0
+            ),
+            exclude_patterns=config.indexing.exclude_patterns,
+            attachment_extensions=config.content.attachment_extensions,
+            max_attachment_size_mb=config.content.max_attachment_size_mb,
+            max_note_read_bytes=config.content.max_note_read_bytes,
+            chunks_per_file=config.search.chunks_per_file,
+            snippet_words=config.search.snippet_words,
+            length_downweight_alpha=config.search.length_downweight_alpha,
+            default_search_mode=config.search.default_mode,
+            max_chunk_words=config.search.max_chunk_words,
+            max_chunk_chars=derive_max_chunk_chars(
+                context_length=embedding_context_length,
+                override=config.search.max_chunk_chars_override,
+            ),
+            max_chunk_chars_override=config.search.max_chunk_chars_override,
+            chunk_overlap_words=config.search.chunk_overlap_words,
+            summarize_max_notes=config.summarize.max_notes,
+            summarize_max_input_chars=config.summarize.max_input_chars,
+            title_field=config.indexing.title_field,
+            searchable_frontmatter_fields=config.indexing.searchable_frontmatter,
+            embed_context=config.embeddings.embed_context,
+            embedding_batch_size=config.embeddings.embedding_batch_size,
+            # Weight maps are stored as frozen sorted tuples on the config
+            # (#639); the Vault API takes plain dicts.
+            folder_weights=(
+                dict(config.search.folder_weights)
+                if config.search.folder_weights is not None
+                else None
+            ),
+            fts_weights=(
+                dict(config.search.fts_weights)
+                if config.search.fts_weights is not None
+                else None
+            ),
+            conventions_file=config.content.conventions_file,
+            okf_mode=config.content.okf_mode,
+            okf_write=config.content.okf_write,
+        )
+
+    def effective_indexed_fields(self, *, okf_active: bool) -> list[str]:
+        """Return the indexed-frontmatter set, OKF-extended when active.
+
+        When OKF read semantics are active at construction time, the OKF
+        scalar keys (``type`` / ``status`` / ``stale_after``) join the
+        configured set so ``document_tags`` carries them (design okf.md §3).
+
+        Args:
+            okf_active: Whether the vault's OKF detection probe reports
+                active read semantics.
+
+        Returns:
+            The effective field list (possibly empty, never ``None``).
+        """
+        fields = list(self.indexed_frontmatter_fields or [])
+        if okf_active:
+            fields.extend(key for key in OKF_INDEXED_FIELDS if key not in fields)
+        return fields
+
+    def effective_exclude_patterns(self) -> Sequence[str] | None:
+        """Return the exclusion patterns with the conventions-file derivation.
+
+        When a conventions file is configured, both fnmatch forms are
+        appended (``name`` and ``**/name`` — the ``**/`` form alone does not
+        match a root-level file) so convention files stay out of the index
+        while remaining disk-readable.  Without one, the configured patterns
+        pass through unchanged (possibly ``None``).
+
+        Returns:
+            The effective pattern sequence, or ``None`` when nothing is
+            excluded.
+
+        Raises:
+            ValueError: If *conventions_file* contains fnmatch
+                metacharacters (which would invert the exclusion).
+        """
+        if not self.conventions_file:
+            return self.exclude_patterns
+        if any(ch in self.conventions_file for ch in "*?[]"):
+            raise ValueError(
+                "conventions_file must not contain fnmatch metacharacters "
+                f"(*, ?, [, ]), got {self.conventions_file!r}"
+            )
+        return [
+            *(self.exclude_patterns or []),
+            self.conventions_file,
+            f"**/{self.conventions_file}",
+        ]
+
+    def effective_state_path(self, source_dir: Path) -> Path:
+        """Return the hash-state path, defaulting under the vault root.
+
+        Args:
+            source_dir: The vault root, used when no explicit ``state_path``
+                is configured.
+
+        Returns:
+            The explicit ``state_path``, or
+            ``{source_dir}/.markdown_vault_mcp/state.json``.
+        """
+        if self.state_path is not None:
+            return self.state_path
+        return source_dir / _DEFAULT_STATE_SUBDIR / _DEFAULT_STATE_FILENAME

--- a/src/markdown_vault_mcp/domain.py
+++ b/src/markdown_vault_mcp/domain.py
@@ -18,7 +18,11 @@ from typing import TYPE_CHECKING
 from fastmcp.dependencies import CurrentContext
 from fastmcp.server.context import Context
 
-from markdown_vault_mcp.config import ProjectConfig, to_vault_kwargs
+from markdown_vault_mcp.config import ProjectConfig
+from markdown_vault_mcp.config_sections._assembly import (
+    to_vault_instances,
+    to_vault_settings,
+)
 from markdown_vault_mcp.vault import Vault
 
 if TYPE_CHECKING:
@@ -117,13 +121,24 @@ class Service:
         config = self._config
         logger.info("Initialising vault from %s", config.source_dir)
 
-        kwargs = to_vault_kwargs(config)
-        if kwargs.get("embedding_provider") is not None:
+        # Settings-first construction (#1158): the config-derived knobs
+        # travel as one VaultSettings; the constructed collaborators stay
+        # explicit keywords, resolved once into VaultInstances.
+        instances = to_vault_instances(config)
+        settings = to_vault_settings(config, instances=instances)
+        if instances.embedding_provider is not None:
             logger.info(
                 "Embedding provider: %s",
-                type(kwargs["embedding_provider"]).__name__,
+                type(instances.embedding_provider).__name__,
             )
-        vault = Vault(**kwargs)
+        vault = Vault(
+            source_dir=config.source_dir,
+            settings=settings,
+            embedding_provider=instances.embedding_provider,
+            summarizer=instances.summarizer,
+            git_strategy=instances.git_strategy,
+            on_write=instances.on_write,
+        )
         self._vault = vault
         set_vault_singleton(vault)
 
@@ -156,7 +171,7 @@ class Service:
         vault.index.reindex_async()
         logger.info("Submitted boot Reindex job to writer")
 
-        if kwargs.get("embedding_provider") is not None:
+        if instances.embedding_provider is not None:
             vault.index.build_embeddings_async()
             logger.info("Submitted BuildEmbeddings job to writer")
 
@@ -171,10 +186,11 @@ class Service:
         )
         from markdown_vault_mcp.exceptions import IndexUnavailableError
 
-        # Use the *resolved* pull interval from kwargs, not config.git.pull_interval_s:
-        # the config default is 600 even on non-git vaults, but to_vault_kwargs()
-        # only passes a non-zero interval through when a git strategy is configured.
-        git_pull_active = kwargs.get("git_pull_interval_s", 0) > 0
+        # Use the *resolved* pull interval from the git assembly, not
+        # config.git.pull_interval_s: the config default is 600 even on
+        # non-git vaults, but to_vault_instances() only resolves a non-zero
+        # interval when a sync-enabled git strategy is configured.
+        git_pull_active = instances.git_pull_interval_s > 0
 
         if should_start_file_watcher(
             config.sync.file_watcher_enabled,

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -76,7 +76,7 @@ from markdown_vault_mcp.utils.text import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Sequence
 
     from markdown_vault_mcp.fts_index import FTSIndex
     from markdown_vault_mcp.scanner import ChunkStrategy
@@ -188,7 +188,7 @@ class DocumentManager:
         read_only: bool = True,
         write_protect_existing: bool = False,
         exclude_patterns: list[str] | None = None,
-        attachment_extensions: list[str] | None = None,
+        attachment_extensions: Sequence[str] | None = None,
         max_note_read_bytes: int = 262144,
         on_write_callback: _OnWriteCallback | WriteCallback | None = None,
         mark_paths_dirty: Callable[[Iterable[str]], None] | None = None,

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -183,7 +183,7 @@ class SearchManager:
         embedding_provider: EmbeddingProvider | None = None,
         indexed_frontmatter_fields: list[str] | None = None,
         exclude_patterns: list[str] | None = None,
-        attachment_extensions: list[str] | None = None,
+        attachment_extensions: Sequence[str] | None = None,
         link_manager: LinkManager | None = None,
         okf_detector: OkfDetector | None = None,
         rebuild_embeddings: Callable[[], None] | None = None,

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -7,10 +7,23 @@ LangChain wrappers, and CLI commands all go through this class.
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import logging
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+# _DEFAULT_STATE_* are re-exported here for backwards compatibility (the
+# state-path default historically lived in this module; domain.py still
+# imports it from here).
+from markdown_vault_mcp.config_sections.vault_settings import (
+    _DEFAULT_STATE_FILENAME as _DEFAULT_STATE_FILENAME,
+)
+from markdown_vault_mcp.config_sections.vault_settings import (
+    _DEFAULT_STATE_SUBDIR as _DEFAULT_STATE_SUBDIR,
+)
+from markdown_vault_mcp.config_sections.vault_settings import (
+    VaultSettings as VaultSettings,  # re-export: settings-first construction (#1158)
+)
 from markdown_vault_mcp.conventions import ConventionsResolver
 from markdown_vault_mcp.embed_text import EmbedTextBuilder
 from markdown_vault_mcp.facets import (
@@ -23,7 +36,6 @@ from markdown_vault_mcp.facets import (
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.indexing import IndexWriteCoordinator
 from markdown_vault_mcp.okf import (
-    OKF_INDEXED_FIELDS,
     OkfAuditReport,
     OkfDetector,
     ReservedFrontmatterPolicy,
@@ -50,9 +62,6 @@ if TYPE_CHECKING:
     from markdown_vault_mcp.vector_index import VectorIndex
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_STATE_SUBDIR = ".markdown_vault_mcp"
-_DEFAULT_STATE_FILENAME = "state.json"
 
 #: Bound on how long OKF convention maintenance (#964) waits for the
 #: single-writer index to drain before refreshing a folder's ``index.md`` so a
@@ -83,6 +92,49 @@ def _resolve_chunk_strategy(strategy: str | ChunkStrategy) -> ChunkStrategy:
             "Valid string values: 'heading', 'whole'."
         )
     return strategy
+
+
+def _settings_from_legacy(legacy: dict[str, Any]) -> VaultSettings:
+    """Build :class:`VaultSettings` from the legacy per-knob constructor kwargs.
+
+    The legacy keyword names match the settings field names one-to-one, so
+    this is a direct explosion; it exists as the named seam of the dual-mode
+    constructor (#1158) — a dict-taking module function rather than 31 more
+    parameters somewhere.
+
+    Args:
+        legacy: Mapping of config-derived legacy kwarg name to passed value.
+
+    Returns:
+        The equivalent :class:`VaultSettings`.
+    """
+    return VaultSettings(**legacy)
+
+
+def _reject_legacy_conflicts(legacy: dict[str, Any]) -> None:
+    """Raise when ``settings=`` is combined with non-default legacy kwargs.
+
+    A caller passing both construction modes is ambiguous — the explicit
+    conflict beats silently ignoring one side.
+
+    Args:
+        legacy: Mapping of config-derived legacy kwarg name to passed value.
+
+    Raises:
+        ValueError: If any config-derived legacy kwarg deviates from its
+            default while ``settings`` is also given.
+    """
+    conflicting = sorted(
+        field.name
+        for field in dataclasses.fields(VaultSettings)
+        if legacy[field.name] != field.default
+    )
+    if conflicting:
+        raise ValueError(
+            "Vault(settings=...) cannot be combined with the deprecated "
+            f"config-derived keyword(s): {', '.join(conflicting)}. "
+            "Pass these values on VaultSettings instead."
+        )
 
 
 class Vault:
@@ -146,8 +198,39 @@ class Vault:
     "Vault thread-safety contract" for the underlying per-thread
     SQLite-connection model.
 
+    **Construction (#1158).** The preferred mode is *settings-first*: pass
+    ``source_dir`` plus a
+    :class:`~markdown_vault_mcp.config_sections.vault_settings.VaultSettings`
+    (``settings=``), and — as needed — the five collaborator keywords that
+    are never config-derived (``embedding_provider``, ``summarizer``,
+    ``git_strategy``, ``on_write``, ``chunk_strategy``).  The per-knob
+    keywords documented below keep working unchanged as a compatibility
+    mode, but mixing the two — ``settings=`` together with a non-default
+    config-derived keyword — raises :exc:`ValueError`.
+
+    .. deprecated::
+        The config-derived per-knob keywords — ``index_path``,
+        ``embeddings_path``, ``read_only``, ``write_protect_existing``,
+        ``state_path``, ``indexed_frontmatter_fields``,
+        ``required_frontmatter``, ``git_pull_interval_s``,
+        ``exclude_patterns``, ``attachment_extensions``,
+        ``max_attachment_size_mb``, ``max_note_read_bytes``,
+        ``chunks_per_file``, ``snippet_words``, ``length_downweight_alpha``,
+        ``default_search_mode``, ``max_chunk_words``, ``max_chunk_chars``,
+        ``max_chunk_chars_override``, ``chunk_overlap_words``,
+        ``summarize_max_notes``, ``summarize_max_input_chars``,
+        ``title_field``, ``searchable_frontmatter_fields``,
+        ``embed_context``, ``embedding_batch_size``, ``folder_weights``,
+        ``fts_weights``, ``conventions_file``, ``okf_mode``, and
+        ``okf_write`` — are superseded by the same-named fields on
+        ``VaultSettings``; removal is scheduled for the next major.
+        ``source_dir`` and the five collaborator keywords are *not*
+        deprecated.
+
     Args:
         source_dir: Root directory of the markdown vault.
+        settings: Config-derived construction settings.  ``None`` (default)
+            builds them from the legacy per-knob keywords below.
         index_path: Path to the SQLite index file.  ``None`` (default) uses
             an in-memory database that is discarded when the object is
             collected.
@@ -166,7 +249,7 @@ class Vault:
             while this one is a fail-safe for a downstream Python consumer
             who constructs a ``Vault`` without naming the argument. Keeping
             it costs nothing — the server path always passes the value
-            explicitly through ``to_vault_kwargs`` — and moving it would be
+            explicitly through ``to_vault_settings`` — and moving it would be
             an independent breaking change to the public library interface.
         write_protect_existing: When ``True``, a write that would overwrite an
             existing file without an *if_match* etag raises
@@ -277,15 +360,86 @@ class Vault:
         conventions_file: str | None = "_conventions.md",
         okf_mode: str = "auto",
         okf_write: bool = False,
+        settings: VaultSettings | None = None,
     ) -> None:
+        # Dual-mode construction (#1158): the config-derived legacy kwargs
+        # map one-to-one onto VaultSettings fields.  Without `settings` they
+        # are folded into one; with it, any non-default legacy value is an
+        # explicit conflict.  Either way, ONE wiring path below consumes
+        # (settings + source_dir + the five collaborator kwargs).
+        legacy: dict[str, Any] = {
+            "index_path": index_path,
+            "embeddings_path": embeddings_path,
+            "read_only": read_only,
+            "write_protect_existing": write_protect_existing,
+            "state_path": state_path,
+            "indexed_frontmatter_fields": indexed_frontmatter_fields,
+            "required_frontmatter": required_frontmatter,
+            "git_pull_interval_s": git_pull_interval_s,
+            "exclude_patterns": exclude_patterns,
+            "attachment_extensions": attachment_extensions,
+            "max_attachment_size_mb": max_attachment_size_mb,
+            "max_note_read_bytes": max_note_read_bytes,
+            "chunks_per_file": chunks_per_file,
+            "snippet_words": snippet_words,
+            "length_downweight_alpha": length_downweight_alpha,
+            "default_search_mode": default_search_mode,
+            "max_chunk_words": max_chunk_words,
+            "max_chunk_chars": max_chunk_chars,
+            "max_chunk_chars_override": max_chunk_chars_override,
+            "chunk_overlap_words": chunk_overlap_words,
+            "summarize_max_notes": summarize_max_notes,
+            "summarize_max_input_chars": summarize_max_input_chars,
+            "title_field": title_field,
+            "searchable_frontmatter_fields": searchable_frontmatter_fields,
+            "embed_context": embed_context,
+            "embedding_batch_size": embedding_batch_size,
+            "folder_weights": folder_weights,
+            "fts_weights": fts_weights,
+            "conventions_file": conventions_file,
+            "okf_mode": okf_mode,
+            "okf_write": okf_write,
+        }
+        if settings is None:
+            settings = _settings_from_legacy(legacy)
+        else:
+            _reject_legacy_conflicts(legacy)
+
         self._source_dir = source_dir
-        self._index_path = index_path
-        self._embeddings_path = embeddings_path
+        # The five collaborators that are never config-derived stay explicit
+        # constructor kwargs in both modes.
         self._embedding_provider = embedding_provider
-        self._embedding_batch_size = embedding_batch_size
-        self._read_only = read_only
-        self._write_protect_existing = write_protect_existing
-        self._indexed_frontmatter_fields: list[str] = indexed_frontmatter_fields or []
+        self._summarizer = summarizer
+        self._on_write = on_write
+        self._git_strategy = git_strategy
+        self._configure(settings, chunk_strategy)
+        self._build_managers(settings)
+        self._build_facets(settings)
+
+    def _configure(
+        self, settings: VaultSettings, chunk_strategy: str | ChunkStrategy
+    ) -> None:
+        """Normalise settings into the vault's configuration attributes.
+
+        Owns the construction-time derivations: OKF detection and the
+        indexed-field extension, chunker construction, the conventions-file
+        exclude derivation, and the state-path default.
+
+        Args:
+            settings: The resolved construction settings.
+            chunk_strategy: ``"heading"`` (default), ``"whole"``, or a custom
+                :class:`~markdown_vault_mcp.scanner.ChunkStrategy` instance.
+
+        Raises:
+            ValueError: If *chunk_strategy* is an unrecognised string name,
+                or ``settings.conventions_file`` contains fnmatch
+                metacharacters.
+        """
+        self._index_path = settings.index_path
+        self._embeddings_path = settings.embeddings_path
+        self._embedding_batch_size = settings.embedding_batch_size
+        self._read_only = settings.read_only
+        self._write_protect_existing = settings.write_protect_existing
         # OKF detection (disk probe, index-independent). When read semantics
         # are active at construction time, the OKF scalar keys join the
         # effective indexed-field set so `document_tags` carries them; the
@@ -294,27 +448,26 @@ class Vault:
         # once (design okf.md §3). A vault that declares OKF mid-session
         # gains annotations immediately but indexed OKF tags only on the
         # next startup.
-        self._okf = OkfDetector(source_dir, okf_mode)
-        if self._okf.state().active:
-            extended = [
-                key
-                for key in OKF_INDEXED_FIELDS
-                if key not in self._indexed_frontmatter_fields
-            ]
-            if extended:
-                self._indexed_frontmatter_fields = [
-                    *self._indexed_frontmatter_fields,
-                    *extended,
-                ]
-                logger.info("okf_indexed_fields_extended fields=%s", ",".join(extended))
-        self._required_frontmatter = required_frontmatter
+        self._okf = OkfDetector(self._source_dir, settings.okf_mode)
+        configured_field_count = len(settings.indexed_frontmatter_fields or [])
+        self._indexed_frontmatter_fields: list[str] = settings.effective_indexed_fields(
+            okf_active=self._okf.state().active
+        )
+        extended = self._indexed_frontmatter_fields[configured_field_count:]
+        if extended:
+            logger.info("okf_indexed_fields_extended fields=%s", ",".join(extended))
+        self._required_frontmatter = (
+            list(settings.required_frontmatter)
+            if settings.required_frontmatter is not None
+            else None
+        )
         # Only inject max_chunk_words when the caller has not provided a
         # custom ChunkStrategy instance or an explicit string name override.
         if isinstance(chunk_strategy, str) and chunk_strategy == "heading":
             self._chunk_strategy: ChunkStrategy = HeadingChunker(
-                max_chunk_words=max_chunk_words,
-                max_chunk_chars=max_chunk_chars,
-                chunk_overlap_words=chunk_overlap_words,
+                max_chunk_words=settings.max_chunk_words,
+                max_chunk_chars=settings.max_chunk_chars,
+                chunk_overlap_words=settings.chunk_overlap_words,
             )
         else:
             # NOTE: When a caller passes an explicit chunk_strategy instance
@@ -329,68 +482,64 @@ class Vault:
         # Stable warm-restart keys recorded into FTS meta at build time (#649):
         # the embedding model name and the explicit char-cap override. A change
         # to either rejects the short-circuit and cold-rebuilds.
-        self._max_chunk_chars_override = max_chunk_chars_override
+        self._max_chunk_chars_override = settings.max_chunk_chars_override
         # None when no provider is configured.
         self._embed_model_name: str | None = (
-            embedding_provider.model_name if embedding_provider is not None else None
+            self._embedding_provider.model_name
+            if self._embedding_provider is not None
+            else None
         )
         # Curated-ranking knobs. ONE shared EmbedTextBuilder is constructed
         # here and threaded to every embedding site so hot, cold, converge,
         # and flush paths all produce identical embedding input.
-        self._title_field = title_field
-        self._searchable_frontmatter_fields: list[str] = (
-            searchable_frontmatter_fields or []
+        self._title_field = settings.title_field
+        self._searchable_frontmatter_fields: list[str] = list(
+            settings.searchable_frontmatter_fields or []
         )
         self._embed_builder = EmbedTextBuilder(
-            embed_context=embed_context,
+            embed_context=settings.embed_context,
             searchable_fields=tuple(self._searchable_frontmatter_fields),
         )
-        self._on_write = on_write
-        self._git_strategy = git_strategy
-        self._git_pull_interval_s = git_pull_interval_s
+        self._git_pull_interval_s = settings.git_pull_interval_s
         # The resolver prunes its folder walk with the *configured* patterns
-        # only — the derived patterns below would otherwise exclude the
-        # convention files themselves.
+        # only — the derived patterns from effective_exclude_patterns() would
+        # otherwise exclude the convention files themselves.
         self._conventions = ConventionsResolver(
-            source_dir, conventions_file, exclude_patterns=exclude_patterns
+            self._source_dir,
+            settings.conventions_file,
+            exclude_patterns=settings.exclude_patterns,
         )
-        if conventions_file:
-            if any(ch in conventions_file for ch in "*?[]"):
-                raise ValueError(
-                    "conventions_file must not contain fnmatch metacharacters "
-                    f"(*, ?, [, ]), got {conventions_file!r}"
-                )
-            # Convention files are index-excluded but stay disk-readable.
-            # Both fnmatch forms are needed: `**/name` alone does not match
-            # a root-level file.
-            exclude_patterns = [
-                *(exclude_patterns or []),
-                conventions_file,
-                f"**/{conventions_file}",
-            ]
-        self._exclude_patterns = exclude_patterns
-        self._attachment_extensions = attachment_extensions
-        self._max_attachment_size_mb = max_attachment_size_mb
-        self._max_note_read_bytes = max_note_read_bytes
-        self._summarizer = summarizer
-        self._summarize_max_notes = summarize_max_notes
-        self._summarize_max_input_chars = summarize_max_input_chars
-
+        # Convention files are index-excluded but stay disk-readable; the
+        # derivation (both fnmatch forms) and the metacharacter validation
+        # live on VaultSettings.
+        effective_excludes = settings.effective_exclude_patterns()
+        self._exclude_patterns: list[str] | None = (
+            list(effective_excludes) if effective_excludes is not None else None
+        )
+        self._attachment_extensions = settings.attachment_extensions
+        self._max_attachment_size_mb = settings.max_attachment_size_mb
+        self._max_note_read_bytes = settings.max_note_read_bytes
+        self._summarize_max_notes = settings.summarize_max_notes
+        self._summarize_max_input_chars = settings.summarize_max_input_chars
         # Default state path: {source_dir}/.markdown_vault_mcp/state.json
-        if state_path is None:
-            self._state_path = (
-                source_dir / _DEFAULT_STATE_SUBDIR / _DEFAULT_STATE_FILENAME
-            )
-        else:
-            self._state_path = state_path
+        self._state_path = settings.effective_state_path(self._source_dir)
 
+    def _build_managers(self, settings: VaultSettings) -> None:
+        """Construct the index/tracker sub-modules and the manager layer.
+
+        Args:
+            settings: The resolved construction settings (search-ranking
+                knobs and the OKF write toggle are consumed here).
+        """
         # Sub-module construction.
-        db_path: Path | str = index_path if index_path is not None else ":memory:"
+        db_path: Path | str = (
+            self._index_path if self._index_path is not None else ":memory:"
+        )
         self._fts = FTSIndex(
             db_path=db_path,
             indexed_frontmatter_fields=self._indexed_frontmatter_fields or None,
             searchable_frontmatter_fields=self._searchable_frontmatter_fields or None,
-            fts_weights=fts_weights,
+            fts_weights=settings.fts_weights,
         )
         self._tracker = ChangeTracker(self._state_path)
 
@@ -409,7 +558,6 @@ class Vault:
         from markdown_vault_mcp.managers.git_query import GitQueryManager
         from markdown_vault_mcp.managers.index import IndexManager
         from markdown_vault_mcp.managers.link import LinkManager
-        from markdown_vault_mcp.managers.okf_migrate import OkfMigrationManager
         from markdown_vault_mcp.managers.search import SearchManager
 
         # 1. LinkManager (no deps)
@@ -476,11 +624,11 @@ class Vault:
             # coordinator routes it through the writer thread, preserving the
             # single-owner invariant (#559): only the writer thread mutates indexes.
             rebuild_embeddings=self._coordinator.rebuild_embeddings,
-            chunks_per_file=chunks_per_file,
-            snippet_words=snippet_words,
-            length_downweight_alpha=length_downweight_alpha,
-            default_mode=default_search_mode,
-            folder_weights=folder_weights,
+            chunks_per_file=settings.chunks_per_file,
+            snippet_words=settings.snippet_words,
+            length_downweight_alpha=settings.length_downweight_alpha,
+            default_mode=settings.default_search_mode,
+            folder_weights=settings.folder_weights,
             embed_text_format=self._embed_builder.format_token(),
         )
         # Deferred write callback (issue #175): the git-commit on_write
@@ -508,7 +656,9 @@ class Vault:
         # OKF_WRITE is on; when on, it stamps provenance and clears verification
         # for write/edit on an OKF-active vault.
         self._okf_write_enrich = build_okf_write_enrich(
-            okf_write=okf_write, detector=self._okf, version=package_version()
+            okf_write=settings.okf_write,
+            detector=self._okf,
+            version=package_version(),
         )
         self._doc_mgr = DocumentManager(
             fts=self._fts,
@@ -525,6 +675,15 @@ class Vault:
             title_field=self._title_field,
             okf_write_enrich=self._okf_write_enrich,
         )
+
+    def _build_facets(self, settings: VaultSettings) -> None:
+        """Construct the facet layer over the managers/coordinator (#604).
+
+        Args:
+            settings: The resolved construction settings (the OKF write
+                toggle gates the convention maintainer).
+        """
+        from markdown_vault_mcp.managers.okf_migrate import OkfMigrationManager
 
         # Facets (#604): thin views over the shared managers/coordinator, exposed via the reader/writer/graph/index accessors.
         self._reader_facet = ReaderFacet(
@@ -554,7 +713,7 @@ class Vault:
         # write/edit it appends to the folder's log.md and refreshes its
         # index.md as secondary writes; failures degrade to a WARNING.
         self._okf_convention = None
-        if okf_write:
+        if settings.okf_write:
             from markdown_vault_mcp._okf_convention import ConventionMaintainer
 
             self._okf_convention = ConventionMaintainer(

--- a/tests/test_background_fts.py
+++ b/tests/test_background_fts.py
@@ -525,13 +525,16 @@ def test_lifespan_cold_start_with_embeddings_submits_both_jobs(
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
 
-    # Inject a MockEmbeddingProvider into to_vault_kwargs so that
-    # kwargs["embedding_provider"] is non-None without needing a real provider.
-    # Patch it where the lifespan uses it (domain.Service.start calls the free
-    # function), not on ProjectConfig (it's no longer a method).
+    # Inject a MockEmbeddingProvider into the resolved instances so the
+    # provider is non-None without needing a real one.  Patch where the
+    # lifespan resolves them (domain.Service.start calls the free functions
+    # to_vault_instances / to_vault_settings since #1158).
+    import dataclasses
+
     from markdown_vault_mcp import domain as deps_mod
 
-    original_to_kwargs = deps_mod.to_vault_kwargs
+    original_to_instances = deps_mod.to_vault_instances
+    original_to_settings = deps_mod.to_vault_settings
 
     # Gate the embeddings build on the writer thread so it provably cannot
     # complete during the handshake — the deterministic replacement for the
@@ -543,14 +546,21 @@ def test_lifespan_cold_start_with_embeddings_submits_both_jobs(
             assert release.wait(10), "embed gate was never released — test bug"
             return super().embed(texts)
 
-    def patched_to_kwargs(config):  # type: ignore[no-untyped-def]
-        kw = original_to_kwargs(config)
-        kw["embedding_provider"] = _GatedProvider()
-        if kw.get("embeddings_path") is None:
-            kw["embeddings_path"] = tmp_path / "vectors"
-        return kw
+    def patched_to_instances(config):  # type: ignore[no-untyped-def]
+        return dataclasses.replace(
+            original_to_instances(config), embedding_provider=_GatedProvider()
+        )
 
-    monkeypatch.setattr(deps_mod, "to_vault_kwargs", patched_to_kwargs)
+    def patched_to_settings(config, *, instances=None):  # type: ignore[no-untyped-def]
+        settings = original_to_settings(config, instances=instances)
+        if settings.embeddings_path is None:
+            settings = dataclasses.replace(
+                settings, embeddings_path=tmp_path / "vectors"
+            )
+        return settings
+
+    monkeypatch.setattr(deps_mod, "to_vault_instances", patched_to_instances)
+    monkeypatch.setattr(deps_mod, "to_vault_settings", patched_to_settings)
 
     server = make_server()
     caplog.set_level(logging.INFO)

--- a/tests/test_embedding_convergence.py
+++ b/tests/test_embedding_convergence.py
@@ -395,17 +395,27 @@ class TestLifespanEmbeddingConvergence:
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEX_PATH", str(tmp_path / "fts.db"))
         monkeypatch.setenv("MARKDOWN_VAULT_MCP_STATE_PATH", str(tmp_path / "s.json"))
 
-        # Inject the mock provider into to_vault_kwargs so the lifespan
-        # submits the boot BuildEmbeddings job without a real provider.
-        original_to_kwargs = deps_mod.to_vault_kwargs
+        # Inject the mock provider into the resolved instances so the
+        # lifespan submits the boot BuildEmbeddings job without a real
+        # provider (domain.Service.start resolves via to_vault_instances /
+        # to_vault_settings since #1158).
+        import dataclasses
 
-        def patched_to_kwargs(config: Any) -> dict[str, Any]:
-            kw = original_to_kwargs(config)
-            kw["embedding_provider"] = MockEmbeddingProvider()
-            kw["embeddings_path"] = tmp_path / "vectors"
-            return kw
+        original_to_instances = deps_mod.to_vault_instances
+        original_to_settings = deps_mod.to_vault_settings
 
-        monkeypatch.setattr(deps_mod, "to_vault_kwargs", patched_to_kwargs)
+        def patched_to_instances(config: Any) -> Any:
+            return dataclasses.replace(
+                original_to_instances(config),
+                embedding_provider=MockEmbeddingProvider(),
+            )
+
+        def patched_to_settings(config: Any, *, instances: Any = None) -> Any:
+            settings = original_to_settings(config, instances=instances)
+            return dataclasses.replace(settings, embeddings_path=tmp_path / "vectors")
+
+        monkeypatch.setattr(deps_mod, "to_vault_instances", patched_to_instances)
+        monkeypatch.setattr(deps_mod, "to_vault_settings", patched_to_settings)
         server = make_server()
 
         async def _run() -> tuple[dict[str, Any], dict[str, Any], list[str]]:

--- a/tests/test_vault_settings.py
+++ b/tests/test_vault_settings.py
@@ -1,0 +1,394 @@
+"""Settings-first Vault construction (#1158).
+
+Pins the dual-mode contract mechanically:
+
+- a signature drift-guard asserts every :class:`VaultSettings` field mirrors a
+  same-named ``Vault.__init__`` keyword with an identical default (including
+  the two deliberate drifts — ``chunk_overlap_words=0`` vs SearchConfig's 40,
+  and the ``read_only=True`` library default vs the server env default);
+- an equivalence test constructs one vault per mode from the same values and
+  compares the resolved wiring;
+- mixing ``settings=`` with a non-default config-derived legacy kwarg is an
+  explicit ``ValueError``;
+- ``VaultSettings.from_project_config`` absorbs the historical
+  ``to_vault_kwargs`` renames and weight-map conversions.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+from markdown_vault_mcp.config import ProjectConfig
+from markdown_vault_mcp.config_sections import VaultSettings
+from markdown_vault_mcp.config_sections._assembly import (
+    to_vault_instances,
+    to_vault_kwargs,
+    to_vault_settings,
+)
+from markdown_vault_mcp.vault import Vault
+
+# The Vault.__init__ keywords that are NOT config-derived and therefore have
+# no VaultSettings field: the root, the five collaborators, and settings.
+_NON_SETTINGS_PARAMS = {
+    "self",
+    "source_dir",
+    "embedding_provider",
+    "summarizer",
+    "git_strategy",
+    "on_write",
+    "chunk_strategy",
+    "settings",
+}
+
+
+class TestSignatureDriftGuard:
+    """VaultSettings fields and Vault legacy kwargs must not drift apart."""
+
+    def test_fields_mirror_init_defaults(self) -> None:
+        """Every field has a same-named Vault kwarg with the same default."""
+        params = inspect.signature(Vault.__init__).parameters
+        for field in dataclasses.fields(VaultSettings):
+            assert field.name in params, (
+                f"VaultSettings.{field.name} has no matching Vault.__init__ kwarg"
+            )
+            assert params[field.name].default == field.default, (
+                f"default drift on {field.name}: Vault.__init__ has "
+                f"{params[field.name].default!r}, VaultSettings has "
+                f"{field.default!r}"
+            )
+
+    def test_every_config_derived_kwarg_has_a_field(self) -> None:
+        """The 31 config-derived Vault kwargs are exactly the settings fields."""
+        params = set(inspect.signature(Vault.__init__).parameters)
+        config_derived = params - _NON_SETTINGS_PARAMS
+        field_names = {field.name for field in dataclasses.fields(VaultSettings)}
+        assert config_derived == field_names
+        assert len(field_names) == 31
+
+    def test_deliberate_default_drifts_are_preserved(self) -> None:
+        """The two known library-vs-server default drifts stay pinned."""
+        settings = VaultSettings()
+        # Library chunker default: no overlap (SearchConfig defaults to 40).
+        assert settings.chunk_overlap_words == 0
+        # Library fail-safe default: read-only (the server env default is
+        # False, #1113); see the Vault docstring rationale.
+        assert settings.read_only is True
+
+
+class TestDualModeEquivalence:
+    """Legacy kwargs and settings-first construction wire identically."""
+
+    _VALUES: ClassVar[dict[str, Any]] = {
+        "read_only": False,
+        "write_protect_existing": True,
+        "indexed_frontmatter_fields": ["cluster"],
+        "required_frontmatter": ["title"],
+        "exclude_patterns": [".trash/**"],
+        "attachment_extensions": ["pdf"],
+        "max_attachment_size_mb": 2.5,
+        "max_note_read_bytes": 1024,
+        "chunks_per_file": 3,
+        "snippet_words": 50,
+        "length_downweight_alpha": 0.5,
+        "default_search_mode": "keyword",
+        "max_chunk_words": 100,
+        "max_chunk_chars_override": 900,
+        "chunk_overlap_words": 10,
+        "summarize_max_notes": 7,
+        "summarize_max_input_chars": 5000,
+        "title_field": "name",
+        "searchable_frontmatter_fields": ["cluster"],
+        "embed_context": True,
+        "embedding_batch_size": 8,
+        "folder_weights": {"notes": 2.0},
+        "fts_weights": {"title": 3.0},
+        "conventions_file": "_house_rules.md",
+    }
+
+    _COMPARED_ATTRS = (
+        "_index_path",
+        "_embeddings_path",
+        "_read_only",
+        "_write_protect_existing",
+        "_state_path",
+        "_indexed_frontmatter_fields",
+        "_required_frontmatter",
+        "_git_pull_interval_s",
+        "_exclude_patterns",
+        "_attachment_extensions",
+        "_max_attachment_size_mb",
+        "_max_note_read_bytes",
+        "_max_chunk_chars_override",
+        "_summarize_max_notes",
+        "_summarize_max_input_chars",
+        "_title_field",
+        "_searchable_frontmatter_fields",
+        "_embedding_batch_size",
+    )
+
+    def test_same_values_resolve_to_same_wiring(self, tmp_path: Path) -> None:
+        values = dict(self._VALUES)
+        values["index_path"] = tmp_path / "idx.db"
+        values["state_path"] = tmp_path / "state.json"
+        legacy = Vault(source_dir=tmp_path, **values)
+        settings_first = Vault(source_dir=tmp_path, settings=VaultSettings(**values))
+        try:
+            for attr in self._COMPARED_ATTRS:
+                assert getattr(legacy, attr) == getattr(settings_first, attr), attr
+            # Chunker construction consumes the same settings values.
+            assert type(legacy._chunk_strategy) is type(settings_first._chunk_strategy)
+            assert vars(legacy._chunk_strategy) == vars(settings_first._chunk_strategy)
+            # Derived exclude patterns include the conventions-file forms.
+            assert legacy.exclude_patterns == [
+                ".trash/**",
+                "_house_rules.md",
+                "**/_house_rules.md",
+            ]
+        finally:
+            legacy.close()
+            settings_first.close()
+
+    def test_default_state_path_matches(self, tmp_path: Path) -> None:
+        """Both modes derive the same default state path under the root."""
+        legacy = Vault(source_dir=tmp_path)
+        settings_first = Vault(source_dir=tmp_path, settings=VaultSettings())
+        try:
+            expected = tmp_path / ".markdown_vault_mcp" / "state.json"
+            assert legacy._state_path == expected
+            assert settings_first._state_path == expected
+        finally:
+            legacy.close()
+            settings_first.close()
+
+
+class TestConflictRejection:
+    """settings= combined with non-default legacy kwargs is an error."""
+
+    def test_non_default_legacy_kwarg_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="read_only"):
+            Vault(source_dir=tmp_path, settings=VaultSettings(), read_only=False)
+
+    def test_error_names_every_conflicting_kwarg(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match=r"max_note_read_bytes.*title_field"):
+            Vault(
+                source_dir=tmp_path,
+                settings=VaultSettings(),
+                title_field="name",
+                max_note_read_bytes=1,
+            )
+
+    def test_default_legacy_values_do_not_conflict(self, tmp_path: Path) -> None:
+        """Explicitly passing a default value alongside settings is accepted."""
+        vault = Vault(
+            source_dir=tmp_path, settings=VaultSettings(read_only=False), read_only=True
+        )
+        try:
+            assert vault._read_only is False  # settings wins; default is inert
+        finally:
+            vault.close()
+
+    def test_collaborator_kwargs_are_not_conflicts(self, tmp_path: Path) -> None:
+        """The five non-config-derived kwargs combine freely with settings."""
+        vault = Vault(
+            source_dir=tmp_path, settings=VaultSettings(), chunk_strategy="whole"
+        )
+        try:
+            from markdown_vault_mcp.scanner import WholeDocumentChunker
+
+            assert isinstance(vault._chunk_strategy, WholeDocumentChunker)
+        finally:
+            vault.close()
+
+
+class TestSettingsDerivations:
+    """The pure derivation methods own the construction-time normalisation."""
+
+    def test_effective_indexed_fields_extends_when_okf_active(self) -> None:
+        settings = VaultSettings(indexed_frontmatter_fields=["cluster", "status"])
+        assert settings.effective_indexed_fields(okf_active=False) == [
+            "cluster",
+            "status",
+        ]
+        assert settings.effective_indexed_fields(okf_active=True) == [
+            "cluster",
+            "status",
+            "type",
+            "stale_after",
+        ]
+
+    def test_effective_exclude_patterns_passthrough_without_conventions(self) -> None:
+        assert VaultSettings(conventions_file=None).effective_exclude_patterns() is None
+        settings = VaultSettings(conventions_file=None, exclude_patterns=(".git/**",))
+        assert settings.effective_exclude_patterns() == (".git/**",)
+
+    def test_effective_exclude_patterns_rejects_metacharacters(self) -> None:
+        settings = VaultSettings(conventions_file="a*.md")
+        with pytest.raises(ValueError, match="fnmatch metacharacters"):
+            settings.effective_exclude_patterns()
+
+    def test_effective_state_path_prefers_explicit(self, tmp_path: Path) -> None:
+        explicit = tmp_path / "elsewhere" / "s.json"
+        assert (
+            VaultSettings(state_path=explicit).effective_state_path(tmp_path)
+            == explicit
+        )
+        assert (
+            VaultSettings().effective_state_path(tmp_path)
+            == tmp_path / ".markdown_vault_mcp" / "state.json"
+        )
+
+
+class TestFromProjectConfig:
+    """from_project_config absorbs the renames and conversions."""
+
+    def test_renames_and_weight_conversion(self) -> None:
+        config = ProjectConfig(
+            source_dir=Path("/tmp/vault"),
+            searchable_fields=["cluster"],
+            default_search_mode="keyword",
+            folder_weights={"notes/": 2.0},
+            fts_weights={"title": 3.0},
+        )
+        settings = VaultSettings.from_project_config(config)
+        # Renames: searchable_frontmatter -> searchable_frontmatter_fields,
+        # default_mode -> default_search_mode.
+        assert settings.searchable_frontmatter_fields == ("cluster",)
+        assert settings.default_search_mode == "keyword"
+        # Weight maps: frozen config tuples back to plain dicts (#639).
+        assert settings.folder_weights == {"notes": 2.0}
+        assert settings.fts_weights == {"title": 3.0}
+
+    def test_chunk_char_cap_derivation(self) -> None:
+        config = ProjectConfig(source_dir=Path("/tmp/vault"))
+        # No provider context: bounded ceiling fallback (#790).
+        assert VaultSettings.from_project_config(config).max_chunk_chars == 1500
+        derived = VaultSettings.from_project_config(
+            config, embedding_context_length=512
+        )
+        assert derived.max_chunk_chars == round(512 * 2.8)
+
+    def test_git_pull_interval_resolution(self, tmp_path: Path) -> None:
+        """Only remote-configured modes resolve a non-zero pull interval."""
+        commit_only = ProjectConfig(source_dir=tmp_path, git_pull_interval_s=123)
+        assert VaultSettings.from_project_config(commit_only).git_pull_interval_s == 0
+        token_mode = ProjectConfig(
+            source_dir=tmp_path, git_token="ghp_secret", git_pull_interval_s=123
+        )
+        assert VaultSettings.from_project_config(token_mode).git_pull_interval_s == 123
+
+
+class TestAssemblyBridges:
+    """to_vault_settings / to_vault_instances and the legacy kwargs bridge."""
+
+    def test_settings_and_instances_agree_on_pull_interval(
+        self, tmp_path: Path
+    ) -> None:
+        """The pure settings derivation matches the git-assembly resolution."""
+        for config in (
+            ProjectConfig(source_dir=tmp_path, git_pull_interval_s=42),
+            ProjectConfig(
+                source_dir=tmp_path, git_token="ghp_secret", git_pull_interval_s=42
+            ),
+        ):
+            instances = to_vault_instances(config)
+            settings = to_vault_settings(config, instances=instances)
+            assert settings.git_pull_interval_s == instances.git_pull_interval_s
+
+    def test_to_vault_kwargs_is_the_settings_explosion(self, tmp_path: Path) -> None:
+        """The deprecated bridge reproduces settings + instances exactly."""
+        config = ProjectConfig(
+            source_dir=tmp_path,
+            read_only=False,
+            exclude=[".obsidian/**"],
+        )
+        instances = to_vault_instances(config)
+        settings = to_vault_settings(config, instances=instances)
+        kwargs = to_vault_kwargs(config)
+        for field in dataclasses.fields(VaultSettings):
+            if field.name in ("summarize_max_notes", "summarize_max_input_chars"):
+                # Historical dict shape: only present with a summarizer.
+                assert field.name not in kwargs
+                continue
+            assert kwargs[field.name] == getattr(settings, field.name), field.name
+        assert kwargs["source_dir"] == config.source_dir
+        assert "embedding_provider" not in kwargs
+        assert kwargs["on_write"] is kwargs["git_strategy"]
+
+    def test_replace_override_pattern(self, tmp_path: Path) -> None:
+        """The CLI-style dataclasses.replace override lands in the vault."""
+        config = ProjectConfig(source_dir=tmp_path)
+        settings = dataclasses.replace(
+            to_vault_settings(config), index_path=tmp_path / "cli.db"
+        )
+        vault = Vault(source_dir=tmp_path, settings=settings)
+        try:
+            assert vault._index_path == tmp_path / "cli.db"
+        finally:
+            vault.close()
+
+
+class TestServiceStart:
+    """domain.Service.start builds settings+instances and uses them as oracle."""
+
+    async def test_start_without_embedding_provider(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp.domain import Service, set_vault_singleton
+
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        (vault_dir / "n.md").write_text("# N\n", encoding="utf-8")
+        monkeypatch.delenv("MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH", raising=False)
+        service = Service(
+            ProjectConfig(
+                source_dir=vault_dir,
+                index_path=tmp_path / "fts.db",
+                state_path=tmp_path / "s.json",
+            )
+        )
+        try:
+            await service.start()
+            assert service.vault._embedding_provider is None
+            assert service.vault.index.embeddings_status()["available"] is False
+        finally:
+            await service.stop()
+            set_vault_singleton(None)
+
+    async def test_start_with_embedding_provider(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp import domain as domain_mod
+        from markdown_vault_mcp.domain import Service, set_vault_singleton
+        from tests.conftest import MockEmbeddingProvider
+
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        (vault_dir / "n.md").write_text("# N\n", encoding="utf-8")
+        provider = MockEmbeddingProvider()
+        original_to_instances = domain_mod.to_vault_instances
+        monkeypatch.setattr(
+            domain_mod,
+            "to_vault_instances",
+            lambda config: dataclasses.replace(
+                original_to_instances(config), embedding_provider=provider
+            ),
+        )
+        service = Service(
+            ProjectConfig(
+                source_dir=vault_dir,
+                index_path=tmp_path / "fts.db",
+                state_path=tmp_path / "s.json",
+                embeddings_path=tmp_path / "vectors",
+            )
+        )
+        try:
+            await service.start()
+            assert service.vault._embedding_provider is provider
+        finally:
+            await service.stop()
+            set_vault_singleton(None)


### PR DESCRIPTION
## Closes / Refs

Closes #1158. Refs #1161 (future-proofing epic)

**Merge order note:** please merge #1160's PR (in flight) before this one — both touch `config_sections/_assembly.py`; this branch will take a base-merge afterwards.

## What & why

`Vault.__init__` took 37 keyword parameters — a config bus that `to_vault_kwargs` re-flattened from the section configs on every construction, making each new knob a five-place change and blocking a future `VaultRegistry`/`VaultClient`. This adds settings-first construction, **dual-mode and non-breaking** per the maintainer's decision:

- New `config_sections/vault_settings.py`: frozen `VaultSettings` — one field per config-derived constructor knob (31 fields), defaults deliberately mirroring Vault's *library* defaults (the `chunk_overlap_words=0` and `read_only=True` drifts vs the server tier are preserved and test-pinned); owns the construction-time derivations (`effective_indexed_fields`, `effective_exclude_patterns`, `effective_state_path`) and `from_project_config` (absorbing the historical renames and weight tuple→dict conversions).
- `_assembly.py`: `to_vault_instances(config)` → frozen `VaultInstances` (the five never-config-derived collaborators + the resolved git pull interval) and `to_vault_settings(config)`. `to_vault_kwargs` remains as a **deprecated delegating bridge** reproducing its historical dict shape exactly — `tests/test_config.py` passes byte-for-byte unchanged.
- `vault.py`: `settings: VaultSettings | None = None` added; all 37 legacy kwargs keep working (docstring-deprecated in one block, no runtime warnings — house style); mixing `settings=` with a non-default config-derived kwarg raises `ValueError` naming each conflict; the body is restructured into `_configure`/`_build_managers`/`_build_facets` with one wiring path serving both modes.
- `domain.Service.start` and the CLI construct settings-first; the two kwargs-dict "oracle" reads in domain are now typed reads on `VaultInstances`; the CLI's index-path override becomes `dataclasses.replace(settings, index_path=...)`.

A signature **drift-guard test** mechanically pins `VaultSettings` fields/defaults against `Vault.__init__` (count, names, defaults, and the two deliberate drifts), and an **equivalence test** builds one vault per mode and compares the resolved wiring — the dual mode cannot silently diverge.

## What this PR deliberately does NOT do

- No removal of the legacy kwargs or `to_vault_kwargs` — that is a major-version change; a follow-up issue is filed against milestone v5.0.
- The 319 existing `Vault(` test construction sites are untouched (only two lifecycle tests retarget their monkeypatch seam from `to_vault_kwargs` to the new pair, assertions unchanged).
- No config-surface change: no new env vars; the section configs are untouched.
- `chunk_strategy` stays an explicit constructor argument (never config-derived; a caller-supplied instance deliberately bypasses the chunker-knob injection).

## Local review

- [x] Ran a local code-review pass on the cumulative diff before creating the PR (range `923e8b1..6a47c45`; verified the conflict-detection default comparison is safe for every field, the `to_vault_kwargs` bridge reproduces the conditional-key historical shape, and the retargeted lifecycle tests keep their assertions).
- [x] No commit carries `!` — dual-mode, fully backward-compatible; `test_config.py` unchanged is the compatibility proof.

**Reviewer flag:** the `PLR0913` per-file-ignore for `vault.py` had to extend the *existing* template-region entry (`["ARG002", "PLR0913"]`) — a second key for the same path would be duplicate-key TOML. It is transitional and goes away with the legacy kwargs (noted for the next template update).

## Docs impact

- [ ] `README.md` — shows no Vault construction; unchanged (verified)
- [x] `docs/` site pages — `docs/api/vault.md` (settings-first headline, deprecated legacy section), `docs/api/config.md`, `docs/api/git.md` example
- [x] `docs/design/` — new "Settings-first construction (#1158)" subsection; constructor sketch rewritten
- [x] Inline docstrings — Google-style throughout `vault_settings.py`; one `.. deprecated::` block on `Vault`; AGENTS.md tree updated

Gates: pytest 3748 passed; ruff/mypy clean; `vault_settings.py` 100% coverage; structural gate 100% (1246 diff lines, 0 violations).

---
_Generated by [Claude Code](https://claude.ai/code/session_015Q12LpD5yLESRHUX7Lpyi8)_