### PR TITLE
fix(okf): exclude reserved files from the stats OKF histograms

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1384,7 +1384,9 @@ what is implemented today:
 - **Stats & config surface**: `stats` gains an `okf` section (mode,
   declared version, `type` histogram + untyped count, status/trust
   breakdowns, stale count — aggregated from the same `documents` rows
-  `stats` already reads); `config://vault` reports `okf_mode` /
+  `stats` already reads, minus the reserved files, which are counted
+  apart as `reserved_count` so the histograms cover the same note
+  population `okf_validate` audits); `config://vault` reports `okf_mode` /
   `okf_active` / `okf_declared_version`; the default server instructions
   gain an OKF guidance sentence whenever the mode permits detection
   (same pre-clone rationale as the conventions sentence).

--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -171,7 +171,11 @@ frontmatter blob; not persisted):
    `sources` are surfaced on `read` (full) and counted on search hits
    (`sources_count`), not inlined into result lists.
 2. `stats` gains an `okf` section: declared version, effective mode,
-   `type` histogram, status/trust-tier breakdowns, stale count.
+   `type` histogram, status/trust-tier breakdowns, stale count. The
+   histograms cover the note population — reserved files are excluded
+   from them and counted apart as `reserved_count` (#1251), so the
+   section reconciles with the `okf_validate` audit rather than
+   contradicting it on a conformant bundle.
 3. Default server instructions gain an OKF paragraph (composed in
    `_instructions.py`, wired through the existing DOMAIN-WIRING seam):
    what the tiers mean, that `log.md`/`index.md` conventions apply, and —
@@ -184,7 +188,8 @@ frontmatter blob; not persisted):
    conditionally, rather than gated on the marker file existing.
 4. Reserved files `index.md`/`log.md` remain indexed (they are searchable
    navigation) but are tagged for the ranking layer (§5) and excluded from
