### PR TITLE
refactor: decouple versioning, index, and identity behind protocol seams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ src/markdown_vault_mcp/
     query.py           -- read-only git history/diff queries; lock-free pure functions
     types.py           -- PullResult/PushResult + pull/push reason-code constants
   scanner.py           -- file discovery, frontmatter parsing, chunking
+  interfaces.py        -- KeywordIndex/GraphStore/KeywordGraphIndex/VectorStore: the search/index storage seam (#1230)
   fts_index.py         -- SQLite FTS5 schema, BM25 search
   _fts_connection.py   -- per-thread sqlite connection registry + SQLITE_LOCKED retry (#760)
   vector_index.py      -- numpy embeddings, cosine similarity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ src/markdown_vault_mcp/
   git/
     __init__.py        -- package facade preserving the historical single-module import surface (incl. test patch targets)
     _run.py            -- low-level git subprocess + credential plumbing
+    interfaces.py      -- HistorySource/Syncer/Versioner/VersionedStore: the versioning seam; GitWriteStrategy is the one implementation (#1229)
     strategy.py        -- GitWriteStrategy: auto-commit per write; composes RepoBootstrap + PushScheduler over one shared lock (#893)
     bootstrap.py       -- RepoBootstrap: managed-clone bootstrap, remote-protocol validation, memoised git-root discovery (#893)
     push_scheduler.py  -- PushScheduler: deferred-push timer + pending-flag mechanics and push execution (#893)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ src/markdown_vault_mcp/
   okf_bundle.py        -- OKF bundle-zip export from live vault state, served via an okf-bundle download ref (#963)
   _okf_convention.py   -- OKF reserved-file maintenance after enforced writes: log.md bullet + index.md refresh (#964)
   _okf_write.py        -- OKF enforced-write runtime: contextvar actor + provenance stamp / verified clear (#964)
-  _identity.py         -- Principal write identity: tool-edge resolution, contextvar carry, claim-key registration (#1160)
+  _identity.py         -- Principal write identity: tool-edge resolution, contextvar carry, claim-key registration (#1160); sole owner of the subject rules (#1231)
   summarizer.py        -- Summarizer ABC + OpenAI-compatible chat-completions backend (#915)
   vault.py             -- thin composition root: settings-first dual-mode construction (#1158), lifecycle, wiring, facet accessors (index-write → indexing/coordinator.py)
   write_callback.py    -- WriteCallbackDispatcher: deferred git-commit callback worker (#599)

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2458,6 +2458,16 @@ untouched. `GitWriteStrategy.__call__` consumes the Principal's
 `display_name`/`email` as the commit `--author` (committer stays the static
 identity); the `git/` package imports nothing from `fastmcp` (guard-tested),
 so non-MCP drivers supply a `Principal` instead of faking request context.
+
+`resolve_mcp_principal()` is the **only** place the subject rules live
+(#1231) — `human:<subject>`, and the `"local"` sentinel counting as no human
+identity. `_okf_write.py` used to re-derive them in a fallback branch that
+read `get_subject()` itself; it now resolves a `Principal` instead, so the
+rules cannot drift between two copies. The dead `resolve_write_actor()` went
+with that branch: since #1160 the write tools stamp
+`principal.okf_actor(...)` directly. Registering the claim keys likewise
+moved out of the git-strategy builder into `to_vault_instances`, so
+configuring identity is not the git builder's job.
 Background paths without an acting person — the pull-loop conflict commits,
 the webhook, the transfer-route uploads — carry no Principal and use the
 static identity / tool actor, as before.

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2529,6 +2529,12 @@ Uses the schema defined in [Database Schema](#database-schema). Note that
 with RRF scoring in hybrid mode; each file appears once with up to
 `chunks_per_file` matching sections).
 
+`FTSIndex` satisfies the `KeywordIndex` and `GraphStore` protocols
+(`interfaces.py`, #1230) structurally — it does not inherit from them. The
+managers are typed against those protocols rather than against this class, so
+the concrete backend is substitutable; `Vault` constructs the `FTSIndex` and
+that construction is where mypy proves the conformance.
+
 ### `vector_index.py`: Numpy Embeddings
 
 Adapted from ifcraftcorpus `embeddings.py`. Rename `EmbeddingIndex` to
@@ -2556,6 +2562,37 @@ Key methods:
   mismatch (the residue of a crash between the two independent atomic
   replaces), which the load-time self-heal routes to a `force=True`
   rebuild (#734).
+
+`VectorIndex` satisfies the `VectorStore` protocol (`interfaces.py`, #1230)
+structurally. The managers hold `VectorStore`; `_vector_loader.py` and
+`EmbeddingsManager` are the factory sites that still name `VectorIndex`
+concretely, because constructing one is exactly what they are for. `load()`
+is deliberately outside the protocol for the same reason — how a backend is
+built is not part of what consumers ask of it.
+
+### `interfaces.py`: Storage Protocols (#1230)
+
+Three protocols for what the managers depend on, mirroring the move already
+made for `EmbeddingProvider` and applying it to the storage that provider
+feeds:
+
+- `KeywordIndex` — the relational document store, full-text search,
+  enumeration, tombstones, and the build-state bookkeeping.
+- `GraphStore` — the link graph. A distinct concept from search: it answers
+  *structure* (what links to what), not *relevance* (what matches a query).
+- `KeywordGraphIndex` — both, which is what one SQLite database serves today.
+  Consumers needing members from both facets are typed against this, so the
+  two concepts stay separable without pretending the current backend
+  separates them.
+- `VectorStore` — the semantic surface.
+
+Each protocol carries exactly what its consumers call, not everything the
+current implementation exposes; grow one when a consumer needs more. A
+protocol wider than its consumers is a god interface with extra steps.
+
+This is the seam the standing "if tens of thousands, evaluate Qdrant" risk
+note needs: substituting a backend is now a matter of satisfying a protocol
+rather than editing six manager constructors.
 
 ### `providers.py`: Embedding Providers
 
@@ -3822,7 +3859,7 @@ real release runs. No committed manifest bump is needed for the bundle.
 | Risk | Mitigation |
 |-|-|
 | VRAM contention (Ollama on RTX 4060 8 GB) | `cpu_only` mode, batch embeddings |
-| Vault scale (numpy in-memory) | Fine for thousands of documents. If tens of thousands, evaluate Qdrant. |
+| Vault scale (numpy in-memory) | Fine for thousands of documents. If tens of thousands, evaluate Qdrant behind the `VectorStore` protocol (`interfaces.py`, #1230). |
 | Concurrent writes (Obsidian + MCP) | Use git as sync layer. MCP server should not write directly to live Obsidian vault without git in between. |
 | FastMCP breaking changes | Pin `>=3.0,<4`. Monitor for 4.0 migration. |
 | `Vault` API doesn't fit ifcraftcorpus | Validate in Phase 1 before building MCP server. |

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3447,6 +3447,34 @@ locks were introduced — so the documented lock-ordering contracts of the
 pull/write paths (`_force_pull_rebase_fallback` requires the lock held;
 `_quiesce_writes` drains before the lock is taken) are unchanged.
 
+**Facet protocols (`git/interfaces.py`, #1229)**: the three concerns are
+also expressed as protocols, so each consumer depends on the surface it uses
+rather than on the concrete class:
+
+- `HistorySource` — `get_file_history` / `get_file_diff`. `GitQueryManager`
+  depends on this and nothing else.
+- `Syncer` — pull/push (`force_pull`, `force_push`, `sync_once`), the loop
+  lifecycle (`start`/`stop`/`flush`/`close`/`set_write_quiescer`), and the
+  repository reads the `git_sync` tool needs (`is_managed`,
+  `resolve_force_repo`, `head_sha`, `branch_name`).
+- `Versioner` — the per-write commit; structurally the same shape as
+  `PrincipalAwareWriteCallback`, restated so the module needs no runtime
+  import beyond `typing`.
+- `VersionedStore` — all three, which is what `Vault` holds.
+
+`GitWriteStrategy` remains the single object implementing all of them, and is
+still wired as both `git_strategy` and `on_write`; `Vault.close()` compares
+the two by identity to avoid closing one object twice. Splitting into three
+*objects* is deliberately not done — the collaborators share one lock, and
+that identity check depends on there being one object.
+
+The promotion of `is_managed`, `resolve_force_repo`, `head_sha`, and
+`branch_name` to the public surface replaced private-attribute reads
+(`strategy._managed`, `strategy._git(...)`) that the MCP tool layer had been
+making; the `git_sync` managed-mode gate now tests `isinstance(strategy,
+Syncer) and strategy.is_managed`, i.e. what the store can do rather than
+which class it is.
+
 For private repos, HTTPS token auth uses:
 
 - `MARKDOWN_VAULT_MCP_GIT_USERNAME` (default `x-access-token`)

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2582,7 +2582,7 @@ built is not part of what consumers ask of it.
 
 ### `interfaces.py`: Storage Protocols (#1230)
 
-Three protocols for what the managers depend on, mirroring the move already
+Three concepts, four protocols, mirroring the move already
 made for `EmbeddingProvider` and applying it to the storage that provider
 feeds:
 
@@ -3587,7 +3587,7 @@ whose restore failed instead of committing stale local content over them.
 auto-commit locally and there is no remote to reach. It gated `sync_once`
 alone, so `force_pull` ran the pipeline regardless — `git fetch origin`
 against a checkout with no `origin` (reporting the retryable-looking
-`fetch_failed`), and `CalledProcessError` out of `_head_sha` against a vault
+`fetch_failed`), and `CalledProcessError` out of `head_sha` against a vault
 that is not a git repository at all. `force_pull` now returns
 `applied=False, reason="pull_disabled"` before running any git command. The
 reason is terminal by construction: retrying cannot change it without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -376,6 +376,12 @@ exclude_lines = [
     "raise NotImplementedError",
     "if TYPE_CHECKING:",
     "if __name__ == .__main__.:",
+    # Ellipsis-only bodies: Protocol members and typing stubs (interfaces.py,
+    # git/interfaces.py, scanner.ChunkStrategy, the write-callback Protocols).
+    # They are declarations, never executed — `isinstance` against a
+    # runtime_checkable Protocol inspects member presence without calling
+    # anything — so counting them as missed lines measures nothing.
+    "^\\s*\\.\\.\\.$",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,12 @@ ignore = ["E501"]
 # removal (which shrinks the signature under the ceiling) is scheduled for
 # the next major. Gate-only rule, so a `# noqa` would be stripped (RUF100).
 "src/markdown_vault_mcp/vault.py" = ["ARG002", "PLR0913"]
+# PLR0913: the facet protocols (#1229) restate the signatures of the methods
+# they describe, so their argument counts are fixed by GitWriteStrategy's
+# existing surface — shrinking them here would only make the protocol stop
+# matching the implementation. Gate-only rule, so a `# noqa` would be
+# stripped (RUF100).
+"src/markdown_vault_mcp/git/interfaces.py" = ["PLR0913"]
 # Depends() and CurrentContext() calls in argument defaults are the standard
 # FastMCP dependency injection pattern — B008 is a false positive here.
 # Context/FastMCP/Vault imports must stay runtime (not TYPE_CHECKING) for

--- a/src/markdown_vault_mcp/_identity.py
+++ b/src/markdown_vault_mcp/_identity.py
@@ -92,7 +92,7 @@ class Principal:
 
         ``human:<subject>`` for an authenticated human, else the tool actor
         ``markdown-vault-mcp/<version>`` — the exact rules of
-        ``_okf_write.resolve_write_actor``, expressed over the resolved value.
+        the design-§6 actor rules, expressed over the resolved value.
 
         Args:
             version: Package version used for the tool actor.

--- a/src/markdown_vault_mcp/_okf_write.py
+++ b/src/markdown_vault_mcp/_okf_write.py
@@ -16,12 +16,12 @@ Actor resolution rules (design §6):
 - a tool actor ``markdown-vault-mcp/<version>`` otherwise (unauthenticated, or a
   non-tool write with no request identity).
 
-Those rules are implemented once, in
-:mod:`markdown_vault_mcp._identity` — including that ``get_subject()`` returns
-the sentinel ``"local"`` under auth mode ``none``, which counts as *no human
-identity* for both actor resolution and ``okf_verify``. This module reads a
-``Principal`` and never the request context directly (#1231); a second copy of
-the rules is a second thing to keep in agreement.
+Those rules are applied once, in :mod:`markdown_vault_mcp._identity` —
+including that ``get_subject()`` returns the sentinel ``"local"`` under auth
+mode ``none``, which counts as *no human identity* for both actor resolution
+and ``okf_verify``. This module reads a ``Principal`` and never the request
+context directly (#1231); a second copy of the rules is a second thing to keep
+in agreement.
 """
 
 from __future__ import annotations
@@ -47,7 +47,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_SUBJECT = "local"  # get_subject() sentinel for startup auth mode "none"
+#: The subject recorded for an unattributable elicit-mode verification. Shares
+#: its spelling with the ``get_subject()`` sentinel that :mod:`._identity`
+#: treats as *no human identity*, but the role here is the opposite: this is a
+#: value deliberately stamped (``human:local``), not one detected and
+#: discarded. Kept separate so narrowing one never silently moves the other.
+_LOCAL_SUBJECT = "local"
 
 
 @dataclass(frozen=True)
@@ -125,8 +130,8 @@ def resolve_human_subject() -> str | None:
     already ``None`` for a non-human caller.  With none bound — a driver that
     is not the MCP server, or a call outside ``write_identity_scope`` — it
     resolves one from the request context rather than re-deriving the rules
-    here, so the ``local``-sentinel handling lives in exactly one place
-    (#1231).
+    here, so the rule that decides what counts as a human subject — including
+    the ``"local"`` sentinel — is applied in exactly one place (#1231).
     """
     principal = current_principal()
     if principal is None:

--- a/src/markdown_vault_mcp/_okf_write.py
+++ b/src/markdown_vault_mcp/_okf_write.py
@@ -16,8 +16,12 @@ Actor resolution rules (design §6):
 - a tool actor ``markdown-vault-mcp/<version>`` otherwise (unauthenticated, or a
   non-tool write with no request identity).
 
-``get_subject()`` returns the sentinel ``"local"`` under auth mode ``none``; that
-is treated as *no human identity* for both actor resolution and ``okf_verify``.
+Those rules are implemented once, in
+:mod:`markdown_vault_mcp._identity` — including that ``get_subject()`` returns
+the sentinel ``"local"`` under auth mode ``none``, which counts as *no human
+identity* for both actor resolution and ``okf_verify``. This module reads a
+``Principal`` and never the request context directly (#1231); a second copy of
+the rules is a second thing to keep in agreement.
 """
 
 from __future__ import annotations
@@ -32,8 +36,8 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import TYPE_CHECKING
 
-from markdown_vault_mcp._identity import current_principal
-from markdown_vault_mcp.okf import _HUMAN_ACTOR_PREFIX, apply_okf_write_stamp
+from markdown_vault_mcp._identity import current_principal, resolve_mcp_principal
+from markdown_vault_mcp.okf import apply_okf_write_stamp
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -111,44 +115,23 @@ def tool_actor(version: str) -> str:
     return f"markdown-vault-mcp/{version}"
 
 
-def resolve_write_actor() -> str:
-    """Resolve the content-write actor from the request identity.
-
-    ``human:<subject>`` when an authenticated subject is present, else the tool
-    actor. Prefers a bound
-    :class:`~markdown_vault_mcp._identity.Principal` (resolved once at the
-    tool edge, #1160); otherwise reads the request context directly, so call
-    inside a tool handler.
-    """
-    principal = current_principal()
-    if principal is not None:
-        return principal.okf_actor(package_version())
-    from fastmcp_pvl_core import get_subject
-
-    subject = get_subject()
-    if subject and subject != _LOCAL_SUBJECT:
-        return f"{_HUMAN_ACTOR_PREFIX}{subject}"
-    return tool_actor(package_version())
-
-
 def resolve_human_subject() -> str | None:
     """Return the authenticated human subject, or ``None`` if unattributable.
 
     Used by ``okf_verify`` to decide whether a verification is attributable
     (``None`` under auth mode ``none`` or when no subject is present).
-    Prefers a bound :class:`~markdown_vault_mcp._identity.Principal` (#1160),
-    whose ``subject`` is already ``None`` for a non-human caller; otherwise
-    reads the request context directly.
+
+    Prefers the principal bound at the tool edge (#1160), whose ``subject`` is
+    already ``None`` for a non-human caller.  With none bound — a driver that
+    is not the MCP server, or a call outside ``write_identity_scope`` — it
+    resolves one from the request context rather than re-deriving the rules
+    here, so the ``local``-sentinel handling lives in exactly one place
+    (#1231).
     """
     principal = current_principal()
-    if principal is not None:
-        return principal.subject
-    from fastmcp_pvl_core import get_subject
-
-    subject = get_subject()
-    if subject and subject != _LOCAL_SUBJECT:
-        return subject
-    return None
+    if principal is None:
+        principal = resolve_mcp_principal()
+    return principal.subject
 
 
 def resolve_verify_subject() -> str:

--- a/src/markdown_vault_mcp/_server_tools/git.py
+++ b/src/markdown_vault_mcp/_server_tools/git.py
@@ -10,7 +10,7 @@ from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 from fastmcp.exceptions import ToolError
 
-from markdown_vault_mcp.git import GitWriteStrategy, PullResult, PushResult
+from markdown_vault_mcp.git import PullResult, PushResult, Syncer
 from markdown_vault_mcp.vault import Vault
 
 from .._icons import _TOOL_ICONS
@@ -27,11 +27,15 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _resolve_managed_strategy(vault: Vault) -> GitWriteStrategy:
-    """Resolve and validate the managed-mode git strategy from a Vault.
+def _resolve_managed_strategy(vault: Vault) -> Syncer:
+    """Resolve and validate the managed-mode git syncer from a Vault.
+
+    Gates on the :class:`~markdown_vault_mcp.git.Syncer` seam rather than the
+    concrete strategy class (#1229), so the check is about what the store can
+    do, not which class implements it.
 
     Returns:
-        The Vault's :class:`GitWriteStrategy` if it's in managed mode.
+        The Vault's syncer if it is in managed mode.
 
     Raises:
         ValueError: If the deployment isn't wired with a managed git
@@ -40,7 +44,7 @@ def _resolve_managed_strategy(vault: Vault) -> GitWriteStrategy:
     # The MCP layer is a trusted consumer of Vault internals — adding
     # a public accessor for this single tool would be scope creep.
     strategy = vault._git_strategy
-    if not isinstance(strategy, GitWriteStrategy) or not strategy._managed:
+    if not isinstance(strategy, Syncer) or not strategy.is_managed:
         raise ValueError(
             "git_sync requires a managed git deployment.  Set "
             "MARKDOWN_VAULT_MCP_GIT_REPO_URL to enable it."
@@ -48,7 +52,7 @@ def _resolve_managed_strategy(vault: Vault) -> GitWriteStrategy:
     return strategy
 
 
-async def _get_branch_name(strategy: GitWriteStrategy, git_root: Path) -> str:
+async def _get_branch_name(strategy: Syncer, git_root: Path) -> str:
     """Return the current branch name, falling back to ``"HEAD"`` on failure.
 
     Used by :func:`git_sync` to populate the ``branch`` field of the
@@ -56,12 +60,8 @@ async def _get_branch_name(strategy: GitWriteStrategy, git_root: Path) -> str:
     git itself; this helper's fallback covers the rarer cases where
     git invocation fails entirely (binary missing, transient FS error).
     """
-
-    def _read_branch() -> str:
-        return strategy._git(git_root, "rev-parse", "--abbrev-ref", "HEAD").strip()
-
     try:
-        return await asyncio.to_thread(_read_branch)
+        return await asyncio.to_thread(strategy.branch_name, git_root)
     except (subprocess.CalledProcessError, FileNotFoundError):
         # Narrow the catch per CLAUDE.md's logging standard so a real bug
         # (e.g. AttributeError) still propagates.
@@ -120,9 +120,9 @@ async def _reindex_after_pull(vault: Vault, pull_dict: dict[str, Any]) -> None:
 
     ``force_pull`` only mutates the working tree; without this call,
     ``search`` / ``list_documents`` / ``get_context`` would serve stale
-    data until the next write.  Mirrors the periodic pull loop's
-    ``on_pull`` callback in :meth:`GitWriteStrategy._pull_loop` —
-    same ``pause_writes()`` + ``reindex()`` pattern.
+    data until the next write.  Mirrors the ``on_pull`` callback the
+    store's own periodic pull loop fires — same ``pause_writes()`` +
+    ``reindex()`` pattern.
 
     On reindex failure: the pull side-effect already happened (HEAD
     moved, files on disk), so failing the whole tool would hide the
@@ -155,14 +155,14 @@ async def _reindex_after_pull(vault: Vault, pull_dict: dict[str, Any]) -> None:
 
 
 async def _run_pull_leg(
-    strategy: GitWriteStrategy,
+    strategy: Syncer,
     vault: Vault,
     *,
     dry_run: bool,
 ) -> dict[str, Any]:
     """Run the pull leg of ``git_sync`` and return its response dict.
 
-    Calls :meth:`GitWriteStrategy.force_pull`, projects the result,
+    Calls :meth:`~markdown_vault_mcp.git.Syncer.force_pull`, projects the result,
     and triggers a reindex when HEAD actually moved (skipped on
     dry-run and on failure).  The reindex's own failure is surfaced
     on the returned dict, not raised.
@@ -188,7 +188,7 @@ async def _run_pull_leg(
     return pull_dict
 
 
-async def _run_push_leg(strategy: GitWriteStrategy, *, dry_run: bool) -> dict[str, Any]:
+async def _run_push_leg(strategy: Syncer, *, dry_run: bool) -> dict[str, Any]:
     """Run the push leg of ``git_sync`` and return its response dict."""
     push_result = await asyncio.to_thread(strategy.force_push, dry_run=dry_run)
     return _format_push_dict(push_result)
@@ -377,8 +377,8 @@ def register(mcp: FastMCP) -> None:
     ) -> dict[str, Any]:
         """Synchronously reconcile the local clone with ``origin``.
 
-        Composes :meth:`GitWriteStrategy.force_pull` and
-        :meth:`GitWriteStrategy.force_push` behind a single tool call so
+        Composes :meth:`~markdown_vault_mcp.git.Syncer.force_pull` and
+        :meth:`~markdown_vault_mcp.git.Syncer.force_push` behind a single tool call so
         an operator can request "pull then push" with one round-trip.
         Only available on managed git deployments
         (``MARKDOWN_VAULT_MCP_GIT_REPO_URL`` set).
@@ -398,7 +398,7 @@ def register(mcp: FastMCP) -> None:
         Args:
             direction: ``"pull"``, ``"push"``, or ``"both"`` (default).
             dry_run: When ``True``, projects pull without moving HEAD.
-                See :meth:`GitWriteStrategy.force_push` for why this is
+                See :meth:`~markdown_vault_mcp.git.Syncer.force_push` for why this is
                 a no-op on the push leg.
 
         Returns:
@@ -426,15 +426,15 @@ def register(mcp: FastMCP) -> None:
 
         Raises:
             ValueError: When the underlying strategy is not a managed
-                :class:`GitWriteStrategy` (i.e. the deployment is not
+                :class:`~markdown_vault_mcp.git.Syncer` (i.e. the deployment is not
                 wired with ``MARKDOWN_VAULT_MCP_GIT_REPO_URL``).
         """
         strategy = _resolve_managed_strategy(vault)
-        git_root = strategy._resolve_force_repo()
+        git_root = strategy.resolve_force_repo()
 
         result: dict[str, Any] = {
             "direction": direction,
-            "head_sha": await asyncio.to_thread(strategy._head_sha, git_root),
+            "head_sha": await asyncio.to_thread(strategy.head_sha, git_root),
             "branch": await _get_branch_name(strategy, git_root),
             "pull": None,
             "push": None,
@@ -457,7 +457,7 @@ def register(mcp: FastMCP) -> None:
                 # Refresh head_sha defensively (today's force_pull leaves
                 # HEAD in place on failure, but allowed to move).
                 result["head_sha"] = await asyncio.to_thread(
-                    strategy._head_sha, git_root
+                    strategy.head_sha, git_root
                 )
                 return result
 
@@ -467,5 +467,5 @@ def register(mcp: FastMCP) -> None:
         # HEAD may have moved (pull leg advanced it).  Refresh once at the
         # end so the caller sees the post-sync state regardless of which
         # legs ran.
-        result["head_sha"] = await asyncio.to_thread(strategy._head_sha, git_root)
+        result["head_sha"] = await asyncio.to_thread(strategy.head_sha, git_root)
         return result

--- a/src/markdown_vault_mcp/config_sections/_assembly.py
+++ b/src/markdown_vault_mcp/config_sections/_assembly.py
@@ -128,14 +128,10 @@ def _build_git_strategy(
     or disables them in lockstep.
     """
     git = config.git
-    # Register the OIDC claim keys with the identity layer: claims are
-    # resolved at the MCP tool edge into a Principal (#1160), not by the
-    # strategy itself (whose dispatcher thread has no request token, #1218).
-    # The kwargs below still carry the keys for the startup identity warning.
-    configure_identity_claims(
-        name_claim=git.commit_name_claim,
-        email_claim=git.commit_email_claim,
-    )
+    # The claim kwargs below no longer drive claim extraction — they inform
+    # only the startup identity warning. Registration with the identity layer
+    # happens in ``to_vault_instances`` (#1231), not here: configuring
+    # identity is not the git builder's job.
     return GitWriteStrategy(
         token=token,
         repo_url=repo_url,
@@ -332,6 +328,15 @@ def to_vault_instances(config: ProjectConfig) -> VaultInstances:
     """
     provider = _resolve_embedding_provider(config)
     summarizer = _resolve_summarizer(config)
+    # Register the OIDC claim keys with the identity layer, which resolves
+    # them at the MCP tool edge into a Principal (#1160) — the strategy's own
+    # dispatcher thread has no request token (#1218). Done here rather than
+    # inside the git-strategy builder so the identity and versioning seams
+    # stay separate at their construction point (#1231).
+    configure_identity_claims(
+        name_claim=config.git.commit_name_claim,
+        email_claim=config.git.commit_email_claim,
+    )
     git_strategy, git_pull_interval_s = _resolve_git(config)
     return VaultInstances(
         embedding_provider=provider,

--- a/src/markdown_vault_mcp/git/__init__.py
+++ b/src/markdown_vault_mcp/git/__init__.py
@@ -32,6 +32,12 @@ from markdown_vault_mcp.git._run import (
     _find_git_root,  # noqa: F401 -- re-exported for the historic import surface
 )
 from markdown_vault_mcp.git.bootstrap import RepoBootstrap
+from markdown_vault_mcp.git.interfaces import (
+    HistorySource,
+    Syncer,
+    VersionedStore,
+    Versioner,
+)
 from markdown_vault_mcp.git.push_scheduler import PushScheduler
 from markdown_vault_mcp.git.strategy import (  # noqa: F401 -- re-exported for the historic import surface
     GitWriteStrategy,
@@ -65,9 +71,13 @@ __all__ = [
     "PUSH_REASON_NO_REMOTE",
     "PUSH_REASON_PUSH_FAILED",
     "GitWriteStrategy",
+    "HistorySource",
     "PullResult",
     "PushResult",
     "PushScheduler",
     "RepoBootstrap",
+    "Syncer",
+    "VersionedStore",
+    "Versioner",
     "git_write_strategy",
 ]

--- a/src/markdown_vault_mcp/git/interfaces.py
+++ b/src/markdown_vault_mcp/git/interfaces.py
@@ -1,0 +1,286 @@
+"""Narrow protocols for the versioned-filestore seam (#1229).
+
+``GitWriteStrategy`` carries three concerns that its consumers want in
+different combinations: **history** (log/diff), **syncing** (pull/push), and
+**versioning** (the per-write commit).  ``GitQueryManager`` reads history and
+nothing else; the webhook pulls and nothing else; the write path commits and
+syncs.  These protocols make that split explicit so each consumer depends on
+the surface it actually uses.
+
+Deliberately **one implementation object, three interfaces** — not three
+objects.  ``GitWriteStrategy`` composes ``RepoBootstrap`` and ``PushScheduler``
+over a single shared :class:`threading.Lock`, and :meth:`Vault.close` tells the
+commit callback from the store by object identity (``on_write is
+git_strategy``).  Splitting the object would break both; splitting the *type*
+costs nothing.
+
+The module imports nothing at runtime beyond ``typing``, which keeps the
+``git`` package free of a ``fastmcp`` dependency (asserted by a guard test) and
+lets any consumer depend on the seam without pulling in the implementation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import contextlib
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from markdown_vault_mcp._identity import Principal
+    from markdown_vault_mcp.git.types import PullResult, PushResult
+    from markdown_vault_mcp.types import CommitDiff, HistoryEntry, WriteOperation
+
+__all__ = [
+    "HistorySource",
+    "Syncer",
+    "VersionedStore",
+    "Versioner",
+]
+
+
+@runtime_checkable
+class HistorySource(Protocol):
+    """Read-only access to a document's revision history.
+
+    The narrowest of the three facets: ``GitQueryManager`` depends on this and
+    nothing else, so a backend that can answer "what changed, and when" is
+    enough to serve the history and diff tools.
+    """
+
+    def get_file_history(
+        self,
+        repo_path: Path,
+        path: Path | None,
+        since: str | None,
+        limit: int,
+        until: str | None = None,
+        *,
+        is_dir: bool = False,
+    ) -> list[HistoryEntry]:
+        """Return commits touching *path*, newest first.
+
+        Args:
+            repo_path: The working tree to query.
+            path: The file or directory to filter by, or ``None`` for the
+                whole tree.
+            since: Lower bound on commit time, in any form the backend
+                accepts, or ``None`` for unbounded.
+            limit: Maximum number of entries to return.
+            until: Upper bound on commit time, or ``None`` for unbounded.
+            is_dir: Whether *path* names a directory rather than a file.
+
+        Returns:
+            The matching history entries, newest first.
+        """
+        ...
+
+    def get_file_diff(
+        self,
+        repo_path: Path,
+        path: Path,
+        ref: str | None,
+        per_commit: bool,
+        since_timestamp: str | None = None,
+        limit: int | None = None,
+        *,
+        summarize_binary: bool = False,
+    ) -> str | list[CommitDiff]:
+        """Return the changes to *path* since *ref* or *since_timestamp*.
+
+        Args:
+            repo_path: The working tree to query.
+            path: The file to diff.
+            ref: The revision to diff against, or ``None`` when
+                *since_timestamp* is supplied instead.
+            per_commit: Whether to return one diff per commit rather than a
+                single aggregate diff.
+            since_timestamp: Lower bound on commit time, used in place of
+                *ref*.
+            limit: Maximum number of commits to include, or ``None``.
+            summarize_binary: Whether to replace binary diffs with a summary
+                line.
+
+        Returns:
+            A unified diff when *per_commit* is false, else one entry per
+            commit.
+        """
+        ...
+
+
+@runtime_checkable
+class Syncer(Protocol):
+    """Replication against a remote, plus the lifecycle that drives it.
+
+    Carries the pull/push surface *and* the loop lifecycle, because the two
+    consumers of this facet — :class:`Vault` and the ``git_sync`` tool — use
+    them together; a backend that syncs is also the thing that has to be
+    started, flushed, and closed.
+    """
+
+    @property
+    def is_managed(self) -> bool:
+        """Whether this store owns a managed clone of a remote repository.
+
+        The ``git_sync`` tool is only meaningful for a managed deployment, and
+        gates on this.
+        """
+        ...
+
+    def force_pull(self, *, dry_run: bool = False) -> PullResult:
+        """Pull from the remote synchronously.
+
+        Args:
+            dry_run: Report what a pull would do without changing the tree.
+
+        Returns:
+            The structured outcome, including a reason code when no pull ran.
+        """
+        ...
+
+    def force_push(self, *, dry_run: bool = False) -> PushResult:
+        """Push local commits to the remote synchronously.
+
+        Args:
+            dry_run: Report what a push would do without contacting the
+                remote.
+
+        Returns:
+            The structured outcome, including a reason code when no push ran.
+        """
+        ...
+
+    def sync_once(self, repo_path: Path) -> bool:
+        """Fetch and fast-forward once.
+
+        Args:
+            repo_path: The working tree to update.
+
+        Returns:
+            ``True`` when the local head advanced.
+        """
+        ...
+
+    def start(
+        self,
+        *,
+        repo_path: Path,
+        pull_interval_s: int,
+        on_pull: Callable[[], object] | None = None,
+    ) -> None:
+        """Start the periodic background pull loop.
+
+        Args:
+            repo_path: The working tree to keep in sync.
+            pull_interval_s: Seconds between pulls; non-positive disables the
+                loop.
+            on_pull: Called after a pull that advanced the head, so the owner
+                can reindex.
+        """
+        ...
+
+    def stop(self) -> None:
+        """Stop the background pull loop, leaving the store usable."""
+        ...
+
+    def flush(self) -> None:
+        """Block until any deferred push has completed."""
+        ...
+
+    def close(self) -> None:
+        """Flush pending work and release resources permanently."""
+        ...
+
+    def set_write_quiescer(
+        self,
+        pause_writes: Callable[[], contextlib.AbstractContextManager[None]],
+        drain_writes: Callable[[], bool],
+    ) -> None:
+        """Wire the callables that hold writes still during a pull.
+
+        Args:
+            pause_writes: Context manager suspending new writes for its
+                duration.
+            drain_writes: Blocks until in-flight writes finish, returning
+                whether the queue drained.
+        """
+        ...
+
+    def resolve_force_repo(self) -> Path:
+        """Return the working tree the ``force_*`` methods operate on.
+
+        Raises:
+            RuntimeError: When the store was constructed without one.
+        """
+        ...
+
+    def head_sha(self, git_root: Path) -> str:
+        """Return the current head revision of *git_root*.
+
+        Args:
+            git_root: The working tree to read.
+
+        Returns:
+            The full revision identifier.
+        """
+        ...
+
+    def branch_name(self, git_root: Path) -> str:
+        """Return the checked-out branch name of *git_root*.
+
+        Args:
+            git_root: The working tree to read.
+
+        Returns:
+            The branch name; a detached head yields ``"HEAD"``.
+        """
+        ...
+
+
+@runtime_checkable
+class Versioner(Protocol):
+    """Commits a single write, attributed to the acting principal.
+
+    Structurally identical to
+    :class:`~markdown_vault_mcp.types.PrincipalAwareWriteCallback`, which the
+    write-callback dispatcher already types against — the two are
+    interchangeable, since protocols match by shape.  Restated here rather
+    than subclassed so this module needs no runtime import, keeping the seam
+    depending on nothing but ``typing``.
+    """
+
+    accepts_principal: bool
+
+    def __call__(
+        self,
+        path: Path,
+        content: str,
+        operation: WriteOperation,
+        *,
+        old_path: Path | None = None,
+        principal: Principal | None = None,
+    ) -> None:
+        """Commit one write, optionally told who performed it.
+
+        Args:
+            path: The file that changed.
+            content: Its new content; ignored by backends that read the file.
+            operation: Which kind of write occurred.
+            old_path: The previous path, for a rename.
+            principal: Who performed the write, for attribution.
+        """
+        ...
+
+
+@runtime_checkable
+class VersionedStore(HistorySource, Syncer, Versioner, Protocol):
+    """All three facets on one object — what :class:`Vault` actually holds.
+
+    The vault receives the same object twice: as ``git_strategy`` for history
+    and syncing, and as ``on_write`` for the commit.  That is deliberate, and
+    :meth:`Vault.close` relies on it — it compares the two by identity to
+    avoid closing one object twice.  Consumers should depend on the single
+    facet they use; this composition exists for the owner that holds all of
+    them.
+    """

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -466,7 +466,7 @@ class GitWriteStrategy:
             ``commits_pulled=0``, ``to_sha`` set to the post-operation
             HEAD, and the provided ``reason`` / ``conflict_files``.
         """
-        new_head = self._head_sha(git_root)
+        new_head = self.head_sha(git_root)
         self._lfs_pull(env=env)
         return PullResult(
             applied=True,
@@ -482,8 +482,21 @@ class GitWriteStrategy:
     # Synchronous force-trigger helpers (used by the ``git_sync`` MCP tool)
     # ------------------------------------------------------------------
 
-    def _resolve_force_repo(self) -> Path:
+    @property
+    def is_managed(self) -> bool:
+        """Whether this strategy owns a managed clone of a remote repository.
+
+        Part of the :class:`~markdown_vault_mcp.git.interfaces.Syncer` seam
+        (#1229): the ``git_sync`` tool gates on it, and did so by reading the
+        private attribute before the promotion.
+        """
+        return self._managed
+
+    def resolve_force_repo(self) -> Path:
         """Return the working tree path used by ``force_*`` methods.
+
+        Returns:
+            The configured working tree.
 
         Raises:
             RuntimeError: When no ``repo_path`` was configured at
@@ -498,9 +511,31 @@ class GitWriteStrategy:
             )
         return self._repo_path
 
-    def _head_sha(self, git_root: Path) -> str:
-        """Return the current HEAD SHA of *git_root*."""
+    def head_sha(self, git_root: Path) -> str:
+        """Return the current HEAD SHA of *git_root*.
+
+        Args:
+            git_root: The working tree to read.
+
+        Returns:
+            The full HEAD SHA.
+        """
         return self._git(git_root, "rev-parse", "HEAD").strip()
+
+    def branch_name(self, git_root: Path) -> str:
+        """Return the checked-out branch name of *git_root*.
+
+        A detached HEAD yields ``"HEAD"`` from git itself.  Failures to invoke
+        git at all propagate; the caller decides whether a fallback is
+        appropriate.
+
+        Args:
+            git_root: The working tree to read.
+
+        Returns:
+            The branch name.
+        """
+        return self._git(git_root, "rev-parse", "--abbrev-ref", "HEAD").strip()
 
     def _git(
         self,
@@ -603,7 +638,7 @@ class GitWriteStrategy:
         ``"pull_disabled"`` **before running any git command** (#1128).
         Without that gate the pipeline ran ``git fetch origin`` on a
         remoteless checkout (answering ``"fetch_failed"``, which reads as
-        retryable) and raised ``CalledProcessError`` out of ``_head_sha``
+        retryable) and raised ``CalledProcessError`` out of ``head_sha``
         on a vault that is not a git repository at all. ``enable_pull``
         gated only the periodic loop before; it now gates every pull.
 
@@ -634,7 +669,7 @@ class GitWriteStrategy:
                 to_sha="",
                 reason=PULL_REASON_PULL_DISABLED,
             )
-        git_root = self._resolve_force_repo()
+        git_root = self.resolve_force_repo()
         return self._pull_pipeline(git_root, dry_run=dry_run)
 
     def _pull_pipeline(
@@ -665,7 +700,7 @@ class GitWriteStrategy:
         env = self._git_env()
         try:
             with self._quiesce_writes(skip=dry_run), self._lock:
-                from_sha = self._head_sha(git_root)
+                from_sha = self.head_sha(git_root)
 
                 # Always fetch first — both dry-run and real-pull need the
                 # remote-tracking ref refreshed before comparing SHAs.
@@ -775,7 +810,7 @@ class GitWriteStrategy:
                     )
 
                 # Fast-forward succeeded.  ``remote_sha`` is the new HEAD —
-                # no need to re-read it via ``_head_sha``.
+                # no need to re-read it via ``head_sha``.
                 self._lfs_pull(env=env)
                 return PullResult(
                     applied=True,
@@ -884,7 +919,7 @@ class GitWriteStrategy:
 
             # Rebase has already completed via ``git rebase --continue`` — HEAD
             # has advanced even if the sibling-files commit below fails.
-            actual_head = self._head_sha(git_root)
+            actual_head = self.head_sha(git_root)
             written = conflict.write_conflict_files(
                 git_root,
                 saved,
@@ -973,10 +1008,10 @@ class GitWriteStrategy:
             RuntimeError: When the strategy was constructed without
                 ``repo_path``.
         """
-        git_root = self._resolve_force_repo()
+        git_root = self.resolve_force_repo()
 
         with self._lock:
-            local_head = self._head_sha(git_root)
+            local_head = self.head_sha(git_root)
 
             # Resolve the remote-tracking SHA before the push.  Mirrors
             # :meth:`force_pull` — derive ``origin/<branch>`` from the current

--- a/src/markdown_vault_mcp/indexing/coordinator.py
+++ b/src/markdown_vault_mcp/indexing/coordinator.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
 
-    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.interfaces import KeywordIndex
     from markdown_vault_mcp.managers.index import IndexManager
 
 logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class IndexWriteCoordinator:
     def __init__(
         self,
         *,
-        fts: FTSIndex,
+        fts: KeywordIndex,
         index_mgr: IndexManager,
         index_path: Path | str | None,
         file_write_lock: threading.RLock,

--- a/src/markdown_vault_mcp/interfaces.py
+++ b/src/markdown_vault_mcp/interfaces.py
@@ -1,0 +1,388 @@
+"""Storage protocols for the search/index seam (#1230).
+
+The managers depend on three distinct concepts, all currently served by two
+concrete classes:
+
+- :class:`KeywordIndex` — the relational document store plus full-text search
+  and the build-state bookkeeping the indexing pipeline keeps.
+- :class:`GraphStore` — the link graph.  Distinct from search because it
+  answers a different question: *structure* (what links to what) rather than
+  *relevance* (what matches a query).
+- :class:`VectorStore` — the semantic surface.
+
+``FTSIndex`` implements the first two over one SQLite database and
+``VectorIndex`` implements the third over numpy; both satisfy these protocols
+structurally, without inheriting from them.  This mirrors the move already
+made for the embedding *provider*
+(:class:`~markdown_vault_mcp.providers.EmbeddingProvider`) and applies it to
+the storage that provider feeds — which is what the design doc's standing note
+about evaluating a different vector backend at scale would need.
+
+**Membership rule:** each protocol carries exactly what its consumers call
+today, not everything its current implementation happens to expose.  Grow one
+when a consumer needs more, rather than up front — a protocol wider than its
+consumers is a god interface with extra steps.
+
+The module imports nothing at runtime beyond ``typing``, so depending on the
+seam never drags in an implementation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+    from pathlib import Path
+
+    from markdown_vault_mcp.fts_index import ChunkingMeta
+    from markdown_vault_mcp.types import (
+        FTSResult,
+        ParsedNote,
+        SkippedFile,
+        SubtreeNote,
+        TocEntry,
+    )
+
+__all__ = [
+    "GraphStore",
+    "KeywordGraphIndex",
+    "KeywordIndex",
+    "VectorStore",
+]
+
+
+@runtime_checkable
+class KeywordIndex(Protocol):
+    """The document store: full-text search, enumeration, and build state.
+
+    Covers what the managers need to put documents in, get them back out by
+    path or query, enumerate them, and track how far a build got.
+    """
+
+    # -- search ---------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        folder: str | None = None,
+        filters: dict[str, str] | None = None,
+        snippet_words: int | None = None,
+    ) -> list[FTSResult]:
+        """Return chunks matching *query*, best first.
+
+        Args:
+            query: The full-text query.
+            limit: Maximum number of results.
+            folder: Restrict to this folder, or ``None`` for the whole vault.
+            filters: Frontmatter field/value pairs a result must match.
+            snippet_words: Approximate snippet length, or ``None`` for the
+                backend default.
+
+        Returns:
+            The matching chunks, ranked.
+        """
+        ...
+
+    # -- reads ----------------------------------------------------------
+
+    def get_note(self, path: str) -> dict[str, Any] | None:
+        """Return the stored row for *path*, or ``None`` if absent."""
+        ...
+
+    def list_notes(self, *, folder: str | None = None) -> list[dict[str, Any]]:
+        """Return every stored note, optionally restricted to *folder*."""
+        ...
+
+    def list_folders(self) -> list[str]:
+        """Return every folder that contains at least one note."""
+        ...
+
+    def list_field_values(self, field: str) -> list[str]:
+        """Return the distinct values indexed for frontmatter *field*."""
+        ...
+
+    def get_recent(
+        self, *, limit: int = 20, folder: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Return the most recently modified notes, newest first."""
+        ...
+
+    def list_chunks(self) -> list[dict[str, Any]]:
+        """Return every stored chunk, for embedding and reconciliation."""
+        ...
+
+    def get_toc(self, path: str, *, max_level: int | None = None) -> list[TocEntry]:
+        """Return the heading outline of the note at *path*."""
+        ...
+
+    def get_subtree_toc(
+        self, prefix: str, *, max_level: int | None = None, max_notes: int = 200
+    ) -> tuple[list[SubtreeNote], bool]:
+        """Return outlines for every note under *prefix*.
+
+        Returns:
+            The notes and whether *max_notes* truncated the result.
+        """
+        ...
+
+    # -- counts ---------------------------------------------------------
+
+    def count_documents(self) -> int:
+        """Return the number of indexed documents."""
+        ...
+
+    def count_chunks(self) -> int:
+        """Return the number of indexed chunks."""
+        ...
+
+    def get_chunk_counts(self, paths: Iterable[str]) -> dict[str, int]:
+        """Return the chunk count for each of *paths*."""
+        ...
+
+    def has_documents(self) -> bool:
+        """Return whether the index holds any document at all."""
+        ...
+
+    # -- writes ---------------------------------------------------------
+
+    def upsert_note(self, note: ParsedNote) -> int:
+        """Insert or replace *note*, returning the number of chunks stored."""
+        ...
+
+    def delete_by_path(self, path: str) -> int:
+        """Remove the note at *path*, returning the number of chunks dropped."""
+        ...
+
+    def optimize(self) -> bool:
+        """Compact the index, returning whether the backend did any work."""
+        ...
+
+    # -- tombstones (#1129) ---------------------------------------------
+
+    def upsert_tombstone(
+        self, skip: SkippedFile, *, content_hash: str, modified_at: float
+    ) -> None:
+        """Record that a file exists but was deliberately not indexed.
+
+        Args:
+            skip: Why the file was skipped.
+            content_hash: The hash the skip decision was made against.
+            modified_at: The file's modification time at that point.
+        """
+        ...
+
+    def get_tombstone(self, path: str) -> dict[str, Any] | None:
+        """Return the tombstone for *path*, or ``None`` if it is not skipped."""
+        ...
+
+    def list_tombstones(self) -> list[dict[str, Any]]:
+        """Return every recorded tombstone."""
+        ...
+
+    # -- build state ----------------------------------------------------
+
+    def is_build_completed(self) -> bool:
+        """Return whether a full build has finished against this index."""
+        ...
+
+    def set_build_completed(self) -> None:
+        """Mark the full build as finished."""
+        ...
+
+    def clear_build_completed(self) -> None:
+        """Clear the build-completed marker, so readiness re-gates."""
+        ...
+
+    def set_chunking_meta(
+        self,
+        *,
+        model: str | None,
+        max_chunk_chars_override: int | None,
+        title_field: str = "title",
+        searchable_fields: str = "",
+        indexed_frontmatter_fields: str = "",
+    ) -> None:
+        """Record the settings the current rows were derived under.
+
+        Args:
+            model: The embedding model in use, or ``None``.
+            max_chunk_chars_override: The configured chunk-size override.
+            title_field: The frontmatter field used as a title.
+            searchable_fields: Serialized searchable frontmatter fields.
+            indexed_frontmatter_fields: Serialized indexed frontmatter fields.
+        """
+        ...
+
+    def get_chunking_meta(self) -> ChunkingMeta:
+        """Return the settings the stored rows were derived under."""
+        ...
+
+
+@runtime_checkable
+class GraphStore(Protocol):
+    """The link graph: what points at what, and what nothing points at.
+
+    A separate concept from search — structure rather than relevance — even
+    though one SQLite database serves both today.
+    """
+
+    def get_backlinks(
+        self, path: str, *, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Return the notes linking to *path*."""
+        ...
+
+    def get_outlinks(
+        self, path: str, *, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Return the notes *path* links to."""
+        ...
+
+    def get_broken_links(self, *, folder: str | None = None) -> list[dict[str, Any]]:
+        """Return links whose target does not exist."""
+        ...
+
+    def get_orphan_notes(self) -> list[dict[str, Any]]:
+        """Return notes nothing links to."""
+        ...
+
+    def get_most_linked(self, limit: int = 10) -> list[dict[str, Any]]:
+        """Return the most linked-to notes, most first."""
+        ...
+
+    def get_connection_path(
+        self, source_path: str, target_path: str, max_depth: int = 10
+    ) -> list[str] | None:
+        """Return a shortest link path between two notes.
+
+        Args:
+            source_path: Where to start.
+            target_path: Where to end.
+            max_depth: How far to search before giving up.
+
+        Returns:
+            The paths along the route, or ``None`` when none exists within
+            *max_depth*.
+        """
+        ...
+
+    def count_links(self) -> int:
+        """Return the total number of links."""
+        ...
+
+    def count_broken_links(self) -> int:
+        """Return the number of links with no target."""
+        ...
+
+    def count_orphans(self) -> int:
+        """Return the number of notes nothing links to."""
+        ...
+
+    def resolve_vault_wikilinks(self) -> int:
+        """Resolve stored wikilink targets to real paths.
+
+        A write, unlike the rest of this protocol: link targets are only
+        resolvable once every note is present, so the indexing pipeline runs
+        this pass at the end of a build.
+
+        Returns:
+            The number of links resolved.
+        """
+        ...
+
+
+@runtime_checkable
+class KeywordGraphIndex(KeywordIndex, GraphStore, Protocol):
+    """Both facets on one object, as the SQLite backend serves them.
+
+    Several managers legitimately need both — searching and then following
+    links, for instance — and today one database answers both. Naming the
+    combination keeps those annotations honest without collapsing the two
+    concepts, so a backend that separates them stays expressible.
+    """
+
+
+@runtime_checkable
+class VectorStore(Protocol):
+    """The semantic surface: embeddings in, nearest neighbours out."""
+
+    @property
+    def count(self) -> int:
+        """Return the number of stored vectors."""
+        ...
+
+    def chunks_by_path(self) -> dict[str, list[dict[str, Any]]]:
+        """Return the stored chunk metadata, grouped by note path."""
+        ...
+
+    def add(self, texts: list[str], metadata: list[dict[str, Any]]) -> int:
+        """Embed *texts* and store them against *metadata*.
+
+        Returns:
+            The number of vectors added.
+        """
+        ...
+
+    def add_vectors(
+        self, raw_vectors: list[list[float]], metadata: list[dict[str, Any]]
+    ) -> int:
+        """Store already-computed *raw_vectors* against *metadata*.
+
+        Returns:
+            The number of vectors added.
+        """
+        ...
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        predicate: Callable[[dict[str, Any]], bool] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return the chunks most similar to *query*.
+
+        Args:
+            query: Text to embed and compare against.
+            limit: Maximum number of results.
+            predicate: Keeps only the chunks it accepts, applied before
+                *limit* so filtering does not silently shrink the result.
+
+        Returns:
+            The nearest chunks, most similar first.
+        """
+        ...
+
+    def search_by_path(
+        self,
+        path: str,
+        *,
+        limit: int = 10,
+        predicate: Callable[[dict[str, Any]], bool] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return the chunks most similar to the note at *path*.
+
+        Args:
+            path: The note to find neighbours for.
+            limit: Maximum number of results.
+            predicate: Keeps only the chunks it accepts.
+
+        Returns:
+            The nearest chunks, most similar first.
+        """
+        ...
+
+    def delete_by_path(self, path: str) -> int:
+        """Remove every vector belonging to *path*.
+
+        Returns:
+            The number of vectors removed.
+        """
+        ...
+
+    def save(self, path: Path) -> None:
+        """Persist the store to *path*."""
+        ...

--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -18,20 +18,20 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    from markdown_vault_mcp.interfaces import VectorStore
     from markdown_vault_mcp.providers import EmbeddingProvider
-    from markdown_vault_mcp.vector_index import VectorIndex
 
 
 def load_or_self_heal(
     *,
     embeddings_path: Path,
     embedding_provider: EmbeddingProvider,
-    get_vectors: Callable[[], VectorIndex | None],
-    set_vectors: Callable[[VectorIndex], None],
+    get_vectors: Callable[[], VectorStore | None],
+    set_vectors: Callable[[VectorStore], None],
     rebuild: Callable[[], object],
     logger: logging.Logger,
     embed_text_format: str = "v1",
-) -> VectorIndex:
+) -> VectorStore:
     """Load the vector sidecar into the caller's slot, self-healing corruption.
 
     Returns the cached index if ``get_vectors()`` is already populated.
@@ -64,7 +64,11 @@ def load_or_self_heal(
             this token so its save records the format.
 
     Returns:
-        A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+        The loaded store.  This function is the backend factory, so it names
+        :class:`~markdown_vault_mcp.vector_index.VectorIndex` concretely when
+        constructing one, but hands it back through the
+        :class:`~markdown_vault_mcp.interfaces.VectorStore` seam its callers
+        hold (#1230).
 
     Raises:
         ValueError: If a self-heal rebuild completes but leaves the slot empty.

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -78,7 +78,7 @@ from markdown_vault_mcp.utils.text import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
-    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.interfaces import KeywordGraphIndex
     from markdown_vault_mcp.scanner import ChunkStrategy
 
 logger = logging.getLogger(__name__)
@@ -180,7 +180,7 @@ class DocumentManager:
 
     def __init__(
         self,
-        fts: FTSIndex,
+        fts: KeywordGraphIndex,
         source_dir: Path,
         *,
         write_lock: threading.RLock,

--- a/src/markdown_vault_mcp/managers/embeddings.py
+++ b/src/markdown_vault_mcp/managers/embeddings.py
@@ -32,11 +32,10 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from markdown_vault_mcp.embed_text import EmbedTextBuilder
-    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.interfaces import KeywordIndex, VectorStore
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.scanner import ChunkStrategy
     from markdown_vault_mcp.types import ParsedNote
-    from markdown_vault_mcp.vector_index import VectorIndex
 
 logger = logging.getLogger(__name__)
 
@@ -95,13 +94,13 @@ class EmbeddingsManager:
     def __init__(
         self,
         *,
-        fts: FTSIndex,
+        fts: KeywordIndex,
         source_dir: Path,
         embeddings_path: Path | None,
         embedding_provider: EmbeddingProvider | None,
         chunk_strategy: ChunkStrategy,
-        get_vectors: Callable[[], VectorIndex | None],
-        set_vectors: Callable[[VectorIndex | None], None],
+        get_vectors: Callable[[], VectorStore | None],
+        set_vectors: Callable[[VectorStore | None], None],
         title_field: str,
         embed_text_builder: EmbedTextBuilder,
         embedding_batch_size: int = _EMBEDDING_BATCH_SIZE,
@@ -325,7 +324,7 @@ class EmbeddingsManager:
             return False
         return not stat_module.S_ISREG(st.st_mode)
 
-    def _load_vectors(self) -> VectorIndex:
+    def _load_vectors(self) -> VectorStore:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
 
         Delegates to
@@ -361,7 +360,7 @@ class EmbeddingsManager:
     # Inline reindex embedding
     # ------------------------------------------------------------------
 
-    def _embed_note_inline(self, vectors: VectorIndex, note: ParsedNote) -> int:
+    def _embed_note_inline(self, vectors: VectorStore, note: ParsedNote) -> int:
         """Embed one changed note's chunks inline, resiliently (#930).
 
         Mirrors the cold-build / convergence contract: chunks are embedded
@@ -607,7 +606,7 @@ class EmbeddingsManager:
 
     def _embed_cold_build_batches(
         self,
-        vectors: VectorIndex,
+        vectors: VectorStore,
         texts: list[str],
         meta: list[dict[str, Any]],
     ) -> int:
@@ -673,7 +672,7 @@ class EmbeddingsManager:
                 )
         return embedded
 
-    def _converge_embeddings(self, vectors: VectorIndex) -> int:
+    def _converge_embeddings(self, vectors: VectorStore) -> int:
         """Reconcile a non-empty vector index with the FTS chunk set (#665).
 
         Chunk identity is the ``(title, heading, content)`` multiset per
@@ -767,7 +766,7 @@ class EmbeddingsManager:
         return added
 
     def _diff_converge_state(
-        self, vectors: VectorIndex
+        self, vectors: VectorStore
     ) -> tuple[dict[str, list[dict[str, Any]]], list[str], list[str], list[str], int]:
         """Diff the FTS chunk set against the sidecar for convergence.
 
@@ -874,7 +873,7 @@ class EmbeddingsManager:
 
     def _reembed_converge_documents(
         self,
-        vectors: VectorIndex,
+        vectors: VectorStore,
         fts_by_path: dict[str, list[dict[str, Any]]],
         paths: list[str],
     ) -> tuple[int, int, int, int]:

--- a/src/markdown_vault_mcp/managers/embeddings.py
+++ b/src/markdown_vault_mcp/managers/embeddings.py
@@ -71,7 +71,7 @@ class EmbeddingsManager:
         embedding_provider: Provider used to generate embeddings.
         chunk_strategy: Strategy for splitting documents into chunks.
         get_vectors: Callback returning the current
-            :class:`~markdown_vault_mcp.vector_index.VectorIndex` (or
+            :class:`~markdown_vault_mcp.interfaces.VectorStore` (or
             ``None``).
         set_vectors: Callback to set the vector index on the owner.
         title_field: Frontmatter key consulted first when resolving document
@@ -325,14 +325,14 @@ class EmbeddingsManager:
         return not stat_module.S_ISREG(st.st_mode)
 
     def _load_vectors(self) -> VectorStore:
-        """Load or return the cached VectorIndex, self-healing corrupt sidecars.
+        """Load or return the cached vector store, self-healing corrupt sidecars.
 
         Delegates to
         :func:`markdown_vault_mcp.managers._vector_loader.load_or_self_heal`;
         see there for the full self-heal contract.
 
         Returns:
-            A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+            The loaded :class:`~markdown_vault_mcp.interfaces.VectorStore`.
 
         Raises:
             RuntimeError: If called without a prior ``_require_vectors()``

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -1,7 +1,7 @@
 """Git history/diff query manager.
 
 Handles read-only git queries (commit history, diffs) with dependency
-injection — receives a :class:`~markdown_vault_mcp.git.GitWriteStrategy`
+injection — receives a :class:`~markdown_vault_mcp.git.HistorySource`
 (or ``None`` when the vault is not a git repository) and the ``source_dir``,
 with no back-reference to :class:`Vault`. Sibling to
 :class:`~markdown_vault_mcp.managers.link.LinkManager`. Extracted from
@@ -23,15 +23,20 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from markdown_vault_mcp.git import GitWriteStrategy
+    from markdown_vault_mcp.git import HistorySource
     from markdown_vault_mcp.types import CommitDiff, HistoryEntry
 
 
 class GitQueryManager:
-    """Read-only git history/diff queries, backed by a ``GitWriteStrategy``.
+    """Read-only git history/diff queries, backed by a ``HistorySource``.
+
+    Depends on the narrowest of the three versioning facets (#1229): this
+    manager calls ``get_file_history`` and ``get_file_diff`` and nothing else,
+    so it is coupled to neither the commit nor the sync surface.
+    ``GitWriteStrategy`` is the implementation the git-backed vault supplies.
 
     Args:
-        git_strategy: The git strategy to query, or ``None`` when the vault's
+        git_strategy: The history source to query, or ``None`` when the vault's
             source directory is not inside a git repository (queries then
             return empty results rather than raising).
         source_dir: Absolute path to the vault root directory.
@@ -44,7 +49,7 @@ class GitQueryManager:
 
     def __init__(
         self,
-        git_strategy: GitWriteStrategy | None,
+        git_strategy: HistorySource | None,
         source_dir: Path,
         attachment_extensions: Sequence[str] | None = None,
     ) -> None:

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -41,11 +41,10 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
-    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.interfaces import KeywordGraphIndex, VectorStore
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.scanner import ChunkStrategy
     from markdown_vault_mcp.tracker import ChangeTracker
-    from markdown_vault_mcp.vector_index import VectorIndex
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +100,7 @@ class IndexManager:
 
     def __init__(
         self,
-        fts: FTSIndex,
+        fts: KeywordGraphIndex,
         tracker: ChangeTracker,
         source_dir: Path,
         *,
@@ -111,8 +110,8 @@ class IndexManager:
         exclude_patterns: list[str] | None = None,
         required_frontmatter: list[str] | None = None,
         indexed_frontmatter_fields: list[str] | None = None,
-        get_vectors: Callable[[], VectorIndex | None],
-        set_vectors: Callable[[VectorIndex | None], None],
+        get_vectors: Callable[[], VectorStore | None],
+        set_vectors: Callable[[VectorStore | None], None],
         embed_model_name: str | None = None,
         max_chunk_chars_override: int | None = None,
         title_field: str = "title",
@@ -202,7 +201,7 @@ class IndexManager:
             candidates.append((abs_path, rel_str))
         return candidates
 
-    def _load_vectors(self) -> VectorIndex:
+    def _load_vectors(self) -> VectorStore:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
 
         Thin delegation to
@@ -214,7 +213,7 @@ class IndexManager:
         """
         return self._embeddings._load_vectors()
 
-    def _embed_note_inline(self, vectors: VectorIndex, note: ParsedNote) -> int:
+    def _embed_note_inline(self, vectors: VectorStore, note: ParsedNote) -> int:
         """Embed one changed note's chunks inline, resiliently (#930).
 
         Thin delegation to
@@ -328,10 +327,10 @@ class IndexManager:
 
     def _purge_stale_excluded(
         self,
-        vectors: VectorIndex | None,
+        vectors: VectorStore | None,
         *,
         keep_paths: set[str] | None = None,
-    ) -> tuple[int, VectorIndex | None]:
+    ) -> tuple[int, VectorStore | None]:
         """Delete indexed rows that now match ``exclude_patterns`` (#255).
 
         Shared by :meth:`build_index` and :meth:`reindex`, carrying the
@@ -748,7 +747,7 @@ class IndexManager:
     def _upsert_parsed_notes(
         self,
         parsed: list[tuple[str, ParsedNote]],
-        vectors: VectorIndex | None,
+        vectors: VectorStore | None,
         *,
         added_paths: set[str],
     ) -> tuple[int, int]:

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -73,7 +73,7 @@ class IndexManager:
         indexed_frontmatter_fields: Frontmatter keys promoted to the
             ``document_tags`` table for structured filtering.
         get_vectors: Callback returning the current
-            :class:`~markdown_vault_mcp.vector_index.VectorIndex` (or
+            :class:`~markdown_vault_mcp.interfaces.VectorStore` (or
             ``None``).
         set_vectors: Callback to set the vector index on the owner.
         embed_model_name: Embedding model name in force at build time, or
@@ -202,14 +202,14 @@ class IndexManager:
         return candidates
 
     def _load_vectors(self) -> VectorStore:
-        """Load or return the cached VectorIndex, self-healing corrupt sidecars.
+        """Load or return the cached vector store, self-healing corrupt sidecars.
 
         Thin delegation to
         :meth:`~markdown_vault_mcp.managers.embeddings.EmbeddingsManager._load_vectors`
         (#1157); see there for the full contract.
 
         Returns:
-            A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+            The loaded :class:`~markdown_vault_mcp.interfaces.VectorStore`.
         """
         return self._embeddings._load_vectors()
 

--- a/src/markdown_vault_mcp/managers/link.py
+++ b/src/markdown_vault_mcp/managers/link.py
@@ -27,7 +27,7 @@ from markdown_vault_mcp.utils import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.interfaces import KeywordGraphIndex
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class LinkManager:
         source_dir: Absolute path to the vault root directory.
     """
 
-    def __init__(self, fts: FTSIndex, source_dir: Path) -> None:
+    def __init__(self, fts: KeywordGraphIndex, source_dir: Path) -> None:
         self._fts = fts
         self._source_dir = source_dir
 

--- a/src/markdown_vault_mcp/managers/link.py
+++ b/src/markdown_vault_mcp/managers/link.py
@@ -2,8 +2,10 @@
 
 Handles all link-related queries (backlinks, outlinks, broken links,
 orphans, most-linked, connection paths) with dependency injection —
-receives only :class:`~markdown_vault_mcp.fts_index.FTSIndex` and a
-``source_dir`` path, no back-reference to :class:`Vault`.
+receives only a :class:`~markdown_vault_mcp.interfaces.KeywordGraphIndex`
+and a ``source_dir`` path, no back-reference to :class:`Vault`.  It uses the
+graph facet plus one relational read (``get_note``), so it is coupled to
+neither search ranking nor the concrete SQLite backend (#1230).
 """
 
 from __future__ import annotations

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -310,7 +310,7 @@ class SearchManager:
             )
 
     def _load_vectors(self) -> VectorStore:
-        """Load or return the cached VectorIndex, self-healing corrupt sidecars.
+        """Load or return the cached vector store, self-healing corrupt sidecars.
 
         Delegates to
         :func:`markdown_vault_mcp.managers._vector_loader.load_or_self_heal`
@@ -318,7 +318,7 @@ class SearchManager:
         self-heal contract.
 
         Returns:
-            A :class:`~markdown_vault_mcp.vector_index.VectorIndex` instance.
+            The loaded :class:`~markdown_vault_mcp.interfaces.VectorStore`.
 
         Raises:
             RuntimeError: If called without a prior ``_require_vectors()``

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -83,12 +83,11 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from pathlib import Path
 
-    from markdown_vault_mcp.fts_index import FTSIndex
+    from markdown_vault_mcp.interfaces import KeywordGraphIndex, VectorStore
     from markdown_vault_mcp.managers.link import LinkManager
     from markdown_vault_mcp.okf import OkfDetector
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.types import FTSResult
-    from markdown_vault_mcp.vector_index import VectorIndex
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +175,7 @@ class SearchManager:
 
     def __init__(
         self,
-        fts: FTSIndex,
+        fts: KeywordGraphIndex,
         source_dir: Path,
         *,
         embeddings_path: Path | None = None,
@@ -222,19 +221,19 @@ class SearchManager:
         self._embed_text_format = embed_text_format
 
         # Vector index is loaded lazily (only if embeddings_path is set).
-        self._vectors: VectorIndex | None = None
+        self._vectors: VectorStore | None = None
 
     # ------------------------------------------------------------------
     # Vector index property (shared with IndexManager's EmbeddingsManager)
     # ------------------------------------------------------------------
 
     @property
-    def vectors(self) -> VectorIndex | None:
+    def vectors(self) -> VectorStore | None:
         """Return the lazily-loaded vector index, or ``None``."""
         return self._vectors
 
     @vectors.setter
-    def vectors(self, value: VectorIndex | None) -> None:
+    def vectors(self, value: VectorStore | None) -> None:
         self._vectors = value
 
     # ------------------------------------------------------------------
@@ -310,7 +309,7 @@ class SearchManager:
                 "'embeddings_path' to be configured."
             )
 
-    def _load_vectors(self) -> VectorIndex:
+    def _load_vectors(self) -> VectorStore:
         """Load or return the cached VectorIndex, self-healing corrupt sidecars.
 
         Delegates to

--- a/src/markdown_vault_mcp/server.py
+++ b/src/markdown_vault_mcp/server.py
@@ -289,7 +289,7 @@ def make_server(
     # ``to_vault_kwargs(config)`` — that call builds an embedding
     # provider (slow, GBs of memory) and may run ``git clone`` as a side
     # effect.  The runtime check inside the ``git_sync`` tool body
-    # (``isinstance(strategy, GitWriteStrategy) and strategy._managed``)
+    # (``isinstance(strategy, Syncer) and strategy.is_managed``)
     # stays aligned with this gate via the same ``config.git.repo_url``
     # value: managed mode requires an explicit remote URL.  See #220 for
     # the broader cleanup of duplicate ``to_vault_kwargs`` calls.

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
-    from markdown_vault_mcp.git import GitWriteStrategy, PullResult
+    from markdown_vault_mcp.git import PullResult, VersionedStore
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.summarizer import Summarizer
     from markdown_vault_mcp.types import (
@@ -334,7 +334,7 @@ class Vault:
         required_frontmatter: list[str] | None = None,
         chunk_strategy: str | ChunkStrategy = "heading",
         on_write: WriteCallback | None = None,
-        git_strategy: GitWriteStrategy | None = None,
+        git_strategy: VersionedStore | None = None,
         git_pull_interval_s: int = 0,
         exclude_patterns: list[str] | None = None,
         attachment_extensions: list[str] | None = None,
@@ -896,8 +896,9 @@ class Vault:
     def force_pull(self) -> PullResult | None:
         """Pull from the git remote synchronously.
 
-        Thin public facade over :meth:`GitWriteStrategy.force_pull` used by
-        the GitHub webhook handler so the strategy stays an implementation detail.
+        Thin public facade over :meth:`~markdown_vault_mcp.git.Syncer.force_pull`
+        used by the GitHub webhook handler so the store stays an implementation
+        detail.
 
         The strategy self-quiesces around its own merge: it pauses new writes
         (via the :meth:`pause_writes` callable wired in :meth:`__init__` through

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -54,12 +54,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from markdown_vault_mcp.git import PullResult, VersionedStore
+    from markdown_vault_mcp.interfaces import VectorStore
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.summarizer import Summarizer
     from markdown_vault_mcp.types import (
         WriteCallback,
     )
-    from markdown_vault_mcp.vector_index import VectorIndex
 
 logger = logging.getLogger(__name__)
 
@@ -969,12 +969,12 @@ class Vault:
         self._coordinator.require_built()
 
     @property
-    def _vectors(self) -> VectorIndex | None:
+    def _vectors(self) -> VectorStore | None:
         """Bridge property: vector index is owned by SearchManager."""
         return self._search_mgr.vectors
 
     @_vectors.setter
-    def _vectors(self, value: VectorIndex | None) -> None:
+    def _vectors(self, value: VectorStore | None) -> None:
         self._search_mgr.vectors = value
 
     # ------------------------------------------------------------------

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -5208,6 +5208,31 @@ class TestGitClaimConfig:
             # other tests' resolve_mcp_principal calls.
             _identity.configure_identity_claims(name_claim=None, email_claim=None)
 
+    def test_claims_registered_by_to_vault_instances(self, tmp_path: Path) -> None:
+        """The assembly registers claim keys, not the git-strategy builder.
+
+        The registration moved out of ``_build_git_strategy`` (#1231) so
+        configuring identity is not the git builder's job.  Pinned against
+        ``to_vault_instances`` directly, since that is now the owner.
+        """
+        from markdown_vault_mcp import _identity
+        from markdown_vault_mcp.config import ProjectConfig
+        from markdown_vault_mcp.config_sections._assembly import to_vault_instances
+
+        config = ProjectConfig(
+            source_dir=tmp_path,
+            read_only=False,
+            git_commit_name_claim="name",
+            git_commit_email_claim="email",
+        )
+        try:
+            to_vault_instances(config)
+
+            assert _identity._name_claim == "name"
+            assert _identity._email_claim == "email"
+        finally:
+            _identity.configure_identity_claims(name_claim=None, email_claim=None)
+
 
 class TestStageAndCommitAuthorSplit:
     """_stage_and_commit sets --author separately from the committer when provided."""

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -220,7 +220,7 @@ class TestForceMethodsErrorBranches:
 
     These tests target the branches the happy-path tests do not exercise:
 
-    * ``_resolve_force_repo`` raising when constructed without ``repo_path``
+    * ``resolve_force_repo`` raising when constructed without ``repo_path``
     * ``force_pull`` ``fetch_failed`` (remote URL unreachable)
     * ``force_pull`` ``no_remote`` (no upstream and no ``origin/HEAD``)
     * ``force_pull`` ``rebased`` (divergent histories on different files)

--- a/tests/test_git_interfaces.py
+++ b/tests/test_git_interfaces.py
@@ -1,0 +1,186 @@
+"""Tests for the versioning seam: the git facet protocols (#1229).
+
+Two things are pinned here.  First, that ``GitWriteStrategy`` really does
+satisfy each facet, so the annotations the consumers now carry are not merely
+decorative.  Second — the point of the seam — that the consumers accept *any*
+object of the right shape, not only that one class: the ``git_sync`` gate used
+to run ``isinstance(strategy, GitWriteStrategy)`` and read a private
+attribute, so a fake proves the coupling is genuinely gone.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from markdown_vault_mcp.git import (
+    GitWriteStrategy,
+    HistorySource,
+    Syncer,
+    VersionedStore,
+    Versioner,
+)
+
+if TYPE_CHECKING:
+    from tests.fixtures.git import GitRepoPair
+
+
+class TestProtocolConformance:
+    """``GitWriteStrategy`` implements all three facets."""
+
+    @pytest.mark.parametrize(
+        "protocol",
+        [HistorySource, Syncer, Versioner, VersionedStore],
+        ids=["history", "syncer", "versioner", "store"],
+    )
+    def test_strategy_satisfies_facet(self, protocol: type) -> None:
+        """The one implementation satisfies each narrow interface.
+
+        Constructed without ``repo_path`` so nothing touches the filesystem —
+        conformance is about the shape, not about having a repository.
+        """
+        assert isinstance(GitWriteStrategy(), protocol)
+
+    def test_unrelated_object_does_not_satisfy_syncer(self) -> None:
+        """The runtime check is a real check, not a rubber stamp."""
+        assert not isinstance(object(), Syncer)
+
+    def test_history_source_does_not_imply_syncer(self) -> None:
+        """The facets are independent: satisfying one is not satisfying all.
+
+        This is what makes the split worth having — a history-only backend is
+        expressible.
+        """
+
+        class HistoryOnly:
+            def get_file_history(self, *args: Any, **kwargs: Any) -> list[Any]: ...
+            def get_file_diff(self, *args: Any, **kwargs: Any) -> str: ...
+
+        assert isinstance(HistoryOnly(), HistorySource)
+        assert not isinstance(HistoryOnly(), Syncer)
+
+
+class TestPromotedPublicSurface:
+    """The members ``_server_tools/git.py`` used to reach for privately."""
+
+    def test_is_managed_reflects_construction(self) -> None:
+        """``is_managed`` replaces the private ``_managed`` read."""
+        assert GitWriteStrategy(managed=True).is_managed is True
+        assert GitWriteStrategy(managed=False).is_managed is False
+
+    def test_resolve_force_repo_returns_configured_path(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """The working tree comes back when one was configured."""
+        strategy = GitWriteStrategy(repo_path=git_repo_pair.local_path)
+        assert strategy.resolve_force_repo() == git_repo_pair.local_path
+
+    def test_resolve_force_repo_raises_without_repo_path(self) -> None:
+        """Without a configured tree the force_* methods have nothing to act on."""
+        with pytest.raises(RuntimeError, match="repo_path"):
+            GitWriteStrategy().resolve_force_repo()
+
+    def test_head_sha_returns_current_revision(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """``head_sha`` reads the checked-out revision of the given tree."""
+        strategy = GitWriteStrategy(repo_path=git_repo_pair.local_path)
+        sha = strategy.head_sha(git_repo_pair.local_path)
+        assert re.fullmatch(r"[0-9a-f]{40}", sha)
+
+    def test_branch_name_returns_checked_out_branch(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """``branch_name`` holds the body the git_sync tool used to inline."""
+        strategy = GitWriteStrategy(repo_path=git_repo_pair.local_path)
+        assert strategy.branch_name(git_repo_pair.local_path) == "main"
+
+
+class _FakeSyncer:
+    """A minimal stand-in that satisfies :class:`Syncer` without inheriting it.
+
+    Only the members the managed-mode gate touches need real behaviour; the
+    rest exist so the structural check passes.
+    """
+
+    def __init__(self, *, is_managed: bool) -> None:
+        self._is_managed = is_managed
+
+    @property
+    def is_managed(self) -> bool:
+        return self._is_managed
+
+    def force_pull(self, *, dry_run: bool = False) -> Any: ...
+    def force_push(self, *, dry_run: bool = False) -> Any: ...
+    def sync_once(self, repo_path: Path) -> bool: ...
+    def start(self, **kwargs: Any) -> None: ...
+    def stop(self) -> None: ...
+    def flush(self) -> None: ...
+    def close(self) -> None: ...
+    def set_write_quiescer(self, *args: Any) -> None: ...
+    def resolve_force_repo(self) -> Path: ...
+    def head_sha(self, git_root: Path) -> str: ...
+    def branch_name(self, git_root: Path) -> str: ...
+
+
+class TestManagedGateAcceptsAnySyncer:
+    """The ``git_sync`` gate depends on the seam, not on the class."""
+
+    def test_fake_syncer_passes_the_managed_gate(self) -> None:
+        """A non-GitWriteStrategy store in managed mode is accepted.
+
+        Before #1229 this raised, because the gate ran an ``isinstance``
+        against the concrete class.
+        """
+        from markdown_vault_mcp._server_tools.git import _resolve_managed_strategy
+
+        fake = _FakeSyncer(is_managed=True)
+        vault = type("_V", (), {"_git_strategy": fake})()
+
+        assert _resolve_managed_strategy(vault) is fake  # type: ignore[arg-type]
+
+    def test_unmanaged_syncer_still_rejected(self) -> None:
+        """Widening the type did not widen what counts as managed."""
+        from markdown_vault_mcp._server_tools.git import _resolve_managed_strategy
+
+        vault = type("_V", (), {"_git_strategy": _FakeSyncer(is_managed=False)})()
+
+        with pytest.raises(ValueError, match="managed git deployment"):
+            _resolve_managed_strategy(vault)  # type: ignore[arg-type]
+
+    def test_absent_strategy_still_rejected(self) -> None:
+        """A vault with no git store at all keeps failing the same way."""
+        from markdown_vault_mcp._server_tools.git import _resolve_managed_strategy
+
+        vault = type("_V", (), {"_git_strategy": None})()
+
+        with pytest.raises(ValueError, match="managed git deployment"):
+            _resolve_managed_strategy(vault)  # type: ignore[arg-type]
+
+
+def test_interfaces_module_imports_nothing_at_runtime() -> None:
+    """The seam stays dependency-free so any driver can depend on it.
+
+    ``git/`` already may not import ``fastmcp``; this narrows it further for
+    the interface module, whose whole point is to be importable without
+    dragging in an implementation.
+    """
+    source = (
+        Path(__file__).parent.parent
+        / "src"
+        / "markdown_vault_mcp"
+        / "git"
+        / "interfaces.py"
+    ).read_text()
+    runtime_imports = [
+        line
+        for line in source.splitlines()
+        if re.match(r"^(import|from)\s", line)
+        if "__future__" not in line and "typing" not in line
+    ]
+    assert runtime_imports == [], (
+        f"git/interfaces.py gained runtime imports: {runtime_imports}"
+    )

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -410,7 +410,7 @@ class TestGitSync:
             push_called = {"count": 0}
 
             def _failing_pull(*_args: object, **_kwargs: object) -> PullResult:
-                head = strategy._head_sha(strategy._resolve_force_repo())
+                head = strategy.head_sha(strategy.resolve_force_repo())
                 return PullResult(
                     applied=False,
                     fast_forward=False,

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -490,7 +490,7 @@ def test_force_pull_is_inert_without_remote_sync(tmp_path: Path) -> None:
 def test_force_pull_on_a_non_git_directory_does_not_raise(tmp_path: Path) -> None:
     """The second reported shape: a plain directory, not a git repo (#1128).
 
-    ``_pull_pipeline``'s ``_head_sha`` raised ``CalledProcessError`` here,
+    ``_pull_pipeline``'s ``head_sha`` raised ``CalledProcessError`` here,
     which escaped the webhook handler as an unhandled 500.
     """
     from markdown_vault_mcp.git.strategy import GitWriteStrategy

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -49,7 +49,7 @@ def _patch_context(
 
 
 class TestPrincipalOkfActor:
-    """okf_actor keeps exact parity with resolve_write_actor's rules."""
+    """okf_actor implements the design-§6 actor rules."""
 
     def test_human_with_subject_is_human_actor(self) -> None:
         p = Principal(subject="peter", display_name=None, email=None, kind="human")
@@ -193,24 +193,6 @@ class TestOkfResolversPreferBoundPrincipal:
     The context-reading fallback path is pinned — unmodified — by
     ``tests/test_okf_write.py``; these tests cover the new preferred branch.
     """
-
-    def test_resolve_write_actor_uses_principal(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from markdown_vault_mcp._okf_write import resolve_write_actor
-
-        # get_subject would say something else entirely; the binding wins.
-        monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: "other")
-        p = Principal(subject="peter", display_name=None, email=None, kind="human")
-        with bound_principal(p):
-            assert resolve_write_actor() == "human:peter"
-
-    def test_resolve_write_actor_local_principal_is_tool_actor(self) -> None:
-        from markdown_vault_mcp._okf_write import resolve_write_actor
-
-        p = Principal(subject=None, display_name=None, email=None, kind="local")
-        with bound_principal(p):
-            assert resolve_write_actor().startswith("markdown-vault-mcp/")
 
     def test_resolve_human_subject_uses_principal(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,0 +1,165 @@
+"""Tests for the search/index storage seam (#1230).
+
+These pin two claims the annotations make.  That ``FTSIndex`` and
+``VectorIndex`` really satisfy the protocols the managers are now typed
+against — mypy checks this statically at the composition root, but a runtime
+check catches a drift a `type: ignore` could hide.  And that the split is
+real: satisfying the keyword facet does not imply satisfying the graph facet,
+which is what makes a backend that separates them expressible.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from markdown_vault_mcp.fts_index import FTSIndex
+from markdown_vault_mcp.interfaces import (
+    GraphStore,
+    KeywordGraphIndex,
+    KeywordIndex,
+    VectorStore,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def fts(tmp_path: Path) -> Iterator[FTSIndex]:
+    """A real on-disk index, closed afterwards."""
+    index = FTSIndex(db_path=str(tmp_path / "index.db"))
+    yield index
+    index.close()
+
+
+class TestFTSIndexConformance:
+    """``FTSIndex`` serves both the keyword and graph facets."""
+
+    @pytest.mark.parametrize(
+        "protocol",
+        [KeywordIndex, GraphStore, KeywordGraphIndex],
+        ids=["keyword", "graph", "combined"],
+    )
+    def test_satisfies_facet(self, fts: FTSIndex, protocol: type) -> None:
+        """One SQLite backend answers both concepts today."""
+        assert isinstance(fts, protocol)
+
+
+class TestVectorIndexConformance:
+    """``VectorIndex`` serves the semantic facet."""
+
+    def test_satisfies_vector_store(self) -> None:
+        """The numpy implementation matches the seam the managers hold."""
+        from markdown_vault_mcp.vector_index import VectorIndex
+
+        class _StubProvider:
+            dimension = 3
+            provider_name = "stub"
+            model_name = "stub"
+            context_length = 128
+
+            def embed(self, texts: list[str]) -> list[list[float]]:
+                return [[0.0, 0.0, 0.0] for _ in texts]
+
+        assert isinstance(VectorIndex(_StubProvider()), VectorStore)  # type: ignore[arg-type]
+
+
+class _GraphOnlyStore:
+    """A backend serving only the link graph — no search, no enumeration.
+
+    Exists to show the two concepts really are separable: this is the shape a
+    future deployment would have if the graph moved to its own store
+    alongside a different search index.
+    """
+
+    def get_backlinks(self, *a: Any, **k: Any) -> list[Any]: ...
+    def get_outlinks(self, *a: Any, **k: Any) -> list[Any]: ...
+    def get_broken_links(self, *a: Any, **k: Any) -> list[Any]: ...
+    def get_orphan_notes(self, *a: Any, **k: Any) -> list[Any]: ...
+    def get_most_linked(self, *a: Any, **k: Any) -> list[Any]: ...
+    def get_connection_path(self, *a: Any, **k: Any) -> list[str] | None: ...
+    def count_links(self) -> int: ...
+    def count_broken_links(self) -> int: ...
+    def count_orphans(self) -> int: ...
+    def resolve_vault_wikilinks(self) -> int: ...
+
+
+class TestFacetsAreIndependent:
+    """The protocols separate concepts, not just names."""
+
+    def test_graph_only_backend_is_not_a_keyword_index(self) -> None:
+        """A store that answers structure need not answer relevance.
+
+        This is the point of splitting the two: it makes a backend that
+        serves the link graph alongside a different search index expressible.
+        """
+        store = _GraphOnlyStore()
+        assert isinstance(store, GraphStore)
+        assert not isinstance(store, KeywordIndex)
+        assert not isinstance(store, KeywordGraphIndex)
+
+    def test_unrelated_object_satisfies_nothing(self) -> None:
+        """The runtime checks are real checks."""
+        assert not isinstance(object(), KeywordIndex)
+        assert not isinstance(object(), GraphStore)
+        assert not isinstance(object(), VectorStore)
+
+
+class TestManagersAcceptAnyConformingStore:
+    """The managers depend on the seam, not on ``FTSIndex``."""
+
+    def test_link_manager_accepts_a_graph_only_store(self, tmp_path: Path) -> None:
+        """``LinkManager`` needs the graph facet plus one relational read.
+
+        Constructing it against a hand-rolled store — never an ``FTSIndex`` —
+        is what shows the dependency is on the protocol.
+        """
+        from markdown_vault_mcp.managers.link import LinkManager
+
+        row = {
+            "source_path": "other.md",
+            "source_title": "Other",
+            "link_text": "Seed",
+            "link_type": "markdown",
+            "fragment": None,
+            "raw_target": "seed.md",
+        }
+
+        class _Store:
+            def get_backlinks(
+                self, path: str, *, limit: int | None = None
+            ) -> list[dict[str, Any]]:
+                return ([row] if path == "seed.md" else [])[:limit]
+
+            def get_note(self, path: str) -> dict[str, Any] | None:
+                return {"path": path, "title": "Seed"}
+
+            def __getattr__(self, name: str) -> Any:
+                # The remaining facet members are unused by this test.
+                raise AttributeError(name)
+
+        mgr = LinkManager(_Store(), tmp_path)  # type: ignore[arg-type]
+
+        backlinks = mgr.get_backlinks("seed.md")
+
+        assert [b.source_path for b in backlinks] == ["other.md"]
+
+
+def test_interfaces_module_imports_nothing_at_runtime() -> None:
+    """The seam stays dependency-free, so depending on it pulls in no backend."""
+    source = (
+        Path(__file__).parent.parent / "src" / "markdown_vault_mcp" / "interfaces.py"
+    ).read_text()
+    runtime_imports = [
+        line
+        for line in source.splitlines()
+        if re.match(r"^(import|from)\s", line)
+        if "__future__" not in line and "typing" not in line
+    ]
+    assert runtime_imports == [], (
+        f"interfaces.py gained runtime imports: {runtime_imports}"
+    )

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -31,7 +31,6 @@ from markdown_vault_mcp._okf_write import (
     okf_write_intent,
     okf_write_suppressed,
     resolve_human_subject,
-    resolve_write_actor,
     tool_actor,
 )
 from markdown_vault_mcp.okf import (
@@ -157,26 +156,6 @@ class TestAppendOkfVerification:
 class TestActorResolution:
     def test_tool_actor_format(self) -> None:
         assert tool_actor("1.2.3") == "markdown-vault-mcp/1.2.3"
-
-    def test_resolve_write_actor_human_when_subject_present(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: "peter")
-        assert resolve_write_actor() == "human:peter"
-
-    def test_resolve_write_actor_tool_when_no_subject(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: None)
-        actor = resolve_write_actor()
-        assert actor.startswith("markdown-vault-mcp/")
-
-    def test_resolve_write_actor_tool_when_local_sentinel(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # get_subject() returns "local" under auth mode none — not a human.
-        monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: "local")
-        assert resolve_write_actor().startswith("markdown-vault-mcp/")
 
     def test_resolve_human_subject_present(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Closes / Refs

Closes #1229, closes #1230, closes #1231

Also files, but does not close, the deferred seams from the same study: #1232, #1233, #1234, #1235, #1236.

## What & why

Epic #1161 decomposed the god classes internally, but every consumer still named the concrete class, so there was no seam to substitute a backend behind. This installs three of the decoupling study's seams as interfaces, behaviour-preserving:

- **Versioning** (`git/interfaces.py`) — `HistorySource`, `Syncer`, `Versioner`, and `VersionedStore` composing all three. `GitWriteStrategy` stays the single object implementing them: the collaborators share one lock, and `Vault.close()` tells the commit callback from the store by object identity, so splitting into three *objects* would break both. Splitting the type costs nothing. `GitQueryManager` now depends on `HistorySource` alone, the `git_sync` tool on `Syncer`.
- **Search/index** (`interfaces.py`) — `KeywordIndex`, `GraphStore`, `KeywordGraphIndex`, `VectorStore`. `FTSIndex` and `VectorIndex` satisfy them structurally, with no inheritance change. This is the seam the design doc's standing "if tens of thousands, evaluate Qdrant" note needs.
- **Identity** — `_okf_write.py` kept a pre-`Principal` fallback that re-implemented the `human:<subject>` and `"local"`-sentinel rules `resolve_mcp_principal` already implements. Two copies of one rule can disagree, which is the failure #1160 was filed against in that same file. It now resolves a `Principal` instead, and the dead `resolve_write_actor` is gone. `configure_identity_claims` moved out of the git-strategy builder into `to_vault_instances`.

Each protocol carries exactly what its consumers call, not everything the current implementation exposes — a protocol wider than its consumers is a god interface with extra steps.

Three behaviour notes for the reviewer:

1. The `git_sync` managed-mode gate weakens from a nominal `isinstance(strategy, GitWriteStrategy)` to a structural `isinstance(strategy, Syncer) and strategy.is_managed`. All in-tree wiring passes the same object; mypy carries the signature guarantee, and a fake `Syncer` in the new tests pins that the coupling is genuinely gone. That gate previously read four private members of the strategy, which is why `is_managed`, `resolve_force_repo`, `head_sha`, and `branch_name` are now public.
2. `resolve_human_subject` now also reads `get_claims()` on its fallback path. That returns `None` outside a request context, so the resolved subject is unchanged. The existing `resolve_human_subject` tests are deliberately untouched — their passing unchanged is the proof.
3. Renaming `_head_sha` / `_resolve_force_repo` would break an out-of-tree monkeypatcher, but private names carry no compatibility promise and the `markdown_vault_mcp.git.subprocess.run` patch target is untouched.

No commit carries `!`: nothing on the operator surface moves, and the package root's public import surface (`tests/public_import_surface.txt`) is empty, so none of these names were on it.

## What this PR deliberately does NOT do

- Multi-vault (`VaultRegistry`): #1232
- Per-user permissions (`AccessPolicy`): #1233
- Format-agnostic core (`DocumentParser`): #1234
- `ArtifactStore` and the markdown-vs-attachment dispatch duplicated in ~7 places: #1235
- Removing the deprecated `commit_name_claim` / `commit_email_claim` kwargs — they shipped in stable v4.1.0 on an importable class, so removal is breaking: #1236
- Splitting `GitWriteStrategy` into separate objects, or extracting the OKF dialect hooks. The adapter layer needed no work: all 77 `asyncio.to_thread` calls were already confined to the MCP modules.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] Any commit carrying `!` breaks an operator or library surface that
      existed at the **last stable release** (see the breaking-change policy
      in `AGENTS.md`) — MCP tool-surface changes alone do not earn a `!`.

## Docs impact

- [ ] `README.md` — nothing operator-facing changed.
- [ ] `docs/` site pages — no MCP tool, resource, prompt, or env var changed.
- [x] `docs/design/` — new `interfaces.py` section; facet protocols documented in the git section; `fts_index.py` / `vector_index.py` conformance noted; the Qdrant risk note now points at `VectorStore`; the identity section records that the subject rules have one owner.
- [x] Inline docstrings — both new modules, the promoted public methods, and the retyped consumers.

`AGENTS.md`'s Project Structure tree carries both new modules.


---
_Generated by [Claude Code](https://claude.ai/code/session_0197qu2QerLNpJSGQAjLjSNN)_