### PR TITLE
fix(git): resolve commit identity at the tool edge so OIDC claims survive the dispatcher thread

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,9 +203,9 @@
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # Git committer email for auto-commits.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
-# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present.
+# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=
-# OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present.
+# OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=
 # Run git lfs pull on startup to fetch LFS-tracked attachments; set to false for repos without LFS.
 # MARKDOWN_VAULT_MCP_GIT_LFS=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ src/markdown_vault_mcp/
   okf_bundle.py        -- OKF bundle-zip export from live vault state, served via an okf-bundle download ref (#963)
   _okf_convention.py   -- OKF reserved-file maintenance after enforced writes: log.md bullet + index.md refresh (#964)
   _okf_write.py        -- OKF enforced-write runtime: contextvar actor + provenance stamp / verified clear (#964)
+  _identity.py         -- Principal write identity: tool-edge resolution, contextvar carry, claim-key registration (#1160)
   summarizer.py        -- Summarizer ABC + OpenAI-compatible chat-completions backend (#915)
   vault.py             -- thin composition root: lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
   write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)

--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ Domain environment variables use the `MARKDOWN_VAULT_MCP_` prefix:
 | `MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S` | `30.0` | No | Seconds of write-idle time before pushing; 0 pushes only on shutdown. |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME` | `markdown-vault-mcp` | No | Git committer name for auto-commits; set this in Docker where git config user.name is empty. |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL` | `noreply@markdown-vault-mcp` | No | Git committer email for auto-commits. |
-| `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` | (none) | No | OIDC claim key used as the commit author name (such as name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. |
-| `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM` | (none) | No | OIDC claim key used as the commit author email (such as email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` | (none) | No | OIDC claim key used as the commit author name (such as name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM` | (none) | No | OIDC claim key used as the commit author email (such as email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim. |
 | `MARKDOWN_VAULT_MCP_GIT_LFS` | `true` | No | Run git lfs pull on startup to fetch LFS-tracked attachments; set to false for repos without LFS. |
 | `MARKDOWN_VAULT_MCP_FILE_WATCHER` | `true` | No | Watch the vault for external filesystem changes; auto-disabled when git pull or the webhook is active. Requires the file-watcher extra. |
 | `MARKDOWN_VAULT_MCP_FILE_WATCHER_DEBOUNCE_S` | `2.0` | No | Seconds of quiet after the last filesystem event before reindexing. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,8 +328,8 @@ Backward compatibility: `GIT_TOKEN` without `GIT_REPO_URL` still works (legacy b
 | `MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S` | float | `30` | Seconds of write-idle time before pushing; `0` = push only on shutdown |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME` | string | `markdown-vault-mcp` | Git committer name for auto-commits; **set this in Docker** where `git config user.name` is empty |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL` | string | `noreply@markdown-vault-mcp` | Git committer email for auto-commits |
-| `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` | string | (none) | OIDC claim key to use as the commit author name when a token is present (such as `name`); falls back to `GIT_COMMIT_NAME` when absent |
-| `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM` | string | (none) | OIDC claim key to use as the commit author e-mail when a token is present (such as `email`); falls back to `GIT_COMMIT_EMAIL` when absent |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` | string | (none) | OIDC claim key to use as the commit author name when a token is present (such as `name`); falls back to `GIT_COMMIT_NAME` when absent. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM` | string | (none) | OIDC claim key to use as the commit author e-mail when a token is present (such as `email`); falls back to `GIT_COMMIT_EMAIL` when absent. Resolved and carried the same way as the name claim |
 | `MARKDOWN_VAULT_MCP_GIT_LFS` | bool | `true` | Run `git lfs pull` on startup to resolve LFS pointers; set to `false` if git-lfs is not installed |
 
 !!! tip "Push delay"

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2318,9 +2318,47 @@ is. An old path git does not track is dropped from the pathspec rather than
 passed — `git add` fails the whole invocation on a pathspec matching nothing,
 which would leave the new path unstaged too.
 
+**Write identity: the `Principal` value (#1160, fixes #1218).** "Who is
+acting" is resolved **once, at the MCP tool edge**, into a frozen
+`Principal` (`_identity.py`: `subject`, `display_name`, `email`,
+`kind: human|local`) — credentials (`GIT_TOKEN`) and permissions
+(`read_only`) deliberately stay off it; they are service configuration, not
+properties of the caller. `resolve_mcp_principal()` performs the single
+request-context read (`fastmcp_pvl_core.get_subject()` + `get_claims()`,
+applying the claim keys registered at startup via
+`configure_identity_claims()`), and the write tools bind the result on a
+contextvar (`write_identity_scope()` in `_server_tools/writer.py`) around
+their `asyncio.to_thread` call, together with the OKF write intent whose
+actor derives from the **same** Principal — so the OKF provenance stamp and
+the git commit author can no longer disagree by construction.
+
+Propagation to the deferred commit is **capture-at-fire**: the historical
+design had `GitWriteStrategy` read the OIDC claims itself via FastMCP's
+`get_access_token()` per commit, but the strategy runs on
+`WriteCallbackDispatcher`'s own daemon thread, where no request context
+exists — the read silently returned `None` and the configured
+`GIT_COMMIT_NAME_CLAIM`/`EMAIL_CLAIM` never applied on the deployed write
+path (#1218; the OKF read worked because `asyncio.to_thread` copies the
+context, a fresh `threading.Thread` does not). `WriteCallbackDispatcher.fire`
+therefore snapshots `current_principal()` — it runs on the request's
+`to_thread` worker, where the contextvar is visible — into the queue item,
+and the worker forwards `principal=` only to callbacks that opt in via the
+`accepts_principal` attribute (`types.ACCEPTS_PRINCIPAL_ATTR`), mirroring
+the `old_path` opt-in above so third-party three-argument callbacks are
+untouched. `GitWriteStrategy.__call__` consumes the Principal's
+`display_name`/`email` as the commit `--author` (committer stays the static
+identity); the `git/` package imports nothing from `fastmcp` (guard-tested),
+so non-MCP drivers supply a `Principal` instead of faking request context.
+Background paths without an acting person — the pull-loop conflict commits,
+the webhook, the transfer-route uploads — carry no Principal and use the
+static identity / tool actor, as before.
+
 **Deprecation note**: `git_write_strategy()` factory function is preserved for
 backward compatibility. Prefer constructing `GitWriteStrategy` directly for
-access to `flush()` and `close()` methods.
+access to `flush()` and `close()` methods. The `commit_name_claim` /
+`commit_email_claim` constructor kwargs no longer drive claim extraction
+(see above); they remain accepted and still inform the startup identity
+warning.
 
 ### `scanner.py`: File Discovery and Parsing
 

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -848,7 +848,7 @@
       "label": "Git Commit Name Claim",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM",
-      "help": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present.",
+      "help": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.",
       "advancedGroup": "Git sync"
     },
     {
@@ -856,7 +856,7 @@
       "label": "Git Commit Email Claim",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM",
-      "help": "OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present.",
+      "help": "OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.",
       "advancedGroup": "Git sync"
     },
     {

--- a/examples/bearer-auth.env
+++ b/examples/bearer-auth.env
@@ -115,9 +115,9 @@ MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S=30.0
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # Git committer email for auto-commits.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
-# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present.
+# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=
-# OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present.
+# OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=
 # Run git lfs pull on startup to fetch LFS-tracked attachments; set to false for repos without LFS.
 MARKDOWN_VAULT_MCP_GIT_LFS=true

--- a/examples/oidc.env
+++ b/examples/oidc.env
@@ -129,9 +129,9 @@ MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S=30.0
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # Git committer email for auto-commits.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
-# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present.
+# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=
-# OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present.
+# OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=
 # Run git lfs pull on startup to fetch LFS-tracked attachments; set to false for repos without LFS.
 MARKDOWN_VAULT_MCP_GIT_LFS=true

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -127,9 +127,9 @@ MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S=30.0
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # Git committer email for auto-commits.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
-# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present.
+# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=
-# OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present.
+# OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=
 # Run git lfs pull on startup to fetch LFS-tracked attachments; set to false for repos without LFS.
 MARKDOWN_VAULT_MCP_GIT_LFS=true

--- a/server.json
+++ b/server.json
@@ -346,11 +346,11 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM",
-          "description": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present."
+          "description": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM",
-          "description": "OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present."
+          "description": "OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_LFS",
@@ -906,11 +906,11 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM",
-          "description": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present."
+          "description": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM",
-          "description": "OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present."
+          "description": "OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_LFS",

--- a/src/markdown_vault_mcp/_identity.py
+++ b/src/markdown_vault_mcp/_identity.py
@@ -1,0 +1,171 @@
+"""Request-scoped write identity: the Principal value and its propagation (#1160).
+
+The vault's write path historically read "who is acting" from the MCP request
+context in two places with two different rules: the git strategy pulled OIDC
+claims via FastMCP's ``get_access_token`` per commit, and the OKF enforced-write
+layer read ``fastmcp_pvl_core.get_subject`` per tool call. The git read ran on
+the write-callback dispatcher's own daemon thread, where no request context
+exists, so the configured name/email claims silently never applied (#1218).
+
+This module replaces both reads with a single resolution at the tool edge:
+
+- :class:`Principal` is a plain, frozen "who" — subject, display name, email,
+  and kind. Credentials (``GIT_TOKEN``) and permissions (``read_only``) are
+  deliberately excluded: they are service-level configuration, not properties
+  of the caller, and a Principal must stay boundary-serializable.
+- :func:`resolve_mcp_principal` performs the one MCP-context read (subject +
+  claims), applying the claim keys registered via
+  :func:`configure_identity_claims`.
+- :func:`bound_principal` / :func:`current_principal` carry the resolved value
+  across ``asyncio.to_thread`` on a contextvar (the same pattern as
+  ``_okf_write``'s intent), and
+  :class:`~markdown_vault_mcp.write_callback.WriteCallbackDispatcher` snapshots
+  it into the queue item at ``fire()`` time so it survives the hop onto the
+  dispatcher thread.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: ``get_subject()`` sentinel for startup auth mode ``none`` — not a human.
+_LOCAL_SUBJECT = "local"
+
+# The OIDC claim keys used for display_name/email resolution. Registered once
+# at startup (config assembly) via ``configure_identity_claims``; module-level
+# because the claim keys are deployment configuration, not per-request state.
+_name_claim: str | None = None
+_email_claim: str | None = None
+
+
+def configure_identity_claims(
+    *, name_claim: str | None, email_claim: str | None
+) -> None:
+    """Register the OIDC claim keys used to resolve display name and email.
+
+    Called once during config assembly with the
+    ``GIT_COMMIT_NAME_CLAIM`` / ``GIT_COMMIT_EMAIL_CLAIM`` settings so
+    :func:`resolve_mcp_principal` knows which claims to read.
+
+    Args:
+        name_claim: Claim key for the human-readable display name, or ``None``
+            when unconfigured.
+        email_claim: Claim key for the email address, or ``None``.
+    """
+    global _name_claim, _email_claim
+    _name_claim = name_claim
+    _email_claim = email_claim
+
+
+@dataclass(frozen=True, slots=True)
+class Principal:
+    """Who is performing a write, resolved once at the MCP tool edge.
+
+    Attributes:
+        subject: Stable authenticated identifier (OIDC ``sub`` or the mapped
+            bearer subject), or ``None`` when the caller is unattributable.
+        display_name: Human-readable name from the configured name claim, or
+            ``None`` when the claim is unconfigured or absent.
+        email: Email address from the configured email claim, or ``None``.
+        kind: ``"human"`` when an authenticated subject is present;
+            ``"local"`` otherwise (no auth, or a token with no usable
+            subject).
+    """
+
+    subject: str | None
+    display_name: str | None
+    email: str | None
+    kind: Literal["human", "local"]
+
+    def okf_actor(self, version: str) -> str:
+        """Return the OKF provenance actor this principal stamps.
+
+        ``human:<subject>`` for an authenticated human, else the tool actor
+        ``markdown-vault-mcp/<version>`` — the exact rules of
+        ``_okf_write.resolve_write_actor``, expressed over the resolved value.
+
+        Args:
+            version: Package version used for the tool actor.
+        """
+        # Function-local imports keep the module graph acyclic: _okf_write
+        # imports this module at load time for current_principal().
+        from markdown_vault_mcp._okf_write import tool_actor
+        from markdown_vault_mcp.okf import _HUMAN_ACTOR_PREFIX
+
+        if self.kind == "human" and self.subject:
+            return f"{_HUMAN_ACTOR_PREFIX}{self.subject}"
+        return tool_actor(version)
+
+
+_principal_var: ContextVar[Principal | None] = ContextVar(
+    "write_principal", default=None
+)
+
+
+@contextmanager
+def bound_principal(principal: Principal) -> Iterator[None]:
+    """Bind *principal* for the duration, resetting it afterward.
+
+    Enter this **before** the ``asyncio.to_thread`` write call so the copied
+    worker context — and the dispatcher's ``fire()`` snapshot taken there —
+    sees it.
+    """
+    token = _principal_var.set(principal)
+    try:
+        yield
+    finally:
+        _principal_var.reset(token)
+
+
+def current_principal() -> Principal | None:
+    """Return the currently bound :class:`Principal`, or ``None``."""
+    return _principal_var.get()
+
+
+def _claim_value(claims: dict[str, Any] | None, key: str | None) -> str | None:
+    """Return the non-empty string value of *key* in *claims*, else ``None``."""
+    if key is None or claims is None:
+        return None
+    value = claims.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def resolve_mcp_principal() -> Principal:
+    """Resolve the caller's :class:`Principal` from the MCP request context.
+
+    Call inside a tool handler (it reads the request context). Subject rules
+    match ``fastmcp_pvl_core.get_subject``: a subject other than the
+    ``"local"`` sentinel makes a ``"human"`` principal; the sentinel or no
+    subject makes a ``"local"`` one with ``subject=None``. Display name and
+    email are read from the token claims using the keys registered via
+    :func:`configure_identity_claims` (non-empty strings only).
+
+    Returns:
+        The resolved principal. Never ``None`` — an unauthenticated caller
+        resolves to a ``"local"`` principal with every field ``None``.
+    """
+    # Function-local imports are deliberate and load-bearing: tests monkeypatch
+    # ``fastmcp_pvl_core.get_subject`` / ``get_claims`` as package attributes,
+    # which only takes effect when the lookup happens at call time (the same
+    # pattern as ``_okf_write``).
+    from fastmcp_pvl_core import get_claims, get_subject
+
+    subject = get_subject()
+    claims = get_claims()
+    display_name = _claim_value(claims, _name_claim)
+    email = _claim_value(claims, _email_claim)
+    if subject and subject != _LOCAL_SUBJECT:
+        return Principal(
+            subject=subject, display_name=display_name, email=email, kind="human"
+        )
+    return Principal(subject=None, display_name=display_name, email=email, kind="local")

--- a/src/markdown_vault_mcp/_okf_write.py
+++ b/src/markdown_vault_mcp/_okf_write.py
@@ -32,6 +32,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import TYPE_CHECKING
 
+from markdown_vault_mcp._identity import current_principal
 from markdown_vault_mcp.okf import _HUMAN_ACTOR_PREFIX, apply_okf_write_stamp
 
 if TYPE_CHECKING:
@@ -114,8 +115,14 @@ def resolve_write_actor() -> str:
     """Resolve the content-write actor from the request identity.
 
     ``human:<subject>`` when an authenticated subject is present, else the tool
-    actor. Call inside a tool handler (it reads the request context).
+    actor. Prefers a bound
+    :class:`~markdown_vault_mcp._identity.Principal` (resolved once at the
+    tool edge, #1160); otherwise reads the request context directly, so call
+    inside a tool handler.
     """
+    principal = current_principal()
+    if principal is not None:
+        return principal.okf_actor(package_version())
     from fastmcp_pvl_core import get_subject
 
     subject = get_subject()
@@ -129,7 +136,13 @@ def resolve_human_subject() -> str | None:
 
     Used by ``okf_verify`` to decide whether a verification is attributable
     (``None`` under auth mode ``none`` or when no subject is present).
+    Prefers a bound :class:`~markdown_vault_mcp._identity.Principal` (#1160),
+    whose ``subject`` is already ``None`` for a non-human caller; otherwise
+    reads the request context directly.
     """
+    principal = current_principal()
+    if principal is not None:
+        return principal.subject
     from fastmcp_pvl_core import get_subject
 
     subject = get_subject()

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import logging
 from dataclasses import asdict
 from datetime import date
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from fastmcp import Context, FastMCP
 from fastmcp.dependencies import CurrentContext, Depends
@@ -24,18 +28,47 @@ from markdown_vault_mcp.utils.text import decode_utf8
 from markdown_vault_mcp.vault import Vault
 
 from .._icons import _TOOL_ICONS
+from .._identity import bound_principal, resolve_mcp_principal
 from .._okf_write import (
     OkfWriteIntent,
     okf_write_intent,
     okf_write_suppressed,
+    package_version,
     resolve_human_subject,
     resolve_verify_subject,
-    resolve_write_actor,
 )
 from ..domain import get_config, get_vault
 from ._common import attach_conventions
 
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def write_identity_scope(*, okf_intent: bool = True) -> Iterator[None]:
+    """Resolve the caller's identity once and bind it for a write (#1160).
+
+    Resolves a :class:`~markdown_vault_mcp._identity.Principal` from the MCP
+    request context and binds it on the identity contextvar, so the write
+    path — and the write-callback dispatcher's ``fire()`` snapshot, which is
+    what carries it onto the commit thread (#1218) — sees it. Enter this
+    **before** the ``asyncio.to_thread`` call so the copied worker context
+    carries the binding.
+
+    Args:
+        okf_intent: Also bind an :class:`~markdown_vault_mcp._okf_write.
+            OkfWriteIntent` whose actor derives from the same principal —
+            for the content writes the OKF enforced-write enricher stamps
+            (``write``/``edit`` operations). ``False`` for operations the
+            enricher never stamps (delete, rename, move_folder, attachments),
+            which bind only the principal for git-commit attribution.
+    """
+    principal = resolve_mcp_principal()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(bound_principal(principal))
+        if okf_intent:
+            actor = principal.okf_actor(package_version())
+            stack.enter_context(okf_write_intent(OkfWriteIntent(actor=actor)))
+        yield
 
 
 # ``fetch_url`` requires a positive size cap. Markdown fetches and
@@ -203,14 +236,19 @@ def register(mcp: FastMCP) -> None:
                     f"Increase MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB if "
                     f"you need the bytes in context."
                 )
-            result = await asyncio.to_thread(
-                vault.writer.write_attachment, path, raw_bytes, if_match=if_match
-            )
+            # Attachments carry no OKF frontmatter; bind only the principal
+            # so the git commit is attributed to the caller (#1218).
+            with write_identity_scope(okf_intent=False):
+                result = await asyncio.to_thread(
+                    vault.writer.write_attachment, path, raw_bytes, if_match=if_match
+                )
             return asdict(result)
-        # Bind the OKF provenance actor for the enforced-write layer (#964).
-        # A no-op unless OKF_WRITE is on; the intent rides the contextvar into
-        # the to_thread worker where the enricher runs.
-        with okf_write_intent(OkfWriteIntent(actor=resolve_write_actor())):
+        # Bind the caller's Principal plus the OKF provenance actor for the
+        # enforced-write layer (#964, #1160). The OKF intent is a no-op unless
+        # OKF_WRITE is on; both values ride contextvars into the to_thread
+        # worker, where the enricher runs and the dispatcher snapshots the
+        # principal for the git commit.
+        with write_identity_scope():
             result = await asyncio.to_thread(
                 vault.writer.write,
                 path,
@@ -292,7 +330,7 @@ def register(mcp: FastMCP) -> None:
                 (ConcurrentModificationError).
         """
         try:
-            with okf_write_intent(OkfWriteIntent(actor=resolve_write_actor())):
+            with write_identity_scope():
                 result = await asyncio.to_thread(
                     vault.writer.edit,
                     path,
@@ -376,7 +414,7 @@ def register(mcp: FastMCP) -> None:
             McpError: If if_match is provided and the file has been modified
                 (ConcurrentModificationError).
         """
-        with okf_write_intent(OkfWriteIntent(actor=resolve_write_actor())):
+        with write_identity_scope():
             result = await asyncio.to_thread(
                 vault.writer.append,
                 path,
@@ -427,7 +465,12 @@ def register(mcp: FastMCP) -> None:
             McpError: If if_match is provided and the file has been modified
                 (ConcurrentModificationError).
         """
-        result = await asyncio.to_thread(vault.writer.delete, path, if_match=if_match)
+        # Bind the caller's Principal so the delete commit is attributed
+        # (#1218); the OKF enricher never runs for deletes, so no intent.
+        with write_identity_scope(okf_intent=False):
+            result = await asyncio.to_thread(
+                vault.writer.delete, path, if_match=if_match
+            )
         return asdict(result)
 
     @mcp.tool(
@@ -482,13 +525,17 @@ def register(mcp: FastMCP) -> None:
             McpError: If if_match is provided and the file has been modified
                 (ConcurrentModificationError).
         """
-        result = await asyncio.to_thread(
-            vault.writer.rename,
-            old_path,
-            new_path,
-            if_match=if_match,
-            update_links=update_links,
-        )
+        # Bind the caller's Principal so the rename commit (and any link-
+        # rewrite commits) are attributed (#1218); no OKF intent — the
+        # enricher's actor for link rewrites stays the tool actor, as before.
+        with write_identity_scope(okf_intent=False):
+            result = await asyncio.to_thread(
+                vault.writer.rename,
+                old_path,
+                new_path,
+                if_match=if_match,
+                update_links=update_links,
+            )
         return asdict(result)
 
     @mcp.tool(
@@ -543,7 +590,11 @@ def register(mcp: FastMCP) -> None:
             ValueError: If a path fails traversal validation or the two paths
                 are nested.
         """
-        result = await asyncio.to_thread(vault.writer.move_folder, old_dir, new_dir)
+        # Bind the caller's Principal so every per-file commit of the move is
+        # attributed (#1218); no OKF intent — the enricher's actor for the
+        # link-rewrite edits stays the tool actor, as before.
+        with write_identity_scope(okf_intent=False):
+            result = await asyncio.to_thread(vault.writer.move_folder, old_dir, new_dir)
         return asdict(result)
 
     @mcp.tool(
@@ -712,11 +763,12 @@ def register(mcp: FastMCP) -> None:
                     f"Response body is not valid UTF-8 (content-type: {ct}). "
                     "Only UTF-8 encoded responses can be saved as .md notes."
                 ) from exc
-            # Bind the OKF provenance actor (#964): fetch writes .md notes
-            # through the same DocumentManager.write path as the write/edit
-            # tools, so the enricher fires on an OKF-active vault. Attribute the
-            # save to the authenticated caller, not the default tool actor.
-            with okf_write_intent(OkfWriteIntent(actor=resolve_write_actor())):
+            # Bind the caller's Principal + OKF provenance actor (#964,
+            # #1160): fetch writes .md notes through the same
+            # DocumentManager.write path as the write/edit tools, so the
+            # enricher fires on an OKF-active vault. Attribute the save to
+            # the authenticated caller, not the default tool actor.
+            with write_identity_scope():
                 result = await asyncio.to_thread(
                     vault.writer.write,
                     path,
@@ -726,13 +778,15 @@ def register(mcp: FastMCP) -> None:
                 )
         else:
             # Attachments never carry OKF frontmatter and go through
-            # write_attachment, which the enricher does not touch — no intent.
-            result = await asyncio.to_thread(
-                vault.writer.write_attachment,
-                path,
-                raw_bytes,
-                if_match=if_match,
-            )
+            # write_attachment, which the enricher does not touch — bind only
+            # the principal for git-commit attribution (#1218).
+            with write_identity_scope(okf_intent=False):
+                result = await asyncio.to_thread(
+                    vault.writer.write_attachment,
+                    path,
+                    raw_bytes,
+                    if_match=if_match,
+                )
 
         # fetch_url already logged the (redacted) source URL; record the vault
         # destination only after the write actually landed.

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -659,7 +659,9 @@ class ProjectConfig:
             "help": (
                 "OIDC claim key used as the commit author name (e.g. name); "
                 "overrides GIT_COMMIT_NAME per request when an OIDC token is "
-                "present."
+                "present. The claim is resolved when the tool call arrives "
+                "and carried to the background commit, so it applies on "
+                "every write."
             ),
             "tags": ("git",),
             "wizard": {"group": "Git sync"},
@@ -671,7 +673,8 @@ class ProjectConfig:
             "help": (
                 "OIDC claim key used as the commit author email (e.g. "
                 "email); overrides GIT_COMMIT_EMAIL per request when an OIDC "
-                "token is present."
+                "token is present. Resolved and carried the same way as the "
+                "name claim."
             ),
             "tags": ("git",),
             "wizard": {"group": "Git sync"},

--- a/src/markdown_vault_mcp/config_sections/_assembly.py
+++ b/src/markdown_vault_mcp/config_sections/_assembly.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastmcp_pvl_core import parse_bool as _parse_bool
 
+from markdown_vault_mcp._identity import configure_identity_claims
 from markdown_vault_mcp.exceptions import ConfigurationError
 from markdown_vault_mcp.git import GitWriteStrategy
 
@@ -120,6 +121,14 @@ def _build_git_strategy(
     or disables them in lockstep.
     """
     git = config.git
+    # Register the OIDC claim keys with the identity layer: claims are
+    # resolved at the MCP tool edge into a Principal (#1160), not by the
+    # strategy itself (whose dispatcher thread has no request token, #1218).
+    # The kwargs below still carry the keys for the startup identity warning.
+    configure_identity_claims(
+        name_claim=git.commit_name_claim,
+        email_claim=git.commit_email_claim,
+    )
     return GitWriteStrategy(
         token=token,
         repo_url=repo_url,

--- a/src/markdown_vault_mcp/git/__init__.py
+++ b/src/markdown_vault_mcp/git/__init__.py
@@ -13,10 +13,15 @@ applies globally, so calls from any submodule that does ``import subprocess`` ar
 still intercepted. Keeping the attribute here preserves those patch targets.
 
 Symbols that a submodule looks up via its own module globals (e.g.
-``_stage_and_commit`` / ``_get_access_token`` in ``strategy``; ``_push`` in
-``push_scheduler`` since #893; ``frontmatter`` in ``conflict``) are patched by
-tests at their real home -- ``markdown_vault_mcp.git.<submodule>.<name>`` --
-not via this package namespace.  "Patch where the name is used."
+``_stage_and_commit`` in ``strategy``; ``_push`` in ``push_scheduler`` since
+#893; ``frontmatter`` in ``conflict``) are patched by tests at their real
+home -- ``markdown_vault_mcp.git.<submodule>.<name>`` -- not via this package
+namespace.  "Patch where the name is used."
+
+This package deliberately imports nothing from ``fastmcp`` (#1160): request
+identity is resolved at the MCP tool edge into a
+:class:`~markdown_vault_mcp._identity.Principal` and passed in, so the git
+layer stays usable from non-MCP drivers. A guard test asserts the absence.
 """
 
 from __future__ import annotations
@@ -30,7 +35,6 @@ from markdown_vault_mcp.git.bootstrap import RepoBootstrap
 from markdown_vault_mcp.git.push_scheduler import PushScheduler
 from markdown_vault_mcp.git.strategy import (  # noqa: F401 -- re-exported for the historic import surface
     GitWriteStrategy,
-    _extract_claim,
     _stage_and_commit,
     git_write_strategy,
 )

--- a/src/markdown_vault_mcp/git/conflict.py
+++ b/src/markdown_vault_mcp/git/conflict.py
@@ -449,9 +449,9 @@ def write_conflict_files(
 
     n = len(written)
     file_list = ", ".join(written)
-    # Conflict resolution runs on the pull background thread, not inside a
-    # request context, so _extract_claim would return None.  Use the static
-    # server identity directly — per-user attribution does not apply here.
+    # Conflict resolution runs on the pull background thread, with no acting
+    # Principal (#1160) — per-user attribution does not apply here.  Use the
+    # static server identity directly.
     # NOTE: this commit is pathspec-less — it commits the whole staged index,
     # not just ``paths_to_add``. That is intentional: it also captures upstream
     # content already staged during conflict resolution (by the rebase's merge,

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -27,9 +27,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from pathlib import Path
 
+    from markdown_vault_mcp._identity import Principal
     from markdown_vault_mcp.types import CommitDiff, HistoryEntry, WriteOperation
-
-from fastmcp.server.dependencies import get_access_token as _get_access_token
 
 from markdown_vault_mcp.git import conflict, query
 from markdown_vault_mcp.git._run import (
@@ -59,25 +58,6 @@ from markdown_vault_mcp.git.types import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_claim(claim_key: str | None) -> str | None:
-    """Return the string value of an OIDC claim from the current request token.
-
-    Returns ``None`` when *claim_key* is ``None``, no access token is present,
-    the key is absent from the token's claims, or the value is not a non-empty
-    string.
-    """
-    if claim_key is None:
-        return None
-    token = _get_access_token()
-    if token is None:
-        return None
-    claims = getattr(token, "claims", None)
-    if not isinstance(claims, dict):
-        return None
-    value = claims.get(claim_key)
-    return value if isinstance(value, str) and value else None
 
 
 class GitWriteStrategy:
@@ -112,6 +92,18 @@ class GitWriteStrategy:
             :attr:`DEFAULT_COMMIT_NAME`.
         commit_email: Git committer email; defaults to
             :attr:`DEFAULT_COMMIT_EMAIL`.
+        commit_name_claim: OIDC claim key configured for the author name.
+        commit_email_claim: OIDC claim key configured for the author email.
+
+            .. deprecated::
+                The two claim kwargs no longer drive claim extraction — the
+                strategy runs on the write-callback dispatcher thread, where
+                no request token exists (#1218). Claims are now resolved at
+                the MCP tool edge into the ``principal`` passed per
+                invocation (register the keys via
+                :func:`markdown_vault_mcp._identity.configure_identity_claims`).
+                They remain accepted, and still inform the startup
+                identity warning (:meth:`_check_identity`).
         git_lfs: When ``True`` (default), run ``git lfs pull`` during
             lazy initialisation so LFS pointers are resolved before the
             first write is committed.  Requires ``git-lfs`` to be on
@@ -283,6 +275,12 @@ class GitWriteStrategy:
     #: See :data:`~markdown_vault_mcp.types.ACCEPTS_OLD_PATH_ATTR`.
     accepts_old_path: bool = True
 
+    #: Opt into the dispatcher's ``principal=`` keyword (#1160), so the commit
+    #: author reflects the identity resolved at the MCP tool edge instead of a
+    #: request-context read that is always empty on the dispatcher thread
+    #: (#1218). See :data:`~markdown_vault_mcp.types.ACCEPTS_PRINCIPAL_ATTR`.
+    accepts_principal: bool = True
+
     def __call__(
         self,
         path: Path,
@@ -290,6 +288,7 @@ class GitWriteStrategy:
         operation: WriteOperation,
         *,
         old_path: Path | None = None,
+        principal: Principal | None = None,
     ) -> None:
         """WriteCallback interface: stage + commit, then schedule push.
 
@@ -301,6 +300,11 @@ class GitWriteStrategy:
             operation: The kind of write that occurred.
             old_path: For a rename, the absolute path the file moved from,
                 so staging can be scoped to it and *path* (#894).
+            principal: The identity performing the write, resolved at the MCP
+                tool edge and snapshotted through the dispatcher queue
+                (#1160). Its display name / email become the commit's
+                ``--author``; ``None`` fields (or no principal) fall back to
+                the static committer identity.
         """
         if self._closed:
             return
@@ -318,20 +322,16 @@ class GitWriteStrategy:
             return
 
         try:
-            effective_name = (
-                _extract_claim(self._commit_name_claim) or self._commit_name
-            )
-            effective_email = (
-                _extract_claim(self._commit_email_claim) or self._commit_email
-            )
+            principal_name = principal.display_name if principal is not None else None
+            principal_email = principal.email if principal is not None else None
+            effective_name = principal_name or self._commit_name
+            effective_email = principal_email or self._commit_email
             logger.debug(
-                "git_identity_resolved name=%s email=%s name_from_claim=%s email_from_claim=%s",
+                "git_identity_resolved name=%s email=%s name_from_principal=%s email_from_principal=%s",
                 effective_name,
                 effective_email,
-                self._commit_name_claim is not None
-                and effective_name != self._commit_name,
-                self._commit_email_claim is not None
-                and effective_email != self._commit_email,
+                principal_name is not None,
+                principal_email is not None,
             )
             with self._lock:
                 _stage_and_commit(

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+if TYPE_CHECKING:
+    from markdown_vault_mcp._identity import Principal
 
 # The four deterministic, non-excluded skip categories surfaced via
 # get_index_status.skipped_files. A plain frozenset (not an enum) keeps the
@@ -865,6 +868,47 @@ class RenameAwareWriteCallback(Protocol):
         old_path: Path | None = None,
     ) -> None:
         """Handle one write, optionally told where a rename moved from."""
+        ...
+
+
+#: Attribute name a :data:`WriteCallback` sets to ``True`` to opt into
+#: receiving the ``principal=`` keyword on dispatches (#1160).
+#:
+#: The write-callback dispatcher runs callbacks on its own daemon thread,
+#: where the MCP request context does not exist — a callback that resolved
+#: identity there always saw ``None`` (#1218). The dispatcher therefore
+#: snapshots the :class:`~markdown_vault_mcp._identity.Principal` bound at
+#: ``fire()`` time (on the request's ``to_thread`` worker, where the
+#: contextvar is visible) into the queue item, and forwards it — but only to
+#: callbacks that advertise this attribute, mirroring
+#: :data:`ACCEPTS_OLD_PATH_ATTR` so a third-party three-argument callback
+#: keeps working untouched.
+ACCEPTS_PRINCIPAL_ATTR = "accepts_principal"
+
+
+class PrincipalAwareWriteCallback(Protocol):
+    """A :data:`WriteCallback` that also accepts the acting principal.
+
+    Structural type for the opt-in described at
+    :data:`ACCEPTS_PRINCIPAL_ATTR`, mirroring
+    :class:`RenameAwareWriteCallback`. The ``old_path`` keyword is included
+    so the dispatcher can express the combined call (a callback opted into
+    both keywords, like ``GitWriteStrategy``) in the type system; the
+    dispatcher only ever passes keywords the callback opted into.
+    """
+
+    accepts_principal: bool
+
+    def __call__(
+        self,
+        path: Path,
+        content: str,
+        operation: WriteOperation,
+        *,
+        old_path: Path | None = None,
+        principal: Principal | None = None,
+    ) -> None:
+        """Handle one write, optionally told who performed it."""
         ...
 
 

--- a/src/markdown_vault_mcp/write_callback.py
+++ b/src/markdown_vault_mcp/write_callback.py
@@ -16,13 +16,16 @@ import queue
 import threading
 from typing import TYPE_CHECKING, cast
 
-from markdown_vault_mcp.types import ACCEPTS_OLD_PATH_ATTR
+from markdown_vault_mcp._identity import current_principal
+from markdown_vault_mcp.types import ACCEPTS_OLD_PATH_ATTR, ACCEPTS_PRINCIPAL_ATTR
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Any
 
+    from markdown_vault_mcp._identity import Principal
     from markdown_vault_mcp.types import (
-        RenameAwareWriteCallback,
+        PrincipalAwareWriteCallback,
         WriteCallback,
         WriteOperation,
     )
@@ -65,12 +68,15 @@ class WriteCallbackDispatcher:
                 ``rename`` dispatches (#894).
         """
         self._on_write = on_write
-        # Read the opt-in once, here, rather than per dispatch: the callback
+        # Read the opt-ins once, here, rather than per dispatch: the callback
         # is fixed for the dispatcher's lifetime, and the worker loop is on
         # the write path.
         self._accepts_old_path = bool(getattr(on_write, ACCEPTS_OLD_PATH_ATTR, False))
+        self._accepts_principal = bool(getattr(on_write, ACCEPTS_PRINCIPAL_ATTR, False))
         self._queue: queue.Queue[
-            tuple[Path, str, WriteOperation, Path | None] | _DrainMarker | None
+            tuple[Path, str, WriteOperation, Path | None, Principal | None]
+            | _DrainMarker
+            | None
         ] = queue.Queue()
         self._worker: threading.Thread | None = None
         # Guards every read/write of ``_worker`` and ``_closed`` AND the
@@ -103,9 +109,18 @@ class WriteCallbackDispatcher:
                 that opted in via
                 :data:`~markdown_vault_mcp.types.ACCEPTS_OLD_PATH_ATTR`;
                 ignored otherwise, and unused for every other operation.
+
+        The currently bound :class:`~markdown_vault_mcp._identity.Principal`
+        is snapshotted **here**, not on the worker: ``fire`` runs on the
+        request's ``to_thread`` worker (whose copied context carries the
+        contextvar), while the dispatcher's own thread has no request context
+        at all — reading identity there is exactly the silent-fallback bug of
+        #1218. The snapshot is forwarded only to a callback that opted in via
+        :data:`~markdown_vault_mcp.types.ACCEPTS_PRINCIPAL_ATTR`.
         """
         if self._on_write is None:
             return
+        principal = current_principal()
         with self._worker_lock:
             if self._closed:
                 logger.warning(
@@ -117,7 +132,7 @@ class WriteCallbackDispatcher:
             self._ensure_worker_locked()
             # Enqueue under the lock so close() cannot slip the sentinel in
             # ahead of this item (which would leave it permanently undrained).
-            self._queue.put((abs_path, content, operation, old_path))
+            self._queue.put((abs_path, content, operation, old_path, principal))
 
     def _ensure_worker_locked(self) -> None:
         """Start the background worker if it is not running.
@@ -146,11 +161,18 @@ class WriteCallbackDispatcher:
                 if isinstance(item, _DrainMarker):
                     item.event.set()
                     continue
-                abs_path, content, operation, old_path = item
+                abs_path, content, operation, old_path, principal = item
                 try:
+                    # Build the opted-in keywords flat so the four
+                    # (old_path, principal) combinations stay one call site.
+                    extra: dict[str, Any] = {}
                     if old_path is not None and self._accepts_old_path:
-                        rename_aware = cast("RenameAwareWriteCallback", on_write)
-                        rename_aware(abs_path, content, operation, old_path=old_path)
+                        extra["old_path"] = old_path
+                    if principal is not None and self._accepts_principal:
+                        extra["principal"] = principal
+                    if extra:
+                        aware = cast("PrincipalAwareWriteCallback", on_write)
+                        aware(abs_path, content, operation, **extra)
                     else:
                         on_write(abs_path, content, operation)
                 except Exception:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4968,101 +4968,42 @@ class TestVaultGitHistoryMethods:
         assert len(out) == 2
 
 
-class TestExtractClaim:
-    """Unit tests for _extract_claim — reads a named claim from the current access token."""
+class TestGitPackageImportClean:
+    """The git package must not import fastmcp (#1160).
 
-    def test_returns_claim_value_when_token_has_claim(self) -> None:
-        """Returns the string claim value when the token carries it."""
-        from unittest.mock import MagicMock, patch
+    Request identity is resolved at the MCP tool edge into a Principal and
+    passed into the strategy; a fastmcp import creeping back into ``git/``
+    would re-couple the write path to the request context — the coupling
+    whose dispatcher-thread read silently broke the claims (#1218).
+    """
 
-        from markdown_vault_mcp.git import _extract_claim
+    def test_no_git_submodule_imports_fastmcp(self) -> None:
+        """No module under markdown_vault_mcp/git/ imports fastmcp."""
+        import re
+        from pathlib import Path
 
-        token = MagicMock()
-        token.claims = {"name": "Alice"}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            assert _extract_claim("name") == "Alice"
+        import markdown_vault_mcp.git as git_pkg
 
-    def test_returns_none_when_no_token(self) -> None:
-        """Returns None when get_access_token() returns None (no-auth / local mode)."""
-        from unittest.mock import patch
-
-        from markdown_vault_mcp.git import _extract_claim
-
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=None
-        ):
-            assert _extract_claim("name") is None
-
-    def test_returns_none_when_claim_absent(self) -> None:
-        """Returns None when the named claim is not in the token."""
-        from unittest.mock import MagicMock, patch
-
-        from markdown_vault_mcp.git import _extract_claim
-
-        token = MagicMock()
-        token.claims = {"sub": "user123"}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            assert _extract_claim("name") is None
-
-    def test_returns_none_when_claim_is_empty_string(self) -> None:
-        """Returns None when the claim value is an empty string."""
-        from unittest.mock import MagicMock, patch
-
-        from markdown_vault_mcp.git import _extract_claim
-
-        token = MagicMock()
-        token.claims = {"name": ""}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            assert _extract_claim("name") is None
-
-    def test_returns_none_when_claim_is_not_string(self) -> None:
-        """Returns None when the claim value is not a string (e.g. boolean, int)."""
-        from unittest.mock import MagicMock, patch
-
-        from markdown_vault_mcp.git import _extract_claim
-
-        token = MagicMock()
-        token.claims = {"email_verified": True}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            assert _extract_claim("email_verified") is None
-
-    def test_returns_none_when_claims_is_not_dict(self) -> None:
-        """Returns None when token.claims is not a dict."""
-        from unittest.mock import MagicMock, patch
-
-        from markdown_vault_mcp.git import _extract_claim
-
-        token = MagicMock()
-        token.claims = None
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            assert _extract_claim("name") is None
-
-    def test_returns_none_when_claim_key_is_none(self) -> None:
-        """Returns None immediately when claim_key is None (claim not configured)."""
-        from unittest.mock import MagicMock, patch
-
-        from markdown_vault_mcp.git import _extract_claim
-
-        token = MagicMock()
-        token.claims = {"name": "Alice"}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            assert _extract_claim(None) is None
+        pkg_dir = Path(git_pkg.__file__).resolve().parent
+        # Match module imports of fastmcp (and submodules), but not
+        # fastmcp_pvl_core.
+        pattern = re.compile(r"^\s*(?:from|import)\s+fastmcp(?:\.|\s|$)", re.M)
+        offenders = [
+            str(f.relative_to(pkg_dir))
+            for f in sorted(pkg_dir.glob("*.py"))
+            if pattern.search(f.read_text(encoding="utf-8"))
+        ]
+        assert offenders == []
 
 
-class TestOidcClaimGitIdentity:
-    """Integration tests for OIDC claim-based git author attribution in GitWriteStrategy."""
+class TestPrincipalGitIdentity:
+    """Principal-based git author attribution in GitWriteStrategy (#1160).
+
+    Claims are resolved at the MCP tool edge into a Principal; the strategy
+    consumes its display_name/email as the commit author instead of reading
+    the request token itself (which is unreachable on the dispatcher thread,
+    #1218).
+    """
 
     def _get_commit_identity(self, repo: Path) -> tuple[str, str]:
         """Return (author_name, author_email) of the most recent commit."""
@@ -5080,119 +5021,113 @@ class TestOidcClaimGitIdentity:
         ).stdout.strip()
         return name, email
 
-    def test_name_claim_used_when_token_has_claim(self, git_repo: Path) -> None:
-        """When commit_name_claim is set and token has the claim, commit uses claim value."""
-        from unittest.mock import MagicMock, patch
+    def test_principal_name_used_when_present(self, git_repo: Path) -> None:
+        """A principal display_name becomes the commit author name."""
+        from markdown_vault_mcp._identity import Principal
 
         strategy = GitWriteStrategy(
             commit_name="bot",
             commit_email="bot@example.com",
-            commit_name_claim="name",
         )
         test_file = git_repo / "note.md"
         test_file.write_text("# Note\n")
 
-        token = MagicMock()
-        token.claims = {"name": "Alice Human"}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            strategy(test_file, "# Note\n", "write")
+        principal = Principal(
+            subject="user123", display_name="Alice Human", email=None, kind="human"
+        )
+        strategy(test_file, "# Note\n", "write", principal=principal)
 
         name, email = self._get_commit_identity(git_repo)
         assert name == "Alice Human"
         assert email == "bot@example.com"
 
-    def test_email_claim_used_when_token_has_claim(self, git_repo: Path) -> None:
-        """When commit_email_claim is set and token has the claim, commit uses claim value."""
-        from unittest.mock import MagicMock, patch
+    def test_principal_email_used_when_present(self, git_repo: Path) -> None:
+        """A principal email becomes the commit author email."""
+        from markdown_vault_mcp._identity import Principal
 
         strategy = GitWriteStrategy(
             commit_name="bot",
             commit_email="bot@example.com",
-            commit_email_claim="email",
         )
         test_file = git_repo / "note.md"
         test_file.write_text("# Note\n")
 
-        token = MagicMock()
-        token.claims = {"email": "alice@humans.org"}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            strategy(test_file, "# Note\n", "write")
+        principal = Principal(
+            subject="user123",
+            display_name=None,
+            email="alice@humans.org",
+            kind="human",
+        )
+        strategy(test_file, "# Note\n", "write", principal=principal)
 
         name, email = self._get_commit_identity(git_repo)
         assert name == "bot"
         assert email == "alice@humans.org"
 
-    def test_both_claims_used_when_token_has_both(self, git_repo: Path) -> None:
-        """Both name and email come from claims when both are configured and present."""
-        from unittest.mock import MagicMock, patch
+    def test_principal_name_and_email_used_when_both_present(
+        self, git_repo: Path
+    ) -> None:
+        """Both author fields come from the principal when both are present."""
+        from markdown_vault_mcp._identity import Principal
 
         strategy = GitWriteStrategy(
             commit_name="bot",
             commit_email="bot@example.com",
-            commit_name_claim="name",
-            commit_email_claim="email",
         )
         test_file = git_repo / "note.md"
         test_file.write_text("# Note\n")
 
-        token = MagicMock()
-        token.claims = {"name": "Alice Human", "email": "alice@humans.org"}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            strategy(test_file, "# Note\n", "write")
+        principal = Principal(
+            subject="user123",
+            display_name="Alice Human",
+            email="alice@humans.org",
+            kind="human",
+        )
+        strategy(test_file, "# Note\n", "write", principal=principal)
 
         name, email = self._get_commit_identity(git_repo)
         assert name == "Alice Human"
         assert email == "alice@humans.org"
 
-    def test_falls_back_to_configured_when_no_token(self, git_repo: Path) -> None:
-        """When no access token, configured name and email are used."""
-        from unittest.mock import patch
-
+    def test_falls_back_to_configured_when_no_principal(self, git_repo: Path) -> None:
+        """Without a principal, the configured static name and email are used."""
         strategy = GitWriteStrategy(
             commit_name="bot",
             commit_email="bot@example.com",
-            commit_name_claim="name",
-            commit_email_claim="email",
         )
         test_file = git_repo / "note.md"
         test_file.write_text("# Note\n")
 
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=None
-        ):
-            strategy(test_file, "# Note\n", "write")
+        strategy(test_file, "# Note\n", "write")
 
         name, email = self._get_commit_identity(git_repo)
         assert name == "bot"
         assert email == "bot@example.com"
 
-    def test_falls_back_when_claim_absent_from_token(self, git_repo: Path) -> None:
-        """When the named claim is not in the token, configured value is used."""
-        from unittest.mock import MagicMock, patch
+    def test_falls_back_when_principal_fields_are_none(self, git_repo: Path) -> None:
+        """A principal with no claim-derived fields falls back to the static identity.
+
+        This is the shape resolve_mcp_principal produces when the token has a
+        subject but the configured claims are absent — the pre-#1160
+        claim-absent fallback, expressed over the resolved value.
+        """
+        from markdown_vault_mcp._identity import Principal
 
         strategy = GitWriteStrategy(
             commit_name="bot",
             commit_email="bot@example.com",
-            commit_name_claim="name",
         )
         test_file = git_repo / "note.md"
         test_file.write_text("# Note\n")
 
-        token = MagicMock()
-        token.claims = {"sub": "user123"}  # has sub but not name
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            strategy(test_file, "# Note\n", "write")
+        principal = Principal(
+            subject="user123", display_name=None, email=None, kind="human"
+        )
+        strategy(test_file, "# Note\n", "write", principal=principal)
 
-        name, _email = self._get_commit_identity(git_repo)
+        name, email = self._get_commit_identity(git_repo)
         assert name == "bot"
+        assert email == "bot@example.com"
 
     def test_no_claim_config_is_backward_compatible(self, git_repo: Path) -> None:
         """Without claim config, strategy uses static name/email as before."""
@@ -5248,7 +5183,10 @@ class TestGitClaimConfig:
         assert config.git.commit_email_claim is None
 
     def test_claim_config_passed_to_strategy(self, tmp_path: Path) -> None:
-        """to_vault_kwargs() passes claim keys to GitWriteStrategy."""
+        """to_vault_kwargs() passes claim keys to GitWriteStrategy and registers
+        them with the identity layer (#1160), which now performs the actual
+        claim extraction at the MCP tool edge."""
+        from markdown_vault_mcp import _identity
         from markdown_vault_mcp.config import ProjectConfig
 
         config = ProjectConfig(
@@ -5257,11 +5195,18 @@ class TestGitClaimConfig:
             git_commit_name_claim="name",
             git_commit_email_claim="email",
         )
-        kwargs = to_vault_kwargs(config)
-        strategy = kwargs["on_write"]
-        assert isinstance(strategy, GitWriteStrategy)
-        assert strategy._commit_name_claim == "name"
-        assert strategy._commit_email_claim == "email"
+        try:
+            kwargs = to_vault_kwargs(config)
+            strategy = kwargs["on_write"]
+            assert isinstance(strategy, GitWriteStrategy)
+            assert strategy._commit_name_claim == "name"
+            assert strategy._commit_email_claim == "email"
+            assert _identity._name_claim == "name"
+            assert _identity._email_claim == "email"
+        finally:
+            # Module-level registration; reset so no claim keys leak into
+            # other tests' resolve_mcp_principal calls.
+            _identity.configure_identity_claims(name_claim=None, email_claim=None)
 
 
 class TestStageAndCommitAuthorSplit:
@@ -5462,7 +5407,7 @@ class TestStageAndCommitAuthorSplit:
 
 
 class TestOidcClaimAuthorCommitterSplit:
-    """GitWriteStrategy uses OIDC claims for author only; committer stays static."""
+    """GitWriteStrategy uses the principal for author only; committer stays static."""
 
     def _get_identity(self, repo: Path) -> tuple[str, str, str, str]:
         """Return (author_name, author_email, committer_name, committer_email)."""
@@ -5477,25 +5422,24 @@ class TestOidcClaimAuthorCommitterSplit:
 
         return _log("%aN"), _log("%aE"), _log("%cN"), _log("%cE")
 
-    def test_claim_sets_author_committer_stays_static(self, git_repo: Path) -> None:
-        """When claim is configured and token present, author = claim, committer = static."""
-        from unittest.mock import MagicMock, patch
+    def test_principal_sets_author_committer_stays_static(self, git_repo: Path) -> None:
+        """With a claim-carrying principal, author = principal, committer = static."""
+        from markdown_vault_mcp._identity import Principal
 
         strategy = GitWriteStrategy(
             commit_name="bot",
             commit_email="bot@srv.com",
-            commit_name_claim="name",
-            commit_email_claim="email",
         )
         f = git_repo / "note.md"
         f.write_text("# hi\n")
 
-        token = MagicMock()
-        token.claims = {"name": "Alice Human", "email": "alice@humans.org"}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            strategy(f, "# hi\n", "write")
+        principal = Principal(
+            subject="user123",
+            display_name="Alice Human",
+            email="alice@humans.org",
+            kind="human",
+        )
+        strategy(f, "# hi\n", "write", principal=principal)
 
         a_name, a_email, c_name, c_email = self._get_identity(git_repo)
         assert a_name == "Alice Human"
@@ -5503,8 +5447,8 @@ class TestOidcClaimAuthorCommitterSplit:
         assert c_name == "bot"
         assert c_email == "bot@srv.com"
 
-    def test_no_claim_config_author_equals_committer(self, git_repo: Path) -> None:
-        """Without claim config, author and committer are both the static identity."""
+    def test_no_principal_author_equals_committer(self, git_repo: Path) -> None:
+        """Without a principal, author and committer are both the static identity."""
         strategy = GitWriteStrategy(
             commit_name="bot",
             commit_email="bot@srv.com",
@@ -5517,9 +5461,70 @@ class TestOidcClaimAuthorCommitterSplit:
         assert a_name == c_name == "bot"
         assert a_email == c_email == "bot@srv.com"
 
-    def test_no_token_falls_back_author_equals_committer(self, git_repo: Path) -> None:
-        """When claim is configured but no token, author falls back to static identity."""
-        from unittest.mock import patch
+    def test_empty_principal_falls_back_author_equals_committer(
+        self, git_repo: Path
+    ) -> None:
+        """A principal with no claim fields falls back to the static identity."""
+        from markdown_vault_mcp._identity import Principal
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@srv.com",
+        )
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+
+        principal = Principal(subject=None, display_name=None, email=None, kind="local")
+        strategy(f, "# hi\n", "write", principal=principal)
+
+        a_name, a_email, c_name, c_email = self._get_identity(git_repo)
+        assert a_name == c_name == "bot"
+        assert a_email == c_email == "bot@srv.com"
+
+    def test_only_name_present_committer_email_unchanged(self, git_repo: Path) -> None:
+        """Name-only principal: author name = principal, email = static for both."""
+        from markdown_vault_mcp._identity import Principal
+
+        strategy = GitWriteStrategy(
+            commit_name="bot",
+            commit_email="bot@srv.com",
+        )
+        f = git_repo / "note.md"
+        f.write_text("# hi\n")
+
+        principal = Principal(
+            subject="user123", display_name="Alice Human", email=None, kind="human"
+        )
+        strategy(f, "# hi\n", "write", principal=principal)
+
+        a_name, a_email, c_name, c_email = self._get_identity(git_repo)
+        assert a_name == "Alice Human"
+        assert a_email == "bot@srv.com"
+        assert c_name == "bot"
+        assert c_email == "bot@srv.com"
+
+
+class TestPrincipalThroughDispatcher:
+    """#1218 regression: claim identity must survive the dispatcher thread.
+
+    The pre-#1160 strategy read the OIDC claims itself, per commit, via
+    FastMCP's ``get_access_token()`` — but the strategy runs on the
+    write-callback dispatcher's own daemon thread, where no request context
+    exists, so that read always returned ``None`` and the configured
+    ``GIT_COMMIT_NAME_CLAIM`` / ``GIT_COMMIT_EMAIL_CLAIM`` silently never
+    applied on the deployed write path. This test drives a write through a
+    REAL ``WriteCallbackDispatcher`` (real worker thread) wired to a real
+    ``GitWriteStrategy`` — the seam every prior claims test bypassed by
+    calling the strategy synchronously. Against the old code this scenario
+    committed with the static author (the token read yields ``None`` on the
+    worker); with identity captured at ``fire()`` time it commits with the
+    claim-derived author while the committer stays static.
+    """
+
+    def test_bound_principal_survives_dispatcher_thread(self, git_repo: Path) -> None:
+        """Author = claim-derived principal, committer = static, via the worker."""
+        from markdown_vault_mcp._identity import Principal, bound_principal
+        from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
 
         strategy = GitWriteStrategy(
             commit_name="bot",
@@ -5527,42 +5532,36 @@ class TestOidcClaimAuthorCommitterSplit:
             commit_name_claim="name",
             commit_email_claim="email",
         )
+        dispatcher = WriteCallbackDispatcher(strategy)
         f = git_repo / "note.md"
         f.write_text("# hi\n")
 
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=None
-        ):
-            strategy(f, "# hi\n", "write")
-
-        a_name, a_email, c_name, c_email = self._get_identity(git_repo)
-        assert a_name == c_name == "bot"
-        assert a_email == c_email == "bot@srv.com"
-
-    def test_only_name_claim_committer_email_unchanged(self, git_repo: Path) -> None:
-        """When only name_claim is configured, author name = claim, email = static for both."""
-        from unittest.mock import MagicMock, patch
-
-        strategy = GitWriteStrategy(
-            commit_name="bot",
-            commit_email="bot@srv.com",
-            commit_name_claim="name",
+        principal = Principal(
+            subject="user123",
+            display_name="Alice Human",
+            email="alice@humans.org",
+            kind="human",
         )
-        f = git_repo / "note.md"
-        f.write_text("# hi\n")
+        # fire() runs on the (simulated) request-side thread where the
+        # contextvar is bound; the commit runs on the dispatcher worker.
+        with bound_principal(principal):
+            dispatcher.fire(f, "# hi\n", "write")
+        assert dispatcher.drain(timeout=10.0)
+        dispatcher.close()
+        strategy.close()
 
-        token = MagicMock()
-        token.claims = {"name": "Alice Human"}
-        with patch(
-            "markdown_vault_mcp.git.strategy._get_access_token", return_value=token
-        ):
-            strategy(f, "# hi\n", "write")
+        def _log(fmt: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(git_repo), "log", "-1", f"--format={fmt}"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
 
-        a_name, a_email, c_name, c_email = self._get_identity(git_repo)
-        assert a_name == "Alice Human"
-        assert a_email == "bot@srv.com"
-        assert c_name == "bot"
-        assert c_email == "bot@srv.com"
+        assert _log("%aN") == "Alice Human"
+        assert _log("%aE") == "alice@humans.org"
+        assert _log("%cN") == "bot"
+        assert _log("%cE") == "bot@srv.com"
 
 
 class TestWriteQuiescer:

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,245 @@
+"""Unit tests for the Principal / identity layer (#1160).
+
+Covers the frozen :class:`~markdown_vault_mcp._identity.Principal` value, its
+OKF actor derivation, the contextvar binding helpers, and
+:func:`~markdown_vault_mcp._identity.resolve_mcp_principal` — including the
+claim-extraction edge cases previously pinned on the git strategy's deleted
+``_extract_claim`` (absent claim, empty string, non-string value, no
+configured key, no token).
+
+The monkeypatch targets are the ``fastmcp_pvl_core`` package attributes —
+enabled by the deliberate function-local imports in ``_identity`` (the same
+pattern ``_okf_write`` uses).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from markdown_vault_mcp import _identity
+from markdown_vault_mcp._identity import (
+    Principal,
+    bound_principal,
+    configure_identity_claims,
+    current_principal,
+    resolve_mcp_principal,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _reset_identity_claims() -> Iterator[None]:
+    """Isolate the module-level claim-key registration per test."""
+    yield
+    configure_identity_claims(name_claim=None, email_claim=None)
+
+
+def _patch_context(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    subject: str | None,
+    claims: dict[str, Any] | None,
+) -> None:
+    monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: subject)
+    monkeypatch.setattr("fastmcp_pvl_core.get_claims", lambda: claims)
+
+
+class TestPrincipalOkfActor:
+    """okf_actor keeps exact parity with resolve_write_actor's rules."""
+
+    def test_human_with_subject_is_human_actor(self) -> None:
+        p = Principal(subject="peter", display_name=None, email=None, kind="human")
+        assert p.okf_actor("1.2.3") == "human:peter"
+
+    def test_local_kind_is_tool_actor(self) -> None:
+        p = Principal(subject=None, display_name=None, email=None, kind="local")
+        assert p.okf_actor("1.2.3") == "markdown-vault-mcp/1.2.3"
+
+    def test_human_without_subject_is_tool_actor(self) -> None:
+        """Defensive: a subject-less principal never stamps ``human:``."""
+        p = Principal(subject=None, display_name="A", email=None, kind="human")
+        assert p.okf_actor("1.2.3") == "markdown-vault-mcp/1.2.3"
+
+
+class TestPrincipalContextVar:
+    """bound_principal / current_principal mirror the OKF intent contextvar."""
+
+    def test_unbound_is_none(self) -> None:
+        assert current_principal() is None
+
+    def test_bound_value_is_visible_and_reset(self) -> None:
+        p = Principal(subject="s", display_name=None, email=None, kind="human")
+        with bound_principal(p):
+            assert current_principal() is p
+        assert current_principal() is None
+
+    def test_nested_bindings_restore_outer(self) -> None:
+        outer = Principal(subject="o", display_name=None, email=None, kind="human")
+        inner = Principal(subject="i", display_name=None, email=None, kind="human")
+        with bound_principal(outer):
+            with bound_principal(inner):
+                assert current_principal() is inner
+            assert current_principal() is outer
+
+
+class TestResolveMcpPrincipal:
+    """resolve_mcp_principal: subject rules + configured-claim extraction."""
+
+    def test_authenticated_subject_makes_human_principal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_context(monkeypatch, subject="peter", claims={"sub": "peter"})
+        p = resolve_mcp_principal()
+        assert p.kind == "human"
+        assert p.subject == "peter"
+
+    def test_local_sentinel_makes_local_principal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The auth-mode-none sentinel maps to kind='local', subject=None."""
+        _patch_context(monkeypatch, subject="local", claims=None)
+        p = resolve_mcp_principal()
+        assert p.kind == "local"
+        assert p.subject is None
+
+    def test_no_subject_makes_local_principal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_context(monkeypatch, subject=None, claims=None)
+        p = resolve_mcp_principal()
+        assert p.kind == "local"
+        assert p.subject is None
+        assert p.display_name is None
+        assert p.email is None
+
+    def test_configured_claims_populate_name_and_email(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim="name", email_claim="email")
+        _patch_context(
+            monkeypatch,
+            subject="user123",
+            claims={"name": "Alice Human", "email": "alice@humans.org"},
+        )
+        p = resolve_mcp_principal()
+        assert p == Principal(
+            subject="user123",
+            display_name="Alice Human",
+            email="alice@humans.org",
+            kind="human",
+        )
+
+    def test_unconfigured_claims_stay_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without registered claim keys, name/email are never read."""
+        _patch_context(
+            monkeypatch, subject="user123", claims={"name": "Alice", "email": "a@b"}
+        )
+        p = resolve_mcp_principal()
+        assert p.display_name is None
+        assert p.email is None
+
+    def test_absent_claim_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        configure_identity_claims(name_claim="name", email_claim="email")
+        _patch_context(monkeypatch, subject="user123", claims={"sub": "user123"})
+        p = resolve_mcp_principal()
+        assert p.display_name is None
+        assert p.email is None
+
+    def test_empty_string_claim_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject="user123", claims={"name": ""})
+        assert resolve_mcp_principal().display_name is None
+
+    def test_non_string_claim_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        configure_identity_claims(name_claim="email_verified", email_claim=None)
+        _patch_context(monkeypatch, subject="user123", claims={"email_verified": True})
+        assert resolve_mcp_principal().display_name is None
+
+    def test_no_token_claims_none_is_handled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_claims() -> None (no token) yields None name/email."""
+        configure_identity_claims(name_claim="name", email_claim="email")
+        _patch_context(monkeypatch, subject="local", claims=None)
+        p = resolve_mcp_principal()
+        assert p.display_name is None
+        assert p.email is None
+
+    def test_claims_without_subject_still_populate_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A token with claims but no usable subject keeps the claim fields.
+
+        Matches the pre-#1160 behaviour where the git author claims and the
+        OKF subject were independent reads: the commit author can come from
+        the claims even when OKF attribution falls back to the tool actor.
+        """
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject=None, claims={"name": "Alice"})
+        p = resolve_mcp_principal()
+        assert p.kind == "local"
+        assert p.display_name == "Alice"
+
+
+class TestOkfResolversPreferBoundPrincipal:
+    """_okf_write's resolvers use the bound Principal when one exists (#1160).
+
+    The context-reading fallback path is pinned — unmodified — by
+    ``tests/test_okf_write.py``; these tests cover the new preferred branch.
+    """
+
+    def test_resolve_write_actor_uses_principal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp._okf_write import resolve_write_actor
+
+        # get_subject would say something else entirely; the binding wins.
+        monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: "other")
+        p = Principal(subject="peter", display_name=None, email=None, kind="human")
+        with bound_principal(p):
+            assert resolve_write_actor() == "human:peter"
+
+    def test_resolve_write_actor_local_principal_is_tool_actor(self) -> None:
+        from markdown_vault_mcp._okf_write import resolve_write_actor
+
+        p = Principal(subject=None, display_name=None, email=None, kind="local")
+        with bound_principal(p):
+            assert resolve_write_actor().startswith("markdown-vault-mcp/")
+
+    def test_resolve_human_subject_uses_principal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from markdown_vault_mcp._okf_write import resolve_human_subject
+
+        monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: "other")
+        p = Principal(subject="peter", display_name=None, email=None, kind="human")
+        with bound_principal(p):
+            assert resolve_human_subject() == "peter"
+
+    def test_resolve_human_subject_local_principal_is_none(self) -> None:
+        from markdown_vault_mcp._okf_write import resolve_human_subject
+
+        p = Principal(subject=None, display_name=None, email=None, kind="local")
+        with bound_principal(p):
+            assert resolve_human_subject() is None
+
+
+class TestConfigureIdentityClaims:
+    def test_registration_is_read_by_resolution(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_context(monkeypatch, subject="u", claims={"nickname": "Al"})
+        configure_identity_claims(name_claim="nickname", email_claim=None)
+        assert resolve_mcp_principal().display_name == "Al"
+        configure_identity_claims(name_claim=None, email_claim=None)
+        assert resolve_mcp_principal().display_name is None
+
+    def test_module_state_is_set(self) -> None:
+        configure_identity_claims(name_claim="a", email_claim="b")
+        assert (_identity._name_claim, _identity._email_claim) == ("a", "b")

--- a/tests/test_write_callback.py
+++ b/tests/test_write_callback.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 
+from markdown_vault_mcp._identity import Principal
 from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
 
 
@@ -338,3 +339,125 @@ class TestOldPathForwarding:
         d.close()
 
         assert calls == [(Path("/new.md"), "x", "rename")]
+
+
+# ---------------------------------------------------------------------------
+# principal forwarding (#1160 / #1218)
+# ---------------------------------------------------------------------------
+
+
+def _make_principal(name: str = "Alice") -> Principal:
+    return Principal(
+        subject="user123", display_name=name, email="a@humans.org", kind="human"
+    )
+
+
+class TestPrincipalForwarding:
+    """The bound Principal reaches opted-in callbacks and nothing else (#1160)."""
+
+    def test_three_arg_callback_is_never_passed_principal(self) -> None:
+        """A three-argument third-party callback keeps working untouched."""
+        from markdown_vault_mcp._identity import bound_principal
+
+        calls, cb = _recorder()
+        d = WriteCallbackDispatcher(cb)  # type: ignore[arg-type]
+        with bound_principal(_make_principal()):
+            d.fire(Path("/a.md"), "x", "write")
+        d.close()
+
+        assert calls == [(Path("/a.md"), "x", "write")]
+
+    def test_opted_in_callback_receives_principal(self) -> None:
+        """A callback advertising the opt-in gets the bound principal."""
+        from markdown_vault_mcp._identity import bound_principal
+        from markdown_vault_mcp.types import ACCEPTS_PRINCIPAL_ATTR
+
+        seen: list[object] = []
+
+        def cb(
+            abs_path: Path,  # noqa: ARG001
+            content: str,  # noqa: ARG001
+            operation: str,  # noqa: ARG001
+            principal: object = None,
+        ) -> None:
+            seen.append(principal)
+
+        setattr(cb, ACCEPTS_PRINCIPAL_ATTR, True)
+
+        principal = _make_principal()
+        d = WriteCallbackDispatcher(cb)  # type: ignore[arg-type]
+        with bound_principal(principal):
+            d.fire(Path("/a.md"), "x", "write")
+        d.close()
+
+        assert seen == [principal]
+
+    def test_principal_is_snapshotted_at_fire_time(self) -> None:
+        """The value bound when fire() ran wins, not a later rebinding.
+
+        This is the #1218 mechanism in miniature: the dispatcher worker has
+        no request context, so the identity must be captured on the firing
+        thread. The worker is held busy so the queue item is processed only
+        after the contextvar has moved on — the earlier snapshot must win.
+        """
+        import threading
+
+        from markdown_vault_mcp._identity import bound_principal
+        from markdown_vault_mcp.types import ACCEPTS_PRINCIPAL_ATTR
+
+        gate = threading.Event()
+        seen: list[object] = []
+
+        def cb(
+            abs_path: Path,  # noqa: ARG001
+            content: str,  # noqa: ARG001
+            operation: str,  # noqa: ARG001
+            principal: object = None,
+        ) -> None:
+            gate.wait(timeout=5)
+            seen.append(principal)
+
+        setattr(cb, ACCEPTS_PRINCIPAL_ATTR, True)
+
+        first = _make_principal("First")
+        second = _make_principal("Second")
+        d = WriteCallbackDispatcher(cb)  # type: ignore[arg-type]
+        with bound_principal(first):
+            d.fire(Path("/a.md"), "x", "write")
+        # The firing context has moved on before the worker processes the
+        # item; the snapshot taken at fire() time must still say "First".
+        with bound_principal(second):
+            gate.set()
+            d.close()
+
+        assert [getattr(p, "display_name", None) for p in seen] == ["First"]
+
+    def test_both_opt_ins_receive_both_keywords(self) -> None:
+        """A callback opted into old_path AND principal receives both."""
+        from markdown_vault_mcp._identity import bound_principal
+        from markdown_vault_mcp.types import (
+            ACCEPTS_OLD_PATH_ATTR,
+            ACCEPTS_PRINCIPAL_ATTR,
+        )
+
+        seen: list[tuple[object, object]] = []
+
+        def cb(
+            abs_path: Path,  # noqa: ARG001
+            content: str,  # noqa: ARG001
+            operation: str,  # noqa: ARG001
+            old_path: Path | None = None,
+            principal: object = None,
+        ) -> None:
+            seen.append((old_path, principal))
+
+        setattr(cb, ACCEPTS_OLD_PATH_ATTR, True)
+        setattr(cb, ACCEPTS_PRINCIPAL_ATTR, True)
+
+        principal = _make_principal()
+        d = WriteCallbackDispatcher(cb)  # type: ignore[arg-type]
+        with bound_principal(principal):
+            d.fire(Path("/new.md"), "x", "rename", old_path=Path("/old.md"))
+        d.close()
+
+        assert seen == [(Path("/old.md"), principal)]


### PR DESCRIPTION
## Closes / Refs

Closes #1160, closes #1218. Refs #1161 (future-proofing epic)

**Merge order note:** please merge this before #1224 — both touch `config_sections/_assembly.py`; #1224 will take a base-merge afterwards.

## What & why

**Problem.** `GIT_COMMIT_NAME_CLAIM`/`GIT_COMMIT_EMAIL_CLAIM` were inert on the deployed write path: `GitWriteStrategy` read the OIDC claims via FastMCP's `get_access_token()` per commit, but the strategy runs on `WriteCallbackDispatcher`'s daemon thread, where no request context exists — the read silently returned `None` and every commit fell back to the static author, while the same write's OKF provenance (contextvar through `asyncio.to_thread`) recorded the human subject (#1218). More broadly, write identity was read from the MCP context in two places with two different rules (#1160).

**Fix.** Identity is now resolved **once, at the MCP tool edge**, into a frozen `Principal` (new private `_identity.py`; credentials and permissions deliberately excluded). The write tools bind it on a contextvar around their `to_thread` call via `write_identity_scope()` — which also derives the OKF write-intent actor from the *same* Principal, removing the rule disagreement by construction. `WriteCallbackDispatcher.fire()` snapshots the bound Principal into the queue item (capture-at-fire — the only point still inside the copied request context) and forwards it only to callbacks opting in via `ACCEPTS_PRINCIPAL_ATTR` (mirroring the #894 `old_path` opt-in). `GitWriteStrategy` consumes `principal.display_name/email` as the commit `--author` with the same per-field static fallback; the `git/` package no longer imports `fastmcp` (guard-tested), keeping it usable from non-MCP drivers.

**Compatibility.** `tests/test_okf_write.py` passes **byte-for-byte unmodified** — the `_okf_write` resolvers prefer a bound Principal and otherwise keep the existing lazy `get_subject` path. Third-party three-argument write callbacks are untouched. The strategy's `commit_name_claim`/`commit_email_claim` ctor kwargs remain accepted (docstring-deprecated) and still feed the startup identity warning. Delete/rename/move_folder/attachment writes — previously identity-less — now carry the Principal for git attribution while their OKF enricher semantics stay byte-identical (principal-only binding).

## What this PR deliberately does NOT do

- No `AccessPolicy`/permissions model and no credentials on the Principal — the service study's later concerns: #1161 out-of-scope list.
- No removal of the deprecated strategy ctor claim kwargs — they still inform `_check_identity`'s startup warning; removal rides the next major (cf. #1225's pattern).
- No change to conflict-commit identity (`git/conflict.py` background commits keep the documented static server identity — per-user attribution genuinely doesn't apply there).

## Local review

- [x] Ran a local code-review pass on the cumulative diff before creating the PR (range `923e8b1..d6e6779`; verified the per-field author fallback preserves old semantics, the 2×2 dispatcher dispatch reproduces each prior case, the previously-unbound write ops keep OKF behaviour byte-identical, and `test_okf_write.py` has a zero diff).
- [x] No commit carries `!` — the fix makes a documented feature work; public callback surface is additive (opt-in attribute).

## Docs impact

- [x] `README.md` — claim-var rows note resolution at tool-call time
- [x] `docs/` site pages — `docs/configuration.md` updated
- [x] `docs/design/` — new "Write identity: the Principal value (#1160, fixes #1218)" section
- [x] Inline docstrings — Google-style throughout `_identity.py`; deprecation notes on the strategy ctor kwargs; AGENTS.md tree gains `_identity.py`

Tests: new #1218 regression drives a write through the **real dispatcher worker thread** into a real git repo (author=claims, committer=static — the false-green the old synchronous tests had is documented in its docstring); principal-forwarding trio + fire-time-snapshot test; claim-extraction edge cases re-pinned on `resolve_mcp_principal`; fastmcp-import-clean guard on `git/`. Gates: pytest 3748 passed; ruff/mypy clean; `_identity.py`/`write_callback.py`/`writer.py` at 100% coverage; structural gate 100% (945 lines, 0 violations).

---
_Generated by [Claude Code](https://claude.ai/code/session_015Q12LpD5yLESRHUX7Lpyi8)_