-   conformance checks (§4) per spec.
+   conformance checks (§4) per spec. They are not notes, so the `stats`
+   histograms (channel 2) exclude them as well.
 
 **Indexing integration:** OKF scalar fields ride the existing
 `document_tags` machinery — when detection is on, the effective

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -212,7 +212,7 @@ Get an overview of the vault's size, capabilities, and configuration. Call this 
 }
 ```
 
-On an OKF bundle (see `MARKDOWN_VAULT_MCP_OKF_MODE` in [Configuration](../configuration.md)), the response also carries an `okf` section: the configured mode, the declared spec version, a per-`type` histogram plus an untyped count, `status` and trust-tier breakdowns, and the stale-note count.
+On an OKF bundle (see `MARKDOWN_VAULT_MCP_OKF_MODE` in [Configuration](../configuration.md)), the response also carries an `okf` section: the configured mode, the declared spec version, a per-`type` histogram plus an untyped count, `status` and trust-tier breakdowns, and the stale-note count. Those counts cover the same note population [`okf_validate`](#okf_validate) audits, so the reserved `index.md` / `log.md` files land in none of them and are reported on their own as `reserved_count`.
 
 ### `embeddings_status`
 

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -507,7 +507,10 @@ def register(mcp: FastMCP) -> None:
             - okf (dict, optional): Present only when the vault is an active
               OKF (Open Knowledge Format) bundle. Carries mode,
               declared_version, a per-``type`` histogram plus untyped_count,
-              status and trust-tier breakdowns, and stale_count.
+              status and trust-tier breakdowns, and stale_count. Those cover
+              the note population 'okf_validate' audits; the reserved
+              ``index.md`` / ``log.md`` files are counted apart as
+              reserved_count.
 
             Index freshness rides in the response's ``_meta.index_stale``
             field — True when the IndexWriter was non-idle, a write completed

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -51,6 +51,7 @@ from markdown_vault_mcp.managers._ranking import (
 from markdown_vault_mcp.managers._vector_loader import load_or_self_heal
 from markdown_vault_mcp.okf import (
     OKF_FILTER_KEYS,
+    OKF_RESERVED_FILENAMES,
     derive_annotation,
     matches_okf_filters,
     okf_downweight_factor,
@@ -1457,8 +1458,11 @@ class SearchManager:
         Iterates the same ``documents`` rows :meth:`stats` already counts
         and aggregates the OKF read annotations: a ``type`` histogram (plus
         an untyped count), lifecycle-``status`` and trust-tier breakdowns,
-        and the stale-note count. Reserved bundle files (``index.md`` /
-        ``log.md``) are ordinary indexed notes and are included.
+        and the stale-note count. The aggregate reports over the OKF *note*
+        population — the same set :func:`~markdown_vault_mcp.okf.audit_bundle`
+        audits — so reserved bundle files (``index.md`` / ``log.md``), which
+        the spec exempts from the ``type`` rule, are excluded from every
+        histogram and reported on their own as ``reserved_count``.
 
         Returns:
             The aggregate dict, or ``None`` when no OKF detector is wired
@@ -1476,7 +1480,11 @@ class SearchManager:
         trust: dict[str, int] = {}
         untyped = 0
         stale = 0
+        reserved = 0
         for row in self._fts.list_notes():
+            if row["path"].rsplit("/", 1)[-1] in OKF_RESERVED_FILENAMES:
+                reserved += 1
+                continue
             metadata = self._parse_frontmatter_json(
                 row.get("frontmatter_json"), row["path"]
             )
@@ -1500,6 +1508,7 @@ class SearchManager:
             "status": dict(sorted(status.items())),
             "trust": dict(sorted(trust.items())),
             "stale_count": stale,
+            "reserved_count": reserved,
         }
 
     # ------------------------------------------------------------------

--- a/tests/test_tools_okf.py
+++ b/tests/test_tools_okf.py
@@ -60,6 +60,22 @@ PLAIN_NOTE = """# Plain
 Zebra background notes.
 """
 
+FOLDER_INDEX = """---
+title: Guides
+---
+# Guides
+"""
+
+RESERVED_LOG = """---
+title: Change history
+---
+# Log
+
+## 2026-01-01
+
+- Seeded the bundle.
+"""
+
 
 def _write_notes(vault: Path, *, declared: bool) -> None:
     (vault / "guides").mkdir(parents=True)
@@ -83,6 +99,25 @@ def plain_vault(tmp_path: Path) -> Path:
     vault = tmp_path / "vault"
     _write_notes(vault, declared=False)
     return vault
+
+
+@pytest.fixture
+def scaffold_vault(tmp_path: Path) -> Path:
+    """A declared bundle holding nothing but reserved files."""
+    vault = tmp_path / "vault"
+    (vault / "guides").mkdir(parents=True)
+    (vault / "index.md").write_text(ROOT_INDEX, encoding="utf-8")
+    (vault / "log.md").write_text(RESERVED_LOG, encoding="utf-8")
+    (vault / "guides" / "index.md").write_text(FOLDER_INDEX, encoding="utf-8")
+    return vault
+
+
+@pytest.fixture
+def _scaffold_env(scaffold_vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_SOURCE_DIR", str(scaffold_vault))
+    monkeypatch.setenv("MARKDOWN_VAULT_MCP_READ_ONLY", "true")
+    for var in _CLEAR_VARS:
+        monkeypatch.delenv(var, raising=False)
 
 
 @pytest.fixture
@@ -217,10 +252,26 @@ class TestDeclaredBundle:
         assert okf["mode"] == "auto"
         assert okf["declared_version"] == "0.2"
         assert okf["types"] == {"Playbook": 1}
-        assert okf["untyped_count"] == 2  # index.md + plain.md
-        assert okf["status"] == {"deprecated": 1, "stable": 2}
-        assert okf["trust"] == {"human-reviewed": 1, "unverified": 2}
+        assert okf["untyped_count"] == 1  # plain.md; index.md is reserved
+        assert okf["status"] == {"deprecated": 1, "stable": 1}
+        assert okf["trust"] == {"human-reviewed": 1, "unverified": 1}
         assert okf["stale_count"] == 1
+        assert okf["reserved_count"] == 1  # index.md
+
+    async def test_stats_and_validate_agree_on_the_note_population(self) -> None:
+        """#1251: both OKF surfaces count the same set of notes."""
+        async with Client(make_server()) as client:
+            await wait_for_mcp_writer_drain(client)
+            stats = _structured(await client.call_tool("stats", {}))
+            report = _structured(await client.call_tool("okf_validate", {}))
+        okf = stats["okf"]
+        typed = sum(okf["types"].values())
+        assert typed + okf["untyped_count"] == report["total_notes"]
+        assert typed == report["conformant_notes"]
+        assert (
+            typed + okf["untyped_count"] + okf["reserved_count"]
+            == stats["document_count"]
+        )
 
     async def test_indexed_fields_extended_and_filterable(self) -> None:
         async with Client(make_server()) as client:
@@ -382,6 +433,28 @@ class TestOkfValidateTool:
         async with Client(make_server()) as client:
             tools = {t.name for t in await client.list_tools()}
         assert "okf_validate" not in tools
+
+
+@pytest.mark.usefixtures("_scaffold_env")
+class TestReservedOnlyBundle:
+    """#1251: a bundle of nothing but reserved files holds zero notes."""
+
+    async def test_stats_counts_reserved_files_apart(self) -> None:
+        async with Client(make_server()) as client:
+            await wait_for_mcp_writer_drain(client)
+            stats = _structured(await client.call_tool("stats", {}))
+            report = _structured(await client.call_tool("okf_validate", {}))
+        okf = stats["okf"]
+        assert okf["types"] == {}
+        assert okf["untyped_count"] == 0
+        assert okf["status"] == {}
+        assert okf["trust"] == {}
+        assert okf["stale_count"] == 0
+        # index.md, guides/index.md and log.md — the whole indexed vault.
+        assert okf["reserved_count"] == 3
+        assert okf["reserved_count"] == stats["document_count"]
+        assert report["total_notes"] == 0
+        assert report["missing_type"]["count"] == 0
 
 
 @pytest.mark.usefixtures("_plain_env")


### PR DESCRIPTION
Closes #1251

## What

`stats`'s `okf` aggregation iterated every indexed row, so a bundle's reserved
`index.md` / `log.md` files landed in `untyped_count` and in the `status` and
`trust` histograms. `okf_validate` filters them before counting, per spec, so a
fully conformant bundle reported untyped notes on one surface and zero findings
on the other — and the visible remedy (add `type:`) targeted files the spec
exempts.

The aggregation now reports over the same note population the audit covers, and
counts the reserved files apart as a new `reserved_count` key so the section
still reconciles with `document_count`.

## Why the divergence existed

`okf_stats` and its "reserved bundle files … are included" docstring landed in
#968; `okf_validate`, which excludes them, landed in #971. The two surfaces were
written one release phase apart and never reconciled — the sentence documented
the behaviour but gave no rationale, and `docs/design/okf.md` already said
reserved files are excluded from conformance checks per spec. This diff replaces
that sentence with a positive statement of the population being reported rather
than deleting it.

This makes five of five reserved-file call sites agree (ranking downweight,
audit, index generation, convention maintainer, and now stats).

Those five sites hand-roll the predicate in three spellings, and #1251 is what
happens when one of them is written without it — filed as #1268 (Decay), not
fixed here.

## Scope decisions

- **`fix:`, not `feat!:`** — a miscount correction, not a deliberate semantic
  redefinition of the tool surface. `reserved_count` is additive.
- **No `INDEX_SEMANTICS_VERSION` bump** — this is read-side aggregation over
  unchanged stored rows; nothing about how a note's rows are derived from its
  bytes changed.
- The issue's `[unverified]` open question about `log.md` is settled in the
  fixture: `OKF_RESERVED_FILENAMES` is `("index.md", "log.md")` and the loop
  filtered neither, so the new scaffold vault covers both.

## Tests

- `test_stats_okf_section` — updated expectations, plus `reserved_count`.
- `test_stats_and_validate_agree_on_the_note_population` — pins the issue's
  *Expected* as an invariant on the mixed vault: `types` sum + `untyped_count`
  == `okf_validate`'s `total_notes`, `types` sum == `conformant_notes`, and the
  three counts sum to `document_count`.
- `TestReservedOnlyBundle` — reproduces the issue's vault shape (root
  `index.md` + a folder `index.md` + `log.md`, no other notes): empty
  histograms, `untyped_count: 0`, `reserved_count: 3`, `total_notes: 0`.

All three fail if the `continue` is removed (mutation-checked).

## Docs

Swept the whole mirror class in one commit: the `okf_stats` docstring, the
`stats` tool docstring, `docs/tools/index.md`, and both `docs/design/okf.md`
channels plus `docs/design/design.md`.

## Self-review fd0b1489..HEAD

Charters: rules, diff, comments, history. Coverage: past-PR charter skipped
(no review history on the touched region beyond #968); normative charter n/a
(no schema or RFC-2119 prose changed). One finding, fixed before push:
`docs/design/okf.md` channel 4 read "excluded from conformance checks (§4) and
from the `stats` histograms (channel 2) per spec" — the spec exempts reserved
files from the `type` rule only, it says nothing about a stats surface. Reworded
so "per spec" attaches only to the conformance claim.

Gates: `pytest -x -q` 3968 passed · ruff check/format clean · mypy clean ·
`scripts/structural_gate.sh` 100% (91 diff lines, 0 violations) · Vale clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RSxDv7WV6p6FD5kZ2h83U

