### PR TITLE
fix(instructions): enforce client-facing budgets

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3015,7 +3015,7 @@ The generated-text compatibility target is a tested configuration matrix,
 not an estimate from the default stdio server. The maximal case enables
 read-write mode, summarization, conventions, OKF, jobs, and HTTP transfer and
 must remain at or below pvl-core's 1,536 UTF-16-unit generated target. It is
-1,495 units as of #1252's acceptance fix. A second case adds representative
+1,507 units as of #1252's acceptance fix. A second case adds representative
 routing and policy and must remain within Claude Code's 2,048-unit limit.
 The mode, summarize limit, conventions, and OKF guidance are `INSTANCE` facts;
 the vault/search seed is `CAPABILITIES`; write, transfer, and job sequences are
@@ -3036,7 +3036,7 @@ units after FastMCP has parsed docstrings and built schemas. Schemas use compact
 sorted JSON so formatting cannot move the baseline. This is a prose/schema
 budget, not the byte size of complete serialized list responses: names, icons,
 annotations, and other protocol metadata are deliberately outside it. The
-initial post-reduction measurement is 57,228 units: 1,495 instructions, 22,853
+initial post-reduction measurement is 57,240 units: 1,507 instructions, 22,853
 tool descriptions,
 27,259 input schemas, 3,353 output schemas, 842 prompt descriptions, 101 prompt
 argument descriptions, 613 resource descriptions, and 712 resource-template

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1174,6 +1174,11 @@ detect: a write that started and finished entirely between two snapshots.
 
 Each such tool accepts an optional `wait_for_pending_writes: bool = false`
 parameter (client-facing name; the internal primitive is still "drain").
