### PR TITLE
fix(vault): report every moved file to the write callback in move_folder

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2350,6 +2350,16 @@ can leave the subtree partially moved with the index unchanged; a subsequent
 allowlisted attachments, and any other files). Only `.md` files are
 re-indexed; non-markdown files are moved on disk without index updates.
 
+Every moved file also gets a `rename` write callback, whether or not its
+extension is allowlisted (#1238). Those two rules are independent, and
+conflating them was a bug: the allowlist governs which files the *tools*
+expose, not what the repository tracks. Git staging is scoped to the paths a
+callback names, so a file moved without one leaves an unstaged delete at the
+old path and an untracked add at the new one, and is never committed —
+silently, since the file does arrive where the caller asked. Skipping the
+move instead is not an option: the source tree is removed afterwards, so an
+unmoved file would be destroyed.
+
 *Link rewrite*: after all files are moved, a single pass over the vault
 rewrites every outbound link (markdown links and wikilinks) whose target falls
 under the old prefix. This covers links between documents inside the moved

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2451,6 +2451,16 @@ file "not ignored", but `git add` still refuses to name a tracked file living
 under an ignored directory, so only `--no-index` predicts the rule the filter
 exists to satisfy.
 
+Two consequences of that filter are load-bearing. A **tracked** path an exclude
+rule covers is still staged, with `git add -u` rather than `-A`: its deletion is
+real, dropping it would leave git serving content the vault no longer has there,
+and `-u` acts on tracked files only, so the exclude rules never apply to it.
+And when the filter leaves nothing at all to stage, `_stage_rename` reports that
+to its caller, which skips the commit rather than falling through — the
+`git diff --cached --quiet` check below it is repository-wide, so an operator's
+own staged work would otherwise be committed under the rename's message and
+pushed, the very leak this section exists to prevent.
+
 **Write identity: the `Principal` value (#1160, fixes #1218).** "Who is
 acting" is resolved **once, at the MCP tool edge**, into a frozen
 `Principal` (`_identity.py`: `subject`, `display_name`, `email`,

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2438,6 +2438,19 @@ is. An old path git does not track is dropped from the pathspec rather than
 passed — `git add` fails the whole invocation on a pathspec matching nothing,
 which would leave the new path unstaged too.
 
+A **gitignored** path is dropped for the same reason (#1238): `git add` exits
+non-zero on an explicitly named ignored pathspec, and once `move_folder`
+started reporting every moved file, the vault's own ignored clutter
+(`.DS_Store`, `.obsidian/`) began arriving here. Force-adding it instead was
+never on the table — that would commit a file the operator deliberately
+excluded — so an ignored path is skipped, and when both sides are ignored the
+`git add` is skipped entirely rather than run with an empty pathspec, which
+would sweep in the whole repository. The probe is
+`git check-ignore --no-index`: the default, index-aware answer calls a tracked
+file "not ignored", but `git add` still refuses to name a tracked file living
+under an ignored directory, so only `--no-index` predicts the rule the filter
+exists to satisfy.
+
 **Write identity: the `Principal` value (#1160, fixes #1218).** "Who is
 acting" is resolved **once, at the MCP tool edge**, into a frozen
 `Principal` (`_identity.py`: `subject`, `display_name`, `email`,

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1588,7 +1588,7 @@ def _is_ignored(root: str, path: Path) -> bool:
     return result.returncode == 0
 
 
-def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
+def _stage_rename(root: str, path: Path, old_path: Path | None) -> bool:
     """Stage both sides of a rename without touching anything else (#894).
 
     ``git add -A`` over an explicit pathspec records the old path's
@@ -1602,9 +1602,13 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
     matches nothing, which would leave the new path unstaged too. A gitignored
     path is omitted for the same reason — ``git add`` exits non-zero on an
     explicitly named ignored pathspec, and force-adding it instead would
-    commit a file the operator deliberately excluded (#1238). When that leaves
-    nothing to stage, the call is skipped entirely rather than run with an
-    empty pathspec, which would sweep in the whole repository.
+    commit a file the operator deliberately excluded (#1238).
+
+    A **tracked** path that an exclude rule covers — committed before its
+    directory was ignored — is the one case that still has to be staged: its
+    deletion is real, and dropping it leaves git serving content the vault no
+    longer has there. ``git add -u`` records it, since ``-u`` acts on tracked
+    files only and the exclude rules never apply to those.
 
     Args:
         root: Git repository root, as a string.
@@ -1613,6 +1617,12 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
             a caller predating #894 — which falls back to the historical
             repository-wide staging, imprecise in exactly the two ways this
             function fixes.
+
+    Returns:
+        Whether anything was staged. ``False`` means both sides were ignored
+        and untrackable, so there is nothing for this operation to commit —
+        the caller must not fall through to a repository-wide diff check,
+        which would commit whatever the operator happened to have staged.
     """
     if old_path is None:
         logger.debug("git_stage_rename_unscoped path=%s", path)
@@ -1628,13 +1638,15 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
             text=True,
             check=True,
         )
-        return
+        return True
 
     pathspec: list[str] = []
+    deletions: list[str] = []
     if not _is_tracked(root, old_path):
         logger.debug("git_stage_rename_old_untracked old_path=%s", old_path)
     elif _is_ignored(root, old_path):
-        logger.debug("git_stage_rename_old_ignored old_path=%s", old_path)
+        logger.debug("git_stage_rename_old_tracked_but_ignored old_path=%s", old_path)
+        deletions.append(str(old_path))
     else:
         pathspec.append(str(old_path))
 
@@ -1643,15 +1655,15 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
     else:
         pathspec.append(str(path))
 
-    if not pathspec:
-        return
-
-    subprocess.run(
-        ["git", "-C", root, "add", "-A", "--", *pathspec],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    for args, spec in (("-u", deletions), ("-A", pathspec)):
+        if spec:
+            subprocess.run(
+                ["git", "-C", root, "add", args, "--", *spec],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+    return bool(deletions or pathspec)
 
 
 def _stage_and_commit(
@@ -1700,7 +1712,13 @@ def _stage_and_commit(
             check=True,
         )
     elif operation == "rename":
-        _stage_rename(root, path, old_path)
+        if not _stage_rename(root, path, old_path):
+            # Nothing this operation touched is stageable. Returning here
+            # rather than falling through matters: the diff check below is
+            # repository-wide, so an operator's unrelated staged work would
+            # otherwise be committed under this rename's message and pushed.
+            logger.debug("git_stage_rename_noop path=%s", path)
+            return
     else:
         subprocess.run(
             ["git", "-C", root, "add", "--", str(path)],

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1563,6 +1563,31 @@ def _is_tracked(root: str, path: Path) -> bool:
     return bool(result.stdout.strip())
 
 
+def _is_ignored(root: str, path: Path) -> bool:
+    """Return whether git's exclude rules would refuse to add *path*.
+
+    ``--no-index`` is deliberate. Without it ``git check-ignore`` answers
+    "not ignored" for anything already in the index, but ``git add`` refuses
+    a pathspec naming a file under an ignored directory *even when that file
+    is tracked* — so the default answer would not match the rule this probe
+    exists to predict.
+
+    Args:
+        root: Git repository root, as a string.
+        path: Absolute path to probe.
+
+    Returns:
+        ``True`` when the path matches an exclude rule.
+    """
+    result = subprocess.run(
+        ["git", "-C", root, "check-ignore", "--no-index", "-q", "--", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
 def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
     """Stage both sides of a rename without touching anything else (#894).
 
@@ -1574,7 +1599,12 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
 
     An untracked old path is omitted from the pathspec rather than passed and
     tolerated: ``git add`` fails the *whole* invocation on a pathspec that
-    matches nothing, which would leave the new path unstaged too.
+    matches nothing, which would leave the new path unstaged too. A gitignored
+    path is omitted for the same reason — ``git add`` exits non-zero on an
+    explicitly named ignored pathspec, and force-adding it instead would
+    commit a file the operator deliberately excluded (#1238). When that leaves
+    nothing to stage, the call is skipped entirely rather than run with an
+    empty pathspec, which would sweep in the whole repository.
 
     Args:
         root: Git repository root, as a string.
@@ -1600,11 +1630,22 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> None:
         )
         return
 
-    pathspec = [str(path)]
-    if _is_tracked(root, old_path):
-        pathspec.insert(0, str(old_path))
-    else:
+    pathspec: list[str] = []
+    if not _is_tracked(root, old_path):
         logger.debug("git_stage_rename_old_untracked old_path=%s", old_path)
+    elif _is_ignored(root, old_path):
+        logger.debug("git_stage_rename_old_ignored old_path=%s", old_path)
+    else:
+        pathspec.append(str(old_path))
+
+    if _is_ignored(root, path):
+        logger.debug("git_stage_rename_new_ignored path=%s", path)
+    else:
+        pathspec.append(str(path))
+
+    if not pathspec:
+        return
+
     subprocess.run(
         ["git", "-C", root, "add", "-A", "--", *pathspec],
         capture_output=True,

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -49,7 +49,6 @@ from markdown_vault_mcp.types import (
     WriteResult,
 )
 from markdown_vault_mcp.utils import (
-    is_allowed_artifact,
     is_note,
     is_path_excluded,
     resolve_inside,
@@ -191,10 +190,6 @@ class DocumentManager:
         would otherwise silently no-op.
         """
         self._check_writable()
-
-    def _effective_attachment_extensions(self) -> frozenset[str]:
-        """Return the effective set of allowed attachment extensions."""
-        return self._artifacts.extensions()
 
     def _is_path_excluded(self, path: str) -> bool:
         """Check whether *path* matches any configured exclude pattern.
@@ -1313,12 +1308,12 @@ class DocumentManager:
             new_dir: Vault-relative target prefix.
 
         Returns:
-            Tuple ``(moves, md_map, attachment_moves)``:
+            Tuple ``(moves, md_map, non_note_moves)``:
 
             * ``moves`` — ``(src_abs, dst_abs)`` for every file to move.
             * ``md_map`` — old→new vault-relative path map (``.md`` only).
-            * ``attachment_moves`` — ``(dst_abs, new_rel_path, src_abs)`` for
-              allowlisted attachments.
+            * ``non_note_moves`` — ``(dst_abs, new_rel_path, src_abs)`` for
+              every other moved file, allowlisted or not (#1238).
 
         Raises:
             DocumentNotFoundError: If the folder contains no files.
@@ -1326,12 +1321,11 @@ class DocumentManager:
         """
         old_rel = old_dir.strip("/")
         new_rel = new_dir.strip("/")
-        attachment_exts = self._effective_attachment_extensions()
         moves: list[tuple[Path, Path]] = []  # (src_abs, dst_abs)
         md_map: dict[str, str] = {}  # old_rel_path -> new_rel_path (.md only)
         # (dst_abs, new_rel, src_abs) — src_abs so the rename callback can
         # scope its git staging to both sides of the move (#894).
-        attachment_moves: list[tuple[Path, str, Path]] = []
+        non_note_moves: list[tuple[Path, str, Path]] = []
         for src_abs in sorted(old_abs.rglob("*")):
             if not src_abs.is_file():
                 continue
@@ -1343,8 +1337,13 @@ class DocumentManager:
             if is_note(old_path):
                 md_map[old_path] = new_path
             else:
-                if is_allowed_artifact(src_abs, attachment_exts):
-                    attachment_moves.append((dst_abs, new_path, src_abs))
+                # Every non-note file that moves gets a rename callback, not
+                # just allowlisted ones (#1238). The allowlist governs which
+                # files the *tools* expose, not what the repository tracks:
+                # git staging is scoped to the paths a callback names, so a
+                # file moved without one is left as an unstaged delete plus an
+                # untracked add, and never committed.
+                non_note_moves.append((dst_abs, new_path, src_abs))
 
         if not moves:
             raise DocumentNotFoundError(f"Folder is empty: {old_dir}")
@@ -1355,25 +1354,25 @@ class DocumentManager:
                 rel = dst_abs.relative_to(self._source_dir.resolve()).as_posix()
                 raise DocumentExistsError(f"Target already exists: {rel}")
 
-        return moves, md_map, attachment_moves
+        return moves, md_map, non_note_moves
 
     def _dispatch_move_callbacks(
         self,
         md_map: dict[str, str],
-        attachment_moves: list[tuple[Path, str, Path]],
+        non_note_moves: list[tuple[Path, str, Path]],
         pending_callbacks: list[tuple[Path, str]],
     ) -> None:
         """Fire write callbacks for a completed folder move.
 
-        Emits ``rename`` for every moved note and allowlisted attachment,
-        and ``edit`` for every rewritten source. A source inside the moved
-        subtree already gets a ``rename`` callback (it is in *md_map*), so
-        its redundant ``edit`` is skipped to avoid a duplicate git commit.
+        Emits ``rename`` for every moved file — notes and everything else
+        alike — and ``edit`` for every rewritten source. A source inside the
+        moved subtree already gets a ``rename`` callback (it is in *md_map*),
+        so its redundant ``edit`` is skipped to avoid a duplicate git commit.
 
         Args:
             md_map: Old→new vault-relative path map for moved notes.
-            attachment_moves: ``(dst_abs, new_rel_path, src_abs)`` for moved
-                allowlisted attachments.
+            non_note_moves: ``(dst_abs, new_rel_path, src_abs)`` for every
+                moved file that is not a note (#1238).
             pending_callbacks: ``(abs_path, new_content)`` for rewritten
                 link sources.
         """
@@ -1386,7 +1385,7 @@ class DocumentManager:
                 _read_text_utf8(new_note_abs),
                 (self._source_dir / old_path).resolve(),
             )
-        for dst_abs, _new_rel, src_abs_moved in attachment_moves:
+        for dst_abs, _new_rel, src_abs_moved in non_note_moves:
             self._notifier.fire_rename(dst_abs, "", src_abs_moved)
         for src_abs, src_content in pending_callbacks:
             src_rel = src_abs.relative_to(source_root).as_posix()
@@ -1446,7 +1445,7 @@ class DocumentManager:
 
             # 1+2. Enumerate the subtree, build the old->new path map, and
             #      gate on destination collisions before moving anything.
-            moves, md_map, attachment_moves = self._plan_folder_move(
+            moves, md_map, non_note_moves = self._plan_folder_move(
                 old_abs, old_dir, new_dir
             )
 
@@ -1486,9 +1485,9 @@ class DocumentManager:
                 move_dirty.extend(dirty_paths)  # rewritten sources
                 self._mark_paths_dirty(move_dirty)
 
-            # 7. Callbacks: rename for every moved note + allowlisted attachment,
-            #    edit for every rewritten source (minus intra-subtree dupes).
-            self._dispatch_move_callbacks(md_map, attachment_moves, pending_callbacks)
+            # 7. Callbacks: rename for every moved file, edit for every
+            #    rewritten source (minus intra-subtree dupes).
+            self._dispatch_move_callbacks(md_map, non_note_moves, pending_callbacks)
 
             # 8. Remove the now-empty source tree. A leftover file (e.g. from a
             #    concurrent write) is logged rather than silently swallowed.

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -1489,8 +1489,10 @@ class DocumentManager:
             #    rewritten source (minus intra-subtree dupes).
             self._dispatch_move_callbacks(md_map, non_note_moves, pending_callbacks)
 
-            # 8. Remove the now-empty source tree. A leftover file (e.g. from a
-            #    concurrent write) is logged rather than silently swallowed.
+            # 8. Remove the source tree. rmtree takes whatever is still in it
+            #    — a file a concurrent write dropped there after step 4 is
+            #    deleted, not preserved. Only a failure to remove is reported,
+            #    and only as a warning: the move itself already succeeded.
             try:
                 shutil.rmtree(old_abs)
             except OSError as exc:

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -167,10 +167,7 @@ def validate_history_path(
         ValueError: *path* is neither ``.md`` nor an allowed attachment
             extension, or it escapes *source_dir*.
     """
-    if not (
-        is_note(path)
-        or is_allowed_artifact_suffix(artifact_suffix(path), attachment_extensions)
-    ):
+    if not (is_note(path) or is_allowed_artifact(path, attachment_extensions)):
         raise ValueError(
             f"Path must be a .md note or a configured attachment type: {path}"
         )

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6200,42 +6200,119 @@ class TestRenameStagingSkipsIgnoredPaths:
         assert _commit_files(git_repo) == {"note.md"}
         assert _worktree_status(git_repo) == set()
 
-    def test_tracked_file_under_an_ignored_directory_is_left_alone(
-        self, git_repo: Path
-    ) -> None:
-        """``check-ignore --no-index`` is why this does not raise.
+    @staticmethod
+    def _commit_legacy(repo: Path) -> Path:
+        """Force-commit ``cache/legacy.md``, tracked despite ``cache/`` being ignored.
 
-        A file committed before its directory was ignored stays tracked, yet
-        ``git add`` still refuses to name it. The default (index-aware)
+        The awkward case ``check-ignore --no-index`` exists for: a file
+        committed before its directory was excluded stays tracked, yet
+        ``git add -A`` still refuses to name it. The default, index-aware
         ``check-ignore`` would call it "not ignored" and let it through.
         """
         import subprocess
 
-        from markdown_vault_mcp.git import _stage_and_commit
-
-        self._seed(git_repo)
-        legacy = git_repo / "cache" / "legacy.md"
+        legacy = repo / "cache" / "legacy.md"
         legacy.parent.mkdir()
         legacy.write_text("# Legacy\n", encoding="utf-8")
         subprocess.run(
-            ["git", "-C", str(git_repo), "add", "-f", "--", str(legacy)],
+            ["git", "-C", str(repo), "add", "-f", "--", str(legacy)],
             capture_output=True,
             check=True,
         )
         subprocess.run(
-            ["git", "-C", str(git_repo), "commit", "-m", "legacy"],
+            ["git", "-C", str(repo), "commit", "-m", "legacy"],
             capture_output=True,
             check=True,
         )
+        return legacy
+
+    def test_tracked_file_moved_within_an_ignored_directory_records_the_deletion(
+        self, git_repo: Path
+    ) -> None:
+        """The destination is unstageable, but the departure is still real.
+
+        Dropping the old path because an exclude rule covers it would leave
+        git serving content the vault no longer has there. ``git add -u``
+        records the deletion: it acts on tracked files only, so the exclude
+        rules never apply to it.
+        """
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+        legacy = self._commit_legacy(git_repo)
+        head_before = _head(git_repo)
 
         moved = git_repo / "cache" / "moved.md"
         legacy.rename(moved)
 
         _stage_and_commit(git_repo, moved, "rename", old_path=legacy)
 
-        # Neither side is stageable, so the commit is skipped and the move
-        # shows up only as an untracked working-tree change.
+        assert _head(git_repo) != head_before
         assert _commit_files(git_repo) == {"cache/legacy.md"}
+        # The old path is gone from the index; the new one is ignored, so it
+        # stays out of the repository rather than being force-added.
+        assert "cache/legacy.md" not in _tracked_files(git_repo)
+        assert "cache/moved.md" not in _tracked_files(git_repo)
+
+    def test_tracked_file_moved_out_of_an_ignored_directory_stages_both_sides(
+        self, git_repo: Path
+    ) -> None:
+        """Codex P2: the deletion must not be dropped with the ignored old path.
+
+        Filtering the old path out of the ``add -A`` pathspec staged the
+        arrival at the new path while silently leaving the departure
+        unstaged, so the commit added a file without removing the one it
+        replaced.
+        """
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+        legacy = self._commit_legacy(git_repo)
+
+        moved = git_repo / "kept.md"
+        legacy.rename(moved)
+
+        _stage_and_commit(git_repo, moved, "rename", old_path=legacy)
+
+        assert _commit_files(git_repo) == {"cache/legacy.md", "kept.md"}
+        assert _worktree_status(git_repo) == set()
+
+    def test_a_noop_rename_does_not_commit_unrelated_staged_work(
+        self, git_repo: Path
+    ) -> None:
+        """Codex P1: skipping the ``git add`` must skip the commit too.
+
+        The diff check in ``_stage_and_commit`` is repository-wide. With
+        nothing staged for this operation, it saw the operator's own staged
+        work and committed it under the rename's message — the exact class of
+        leak #894 exists to prevent, through a new door.
+        """
+        import subprocess
+
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+
+        # The operator stages something of their own, deliberately uncommitted.
+        (git_repo / "note.md").write_text("# Staged by the operator\n", "utf-8")
+        subprocess.run(
+            ["git", "-C", str(git_repo), "add", "--", str(git_repo / "note.md")],
+            capture_output=True,
+            check=True,
+        )
+        head_before = _head(git_repo)
+
+        old_abs = git_repo / "a" / ".DS_Store"
+        new_abs = git_repo / "b" / ".DS_Store"
+        old_abs.parent.mkdir()
+        new_abs.parent.mkdir()
+        new_abs.write_bytes(b"junk")
+
+        _stage_and_commit(git_repo, new_abs, "rename", old_path=old_abs)
+
+        assert _head(git_repo) == head_before
+        # Still staged, still theirs to commit when they choose.
+        assert _worktree_status(git_repo) == {"M  note.md"}
 
 
 def _head(repo: Path) -> str:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6122,3 +6122,252 @@ class TestRenameCommitEndToEnd:
             " M bystander.md",
             "?? .markdown_vault_mcp/",
         }
+
+
+# ---------------------------------------------------------------------------
+# gitignored renames (#1238)
+# ---------------------------------------------------------------------------
+
+
+class TestRenameStagingSkipsIgnoredPaths:
+    """A gitignored file's move is a no-op for git, not a failed ``git add``.
+
+    Since #1238 ``move_folder`` reports *every* moved file to the write
+    callback, not just the ones on the attachment allowlist. That is what
+    lets git learn about a moved ``.bin`` or ``.txt``; it also means the
+    vault's own ignored clutter (``.DS_Store``, ``.obsidian/``) now reaches
+    the staging helper. ``git add -A`` exits non-zero on an explicitly named
+    ignored pathspec, so without filtering each such file would raise
+    ``CalledProcessError`` and log a git error on every folder move.
+    """
+
+    @staticmethod
+    def _seed(repo: Path) -> None:
+        """Commit a note plus a ``.gitignore`` excluding ``.DS_Store``."""
+        import subprocess
+
+        (repo / ".gitignore").write_text(".DS_Store\ncache/\n", encoding="utf-8")
+        (repo / "note.md").write_text("# Note\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "seed"],
+            capture_output=True,
+            check=True,
+        )
+
+    def test_moving_an_ignored_file_does_not_raise(self, git_repo: Path) -> None:
+        """Both sides ignored: nothing to stage, and no error."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+        head_before = _head(git_repo)
+
+        old_abs = git_repo / "a" / ".DS_Store"
+        new_abs = git_repo / "b" / ".DS_Store"
+        old_abs.parent.mkdir()
+        new_abs.parent.mkdir()
+        new_abs.write_bytes(b"junk")
+
+        _stage_and_commit(git_repo, new_abs, "rename", old_path=old_abs)
+
+        # Nothing was staged, so nothing was committed and the ignored file
+        # stays invisible to git rather than being force-added.
+        assert _head(git_repo) == head_before
+        assert _worktree_status(git_repo) == set()
+
+    def test_ignored_destination_still_records_the_deletion(
+        self, git_repo: Path
+    ) -> None:
+        """A tracked file moved *into* an ignored folder is deleted, not added.
+
+        Only the ignored half drops out of the pathspec; the old path's
+        disappearance is still recorded, so git does not keep serving content
+        the vault no longer has there.
+        """
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+
+        old_abs = git_repo / "note.md"
+        new_abs = git_repo / "cache" / "note.md"
+        new_abs.parent.mkdir()
+        old_abs.rename(new_abs)
+
+        _stage_and_commit(git_repo, new_abs, "rename", old_path=old_abs)
+
+        assert _commit_files(git_repo) == {"note.md"}
+        assert _worktree_status(git_repo) == set()
+
+    def test_tracked_file_under_an_ignored_directory_is_left_alone(
+        self, git_repo: Path
+    ) -> None:
+        """``check-ignore --no-index`` is why this does not raise.
+
+        A file committed before its directory was ignored stays tracked, yet
+        ``git add`` still refuses to name it. The default (index-aware)
+        ``check-ignore`` would call it "not ignored" and let it through.
+        """
+        import subprocess
+
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._seed(git_repo)
+        legacy = git_repo / "cache" / "legacy.md"
+        legacy.parent.mkdir()
+        legacy.write_text("# Legacy\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(git_repo), "add", "-f", "--", str(legacy)],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(git_repo), "commit", "-m", "legacy"],
+            capture_output=True,
+            check=True,
+        )
+
+        moved = git_repo / "cache" / "moved.md"
+        legacy.rename(moved)
+
+        _stage_and_commit(git_repo, moved, "rename", old_path=legacy)
+
+        # Neither side is stageable, so the commit is skipped and the move
+        # shows up only as an untracked working-tree change.
+        assert _commit_files(git_repo) == {"cache/legacy.md"}
+
+
+def _head(repo: Path) -> str:
+    """Return the repository's current HEAD sha."""
+    import subprocess
+
+    out = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+class TestMoveFolderCommitsEveryFile:
+    """``move_folder`` end-to-end over a real git-backed vault (#1238)."""
+
+    @staticmethod
+    def _vault_repo(tmp_path: Path) -> Path:
+        """A git repo whose ``src/`` folder holds a note and three artifacts."""
+        import subprocess
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        for cmd in (
+            ["git", "-C", str(vault), "init"],
+            ["git", "-C", str(vault), "config", "user.email", "t@t.com"],
+            ["git", "-C", str(vault), "config", "user.name", "T"],
+        ):
+            subprocess.run(cmd, capture_output=True, check=True)
+        (vault / ".gitignore").write_text(".DS_Store\n", encoding="utf-8")
+        src = vault / "src"
+        src.mkdir()
+        (src / "note.md").write_text("# Note\n", encoding="utf-8")
+        (src / "photo.png").write_bytes(b"\x89PNG\r\n")
+        # Not on the attachment allowlist, so before #1238 it moved without a
+        # callback and git was never told.
+        (src / "data.bin").write_bytes(b"\x00\x01")
+        (src / ".DS_Store").write_bytes(b"junk")
+        subprocess.run(
+            ["git", "-C", str(vault), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(vault), "commit", "-m", "seed"],
+            capture_output=True,
+            check=True,
+        )
+        return vault
+
+    def test_every_moved_file_lands_in_a_commit(self, tmp_path: Path) -> None:
+        """After the move, git tracks the files at their new paths only.
+
+        The regression #1238 fixes: a non-allowlisted file was moved on disk
+        but never staged, leaving the repository with an unstaged delete and
+        an untracked add that no later commit would pick up.
+        """
+        from markdown_vault_mcp.git.strategy import GitWriteStrategy
+        from markdown_vault_mcp.vault import Vault
+
+        vault = self._vault_repo(tmp_path)
+        strategy = GitWriteStrategy(
+            token=None,
+            repo_url=None,
+            managed=False,
+            enable_pull=False,
+            enable_push=False,
+            repo_path=vault,
+        )
+        col = Vault(
+            source_dir=vault,
+            git_strategy=strategy,
+            on_write=strategy,
+            read_only=False,
+        )
+        try:
+            col.index.build_index()
+            col.writer.move_folder("src", "dst")
+            col._write_callback.drain()
+        finally:
+            col.close()
+
+        tracked = _tracked_files(vault)
+        assert "dst/note.md" in tracked
+        assert "dst/photo.png" in tracked
+        assert "dst/data.bin" in tracked
+        assert not any(name.startswith("src/") for name in tracked)
+        # The ignored file moved on disk but stayed out of the repository,
+        # and staging it never errored.
+        assert (vault / "dst" / ".DS_Store").exists()
+        assert ".DS_Store" not in " ".join(tracked)
+
+    def test_the_move_leaves_no_unstaged_remnant(self, tmp_path: Path) -> None:
+        """Nothing from the moved folder is left dirty or untracked."""
+        from markdown_vault_mcp.git.strategy import GitWriteStrategy
+        from markdown_vault_mcp.vault import Vault
+
+        vault = self._vault_repo(tmp_path)
+        strategy = GitWriteStrategy(
+            token=None,
+            repo_url=None,
+            managed=False,
+            enable_pull=False,
+            enable_push=False,
+            repo_path=vault,
+        )
+        col = Vault(
+            source_dir=vault,
+            git_strategy=strategy,
+            on_write=strategy,
+            read_only=False,
+        )
+        try:
+            col.index.build_index()
+            col.writer.move_folder("src", "dst")
+            col._write_callback.drain()
+        finally:
+            col.close()
+
+        # Only the index state directory the Vault created remains, which was
+        # never the server's to commit.
+        assert _worktree_status(vault) == {"?? .markdown_vault_mcp/"}
+
+
+def _tracked_files(repo: Path) -> set[str]:
+    """Return every path in the repository index."""
+    import subprocess
+
+    out = subprocess.run(
+        ["git", "-C", str(repo), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line for line in out.stdout.splitlines() if line.strip()}

--- a/tests/test_move_folder.py
+++ b/tests/test_move_folder.py
@@ -7,6 +7,7 @@ mirroring the established writable-Vault test pattern in
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -22,7 +23,6 @@ from tests.conftest import wait_for_writer_drain
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
 
 @pytest.fixture
@@ -256,6 +256,52 @@ def test_move_folder_carries_non_allowlisted_file(
     assert (source_dir / "archive/.DS_Store").is_file()
     assert not (source_dir / "drafts").exists()
     assert result.files_moved == 2
+
+
+def test_move_folder_reports_every_moved_file_to_the_write_callback(
+    source_dir: Path,
+) -> None:
+    """Moving a file and not reporting it loses it (#1238).
+
+    Git staging is scoped to the paths a callback names, so a file moved
+    without one leaves an unstaged delete at the old path and an untracked
+    add at the new one, and is never committed. The allowlist governs which
+    files the *tools* expose, not what the repository tracks — so every
+    moved file gets a rename callback, allowlisted or not.
+
+    Asserting the disk result alone is what let this through before: the
+    file does arrive at its new path either way.
+    """
+    calls: list[tuple[str, ...]] = []
+
+    col = Vault(
+        source_dir=source_dir,
+        read_only=False,
+        attachment_extensions=["png"],
+        on_write=lambda path, _content, operation: calls.append(
+            (operation, Path(path).name)
+        ),
+    )
+    try:
+        col.index.build_index()
+        _write(col, "drafts/note.md", "n\n")
+        (source_dir / "drafts" / "pic.png").write_bytes(b"\x89PNG\r\n")
+        (source_dir / "drafts" / ".DS_Store").write_bytes(b"junk")
+        calls.clear()
+
+        col.writer.move_folder("drafts", "archive")
+        wait_for_writer_drain(col)
+    finally:
+        col.close()
+
+    renamed = {name for operation, name in calls if operation == "rename"}
+
+    assert "note.md" in renamed, "the note should be reported"
+    assert "pic.png" in renamed, "an allowlisted attachment should be reported"
+    assert ".DS_Store" in renamed, (
+        "a non-allowlisted file is moved on disk, so git must be told about "
+        "it too — otherwise it silently leaves the repository"
+    )
 
 
 def test_move_folder_rejects_nested_target(vault: Vault) -> None:


### PR DESCRIPTION
## Closes / Refs

Closes #1238

(#1238 was auto-closed when #1242 merged, since that PR filed it while deliberately leaving the branch untouched. Reopened, and closed for real here.)

## What & why

`move_folder` moved every file under the source directory but fired a rename callback only for notes and allowlisted attachments. A file that was neither — `notes/scratch.bin` under the default allowlist — arrived at its destination with git never told: an unstaged delete at the old path, an untracked add at the new one, and no commit. Silent, because the file *does* land where the caller asked.

The issue left open which way to resolve it. The code answers: `_plan_folder_move`'s docstring already promises to move every file, and step 8 `rmtree`s the source afterwards, so refusing to move a non-allowlisted file would not make `move_folder` partial — it would destroy the file. So every moved file now gets a callback, and the allowlist stays what it reads as everywhere else: a rule about which files the *tools* expose, not about what the repository carries.

Widening that gate then exposed three defects in the staging path it newly feeds — one I found in self-review, two that Codex found. All three are in `_stage_rename`, and all three are about the same thing: what `git add` will and will not accept.

**Ignored paths break `git add -A`.** The files this fix newly routes to git are precisely the ones a vault tends to gitignore — `.DS_Store`, `.obsidian/` — and `git add -A` exits non-zero on an explicitly named ignored pathspec. Every folder move would have logged a git error per ignored file. Ignored paths are now dropped. Force-adding was never on the table: that commits a file the operator deliberately excluded.

**But a tracked path an exclude rule covers still has to be staged.** A file committed before its directory was ignored stays tracked, so its deletion is real. Dropping it with the rest meant moving one out to a normal path staged the arrival and silently left the departure — git kept serving stale content at the old path. `git add -u` records it, since `-u` acts on tracked files only and the exclude rules never apply to those. Before #1238 this same case raised instead; loud and wrong became quiet and wrong, which is worse.

**And skipping the `git add` must skip the commit.** The diff check in `_stage_and_commit` is repository-wide, so a rename with nothing stageable — a folder of `.DS_Store` files suffices — found whatever the operator had staged of their own, committed it under the rename's message, and pushed it. That is the exact leak #894 exists to prevent, reopened through a new door. `_stage_rename` now reports whether it staged anything and the caller returns early when it did not.

One probe detail is load-bearing: `git check-ignore` runs with `--no-index`. The default, index-aware answer calls a tracked file "not ignored", but `git add -A` still refuses to name a tracked file living under an ignored directory. Only `--no-index` predicts the rule the filter exists to satisfy, and there is a test for exactly that case.

Every one of these was unreachable by the existing suite. `tests/test_git.py` contained no `move_folder` test at all, which is why the original defect went unnoticed. It has one now, end to end over a real repository.

## What this PR deliberately does NOT do

- Does not change what `move_folder` moves, only what it reports. The collision gate, link rewriting, and index handling are untouched.
- **#1249** — the residual half of the commit leak: the same repository-wide diff check can still commit unrelated staged work whenever a `git add` *runs* but stages nothing (writing byte-identical content). Pre-existing, and it affects the `write`/`delete` branches too, so scoping that check belongs in its own change.
- **#1250** — `_stage_rename` now runs up to four `git` subprocesses per renamed file versus one before. `check-ignore` takes multiple pathspecs, so the two probes batch into one; deferred because it would have obscured the correctness fix.
- Does not revisit the raw-vs-resolved suffix policy or the attachment-extension case policy — both still open from #1235's deferrals (#1239, #1241).
- Does not add a `vault.artifacts` accessor or otherwise widen the surface #1242 settled.

## Local review

- [x] Self-reviewed the cumulative diff before opening, which caught the `git add -A` regression, a comment claiming `rmtree` "logs" a leftover file it in fact deletes, and `is_allowed_artifact` losing its last production caller (rewired into `validate_history_path`, which was spelling out its body inline). Both Codex findings were then confirmed against the code and fixed in `47bb94f`; both threads answered and resolved.
- [x] No commit carries `!`. Nothing changes an operator surface or a public import; the MCP tool signatures are unchanged, and the behaviour change is strictly "git now learns about files it was silently losing".

## Docs impact

- [ ] `README.md` — no user-facing option or tool changed.
- [ ] `docs/` site pages — `move_folder`'s documented contract ("all files in the subtree are moved") already described the intended behaviour; only the git-side consequence was wrong, and that is internal.
- [x] `docs/design/` — the `move_folder` file-move policy states the callback rule and why the two rules are independent; the #894 per-operation staging section records the ignored-path filter, the tracked-but-ignored deletion rule, the no-op propagation, and the `--no-index` reasoning.
- [x] Inline docstrings — `_stage_rename` and the new `_is_ignored`.

## Verification

- `uv run pytest -x -q` — 3891 passed, 4 skipped
- `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .` — clean, whole tree
- `uv run mypy src/ tests/` — no issues in 215 files
- `bash scripts/structural_gate.sh` — 100%, 0 violations over 394 diff lines
- `uv run pre-commit run --all-files` — all hooks pass
- Every new test verified to fail against the code it fixes, by stashing the fix and re-running: the ignored-path tests raise `CalledProcessError`, the tracked-deletion test leaves the departure unstaged, the no-op test advances HEAD, and both `move_folder` end-to-end tests fail with `?? dst/data.bin`.
- `git add -u` on a tracked path under an ignored directory was confirmed in a scratch repository before the fix relying on it was written — it exits 0, stages the deletion, and git pairs it as R100.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197qu2QerLNpJSGQAjLjSNN