### PR TITLE
refactor: give the note/artifact boundary one owner and extract ArtifactStore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ src/markdown_vault_mcp/
     text.py            -- text normalization, position mapping, fuzzy matching
     links.py           -- link target computation and replacement
     serialization.py   -- toc_payload: TocEntry/SubtreeToc → JSON-able dicts
+    content_kind.py    -- is_note/is_allowed_artifact/is_attachment: single owner of the note-vs-artifact boundary + the registry of the three '.md' axes (#1235)
     fs.py              -- filesystem traversal helpers: symlink-aware iteration, directory pruning (#508, #835)
     fts.py             -- fts_row_to_note_info: FTS row → NoteInfo conversion shared across managers
   managers/
@@ -25,7 +26,10 @@ src/markdown_vault_mcp/
     search.py          -- SearchManager: keyword/semantic/hybrid search, list, context, stats
     index.py           -- IndexManager: build_index, reindex, dirty-path FTS refresh; delegates embeddings to the composed EmbeddingsManager (#1157)
     embeddings.py      -- EmbeddingsManager: vector lifecycle — cold build, convergence, inline embed, deferred flush, status (#1157); internal collaborator, not re-exported
-    document.py        -- DocumentManager: CRUD, attachments, backlinks; path checks delegate to utils.validate_path
+    document.py        -- DocumentManager: note CRUD, backlinks, delete/rename/move orchestration; artifact CRUD delegated to ArtifactStore (#1235)
+    artifacts.py       -- ArtifactStore: validate/size/read/write/unlink/move for non-.md artifacts over the manager's shared lock + notifier (#1235); internal collaborator, not re-exported
+    _write_notifier.py -- WriteNotifier: single owner of write-callback dispatch shape incl. the old_path opt-in probe (#894, #1235)
+    _write_kernel.py   -- atomic_write / check_if_match / umask cache: the pure write primitives both the note and artifact paths use (#1235)
     git_query.py       -- GitQueryManager: git history/diff reads (#610)
     summarize.py       -- SummarizeManager: LLM-backed note/subtree summarization, map-reduce batching (#922)
     okf_migrate.py     -- OkfMigrationManager: one-shot OKF transforms — link conversion, index generation, log seeding (#963)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ src/markdown_vault_mcp/
     text.py            -- text normalization, position mapping, fuzzy matching
     links.py           -- link target computation and replacement
     serialization.py   -- toc_payload: TocEntry/SubtreeToc → JSON-able dicts
-    content_kind.py    -- is_note/is_allowed_artifact/is_attachment: single owner of the note-vs-artifact boundary + the registry of the three '.md' axes (#1235)
+    content_kind.py    -- is_note/has_md_suffix/artifact_suffix/is_allowed_artifact(_suffix): single owner of the note-vs-artifact boundary + the registry of the three '.md' axes (#1235)
     fs.py              -- filesystem traversal helpers: symlink-aware iteration, directory pruning (#508, #835)
     fts.py             -- fts_row_to_note_info: FTS row → NoteInfo conversion shared across managers
   managers/

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1484,9 +1484,10 @@ attachment write operations.
 
 The resolve-then-contain-then-raise sequence itself lives in one shared
 helper, `utils.resolve_inside(path, base)` (#876): every raising validator —
-`validate_path`, `validate_history_path`, `validate_history_dir`, the
-attachment/folder validators in `DocumentManager`, the conventions folder
-normalizer, and the transfer-sink upload/download/bundle checks — delegates
+`validate_path`, `validate_history_path`, `validate_history_dir`,
+`ArtifactStore.validate_path` and `DocumentManager._validate_dir_path`, the
+conventions folder normalizer, and the transfer-sink upload/download/bundle
+checks — delegates
 containment to it. Site-specific policy stays local: extension allowlists,
 `_validate_dir_path` additionally rejecting the vault root, and read paths
 that return `None` instead of raising.
@@ -2604,6 +2605,16 @@ This is the seam the standing "if tens of thousands, evaluate Qdrant" risk
 note needs: substituting a backend is now a matter of satisfying a protocol
 rather than editing six manager constructors.
 
+**When not to add one.** `ArtifactStore` (#1235) deliberately is *not* a
+protocol, and the reasoning is the membership rule above read backwards: it has
+one implementation, one consumer, and no substitution need, so an interface
+would be a one-implementation abstraction — the thing this module warns
+against. The caller that looks like it would motivate one, `VaultTransferSink`,
+structurally cannot hold a vault-owned object; it is served by the pure
+predicates in `utils/content_kind.py`. Check both — several consumers wanting
+different subsets, and a real backend-swap need — before adding a protocol
+here.
+
 ### `providers.py`: Embedding Providers
 
 Copied from ifcraftcorpus, adapted:
@@ -3293,6 +3304,58 @@ identity_providers:
 The server supports reading and writing non-markdown binary files (PDFs, images, and so on) by overloading the existing MCP tools, with no new tool registrations.
 
 **Extension-based dispatch**: `.md` files always follow the markdown path. All other extensions are treated as attachments if they appear in the configured allowlist.
+
+That decision has a single owner, `utils/content_kind.py` (#1235). It was
+previously re-derived from the path string at roughly fifteen call sites whose
+answers disagreed — some consulted the allowlist, others tested only the
+suffix, and three different case policies were in use.
+
+**Three axes** ride on the `.md` extension. All ask the same question and share
+`is_note()`; what differs is what a *non-note* means, so they are documented
+rather than collapsed into one tri-state:
+
+| Axis | Meaning of non-note | Where |
+|---|---|---|
+| Artifact | an attachment | `ArtifactStore`, `DocumentManager` delete/rename/move, the transfer sink, the `read`/`write`/`fetch` tools |
+| Folder | a directory scope | `DocumentManager.get_toc`, `SummarizeManager._expand_path` |
+| Indexability | not a candidate for the index | `IndexManager`, `EmbeddingsManager`, `utils.fs.iter_markdown_files` |
+
+Routing the indexability axis through the same predicate is what makes a
+future non-markdown format a single edit rather than a hunt.
+
+**Two divergences are deliberate and preserved**, recorded in that module:
+
+- *Case.* Routing is case-sensitive. `SearchManager._attachment_info` is
+  case-insensitive (`has_md_suffix`). `DocumentManager.read`'s note-size cap
+  uses a third spelling and stays inline, because that method validates no
+  extension at all — a file named `NOTE.MD` really does reach it.
+- *Resolution.* Some callers take the extension from the raw caller string
+  (before the traversal guard), others from the resolved path (after). Symlinks
+  make those differ, so nothing in `content_kind` resolves; each caller passes
+  the object whose extension it means.
+
+`is_attachment()` is **not** the routing test: the tool layer routes on
+`not is_note(path)` alone, so a non-allowlisted file still reaches the
+attachment branch and is rejected there with the error naming
+`MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS`.
+
+**Storage**: `ArtifactStore` (`managers/artifacts.py`) owns artifact
+validate/size/read/write/unlink/move. It is composed into `DocumentManager`
+and shares that manager's write lock and `WriteNotifier` — the same objects,
+following the #893 collaborator precedent — so artifact writes serialise
+against note writes and `Vault.pause_writes` holds both still. `unlink` and
+`move` return paths and fire no callback: `delete` and `rename` fire one after
+their branch closes, for notes and artifacts alike.
+
+It is a plain class, not a protocol, under the membership rule in
+`interfaces.py`: one implementation, one consumer, no substitution need. The
+one caller that might motivate an interface, `VaultTransferSink`, cannot hold a
+vault-owned object at all — it validates from a `ProjectConfig` at link-mint
+time, before any vault is resolved — and is served by the pure predicates
+instead. Artifacts also get no facet and no `vault.artifacts` accessor:
+`read_attachment`/`write_attachment` are already reachable through
+`vault.reader`/`vault.writer`, and a second public route would recreate exactly
+the duplication this removed.
 
 **Default allowlist**: `pdf png jpg jpeg gif webp svg bmp tiff docx xlsx pptx odt ods odp zip tar gz mp3 mp4 wav ogg txt csv tsv json yaml toml xml html css js ts`. The `.md` extension is always excluded regardless of configuration.
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3317,11 +3317,14 @@ rather than collapsed into one tri-state:
 | Axis | Meaning of non-note | Where |
 |---|---|---|
 | Artifact | an attachment | `ArtifactStore`, `DocumentManager` delete/rename/move, the transfer sink, the `read`/`write`/`fetch` tools |
-| Folder | a directory scope | `DocumentManager.get_toc`, `SummarizeManager._expand_path` |
+| Folder | a directory scope | `DocumentManager.get_toc`, `SummarizeManager._expand_path`, `ConventionsResolver` |
 | Indexability | not a candidate for the index | `IndexManager`, `EmbeddingsManager`, `utils.fs.iter_markdown_files` |
 
-Routing the indexability axis through the same predicate is what makes a
-future non-markdown format a single edit rather than a hunt.
+Routing the indexability axis through the same predicate narrows a future
+non-markdown format to that one predicate plus the two glob defaults that
+still spell the rule in another language (`scanner`'s `**/*.md` and
+`tracker`'s comparison against it) — rather than a hunt through a dozen
+spellings.
 
 **Two divergences are deliberate and preserved** (#1240), recorded in that module:
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3323,7 +3323,7 @@ rather than collapsed into one tri-state:
 Routing the indexability axis through the same predicate is what makes a
 future non-markdown format a single edit rather than a hunt.
 
-**Two divergences are deliberate and preserved**, recorded in that module:
+**Two divergences are deliberate and preserved** (#1240), recorded in that module:
 
 - *Case.* Routing is case-sensitive. `SearchManager._attachment_info` is
   case-insensitive (`has_md_suffix`). `DocumentManager.read`'s note-size cap

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 
+from markdown_vault_mcp.utils import is_note
 from markdown_vault_mcp.utils.serialization import toc_payload
 from markdown_vault_mcp.vault import Vault
 
@@ -232,7 +233,7 @@ def register(mcp: FastMCP) -> None:
                 ``MARKDOWN_VAULT_MCP_MAX_ATTACHMENT_SIZE_MB``, or the requested
                 section heading is not found.
         """
-        if not path.endswith(".md"):
+        if not is_note(path):
             cap_mb = vault.max_attachment_size_mb
             if cap_mb > 0:
                 size = await asyncio.to_thread(vault.reader.attachment_size, path)

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -24,6 +24,7 @@ from markdown_vault_mcp.exceptions import (
     EditConflictError,
 )
 from markdown_vault_mcp.okf import _HUMAN_ACTOR_PREFIX, append_okf_verification
+from markdown_vault_mcp.utils import is_note
 from markdown_vault_mcp.utils.text import decode_utf8
 from markdown_vault_mcp.vault import Vault
 
@@ -218,7 +219,7 @@ def register(mcp: FastMCP) -> None:
                 (DocumentExistsError) — use 'edit' or 'append' instead, or
                 read the file first and pass its etag as if_match.
         """
-        if not path.endswith(".md"):
+        if not is_note(path):
             if not content_base64:
                 raise ValueError(
                     f"content_base64 is required for non-.md attachments: {path}"
@@ -706,7 +707,7 @@ def register(mcp: FastMCP) -> None:
         # positive setting (which floors to 0 bytes) counts as "no cap" —
         # matching the pre-#862 guard — rather than tripping fetch_url's
         # positive-max_bytes validation on every attachment fetch.
-        is_markdown = path.endswith(".md")
+        is_markdown = is_note(path)
         cap_bytes = (
             0
             if is_markdown or vault.max_attachment_size_mb <= 0

--- a/src/markdown_vault_mcp/_transfer_sink.py
+++ b/src/markdown_vault_mcp/_transfer_sink.py
@@ -34,7 +34,10 @@ from fastmcp_pvl_core import (
 from markdown_vault_mcp.domain import get_vault_singleton
 from markdown_vault_mcp.okf_bundle import build_okf_bundle
 from markdown_vault_mcp.utils import (
+    artifact_suffix,
     effective_attachment_extensions,
+    is_allowed_artifact_suffix,
+    is_note,
     resolve_inside,
     validate_path,
 )
@@ -90,13 +93,13 @@ def _validate_destination(
     Raises:
         ValueError: On path traversal or a disallowed attachment extension.
     """
-    if path.endswith(".md"):
+    if is_note(path):
         validate_path(path, source_dir)
         return
     resolved = resolve_inside(path, source_dir)
     exts = effective_attachment_extensions(attachment_extensions)
-    ext = resolved.suffix.lstrip(".").lower()
-    if "*" not in exts and ext not in exts:
+    ext = artifact_suffix(resolved)
+    if not is_allowed_artifact_suffix(ext, exts):
         raise ValueError(f"Attachment extension not allowed: .{ext}")
 
 
@@ -119,8 +122,8 @@ def _validate_source(
         ValueError: On path traversal, a missing file, or a disallowed
             attachment extension.
     """
-    is_attachment = not path.endswith(".md")
-    if not is_attachment:
+    is_artifact = not is_note(path)
+    if not is_artifact:
         resolved = validate_path(path, source_dir)
     else:
         resolved = resolve_inside(path, source_dir)
@@ -129,12 +132,12 @@ def _validate_source(
     except OSError as exc:  # pragma: no cover - defensive: stat fault on is_file()
         raise ValueError(f"File not accessible: {path}") from exc
     if not exists:
-        kind = "Attachment" if is_attachment else "Note"
+        kind = "Attachment" if is_artifact else "Note"
         raise ValueError(f"{kind} not found: {path}")
-    if is_attachment:
+    if is_artifact:
         exts = effective_attachment_extensions(attachment_extensions)
-        ext = resolved.suffix.lstrip(".").lower()
-        if "*" not in exts and ext not in exts:
+        ext = artifact_suffix(resolved)
+        if not is_allowed_artifact_suffix(ext, exts):
             raise ValueError(f"Attachment extension not allowed: .{ext}")
 
 
@@ -257,7 +260,7 @@ class VaultTransferSink:
             return await self._read_bundle(scope)
         vault = self._resolve_vault()
         filename = Path(handle).name
-        if handle.endswith(".md"):
+        if is_note(handle):
             note = await asyncio.to_thread(vault.reader.read, handle)
             if note is None:
                 logger.warning("transfer_download_note_gone path=%s", handle)
@@ -332,7 +335,7 @@ class VaultTransferSink:
             UnicodeDecodeError: A note upload whose body is not valid UTF-8.
         """
         vault = self._resolve_vault()
-        if handle.endswith(".md"):
+        if is_note(handle):
             text = decode_utf8(body)  # strips a leading BOM (#681); raises on bad UTF-8
             await asyncio.to_thread(vault.writer.write, handle, text)
         else:

--- a/src/markdown_vault_mcp/conventions.py
+++ b/src/markdown_vault_mcp/conventions.py
@@ -23,7 +23,11 @@ from typing import TYPE_CHECKING
 import frontmatter as fm
 import yaml
 
-from markdown_vault_mcp.utils import is_path_excluded, resolve_inside
+from markdown_vault_mcp.utils import (
+    is_note,
+    is_path_excluded,
+    resolve_inside,
+)
 from markdown_vault_mcp.utils.fs import iter_markdown_files
 
 if TYPE_CHECKING:
@@ -168,7 +172,7 @@ class ConventionsResolver:
             ValueError: If the path escapes the vault root.
         """
         cleaned = path.replace("\\", "/").strip("/")
-        if cleaned.endswith(".md"):
+        if is_note(cleaned):
             cleaned = cleaned.rsplit("/", 1)[0] if "/" in cleaned else ""
         if not cleaned:
             return ""

--- a/src/markdown_vault_mcp/managers/_write_kernel.py
+++ b/src/markdown_vault_mcp/managers/_write_kernel.py
@@ -1,0 +1,127 @@
+"""File-write primitives shared by the document and artifact paths (#1235).
+
+``DocumentManager`` and
+:class:`~markdown_vault_mcp.managers.artifacts.ArtifactStore` write bytes the
+same way: atomically, and under the same etag precondition. These are the
+genuinely pure parts of that — they read no manager state — so they live here
+as module functions rather than being inherited or copied.
+
+The umask handling is load-bearing: :mod:`tempfile` hardcodes ``0o600``, so a
+freshly-created file is chmod'd after the replace to match what a plain
+``open(path, "w")`` would have produced.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import threading
+from pathlib import Path
+
+from markdown_vault_mcp.exceptions import ConcurrentModificationError
+from markdown_vault_mcp.hashing import compute_file_hash
+
+__all__ = ["atomic_write", "check_if_match", "new_file_mode"]
+
+_UMASK_LOCK = threading.Lock()
+_umask: int | None = None
+
+
+def _process_umask() -> int:
+    """Return the process umask, read once and cached.
+
+    ``os.umask`` is set-and-restore with no read-only accessor; we read it
+    once under a lock so concurrent writers serialise the set-and-restore
+    and never observe a transient mask. The umask is set by the parent
+    (shell / systemd) before Python starts and is effectively immutable
+    for the service lifetime, so a one-time read is correct.
+    """
+    global _umask
+    if _umask is not None:
+        return _umask
+    with _UMASK_LOCK:
+        # The lock serialises the set-and-restore so no writer in this
+        # module observes a transient mask. A second writer that lost the
+        # outer cache check re-reads and re-sets the same value (the umask
+        # is process-global), so no inner guard is needed.
+        mask = os.umask(0o077)
+        os.umask(mask)
+        _umask = mask
+    return _umask
+
+
+def new_file_mode() -> int:
+    """Mode for a freshly-created file, matching a plain ``open(path, "w")``."""
+    return 0o666 & ~_process_umask()
+
+
+def check_if_match(abs_path: Path, path: str, if_match: str | None) -> None:
+    """Enforce an optional etag precondition on *abs_path*.
+
+    Args:
+        abs_path: Absolute path of the file the etag refers to.
+        path: Vault-relative path, used in the error.
+        if_match: Etag from a previous read, or ``None`` to skip the
+            check. A file that does not exist counts as a mismatch.
+
+    Raises:
+        ConcurrentModificationError: If *if_match* is provided and does
+            not match the current file hash (or the file is missing).
+    """
+    if if_match is None:
+        return
+    if not abs_path.is_file():
+        raise ConcurrentModificationError(
+            path,
+            expected=if_match,
+            actual="(file does not exist)",
+        )
+    current_hash = compute_file_hash(abs_path)
+    if current_hash != if_match:
+        raise ConcurrentModificationError(path, expected=if_match, actual=current_hash)
+
+
+def atomic_write(abs_path: Path, data: str | bytes) -> None:
+    """Write *data* to *abs_path* atomically via a sibling tempfile.
+
+    The temp file lands with :meth:`Path.replace` semantics; permission
+    bits are preserved when the target already exists. A freshly-created
+    target is chmod'd to ``0o666 & ~umask`` after the replace so fresh
+    writes honour the process umask (matching a plain ``open``) instead
+    of the ``0o600`` ``tempfile`` hardcodes. On failure the temp file is
+    removed and the original is left untouched.
+
+    Args:
+        abs_path: Absolute destination path.
+        data: Text (written UTF-8) or raw bytes.
+    """
+    existed = abs_path.is_file()
+    if isinstance(data, str):
+        with tempfile.NamedTemporaryFile(
+            dir=abs_path.parent,
+            mode="w",
+            encoding="utf-8",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp.write(data)
+            tmp_name = tmp.name
+    else:
+        with tempfile.NamedTemporaryFile(
+            dir=abs_path.parent,
+            mode="wb",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp.write(data)
+            tmp_name = tmp.name
+    if existed:
+        shutil.copymode(abs_path, tmp_name)
+    try:
+        Path(tmp_name).replace(abs_path)
+    except Exception:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
+    if not existed:
+        abs_path.chmod(new_file_mode())

--- a/src/markdown_vault_mcp/managers/_write_notifier.py
+++ b/src/markdown_vault_mcp/managers/_write_notifier.py
@@ -1,0 +1,88 @@
+"""Single owner of write-callback dispatch shape (#1235).
+
+``DocumentManager`` and :class:`~markdown_vault_mcp.managers.artifacts.ArtifactStore`
+both report completed writes to the same callback, and both must dispatch it
+identically — including the ``old_path`` opt-in probe (#894), which is easy to
+get subtly wrong twice. This holds that logic once; the two share one instance
+by reference, never a copy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, cast
+
+from markdown_vault_mcp.types import ACCEPTS_OLD_PATH_ATTR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from markdown_vault_mcp.types import WriteCallback, WriteOperation
+
+__all__ = ["OnWriteCallback", "WriteNotifier"]
+
+
+class OnWriteCallback(Protocol):
+    """The write-callback shape the managers dispatch to.
+
+    Widens :data:`~markdown_vault_mcp.types.WriteCallback` with the optional
+    ``old_path`` keyword the rename sites pass (#894).  The dispatcher this is
+    wired to — :meth:`WriteCallbackDispatcher.fire` — accepts it
+    unconditionally and forwards it only to callbacks that opted in, so a
+    three-argument ``on_write`` remains valid at the ``Vault`` boundary.
+    """
+
+    def __call__(
+        self,
+        path: Path,
+        content: str,
+        operation: WriteOperation,
+        /,
+        old_path: Path | None = None,
+    ) -> None:
+        """Record one completed write."""
+        ...
+
+
+class WriteNotifier:
+    """Dispatches completed writes to the configured callback.
+
+    Args:
+        on_write: The vault's write callback, or ``None`` for a vault with no
+            versioning backend (dispatch then becomes a no-op).
+    """
+
+    def __init__(self, on_write: OnWriteCallback | WriteCallback | None) -> None:
+        self._callback: OnWriteCallback | WriteCallback = on_write or (
+            lambda *_a, **_kw: None
+        )
+        #: Probed once at construction: whether the callback opted into
+        #: ``old_path`` (#894).  A callback that did not keeps the historical
+        #: three-argument call.
+        self._takes_old_path = bool(getattr(on_write, ACCEPTS_OLD_PATH_ATTR, False))
+
+    def fire(self, abs_path: Path, content: str, operation: WriteOperation) -> None:
+        """Report one completed write.
+
+        Args:
+            abs_path: Absolute path that was written.
+            content: The content written (``""`` where the callback does not
+                need it, as for artifacts and deletes).
+            operation: Which kind of write completed.
+        """
+        self._callback(abs_path, content, operation)
+
+    def fire_rename(self, new_abs: Path, content: str, old_abs: Path) -> None:
+        """Report a rename, passing both sides when the callback accepts them.
+
+        Args:
+            new_abs: Absolute path the file now lives at.
+            content: File content at the new path (``""`` for artifacts).
+            old_abs: Absolute path the file moved from, so a callback that
+                opted in can scope its git staging to the two paths the rename
+                touched instead of staging the whole repository (#894).
+        """
+        if self._takes_old_path:
+            rename_aware = cast("OnWriteCallback", self._callback)
+            rename_aware(new_abs, content, "rename", old_path=old_abs)
+        else:
+            self._callback(new_abs, content, "rename")

--- a/src/markdown_vault_mcp/managers/artifacts.py
+++ b/src/markdown_vault_mcp/managers/artifacts.py
@@ -116,8 +116,7 @@ class ArtifactStore:
         """
         if self._policy.read_only:
             raise ReadOnlyError(
-                "Vault is read-only. Set MARKDOWN_VAULT_MCP_READ_ONLY=false "
-                "to enable writes."
+                "Vault is read-only; write operations are not permitted."
             )
 
     def _check_no_clobber(

--- a/src/markdown_vault_mcp/managers/artifacts.py
+++ b/src/markdown_vault_mcp/managers/artifacts.py
@@ -1,0 +1,318 @@
+"""Artifact (non-``.md`` attachment) storage (#1235).
+
+A collaborator composed into
+:class:`~markdown_vault_mcp.managers.document.DocumentManager`, following the
+#893 precedent set by :class:`~markdown_vault_mcp.git.bootstrap.RepoBootstrap`
+and :class:`~markdown_vault_mcp.git.push_scheduler.PushScheduler`: it shares
+the manager's write lock and write notifier — **the same objects**, never
+copies — and introduces no lock of its own. A private lock here would stop
+artifact writes serialising against note writes, and would leave
+:meth:`Vault.pause_writes` unable to hold artifacts still during a git rebase.
+
+Deliberately a plain class, not a Protocol. The seams in
+:mod:`markdown_vault_mcp.interfaces` earned theirs because several consumers
+wanted different subsets and a backend swap was a documented need; this has one
+implementation and one consumer. The one caller that might motivate an
+interface — ``VaultTransferSink`` — cannot hold a vault-owned object at all,
+since it validates at link-mint time from a ``ProjectConfig`` before any vault
+is resolved; it is served by the pure predicates in
+:mod:`markdown_vault_mcp.utils.content_kind` instead.
+
+:meth:`unlink` and :meth:`move` return paths and fire nothing. In ``delete``
+and ``rename`` the manager fires one callback after the branch closes, for
+both notes and artifacts alike; owning that here would either double-fire or
+move it outside the lock.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import mimetypes
+import shutil
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.exceptions import (
+    DocumentExistsError,
+    DocumentNotFoundError,
+    ReadOnlyError,
+)
+from markdown_vault_mcp.hashing import compute_etag
+from markdown_vault_mcp.managers._write_kernel import atomic_write, check_if_match
+from markdown_vault_mcp.types import AttachmentContent, WriteResult
+from markdown_vault_mcp.utils import (
+    artifact_suffix,
+    effective_attachment_extensions,
+    is_allowed_artifact_suffix,
+    is_note,
+    resolve_inside,
+)
+
+if TYPE_CHECKING:
+    import threading
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from markdown_vault_mcp.managers._write_notifier import WriteNotifier
+
+__all__ = ["ArtifactPolicy", "ArtifactStore"]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ArtifactPolicy:
+    """Construction-time artifact policy, mirroring the manager's own.
+
+    All three are immutable for the manager's lifetime — ``pause_writes``
+    suspends writing through the lock, not by flipping ``read_only`` — so the
+    store may safely hold its own copies rather than reading back through the
+    manager.
+
+    Attributes:
+        attachment_extensions: Configured allowlist, or ``None`` for the
+            default set.
+        read_only: When ``True`` every write is refused.
+        write_protect_existing: When ``True`` a blind overwrite of an existing
+            file is refused unless the caller proves a prior read.
+    """
+
+    attachment_extensions: Sequence[str] | None = None
+    read_only: bool = True
+    write_protect_existing: bool = False
+
+
+class ArtifactStore:
+    """Validate, read, write, unlink and move non-``.md`` artifacts.
+
+    Args:
+        source_dir: Absolute path to the vault root directory.
+        write_lock: The manager's shared re-entrant write lock — the same
+            object, so artifact and note writes serialise against each other.
+        notifier: The manager's shared write notifier.
+        policy: Construction-time artifact policy.
+    """
+
+    def __init__(
+        self,
+        source_dir: Path,
+        *,
+        write_lock: threading.RLock,
+        notifier: WriteNotifier,
+        policy: ArtifactPolicy,
+    ) -> None:
+        self._source_dir = source_dir
+        self._file_write_lock = write_lock
+        self._notifier = notifier
+        self._policy = policy
+
+    def extensions(self) -> frozenset[str]:
+        """Return the effective allowlist of artifact extensions."""
+        return effective_attachment_extensions(self._policy.attachment_extensions)
+
+    def _check_writable(self) -> None:
+        """Raise when the vault is read-only.
+
+        Raises:
+            ReadOnlyError: If the vault was constructed read-only.
+        """
+        if self._policy.read_only:
+            raise ReadOnlyError(
+                "Vault is read-only. Set MARKDOWN_VAULT_MCP_READ_ONLY=false "
+                "to enable writes."
+            )
+
+    def _check_no_clobber(
+        self, abs_path: Path, path: str, if_match: str | None
+    ) -> None:
+        """Reject a blind overwrite when write protection is enabled.
+
+        Args:
+            abs_path: Absolute path of the target file.
+            path: Vault-relative path, used in the error.
+            if_match: Etag supplied by the caller, or ``None``.
+
+        Raises:
+            DocumentExistsError: If write protection is enabled, *if_match* is
+                ``None``, and *abs_path* already exists.
+        """
+        if not self._policy.write_protect_existing or if_match is not None:
+            return
+        if abs_path.is_file():
+            raise DocumentExistsError(
+                f"{path} exists; overwriting requires proof of read: call "
+                "'read', then retry with if_match=<etag> — or use 'edit' for "
+                "targeted changes, or 'append' to add to the end. Do not "
+                "delete and recreate: that destroys the note first and "
+                "proves nothing. (Write protection is enabled by the "
+                "operator: MARKDOWN_VAULT_MCP_WRITE_PROTECT_EXISTING.)"
+            )
+
+    def validate_path(self, path: str) -> Path:
+        """Resolve and validate a non-``.md`` artifact path.
+
+        The extension is taken from the caller's spelling, before the
+        traversal guard resolves it — a symlink is judged by its name here.
+
+        Args:
+            path: Relative artifact path.
+
+        Returns:
+            The resolved absolute path.
+
+        Raises:
+            ValueError: If the path escapes the source directory, ends with
+                ``.md``, or has an extension not in the allowlist.
+        """
+        if is_note(path):
+            raise ValueError(
+                f"Path ends with '.md' — use the note read/write methods "
+                f"instead: {path}"
+            )
+        exts = self.extensions()
+        suffix = artifact_suffix(path)
+        if not is_allowed_artifact_suffix(suffix, exts):
+            allowed_str = ", ".join(f".{e}" for e in sorted(exts))
+            raise ValueError(
+                f"Extension '.{suffix}' is not in the attachment allowlist. "
+                f"Allowed: {allowed_str}. "
+                "Set MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS=* to allow "
+                "all non-.md files."
+            )
+        return resolve_inside(path, self._source_dir)
+
+    def size(self, path: str) -> int:
+        """Return the on-disk byte size of an artifact without reading it.
+
+        Kept separate from :meth:`read` so the MCP layer can enforce its size
+        cap by ``stat`` before any bytes are loaded into memory.
+
+        Args:
+            path: Relative artifact path.
+
+        Returns:
+            The file size in bytes.
+
+        Raises:
+            ValueError: If the path is invalid or the file does not exist.
+        """
+        abs_path = self.validate_path(path)
+        try:
+            if not abs_path.is_file():
+                raise ValueError(f"Attachment not found: {path}")
+            return abs_path.stat().st_size
+        except OSError as exc:
+            raise ValueError(f"Attachment not found: {path}") from exc
+
+    def read(self, path: str) -> AttachmentContent:
+        """Read an artifact's bytes, base64-encoded, with its metadata.
+
+        Args:
+            path: Relative artifact path.
+
+        Returns:
+            The artifact content and metadata.
+
+        Raises:
+            ValueError: If the path is invalid or the file does not exist.
+        """
+        abs_path = self.validate_path(path)
+        if not abs_path.is_file():
+            raise ValueError(f"Attachment not found: {path}")
+        stat = abs_path.stat()
+        mime_type, _ = mimetypes.guess_type(path)
+        raw = abs_path.read_bytes()
+        return AttachmentContent(
+            path=path,
+            mime_type=mime_type,
+            size_bytes=stat.st_size,
+            content_base64=base64.b64encode(raw).decode("ascii"),
+            modified_at=stat.st_mtime,
+            etag=compute_etag(raw),
+        )
+
+    def write(
+        self, path: str, content: bytes, if_match: str | None = None
+    ) -> WriteResult:
+        """Write raw bytes to an artifact path, creating parents as needed.
+
+        Args:
+            path: Relative artifact path.
+            content: Raw bytes to write.
+            if_match: Etag from a previous read, enforced as a precondition.
+
+        Returns:
+            The write result, recording whether the file was created.
+
+        Raises:
+            ReadOnlyError: If the vault is read-only.
+            ConcurrentModificationError: If *if_match* does not match.
+            DocumentExistsError: If write protection refuses a blind overwrite.
+            ValueError: If the path is invalid.
+        """
+        self._check_writable()
+        with self._file_write_lock:
+            abs_path = self.validate_path(path)
+            self._check_no_clobber(abs_path, path, if_match)
+            check_if_match(abs_path, path, if_match)
+            created = not abs_path.is_file()
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write(abs_path, content)
+            result = WriteResult(path=path, created=created)
+            self._notifier.fire(abs_path, "", "write")
+        return result
+
+    def unlink(self, path: str, if_match: str | None) -> Path:
+        """Delete an artifact, returning the path it occupied.
+
+        Fires no callback: the caller reports the delete once, after its own
+        note/artifact branch closes.
+
+        Args:
+            path: Relative artifact path.
+            if_match: Etag from a previous read, enforced as a precondition.
+
+        Returns:
+            The absolute path that was removed.
+
+        Raises:
+            DocumentNotFoundError: If the artifact does not exist.
+            ConcurrentModificationError: If *if_match* does not match.
+            ValueError: If the path is invalid.
+        """
+        abs_path = self.validate_path(path)
+        if not abs_path.is_file():
+            raise DocumentNotFoundError(f"Attachment not found: {path}")
+        check_if_match(abs_path, path, if_match)
+        abs_path.unlink()
+        return abs_path
+
+    def move(
+        self, old_path: str, new_path: str, if_match: str | None
+    ) -> tuple[Path, Path]:
+        """Move an artifact, returning the old and new absolute paths.
+
+        Fires no callback, for the same reason as :meth:`unlink`.
+
+        Args:
+            old_path: Current relative artifact path.
+            new_path: Destination relative artifact path.
+            if_match: Etag from a previous read of *old_path*.
+
+        Returns:
+            ``(old_abs, new_abs)``.
+
+        Raises:
+            DocumentNotFoundError: If *old_path* does not exist.
+            DocumentExistsError: If *new_path* already exists.
+            ConcurrentModificationError: If *if_match* does not match.
+            ValueError: If either path is invalid.
+        """
+        old_abs = self.validate_path(old_path)
+        new_abs = self.validate_path(new_path)
+        if not old_abs.is_file():
+            raise DocumentNotFoundError(f"Attachment not found: {old_path}")
+        if new_abs.is_file():
+            raise DocumentExistsError(f"Target already exists: {new_path}")
+        check_if_match(old_abs, old_path, if_match)
+        new_abs.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(old_abs), str(new_abs))
+        return old_abs, new_abs

--- a/src/markdown_vault_mcp/managers/artifacts.py
+++ b/src/markdown_vault_mcp/managers/artifacts.py
@@ -265,6 +265,11 @@ class ArtifactStore:
         Fires no callback: the caller reports the delete once, after its own
         note/artifact branch closes.
 
+        Guards read-only and takes the shared lock itself rather than relying
+        on the caller to have done so, so the store's policy holds however it
+        is reached. The lock is re-entrant, so the nested acquisition when
+        ``DocumentManager.delete`` already holds it is free.
+
         Args:
             path: Relative artifact path.
             if_match: Etag from a previous read, enforced as a precondition.
@@ -273,15 +278,18 @@ class ArtifactStore:
             The absolute path that was removed.
 
         Raises:
+            ReadOnlyError: If the vault is read-only.
             DocumentNotFoundError: If the artifact does not exist.
             ConcurrentModificationError: If *if_match* does not match.
             ValueError: If the path is invalid.
         """
-        abs_path = self.validate_path(path)
-        if not abs_path.is_file():
-            raise DocumentNotFoundError(f"Attachment not found: {path}")
-        check_if_match(abs_path, path, if_match)
-        abs_path.unlink()
+        self._check_writable()
+        with self._file_write_lock:
+            abs_path = self.validate_path(path)
+            if not abs_path.is_file():
+                raise DocumentNotFoundError(f"Attachment not found: {path}")
+            check_if_match(abs_path, path, if_match)
+            abs_path.unlink()
         return abs_path
 
     def move(
@@ -289,7 +297,8 @@ class ArtifactStore:
     ) -> tuple[Path, Path]:
         """Move an artifact, returning the old and new absolute paths.
 
-        Fires no callback, for the same reason as :meth:`unlink`.
+        Fires no callback, and guards read-only and the shared lock, for the
+        same reasons as :meth:`unlink`.
 
         Args:
             old_path: Current relative artifact path.
@@ -300,18 +309,21 @@ class ArtifactStore:
             ``(old_abs, new_abs)``.
 
         Raises:
+            ReadOnlyError: If the vault is read-only.
             DocumentNotFoundError: If *old_path* does not exist.
             DocumentExistsError: If *new_path* already exists.
             ConcurrentModificationError: If *if_match* does not match.
             ValueError: If either path is invalid.
         """
-        old_abs = self.validate_path(old_path)
-        new_abs = self.validate_path(new_path)
-        if not old_abs.is_file():
-            raise DocumentNotFoundError(f"Attachment not found: {old_path}")
-        if new_abs.is_file():
-            raise DocumentExistsError(f"Target already exists: {new_path}")
-        check_if_match(old_abs, old_path, if_match)
-        new_abs.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(old_abs), str(new_abs))
+        self._check_writable()
+        with self._file_write_lock:
+            old_abs = self.validate_path(old_path)
+            new_abs = self.validate_path(new_path)
+            if not old_abs.is_file():
+                raise DocumentNotFoundError(f"Attachment not found: {old_path}")
+            if new_abs.is_file():
+                raise DocumentExistsError(f"Target already exists: {new_path}")
+            check_if_match(old_abs, old_path, if_match)
+            new_abs.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(old_abs), str(new_abs))
         return old_abs, new_abs

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -202,21 +202,6 @@ class DocumentManager:
         """Return the effective set of allowed attachment extensions."""
         return self._artifacts.extensions()
 
-    def _is_attachment(self, path: str) -> bool:
-        """Return True if *path* is an allowed non-.md attachment.
-
-        Args:
-            path: Relative path to check.
-
-        Returns:
-            ``True`` when the extension is in the allowlist and is not ``.md``.
-        """
-        if path.endswith(".md"):
-            return False
-        suffix = Path(path).suffix.lstrip(".").lower()
-        exts = self._effective_attachment_extensions()
-        return "*" in exts or suffix in exts
-
     def _is_path_excluded(self, path: str) -> bool:
         """Check whether *path* matches any configured exclude pattern.
 

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -18,7 +18,7 @@ import threading
 from collections import defaultdict
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any
 
 import frontmatter as fm
 import yaml
@@ -31,13 +31,16 @@ from markdown_vault_mcp.exceptions import (
     ReadOnlyError,
 )
 from markdown_vault_mcp.hashing import compute_etag, compute_file_hash
+from markdown_vault_mcp.managers._write_notifier import (
+    OnWriteCallback,
+    WriteNotifier,
+)
 from markdown_vault_mcp.scanner import (
     extract_section,
     list_section_headings,
     parse_note,
 )
 from markdown_vault_mcp.types import (
-    ACCEPTS_OLD_PATH_ATTR,
     AttachmentContent,
     DeleteResult,
     EditResult,
@@ -86,28 +89,6 @@ if TYPE_CHECKING:
     from markdown_vault_mcp.scanner import ChunkStrategy
 
 logger = logging.getLogger(__name__)
-
-
-class _OnWriteCallback(Protocol):
-    """The write-callback shape DocumentManager dispatches to.
-
-    Widens :data:`~markdown_vault_mcp.types.WriteCallback` with the optional
-    ``old_path`` keyword the rename sites pass (#894).  The dispatcher this
-    is wired to — :meth:`WriteCallbackDispatcher.fire` — accepts it
-    unconditionally and forwards it only to callbacks that opted in, so a
-    three-argument ``on_write`` remains valid at the ``Vault`` boundary.
-    """
-
-    def __call__(
-        self,
-        path: Path,
-        content: str,
-        operation: WriteOperation,
-        /,
-        old_path: Path | None = None,
-    ) -> None:
-        """Record one completed write."""
-        ...
 
 
 _UMASK_LOCK = threading.Lock()
@@ -194,7 +175,7 @@ class DocumentManager:
         exclude_patterns: list[str] | None = None,
         attachment_extensions: Sequence[str] | None = None,
         max_note_read_bytes: int = 262144,
-        on_write_callback: _OnWriteCallback | WriteCallback | None = None,
+        on_write_callback: OnWriteCallback | WriteCallback | None = None,
         mark_paths_dirty: Callable[[Iterable[str]], None] | None = None,
         title_field: str = "title",
         okf_write_enrich: Callable[[str, WriteOperation], str] | None = None,
@@ -208,15 +189,12 @@ class DocumentManager:
         self._exclude_patterns = exclude_patterns
         self._attachment_extensions = attachment_extensions
         self._max_note_read_bytes = max_note_read_bytes
-        self._on_write_callback = on_write_callback or (lambda *_a, **_kw: None)
+        self._notifier = WriteNotifier(on_write_callback)
         # Same opt-in probe the dispatcher uses (#894): a callback wired
         # straight into this manager — the isolation tests, and any consumer
         # constructing DocumentManager directly — may still be the published
         # three-argument shape, which must not be handed a keyword it cannot
         # take.
-        self._callback_takes_old_path = bool(
-            getattr(on_write_callback, ACCEPTS_OLD_PATH_ATTR, False)
-        )
         self._mark_paths_dirty = mark_paths_dirty
         self._title_field = title_field
         # OKF enforced-write hook (#964): transforms the final note text
@@ -865,7 +843,7 @@ class DocumentManager:
         self._atomic_write(abs_path, content)
         if self._mark_paths_dirty is not None:
             self._mark_paths_dirty([path])
-        self._on_write_callback(abs_path, content, operation)
+        self._notifier.fire(abs_path, content, operation)
 
     def append(
         self,
@@ -975,7 +953,7 @@ class DocumentManager:
             abs_path.parent.mkdir(parents=True, exist_ok=True)
             self._atomic_write(abs_path, content)
             result = WriteResult(path=path, created=created)
-            self._on_write_callback(abs_path, "", "write")
+            self._notifier.fire(abs_path, "", "write")
 
         return result
 
@@ -1236,7 +1214,7 @@ class DocumentManager:
                 self._check_if_match(abs_path, path, if_match)
                 abs_path.unlink()
 
-            self._on_write_callback(abs_path, "", "delete")
+            self._notifier.fire(abs_path, "", "delete")
 
         return DeleteResult(path=path)
 
@@ -1337,9 +1315,9 @@ class DocumentManager:
 
                 callback_content = ""
 
-            self._fire_rename(new_abs, callback_content, old_abs)
+            self._notifier.fire_rename(new_abs, callback_content, old_abs)
             for src_abs, src_content in backlink_callbacks:
-                self._on_write_callback(src_abs, src_content, "edit")
+                self._notifier.fire(src_abs, src_content, "edit")
 
         return RenameResult(
             old_path=old_path,
@@ -1567,22 +1545,6 @@ class DocumentManager:
 
         return moves, md_map, attachment_moves
 
-    def _fire_rename(self, new_abs: Path, content: str, old_abs: Path) -> None:
-        """Fire the write callback for a rename, passing both sides when it can.
-
-        Args:
-            new_abs: Absolute path the file now lives at.
-            content: File content at the new path (``""`` for attachments).
-            old_abs: Absolute path the file moved from, so a callback that
-                opted in can scope its git staging to the two paths the
-                rename touched instead of staging the whole repository (#894).
-        """
-        if self._callback_takes_old_path:
-            rename_aware = cast("_OnWriteCallback", self._on_write_callback)
-            rename_aware(new_abs, content, "rename", old_path=old_abs)
-        else:
-            self._on_write_callback(new_abs, content, "rename")
-
     def _dispatch_move_callbacks(
         self,
         md_map: dict[str, str],
@@ -1607,18 +1569,18 @@ class DocumentManager:
         source_root = self._source_dir.resolve()
         for old_path, new_path in md_map.items():
             new_note_abs = (self._source_dir / new_path).resolve()
-            self._fire_rename(
+            self._notifier.fire_rename(
                 new_note_abs,
                 _read_text_utf8(new_note_abs),
                 (self._source_dir / old_path).resolve(),
             )
         for dst_abs, _new_rel, src_abs_moved in attachment_moves:
-            self._fire_rename(dst_abs, "", src_abs_moved)
+            self._notifier.fire_rename(dst_abs, "", src_abs_moved)
         for src_abs, src_content in pending_callbacks:
             src_rel = src_abs.relative_to(source_root).as_posix()
             if src_rel in moved_note_paths:
                 continue
-            self._on_write_callback(src_abs, src_content, "edit")
+            self._notifier.fire(src_abs, src_content, "edit")
 
     def move_folder(self, old_dir: str, new_dir: str) -> MoveFolderResult:
         """Move an entire folder subtree to a new prefix, rewriting links.

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -51,7 +51,11 @@ from markdown_vault_mcp.types import (
     WriteResult,
 )
 from markdown_vault_mcp.utils import (
+    artifact_suffix,
     effective_attachment_extensions,
+    is_allowed_artifact,
+    is_allowed_artifact_suffix,
+    is_note,
     is_path_excluded,
     resolve_inside,
     validate_path,
@@ -309,14 +313,14 @@ class DocumentManager:
             ValueError: If the path escapes the source directory, ends with
                 ``.md``, or has an extension not in the attachment allowlist.
         """
-        if path.endswith(".md"):
+        if is_note(path):
             raise ValueError(
                 f"Path ends with '.md' — use the note read/write methods "
                 f"instead: {path}"
             )
         exts = self._effective_attachment_extensions()
-        suffix = Path(path).suffix.lstrip(".").lower()
-        if "*" not in exts and suffix not in exts:
+        suffix = artifact_suffix(path)
+        if not is_allowed_artifact_suffix(suffix, exts):
             allowed_str = ", ".join(f".{e}" for e in sorted(exts))
             raise ValueError(
                 f"Extension '.{suffix}' is not in the attachment allowlist. "
@@ -1217,7 +1221,7 @@ class DocumentManager:
         """
         self._check_writable()
         with self._file_write_lock:
-            if path.endswith(".md"):
+            if is_note(path):
                 abs_path = self._validate_path(path)
                 if not abs_path.is_file():
                     raise DocumentNotFoundError(f"Document not found: {path}")
@@ -1285,7 +1289,7 @@ class DocumentManager:
         backlink_callbacks: list[tuple[Path, str]] = []
 
         with self._file_write_lock:
-            if old_path.endswith(".md"):
+            if is_note(old_path):
                 old_abs = self._validate_path(old_path)
                 new_abs = self._validate_path(new_path)
 
@@ -1546,11 +1550,10 @@ class DocumentManager:
             new_path = f"{new_rel}/{rel_within}"
             dst_abs = (self._source_dir / new_path).resolve()
             moves.append((src_abs, dst_abs))
-            if old_path.endswith(".md"):
+            if is_note(old_path):
                 md_map[old_path] = new_path
             else:
-                suffix = src_abs.suffix.lstrip(".").lower()
-                if "*" in attachment_exts or suffix in attachment_exts:
+                if is_allowed_artifact(src_abs, attachment_exts):
                     attachment_moves.append((dst_abs, new_path, src_abs))
 
         if not moves:

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -635,7 +635,7 @@ class DocumentManager:
             raise ValueError(f"max_notes must be >= 1, got {max_notes!r}")
         if max_level is not None and max_level < 1:
             raise ValueError(f"max_level must be >= 1, got {max_level!r}")
-        if path.endswith(".md"):
+        if is_note(path):
             return self._note_toc(path, max_level=max_level)
         return self._subtree_toc(path, max_level=max_level, max_notes=max_notes)
 

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -148,7 +148,6 @@ class DocumentManager:
         self._read_only = read_only
         self._write_protect_existing = write_protect_existing
         self._exclude_patterns = exclude_patterns
-        self._attachment_extensions = attachment_extensions
         self._max_note_read_bytes = max_note_read_bytes
         self._notifier = WriteNotifier(on_write_callback)
         self._artifacts = ArtifactStore(
@@ -161,11 +160,6 @@ class DocumentManager:
                 write_protect_existing=write_protect_existing,
             ),
         )
-        # Same opt-in probe the dispatcher uses (#894): a callback wired
-        # straight into this manager — the isolation tests, and any consumer
-        # constructing DocumentManager directly — may still be the published
-        # three-argument shape, which must not be handed a keyword it cannot
-        # take.
         self._mark_paths_dirty = mark_paths_dirty
         self._title_field = title_field
         # OKF enforced-write hook (#964): transforms the final note text
@@ -788,7 +782,6 @@ class DocumentManager:
             ValueError: If the path escapes the source directory or has an
                 extension not in the allowlist.
         """
-        self._check_writable()
         return self._artifacts.write(path, content, if_match)
 
     def edit(

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -7,14 +7,9 @@ and no back-reference to :class:`Vault`.
 
 from __future__ import annotations
 
-import base64
 import logging
-import mimetypes
-import os
 import shutil
 import sqlite3
-import tempfile
-import threading
 from collections import defaultdict
 from dataclasses import replace
 from pathlib import Path
@@ -24,17 +19,17 @@ import frontmatter as fm
 import yaml
 
 from markdown_vault_mcp.exceptions import (
-    ConcurrentModificationError,
     DocumentExistsError,
     DocumentNotFoundError,
     EditConflictError,
     ReadOnlyError,
 )
-from markdown_vault_mcp.hashing import compute_etag, compute_file_hash
+from markdown_vault_mcp.managers._write_kernel import atomic_write, check_if_match
 from markdown_vault_mcp.managers._write_notifier import (
     OnWriteCallback,
     WriteNotifier,
 )
+from markdown_vault_mcp.managers.artifacts import ArtifactPolicy, ArtifactStore
 from markdown_vault_mcp.scanner import (
     extract_section,
     list_section_headings,
@@ -54,10 +49,7 @@ from markdown_vault_mcp.types import (
     WriteResult,
 )
 from markdown_vault_mcp.utils import (
-    artifact_suffix,
-    effective_attachment_extensions,
     is_allowed_artifact,
-    is_allowed_artifact_suffix,
     is_note,
     is_path_excluded,
     resolve_inside,
@@ -83,44 +75,13 @@ from markdown_vault_mcp.utils.text import (
 )
 
 if TYPE_CHECKING:
+    import threading
     from collections.abc import Callable, Iterable, Sequence
 
     from markdown_vault_mcp.interfaces import KeywordGraphIndex
     from markdown_vault_mcp.scanner import ChunkStrategy
 
 logger = logging.getLogger(__name__)
-
-
-_UMASK_LOCK = threading.Lock()
-_umask: int | None = None
-
-
-def _process_umask() -> int:
-    """Return the process umask, read once and cached.
-
-    ``os.umask`` is set-and-restore with no read-only accessor; we read it
-    once under a lock so concurrent writers serialise the set-and-restore
-    and never observe a transient mask. The umask is set by the parent
-    (shell / systemd) before Python starts and is effectively immutable
-    for the service lifetime, so a one-time read is correct.
-    """
-    global _umask
-    if _umask is not None:
-        return _umask
-    with _UMASK_LOCK:
-        # The lock serialises the set-and-restore so no writer in this
-        # module observes a transient mask. A second writer that lost the
-        # outer cache check re-reads and re-sets the same value (the umask
-        # is process-global), so no inner guard is needed.
-        mask = os.umask(0o077)
-        os.umask(mask)
-        _umask = mask
-    return _umask
-
-
-def _new_file_mode() -> int:
-    """Mode for a freshly-created file, matching a plain ``open(path, "w")``."""
-    return 0o666 & ~_process_umask()
 
 
 class DocumentManager:
@@ -190,6 +151,16 @@ class DocumentManager:
         self._attachment_extensions = attachment_extensions
         self._max_note_read_bytes = max_note_read_bytes
         self._notifier = WriteNotifier(on_write_callback)
+        self._artifacts = ArtifactStore(
+            source_dir,
+            write_lock=write_lock,
+            notifier=self._notifier,
+            policy=ArtifactPolicy(
+                attachment_extensions=attachment_extensions,
+                read_only=read_only,
+                write_protect_existing=write_protect_existing,
+            ),
+        )
         # Same opt-in probe the dispatcher uses (#894): a callback wired
         # straight into this manager — the isolation tests, and any consumer
         # constructing DocumentManager directly — may still be the published
@@ -228,13 +199,8 @@ class DocumentManager:
         self._check_writable()
 
     def _effective_attachment_extensions(self) -> frozenset[str]:
-        """Return the effective set of allowed attachment extensions.
-
-        Returns:
-            Frozenset of lower-case extension strings (without leading dot).
-            The special value ``frozenset(["*"])`` means all non-.md files.
-        """
-        return effective_attachment_extensions(self._attachment_extensions)
+        """Return the effective set of allowed attachment extensions."""
+        return self._artifacts.extensions()
 
     def _is_attachment(self, path: str) -> bool:
         """Return True if *path* is an allowed non-.md attachment.
@@ -281,6 +247,9 @@ class DocumentManager:
     def _validate_attachment_path(self, path: str) -> Path:
         """Resolve and validate a non-.md attachment path.
 
+        Thin delegator to :meth:`ArtifactStore.validate_path` (#1235); kept
+        because ``Vault`` and the tests reach for it by this name.
+
         Args:
             path: Relative attachment path.
 
@@ -291,22 +260,7 @@ class DocumentManager:
             ValueError: If the path escapes the source directory, ends with
                 ``.md``, or has an extension not in the attachment allowlist.
         """
-        if is_note(path):
-            raise ValueError(
-                f"Path ends with '.md' — use the note read/write methods "
-                f"instead: {path}"
-            )
-        exts = self._effective_attachment_extensions()
-        suffix = artifact_suffix(path)
-        if not is_allowed_artifact_suffix(suffix, exts):
-            allowed_str = ", ".join(f".{e}" for e in sorted(exts))
-            raise ValueError(
-                f"Extension '.{suffix}' is not in the attachment allowlist. "
-                f"Allowed: {allowed_str}. "
-                "Set MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS=* to allow "
-                "all non-.md files."
-            )
-        return resolve_inside(path, self._source_dir)
+        return self._artifacts.validate_path(path)
 
     def _validate_dir_path(self, path: str) -> Path:
         """Resolve a relative folder path and validate it is inside the vault.
@@ -535,13 +489,7 @@ class DocumentManager:
             ValueError: If the path escapes the source directory, has an
                 extension not in the allowlist, or the file does not exist.
         """
-        abs_path = self._validate_attachment_path(path)
-        try:
-            if not abs_path.is_file():
-                raise ValueError(f"Attachment not found: {path}")
-            return abs_path.stat().st_size
-        except OSError as exc:
-            raise ValueError(f"Attachment not found: {path}") from exc
+        return self._artifacts.size(path)
 
     def read_attachment(self, path: str) -> AttachmentContent:
         """Read the binary content of a non-.md attachment.
@@ -557,25 +505,7 @@ class DocumentManager:
             ValueError: If the path escapes the source directory, has an
                 extension not in the allowlist, or the file does not exist.
         """
-        abs_path = self._validate_attachment_path(path)
-        if not abs_path.is_file():
-            raise ValueError(f"Attachment not found: {path}")
-
-        stat = abs_path.stat()
-        size_bytes = stat.st_size
-
-        mime_type, _ = mimetypes.guess_type(path)
-        raw = abs_path.read_bytes()
-        content_base64 = base64.b64encode(raw).decode("ascii")
-        etag = compute_etag(raw)
-        return AttachmentContent(
-            path=path,
-            mime_type=mime_type,
-            size_bytes=size_bytes,
-            content_base64=content_base64,
-            modified_at=stat.st_mtime,
-            etag=etag,
-        )
+        return self._artifacts.read(path)
 
     def get_toc(
         self,
@@ -655,33 +585,6 @@ class DocumentManager:
     # Write operations
     # ------------------------------------------------------------------
 
-    def _check_if_match(self, abs_path: Path, path: str, if_match: str | None) -> None:
-        """Enforce an optional etag precondition on *abs_path*.
-
-        Args:
-            abs_path: Absolute path of the file the etag refers to.
-            path: Vault-relative path, used in the error.
-            if_match: Etag from a previous read, or ``None`` to skip the
-                check. A file that does not exist counts as a mismatch.
-
-        Raises:
-            ConcurrentModificationError: If *if_match* is provided and does
-                not match the current file hash (or the file is missing).
-        """
-        if if_match is None:
-            return
-        if not abs_path.is_file():
-            raise ConcurrentModificationError(
-                path,
-                expected=if_match,
-                actual="(file does not exist)",
-            )
-        current_hash = compute_file_hash(abs_path)
-        if current_hash != if_match:
-            raise ConcurrentModificationError(
-                path, expected=if_match, actual=current_hash
-            )
-
     def _check_no_clobber(
         self, abs_path: Path, path: str, if_match: str | None
     ) -> None:
@@ -711,50 +614,6 @@ class DocumentManager:
                 "proves nothing. (Write protection is enabled by the "
                 "operator: MARKDOWN_VAULT_MCP_WRITE_PROTECT_EXISTING.)"
             )
-
-    def _atomic_write(self, abs_path: Path, data: str | bytes) -> None:
-        """Write *data* to *abs_path* atomically via a sibling tempfile.
-
-        The temp file lands with :meth:`Path.replace` semantics; permission
-        bits are preserved when the target already exists. A freshly-created
-        target is chmod'd to ``0o666 & ~umask`` after the replace so fresh
-        writes honour the process umask (matching a plain ``open``) instead
-        of the ``0o600`` ``tempfile`` hardcodes. On failure the temp file is
-        removed and the original is left untouched.
-
-        Args:
-            abs_path: Absolute destination path.
-            data: Text (written UTF-8) or raw bytes.
-        """
-        existed = abs_path.is_file()
-        if isinstance(data, str):
-            with tempfile.NamedTemporaryFile(
-                dir=abs_path.parent,
-                mode="w",
-                encoding="utf-8",
-                suffix=".tmp",
-                delete=False,
-            ) as tmp:
-                tmp.write(data)
-                tmp_name = tmp.name
-        else:
-            with tempfile.NamedTemporaryFile(
-                dir=abs_path.parent,
-                mode="wb",
-                suffix=".tmp",
-                delete=False,
-            ) as tmp:
-                tmp.write(data)
-                tmp_name = tmp.name
-        if existed:
-            shutil.copymode(abs_path, tmp_name)
-        try:
-            Path(tmp_name).replace(abs_path)
-        except Exception:
-            Path(tmp_name).unlink(missing_ok=True)
-            raise
-        if not existed:
-            abs_path.chmod(_new_file_mode())
 
     def write(
         self,
@@ -801,7 +660,7 @@ class DocumentManager:
             abs_path = self._validate_path(path)
             if not allow_overwrite:
                 self._check_no_clobber(abs_path, path, if_match)
-            self._check_if_match(abs_path, path, if_match)
+            check_if_match(abs_path, path, if_match)
             created = not abs_path.is_file()
 
             abs_path.parent.mkdir(parents=True, exist_ok=True)
@@ -840,7 +699,7 @@ class DocumentManager:
         """
         if self._okf_write_enrich is not None:
             content = self._okf_write_enrich(content, operation)
-        self._atomic_write(abs_path, content)
+        atomic_write(abs_path, content)
         if self._mark_paths_dirty is not None:
             self._mark_paths_dirty([path])
         self._notifier.fire(abs_path, content, operation)
@@ -897,7 +756,7 @@ class DocumentManager:
             existed = abs_path.is_file()
             if not existed and not create_if_missing:
                 raise DocumentNotFoundError(f"Document not found: {path}")
-            self._check_if_match(abs_path, path, if_match)
+            check_if_match(abs_path, path, if_match)
 
             if existed:
                 file_content = _read_text_utf8(abs_path)
@@ -945,17 +804,7 @@ class DocumentManager:
                 extension not in the allowlist.
         """
         self._check_writable()
-        with self._file_write_lock:
-            abs_path = self._validate_attachment_path(path)
-            self._check_no_clobber(abs_path, path, if_match)
-            self._check_if_match(abs_path, path, if_match)
-            created = not abs_path.is_file()
-            abs_path.parent.mkdir(parents=True, exist_ok=True)
-            self._atomic_write(abs_path, content)
-            result = WriteResult(path=path, created=created)
-            self._notifier.fire(abs_path, "", "write")
-
-        return result
+        return self._artifacts.write(path, content, if_match)
 
     def edit(
         self,
@@ -1039,7 +888,7 @@ class DocumentManager:
             if not abs_path.is_file():
                 raise DocumentNotFoundError(f"Document not found: {path}")
 
-            self._check_if_match(abs_path, path, if_match)
+            check_if_match(abs_path, path, if_match)
 
             file_content = _read_text_utf8(abs_path)
 
@@ -1203,16 +1052,12 @@ class DocumentManager:
                 abs_path = self._validate_path(path)
                 if not abs_path.is_file():
                     raise DocumentNotFoundError(f"Document not found: {path}")
-                self._check_if_match(abs_path, path, if_match)
+                check_if_match(abs_path, path, if_match)
                 abs_path.unlink()
                 if self._mark_paths_dirty is not None:
                     self._mark_paths_dirty([path])
             else:
-                abs_path = self._validate_attachment_path(path)
-                if not abs_path.is_file():
-                    raise DocumentNotFoundError(f"Attachment not found: {path}")
-                self._check_if_match(abs_path, path, if_match)
-                abs_path.unlink()
+                abs_path = self._artifacts.unlink(path, if_match)
 
             self._notifier.fire(abs_path, "", "delete")
 
@@ -1275,7 +1120,7 @@ class DocumentManager:
                     raise DocumentNotFoundError(f"Document not found: {old_path}")
                 if new_abs.is_file():
                     raise DocumentExistsError(f"Target already exists: {new_path}")
-                self._check_if_match(old_abs, old_path, if_match)
+                check_if_match(old_abs, old_path, if_match)
 
                 backlinks = self._fts.get_backlinks(old_path) if update_links else []
 
@@ -1301,18 +1146,7 @@ class DocumentManager:
                     dirty.extend(backlink_paths)
                     self._mark_paths_dirty(dirty)
             else:
-                old_abs = self._validate_attachment_path(old_path)
-                new_abs = self._validate_attachment_path(new_path)
-
-                if not old_abs.is_file():
-                    raise DocumentNotFoundError(f"Attachment not found: {old_path}")
-                if new_abs.is_file():
-                    raise DocumentExistsError(f"Target already exists: {new_path}")
-                self._check_if_match(old_abs, old_path, if_match)
-
-                new_abs.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(old_abs), str(new_abs))
-
+                old_abs, new_abs = self._artifacts.move(old_path, new_path, if_match)
                 callback_content = ""
 
             self._notifier.fire_rename(new_abs, callback_content, old_abs)
@@ -1360,7 +1194,7 @@ class DocumentManager:
                 old_path=target_old,
             )
             content = _apply_link_replacement(content, link_type, raw_target, new_raw)
-        self._atomic_write(source_abs, content)
+        atomic_write(source_abs, content)
         return content
 
     def _rewrite_link_sources(

--- a/src/markdown_vault_mcp/managers/embeddings.py
+++ b/src/markdown_vault_mcp/managers/embeddings.py
@@ -26,6 +26,7 @@ from markdown_vault_mcp.exceptions import EmbeddingsNotConfiguredError
 from markdown_vault_mcp.fts_index import _derive_folder
 from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
 from markdown_vault_mcp.scanner import parse_note
+from markdown_vault_mcp.utils import is_note
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1093,7 +1094,7 @@ class EmbeddingsManager:
                 # Excluded paths (e.g. convention files) never get vectors,
                 # mirroring the FTS guard in process_dirty_paths → delete.
                 pre_embedded.append((path, None, None, False))
-            elif abs_path.is_file() and path.endswith(".md"):
+            elif abs_path.is_file() and is_note(path):
                 try:
                     note = parse_note(
                         abs_path,

--- a/src/markdown_vault_mcp/managers/git_query.py
+++ b/src/markdown_vault_mcp/managers/git_query.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.utils import (
     effective_attachment_extensions,
+    is_note,
     validate_history_dir,
     validate_history_path,
 )
@@ -206,5 +207,5 @@ class GitQueryManager:
             since_timestamp=since_timestamp,
             limit=limit if per_commit else None,
             # True for any non-.md path; get_file_diff only emits --stat if git also reports it binary — text attachments fall through to a full diff.
-            summarize_binary=not path.endswith(".md"),
+            summarize_binary=not is_note(path),
         )

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -34,7 +34,10 @@ from markdown_vault_mcp.scanner import (
     scan_directory,
 )
 from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult, SkippedFile
-from markdown_vault_mcp.utils import is_path_excluded
+from markdown_vault_mcp.utils import (
+    is_note,
+    is_path_excluded,
+)
 from markdown_vault_mcp.utils.fs import iter_markdown_files
 
 if TYPE_CHECKING:
@@ -919,7 +922,7 @@ class IndexManager:
                         # before the exclusion existed.
                         self._fts.delete_by_path(path)
                         continue
-                    if abs_path.is_file() and path.endswith(".md"):
+                    if abs_path.is_file() and is_note(path):
                         note = parse_note(
                             abs_path,
                             self._source_dir,

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -69,9 +69,12 @@ from markdown_vault_mcp.types import (
     VaultStats,
 )
 from markdown_vault_mcp.utils import (
+    artifact_suffix,
     effective_attachment_extensions,
     folder_matches,
     fts_row_to_note_info,
+    has_md_suffix,
+    is_allowed_artifact_suffix,
     is_path_excluded,
     normalize_folder,
     validate_path,
@@ -1353,11 +1356,11 @@ class SearchManager:
             An :class:`~markdown_vault_mcp.types.AttachmentInfo`, or
             ``None`` when the entry is filtered out or unreadable.
         """
-        suffix = abs_path.suffix.lstrip(".").lower()
+        suffix = artifact_suffix(abs_path)
         if (
             not abs_path.is_file()
-            or abs_path.suffix.lower() == ".md"
-            or ("*" not in exts and suffix not in exts)
+            or has_md_suffix(abs_path)
+            or not is_allowed_artifact_suffix(suffix, exts)
         ):
             return None
         rel = self._attachment_rel_path(abs_path)

--- a/src/markdown_vault_mcp/managers/summarize.py
+++ b/src/markdown_vault_mcp/managers/summarize.py
@@ -28,6 +28,7 @@ from markdown_vault_mcp.types import (
     SummaryResult,
     SummarySource,
 )
+from markdown_vault_mcp.utils import is_note
 
 if TYPE_CHECKING:
     from markdown_vault_mcp.managers.document import DocumentManager
@@ -233,7 +234,7 @@ class SummarizeManager:
 
     def _expand_path(self, path: str) -> list[str]:
         """Resolve one input path to note paths (single note or subtree)."""
-        if path.endswith(".md"):
+        if is_note(path):
             return [path]
         # Expand generously so the pre-cap match count is known; the
         # note limit is applied by _resolve_paths afterwards.

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import fnmatch
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-from markdown_vault_mcp.types import DEFAULT_ATTACHMENT_EXTENSIONS
+from markdown_vault_mcp.utils.content_kind import (
+    artifact_suffix,
+    effective_attachment_extensions,
+    has_md_suffix,
+    is_allowed_artifact,
+    is_allowed_artifact_suffix,
+    is_attachment,
+    is_note,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 from markdown_vault_mcp.utils.fts import fts_row_to_note_info
 from markdown_vault_mcp.utils.links import (
     apply_link_replacement,
@@ -85,24 +93,6 @@ def folder_matches(row_folder: str, folder: str) -> bool:
     return row_folder == folder or row_folder.startswith(folder + "/")
 
 
-def effective_attachment_extensions(
-    attachment_extensions: Sequence[str] | None,
-) -> frozenset[str]:
-    """Return the effective set of allowed attachment extensions.
-
-    Args:
-        attachment_extensions: User-configured extension list, or ``None``
-            to use the default set.
-
-    Returns:
-        Frozenset of lower-case extension strings (without leading dot).
-        The special value ``frozenset(["*"])`` means all non-.md files.
-    """
-    if attachment_extensions is None:
-        return DEFAULT_ATTACHMENT_EXTENSIONS
-    return frozenset(attachment_extensions)
-
-
 def resolve_inside(path: str, base: Path, *, original: str | None = None) -> Path:
     """Resolve *path* against *base* and verify the result stays inside it.
 
@@ -147,7 +137,7 @@ def validate_path(path: str, source_dir: Path) -> Path:
         ValueError: If the path escapes the source directory or does
             not end with ``.md``.
     """
-    if not path.endswith(".md"):
+    if not is_note(path):
         raise ValueError(f"Path must end with '.md': {path}")
     return resolve_inside(path, source_dir)
 
@@ -178,11 +168,9 @@ def validate_history_path(
         ValueError: *path* is neither ``.md`` nor an allowed attachment
             extension, or it escapes *source_dir*.
     """
-    suffix = Path(path).suffix.lstrip(".").lower()
     if not (
-        path.endswith(".md")
-        or "*" in attachment_extensions
-        or suffix in attachment_extensions
+        is_note(path)
+        or is_allowed_artifact_suffix(artifact_suffix(path), attachment_extensions)
     ):
         raise ValueError(
             f"Path must be a .md note or a configured attachment type: {path}"
@@ -222,11 +210,17 @@ def validate_history_dir(path: str, source_dir: Path) -> Path:
 __all__ = [
     "CHAR_SUBS",
     "apply_link_replacement",
+    "artifact_suffix",
     "build_position_map",
     "compute_new_raw_target",
     "effective_attachment_extensions",
     "find_closest_match",
     "fts_row_to_note_info",
+    "has_md_suffix",
+    "is_allowed_artifact",
+    "is_allowed_artifact_suffix",
+    "is_attachment",
+    "is_note",
     "is_path_excluded",
     "normalize_text",
     "resolve_inside",

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -11,7 +11,6 @@ from markdown_vault_mcp.utils.content_kind import (
     has_md_suffix,
     is_allowed_artifact,
     is_allowed_artifact_suffix,
-    is_attachment,
     is_note,
 )
 
@@ -219,7 +218,6 @@ __all__ = [
     "has_md_suffix",
     "is_allowed_artifact",
     "is_allowed_artifact_suffix",
-    "is_attachment",
     "is_note",
     "is_path_excluded",
     "normalize_text",

--- a/src/markdown_vault_mcp/utils/content_kind.py
+++ b/src/markdown_vault_mcp/utils/content_kind.py
@@ -148,7 +148,6 @@ def is_allowed_artifact(path: str | Path, extensions: frozenset[str]) -> bool:
     return is_allowed_artifact_suffix(artifact_suffix(path), extensions)
 
 
-
 def effective_attachment_extensions(
     attachment_extensions: Sequence[str] | None,
 ) -> frozenset[str]:

--- a/src/markdown_vault_mcp/utils/content_kind.py
+++ b/src/markdown_vault_mcp/utils/content_kind.py
@@ -1,0 +1,182 @@
+"""Which kind of thing a vault path names (#1235).
+
+Every routing test that asks *"is this path a markdown note?"* lives here, so
+there is one spelling of the question instead of one per call site.
+
+**Three axes** ride on the ``.md`` extension.  They ask the same question and
+share :func:`is_note`; what differs — and what must **not** be unified — is
+what a *non-note* means:
+
+* **ARTIFACT** — an attachment.  Decides which CRUD path a write takes and
+  which validator runs (``DocumentManager``, ``ArtifactStore``, the transfer
+  sink, the ``read``/``write``/``fetch`` tools).
+* **FOLDER** — a directory scope: ``DocumentManager.get_toc`` and
+  ``SummarizeManager._expand_path`` treat a non-note path as a subtree prefix.
+* **INDEXABILITY** — not a candidate for the index: ``IndexManager``,
+  ``EmbeddingsManager``, ``utils.fs.iter_markdown_files``.
+
+Collapsing those three into one tri-state would make the folder sites claim a
+path is "an artifact" when they mean "a folder", so the distinction is kept in
+prose rather than in the type.
+
+**Two divergences are deliberate and PRESERVED here, not unified:**
+
+* **Case.**  Routing is case-sensitive (:func:`is_note`).
+  ``SearchManager._attachment_info`` is case-*insensitive* and uses
+  :func:`has_md_suffix`.  ``DocumentManager.read``'s note-size cap uses a third
+  spelling (``path.lower().endswith(".md")``) and stays inline, because that
+  method validates no extension at all — a file named ``NOTE.MD`` really does
+  reach it and really does get the cap.
+* **Resolution.**  Some callers take the extension from the raw caller string
+  (before the traversal guard), others from the ``.resolve()``d path (after).
+  Symlinks make those differ: ``link.pdf -> target.bin`` is ``pdf`` by name and
+  ``bin`` by target.  Nothing here resolves — each caller passes the object
+  whose extension it means.
+
+Not owned here, because they are not path predicates: glob patterns that state
+the same rule in another language (``scanner``'s ``**/*.md``, ``tracker``'s
+comparison against it), and name normalization / display (appending ``.md`` to
+a bare wikilink, stripping it for a label).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from markdown_vault_mcp.types import DEFAULT_ATTACHMENT_EXTENSIONS
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "artifact_suffix",
+    "effective_attachment_extensions",
+    "has_md_suffix",
+    "is_allowed_artifact",
+    "is_allowed_artifact_suffix",
+    "is_attachment",
+    "is_note",
+]
+
+
+def is_note(path: str) -> bool:
+    """Return whether *path* names a markdown note.
+
+    The routing test: case-**sensitive**, matching every dispatch site in the
+    codebase.  Use :func:`has_md_suffix` where case-insensitivity is intended.
+
+    Args:
+        path: A vault-relative path.
+
+    Returns:
+        ``True`` when *path* ends in ``.md``.
+    """
+    return path.endswith(".md")
+
+
+def has_md_suffix(path: str | Path) -> bool:
+    """Return whether *path* has a ``.md`` suffix, ignoring case.
+
+    Not a substitute for :func:`is_note`: it accepts ``NOTE.MD``, and it reads
+    the suffix through :class:`~pathlib.Path`, so a file literally named
+    ``.md`` has no suffix and does not match.
+
+    Args:
+        path: A vault-relative path.
+
+    Returns:
+        ``True`` when the suffix is ``.md`` in any case.
+    """
+    return Path(path).suffix.lower() == ".md"
+
+
+def artifact_suffix(path: str | Path) -> str:
+    """Return *path*'s extension, lower-cased and without the leading dot.
+
+    Does not resolve symlinks.  Pass a ``str`` to test the caller's spelling,
+    or an already-resolved :class:`~pathlib.Path` to test the on-disk target —
+    the two differ for a symlink, and that choice belongs to the caller.
+
+    Args:
+        path: A vault-relative path or a resolved path.
+
+    Returns:
+        The extension, or ``""`` when there is none.
+    """
+    return Path(path).suffix.lstrip(".").lower()
+
+
+def is_allowed_artifact_suffix(suffix: str, extensions: frozenset[str]) -> bool:
+    """Return whether a bare *suffix* is in the attachment allowlist.
+
+    Args:
+        suffix: A dot-less, lower-cased extension, as from
+            :func:`artifact_suffix`.
+        extensions: The effective allowlist; ``{"*"}`` allows everything.
+
+    Returns:
+        ``True`` when the suffix is allowed.
+    """
+    return "*" in extensions or suffix in extensions
+
+
+def is_allowed_artifact(path: str | Path, extensions: frozenset[str]) -> bool:
+    """Return whether *path*'s extension is in the attachment allowlist.
+
+    Says nothing about ``.md`` — a note passes this test whenever ``md`` is
+    allowlisted.  Combine with :func:`is_note` when both matter, or use
+    :func:`is_attachment`.
+
+    Args:
+        path: A vault-relative path or a resolved path (see
+            :func:`artifact_suffix` on which to pass).
+        extensions: The effective allowlist.
+
+    Returns:
+        ``True`` when the extension is allowed.
+    """
+    return is_allowed_artifact_suffix(artifact_suffix(path), extensions)
+
+
+def is_attachment(path: str, extensions: frozenset[str]) -> bool:
+    """Return whether *path* is a non-note file of an allowlisted type.
+
+    **Not the routing test.**  The tool layer and the transfer sink route on
+    ``not is_note(path)`` alone, so a non-allowlisted, non-``.md`` file still
+    reaches the attachment branch and is rejected *there* — with the error that
+    names ``MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS``.  Routing on this
+    predicate instead would send such a file down the note path and change that
+    operator-facing message.
+
+    Args:
+        path: A vault-relative path.
+        extensions: The effective allowlist.
+
+    Returns:
+        ``True`` when *path* is an allowlisted attachment.
+    """
+    return not is_note(path) and is_allowed_artifact(path, extensions)
+
+
+def effective_attachment_extensions(
+    attachment_extensions: Sequence[str] | None,
+) -> frozenset[str]:
+    """Return the effective set of allowed attachment extensions.
+
+    Note the configured values are used verbatim: unlike the path side, they
+    are not lower-cased or dot-stripped, so a config of ``["PDF"]`` or
+    ``[".pdf"]`` matches nothing. That asymmetry is pre-existing and pinned by
+    a test rather than fixed here.
+
+    Args:
+        attachment_extensions: User-configured extension list, or ``None``
+            to use the default set.
+
+    Returns:
+        Frozenset of lower-case extension strings (without leading dot).
+        The special value ``frozenset(["*"])`` means all non-.md files.
+    """
+    if attachment_extensions is None:
+        return DEFAULT_ATTACHMENT_EXTENSIONS
+    return frozenset(attachment_extensions)

--- a/src/markdown_vault_mcp/utils/content_kind.py
+++ b/src/markdown_vault_mcp/utils/content_kind.py
@@ -11,7 +11,8 @@ what a *non-note* means:
   which validator runs (``DocumentManager``, ``ArtifactStore``, the transfer
   sink, the ``read``/``write``/``fetch`` tools).
 * **FOLDER** — a directory scope: ``DocumentManager.get_toc`` and
-  ``SummarizeManager._expand_path`` treat a non-note path as a subtree prefix.
+  ``SummarizeManager._expand_path`` treat a non-note path as a subtree prefix,
+  and ``ConventionsResolver`` folds a note path to its parent folder.
 * **INDEXABILITY** — not a candidate for the index: ``IndexManager``,
   ``EmbeddingsManager``, ``utils.fs.iter_markdown_files``.
 
@@ -32,6 +33,15 @@ prose rather than in the type.
   Symlinks make those differ: ``link.pdf -> target.bin`` is ``pdf`` by name and
   ``bin`` by target.  Nothing here resolves — each caller passes the object
   whose extension it means.
+
+There is deliberately no ``is_attachment(path, extensions)`` helper. It reads
+like the routing test and is not one — the tool layer and the transfer sink
+route on ``not is_note(path)`` alone, so a non-allowlisted file still reaches
+the artifact branch and is rejected there with the error naming
+``MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS``. A caller that genuinely wants
+"non-note and allowlisted" composes the two predicates at the point of use,
+where the surrounding branch shows which it meant. The private method this
+module replaced had exactly that misleading name and zero callers (#1235).
 
 Not owned here, because they are not path predicates: glob patterns that state
 the same rule in another language (``scanner``'s ``**/*.md``, ``tracker``'s
@@ -55,7 +65,6 @@ __all__ = [
     "has_md_suffix",
     "is_allowed_artifact",
     "is_allowed_artifact_suffix",
-    "is_attachment",
     "is_note",
 ]
 
@@ -125,8 +134,8 @@ def is_allowed_artifact(path: str | Path, extensions: frozenset[str]) -> bool:
     """Return whether *path*'s extension is in the attachment allowlist.
 
     Says nothing about ``.md`` — a note passes this test whenever ``md`` is
-    allowlisted.  Combine with :func:`is_note` when both matter, or use
-    :func:`is_attachment`.
+    allowlisted.  Combine with :func:`is_note` when both matter, at the point
+    of use rather than through a helper (see the module docstring).
 
     Args:
         path: A vault-relative path or a resolved path (see
@@ -138,25 +147,6 @@ def is_allowed_artifact(path: str | Path, extensions: frozenset[str]) -> bool:
     """
     return is_allowed_artifact_suffix(artifact_suffix(path), extensions)
 
-
-def is_attachment(path: str, extensions: frozenset[str]) -> bool:
-    """Return whether *path* is a non-note file of an allowlisted type.
-
-    **Not the routing test.**  The tool layer and the transfer sink route on
-    ``not is_note(path)`` alone, so a non-allowlisted, non-``.md`` file still
-    reaches the attachment branch and is rejected *there* — with the error that
-    names ``MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS``.  Routing on this
-    predicate instead would send such a file down the note path and change that
-    operator-facing message.
-
-    Args:
-        path: A vault-relative path.
-        extensions: The effective allowlist.
-
-    Returns:
-        ``True`` when *path* is an allowlisted attachment.
-    """
-    return not is_note(path) and is_allowed_artifact(path, extensions)
 
 
 def effective_attachment_extensions(

--- a/src/markdown_vault_mcp/utils/content_kind.py
+++ b/src/markdown_vault_mcp/utils/content_kind.py
@@ -19,7 +19,7 @@ Collapsing those three into one tri-state would make the folder sites claim a
 path is "an artifact" when they mean "a folder", so the distinction is kept in
 prose rather than in the type.
 
-**Two divergences are deliberate and PRESERVED here, not unified:**
+**Two divergences are deliberate and PRESERVED here, not unified** (#1240):
 
 * **Case.**  Routing is case-sensitive (:func:`is_note`).
   ``SearchManager._attachment_info`` is case-*insensitive* and uses
@@ -167,7 +167,7 @@ def effective_attachment_extensions(
     Note the configured values are used verbatim: unlike the path side, they
     are not lower-cased or dot-stripped, so a config of ``["PDF"]`` or
     ``[".pdf"]`` matches nothing. That asymmetry is pre-existing and pinned by
-    a test rather than fixed here.
+    a test rather than fixed here (#1239).
 
     Args:
         attachment_extensions: User-configured extension list, or ``None``

--- a/src/markdown_vault_mcp/utils/fs.py
+++ b/src/markdown_vault_mcp/utils/fs.py
@@ -7,6 +7,8 @@ import os
 import sys
 from typing import TYPE_CHECKING, Any
 
+from markdown_vault_mcp.utils.content_kind import is_note
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
     from pathlib import Path
@@ -191,5 +193,5 @@ def iter_markdown_files(
             dirnames[:] = kept
         base = source_dir / rel_prefix if rel_prefix else source_dir
         for filename in filenames:
-            if filename.endswith(".md"):
+            if is_note(filename):
                 yield base / filename

--- a/tests/test_managers_artifacts.py
+++ b/tests/test_managers_artifacts.py
@@ -1,0 +1,286 @@
+"""Tests for :class:`ArtifactStore` (#1235).
+
+Constructed directly, with no ``DocumentManager`` and no FTS index, so these
+exercise the store rather than the manager that composes it.
+
+Two are structural rather than behavioural. The wiring test pins that the
+store shares the manager's lock and notifier *by identity*: a private lock
+would stop artifact writes serialising against note writes and would leave
+``Vault.pause_writes`` unable to hold artifacts still during a git rebase. And
+``unlink``/``move`` are asserted to fire *no* callback, because the manager
+fires exactly one after its note/artifact branch closes — owning it in the
+store would double-fire or move it outside the lock.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from markdown_vault_mcp.exceptions import (
+    ConcurrentModificationError,
+    DocumentExistsError,
+    DocumentNotFoundError,
+    ReadOnlyError,
+)
+from markdown_vault_mcp.hashing import compute_etag
+from markdown_vault_mcp.managers._write_notifier import WriteNotifier
+from markdown_vault_mcp.managers.artifacts import ArtifactPolicy, ArtifactStore
+
+if TYPE_CHECKING:
+    from markdown_vault_mcp.types import WriteOperation
+
+
+class _Recorder:
+    """Captures the calls a WriteNotifier would forward."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Path, str, str]] = []
+        self.renames: list[tuple[Path, str, Path]] = []
+
+    def __call__(
+        self, path: Path, content: str, operation: WriteOperation, /, **_kw: Any
+    ) -> None:
+        if operation == "rename":
+            self.renames.append((path, content, Path()))
+        else:
+            self.calls.append((path, content, operation))
+
+
+def _store(
+    tmp_path: Path,
+    *,
+    extensions: list[str] | None = None,
+    read_only: bool = False,
+    write_protect_existing: bool = False,
+) -> tuple[ArtifactStore, _Recorder]:
+    recorder = _Recorder()
+    store = ArtifactStore(
+        tmp_path,
+        write_lock=threading.RLock(),
+        notifier=WriteNotifier(recorder),
+        policy=ArtifactPolicy(
+            attachment_extensions=extensions,
+            read_only=read_only,
+            write_protect_existing=write_protect_existing,
+        ),
+    )
+    return store, recorder
+
+
+class TestValidatePath:
+    def test_accepts_allowlisted(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        assert store.validate_path("assets/a.png") == tmp_path / "assets/a.png"
+
+    def test_rejects_markdown(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        with pytest.raises(ValueError, match="use the note read/write methods"):
+            store.validate_path("note.md")
+
+    def test_rejects_traversal(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        with pytest.raises(ValueError, match="traversal"):
+            store.validate_path("../outside.png")
+
+    def test_rejects_disallowed_extension_naming_the_env_var(
+        self, tmp_path: Path
+    ) -> None:
+        """The operator-facing hint is the contract, not an implementation detail."""
+        store, _ = _store(tmp_path, extensions=["png"])
+        with pytest.raises(ValueError) as exc:
+            store.validate_path("a.xyz")
+        assert "not in the attachment allowlist" in str(exc.value)
+        assert "MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS" in str(exc.value)
+
+    def test_wildcard_accepts_anything_non_markdown(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path, extensions=["*"])
+        assert store.validate_path("a.whatever")
+        with pytest.raises(ValueError, match="use the note read/write methods"):
+            store.validate_path("a.md")
+
+
+class TestSize:
+    def test_returns_byte_size(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"12345")
+        assert store.size("a.png") == 5
+
+    def test_missing_raises(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        with pytest.raises(ValueError, match="Attachment not found"):
+            store.size("gone.png")
+
+    def test_stat_race_surfaces_as_value_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A file vanishing between is_file() and stat() is not an OSError leak."""
+        store, _ = _store(tmp_path)
+
+        class _Racy:
+            def is_file(self) -> bool:
+                return True
+
+            def stat(self) -> object:
+                raise OSError("vanished mid-stat")
+
+        monkeypatch.setattr(store, "validate_path", lambda _p: _Racy())
+        with pytest.raises(ValueError, match="Attachment not found"):
+            store.size("gone.png")
+
+
+class TestRead:
+    def test_returns_content_and_metadata(self, tmp_path: Path) -> None:
+        import base64
+
+        store, _ = _store(tmp_path)
+        raw = b"\x89PNG fake"
+        (tmp_path / "a.png").write_bytes(raw)
+
+        got = store.read("a.png")
+
+        assert got.path == "a.png"
+        assert got.mime_type == "image/png"
+        assert got.size_bytes == len(raw)
+        assert base64.b64decode(got.content_base64) == raw
+        assert got.etag == compute_etag(raw)
+
+    def test_missing_raises(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        with pytest.raises(ValueError, match="Attachment not found"):
+            store.read("gone.png")
+
+
+class TestWrite:
+    def test_creates_and_reports_created(self, tmp_path: Path) -> None:
+        store, rec = _store(tmp_path)
+        result = store.write("assets/a.png", b"bytes")
+
+        assert result.created is True
+        assert (tmp_path / "assets/a.png").read_bytes() == b"bytes"
+        assert rec.calls == [(tmp_path / "assets/a.png", "", "write")]
+
+    def test_overwrite_reports_not_created(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"old")
+        assert store.write("a.png", b"new").created is False
+        assert (tmp_path / "a.png").read_bytes() == b"new"
+
+    def test_read_only_refuses(self, tmp_path: Path) -> None:
+        store, rec = _store(tmp_path, read_only=True)
+        with pytest.raises(ReadOnlyError):
+            store.write("a.png", b"x")
+        assert rec.calls == []
+
+    def test_write_protect_refuses_blind_overwrite(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path, write_protect_existing=True)
+        (tmp_path / "a.png").write_bytes(b"old")
+        with pytest.raises(DocumentExistsError, match="proof of read"):
+            store.write("a.png", b"new")
+
+    def test_write_protect_allows_with_if_match(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path, write_protect_existing=True)
+        (tmp_path / "a.png").write_bytes(b"old")
+        from markdown_vault_mcp.hashing import compute_file_hash
+
+        etag = compute_file_hash(tmp_path / "a.png")
+        assert store.write("a.png", b"new", etag).created is False
+
+    def test_if_match_mismatch_raises(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"old")
+        with pytest.raises(ConcurrentModificationError):
+            store.write("a.png", b"new", "not-the-etag")
+
+    def test_if_match_on_missing_file_raises(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        with pytest.raises(ConcurrentModificationError):
+            store.write("a.png", b"x", "some-etag")
+
+
+class TestUnlinkAndMove:
+    def test_unlink_removes_and_fires_nothing(self, tmp_path: Path) -> None:
+        """The manager owns the delete callback, so the store must stay silent."""
+        store, rec = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"x")
+
+        removed = store.unlink("a.png", None)
+
+        assert removed == tmp_path / "a.png"
+        assert not (tmp_path / "a.png").exists()
+        assert rec.calls == []
+        assert rec.renames == []
+
+    def test_unlink_missing_raises(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        with pytest.raises(DocumentNotFoundError, match="Attachment not found"):
+            store.unlink("gone.png", None)
+
+    def test_unlink_honours_if_match(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"x")
+        with pytest.raises(ConcurrentModificationError):
+            store.unlink("a.png", "wrong")
+
+    def test_move_relocates_and_fires_nothing(self, tmp_path: Path) -> None:
+        store, rec = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"x")
+
+        old_abs, new_abs = store.move("a.png", "sub/b.png", None)
+
+        assert old_abs == tmp_path / "a.png"
+        assert new_abs == tmp_path / "sub/b.png"
+        assert new_abs.read_bytes() == b"x"
+        assert rec.calls == []
+        assert rec.renames == []
+
+    def test_move_missing_source_raises(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        with pytest.raises(DocumentNotFoundError, match="Attachment not found"):
+            store.move("gone.png", "b.png", None)
+
+    def test_move_onto_existing_target_raises(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"x")
+        (tmp_path / "b.png").write_bytes(b"y")
+        with pytest.raises(DocumentExistsError, match="Target already exists"):
+            store.move("a.png", "b.png", None)
+
+    def test_move_honours_if_match(self, tmp_path: Path) -> None:
+        store, _ = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"x")
+        with pytest.raises(ConcurrentModificationError):
+            store.move("a.png", "b.png", "wrong")
+
+
+class TestSharedWiring:
+    """The store must share the manager's lock and notifier, not copy them."""
+
+    def test_manager_passes_its_own_lock_and_notifier(self, tmp_path: Path) -> None:
+        """Identity, not equality.
+
+        A private lock in the store would stop artifact writes serialising
+        against note writes, and would leave Vault.pause_writes unable to hold
+        artifacts still during a git rebase.
+        """
+        from markdown_vault_mcp.fts_index import FTSIndex
+        from markdown_vault_mcp.managers.document import DocumentManager
+        from markdown_vault_mcp.scanner import HeadingChunker
+
+        fts = FTSIndex(db_path=":memory:")
+        try:
+            lock = threading.RLock()
+            mgr = DocumentManager(
+                fts,
+                tmp_path,
+                write_lock=lock,
+                chunk_strategy=HeadingChunker(),
+                read_only=False,
+            )
+            assert mgr._artifacts._file_write_lock is lock
+            assert mgr._artifacts._notifier is mgr._notifier
+        finally:
+            fts.close()

--- a/tests/test_managers_artifacts.py
+++ b/tests/test_managers_artifacts.py
@@ -288,6 +288,52 @@ class TestUnlinkAndMove:
         with pytest.raises(ConcurrentModificationError):
             store.move("a.png", "b.png", "wrong")
 
+    def test_unlink_refuses_on_a_read_only_store(self, tmp_path: Path) -> None:
+        """The store enforces its own policy, not just the manager's.
+
+        DocumentManager.delete happens to check first, so this guard is
+        unreachable through that path -- which is exactly why it needs a test:
+        a store used directly would otherwise delete from a read-only vault.
+        """
+        store, _ = _store(tmp_path, read_only=True)
+        (tmp_path / "a.png").write_bytes(b"x")
+
+        with pytest.raises(ReadOnlyError):
+            store.unlink("a.png", None)
+
+        assert (tmp_path / "a.png").exists()
+
+    def test_move_refuses_on_a_read_only_store(self, tmp_path: Path) -> None:
+        """Same for move: policy holds however the store is reached."""
+        store, _ = _store(tmp_path, read_only=True)
+        (tmp_path / "a.png").write_bytes(b"x")
+
+        with pytest.raises(ReadOnlyError):
+            store.move("a.png", "b.png", None)
+
+        assert (tmp_path / "a.png").exists()
+        assert not (tmp_path / "b.png").exists()
+
+    def test_unlink_and_move_are_reentrant_under_the_managers_lock(
+        self, tmp_path: Path
+    ) -> None:
+        """Taking the lock inside must not deadlock the manager that holds it.
+
+        DocumentManager.delete and .rename call these while already holding
+        the shared lock. It is an RLock, so re-acquiring on the same thread is
+        free -- this pins that, since a plain Lock here would hang the vault.
+        """
+        store, _ = _store(tmp_path)
+        (tmp_path / "a.png").write_bytes(b"x")
+        (tmp_path / "c.png").write_bytes(b"y")
+
+        with store._file_write_lock:
+            assert store.unlink("a.png", None) == tmp_path / "a.png"
+            old_abs, new_abs = store.move("c.png", "d.png", None)
+
+        assert not old_abs.exists()
+        assert new_abs.read_bytes() == b"y"
+
 
 class TestSharedWiring:
     """The store must share the manager's lock and notifier, not copy them."""

--- a/tests/test_managers_artifacts.py
+++ b/tests/test_managers_artifacts.py
@@ -170,10 +170,43 @@ class TestWrite:
         assert (tmp_path / "a.png").read_bytes() == b"new"
 
     def test_read_only_refuses(self, tmp_path: Path) -> None:
+        """Message pinned, not just the type.
+
+        The store and DocumentManager must refuse a read-only vault with the
+        same words: an operator hitting this sees one wording whichever path
+        raised, and pinning it is what stops the two drifting apart.
+        """
         store, rec = _store(tmp_path, read_only=True)
-        with pytest.raises(ReadOnlyError):
+        with pytest.raises(
+            ReadOnlyError,
+            match="Vault is read-only; write operations are not permitted",
+        ):
             store.write("a.png", b"x")
         assert rec.calls == []
+
+    def test_read_only_message_matches_the_manager(self, tmp_path: Path) -> None:
+        """The two guards state the same rule, so they must say the same thing."""
+        from markdown_vault_mcp.fts_index import FTSIndex
+        from markdown_vault_mcp.managers.document import DocumentManager
+        from markdown_vault_mcp.scanner import HeadingChunker
+
+        store, _ = _store(tmp_path, read_only=True)
+        fts = FTSIndex(db_path=":memory:")
+        try:
+            mgr = DocumentManager(
+                fts,
+                tmp_path,
+                write_lock=threading.RLock(),
+                chunk_strategy=HeadingChunker(),
+                read_only=True,
+            )
+            with pytest.raises(ReadOnlyError) as from_store:
+                store.write("a.png", b"x")
+            with pytest.raises(ReadOnlyError) as from_manager:
+                mgr.write("a.md", "x")
+            assert str(from_store.value) == str(from_manager.value)
+        finally:
+            fts.close()
 
     def test_write_protect_refuses_blind_overwrite(self, tmp_path: Path) -> None:
         store, _ = _store(tmp_path, write_protect_existing=True)

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -868,7 +868,7 @@ class TestAttachmentSize:
             def stat(self) -> object:
                 raise OSError("vanished mid-stat")
 
-        monkeypatch.setattr(mgr, "_validate_attachment_path", lambda _p: _Racy())
+        monkeypatch.setattr(mgr._artifacts, "validate_path", lambda _p: _Racy())
         with pytest.raises(ValueError, match="Attachment not found"):
             mgr.attachment_size("gone.bin")
 

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -713,10 +713,6 @@ class TestValidation:
     def test_check_writable_ok_when_writable(self, doc_mgr: DocumentManager) -> None:
         doc_mgr._check_writable()  # should not raise
 
-    def test_is_attachment(self, doc_mgr: DocumentManager) -> None:
-        assert doc_mgr._is_attachment("image.png") is True
-        assert doc_mgr._is_attachment("note.md") is False
-
     def test_get_toc_folder_traversal_raises(self, doc_mgr: DocumentManager) -> None:
         with pytest.raises(ValueError, match="Path traversal"):
             doc_mgr.get_toc("../../etc")

--- a/tests/test_utils_content_kind.py
+++ b/tests/test_utils_content_kind.py
@@ -169,7 +169,7 @@ class TestEffectiveAttachmentExtensions:
         Only the *path* side is lower-cased and dot-stripped, so an operator
         who writes ``PDF`` or ``.pdf`` in the allowlist matches nothing. Pinning
         it here makes the eventual fix a visible one-line flip in this test
-        rather than a silent semantic drift.
+        rather than a silent semantic drift. Tracked as #1239.
         """
         assert (
             is_allowed_artifact("report.pdf", effective_attachment_extensions(["PDF"]))

--- a/tests/test_utils_content_kind.py
+++ b/tests/test_utils_content_kind.py
@@ -1,11 +1,13 @@
 """Tests for the note/artifact boundary predicate (#1235).
 
-Two of these are tripwires rather than ordinary coverage. The symlink test
-pins that :func:`is_allowed_artifact` never resolves, because the transfer
-sink deliberately passes a resolved path while ``DocumentManager`` passes the
-raw string — a helper that resolved internally would silently change the
-sink's symlink policy. And the ``has_md_suffix`` cases pin that it is *not*
-:func:`is_note` with ``.lower()`` bolted on, so the two stay non-interchangeable.
+Two of these are tripwires rather than ordinary coverage. The symlink tests
+pin that :func:`artifact_suffix` — the function every extension check shares —
+never resolves. The transfer sink deliberately passes an already-resolved path
+so it judges a symlink by its target, while ``ArtifactStore.validate_path``
+passes the raw string so it judges by name; a helper that resolved internally
+would silently change the sink's policy. And the ``has_md_suffix`` cases pin
+that it is *not* :func:`is_note` with ``.lower()`` bolted on, so the two stay
+non-interchangeable.
 """
 
 from __future__ import annotations
@@ -21,7 +23,6 @@ from markdown_vault_mcp.utils.content_kind import (
     has_md_suffix,
     is_allowed_artifact,
     is_allowed_artifact_suffix,
-    is_attachment,
     is_note,
 )
 
@@ -126,30 +127,44 @@ class TestAllowlist:
         assert is_allowed_artifact(link.resolve(), allow_pdf) is False
 
 
-class TestIsAttachment:
-    """The five assertions migrated from DocumentManager._is_attachment."""
+class TestNonNoteAllowlistedComposition:
+    """The concept the deleted ``_is_attachment`` named, composed at the call site.
 
-    def test_allowlisted_non_note_is_an_attachment(self) -> None:
-        assert is_attachment("image.png", DEFAULT_ATTACHMENT_EXTENSIONS) is True
-        assert is_attachment("assets/report.pdf", DEFAULT_ATTACHMENT_EXTENSIONS) is True
+    There is no ``is_attachment`` helper: the name reads like the routing test
+    and is not one. These pin the same five cases the old private method did,
+    expressed the way a caller must express them.
+    """
+
+    @staticmethod
+    def _is_attachment(path: str, exts: frozenset[str]) -> bool:
+        return not is_note(path) and is_allowed_artifact(path, exts)
+
+    def test_allowlisted_non_note(self) -> None:
+        assert self._is_attachment("image.png", DEFAULT_ATTACHMENT_EXTENSIONS) is True
+        assert (
+            self._is_attachment("assets/report.pdf", DEFAULT_ATTACHMENT_EXTENSIONS)
+            is True
+        )
 
     def test_note_is_never_an_attachment(self) -> None:
-        assert is_attachment("note.md", DEFAULT_ATTACHMENT_EXTENSIONS) is False
-        assert is_attachment("notes/note.md", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+        assert self._is_attachment("note.md", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+        assert (
+            self._is_attachment("notes/note.md", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+        )
 
     def test_non_allowlisted_is_not_an_attachment(self) -> None:
-        assert is_attachment("file.xyz", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+        assert self._is_attachment("file.xyz", DEFAULT_ATTACHMENT_EXTENSIONS) is False
 
     def test_wildcard_accepts_any_non_note(self) -> None:
-        assert is_attachment("file.xyz", _WILDCARD) is True
-        assert is_attachment("file.bin", _WILDCARD) is True
-        assert is_attachment("notes/note.md", _WILDCARD) is False
+        assert self._is_attachment("file.xyz", _WILDCARD) is True
+        assert self._is_attachment("file.bin", _WILDCARD) is True
+        assert self._is_attachment("notes/note.md", _WILDCARD) is False
 
-    def test_is_not_the_routing_predicate(self) -> None:
+    def test_routing_does_not_use_this_composition(self) -> None:
         """A non-allowlisted, non-note file is not an attachment, yet the tool
-        layer must still route it to the attachment branch so it is rejected
-        with the allowlist error. Pins why the two are separate functions."""
-        assert is_attachment("file.xyz", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+        layer must still route it to the artifact branch so it is rejected
+        there with the allowlist error. Pins why no helper exists."""
+        assert self._is_attachment("file.xyz", DEFAULT_ATTACHMENT_EXTENSIONS) is False
         assert is_note("file.xyz") is False
 
 

--- a/tests/test_utils_content_kind.py
+++ b/tests/test_utils_content_kind.py
@@ -1,0 +1,181 @@
+"""Tests for the note/artifact boundary predicate (#1235).
+
+Two of these are tripwires rather than ordinary coverage. The symlink test
+pins that :func:`is_allowed_artifact` never resolves, because the transfer
+sink deliberately passes a resolved path while ``DocumentManager`` passes the
+raw string — a helper that resolved internally would silently change the
+sink's symlink policy. And the ``has_md_suffix`` cases pin that it is *not*
+:func:`is_note` with ``.lower()`` bolted on, so the two stay non-interchangeable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from markdown_vault_mcp.types import DEFAULT_ATTACHMENT_EXTENSIONS
+from markdown_vault_mcp.utils.content_kind import (
+    artifact_suffix,
+    effective_attachment_extensions,
+    has_md_suffix,
+    is_allowed_artifact,
+    is_allowed_artifact_suffix,
+    is_attachment,
+    is_note,
+)
+
+_WILDCARD = frozenset({"*"})
+
+
+class TestIsNote:
+    """The routing predicate: case-sensitive, by design."""
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("a.md", True),
+            ("notes/deep/a.md", True),
+            ("a.MD", False),
+            ("a.Md", False),
+            ("a.markdown", False),
+            ("a.png", False),
+            ("md", False),
+            ("", False),
+        ],
+    )
+    def test_routing_cases(self, path: str, expected: bool) -> None:
+        """``NOTE.MD`` is deliberately not a note here — see the module docstring."""
+        assert is_note(path) is expected
+
+
+class TestHasMdSuffix:
+    """The case-insensitive variant, used only by SearchManager."""
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [("a.md", True), ("a.MD", True), ("a.Md", True), ("a.png", False)],
+    )
+    def test_ignores_case(self, path: str, expected: bool) -> None:
+        assert has_md_suffix(path) is expected
+
+    def test_is_not_is_note_with_lower(self) -> None:
+        """A file literally named ``.md`` has no suffix, so the two differ.
+
+        Pins that the pair cannot be collapsed into one function.
+        """
+        assert is_note(".md") is True
+        assert has_md_suffix(".md") is False
+
+    def test_accepts_path_objects(self) -> None:
+        assert has_md_suffix(Path("notes/a.MD")) is True
+
+
+class TestArtifactSuffix:
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("a.PDF", "pdf"),
+            ("a.pdf", "pdf"),
+            ("a", ""),
+            ("a.tar.gz", "gz"),
+            ("dir/a.PnG", "png"),
+        ],
+    )
+    def test_normalizes(self, path: str, expected: str) -> None:
+        assert artifact_suffix(path) == expected
+
+    def test_path_and_str_agree(self) -> None:
+        assert artifact_suffix(Path("a/b.PDF")) == artifact_suffix("a/b.PDF")
+
+
+class TestAllowlist:
+    def test_wildcard_allows_anything(self) -> None:
+        assert is_allowed_artifact_suffix("xyz", _WILDCARD) is True
+        assert is_allowed_artifact_suffix("", _WILDCARD) is True
+
+    def test_membership(self) -> None:
+        assert is_allowed_artifact_suffix("pdf", frozenset({"pdf"})) is True
+        assert is_allowed_artifact_suffix("xyz", frozenset({"pdf"})) is False
+
+    def test_empty_suffix_not_in_named_allowlist(self) -> None:
+        assert is_allowed_artifact_suffix("", frozenset({"pdf"})) is False
+
+    def test_is_allowed_artifact_says_nothing_about_md(self) -> None:
+        """A note passes whenever ``md`` is allowlisted — that is why the
+        routing sites combine this with :func:`is_note` rather than replacing it."""
+        assert is_allowed_artifact("a.md", frozenset({"md"})) is True
+
+    def test_does_not_resolve_symlinks(self, tmp_path: Path) -> None:
+        """The caller chooses name-vs-target; the helper never resolves.
+
+        The transfer sink passes an already-resolved path and so tests the
+        symlink's *target*; DocumentManager passes the raw string and so tests
+        the *name*. Resolving here would silently change the sink's policy.
+        """
+        target = tmp_path / "target.bin"
+        target.write_bytes(b"x")
+        link = tmp_path / "link.pdf"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):  # pragma: no cover - platform
+            pytest.skip("symlinks unavailable")
+
+        allow_pdf = frozenset({"pdf"})
+        assert is_allowed_artifact(link, allow_pdf) is True
+        assert is_allowed_artifact(link.resolve(), allow_pdf) is False
+
+
+class TestIsAttachment:
+    """The five assertions migrated from DocumentManager._is_attachment."""
+
+    def test_allowlisted_non_note_is_an_attachment(self) -> None:
+        assert is_attachment("image.png", DEFAULT_ATTACHMENT_EXTENSIONS) is True
+        assert is_attachment("assets/report.pdf", DEFAULT_ATTACHMENT_EXTENSIONS) is True
+
+    def test_note_is_never_an_attachment(self) -> None:
+        assert is_attachment("note.md", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+        assert is_attachment("notes/note.md", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+
+    def test_non_allowlisted_is_not_an_attachment(self) -> None:
+        assert is_attachment("file.xyz", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+
+    def test_wildcard_accepts_any_non_note(self) -> None:
+        assert is_attachment("file.xyz", _WILDCARD) is True
+        assert is_attachment("file.bin", _WILDCARD) is True
+        assert is_attachment("notes/note.md", _WILDCARD) is False
+
+    def test_is_not_the_routing_predicate(self) -> None:
+        """A non-allowlisted, non-note file is not an attachment, yet the tool
+        layer must still route it to the attachment branch so it is rejected
+        with the allowlist error. Pins why the two are separate functions."""
+        assert is_attachment("file.xyz", DEFAULT_ATTACHMENT_EXTENSIONS) is False
+        assert is_note("file.xyz") is False
+
+
+class TestEffectiveAttachmentExtensions:
+    def test_none_means_defaults(self) -> None:
+        assert effective_attachment_extensions(None) is DEFAULT_ATTACHMENT_EXTENSIONS
+
+    def test_explicit_list_is_used(self) -> None:
+        assert effective_attachment_extensions(["pdf"]) == frozenset({"pdf"})
+
+    def test_wildcard_passes_through(self) -> None:
+        assert effective_attachment_extensions(["*"]) == _WILDCARD
+
+    def test_config_side_is_not_normalized_today(self) -> None:
+        """Pins a known asymmetry as current behaviour, not as desirable.
+
+        Only the *path* side is lower-cased and dot-stripped, so an operator
+        who writes ``PDF`` or ``.pdf`` in the allowlist matches nothing. Pinning
+        it here makes the eventual fix a visible one-line flip in this test
+        rather than a silent semantic drift.
+        """
+        assert (
+            is_allowed_artifact("report.pdf", effective_attachment_extensions(["PDF"]))
+            is False
+        )
+        assert (
+            is_allowed_artifact("report.pdf", effective_attachment_extensions([".pdf"]))
+            is False
+        )

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -2100,29 +2100,6 @@ class TestAtomicWrites:
 
 
 class TestAttachmentHelpers:
-    def test_is_attachment_pdf(self, vault_path: Path) -> None:
-        """_is_attachment() returns True for a .pdf path with default allowlist."""
-        col = Vault(source_dir=vault_path)
-        assert col._doc_mgr._is_attachment("assets/report.pdf") is True
-
-    def test_is_attachment_md_always_false(self, vault_path: Path) -> None:
-        """_is_attachment() always returns False for .md paths."""
-        col = Vault(source_dir=vault_path)
-        assert col._doc_mgr._is_attachment("notes/note.md") is False
-
-    def test_is_attachment_disallowed_extension(self, vault_path: Path) -> None:
-        """_is_attachment() returns False for extensions not in the default list."""
-        col = Vault(source_dir=vault_path)
-        # .xyz is not in the default list
-        assert col._doc_mgr._is_attachment("file.xyz") is False
-
-    def test_is_attachment_wildcard_allows_all(self, vault_path: Path) -> None:
-        """_is_attachment() returns True for any non-.md extension when '*' is set."""
-        col = Vault(source_dir=vault_path, attachment_extensions=["*"])
-        assert col._doc_mgr._is_attachment("file.xyz") is True
-        assert col._doc_mgr._is_attachment("file.bin") is True
-        assert col._doc_mgr._is_attachment("notes/note.md") is False
-
     def test_validate_attachment_path_rejects_md(self, vault_path: Path) -> None:
         """_validate_attachment_path() raises ValueError for .md paths."""
         col = Vault(source_dir=vault_path)

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -2031,7 +2031,7 @@ class TestAtomicWrites:
         self, writable: Vault, vault_path: Path
     ) -> None:
         """A freshly written document lands at 0o666 & ~umask, not tempfile's 0o600."""
-        from markdown_vault_mcp.managers import document as doc
+        from markdown_vault_mcp.managers import _write_kernel as doc
 
         old = os.umask(0o027)
         doc._umask = None  # force a re-read of the umask we just set
@@ -2049,7 +2049,7 @@ class TestAtomicWrites:
         self, writable: Vault, vault_path: Path
     ) -> None:
         """A freshly written attachment lands at 0o666 & ~umask, not 0o600."""
-        from markdown_vault_mcp.managers import document as doc
+        from markdown_vault_mcp.managers import _write_kernel as doc
 
         old = os.umask(0o027)
         doc._umask = None
@@ -2065,7 +2065,7 @@ class TestAtomicWrites:
 
     def test_process_umask_caches_across_calls(self) -> None:
         """_process_umask caches: repeat calls return the same value."""
-        from markdown_vault_mcp.managers import document as doc
+        from markdown_vault_mcp.managers import _write_kernel as doc
 
         doc._umask = None
         try:


### PR DESCRIPTION
## Closes / Refs

Closes #1235

Also files, but does not close: #1238, #1239, #1240, #1241.

## What & why

The question *"is this path a markdown note?"* was spelled out at roughly twenty call sites, and the answers disagreed — some consulted the extension allowlist, others tested only the suffix, and three different case policies were in use. Attachment CRUD also lived inside `DocumentManager`, so the class that owns documents owned the not-documents.

**The issue undercounts.** It says seven sites; there are about twenty, across three *different* axes that all ask the same question and differ only in what a non-note means:

| Axis | Meaning of non-note | Where |
|---|---|---|
| Artifact | an attachment | `ArtifactStore`, `DocumentManager` delete/rename/move, the transfer sink, the `read`/`write`/`fetch` tools |
| Folder | a directory scope | `get_toc`, `SummarizeManager._expand_path`, `ConventionsResolver` |
| Indexability | not a candidate for the index | `IndexManager`, `EmbeddingsManager`, `utils.fs.iter_markdown_files` |

All three now share `is_note()`. Keeping three spellings bought nothing; collapsing the three *interpretations* into one tri-state would have been the real mistake, so the axis table lives in the module docstring instead. Routing the indexability axis is what makes #1234 (`DocumentParser`) tractable — "indexable" stops meaning "markdown" in one predicate plus the two glob defaults, rather than across a dozen spellings.

- **`utils/content_kind.py`** — `is_note`, `has_md_suffix`, `artifact_suffix`, `is_allowed_artifact(_suffix)`, and the moved `effective_attachment_extensions`. Pure functions, because the transfer sink cannot reach a vault-owned object.
- **`managers/artifacts.py`** — `ArtifactStore` owns artifact validate/size/read/write/unlink/move, composed into `DocumentManager` sharing that manager's write lock and `WriteNotifier` **by identity** (the #893 collaborator precedent). A private lock would stop artifact writes serialising against note writes and leave `Vault.pause_writes` unable to hold artifacts still during a git rebase; a test asserts identity.
- **`managers/_write_notifier.py` / `_write_kernel.py`** — the callback dispatch shape (including the `old_path` opt-in probe) and the pure write primitives, so both paths share one implementation rather than two copies.
- The dead `DocumentManager._is_attachment` is deleted. It had zero production callers, and its name read like the routing predicate while its semantics were not.

There is deliberately **no `is_attachment()` helper**: the tool layer routes on `not is_note(path)` alone, so a non-allowlisted file still reaches the artifact branch and is rejected there with the error naming `MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS`. Callers that want "non-note and allowlisted" compose the two predicates where the surrounding branch shows which they meant.

## Two divergences deliberately preserved (#1240)

Both were found during the work, both are real, and neither is safe to unify inside a behaviour-preserving refactor. They are documented in `content_kind.py` and pinned by tests.

1. **Case.** `DocumentManager.read` applies no extension validation of its own — only an inline traversal check — so a file named `NOTE.MD` genuinely reaches its size-cap line and genuinely gets the cap. `SearchManager` is case-insensitive; routing is case-sensitive. Unifying changes behaviour, with a wildcard-allowlist blast radius.
2. **Resolution.** The transfer sink reads the extension from the **resolved** path; `ArtifactStore` reads it from the **raw** string. Since `resolve_inside` follows symlinks, `link.pdf → target.bin` is `pdf` to one and `bin` to the other. `content_kind` therefore never resolves — each caller passes the object whose extension it means. This one is security-adjacent, which is exactly why it is not being decided here.

## What this PR deliberately does NOT do

- Fix `move_folder` moving a non-allowlisted file without firing a rename callback, so git never learns: #1238. Left untouched so the fix stays reviewable.
- Normalize the config side of the allowlist, so `PDF` or `.pdf` silently matches nothing: #1239 (pinned as current behaviour by a named test).
- Settle the case / symlink-resolution policies: #1240.
- Remove the base64 round-trip the sink and bundle exporter pay: #1241.
- Add an `ArtifactStore` **protocol** — one implementation, one consumer, no substitution need, and the caller that might motivate one cannot hold a vault-owned object. The design doc's storage-protocols section gains a "when not to add one" note, since that is where someone will look before adding a protocol. (`src/markdown_vault_mcp/interfaces.py` itself is unchanged by this PR.)
- Add a `vault.artifacts` accessor — `read_attachment`/`write_attachment` are already reachable via `vault.reader`/`vault.writer`, and a second public route would recreate this very duplication one layer up.
- Touch the glob patterns or the name-normalization sites: they state the rule in another language, or are string surgery, not routing tests.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] Any commit carrying `!` breaks an operator or library surface that existed at the **last stable release** — none here: no env var, config, CLI flag or on-disk format moves, and the package root's public import surface is empty.

The local review found seven issues, all fixed in `475af39`. The two worth naming: `is_attachment` was dead code replacing dead code, and `ArtifactStore._check_writable` had invented its own read-only wording while the manager kept the original — with the delegator's duplicate check making the store's guard unreachable, so the drift was invisible. There is now one guard, one message, and a test asserting the two are equal rather than merely both raising.

Codex review then found two more, fixed in `edf3b9c`: `unlink`/`move` enforced neither `read_only` nor the shared lock, relying on `DocumentManager` to guard around them — true of every in-tree caller, so no reachable defect, but it left the store enforcing less than its own docstring claimed. Both now guard as `write()` does; the lock is re-entrant, so nesting under the manager's is free, and a test calls both while holding it because a plain `Lock` there would deadlock rather than fail visibly.

Two behaviour-preservation notes for the reviewer:

1. Commits 2 and 2b touch **zero test files**. The suite passing unedited is the proof for the predicate substitutions; the diff is reviewable line-by-line against the axis table.
2. Four test edits were needed in the extraction, and one is worth knowing about: `test_managers_document.py`'s `attachment_size` race test monkeypatched an *instance* attribute that the extraction would have turned into a no-op — leaving the test **passing while the `OSError` branch silently lost coverage**. Repointed, and coverage verified rather than assumed.

## Docs impact

- [ ] `README.md` — nothing operator-facing changed.
- [ ] `docs/` site pages — no MCP tool, resource, prompt, or env var changed.
- [x] `docs/design/` — the attachment-dispatch section now names `utils.content_kind` as owner and carries the axis table and both divergences; the path-traversal section names `ArtifactStore.validate_path`; the storage-protocols section gains the "when not to add a protocol" note.
- [x] Inline docstrings — all four new modules, plus the retyped call sites.

`AGENTS.md`'s Project Structure tree carries all four new modules.

---
_Generated by [Claude Code](https://claude.ai/code/session_0197qu2QerLNpJSGQAjLjSNN)_