+Its wire-schema description is owned once by the shared
+`_WaitForPendingWrites` `Annotated` alias in `_server_tools/_common.py`;
+the longer per-tool `Args:` entries remain developer documentation. This
+prevents the same schema prose from being copied into every read tool while
+keeping the runtime signatures and Google-style docstrings explicit (#1010).
 When `true`, the tool layer polls `IndexFacet.is_drained()`
 with `asyncio.sleep` until the writer drains or
 `MARKDOWN_VAULT_MCP_DRAIN_TIMEOUT_S` (default 60 s) elapses, then
@@ -3005,6 +3010,45 @@ concise routing context at `ROUTING`, and
 and logs a deprecation warning; when it is set, both additive variables are
 ignored. None reaches `ProjectConfig`: a domain field mirroring them would be
 a second, silently-diverging reader of the same variables.
+
+The generated-text compatibility target is a tested configuration matrix,
+not an estimate from the default stdio server. The maximal case enables
+read-write mode, summarization, conventions, OKF, jobs, and HTTP transfer and
+must remain at or below pvl-core's 1,536 UTF-16-unit generated target. It is
+1,495 units as of #1252's acceptance fix. A second case adds representative
+routing and policy and must remain within Claude Code's 2,048-unit limit.
+The mode, summarize limit, conventions, and OKF guidance are `INSTANCE` facts;
+the vault/search seed is `CAPABILITIES`; write, transfer, and job sequences are
+`WORKFLOWS`.
+
+Instructions deliberately carry only concise discovery seeds, enforced facts,
+and the vault-wide OKF interpretation/editing rule. Tool descriptions own the
+detailed call contract. This reduces the overlap identified by #1257 without
+claiming that every repeated workflow sentence is safely removable: whether a
+tool-searching client needs a larger discovery seed remains an experiment and
+#1257 stays open for that evidence.
+
+**Client-facing surface budget**: `tests/test_client_surface_budget.py`
+constructs the maximal discoverable HTTP surface (read-write, summarization,
+OKF enforced writes, managed Git, transfer, jobs, prompts, resources, and
+resource templates), enumerates real MCP protocol objects, and measures UTF-16
+units after FastMCP has parsed docstrings and built schemas. Schemas use compact,
+sorted JSON so formatting cannot move the baseline. This is a prose/schema
+budget, not the byte size of complete serialized list responses: names, icons,
+annotations, and other protocol metadata are deliberately outside it. The
+initial post-reduction measurement is 57,228 units: 1,495 instructions, 22,853
+tool descriptions,
+27,259 input schemas, 3,353 output schemas, 842 prompt descriptions, 101 prompt
+argument descriptions, 613 resource descriptions, and 712 resource-template
+descriptions. Reviewed category ceilings plus a 58,000-unit total ceiling make
+future growth visible without turning the exact measurement into a golden
+snapshot.
+
+Parameterless tools always pass an explicit concise `description=` at
+registration. Otherwise FastMCP falls back to the complete raw docstring when
+it extracts no parameters, exposing developer-only `Returns:` detail and making
+the wire cost depend on whether the tool happens to accept an argument (#1253;
+upstream FastMCP #4952).
 
 **Tool semantics**:
 - `read(path)` returns full file content + frontmatter metadata

--- a/src/markdown_vault_mcp/_instructions.py
+++ b/src/markdown_vault_mcp/_instructions.py
@@ -155,9 +155,9 @@ def _domain_snippets(
     if conventions_file is not None:
         snippets.append(
             Snippet(
-                "Before creating, restructuring, or linking notes, call "
-                f"'get_conventions(path)' and follow it ('{conventions_file}' "
-                "configured).",
+                "Before changing or linking notes, call "
+                "'get_conventions(path)'; follow it and write-result "
+                f"'conventions' ('{conventions_file}' configured).",
                 InstructionRole.INSTANCE,
                 ("get_conventions",),
             )

--- a/src/markdown_vault_mcp/_instructions.py
+++ b/src/markdown_vault_mcp/_instructions.py
@@ -118,96 +118,70 @@ def _domain_snippets(
     Returns:
         The applicable guidance fragments, in the order they are composed.
     """
+    # Enforced here, so announced here — see above. Keep the deployment mode
+    # first among INSTANCE facts because it is the most consequential routing
+    # constraint for a caller.
     snippets = [
         Snippet(
-            "A searchable markdown document vault. "
-            "Paths are always relative (e.g. 'Journal/note.md').",
-            InstructionRole.CAPABILITIES,
+            "This instance is READ-ONLY; write tools are not available."
+            if read_only
+            else "This instance is READ-WRITE; write tools are available.",
+            InstructionRole.INSTANCE,
         )
     ]
-    if not read_only:
-        snippets.append(
-            Snippet(
-                "Write tools: use 'write' to create, 'edit' for targeted changes "
-                "(read first), 'append' to add to the end of a note (no read "
-                "needed), 'rename' to move (pass update_links=True to fix links "
-                "in other notes), 'delete' to remove. Use 'move_folder(old_dir, "
-                "new_dir)' to move an entire folder subtree and rewrite all vault "
-                "links in one call. All write operations update the "
-                "search index immediately — never call 'reindex' after write, edit, "
-                "append, delete, or rename.",
-                InstructionRole.WORKFLOWS,
-                _WRITE_SNIPPET_TOOLS,
-            )
-        )
     snippets.append(
         Snippet(
-            "Use 'search' to find documents, 'read' for full content, "
-            "'list_documents' to enumerate, 'stats' to check capabilities. Omit "
-            "'mode' on 'search' and the server picks the best mode this vault can "
-            "serve — hybrid where embeddings exist, keyword otherwise; pass "
-            "mode='keyword' for exact terms, operators, or filenames. "
-            "'browse_vault' and 'show_context' open a visual UI for the user — do "
-            "not call them to retrieve vault content; use 'search', 'read', "
-            "'list_documents', or 'get_context' instead.",
-            InstructionRole.WORKFLOWS,
+            "Notes use vault-relative paths. 'search' finds; 'read' returns full "
+            "content; 'list_documents' enumerates; 'stats' reports capabilities. "
+            "Omit 'mode' for automatic search; use 'keyword' for exact terms.",
+            InstructionRole.CAPABILITIES,
             ("search", "read", "list_documents", "stats"),
         )
     )
     snippets.append(
         Snippet(
-            "No summarization backend is configured, so there is no "
-            "'summarize' tool; for multi-note or folder summaries use the "
-            "'summarize-subtree' prompt, which summarizes in batches "
-            "(delegated to subagents when available) instead of pulling "
-            "every note into your context.",
-            InstructionRole.WORKFLOWS,
+            "No 'summarize' tool is configured; use the 'summarize-subtree' "
+            "prompt for multi-note or folder summaries.",
+            InstructionRole.INSTANCE,
         )
         if summarize_note_limit is None
         else Snippet(
-            f"The 'summarize' tool reads at most {summarize_note_limit} "
-            "notes per call; for a folder larger than that (check with "
-            "'get_toc'), call it once per subfolder and combine the results.",
-            InstructionRole.WORKFLOWS,
+            f"'summarize' handles at most {summarize_note_limit} notes per call; "
+            "split larger folders with 'get_toc'.",
+            InstructionRole.INSTANCE,
             ("summarize", "get_toc"),
         )
     )
     if conventions_file is not None:
         snippets.append(
             Snippet(
-                f"Folders may carry authoring conventions in '{conventions_file}' "
-                "files; call 'get_conventions(path)' before creating or "
-                "restructuring notes, and follow any 'conventions' returned by "
-                "write/edit results.",
-                InstructionRole.WORKFLOWS,
+                "Before creating, restructuring, or linking notes, call "
+                f"'get_conventions(path)' and follow it ('{conventions_file}' "
+                "configured).",
+                InstructionRole.INSTANCE,
                 ("get_conventions",),
             )
         )
     if okf_mode != "off":
         snippets.append(
             Snippet(
-                "When the vault is an OKF bundle (Open Knowledge Format — "
-                "'okf_version' declared in the root 'index.md'; check the 'okf' "
-                "section of 'stats'), search/read results carry an 'okf' key with "
-                "each note's type, lifecycle status, staleness, and trust tier "
-                "(unverified / machine-confirmed / human-reviewed) — weigh "
-                "deprecated, stale, or unverified notes accordingly. When editing "
-                "such a vault, follow OKF conventions: record changes in 'log.md', "
-                "keep 'index.md' listings current, and prefer root-relative "
-                "markdown links for new cross-references.",
-                InstructionRole.WORKFLOWS,
+                "If 'stats.okf' reports an OKF bundle ('okf_version' in root "
+                "'index.md'), discount deprecated, stale, or unverified notes by "
+                "trust tier. For edits, update 'log.md'/'index.md' and use "
+                "root-relative Markdown links.",
+                InstructionRole.INSTANCE,
             )
         )
-    # Enforced here, so announced here — see above. ``INSTANCE`` gives the
-    # deployment mode its semantic position alongside operator routing context.
-    snippets.append(
-        Snippet(
-            "This instance is READ-ONLY — write tools are not available."
-            if read_only
-            else "This instance is READ-WRITE — write tools are available.",
-            InstructionRole.INSTANCE,
+    if not read_only:
+        snippets.append(
+            Snippet(
+                "Use 'write'/'edit'/'append' to change notes, "
+                "'rename'/'move_folder' to move, and 'delete' to remove. Writes "
+                "update the index; never call 'reindex' afterward.",
+                InstructionRole.WORKFLOWS,
+                _WRITE_SNIPPET_TOOLS,
+            )
         )
-    )
     return snippets
 
 

--- a/src/markdown_vault_mcp/_server_tools/_common.py
+++ b/src/markdown_vault_mcp/_server_tools/_common.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 from dataclasses import asdict
-from typing import Any, TypeVar
+from typing import Annotated, Any, TypeVar
 
 from fastmcp.tools import ToolResult
 
@@ -19,6 +19,12 @@ logger = logging.getLogger(__name__)
 # ToolResult, so its result must be `return`ed directly from a tool, never
 # stored or processed as `_T` (mypy would not catch the mismatch).
 _T = TypeVar("_T")
+
+_WaitForPendingWrites = Annotated[
+    bool,
+    "Wait for recent index writes. On timeout, answer from the current index "
+    "with _meta.index_stale=true. Default false.",
+]
 
 
 def conventions_payload(vault: Vault, path: str) -> list[dict[str, str]]:

--- a/src/markdown_vault_mcp/_server_tools/graph.py
+++ b/src/markdown_vault_mcp/_server_tools/graph.py
@@ -12,7 +12,11 @@ from markdown_vault_mcp.vault import Vault
 from .._icons import _TOOL_ICONS
 from .._server_queryable import needs_queryable
 from ..domain import get_vault
-from ._common import _maybe_wait_for_drain, _staleness_result
+from ._common import (
+    _maybe_wait_for_drain,
+    _staleness_result,
+    _WaitForPendingWrites,
+)
 
 
 def register(mcp: FastMCP) -> None:
@@ -31,7 +35,7 @@ def register(mcp: FastMCP) -> None:
     async def get_backlinks(
         path: str,
         limit: int | None = None,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Find all documents that link TO the given document (backlinks).
@@ -113,7 +117,7 @@ def register(mcp: FastMCP) -> None:
     async def get_outlinks(
         path: str,
         limit: int | None = None,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Find all links FROM the given document to other documents (outlinks).
@@ -191,7 +195,7 @@ def register(mcp: FastMCP) -> None:
     )
     async def get_broken_links(
         folder: str | None = None,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Find all links that point to non-existent documents (broken links).
@@ -259,7 +263,7 @@ def register(mcp: FastMCP) -> None:
         },
     )
     async def get_orphan_notes(
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Return all notes with no inbound or outbound links.
@@ -324,7 +328,7 @@ def register(mcp: FastMCP) -> None:
     )
     async def get_most_linked(
         limit: int = 10,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Return the documents with the most inbound links, ranked by backlink count.
@@ -384,7 +388,7 @@ def register(mcp: FastMCP) -> None:
         source: str,
         target: str,
         max_depth: int = 10,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> dict[str, Any]:
         """Find the shortest connection path between two notes in the link graph.

--- a/src/markdown_vault_mcp/_server_tools/index.py
+++ b/src/markdown_vault_mcp/_server_tools/index.py
@@ -31,6 +31,7 @@ def register(mcp: FastMCP) -> None:
     """
 
     @mcp.tool(
+        description="Check embedding provider and vector-index status.",
         icons=_TOOL_ICONS["embeddings_status"],
         annotations={
             "title": "Embeddings Status",
@@ -63,6 +64,7 @@ def register(mcp: FastMCP) -> None:
         return await asyncio.to_thread(vault.index.embeddings_status)
 
     @mcp.tool(
+        description="Report FTS index readiness, progress, and last build error.",
         annotations={
             "title": "Index Status",
             "readOnlyHint": True,

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -17,6 +17,7 @@ from ..domain import get_vault
 from ._common import (
     _maybe_wait_for_drain,
     _staleness_result,
+    _WaitForPendingWrites,
     attach_conventions,
     attach_okf,
     attach_okf_to_results,
@@ -43,7 +44,7 @@ def register(mcp: FastMCP) -> None:
         filters: dict[str, str] | None = None,
         chunks_per_file: int | None = None,
         snippet_words: int | None = None,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Find documents matching a query using full-text or semantic search.
@@ -272,7 +273,7 @@ def register(mcp: FastMCP) -> None:
         pattern: str | None = None,
         include_attachments: bool = False,
         filters: dict[str, str] | None = None,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """List documents (and optionally attachments) in the vault.
@@ -353,7 +354,7 @@ def register(mcp: FastMCP) -> None:
         },
     )
     async def list_folders(
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[str]:
         """List all folder paths that contain documents.
@@ -406,7 +407,7 @@ def register(mcp: FastMCP) -> None:
     )
     async def list_tags(
         field: str = "tags",
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[str]:
         """List all distinct values for a frontmatter field across the vault.
@@ -462,7 +463,7 @@ def register(mcp: FastMCP) -> None:
         },
     )
     async def stats(
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> dict[str, Any]:
         """Get an overview of the vault's size, capabilities, and configuration.
@@ -540,7 +541,7 @@ def register(mcp: FastMCP) -> None:
         chunks_per_file: int | None = None,
         folder: str | None = None,
         filters: dict[str, str] | None = None,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Find notes most semantically similar to the given document.
@@ -649,7 +650,7 @@ def register(mcp: FastMCP) -> None:
         path: str,
         max_level: int | None = None,
         max_notes: int = 200,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Heading outline for a single note or a whole folder subtree.
@@ -714,7 +715,7 @@ def register(mcp: FastMCP) -> None:
     async def get_recent(
         limit: int = 20,
         folder: str | None = None,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
         """Get the most recently modified notes in the vault.
@@ -779,7 +780,7 @@ def register(mcp: FastMCP) -> None:
         path: str,
         similar_limit: int = 5,
         link_limit: int = 10,
-        wait_for_pending_writes: bool = False,
+        wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> dict[str, Any]:
         """Get a consolidated context dossier for a document.
@@ -965,6 +966,7 @@ def register(mcp: FastMCP) -> None:
         return await asyncio.to_thread(_lookup)
 
     @mcp.tool(
+        description="Audit the vault's Open Knowledge Format conformance.",
         icons=_TOOL_ICONS["okf_validate"],
         tags={"okf"},
         annotations={

--- a/tests/test_client_surface_budget.py
+++ b/tests/test_client_surface_budget.py
@@ -1,0 +1,143 @@
+"""Budgets for model-facing MCP prose and schemas (#1253)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp_pvl_core import utf16_code_units
+
+from tests.server_factory import make_server
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+_WAIT_DESCRIPTION = (
+    "Wait for recent index writes. On timeout, answer from the current index "
+    "with _meta.index_stale=true. Default false."
+)
+
+_SURFACE_LIMITS = {
+    "instructions": 1_536,
+    "tool_descriptions": 23_500,
+    "tool_input_schemas": 27_600,
+    "tool_output_schemas": 3_500,
+    "prompt_descriptions": 900,
+    "prompt_arguments": 150,
+    "resource_descriptions": 700,
+    "resource_template_descriptions": 800,
+}
+_TOTAL_SURFACE_LIMIT = 58_000
+
+
+@pytest.fixture
+def maximal_surface_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FastMCP:
+    """Build the largest client-visible surface without starting the vault."""
+    from markdown_vault_mcp import server as server_module
+
+    @asynccontextmanager
+    async def _skip_lifespan(_: FastMCP) -> AsyncIterator[dict[str, Any]]:
+        yield {}
+
+    monkeypatch.setattr(server_module, "server_lifespan", _skip_lifespan)
+    (tmp_path / "index.md").write_text(
+        "---\nokf_version: 0.2\n---\n# Index\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(tmp_path))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "false")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_BASE_URL", "https://vault.example")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_OKF_MODE", "on")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_OKF_WRITE", "true")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_OKF_VERIFY", "elicit")
+    monkeypatch.setenv(
+        "MARKDOWN_VAULT_MCP_GIT_REPO_URL", "https://github.com/example/vault.git"
+    )
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_KV_STORE_URL", "memory://")
+    return make_server(transport="http")
+
+
+def _compact_schema(schema: dict[str, Any]) -> str:
+    return json.dumps(
+        schema,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _units(values: list[str | None]) -> int:
+    return sum(utf16_code_units(value or "") for value in values)
+
+
+@pytest.mark.asyncio
+async def test_maximal_client_surface_stays_within_reviewed_budgets(
+    maximal_surface_server: FastMCP,
+) -> None:
+    """Measure post-parse protocol objects, not source docstrings."""
+    async with Client(maximal_surface_server) as client:
+        tools = await client.list_tools()
+        prompts = await client.list_prompts()
+        resources = await client.list_resources()
+        resource_templates = await client.list_resource_templates()
+
+    actual = {
+        "instructions": utf16_code_units(maximal_surface_server.instructions or ""),
+        "tool_descriptions": _units([tool.description for tool in tools]),
+        "tool_input_schemas": _units(
+            [_compact_schema(tool.inputSchema) for tool in tools]
+        ),
+        "tool_output_schemas": _units(
+            [
+                _compact_schema(tool.outputSchema)
+                for tool in tools
+                if tool.outputSchema is not None
+            ]
+        ),
+        "prompt_descriptions": _units([prompt.description for prompt in prompts]),
+        "prompt_arguments": _units(
+            [
+                argument.description
+                for prompt in prompts
+                for argument in (prompt.arguments or [])
+            ]
+        ),
+        "resource_descriptions": _units(
+            [resource.description for resource in resources]
+        ),
+        "resource_template_descriptions": _units(
+            [resource.description for resource in resource_templates]
+        ),
+    }
+    exceeded = {
+        name: (actual[name], limit)
+        for name, limit in _SURFACE_LIMITS.items()
+        if actual[name] > limit
+    }
+    assert not exceeded, f"client-surface category budgets exceeded: {exceeded}"
+    assert sum(actual.values()) <= _TOTAL_SURFACE_LIMIT, actual
+
+    wait_descriptions = [
+        tool.inputSchema["properties"]["wait_for_pending_writes"]["description"]
+        for tool in tools
+        if "wait_for_pending_writes" in tool.inputSchema.get("properties", {})
+    ]
+    assert wait_descriptions
+    assert set(wait_descriptions) == {_WAIT_DESCRIPTION}
+
+    expected_descriptions = {
+        "embeddings_status": "Check embedding provider and vector-index status.",
+        "get_index_status": (
+            "Report FTS index readiness, progress, and last build error."
+        ),
+        "okf_validate": "Audit the vault's Open Knowledge Format conformance.",
+    }
+    descriptions = {tool.name: tool.description for tool in tools}
+    for name, expected in expected_descriptions.items():
+        assert descriptions[name] == expected
+        assert "Returns:" not in (descriptions[name] or "")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -34,6 +34,7 @@ _CLEAR_VARS = (
     "MARKDOWN_VAULT_MCP_GIT_TOKEN",
     "MARKDOWN_VAULT_MCP_TEMPLATES_FOLDER",
     "MARKDOWN_VAULT_MCP_SERVER_NAME",
+    "MARKDOWN_VAULT_MCP_INSTANCE_DESCRIPTION",
     "MARKDOWN_VAULT_MCP_INSTRUCTIONS",
     "MARKDOWN_VAULT_MCP_INSTRUCTIONS_EXTRA",
     # Auth vars — ensure non-auth tests run unauthenticated
@@ -116,6 +117,14 @@ def _mcp_env_with_fields(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setenv("MARKDOWN_VAULT_MCP_INDEXED_FIELDS", "cluster,tags")
 
 
+@pytest.fixture
+def _mcp_env_maximal(_mcp_env_writable: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable every feature that contributes generated instructions."""
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_BASE_URL", "https://vault.example")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SUMMARIZE_OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_OKF_MODE", "on")
+
+
 # ---------------------------------------------------------------------------
 # Server identity
 # ---------------------------------------------------------------------------
@@ -179,7 +188,91 @@ class TestServerIdentity:
             mode = [s for s in snippets if expected in s.text]
             assert len(mode) == 1, f"expected exactly one {expected} snippet"
             assert mode[0].role is InstructionRole.INSTANCE
-            assert snippets[-1] is mode[0], "the mode line is composed last"
+            assert snippets[0] is mode[0], "the mode fact must be composed first"
+
+    def test_domain_snippets_use_their_normative_roles(self) -> None:
+        """Pin the role ownership required by pvl-core's #299 design."""
+        from fastmcp_pvl_core import InstructionRole
+
+        from markdown_vault_mcp._instructions import _domain_snippets
+
+        snippets = _domain_snippets(
+            read_only=False,
+            conventions_file="_conventions.md",
+            summarize_note_limit=50,
+            okf_mode="on",
+        )
+        roles = {snippet.text: snippet.role for snippet in snippets}
+
+        assert roles[next(text for text in roles if "'summarize' handles" in text)] is (
+            InstructionRole.INSTANCE
+        )
+        assert roles[next(text for text in roles if "get_conventions" in text)] is (
+            InstructionRole.INSTANCE
+        )
+        assert roles[next(text for text in roles if "OKF bundle" in text)] is (
+            InstructionRole.INSTANCE
+        )
+        assert roles[next(text for text in roles if "'search' finds" in text)] is (
+            InstructionRole.CAPABILITIES
+        )
+        assert roles[next(text for text in roles if "'write'/'edit'" in text)] is (
+            InstructionRole.WORKFLOWS
+        )
+
+    @pytest.mark.usefixtures("_mcp_env_maximal")
+    def test_maximal_generated_instructions_fit_target(self) -> None:
+        """The complete generated feature matrix keeps operator headroom."""
+        from fastmcp_pvl_core import (
+            GENERATED_INSTRUCTIONS_TARGET_UTF16,
+            utf16_code_units,
+        )
+
+        text = make_server(transport="http").instructions or ""
+        for required in (
+            "READ-WRITE",
+            "summarize",
+            "get_conventions",
+            "OKF bundle",
+            "create_upload_link",
+            "get_job_result",
+        ):
+            assert required in text
+        assert utf16_code_units(text) <= GENERATED_INSTRUCTIONS_TARGET_UTF16
+
+    @pytest.mark.usefixtures("_mcp_env_maximal")
+    def test_representative_operator_context_fits_client_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Routing and policy retain their positions inside the client budget."""
+        from fastmcp_pvl_core import (
+            CLAUDE_CODE_INSTRUCTIONS_LIMIT_UTF16,
+            utf16_code_units,
+        )
+
+        routing = "Contains projects, meetings, and operational notes."
+        policy = "Prefer concise answers and cite each note by path."
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_INSTANCE_DESCRIPTION", routing)
+        monkeypatch.setenv("MARKDOWN_VAULT_MCP_INSTRUCTIONS_EXTRA", policy)
+
+        text = make_server(transport="http").instructions or ""
+        assert utf16_code_units(text) <= CLAUDE_CODE_INSTRUCTIONS_LIMIT_UTF16
+        assert text.index(routing) < text.index("READ-WRITE") < text.index(policy)
+        assert text.index(policy) < text.index("'search' finds")
+        assert text.index("get_job_result") < text.index("Full documentation")
+
+    @pytest.mark.usefixtures("_mcp_env")
+    def test_distinct_server_names_produce_distinct_identity_prefixes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        prefixes = []
+        for name in ("work-vault", "corpus-mcp"):
+            monkeypatch.setenv("MARKDOWN_VAULT_MCP_SERVER_NAME", name)
+            text = make_server().instructions or ""
+            prefixes.append(text.splitlines()[0])
+            assert prefixes[-1].startswith(f"{name}: ")
+
+        assert prefixes[0] != prefixes[1]
 
     @pytest.mark.usefixtures("_mcp_env")
     def test_no_domain_snippet_is_silently_pruned(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -145,8 +145,13 @@ def test_instructions_compose_semantic_operator_roles(
         "markdown-vault-mcp: Generic markdown vault MCP with hybrid search"
     )
     assert sections[1] == "Demo material."
-    assert sections[2] == "This instance is READ-WRITE — write tools are available."
-    assert sections[3] == "House rule: be brief."
+    mode = "This instance is READ-WRITE; write tools are available."
+    policy = "House rule: be brief."
+    assert sections[2] == mode
+    assert sections.index(mode) < sections.index(policy)
+    assert sections.index(policy) < next(
+        index for index, section in enumerate(sections) if "'search' finds" in section
+    )
     assert sections[-1] == (
         "Full documentation for this server: "
         "https://pvliesdonk.github.io/markdown-vault-mcp/latest/llms.txt"

--- a/tests/test_tools_conventions.py
+++ b/tests/test_tools_conventions.py
@@ -191,6 +191,7 @@ class TestConfigSurface:
         server = make_server()
         assert "_conventions.md" in (server.instructions or "")
         assert "get_conventions" in (server.instructions or "")
+        assert "write-result 'conventions'" in (server.instructions or "")
 
     async def test_instructions_omit_conventions_when_disabled(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Closes / Refs

Closes #1252, closes #1253, closes #1010

## What & why

Compacts and correctly classifies the composed vault instructions so the maximal generated feature matrix fits pvl-core's 1,536 UTF-16-unit target, with representative operator context fitting Claude Code's 2,048-unit limit. It also establishes reviewed post-parse prose/schema budgets, single-sources the repeated `wait_for_pending_writes` wire description, and prevents parameterless tool docstrings from leaking `Returns:` sections.

## What this PR deliberately does NOT do

- Determine how much discovery guidance tool-searching clients can safely lose: #1257
- Add server-side Tool Search or CodeMode: pvliesdonk/fastmcp-pvl-core#300
- Resolve programmatic `ProjectConfig.server_name` identity divergence in template-owned code: pvliesdonk/fastmcp-server-template#555

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] Any commit carrying `!` breaks an operator or library surface that existed at the **last stable release**. This PR carries no `!` commit.

### Self-review `4d422d58..eae1d013`

Charters: rules, diff, adjacent commitments, history, normative conformance.
Coverage: full local diff, including the new surface-budget test; hosted past-PR review history was not inspected.

No blocker or important findings survived review. An independent read-only pass and Repowise change-risk analysis also found no introduced findings; the structural diff gate reports 100% with zero violations.

## Docs impact

- [x] `README.md` reviewed; no change needed because the operator-facing thresholds were already documented.
- [x] `docs/` site pages reviewed; no change needed for unchanged tool semantics.
- [x] `docs/design/` updated with role ownership, maximal instruction accounting, surface categories, and #1257's experiment boundary.
- [x] Inline docstrings reviewed; detailed developer documentation remains intact while explicit wire descriptions override only client-facing parsing.

## Validation

- `uv run pytest -x -q`: 3,896 passed, 4 skipped
- Coverage: 97% overall; changed source files 100%
- Ruff check/format, mypy, pre-commit, Vale: passed
- `bash scripts/structural_gate.sh`: 100%, zero violations
- Push hooks: passed

---
_Generated by [Claude Code](https://claude.ai/code)_