### PR TITLE
feat(index): record skip tombstones so FTS absence means deleted

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -586,6 +586,67 @@ lifespan behind the initial build job, #665) + explicit `reindex` tool call
 Architecture supports adding `watch_interval` or watchdog integration later
 without refactoring.
 
+### Skip Tombstones (#1129)
+
+**Absence semantics.** Absence of a `documents` row means exactly one thing:
+the path is *not an index candidate* — deleted, non-markdown, or excluded by
+pattern. Every surfaced deterministic skip (the four `SKIP_CATEGORIES`:
+`parse_error`, `encoding_error`, `missing_frontmatter`, `internal_error`)
+instead stays PRESENT as a *tombstone* row: `skip_category` non-NULL,
+`chunk_count = 0`, no child rows. Excluded-by-pattern files stay absent —
+exclusion is config-static, so their absence is already unambiguous — and so
+do transient `OSError` skips (nothing is recorded; the file retries next
+scan). Walk incompleteness is not representable as tombstones, so the
+embeddings empty-build check keeps its `on_walk_error` source walk.
+
+**Invariant.** A tombstone row exists iff the path is currently in the
+tracker's `skip_reasons` registry, which stays authoritative for
+`get_index_status.skipped_files`; the two are kept in lockstep by the three
+skip-recording pipelines (`build_index`, `reindex`/`_parse_changed_notes`,
+`process_dirty_paths`) through the shared `IndexManager._tombstone_skip`
+helper, and by `IndexManager._sync_tombstones`, which garbage-collects
+tombstones whose path left the registry (a skipped file deleted from disk
+leaves the registry silently — it was never indexed — so its tombstone is
+dropped after each `update_state`).
+
+**Readers.** All direct-`documents` readers query the `documents_live` view,
+so tombstones are invisible to every existing consumer — non-breaking by
+construction. Queries that reach `documents` through child tables (the FTS5
+MATCH join, `list_chunks`, `get_toc`, `get_backlinks`, `list_field_values`)
+are naturally safe because tombstones have no child rows.
+
+**Stale-row fix.** Before #1129, a file that *became* unparseable kept its
+last-good FTS row on `reindex` (and on `process_dirty_paths`), serving stale
+content from search/read indefinitely. Tombstoning replaces that row, so the
+stale content stops being served while the path remains distinguishable from
+a deletion.
+
+**Links to tombstones stay broken — by decision.** `get_broken_links` /
+`count_broken_links` / `get_outlinks.exists` check `documents_live`, and
+vault-wide wikilink resolution never resolves to a tombstone. A skipped file
+contributes no readable content, so pretending its link targets exist would
+hide exactly the problem the tombstone records.
+
+**Warm restart.** The coordinator's warm-restart gate keys on
+`FTSIndex.has_documents()` (ANY row, tombstones included), so an
+all-tombstone vault short-circuits like any completed build; reported stats
+stay on the live `count_documents()`.
+
+**Embeddings.** Tombstones give the vector convergence a direct answer to
+"is this FTS absence deliberate?" (#1130): a stale sidecar path is
+reclaimable iff it has a tombstone (any category), is excluded, or its
+source is gone from disk (one `stat`, transient-`OSError`-aware, with an
+unavailable source *root* confirming nothing); and an empty embedding build
+is authoritative iff every candidate absent from FTS has a tombstone. The
+former per-candidate re-parse loops are gone.
+
+**Migration.** The columns are additive (`ALTER TABLE` on open, following
+the `chunk_count` precedent) and `INDEX_SEMANTICS_VERSION` was bumped to 3:
+a pre-tombstone index has ambiguous absences, so the first start after the
+upgrade cold-rebuilds once and materialises tombstones for existing skips.
+Non-breaking and minor-releasable — no operator action, and tombstones are
+invisible to every reader.
+
 ### Incremental Reindex
 
 Full numpy array rebuild on every reindex (filter unchanged rows + append new).
@@ -1831,7 +1892,10 @@ class MostLinkedNote:
 Full DDL for the SQLite database used by `FTSIndex`:
 
 ```sql
--- Documents table: one row per .md file
+-- Documents table: one row per .md file — live documents AND skip
+-- tombstones (#1129). skip_category IS NULL marks a live row; a tombstone
+-- carries the surfaced skip category/detail, chunk_count = 0, and no child
+-- rows at all (no sections/notes_fts/links/document_tags/document_aliases).
 CREATE TABLE IF NOT EXISTS documents (
     id INTEGER PRIMARY KEY,
     path TEXT UNIQUE NOT NULL,        -- relative path (document identity)
@@ -1839,8 +1903,17 @@ CREATE TABLE IF NOT EXISTS documents (
     folder TEXT NOT NULL DEFAULT '',  -- derived from path parent
     frontmatter_json TEXT,            -- raw YAML frontmatter as JSON (for display)
     content_hash TEXT NOT NULL,       -- SHA256 of raw file content
-    modified_at REAL NOT NULL         -- file mtime
+    modified_at REAL NOT NULL,        -- file mtime
+    skip_category TEXT,               -- NULL = live; else a SKIP_CATEGORIES value
+    skip_detail TEXT NOT NULL DEFAULT ''
 );
+
+-- Reader view: every direct-documents reader goes through this, so
+-- tombstones are invisible to all existing consumers. Dropped and
+-- recreated on every open so future column additions refresh the
+-- SELECT * expansion.
+CREATE VIEW documents_live AS
+    SELECT * FROM documents WHERE skip_category IS NULL;
 
 -- Sections table: one row per chunk within a document
 CREATE TABLE IF NOT EXISTS sections (

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -277,7 +277,7 @@ No parameters.
 
 ### `reindex`
 
-Incrementally update the full-text search index to reflect file changes made outside this server. Only changed files are processed; unchanged documents are skipped, and files deliberately excluded from the index (missing required frontmatter, exclude-pattern matches, unparseable content) are remembered across scans so they are not re-parsed or re-reported until their content changes (#665).
+Incrementally update the full-text search index to reflect file changes made outside this server. Only changed files are processed; unchanged documents are skipped, and files deliberately excluded from the index (missing required frontmatter, exclude-pattern matches, unparseable content) are remembered across scans so they are not re-parsed or re-reported until their content changes (#665). A previously indexed note that becomes unparseable is dropped from search and read results in the same pass — it no longer serves its last-good content — and shows up in `skipped_files` until it is fixed or deleted (#1129).
 
 If semantic search is configured, the reindex job re-embeds the changed documents on the writer thread. Poll `get_index_status` and watch the `dirty_embeddings` counter to observe embedding convergence.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -277,7 +277,7 @@ No parameters.
 
 ### `reindex`
 
-Incrementally update the full-text search index to reflect file changes made outside this server. Only changed files are processed; unchanged documents are skipped, and files deliberately excluded from the index (missing required frontmatter, exclude-pattern matches, unparseable content) are remembered across scans so they are not re-parsed or re-reported until their content changes (#665). A previously indexed note that becomes unparseable is dropped from search and read results in the same pass — it no longer serves its last-good content — and shows up in `skipped_files` until it is fixed or deleted (#1129).
+Incrementally update the full-text search index to reflect file changes made outside this server. Only changed files are processed; unchanged documents are skipped, and files deliberately excluded from the index (missing required frontmatter, exclude-pattern matches, unparseable content) are remembered across scans so they are not re-parsed or re-reported until their content changes (#665). A previously indexed note that becomes unparseable is dropped from search and read results in the same pass (it no longer serves its last-good content) and shows up in `skipped_files` until it is fixed or deleted (#1129).
 
 If semantic search is configured, the reindex job re-embeds the changed documents on the writer thread. Poll `get_index_status` and watch the `dirty_embeddings` counter to observe embedding convergence.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,14 @@ ignore = ["E501"]
 # IndexManager (#1157; callable injection per the #736 precedent). Same
 # gate-only mechanism as okf_migrate.py above.
 "src/markdown_vault_mcp/managers/embeddings.py" = ["PLR0913"]
+# fts_index.py is the single SQL owner: several queries are assembled from
+# code-owned fragments (folder LIKE clauses, `?`-placeholder lists, snippet
+# projections) with every value bound as a parameter — no user input ever
+# reaches the SQL text. S608 flags any string-built query on sight, so a
+# diff touching one of these lines would need a routine `# noqa` that the
+# base pass strips as unused (RUF100, S isn't in the base select) — the same
+# gate-only mechanism as the git/ package's S603/S607 entry above.
+"src/markdown_vault_mcp/fts_index.py" = ["S608"]
 # Test fixtures import vault/protocol types only used in annotations.
 "tests/conftest.py" = ["TC002", "TC003"]
 # _install_fake_openai's keyword-only scenario toggles (content/refusal/

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -1,4 +1,24 @@
-"""SQLite FTS5 index for full-text search and tag filtering."""
+"""SQLite FTS5 index for full-text search and tag filtering.
+
+**Skip tombstones (#1129):** files that a scan deliberately skipped for one
+of the four surfaced :data:`~markdown_vault_mcp.types.SKIP_CATEGORIES` are
+kept PRESENT in the ``documents`` table as *tombstone* rows — ``skip_category``
+non-NULL, ``chunk_count = 0``, and no child rows (no ``sections``,
+``notes_fts``, ``links``, ``document_tags``, or ``document_aliases`` entries).
+Absence of a ``documents`` row therefore means exactly one thing: the path is
+not an index candidate at all (deleted, non-markdown, or excluded by
+pattern). Every reader query goes through the ``documents_live`` view
+(``WHERE skip_category IS NULL``), so tombstones are invisible to all
+existing consumers. Queries that join ``documents`` through child tables —
+the FTS5 MATCH search join, :meth:`FTSIndex.list_chunks`,
+:meth:`FTSIndex.get_toc`, :meth:`FTSIndex.get_backlinks`, and
+:meth:`FTSIndex.list_field_values` — are naturally tombstone-safe because a
+tombstone has no child rows, and deliberately keep reading ``documents``.
+Links pointing at a tombstoned file intentionally stay *broken* (and
+vault-wide wikilinks never resolve to a tombstone): the file contributes no
+readable content, so pretending its link target exists would only hide the
+problem the tombstone records.
+"""
 
 from __future__ import annotations
 
@@ -20,7 +40,13 @@ from markdown_vault_mcp._fts_connection import (
     retry_on_sqlite_locked as _retry_on_sqlite_locked,
 )
 from markdown_vault_mcp.embed_text import fields_text as _fields_text
-from markdown_vault_mcp.types import FTSResult, ParsedNote, SubtreeNote, TocEntry
+from markdown_vault_mcp.types import (
+    FTSResult,
+    ParsedNote,
+    SkippedFile,
+    SubtreeNote,
+    TocEntry,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -89,7 +115,9 @@ CREATE TABLE IF NOT EXISTS documents (
     content_hash TEXT NOT NULL,
     modified_at REAL NOT NULL,
     chunk_count INTEGER NOT NULL DEFAULT 1,
-    content_chars INTEGER NOT NULL DEFAULT 0
+    content_chars INTEGER NOT NULL DEFAULT 0,
+    skip_category TEXT,
+    skip_detail TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS sections (
@@ -211,7 +239,13 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: short-circuit is rejected and every file is re-parsed once. Changes that
 #: only affect how stored rows are *queried* or *rendered* (ranking, snippets,
 #: response shaping) need no bump — nothing on disk went stale.
-INDEX_SEMANTICS_VERSION = 2
+#:
+#: Version 3 (#1129): skipped files became part of the stored row set —
+#: every surfaced deterministic skip now writes a tombstone row into
+#: ``documents``. An index built by an older pipeline has no tombstones, so
+#: its row absences are ambiguous (skipped vs. deleted); the bump forces the
+#: one cold rebuild that materialises tombstones for existing skips.
+INDEX_SEMANTICS_VERSION = 3
 
 
 class ChunkingMeta(NamedTuple):
@@ -463,8 +497,17 @@ class FTSIndex:
                 logger.debug(
                     "fts_index: content_chars column already added by concurrent process"
                 )
+        self._migrate_tombstone_columns(conn, cols)
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_sections_docid ON sections(document_id)"
+        )
+        # Drop-then-create so a future documents column addition refreshes the
+        # view's SELECT * expansion (a view snapshots the column list at
+        # CREATE time).
+        conn.execute("DROP VIEW IF EXISTS documents_live")
+        conn.execute(
+            "CREATE VIEW documents_live AS "
+            "SELECT * FROM documents WHERE skip_category IS NULL"
         )
         conn.commit()
         self._migrate_notes_fts_summary(conn)
@@ -480,6 +523,43 @@ class FTSIndex:
                     result[0] if result else "no result",
                 )
         conn.commit()
+
+    def _migrate_tombstone_columns(
+        self, conn: sqlite3.Connection, cols: set[str]
+    ) -> None:
+        """Add the skip-tombstone columns to a pre-#1129 ``documents`` table.
+
+        Additive migration following the ``chunk_count`` / ``content_chars``
+        precedent: ``ALTER TABLE ADD COLUMN`` guarded by the PRAGMA column
+        set, tolerating a duplicate-column race with a concurrent process.
+        ``skip_category`` is ``NULL`` on every pre-existing row, so all
+        migrated rows read as live through ``documents_live``.
+
+        Args:
+            conn: The primary connection (inside :meth:`_init_schema`).
+            cols: The ``PRAGMA table_info(documents)`` column-name set.
+        """
+        for name, ddl in (
+            ("skip_category", "ALTER TABLE documents ADD COLUMN skip_category TEXT"),
+            (
+                "skip_detail",
+                "ALTER TABLE documents ADD COLUMN skip_detail TEXT NOT NULL DEFAULT ''",
+            ),
+        ):
+            if name in cols:
+                continue
+            try:
+                conn.execute(ddl)
+                conn.commit()
+                logger.info(
+                    "fts_index: migrated documents table — added %s column", name
+                )
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+                logger.debug(
+                    "fts_index: %s column already added by concurrent process", name
+                )
 
     def _migrate_notes_fts_summary(self, conn: sqlite3.Connection) -> None:
         """Migrate a legacy 5-column ``notes_fts`` to the 6-column schema.
@@ -973,6 +1053,114 @@ class FTSIndex:
             logger.debug("delete_by_path: removed %s", path)
         return deleted
 
+    # ------------------------------------------------------------------
+    # Skip tombstones (issue #1129)
+    # ------------------------------------------------------------------
+
+    @_retry_on_locked
+    def upsert_tombstone(
+        self, skip: SkippedFile, *, content_hash: str, modified_at: float
+    ) -> None:
+        """Record a surfaced skip as a tombstone row in ``documents``.
+
+        Deletes any existing rows for ``skip.path`` (live or tombstone) and
+        inserts a bare document row carrying the skip category and detail —
+        ``chunk_count = 0``, ``content_chars = 0``, and deliberately **no**
+        child rows (no ``sections``, ``notes_fts``, ``links``,
+        ``document_tags``, or ``document_aliases`` entries), so every reader
+        that joins through a child table sees nothing and ``documents_live``
+        hides the row from direct readers. The delete + insert run in one
+        transaction, mirroring :meth:`upsert_note`.
+
+        Args:
+            skip: The surfaced skip to record; ``skip.category`` must be one
+                of :data:`~markdown_vault_mcp.types.SKIP_CATEGORIES`.
+            content_hash: SHA-256 of the exact bytes that were evaluated,
+                matching what the tracker records for the skip.
+            modified_at: The file's mtime at skip time.
+        """
+        folder = _derive_folder(skip.path)
+        conn = self._conn()
+        with conn:
+            cur = conn.cursor()
+            self._delete_document(cur, skip.path)
+            cur.execute(
+                """
+                INSERT INTO documents (path, title, folder, frontmatter_json,
+                                       content_hash, modified_at, chunk_count,
+                                       content_chars, skip_category, skip_detail)
+                VALUES (?, ?, ?, NULL, ?, ?, 0, 0, ?, ?)
+                """,
+                (
+                    skip.path,
+                    Path(skip.path).stem,
+                    folder,
+                    content_hash,
+                    modified_at,
+                    skip.category,
+                    skip.detail,
+                ),
+            )
+        logger.debug(
+            "upsert_tombstone: recorded %s (category=%s)", skip.path, skip.category
+        )
+
+    @_retry_on_locked
+    def get_tombstone(self, path: str) -> dict[str, Any] | None:
+        """Return the tombstone row for *path*, or ``None``.
+
+        Args:
+            path: Relative document path.
+
+        Returns:
+            A dict with keys ``path``, ``skip_category``, ``skip_detail``,
+            ``content_hash``, ``modified_at``, or ``None`` when the path has
+            no tombstone (absent entirely, or present as a live document).
+        """
+        row = (
+            self._conn()
+            .execute(
+                """
+                SELECT path, skip_category, skip_detail, content_hash, modified_at
+                FROM documents
+                WHERE path = ? AND skip_category IS NOT NULL
+                """,
+                (path,),
+            )
+            .fetchone()
+        )
+        return dict(row) if row is not None else None
+
+    @_retry_on_locked
+    def list_tombstones(self) -> list[dict[str, Any]]:
+        """Return every tombstone row, ordered by path.
+
+        Returns:
+            List of dicts with the same shape as :meth:`get_tombstone`.
+        """
+        cur = self._conn().execute(
+            """
+            SELECT path, skip_category, skip_detail, content_hash, modified_at
+            FROM documents
+            WHERE skip_category IS NOT NULL
+            ORDER BY path
+            """
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+    @_retry_on_locked
+    def has_documents(self) -> bool:
+        """Return ``True`` when ``documents`` holds ANY row, tombstones included.
+
+        The warm-restart gate (#1129): an index whose candidates were all
+        skipped is still a completed build, so the short-circuit must count
+        tombstones — keying on live rows alone would cold-rebuild an
+        all-tombstone vault on every boot. A truly empty table (no build has
+        ever recorded anything) still reads ``False``.
+        """
+        row = self._conn().execute("SELECT 1 FROM documents LIMIT 1").fetchone()
+        return row is not None
+
     def optimize(self) -> bool:
         """Merge FTS5 inverted-index segments, dropping deleted-document tokens.
 
@@ -1384,7 +1572,7 @@ class FTSIndex:
             """
             SELECT path, title, folder, frontmatter_json,
                    content_hash, modified_at, content_chars
-            FROM documents
+            FROM documents_live
             WHERE path = ?
             """,
             (path,),
@@ -1413,7 +1601,7 @@ class FTSIndex:
                 """
                 SELECT path, title, folder, frontmatter_json,
                        content_hash, modified_at, content_chars
-                FROM documents
+                FROM documents_live
                 WHERE folder = ? OR folder LIKE ? ESCAPE '\\'
                 ORDER BY path
                 """,
@@ -1424,7 +1612,7 @@ class FTSIndex:
                 """
                 SELECT path, title, folder, frontmatter_json,
                        content_hash, modified_at, content_chars
-                FROM documents
+                FROM documents_live
                 ORDER BY path
                 """
             )
@@ -1438,7 +1626,7 @@ class FTSIndex:
             Sorted list of folder strings (including ``""`` for the root).
         """
         cur = self._conn().execute(
-            "SELECT DISTINCT folder FROM documents ORDER BY folder"
+            "SELECT DISTINCT folder FROM documents_live ORDER BY folder"
         )
         return [row[0] for row in cur.fetchall()]
 
@@ -1468,8 +1656,8 @@ class FTSIndex:
 
     @_retry_on_locked
     def count_documents(self) -> int:
-        """Return the total number of indexed documents."""
-        row = self._conn().execute("SELECT COUNT(*) FROM documents").fetchone()
+        """Return the total number of live (non-tombstone) indexed documents."""
+        row = self._conn().execute("SELECT COUNT(*) FROM documents_live").fetchone()
         return int(row[0])
 
     @_retry_on_locked
@@ -1584,7 +1772,7 @@ class FTSIndex:
             .execute(
                 """
             SELECT id, path, title, content_chars
-            FROM documents
+            FROM documents_live
             WHERE (folder = ? OR folder LIKE ? ESCAPE '\\')
             ORDER BY path ASC
             LIMIT ?
@@ -1680,7 +1868,10 @@ class FTSIndex:
         """Return all links FROM the given document.
 
         Uses a LEFT JOIN to check target existence in a single query,
-        avoiding N+1 round-trips.
+        avoiding N+1 round-trips. Existence is checked against
+        ``documents_live``, so a link to a tombstoned (skipped) file reports
+        ``exists = False`` — consistent with :meth:`get_broken_links`
+        treating such links as broken (#1129).
 
         Args:
             path: Relative document path that is the link source
@@ -1703,7 +1894,7 @@ class FTSIndex:
                    (t.id IS NOT NULL) AS target_exists
             FROM links l
             JOIN documents d ON d.id = l.source_id
-            LEFT JOIN documents t ON t.path = l.target_path
+            LEFT JOIN documents_live t ON t.path = l.target_path
             WHERE d.path = ?
             ORDER BY l.rowid
             {limit_clause}
@@ -1755,7 +1946,8 @@ class FTSIndex:
         # Load all document paths once into a Python set/list for in-memory
         # matching — avoids O(N) SQL round-trips (one SELECT per wikilink row).
         doc_paths: list[str] = [
-            r["path"] for r in conn.execute("SELECT path FROM documents").fetchall()
+            r["path"]
+            for r in conn.execute("SELECT path FROM documents_live").fetchall()
         ]
 
         # Build alias → document path mapping for fallback resolution.
@@ -1856,7 +2048,7 @@ class FTSIndex:
             FROM links l
             JOIN documents d ON d.id = l.source_id
             WHERE NOT EXISTS (
-                SELECT 1 FROM documents d2 WHERE d2.path = l.target_path
+                SELECT 1 FROM documents_live d2 WHERE d2.path = l.target_path
             )
               {folder_clause}
             ORDER BY d.path, l.rowid
@@ -1885,7 +2077,7 @@ class FTSIndex:
                 """
                 SELECT path, title, folder, frontmatter_json,
                        modified_at, content_chars
-                FROM documents
+                FROM documents_live
                 WHERE folder = ? OR folder LIKE ? ESCAPE '\\'
                 ORDER BY modified_at DESC
                 LIMIT ?
@@ -1897,7 +2089,7 @@ class FTSIndex:
                 """
                 SELECT path, title, folder, frontmatter_json,
                        modified_at, content_chars
-                FROM documents
+                FROM documents_live
                 ORDER BY modified_at DESC
                 LIMIT ?
                 """,
@@ -1921,7 +2113,7 @@ class FTSIndex:
         cur = self._conn().execute(
             """
             SELECT path, title, folder, frontmatter_json, modified_at, content_chars
-            FROM documents d
+            FROM documents_live d
             WHERE NOT EXISTS (SELECT 1 FROM links WHERE source_id = d.id)
               AND NOT EXISTS (SELECT 1 FROM links WHERE target_path = d.path)
             ORDER BY path
@@ -1947,7 +2139,7 @@ class FTSIndex:
                    d.folder,
                    COUNT(DISTINCT l.source_id) AS backlink_count
             FROM links l
-            JOIN documents d ON d.path = l.target_path
+            JOIN documents_live d ON d.path = l.target_path
             GROUP BY d.path, d.title, d.folder
             ORDER BY backlink_count DESC
             LIMIT ?
@@ -1987,7 +2179,7 @@ class FTSIndex:
         for path in (source_path, target_path):
             row = (
                 self._conn()
-                .execute("SELECT 1 FROM documents WHERE path = ?", (path,))
+                .execute("SELECT 1 FROM documents_live WHERE path = ?", (path,))
                 .fetchone()
             )
             if row is None:
@@ -2001,8 +2193,8 @@ class FTSIndex:
         adj: dict[str, set[str]] = {}
         cur = self._conn().execute(
             "SELECT d1.path, d2.path FROM links l"
-            " JOIN documents d1 ON d1.id = l.source_id"
-            " JOIN documents d2 ON d2.path = l.target_path"
+            " JOIN documents_live d1 ON d1.id = l.source_id"
+            " JOIN documents_live d2 ON d2.path = l.target_path"
         )
         for src, tgt in cur.fetchall():
             adj.setdefault(src, set()).add(tgt)
@@ -2083,7 +2275,7 @@ class FTSIndex:
             SELECT COUNT(*)
             FROM links
             WHERE NOT EXISTS (
-                SELECT 1 FROM documents d WHERE d.path = links.target_path
+                SELECT 1 FROM documents_live d WHERE d.path = links.target_path
             )
             """
         )
@@ -2098,7 +2290,7 @@ class FTSIndex:
         return self._count_links_query(
             """
             SELECT COUNT(*)
-            FROM documents d
+            FROM documents_live d
             WHERE NOT EXISTS (SELECT 1 FROM links WHERE source_id = d.id)
               AND NOT EXISTS (SELECT 1 FROM links WHERE target_path = d.path)
             """
@@ -2117,7 +2309,7 @@ class FTSIndex:
         """
         row = (
             self._conn()
-            .execute("SELECT chunk_count FROM documents WHERE path = ?", (path,))
+            .execute("SELECT chunk_count FROM documents_live WHERE path = ?", (path,))
             .fetchone()
         )
         return int(row["chunk_count"]) if row else 1
@@ -2155,7 +2347,8 @@ class FTSIndex:
         rows = (
             self._conn()
             .execute(
-                f"SELECT path, chunk_count FROM documents WHERE path IN ({placeholders})",
+                "SELECT path, chunk_count FROM documents_live "
+                f"WHERE path IN ({placeholders})",
                 paths,
             )
             .fetchall()

--- a/src/markdown_vault_mcp/indexing/coordinator.py
+++ b/src/markdown_vault_mcp/indexing/coordinator.py
@@ -273,23 +273,27 @@ class IndexWriteCoordinator:
 
     def build_index(self, *, force: bool = False) -> IndexStats:
         """Scan source_dir and build the FTS index (warm restart is O(1))."""
+        # The gate counts ANY documents row — tombstones included (#1129): an
+        # all-tombstone vault (every candidate skipped) is a completed build
+        # and must warm-restart; a truly empty index still rebuilds. Reported
+        # stats stay on the live count.
         if (
             not force
             and self._fts.is_build_completed()
             and self._chunking_meta_matches()
+            and self._fts.has_documents()
         ):
-            existing = self._fts.list_notes()
-            if existing:
-                logger.debug(
-                    "build_index: index already populated (%d docs), skipping",
-                    len(existing),
-                )
-                self._readiness.mark_built()
-                return IndexStats(
-                    documents_indexed=len(existing),
-                    chunks_indexed=0,
-                    skipped=0,
-                )
+            live = self._fts.count_documents()
+            logger.debug(
+                "build_index: index already populated (%d docs), skipping",
+                live,
+            )
+            self._readiness.mark_built()
+            return IndexStats(
+                documents_indexed=live,
+                chunks_indexed=0,
+                skipped=0,
+            )
         self._readiness.begin_sync_build()
         self._fts.clear_build_completed()
         try:
@@ -360,27 +364,28 @@ class IndexWriteCoordinator:
         Warm-restart short-circuit returns an already-resolved Future
         without touching the writer queue, mirroring :meth:`build_index`.
         """
+        # Same tombstone-inclusive gate as build_index (#1129).
         if (
             not force
             and self._fts.is_build_completed()
             and self._chunking_meta_matches()
+            and self._fts.has_documents()
         ):
-            existing = self._fts.list_notes()
-            if existing:
-                logger.debug(
-                    "build_index_async: index already populated (%d docs), skipping",
-                    len(existing),
+            live = self._fts.count_documents()
+            logger.debug(
+                "build_index_async: index already populated (%d docs), skipping",
+                live,
+            )
+            self._readiness.mark_built()
+            fut: Future[IndexStats] = Future()
+            fut.set_result(
+                IndexStats(
+                    documents_indexed=live,
+                    chunks_indexed=0,
+                    skipped=0,
                 )
-                self._readiness.mark_built()
-                fut: Future[IndexStats] = Future()
-                fut.set_result(
-                    IndexStats(
-                        documents_indexed=len(existing),
-                        chunks_indexed=0,
-                        skipped=0,
-                    )
-                )
-                return fut
+            )
+            return fut
 
         self._readiness.begin_async_build()
         self._fts.clear_build_completed()

--- a/src/markdown_vault_mcp/managers/embeddings.py
+++ b/src/markdown_vault_mcp/managers/embeddings.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import stat as stat_module
 import time
 from collections import Counter
 from typing import TYPE_CHECKING, Any
@@ -24,12 +25,7 @@ from markdown_vault_mcp.embed_text import is_embeddable
 from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
 from markdown_vault_mcp.fts_index import _derive_folder
 from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
-from markdown_vault_mcp.scanner import (
-    CategorizedSkip,
-    parse_note,
-    parse_note_categorized,
-)
-from markdown_vault_mcp.types import ParsedNote
+from markdown_vault_mcp.scanner import parse_note
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,6 +35,7 @@ if TYPE_CHECKING:
     from markdown_vault_mcp.fts_index import FTSIndex
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.scanner import ChunkStrategy
+    from markdown_vault_mcp.types import ParsedNote
     from markdown_vault_mcp.vector_index import VectorIndex
 
 logger = logging.getLogger(__name__)
@@ -74,8 +71,6 @@ class EmbeddingsManager:
             ``None`` disables embedding support.
         embedding_provider: Provider used to generate embeddings.
         chunk_strategy: Strategy for splitting documents into chunks.
-        required_frontmatter: If provided, documents missing any listed
-            field are excluded from the index entirely.
         get_vectors: Callback returning the current
             :class:`~markdown_vault_mcp.vector_index.VectorIndex` (or
             ``None``).
@@ -94,7 +89,7 @@ class EmbeddingsManager:
             ``_is_path_excluded``), so both pipelines share one policy.
         discover_candidates: Injected source-tree discovery (the owner's
             ``_discover_indexable_candidates``), used by the authoritative
-            emptiness / stale-path confirmation walks.
+            empty-build check's source walk.
     """
 
     def __init__(
@@ -105,7 +100,6 @@ class EmbeddingsManager:
         embeddings_path: Path | None,
         embedding_provider: EmbeddingProvider | None,
         chunk_strategy: ChunkStrategy,
-        required_frontmatter: list[str] | None,
         get_vectors: Callable[[], VectorIndex | None],
         set_vectors: Callable[[VectorIndex | None], None],
         title_field: str,
@@ -119,7 +113,6 @@ class EmbeddingsManager:
         self._embeddings_path = embeddings_path
         self._embedding_provider = embedding_provider
         self._chunk_strategy = chunk_strategy
-        self._required_frontmatter = required_frontmatter
         self._get_vectors = get_vectors
         self._set_vectors = set_vectors
         self._title_field = title_field
@@ -233,8 +226,12 @@ class EmbeddingsManager:
         A forced FTS rebuild can omit a source that failed parsing, leaving no
         row for :meth:`build_embeddings` to re-parse. Before replacing an old
         sidecar with an empty one, inspect only source candidates absent from
-        FTS. Deliberate required-frontmatter skips are authoritative; parse,
-        I/O, and FTS-population gaps are not.
+        FTS: since #1129, every deliberate skip (any surfaced category) leaves
+        a tombstone row, so a candidate is accounted for iff it has one — no
+        per-candidate re-parse needed. A candidate with neither a live row
+        nor a tombstone is an FTS-population gap, and an incomplete source
+        walk can hide candidates entirely (walk incompleteness is not
+        representable as tombstones), so both still veto the empty save.
         """
         walk_incomplete = False
 
@@ -247,22 +244,11 @@ class EmbeddingsManager:
             logger.warning("build_embeddings_source_walk_incomplete (no vectors saved)")
             return False
 
-        for abs_path, path in candidates:
+        for _abs_path, path in candidates:
             if path in indexed_paths:
                 continue
-            outcome = parse_note_categorized(
-                abs_path,
-                self._source_dir,
-                self._chunk_strategy,
-                rel_path=path,
-                title_field=self._title_field,
-                required_frontmatter=self._required_frontmatter,
-                log_context="build_embeddings",
-            )
-            if (
-                isinstance(outcome, CategorizedSkip)
-                and outcome.skip.category == "missing_frontmatter"
-            ):
+            if self._fts.get_tombstone(path) is not None:
+                # Deliberately skipped — the absence is recorded, not a gap.
                 continue
             logger.warning(
                 "build_embeddings_unindexed_source path=%s (no vectors saved)",
@@ -275,19 +261,20 @@ class EmbeddingsManager:
         """Return the stale sidecar paths whose FTS absence is authoritative.
 
         A path present in the vector sidecar but absent from the FTS index is
-        reclaimable only when the absence means "deleted or deliberately not
-        indexed". Absence equally covers a source the producing build failed
-        to parse or a walk failed to see (#1129), and deleting those vectors
-        turns a transient build gap into semantic-search loss that no later
-        pass repairs while the gap persists (#1130).
+        reclaimable only when the absence means "not an index candidate".
+        Since #1129 that is a direct check: a deliberately skipped candidate
+        has a tombstone row, so a path is reclaimable iff it has a tombstone
+        OR its source is no longer a candidate at all (excluded by pattern,
+        or gone from disk — one ``stat`` replaces the former full
+        re-parse/walk). The conservative default stands (#1130): a source
+        still on disk with neither a live row nor a tombstone is a build gap
+        — the FTS gap, not the source, is the anomaly — so its vectors are
+        kept for the pass that next sees it.
 
-        The convergence-side mirror of
-        :meth:`_empty_embedding_build_is_authoritative`: an incomplete source
-        walk confirms nothing, and a source still present on disk keeps its
-        vectors unless re-parsing shows a state the current build would also
-        decline to embed — a deliberate ``missing_frontmatter`` skip, or a
-        note whose chunks yield no embeddable text (#930/#1087) — so
-        reclaiming those is convergent rather than lossy.
+        An unavailable source *root* (unmounted volume, not-yet-populated
+        checkout) would make every per-path stat read as "gone" and wipe the
+        whole sidecar, so it confirms nothing — the cheap root check replaces
+        the former walk-incompleteness guard for this method.
 
         Args:
             stale_paths: Sidecar paths absent from the FTS chunk listing.
@@ -295,71 +282,48 @@ class EmbeddingsManager:
         Returns:
             The subset safe to reclaim, in input order.
         """
-        walk_incomplete = False
-
-        def _record_walk_error(_exc: OSError) -> None:
-            nonlocal walk_incomplete
-            walk_incomplete = True
-
-        candidates = self._discover_candidates(on_walk_error=_record_walk_error)
-        if walk_incomplete:
+        if stale_paths and not self._source_dir.is_dir():
             logger.warning(
-                "build_embeddings_converge_walk_incomplete kept=%d "
+                "build_embeddings_converge_source_root_unavailable kept=%d "
                 "(no vectors removed)",
                 len(stale_paths),
             )
             return []
-        present = {rel: abs_path for abs_path, rel in candidates}
         confirmed: list[str] = []
         for path in stale_paths:
-            abs_path = present.get(path)
-            if abs_path is None:
+            if self._fts.get_tombstone(path) is not None:
+                confirmed.append(path)
+                continue
+            if self._is_path_excluded(path) or self._stale_source_gone(path):
                 # Deleted or excluded — the reclaim convergence exists for.
                 confirmed.append(path)
                 continue
-            outcome = parse_note_categorized(
-                abs_path,
-                self._source_dir,
-                self._chunk_strategy,
-                rel_path=path,
-                title_field=self._title_field,
-                required_frontmatter=self._required_frontmatter,
-                log_context="build_embeddings",
+            logger.warning(
+                "build_embeddings_converge_kept path=%s "
+                "(source present but absent from FTS; vectors kept)",
+                path,
             )
-            if self._stale_source_is_reclaimable(path, outcome):
-                confirmed.append(path)
-            else:
-                logger.warning(
-                    "build_embeddings_converge_kept path=%s "
-                    "(source present but absent from FTS; vectors kept)",
-                    path,
-                )
         return confirmed
 
-    def _stale_source_is_reclaimable(
-        self, path: str, outcome: ParsedNote | CategorizedSkip | None
-    ) -> bool:
-        """Return whether a still-on-disk stale source's vectors may go.
+    def _stale_source_gone(self, path: str) -> bool:
+        """Return whether a stale sidecar path's source file is gone from disk.
 
-        ``True`` only for the two states the current build would also decline
-        to embed: a deliberate ``missing_frontmatter`` skip, or a note that
-        parses but yields no embeddable chunk text (#930/#1087). A transient
-        ``OSError`` (``None``), any other skip category, or a note that would
-        embed today all keep their vectors — the FTS gap, not the source, is
-        the anomaly there (#1130).
+        ``FileNotFoundError`` / ``NotADirectoryError`` mean the source is
+        genuinely not there (or no longer a file), so its vectors are
+        reclaimable. Any other ``OSError`` — a permission flap, an I/O error
+        — is possibly transient and reads as *present*, so the conservative
+        keep applies and the next pass re-checks (#1130).
         """
-        if isinstance(outcome, CategorizedSkip):
-            return outcome.skip.category == "missing_frontmatter"
-        if isinstance(outcome, ParsedNote):
-            texts, _meta = self._embed_inputs(
-                path=path,
-                title=outcome.title,
-                folder=_derive_folder(outcome.path),
-                frontmatter=outcome.frontmatter,
-                chunks=outcome.chunks,
+        try:
+            st = (self._source_dir / path).stat()
+        except (FileNotFoundError, NotADirectoryError):
+            return True
+        except OSError as exc:
+            logger.debug(
+                "build_embeddings_converge_stat_failed path=%s err=%s", path, exc
             )
-            return not texts
-        return False
+            return False
+        return not stat_module.S_ISREG(st.st_mode)
 
     def _load_vectors(self) -> VectorIndex:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
@@ -723,12 +687,12 @@ class EmbeddingsManager:
         affected documents and converges after it.  Documents present only
         in the vector index lose their vectors when that absence is
         authoritative — deleted, newly excluded, or deliberately skipped
-        while no server ran.  FTS absence alone does not establish that: it
-        equally covers a source the producing build failed to parse or a
-        walk failed to see (#1129), so paths FTS has no rows for at all are
-        first confirmed against the source tree via
-        :meth:`_confirm_stale_vector_paths`, and an unconfirmed path keeps
-        its vectors for the pass that next sees its source (#1130).
+        (which since #1129 leaves a tombstone row).  Paths FTS has no rows
+        for at all are confirmed via :meth:`_confirm_stale_vector_paths`
+        (tombstone lookup, exclusion check, or a source ``stat``); an
+        unconfirmed path — source on disk, no live row, no tombstone: a
+        build gap — keeps its vectors for the pass that next sees its
+        source (#1130).
         Documents missing from the vector index are embedded; documents
         whose chunk multiset differs in any way (modified content, changed
         title, re-chunked boundaries) are re-embedded in full.  The sidecar
@@ -886,9 +850,10 @@ class EmbeddingsManager:
         vec_by_path = vectors.chunks_by_path()
 
         stale_paths = [p for p in vec_by_path if p not in fts_by_path]
-        # Sidecar paths FTS does not know at all cannot be reclaimed on row
-        # absence alone — that also covers parse failures and discovery gaps
-        # (#1129) — so they need source-side confirmation first (#1130).
+        # Sidecar paths FTS has no chunk rows for cannot be reclaimed on row
+        # absence alone: they must carry a skip tombstone, be excluded, or be
+        # gone from disk (#1129); anything else is a build gap whose vectors
+        # are kept (#1130).
         unconfirmed = [p for p in stale_paths if p not in fts_chunk_paths]
         if unconfirmed:
             kept = set(unconfirmed) - set(self._confirm_stale_vector_paths(unconfirmed))

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -144,7 +144,6 @@ class IndexManager:
             embeddings_path=embeddings_path,
             embedding_provider=embedding_provider,
             chunk_strategy=chunk_strategy,
-            required_frontmatter=required_frontmatter,
             get_vectors=get_vectors,
             set_vectors=set_vectors,
             title_field=title_field,
@@ -276,6 +275,57 @@ class IndexManager:
             return False
         return True
 
+    def _tombstone_skip(
+        self,
+        skip: SkippedFile,
+        abs_path: Path,
+        *,
+        content_hash: str | None = None,
+    ) -> None:
+        """Record a surfaced skip as an FTS tombstone row (#1129).
+
+        The single skip-recording choke point shared by all three pipelines
+        (:meth:`build_index`, :meth:`reindex`, :meth:`process_dirty_paths`),
+        so the hash/mtime provenance is computed consistently with
+        :meth:`_record_skip_hash`: a transient ``OSError`` while reading the
+        file records nothing — the file retries on the next scan, matching
+        the tracker's transient policy. Any pre-existing row for the path
+        (a stale live row included) is replaced inside the upsert.
+
+        Args:
+            skip: The surfaced skip to record.
+            abs_path: Absolute path of the skipped file, hashed/stat'ed when
+                *content_hash* needs computing.
+            content_hash: Hash of the exact bytes that were evaluated, when
+                the caller already has it (avoids a second, raceable read).
+        """
+        try:
+            if content_hash is None:
+                content_hash = compute_file_hash(abs_path)
+            modified_at = abs_path.stat().st_mtime
+        except OSError as exc:
+            logger.debug("tombstone_skip_read_failed path=%s err=%s", skip.path, exc)
+            return
+        self._fts.upsert_tombstone(
+            skip, content_hash=content_hash, modified_at=modified_at
+        )
+
+    def _sync_tombstones(self) -> None:
+        """Drop tombstone rows whose skip left the tracker registry (#1129).
+
+        The tracker's ``skip_reasons`` map stays authoritative for what is
+        currently skipped; tombstones mirror it in the FTS index. A skipped
+        file that is deleted from disk (or newly excluded) leaves the
+        registry silently on the next scan — it was never indexed, so no
+        ``deleted`` event fires — and its tombstone must not linger as a
+        phantom candidate. Called after ``update_state`` so the re-read
+        registry reflects this pass.
+        """
+        reasons = self._tracker.skip_reasons()
+        for row in self._fts.list_tombstones():
+            if row["path"] not in reasons:
+                self._fts.delete_by_path(row["path"])
+
     def _purge_stale_excluded(
         self,
         vectors: VectorIndex | None,
@@ -358,13 +408,19 @@ class IndexManager:
             logger.info("build_index(force=True): dropping and rebuilding index")
             for row in self._fts.list_notes():
                 self._fts.delete_by_path(row["path"])
+            # list_notes() is live-only, so tombstones need their own wipe;
+            # the scan below re-creates one per still-skipped candidate.
+            for row in self._fts.list_tombstones():
+                self._fts.delete_by_path(row["path"])
 
         logger.info("build_index: scanning %s", self._source_dir)
 
         skip_reasons: dict[str, dict[str, str]] = {}
+        skip_files: dict[str, SkippedFile] = {}
 
         def _collect_skip(sf: SkippedFile) -> None:
             skip_reasons[sf.path] = {"category": sf.category, "detail": sf.detail}
+            skip_files[sf.path] = sf
 
         notes = list(
             scan_directory(
@@ -436,18 +492,29 @@ class IndexManager:
                 continue
             # A failed hash is possibly transient — left unrecorded so the
             # next scan retries the file (#802; see _record_skip_hash).
-            self._record_skip_hash(
+            recorded = self._record_skip_hash(
                 skipped_state,
                 rel_str,
                 abs_path,
                 event="build_index",
                 surfaced=rel_str in skip_reasons,
             )
+            # Surfaced skips are also recorded as FTS tombstone rows (#1129),
+            # reusing the hash just computed so both records cover the same
+            # bytes. A transient (unrecorded) hash tombstones nothing —
+            # tracker and tombstone stay in lockstep.
+            if recorded and rel_str in skip_files:
+                self._tombstone_skip(
+                    skip_files[rel_str],
+                    abs_path,
+                    content_hash=skipped_state[rel_str],
+                )
 
         # Update tracker state so reindex() knows the baseline.
         self._tracker.update_state(
             notes, skipped=skipped_state, skip_reasons=skip_reasons
         )
+        self._sync_tombstones()
 
         if errored:
             logger.warning(
@@ -591,6 +658,7 @@ class IndexManager:
         self._tracker.update_state(
             state_notes, skipped=newly_skipped, skip_reasons=newly_skip_reasons
         )
+        self._sync_tombstones()
 
         return ReindexResult(
             added=indexed_added,
@@ -666,6 +734,12 @@ class IndexManager:
                         "category": sf.category,
                         "detail": sf.detail,
                     }
+                    # Tombstone the skip in FTS (#1129). This *replaces* any
+                    # stale live row: a file that becomes unparseable stops
+                    # serving its last-good content from search/read instead
+                    # of serving it indefinitely. Reuses the hash recorded
+                    # above so tracker and tombstone cover the same bytes.
+                    self._tombstone_skip(sf, abs_path, content_hash=newly_skipped[path])
                 continue
             parsed.append((path, outcome))
 
@@ -814,6 +888,10 @@ class IndexManager:
         validation failures (``ValueError``) are caught, logged at
         WARNING, and skipped so a single bad note does not starve the
         rest — matching the coverage in :meth:`flush_dirty_embeddings`.
+        A ``yaml.YAMLError`` additionally replaces the note's stale row with
+        a ``parse_error`` tombstone, and a note missing required frontmatter
+        is tombstoned rather than deleted, so FTS absence keeps meaning
+        "not a candidate" (#1129).
         When the parse failure stems from the file disappearing between
         the ``is_file()`` check and ``parse_note()``, the stale FTS row
         is deleted so keyword/hybrid search results stay consistent with
@@ -849,11 +927,27 @@ class IndexManager:
                             self._chunk_strategy,
                             title_field=self._title_field,
                         )
-                        if self._required_frontmatter and not all(
-                            k in (note.frontmatter or {})
-                            for k in self._required_frontmatter
-                        ):
-                            self._fts.delete_by_path(path)
+                        missing = [
+                            k
+                            for k in (self._required_frontmatter or [])
+                            if k not in (note.frontmatter or {})
+                        ]
+                        if missing:
+                            # Tombstone rather than delete (#1129): the file
+                            # is still a candidate, so its row must stay
+                            # present (invisibly) instead of becoming
+                            # indistinguishable from a deletion. The parsed
+                            # note's own hash/mtime cover the exact bytes
+                            # that were evaluated (#888 pattern).
+                            self._fts.upsert_tombstone(
+                                SkippedFile(
+                                    path=path,
+                                    category="missing_frontmatter",
+                                    detail=f"missing: {missing}",
+                                ),
+                                content_hash=note.content_hash,
+                                modified_at=note.modified_at,
+                            )
                             continue
                         self._fts.upsert_note(note)
                     else:
@@ -888,6 +982,15 @@ class IndexManager:
                         "process_dirty_paths: skipping %s (malformed frontmatter): %s",
                         path,
                         exc,
+                    )
+                    # Tombstone instead of keeping the stale row (#1129): a
+                    # note edited into unparseable frontmatter must stop
+                    # serving its last-good content. A transient read failure
+                    # inside the helper records nothing (row kept; the next
+                    # scan retries).
+                    self._tombstone_skip(
+                        SkippedFile(path=path, category="parse_error", detail=str(exc)),
+                        abs_path,
                     )
                     continue
                 # sqlite3 / programming-bug exceptions propagate: fail the

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -1093,19 +1093,18 @@ class TestBuildEmbeddings:
         assert mgr.build_embeddings() == 1
         assert VectorIndex.load(embeddings_path, provider).count == 1
 
-        # An unreadable source is not authoritative: keep its last good vector.
+        # An unreadable source is not authoritative while its live FTS row
+        # still exists: the re-parse fails, so keep its last good vector.
         note.write_text("---\ntitle: [unclosed\n---\nbody", encoding="utf-8")
         assert mgr.build_embeddings(force=True) == 0
         assert VectorIndex.load(embeddings_path, provider).count == 1
 
-        # The same guarantee must hold after a forced FTS rebuild has skipped
-        # the malformed source and therefore no longer exposes its old row.
+        # A forced FTS rebuild tombstones the malformed source (#1129).
         mgr.build_index(force=True)
-        assert mgr.build_embeddings(force=True) == 0
-        assert VectorIndex.load(embeddings_path, provider).count == 1
 
-        # An incomplete directory walk is equally non-authoritative, even
-        # when the unreadable subtree leaves discovery with no candidates.
+        # An incomplete directory walk is never authoritative, even when the
+        # unreadable subtree leaves discovery with no candidates — walk
+        # incompleteness is not representable as tombstones.
         def incomplete_walk(_source, _excludes, *, on_error=None):
             if on_error is not None:
                 on_error(PermissionError("unreadable subtree"))
@@ -1116,8 +1115,14 @@ class TestBuildEmbeddings:
             assert mgr.build_embeddings(force=True) == 0
             assert VectorIndex.load(embeddings_path, provider).count == 1
 
-        # A successful parse with no embeddable text is authoritative: the
-        # empty index must reach disk so a restart cannot revive stale vectors.
+        # With the walk intact, the absentee now carries a tombstone, so the
+        # empty build IS authoritative (#1129): the unparseable file stops
+        # serving its stale vector, mirroring the FTS stale-row fix.
+        assert mgr.build_embeddings(force=True) == 0
+        assert VectorIndex.load(embeddings_path, provider).count == 0
+
+        # A successful parse with no embeddable text is likewise
+        # authoritative: the empty index reaches disk.
         note.write_text("---\ntitle: Note\n---\n", encoding="utf-8")
         mgr.build_index(force=True)
         assert mgr.build_embeddings(force=True) == 0
@@ -1166,10 +1171,12 @@ class TestConvergeStaleConfirmation:
     """FTS row absence alone must not delete a still-existing source's vectors.
 
     ``_converge_embeddings`` reclaims vectors for paths absent from FTS.
-    Absence also covers sources a build could not parse or a walk could not
-    see (#1129), so an unconfirmed absence must keep the vectors (#1130)
-    while genuine deletions, exclusions, deliberate ``missing_frontmatter``
-    skips, and body-less notes (#930/#1087) still reclaim.
+    Since #1129 every deliberate skip leaves a tombstone row, so a stale
+    sidecar path is reclaimable iff it has a tombstone OR its source is no
+    longer a candidate (deleted / excluded). A source still on disk with
+    neither a live row nor a tombstone is a build gap and keeps its vectors
+    (#1130); an unavailable source root or a possibly-transient stat failure
+    likewise confirms nothing.
     """
 
     @staticmethod
@@ -1207,19 +1214,49 @@ class TestConvergeStaleConfirmation:
 
         return set(VectorIndex.load(embeddings_path, provider).chunks_by_path())
 
-    def test_unparseable_source_keeps_vectors(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Shape A of #1130: parse failure + forced FTS rebuild loses nothing."""
+    def test_unparseable_source_reclaims_via_tombstone(self, tmp_path: Path) -> None:
+        """A parse-failure skip is tombstoned (#1129), so its vectors reclaim.
+
+        The stale-content counterpart of the FTS fix: a file that becomes
+        unparseable stops serving its last-good vectors too — the tombstone
+        records the absence as deliberate, so convergence reclaims instead
+        of conservatively keeping them (the pre-#1129 #1130 behaviour).
+        """
         vault, embeddings_path, provider, mgr = self._embedded_pair(tmp_path)
 
-        # Corrupt bad.md; a forced FTS rebuild drops its row while the file
-        # is still on disk.
+        # Corrupt bad.md; a forced FTS rebuild replaces its row with a
+        # parse_error tombstone while the file is still on disk.
         (vault / "bad.md").write_text(
             "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
         )
         mgr.build_index(force=True)
         assert {row["path"] for row in mgr._fts.list_notes()} == {"good.md"}
+        assert mgr._fts.get_tombstone("bad.md") is not None
+
+        mgr.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {"good.md"}
+
+        # Once repaired and re-indexed, the note converges back in.
+        (vault / "bad.md").write_text(
+            "---\ntitle: Bad\n---\n# Bad\n\nRepaired body.\n", encoding="utf-8"
+        )
+        mgr.build_index(force=True)
+        mgr.build_embeddings()
+        assert self._sidecar_paths(embeddings_path, provider) == {
+            "good.md",
+            "bad.md",
+        }
+
+    def test_fts_gap_keeps_vectors(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Shape A of #1130: no row, no tombstone, source on disk → keep."""
+        _vault, embeddings_path, provider, mgr = self._embedded_pair(tmp_path)
+
+        # Simulate a build gap: the row vanishes without a tombstone while
+        # the (perfectly valid) source stays on disk.
+        mgr._fts.delete_by_path("bad.md")
+        assert mgr._fts.get_tombstone("bad.md") is None
 
         with caplog.at_level(
             logging.WARNING, logger="markdown_vault_mcp.managers.index"
@@ -1235,26 +1272,8 @@ class TestConvergeStaleConfirmation:
             for r in caplog.records
         )
 
-        # A second pass does not erode the guarantee.
-        mgr.build_embeddings()
-        assert self._sidecar_paths(embeddings_path, provider) == {
-            "good.md",
-            "bad.md",
-        }
-
-        # Once the source is valid again but FTS has not yet caught up, the
-        # gap is FTS-side, so the vectors still stay.
-        (vault / "bad.md").write_text(
-            "---\ntitle: Bad\n---\n# Bad\n\nRepaired body.\n", encoding="utf-8"
-        )
-        mgr.build_embeddings()
-        assert self._sidecar_paths(embeddings_path, provider) == {
-            "good.md",
-            "bad.md",
-        }
-
-        # After reindexing picks the repaired file back up, convergence heals.
-        mgr.build_index()
+        # After a rebuild picks the file back up, convergence heals.
+        mgr.build_index(force=True)
         mgr.build_embeddings()
         assert {row["path"] for row in mgr._fts.list_notes()} == {
             "good.md",
@@ -1274,8 +1293,8 @@ class TestConvergeStaleConfirmation:
         vault, embeddings_path, provider, _mgr = self._embedded_pair(tmp_path)
 
         # Cold boot against the same sidecar with the source tree unavailable
-        # (unmounted volume / not-yet-populated checkout): the walk is
-        # incomplete, so nothing is authoritative and nothing is removed.
+        # (unmounted volume / not-yet-populated checkout): the source root is
+        # gone, so nothing is authoritative and nothing is removed.
         shutil.rmtree(vault)
         state2 = tmp_path / "state2"
         state2.mkdir()
@@ -1296,7 +1315,7 @@ class TestConvergeStaleConfirmation:
             "bad.md",
         }
         assert any(
-            "build_embeddings_converge_walk_incomplete" in r.getMessage()
+            "build_embeddings_converge_source_root_unavailable" in r.getMessage()
             for r in caplog.records
         )
 
@@ -1371,18 +1390,22 @@ class TestConvergeStaleConfirmation:
     def test_transient_oserror_keeps_vectors(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A possibly-transient read failure confirms nothing."""
-        from markdown_vault_mcp.managers import embeddings as embeddings_module
+        """A possibly-transient stat failure confirms nothing (#1130)."""
+        import pathlib
 
-        vault, embeddings_path, provider, mgr = self._embedded_pair(tmp_path)
+        _vault, embeddings_path, provider, mgr = self._embedded_pair(tmp_path)
 
-        (vault / "bad.md").write_text(
-            "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
-        )
-        mgr.build_index(force=True)
-        monkeypatch.setattr(
-            embeddings_module, "parse_note_categorized", lambda *_a, **_kw: None
-        )
+        # Build gap (no row, no tombstone) whose source momentarily cannot
+        # be stat'ed: a permission flap must read as "present" and keep.
+        mgr._fts.delete_by_path("bad.md")
+        real_stat = pathlib.Path.stat
+
+        def flaky_stat(self: pathlib.Path, **kwargs: object):
+            if self.name == "bad.md":
+                raise PermissionError("transient permission flap")
+            return real_stat(self, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(pathlib.Path, "stat", flaky_stat)
         mgr.build_embeddings()
         assert self._sidecar_paths(embeddings_path, provider) == {
             "good.md",

--- a/tests/test_skip_tombstones.py
+++ b/tests/test_skip_tombstones.py
@@ -1,0 +1,634 @@
+"""Skip tombstones (#1129): FTS absence means "not an index candidate".
+
+Files skipped for a surfaced :data:`~markdown_vault_mcp.types.SKIP_CATEGORIES`
+reason stay PRESENT in the ``documents`` table as tombstone rows — invisible
+to every reader (which all go through the ``documents_live`` view), but
+distinguishable from a deletion. These tests pin:
+
+- the additive schema migration on a pre-#1129 database;
+- tombstone CRUD including live ↔ tombstone transitions;
+- tombstone invisibility across every direct-``documents`` reader;
+- the broken-links decision (links to tombstones stay broken; wikilinks do
+  not resolve to tombstones);
+- the pipeline wiring (build / reindex / process_dirty_paths) plus the
+  tracker-registry lockstep and tombstone garbage collection;
+- the stale-row regression fix: a file that becomes unparseable stops
+  serving its last-good content;
+- the warm-restart gate on an all-tombstone vault;
+- the embeddings gap semantics that tombstones enable.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.types import Chunk, LinkInfo, ParsedNote, SkippedFile
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _note(
+    path: str,
+    *,
+    content: str = "some body text",
+    links: list[LinkInfo] | None = None,
+    content_hash: str = "hash",
+    modified_at: float = 1000.0,
+) -> ParsedNote:
+    """Build a one-chunk ParsedNote for index fixtures."""
+    return ParsedNote(
+        path=path,
+        frontmatter={},
+        title=path.rsplit("/", 1)[-1].removesuffix(".md"),
+        chunks=[Chunk(heading=None, heading_level=0, content=content, start_line=1)],
+        content_hash=content_hash,
+        modified_at=modified_at,
+        links=links or [],
+        content_chars=len(content),
+    )
+
+
+TOMB = "ghost/tomb.md"
+
+
+@pytest.fixture()
+def mixed_index() -> FTSIndex:
+    """One live doc linking a second live doc AND a tombstoned path.
+
+    ``sub/live.md`` carries a markdown link to the tombstone and a bare
+    wikilink whose stem matches only the tombstone, plus a link to
+    ``sub/other.md`` so live-graph queries have something to return.
+    """
+    idx = FTSIndex(":memory:")
+    idx.upsert_note(
+        _note(
+            "sub/live.md",
+            content="alpha searchable content",
+            links=[
+                LinkInfo(
+                    target_path=TOMB,
+                    link_text="tomb",
+                    link_type="markdown",
+                    raw_target="../ghost/tomb.md",
+                ),
+                LinkInfo(
+                    target_path="tomb.md",
+                    link_text="tomb",
+                    link_type="wikilink",
+                    raw_target="tomb",
+                ),
+                LinkInfo(
+                    target_path="sub/other.md",
+                    link_text="other",
+                    link_type="markdown",
+                    raw_target="other.md",
+                ),
+            ],
+        )
+    )
+    idx.upsert_note(_note("sub/other.md", content="beta other content"))
+    idx.upsert_tombstone(
+        SkippedFile(path=TOMB, category="parse_error", detail="bad yaml"),
+        content_hash="tombhash",
+        modified_at=2000.0,
+    )
+    return idx
+
+
+# ---------------------------------------------------------------------------
+# Schema migration
+# ---------------------------------------------------------------------------
+
+
+class TestMigration:
+    def test_v2_database_gains_tombstone_columns_and_view(self, tmp_path: Path) -> None:
+        """Opening a pre-#1129 DB adds the columns; old rows read as live."""
+        db = tmp_path / "index.db"
+        conn = sqlite3.connect(db)
+        conn.executescript(
+            """
+            CREATE TABLE documents (
+                id INTEGER PRIMARY KEY,
+                path TEXT UNIQUE NOT NULL,
+                title TEXT NOT NULL,
+                folder TEXT NOT NULL DEFAULT '',
+                frontmatter_json TEXT,
+                content_hash TEXT NOT NULL,
+                modified_at REAL NOT NULL,
+                chunk_count INTEGER NOT NULL DEFAULT 1,
+                content_chars INTEGER NOT NULL DEFAULT 0
+            );
+            INSERT INTO documents
+                (path, title, folder, content_hash, modified_at)
+            VALUES ('old.md', 'Old', '', 'h', 1.0);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        idx = FTSIndex(db)
+        try:
+            cols = {
+                r[1]
+                for r in idx._conn().execute("PRAGMA table_info(documents)").fetchall()
+            }
+            assert {"skip_category", "skip_detail"} <= cols
+            # The migrated row is live and visible through documents_live.
+            assert [r["path"] for r in idx.list_notes()] == ["old.md"]
+            assert idx.get_tombstone("old.md") is None
+            # The view exists and tombstones written post-migration hide.
+            idx.upsert_tombstone(
+                SkippedFile(path="skip.md", category="parse_error", detail="x"),
+                content_hash="h2",
+                modified_at=2.0,
+            )
+            assert [r["path"] for r in idx.list_notes()] == ["old.md"]
+        finally:
+            idx.close()
+
+    def test_stale_semantics_version_triggers_rebuild_with_tombstones(
+        self, tmp_path: Path
+    ) -> None:
+        """A v2 (pre-tombstone) index cold-rebuilds once and gains tombstones."""
+        from tests.test_index_coordinator import make_coordinator
+
+        (tmp_path / "a.md").write_text("# A\n\nbody\n", encoding="utf-8")
+        (tmp_path / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
+        )
+        db = tmp_path / "index.db"
+        coord = make_coordinator(tmp_path, db=db)
+        try:
+            coord.build_index()
+            fts = coord._fts
+            assert fts.get_tombstone("bad.md") is not None
+            # Simulate a v2 index: downgrade the recorded semantics version
+            # and drop the tombstone rows that version could not have written.
+            for row in fts.list_tombstones():
+                fts.delete_by_path(row["path"])
+            conn = fts._conn()
+            with conn:
+                conn.execute(
+                    "UPDATE meta SET value = '2' WHERE key = 'index_semantics_version'"
+                )
+        finally:
+            coord.close(timeout=5)
+
+        coord2 = make_coordinator(tmp_path, db=db)
+        try:
+            stats = coord2.build_index()
+            # A warm-restart short-circuit reports chunks_indexed == 0; the
+            # provenance mismatch must instead run a real scan.
+            assert stats.chunks_indexed > 0
+            assert coord2._fts.get_tombstone("bad.md") is not None
+            assert coord2._fts.get_chunking_meta().semantics_version >= 3
+        finally:
+            coord2.close(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Tombstone CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestTombstoneCrud:
+    def test_upsert_get_list_roundtrip(self) -> None:
+        idx = FTSIndex(":memory:")
+        skip = SkippedFile(
+            path="a/b.md", category="missing_frontmatter", detail="missing: ['title']"
+        )
+        idx.upsert_tombstone(skip, content_hash="h1", modified_at=10.0)
+        tomb = idx.get_tombstone("a/b.md")
+        assert tomb == {
+            "path": "a/b.md",
+            "skip_category": "missing_frontmatter",
+            "skip_detail": "missing: ['title']",
+            "content_hash": "h1",
+            "modified_at": 10.0,
+        }
+        assert idx.list_tombstones() == [tomb]
+        assert idx.get_tombstone("other.md") is None
+
+    def test_tombstone_has_no_child_rows_or_fts_rows(self) -> None:
+        idx = FTSIndex(":memory:")
+        idx.upsert_tombstone(
+            SkippedFile(path="t.md", category="internal_error", detail="boom"),
+            content_hash="h",
+            modified_at=1.0,
+        )
+        conn = idx._conn()
+        assert conn.execute("SELECT COUNT(*) FROM sections").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM notes_fts").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM links").fetchone()[0] == 0
+        row = conn.execute(
+            "SELECT title, chunk_count, content_chars FROM documents"
+        ).fetchone()
+        assert (row["title"], row["chunk_count"], row["content_chars"]) == ("t", 0, 0)
+
+    def test_live_to_tombstone_and_back(self) -> None:
+        idx = FTSIndex(":memory:")
+        idx.upsert_note(_note("n.md", content="visible words"))
+        assert idx.search("visible")
+        idx.upsert_tombstone(
+            SkippedFile(path="n.md", category="parse_error", detail="x"),
+            content_hash="h2",
+            modified_at=2.0,
+        )
+        # live → tombstone: the old content stops being served everywhere.
+        assert idx.get_note("n.md") is None
+        assert idx.search("visible") == []
+        assert idx.count_documents() == 0
+        # tombstone → live: a successful re-parse replaces the tombstone.
+        idx.upsert_note(_note("n.md", content="repaired words"))
+        assert idx.get_tombstone("n.md") is None
+        assert idx.search("repaired")
+
+    def test_delete_by_path_removes_tombstone(self) -> None:
+        idx = FTSIndex(":memory:")
+        idx.upsert_tombstone(
+            SkippedFile(path="t.md", category="encoding_error", detail="x"),
+            content_hash="h",
+            modified_at=1.0,
+        )
+        assert idx.delete_by_path("t.md") == 1
+        assert idx.get_tombstone("t.md") is None
+        assert not idx.has_documents()
+
+    def test_has_documents_counts_tombstones(self) -> None:
+        idx = FTSIndex(":memory:")
+        assert not idx.has_documents()
+        idx.upsert_tombstone(
+            SkippedFile(path="t.md", category="parse_error", detail="x"),
+            content_hash="h",
+            modified_at=1.0,
+        )
+        assert idx.has_documents()
+        assert idx.count_documents() == 0
+
+
+# ---------------------------------------------------------------------------
+# Reader invisibility — one case per direct-``documents`` consumer
+# ---------------------------------------------------------------------------
+
+
+def _check_get_note(idx: FTSIndex) -> None:
+    assert idx.get_note(TOMB) is None
+
+
+def _check_list_notes(idx: FTSIndex) -> None:
+    assert {r["path"] for r in idx.list_notes()} == {"sub/live.md", "sub/other.md"}
+
+
+def _check_list_notes_folder(idx: FTSIndex) -> None:
+    assert idx.list_notes(folder="ghost") == []
+
+
+def _check_list_folders(idx: FTSIndex) -> None:
+    assert idx.list_folders() == ["sub"]
+
+
+def _check_count_documents(idx: FTSIndex) -> None:
+    assert idx.count_documents() == 2
+
+
+def _check_get_subtree_toc(idx: FTSIndex) -> None:
+    notes, truncated = idx.get_subtree_toc("ghost")
+    assert notes == [] and truncated is False
+
+
+def _check_get_recent(idx: FTSIndex) -> None:
+    # The tombstone carries the newest modified_at (2000.0) but never shows.
+    assert {r["path"] for r in idx.get_recent(limit=10)} == {
+        "sub/other.md",
+        "sub/live.md",
+    }
+
+
+def _check_get_orphan_notes(idx: FTSIndex) -> None:
+    assert TOMB not in {r["path"] for r in idx.get_orphan_notes()}
+
+
+def _check_get_broken_links(idx: FTSIndex) -> None:
+    broken = {
+        (row["source_path"], row["target_path"]) for row in idx.get_broken_links()
+    }
+    assert ("sub/live.md", TOMB) in broken
+
+
+def _check_count_broken_links(idx: FTSIndex) -> None:
+    # The markdown link to the tombstone and the unresolved wikilink.
+    assert idx.count_broken_links() == 2
+
+
+def _check_count_orphans(idx: FTSIndex) -> None:
+    assert idx.count_orphans() == 0
+
+
+def _check_get_most_linked(idx: FTSIndex) -> None:
+    assert TOMB not in {r["path"] for r in idx.get_most_linked(limit=10)}
+
+
+def _check_get_connection_path(idx: FTSIndex) -> None:
+    with pytest.raises(ValueError, match="not found"):
+        idx.get_connection_path("sub/live.md", TOMB)
+
+
+def _check_get_chunk_count(idx: FTSIndex) -> None:
+    # Not-found default (1), NOT the tombstone's stored 0.
+    assert idx.get_chunk_count(TOMB) == 1
+
+
+def _check_get_chunk_counts(idx: FTSIndex) -> None:
+    assert idx.get_chunk_counts(["sub/live.md", TOMB]) == {"sub/live.md": 1}
+
+
+def _check_search(idx: FTSIndex) -> None:
+    assert TOMB not in {r.path for r in idx.search("tomb")}
+
+
+def _check_get_outlinks(idx: FTSIndex) -> None:
+    by_target = {row["target_path"]: row for row in idx.get_outlinks("sub/live.md")}
+    assert not by_target[TOMB]["target_exists"]
+    assert by_target["sub/other.md"]["target_exists"]
+
+
+@pytest.mark.parametrize(
+    "check",
+    [
+        _check_get_note,
+        _check_list_notes,
+        _check_list_notes_folder,
+        _check_list_folders,
+        _check_count_documents,
+        _check_get_subtree_toc,
+        _check_get_recent,
+        _check_get_orphan_notes,
+        _check_get_broken_links,
+        _check_count_broken_links,
+        _check_count_orphans,
+        _check_get_most_linked,
+        _check_get_connection_path,
+        _check_get_chunk_count,
+        _check_get_chunk_counts,
+        _check_search,
+        _check_get_outlinks,
+    ],
+    ids=lambda fn: fn.__name__.removeprefix("_check_"),
+)
+def test_tombstone_invisible_to_reader(
+    mixed_index: FTSIndex, check: Callable[[FTSIndex], None]
+) -> None:
+    """Every direct-``documents`` reader treats the tombstone as absent."""
+    check(mixed_index)
+
+
+def test_wikilink_does_not_resolve_to_tombstone(mixed_index: FTSIndex) -> None:
+    """Vault-wide wikilink resolution ignores tombstones — the link stays broken."""
+    mixed_index.resolve_vault_wikilinks()
+    wikilink_targets = {
+        row["target_path"]
+        for row in mixed_index.get_outlinks("sub/live.md")
+        if row["link_type"] == "wikilink"
+    }
+    assert wikilink_targets == {"tomb.md"}  # unresolved, not ghost/tomb.md
+    broken_targets = {row["target_path"] for row in mixed_index.get_broken_links()}
+    assert {"tomb.md", TOMB} <= broken_targets
+
+
+# ---------------------------------------------------------------------------
+# Pipeline wiring (IndexManager)
+# ---------------------------------------------------------------------------
+
+
+class TestPipelines:
+    @staticmethod
+    def _mgr(vault: Path, state_dir: Path, **overrides):
+        from tests.test_managers_index import _make_index_mgr
+
+        return _make_index_mgr(vault, state_dir, **overrides)
+
+    def test_build_index_tombstones_surfaced_skips(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text("# Good\n\nbody\n", encoding="utf-8")
+        (vault / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
+        )
+        mgr, fts, _ = self._mgr(vault, tmp_path)
+        mgr.build_index()
+        tomb = fts.get_tombstone("bad.md")
+        assert tomb is not None
+        assert tomb["skip_category"] == "parse_error"
+        assert [r["path"] for r in fts.list_notes()] == ["good.md"]
+        # Lockstep: the tracker registry surfaces the same skip.
+        assert [s.path for s in mgr.skipped_files()] == ["bad.md"]
+
+    def test_force_rebuild_recreates_tombstones(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "bad.md").write_text(
+            "---\ntitle: [unclosed\n---\nbody", encoding="utf-8"
+        )
+        mgr, fts, _ = self._mgr(vault, tmp_path)
+        mgr.build_index()
+        assert fts.get_tombstone("bad.md") is not None
+        mgr.build_index(force=True)
+        assert fts.get_tombstone("bad.md") is not None
+        assert fts.count_documents() == 0
+
+    def test_reindex_unparseable_stops_serving_stale_content(
+        self, tmp_path: Path
+    ) -> None:
+        """REGRESSION (#1129 headline): reindex replaces the stale row.
+
+        Previously a file that became unparseable KEPT its last-good FTS row,
+        serving stale content from search/read indefinitely.
+        """
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        note = vault / "note.md"
+        note.write_text("# Note\n\nunique stale marker text\n", encoding="utf-8")
+        mgr, fts, _ = self._mgr(vault, tmp_path)
+        mgr.build_index()
+        assert fts.search("stale marker")
+        assert fts.get_note("note.md") is not None
+
+        note.write_text("---\ntitle: [unclosed\n---\nbody", encoding="utf-8")
+        result = mgr.reindex()
+        assert result.skipped >= 1
+        # The stale content is gone from every read surface...
+        assert fts.search("stale marker") == []
+        assert fts.get_note("note.md") is None
+        # ...but the path is distinguishable from a deletion.
+        tomb = fts.get_tombstone("note.md")
+        assert tomb is not None and tomb["skip_category"] == "parse_error"
+        # Lockstep with the get_index_status registry.
+        assert [s.category for s in mgr.skipped_files()] == ["parse_error"]
+
+    def test_reindex_gc_drops_tombstone_of_deleted_file(self, tmp_path: Path) -> None:
+        """A skipped file deleted from disk loses its tombstone (registry lockstep)."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "good.md").write_text("# Good\n\nbody\n", encoding="utf-8")
+        bad = vault / "bad.md"
+        bad.write_text("---\ntitle: [unclosed\n---\nbody", encoding="utf-8")
+        mgr, fts, _ = self._mgr(vault, tmp_path)
+        mgr.build_index()
+        assert fts.get_tombstone("bad.md") is not None
+
+        bad.unlink()
+        mgr.reindex()
+        assert fts.get_tombstone("bad.md") is None
+        assert mgr.skipped_files() == []
+
+    def test_reindex_fixed_file_replaces_tombstone(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        bad = vault / "bad.md"
+        bad.write_text("---\ntitle: [unclosed\n---\nbody", encoding="utf-8")
+        mgr, fts, _ = self._mgr(vault, tmp_path)
+        mgr.build_index()
+        assert fts.get_tombstone("bad.md") is not None
+
+        bad.write_text("# Fixed\n\nnow parseable\n", encoding="utf-8")
+        result = mgr.reindex()
+        assert result.added == 1
+        assert fts.get_tombstone("bad.md") is None
+        assert fts.get_note("bad.md") is not None
+
+    def test_process_dirty_paths_parse_error_tombstones(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        note = vault / "note.md"
+        note.write_text("# Note\n\nserved body\n", encoding="utf-8")
+        mgr, fts, _ = self._mgr(vault, tmp_path)
+        mgr.build_index()
+        assert fts.get_note("note.md") is not None
+
+        note.write_text("---\ntitle: [unclosed\n---\nbody", encoding="utf-8")
+        mgr.process_dirty_paths({"note.md"})
+        assert fts.get_note("note.md") is None
+        tomb = fts.get_tombstone("note.md")
+        assert tomb is not None and tomb["skip_category"] == "parse_error"
+
+    def test_process_dirty_paths_missing_frontmatter_tombstones(
+        self, tmp_path: Path
+    ) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        note = vault / "note.md"
+        note.write_text("---\ntitle: Note\n---\n# Note\n\nbody\n", encoding="utf-8")
+        mgr, fts, _ = self._mgr(vault, tmp_path, required_frontmatter=["title"])
+        mgr.build_index()
+        assert fts.get_note("note.md") is not None
+
+        note.write_text("# Note\n\nbody without frontmatter\n", encoding="utf-8")
+        mgr.process_dirty_paths({"note.md"})
+        assert fts.get_note("note.md") is None
+        tomb = fts.get_tombstone("note.md")
+        assert tomb is not None
+        assert tomb["skip_category"] == "missing_frontmatter"
+        assert "title" in tomb["skip_detail"]
+
+    def test_tombstone_skip_transient_read_failure_records_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """An OSError while hashing/stat-ing tombstones nothing (retry policy)."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        mgr, fts, _ = self._mgr(vault, tmp_path)
+        mgr._tombstone_skip(
+            SkippedFile(path="gone.md", category="parse_error", detail="x"),
+            vault / "gone.md",  # does not exist → OSError on hash
+        )
+        assert fts.get_tombstone("gone.md") is None
+        assert not fts.has_documents()
+
+    def test_process_dirty_paths_excluded_still_deletes(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "note.md").write_text("# Note\n\nbody\n", encoding="utf-8")
+        mgr, fts, _ = self._mgr(vault, tmp_path, exclude_patterns=["note.md"])
+        fts.upsert_note(_note("note.md"))
+        mgr.process_dirty_paths({"note.md"})
+        assert fts.get_note("note.md") is None
+        assert fts.get_tombstone("note.md") is None
+
+
+# ---------------------------------------------------------------------------
+# Warm restart (coordinator)
+# ---------------------------------------------------------------------------
+
+
+def test_all_tombstone_vault_warm_restarts(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A vault whose only candidates are skipped short-circuits on restart."""
+    from tests.test_index_coordinator import make_coordinator
+
+    # make_coordinator seeds a.md when absent; pre-empt it with an
+    # unparseable file so the vault holds tombstones only.
+    (tmp_path / "a.md").write_text("---\ntitle: [unclosed\n---\nbody", encoding="utf-8")
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, db=db)
+    try:
+        coord.build_index()
+        assert coord._fts.count_documents() == 0
+        assert coord._fts.list_tombstones() != []
+    finally:
+        coord.close(timeout=5)
+
+    coord2 = make_coordinator(tmp_path, db=db)
+    try:
+        with caplog.at_level(
+            logging.DEBUG, logger="markdown_vault_mcp.indexing.coordinator"
+        ):
+            stats = coord2.build_index()
+        assert stats.documents_indexed == 0
+        assert any("index already populated" in r.getMessage() for r in caplog.records)
+    finally:
+        coord2.close(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Embeddings gap semantics
+# ---------------------------------------------------------------------------
+
+
+def test_empty_build_not_authoritative_without_tombstone(tmp_path: Path) -> None:
+    """An absentee with neither row nor tombstone vetoes the empty save."""
+    from markdown_vault_mcp.vector_index import VectorIndex
+    from tests.conftest import MockEmbeddingProvider
+    from tests.test_managers_index import _make_index_mgr
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "note.md").write_text("# Note\n\nbody\n", encoding="utf-8")
+    embeddings_path = tmp_path / "embeddings"
+    provider = MockEmbeddingProvider()
+    mgr, fts, _ = _make_index_mgr(
+        vault,
+        tmp_path,
+        embeddings_path=embeddings_path,
+        embedding_provider=provider,
+    )
+    mgr.build_index()
+    assert mgr.build_embeddings() == 1
+    assert VectorIndex.load(embeddings_path, provider).count == 1
+
+    # Build gap: the row (and any tombstone) vanish while the source stays.
+    fts.delete_by_path("note.md")
+    assert mgr.build_embeddings(force=True) == 0
+    # The empty index must NOT reach disk — the old vector survives.
+    assert VectorIndex.load(embeddings_path, provider).count == 1


### PR DESCRIPTION
## Closes / Refs

Closes #1129. Refs #1161 (future-proofing epic), refs #1115, refs #1130

## What & why

Skipped files (the four `SKIP_CATEGORIES`: `parse_error`, `encoding_error`, `missing_frontmatter`, `internal_error`) are now **present** in the FTS index as tombstone rows — `skip_category` non-NULL, `chunk_count = 0`, no child rows — so absence of a `documents` row means exactly one thing: *not an index candidate* (deleted, non-markdown, or excluded by pattern). All direct readers query the new `documents_live` view, making tombstones invisible to every existing consumer; child-table joins (search MATCH, chunks, TOC, backlinks, field values) are naturally tombstone-safe and deliberately unchanged.

**Behaviour fix:** a previously indexed note that becomes unparseable no longer serves its last-good content — `reindex` and `process_dirty_paths` replace the stale row with a tombstone, so the note drops out of search/read while staying listed in `get_index_status.skipped_files` (the tracker registry remains authoritative and is kept in lockstep, including tombstone GC when a skipped file leaves the registry). Previously the three pipelines handled the same failure three different ways (build: no row; reindex: stale row kept; watcher: mixed) — they now converge on one shared choke point.

The same fix reaches the vector sidecar: convergence and the empty-build authoritative check treat a tombstoned absence as deliberate, replacing the #1115/#1130 per-candidate re-parse/walk machinery with a tombstone lookup plus one transient-aware stat (net −35 lines in `managers/embeddings.py`; the vanished-root and transient-failure protections the characterization suites pin are preserved).

**Broken links, by decision:** links to tombstoned files stay broken, `get_outlinks` reports `exists=False` for them, and wikilinks never resolve to a tombstone — a skipped file contributes no readable content, so pretending its target exists would hide exactly the problem the tombstone records.

**Migration story:** automatic and non-breaking (minor-releasable). The columns are additive (`ALTER TABLE` on open, `chunk_count` precedent) and `INDEX_SEMANTICS_VERSION` is bumped 2 → 3, so the first start after upgrade cold-rebuilds once and materialises tombstones for existing skips; no operator action, no re-embedding (chunking provenance unchanged). The warm-restart gate now keys on `has_documents()` (tombstones included) so an all-tombstone vault short-circuits like any completed build.

## What this PR deliberately does NOT do

- Excluded-by-pattern files are NOT tombstoned — exclusion is config-static and derivable without filesystem state; tombstoning it would couple index contents to `exclude_patterns`.
- `get_index_status` keeps reading the tracker registry; deriving that surface from tombstones is a possible follow-up, kept out to keep this diff reviewable.
- Walk-incompleteness stays guarded by the #1115 `on_walk_error` mechanism — an unreadable directory yields no candidate and hence no tombstone, so it cannot be represented by one.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before creating the PR (range `923e8b1..4fef21f`; verified the migration follows the additive precedent, `upsert_note`'s delete-first clears a prior tombstone for live↔tombstone transitions, the warm-restart gate change preserves the empty-index rebuild, the lockstep GC respects the transient-OSError policy, and the four updated characterization tests encode exactly the approved semantics change).
- [x] No commit carries `!` — additive schema, automatic migration, tombstones invisible to all existing readers; `feat` per the changelog rules (the semantics-version bump and stale-row fix are user-visible).

**Reviewer flags:** a per-file `S608` ignore for `fts_index.py` was added inside the PROJECT-RUFF-IGNORES sentinels (code-owned SQL fragments, all values parameter-bound — same gate-only rationale as the `git/` S603/S607 entry); `get_outlinks`' existence join was added to the reader list for consistency with the broken-links decision.

## Docs impact

- [ ] `README.md` — no operator-facing configuration change
- [x] `docs/` site pages — `docs/tools/index.md` sentence on unparseable notes dropping from search/read
- [x] `docs/design/` — new "Skip Tombstones (#1129)" section + DDL updated
- [x] Inline docstrings — module docstring documents the absence semantics; the normative `INDEX_SEMANTICS_VERSION` docstring records version 3

Gates: pytest 3764 passed; ruff/mypy clean; diff coverage 92%+ (remaining miss is the duplicate-column race branch, same as the untested `chunk_count` precedent); structural gate 100%. New `tests/test_skip_tombstones.py` (36 tests) incl. a parametrized 17-consumer reader-exclusion matrix and the reindex stale-content regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Q12LpD5yLESRHUX7Lpyi8)_