### PR TITLE
feat(embeddings): embed queries and documents asymmetrically

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -34,6 +34,24 @@ For OpenAI-compatible APIs, set `OPENAI_BASE_URL` and
 `MARKDOWN_VAULT_MCP_VOYAGE_MODEL`. It is never auto-detected: select it
 explicitly.
 
+## Documents and Queries
+
+`EmbeddingProvider` has two embedding doors. `embed()` is the document side,
+used everywhere text is embedded for storage; `embed_query()` is the search
+side. Only `embed()` is abstract. `embed_query()` defaults to it, so a
+provider whose model draws no query/document distinction writes nothing
+extra and embeds both sides identically.
+
+```python
+vectors = provider.embed(["a stored note"])       # index side
+query_vector = provider.embed_query(["a search"])  # search side
+```
+
+`VoyageProvider` overrides both, sending Voyage's `input_type` parameter so
+the vendor prepends its document or query retrieval prompt. Because that
+changes the embedding space, it also reports a non-empty `provider_variant`,
+which the vector sidecar records next to the provider and model names.
+
 ## API Reference
 
 <!-- vale off -->

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2699,11 +2699,35 @@ sidecar records ``voyage`` as its provider identity. Unlike the other three,
 for an unrelated tool must not silently take over an index and force a
 re-embed.
 
+**Asymmetric embedding (#1135)**: retrieval-tuned models treat a stored
+document and a query against it differently, so the ABC has two embedding
+doors — ``embed`` (documents, the indexing side) and ``embed_query`` (the
+search side). Only ``embed`` is abstract; ``embed_query`` defaults to it, so a
+provider whose model draws no distinction — and any subclass written before
+the split — stays symmetric with nothing to implement, which is why this was
+an additive ``feat`` rather than an ABC break. ``VoyageProvider`` overrides
+both, sending Voyage's ``input_type`` (``"document"`` / ``"query"``) as
+``extra_body`` through the shared transport, which omits the field entirely
+unless a caller asks for it — OpenAI and Ollama answer unknown request fields
+with the same HTTP 400 as the three above. ``VectorIndex.search`` is the only
+query-side call site; every other embedding call is document-side.
+
+Typed vectors sit in a different space from the untyped ones a pre-#1135
+Voyage vault holds, so the provider also reports a ``provider_variant``
+token (``""`` by default, ``"input_type"`` for Voyage) that joins
+``provider``/``model`` as a third identity component in the vector sidecar's
+``index_metadata``. An absent key reads back as ``""``, so vaults on the other
+three providers keep loading warm while an existing Voyage vault fails the
+check once and takes the same ``build_embeddings(force=True)`` self-heal a
+model change takes. This is the vector sidecar's own identity mechanism, not
+the FTS one: ``INDEX_SEMANTICS_VERSION`` governs how a note's stored *rows*
+derive from its bytes, and those are untouched here.
+
 **Acceptance bar for named provider presets (#1134)**: a named
 ``EMBEDDING_PROVIDER`` value is reserved for a vendor whose API has behavior the
 generic OpenAI-compatible transport cannot express. Voyage clears it on two
 counts — the strict request-shape rejections above, and the query/document
-``input_type`` asymmetry that needs a per-call ABC parameter (#1135); Ollama
+``input_type`` asymmetry now implemented in ``embed``/``embed_query`` (#1135); Ollama
 clears it as a local runtime with no API key, a CPU-only mode, and native
 context-length and reachability probes. Every other OpenAI-compatible endpoint
 (Jina, Mistral, SiliconFlow, LiteLLM, vLLM, Text Embeddings Inference, gateway

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -243,6 +243,22 @@ MARKDOWN_VAULT_MCP_VOYAGE_MODEL=voyage-4-large
 
 The default is `voyage-4`, the balanced member of the family; `voyage-4-large` trades cost for retrieval quality and `voyage-4-lite` trades quality for cost. The voyage-4 and voyage-3.5 families take 32,000 tokens of input and return 1024-dimensional vectors by default. Changing the model re-embeds the vault once on the next startup.
 
+### Queries and documents are embedded differently
+
+Voyage's models are tuned for retrieval, and the vendor asks callers to say
+which side of a search each text is on. The server does: notes are embedded as
+`input_type: document` and search queries as `input_type: query`, which makes
+Voyage prepend its own retrieval prompt to each. Nothing to configure: it is
+how the `voyage` provider embeds.
+
+!!! note "Voyage vaults re-embed once on upgrade"
+    Vaults embedded before this behavior existed hold vectors Voyage produced
+    with no `input_type` at all. Those sit in a different space from the typed
+    ones, so the vector sidecar's identity check fails on the first startup
+    after the upgrade and the vault re-embeds itself once, exactly as it does
+    after a model change. The rebuild is automatic; it costs one pass of Voyage
+    API calls over the vault.
+
 !!! note "Voyage must be selected explicitly"
     Unlike the other three, `voyage` is not in the auto-detection chain. A `VOYAGE_API_KEY` exported for some other tool would otherwise take over an existing index and force a full re-embed.
 
@@ -326,6 +342,12 @@ whose base64 default is widely accepted. This narrow request shape is why
 strict endpoints work: Voyage answers HTTP 400 to `dimensions`, to `user`,
 and to `encoding_format="float"`. An endpoint that requires a
 field outside `model` and `input` cannot be driven this way.
+
+The one addition is vendor-specific and reached only through a named provider:
+[`voyage`](#voyage-ai) also sends `input_type`. Driving Voyage through this
+`openai` recipe instead sends no `input_type`, so it does not get the
+query/document asymmetry. That is one more reason to prefer the named
+provider.
 
 ### Caveats worth knowing
 

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -352,14 +352,16 @@ provider.
 ### Caveats worth knowing
 
 !!! warning "Changing only the base URL is invisible to the index"
-    The vector sidecar records the provider name and the model name, and a
-    mismatch on startup re-embeds the vault automatically. Both values stay
-    `openai` and your configured model string no matter which vendor serves
-    them, so aiming `OPENAI_BASE_URL` at a different vendor while keeping
-    the same model name goes undetected: vectors from two different models
-    end up in one index, and search quality degrades quietly. Force the rebuild
-    yourself by deleting the two sidecar files beside `EMBEDDINGS_PATH`
-    (the `.npy` matrix and the `.json` metadata) and restarting.
+    The vector sidecar records the provider name, the model name, and how
+    that provider embeds, and a mismatch on startup re-embeds the vault
+    automatically. Under this recipe the first two stay `openai` and your
+    configured model string no matter which vendor serves them, and the
+    third is always empty, so aiming `OPENAI_BASE_URL` at a different vendor
+    while keeping the same model name goes undetected: vectors from two
+    different models end up in one index, and search quality degrades
+    quietly. Force the rebuild yourself by deleting the two sidecar files
+    beside `EMBEDDINGS_PATH` (the `.npy` matrix and the `.json` metadata)
+    and restarting.
 
 !!! note "Unknown context length falls back to a 1500-character chunk cap"
     The chunk cap derives from the model's context length. That is known only

--- a/src/markdown_vault_mcp/managers/_vector_loader.py
+++ b/src/markdown_vault_mcp/managers/_vector_loader.py
@@ -60,7 +60,7 @@ def load_or_self_heal(
             A persisted sidecar with a different token (absent key reads as
             ``"v1"``) raises ``VectorIndexCompatibilityError`` inside
             :meth:`VectorIndex.load` and routes to the same rebuild path as
-            a provider/model mismatch; a fresh empty index is stamped with
+            an embedding-identity mismatch; a fresh empty index is stamped with
             this token so its save records the format.
 
     Returns:

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -167,8 +167,9 @@ class SearchManager:
             :meth:`okf_stats`. ``None`` keeps every OKF surface inert.
         rebuild_embeddings: Callback to rebuild all embeddings from scratch.
             Invoked by ``_load_vectors`` on any unrecoverable sidecar fault —
-            a provider/model mismatch, an embedding-text format mismatch, a
-            row-count mismatch, or a truncated/zero-byte/incomplete sidecar.
+            an embedding-identity mismatch (provider, model, or provider
+            variant), an embedding-text format mismatch, a row-count
+            mismatch, or a truncated/zero-byte/incomplete sidecar.
         folder_weights: Folder-prefix score multipliers applied to every
             search mode just before file grouping.  ``None`` disables the
             boost.

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -87,8 +87,8 @@ class _OpenAICompatEmbeddings:
     Owns the SDK client, the ``embeddings.create`` call, input-order
     restoration, and error mapping. :class:`OpenAIProvider`,
     :class:`OllamaProvider` and :class:`VoyageProvider` are thin presets over
-    this one code path; the ``input_type`` parameter below is the only place
-    the transport branches for one of them (#1135).
+    this one code path; the ``input_type`` parameter below is Voyage's one
+    accommodation in it (#1135), as ``_PLACEHOLDER_API_KEY`` is Ollama's.
 
     Args:
         api_key: API key, or ``None`` for keyless endpoints (a placeholder

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -85,8 +85,10 @@ class _OpenAICompatEmbeddings:
     """Shared OpenAI-compatible embeddings transport (official openai SDK).
 
     Owns the SDK client, the ``embeddings.create`` call, input-order
-    restoration, and error mapping. :class:`OpenAIProvider` and
-    :class:`OllamaProvider` are thin presets over this one code path.
+    restoration, and error mapping. :class:`OpenAIProvider`,
+    :class:`OllamaProvider` and :class:`VoyageProvider` are thin presets over
+    this one code path; the ``input_type`` parameter below is the only place
+    the transport branches for one of them (#1135).
 
     Args:
         api_key: API key, or ``None`` for keyless endpoints (a placeholder

--- a/src/markdown_vault_mcp/providers.py
+++ b/src/markdown_vault_mcp/providers.py
@@ -122,11 +122,18 @@ class _OpenAICompatEmbeddings:
         self._model = model
         self._label = label
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
+    def embed(
+        self, texts: list[str], *, input_type: str | None = None
+    ) -> list[list[float]]:
         """Embed a batch of texts, returning vectors in input order.
 
         Args:
             texts: List of strings to embed.
+            input_type: Optional Voyage ``input_type`` value (``"document"``
+                or ``"query"``). Sent as an extra request field only when not
+                ``None`` — OpenAI and Ollama answer unknown fields with an
+                HTTP 400, so the default keeps their request body exactly
+                ``{model, input}``.
 
         Returns:
             List of embedding vectors, one per input text.
@@ -135,7 +142,16 @@ class _OpenAICompatEmbeddings:
             RuntimeError: If the embeddings request fails.
         """
         try:
-            response = self._client.embeddings.create(model=self._model, input=texts)
+            if input_type is None:
+                response = self._client.embeddings.create(
+                    model=self._model, input=texts
+                )
+            else:
+                response = self._client.embeddings.create(
+                    model=self._model,
+                    input=texts,
+                    extra_body={"input_type": input_type},
+                )
         except self._openai.OpenAIError as exc:
             raise RuntimeError(
                 f"{self._label} embeddings request failed: {exc}"
@@ -146,11 +162,23 @@ class _OpenAICompatEmbeddings:
 
 
 class EmbeddingProvider(ABC):
-    """Abstract base class for embedding providers."""
+    """Abstract base class for embedding providers.
+
+    Retrieval-tuned models embed the two sides of a search asymmetrically —
+    a stored *document* and a *query* against it get different treatment —
+    so the class has two embedding doors: :meth:`embed` for the indexing
+    side and :meth:`embed_query` for the search side. Only :meth:`embed` is
+    abstract; :meth:`embed_query` defaults to it, so a provider whose model
+    has no such distinction (and any subclass written before the split)
+    stays symmetric with nothing to implement (#1135).
+    """
 
     @abstractmethod
     def embed(self, texts: list[str]) -> list[list[float]]:
-        """Embed a batch of texts.
+        """Embed a batch of texts for storage in the index.
+
+        This is the document side of retrieval. Query text goes through
+        :meth:`embed_query` instead.
 
         Args:
             texts: List of strings to embed.
@@ -159,6 +187,36 @@ class EmbeddingProvider(ABC):
             List of embedding vectors, one per input text.
         """
         ...
+
+    def embed_query(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of search queries.
+
+        Defaults to :meth:`embed` — symmetric embedding, which is correct
+        for every model that draws no query/document distinction. Providers
+        whose models do (Voyage) override this.
+
+        Args:
+            texts: List of query strings to embed.
+
+        Returns:
+            List of embedding vectors, one per input text.
+        """
+        return self.embed(texts)
+
+    @property
+    def provider_variant(self) -> str:
+        """Identity token for the embedding space this provider produces.
+
+        Persisted alongside ``provider_name``/``model_name`` in the vector
+        sidecar so that a change in *how* a provider embeds — not which
+        provider or model it is — is caught at load and routed to the same
+        rebuild as a model change. Defaults to ``""``: one provider plus one
+        model means one embedding space.
+
+        Returns:
+            A stable token, or ``""`` when the provider has a single space.
+        """
+        return ""
 
     @property
     @abstractmethod
@@ -531,6 +589,12 @@ class VoyageProvider(EmbeddingProvider):
     SDK, whose base64 default Voyage accepts — so no request shaping is needed
     here, but none of those three fields may start being sent either.
 
+    ``input_type`` is the one extra field this provider does send (#1135).
+    It is Voyage's own parameter rather than an OpenAI one, which is why the
+    transport passes it as ``extra_body`` and only when a caller asks for it:
+    OpenAI and Ollama would answer it with the same HTTP 400 as the three
+    fields above.
+
     Args:
         api_key: Voyage API key for authentication.
         model: Embedding model name.
@@ -575,8 +639,35 @@ class VoyageProvider(EmbeddingProvider):
 
         logger.debug("VoyageProvider initialised: model=%s", self._model)
 
+    def _embed(self, texts: list[str], input_type: str) -> list[list[float]]:
+        """Embed *texts* with an explicit Voyage ``input_type``.
+
+        Both public doors route here so the dimension cache is filled once,
+        whichever side embedded first.
+
+        Args:
+            texts: List of strings to embed.
+            input_type: ``"document"`` or ``"query"``.
+
+        Returns:
+            List of embedding vectors in input order.
+
+        Raises:
+            RuntimeError: If the embeddings request fails.
+        """
+        embeddings = self._compat.embed(texts, input_type=input_type)
+
+        # Cache dimension from first successful call.
+        if self._dimension is None and embeddings:
+            self._dimension = len(embeddings[0])
+
+        return embeddings
+
     def embed(self, texts: list[str]) -> list[list[float]]:
-        """Embed a batch of texts via Voyage's Embeddings API.
+        """Embed a batch of documents via Voyage's Embeddings API.
+
+        Sends ``input_type="document"``, which makes Voyage prepend its
+        document retrieval prompt.
 
         Args:
             texts: List of strings to embed.
@@ -587,13 +678,25 @@ class VoyageProvider(EmbeddingProvider):
         Raises:
             RuntimeError: If the embeddings request fails.
         """
-        embeddings = self._compat.embed(texts)
+        return self._embed(texts, "document")
 
-        # Cache dimension from first successful call.
-        if self._dimension is None and embeddings:
-            self._dimension = len(embeddings[0])
+    def embed_query(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of search queries via Voyage's Embeddings API.
 
-        return embeddings
+        Sends ``input_type="query"``, which makes Voyage prepend its query
+        retrieval prompt — the other half of the asymmetry :meth:`embed`
+        supplies.
+
+        Args:
+            texts: List of query strings to embed.
+
+        Returns:
+            List of embedding vectors in input order.
+
+        Raises:
+            RuntimeError: If the embeddings request fails.
+        """
+        return self._embed(texts, "query")
 
     @property
     def dimension(self) -> int:
@@ -616,6 +719,18 @@ class VoyageProvider(EmbeddingProvider):
     @property
     def provider_name(self) -> str:
         return "voyage"
+
+    @property
+    def provider_variant(self) -> str:
+        """Identity token for Voyage's typed embedding space.
+
+        Voyage prepends a different retrieval prompt per ``input_type``, so
+        vectors written before #1135 (sent untyped) sit in a different space
+        from the ones this provider writes now. The token differs from the
+        ``""`` a pre-#1135 sidecar reads back as, so an existing Voyage vault
+        fails the identity check on first load and re-embeds once.
+        """
+        return "input_type"
 
     @property
     def model_name(self) -> str:

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -74,7 +74,7 @@ def _check_persisted_identity(
     expected = (provider.provider_name, provider.model_name, provider.provider_variant)
     if persisted != expected:
         raise VectorIndexCompatibilityError(
-            "Embedding provider/model mismatch for persisted index at "
+            "Embedding identity mismatch for persisted index at "
             f"{path}: stored provider={persisted[0]!r}, "
             f"stored model={persisted[1]!r}, "
             f"stored variant={persisted[2]!r}, "

--- a/src/markdown_vault_mcp/vector_index.py
+++ b/src/markdown_vault_mcp/vector_index.py
@@ -42,6 +42,48 @@ class VectorIndexCorruptError(RuntimeError):
     """
 
 
+def _check_persisted_identity(
+    *,
+    path: Path,
+    index_meta: dict[str, Any],
+    provider: EmbeddingProvider,
+) -> None:
+    """Raise if a sidecar's ``index_metadata`` names a different embedding space.
+
+    Three fields make up that identity: the provider, its model, and the
+    provider's :attr:`~markdown_vault_mcp.providers.EmbeddingProvider.provider_variant`
+    — how that provider embeds, which for Voyage changed when typed
+    ``input_type`` requests arrived (#1135). A sidecar written before the
+    variant existed carries no key and reads back as ``""``, which is what
+    every provider without a variant reports, so only the providers that
+    grew one see a mismatch.
+
+    Args:
+        path: Sidecar base path, for the error message.
+        index_meta: The persisted ``index_metadata`` mapping.
+        provider: The provider the index is being loaded against.
+
+    Raises:
+        VectorIndexCompatibilityError: On any identity mismatch.
+    """
+    persisted = (
+        index_meta.get("provider"),
+        index_meta.get("model"),
+        index_meta.get("provider_variant") or "",
+    )
+    expected = (provider.provider_name, provider.model_name, provider.provider_variant)
+    if persisted != expected:
+        raise VectorIndexCompatibilityError(
+            "Embedding provider/model mismatch for persisted index at "
+            f"{path}: stored provider={persisted[0]!r}, "
+            f"stored model={persisted[1]!r}, "
+            f"stored variant={persisted[2]!r}, "
+            f"current provider={expected[0]!r}, "
+            f"current model={expected[1]!r}, "
+            f"current variant={expected[2]!r}."
+        )
+
+
 class VectorIndex:
     """Cosine-similarity vector index backed by numpy.
 
@@ -72,7 +114,8 @@ class VectorIndex:
         """Initialise an empty VectorIndex.
 
         Args:
-            provider: Embedding provider used for query embedding.
+            provider: Embedding provider used to embed stored texts
+                (:meth:`add`) and queries (:meth:`search`).
             embed_text_format: Embedding-text format token persisted by
                 :meth:`save`.
 
@@ -122,8 +165,9 @@ class VectorIndex:
         Raises:
             ImportError: If ``numpy`` is not installed.
             FileNotFoundError: If either sidecar file is missing.
-            VectorIndexCompatibilityError: If the persisted provider/model or
-                embedding-text format does not match the current one.
+            VectorIndexCompatibilityError: If the persisted provider,
+                model, provider variant, or embedding-text format does not
+                match the current one.
             VectorIndexCorruptError: If the embeddings and metadata sidecars
                 disagree on row count (an incomplete atomic save).
         """
@@ -141,8 +185,6 @@ class VectorIndex:
             payload = json.load(fh)
 
         metadata: list[dict[str, Any]]
-        expected_provider = provider.provider_name
-        expected_model = provider.model_name
         persisted_format = "v1"
         if isinstance(payload, list):
             metadata = payload
@@ -153,22 +195,12 @@ class VectorIndex:
         else:
             metadata = payload.get("rows", [])
             index_meta = payload.get("index_metadata", {})
-            persisted_provider = index_meta.get("provider")
-            persisted_model = index_meta.get("model")
             # A sidecar written before embedding-text enrichment carries no
             # format key; it holds raw-content vectors, i.e. format v1.
             persisted_format = index_meta.get("embed_text_format") or "v1"
-            if (
-                persisted_provider != expected_provider
-                or persisted_model != expected_model
-            ):
-                raise VectorIndexCompatibilityError(
-                    "Embedding provider/model mismatch for persisted index at "
-                    f"{path}: stored provider={persisted_provider!r}, "
-                    f"stored model={persisted_model!r}, "
-                    f"current provider={expected_provider!r}, "
-                    f"current model={expected_model!r}."
-                )
+            _check_persisted_identity(
+                path=path, index_meta=index_meta, provider=provider
+            )
 
         if (
             expected_embed_text_format is not None
@@ -399,7 +431,7 @@ class VectorIndex:
             self.count,
         )
 
-        raw = self._provider.embed([query])
+        raw = self._provider.embed_query([query])
         q_vec = np.array(raw[0], dtype=np.float32)
 
         norm = np.linalg.norm(q_vec)
@@ -567,6 +599,7 @@ class VectorIndex:
             "index_metadata": {
                 "provider": self._provider.provider_name,
                 "model": self._provider.model_name,
+                "provider_variant": self._provider.provider_variant,
                 "dimension": (
                     int(self._embeddings.shape[1]) if self._embeddings.ndim == 2 else 0
                 ),

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -2260,9 +2260,9 @@ class TestReindexSkipReasons:
 class _CapturingProvider(EmbeddingProvider):
     """Deterministic provider that records every embedded text.
 
-    Implements only the abstract surface, so it also stands as the working
-    proof that a provider written before the query/document split keeps
-    working: ``embed_query`` and ``provider_variant`` come from the ABC.
+    Implements only the abstract surface; the indexing paths below therefore
+    exercise a provider that predates the query/document split. The query
+    door's default is pinned in ``tests/test_providers.py``.
     """
 
     def __init__(self) -> None:

--- a/tests/test_managers_index.py
+++ b/tests/test_managers_index.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.managers.index import IndexManager
+from markdown_vault_mcp.providers import EmbeddingProvider
 from markdown_vault_mcp.scanner import HeadingChunker
 from markdown_vault_mcp.tracker import ChangeTracker
 from markdown_vault_mcp.types import IndexStats, ReindexResult
@@ -2256,11 +2257,13 @@ class TestReindexSkipReasons:
 # ---------------------------------------------------------------------------
 
 
-class _CapturingProvider:
-    """Deterministic provider that records every embedded text."""
+class _CapturingProvider(EmbeddingProvider):
+    """Deterministic provider that records every embedded text.
 
-    provider_name = "capturing"
-    model_name = "capturing-model"
+    Implements only the abstract surface, so it also stands as the working
+    proof that a provider written before the query/document split keeps
+    working: ``embed_query`` and ``provider_variant`` come from the ABC.
+    """
 
     def __init__(self) -> None:
         self.texts: list[str] = []
@@ -2268,6 +2271,22 @@ class _CapturingProvider:
     def embed(self, texts: list[str]) -> list[list[float]]:
         self.texts.extend(texts)
         return [[1.0, 0.0] for _ in texts]
+
+    @property
+    def dimension(self) -> int:
+        return 2
+
+    @property
+    def provider_name(self) -> str:
+        return "capturing"
+
+    @property
+    def model_name(self) -> str:
+        return "capturing-model"
+
+    @property
+    def context_length(self) -> int | None:
+        return None
 
 
 def _enriched_vault(tmp_path: Path) -> Path:

--- a/tests/test_managers_search.py
+++ b/tests/test_managers_search.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 from markdown_vault_mcp.fts_index import FTSIndex
 from markdown_vault_mcp.managers.link import LinkManager
 from markdown_vault_mcp.managers.search import SearchManager
+from markdown_vault_mcp.providers import EmbeddingProvider
 from markdown_vault_mcp.scanner import scan_directory
 from markdown_vault_mcp.types import (
     AttachmentInfo,
@@ -758,19 +759,36 @@ class TestGetSimilarFilters:
         assert "alpha.md" not in [r.path for r in unfiltered]
 
 
-class _FixedQueryProvider:
+class _FixedQueryProvider(EmbeddingProvider):
     """Embeds every query to the same unit vector along the first axis.
 
     The stored document vectors are written directly onto the index, so the
     cosine of each chunk against the query is just that chunk's first
     coordinate. This gives a test exact control over chunk ranks.
-    """
 
-    provider_name = "fixed"
-    model_name = "fixed-model"
+    Only ``embed`` is implemented, so queries reach it through the ABC's
+    default ``embed_query`` — the symmetric behaviour every provider without
+    a query/document distinction keeps.
+    """
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         return [[1.0, 0.0] for _ in texts]
+
+    @property
+    def dimension(self) -> int:
+        return 2
+
+    @property
+    def provider_name(self) -> str:
+        return "fixed"
+
+    @property
+    def model_name(self) -> str:
+        return "fixed-model"
+
+    @property
+    def context_length(self) -> int | None:
+        return None
 
 
 def _semantic_mgr_with_ranked_chunks(base: Path) -> SearchManager:
@@ -1601,18 +1619,32 @@ class TestGetContextSurfacesInternalFailure:
 # ---------------------------------------------------------------------------
 
 
-class _UnitQueryProvider:
+class _UnitQueryProvider(EmbeddingProvider):
     """Embeds every text (query or chunk) to the same unit vector.
 
     Every stored chunk then scores an identical, positive cosine against any
-    query, so the folder boost alone decides the ordering.
+    query, so the folder boost alone decides the ordering. Queries reach
+    ``embed`` through the ABC's default ``embed_query``.
     """
-
-    provider_name = "unit"
-    model_name = "unit-model"
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         return [[1.0, 0.0] for _ in texts]
+
+    @property
+    def dimension(self) -> int:
+        return 2
+
+    @property
+    def provider_name(self) -> str:
+        return "unit"
+
+    @property
+    def model_name(self) -> str:
+        return "unit-model"
+
+    @property
+    def context_length(self) -> int | None:
+        return None
 
 
 @pytest.fixture()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -395,12 +395,14 @@ class TestVoyageProvider:
     def test_embed_sends_no_params_voyage_rejects(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Only ``model``/``input``/``extra_body`` go on the wire.
+        """Only ``model``, ``input`` and ``input_type`` reach Voyage.
 
         Voyage answers ``dimensions`` and ``user`` with HTTP 400 and rejects
         ``encoding_format="float"`` outright, so the request must carry neither
         — ``encoding_format`` is left to the SDK, whose base64 default Voyage
-        accepts. ``extra_body`` carries ``input_type`` and nothing else.
+        accepts. ``input_type`` travels as the SDK's ``extra_body`` kwarg,
+        which the client merges into the JSON body, so pinning the kwarg set
+        here pins the request body.
         """
         captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
         VoyageProvider(api_key="pa-test").embed(["hello"])

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -407,12 +407,12 @@ class TestVoyageProvider:
 
         (kwargs,) = captured["create_calls"]
         assert set(kwargs) == {"model", "input", "extra_body"}
-        assert kwargs["extra_body"] == {"input_type": "document"}
+        assert set(kwargs["extra_body"]) == {"input_type"}
 
     def test_embed_sends_document_input_type(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The indexing door asks Voyage for the document retrieval prompt."""
+        """The indexing door sends ``input_type: document``."""
         captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
         VoyageProvider(api_key="pa-test").embed(["a note"])
 
@@ -422,7 +422,7 @@ class TestVoyageProvider:
     def test_embed_query_sends_query_input_type(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The search door asks Voyage for the query retrieval prompt."""
+        """The search door sends ``input_type: query``."""
         captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
         result = VoyageProvider(api_key="pa-test").embed_query(["a question"])
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -395,18 +395,68 @@ class TestVoyageProvider:
     def test_embed_sends_no_params_voyage_rejects(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Only ``model``/``input`` go on the wire.
+        """Only ``model``/``input``/``extra_body`` go on the wire.
 
         Voyage answers ``dimensions`` and ``user`` with HTTP 400 and rejects
         ``encoding_format="float"`` outright, so the request must carry neither
         — ``encoding_format`` is left to the SDK, whose base64 default Voyage
-        accepts.
+        accepts. ``extra_body`` carries ``input_type`` and nothing else.
         """
         captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
         VoyageProvider(api_key="pa-test").embed(["hello"])
 
         (kwargs,) = captured["create_calls"]
-        assert set(kwargs) == {"model", "input"}
+        assert set(kwargs) == {"model", "input", "extra_body"}
+        assert kwargs["extra_body"] == {"input_type": "document"}
+
+    def test_embed_sends_document_input_type(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The indexing door asks Voyage for the document retrieval prompt."""
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
+        VoyageProvider(api_key="pa-test").embed(["a note"])
+
+        (kwargs,) = captured["create_calls"]
+        assert kwargs["extra_body"] == {"input_type": "document"}
+
+    def test_embed_query_sends_query_input_type(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The search door asks Voyage for the query retrieval prompt."""
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
+        result = VoyageProvider(api_key="pa-test").embed_query(["a question"])
+
+        (kwargs,) = captured["create_calls"]
+        assert kwargs["input"] == ["a question"]
+        assert kwargs["extra_body"] == {"input_type": "query"}
+        assert result == [[0.1]]
+
+    def test_embed_query_maps_sdk_error_to_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The query door maps transport failures exactly as ``embed`` does."""
+        _install_fake_openai(monkeypatch, raise_error=True)
+        provider = VoyageProvider(api_key="pa-test")
+        with pytest.raises(RuntimeError, match="VoyageProvider embeddings request"):
+            provider.embed_query(["hello"])
+
+    def test_embed_query_fills_the_shared_dimension_cache(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A query-first provider caches the dimension, sparing a paid probe."""
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1] * 1024])
+        provider = VoyageProvider(api_key="pa-test")
+
+        provider.embed_query(["hello"])
+        assert provider.dimension == 1024
+        assert len(captured["create_calls"]) == 1
+
+    def test_provider_variant_marks_the_typed_embedding_space(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Voyage reports a variant, so pre-#1135 untyped sidecars re-embed."""
+        _install_fake_openai(monkeypatch)
+        assert VoyageProvider(api_key="pa-test").provider_variant == "input_type"
 
     def test_custom_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
@@ -656,6 +706,80 @@ def test_embedding_provider_requires_context_length():
     from markdown_vault_mcp.providers import EmbeddingProvider
 
     assert "context_length" in EmbeddingProvider.__abstractmethods__
+
+
+class TestAsymmetricEmbeddingSurface:
+    """The two embedding doors and the identity token that guards them (#1135)."""
+
+    def test_subclass_implementing_only_embed_stays_instantiable(self) -> None:
+        """``embed_query``/``provider_variant`` are concrete, so the abstract set is unchanged.
+
+        This is the compatibility claim for downstream subclasses: adding the
+        query door must not make an existing implementation abstract.
+        """
+        from markdown_vault_mcp.providers import EmbeddingProvider
+
+        assert "embed_query" not in EmbeddingProvider.__abstractmethods__
+        assert "provider_variant" not in EmbeddingProvider.__abstractmethods__
+
+    def test_default_embed_query_delegates_to_embed(self) -> None:
+        """A provider with no query/document distinction embeds both sides alike."""
+        from markdown_vault_mcp.providers import EmbeddingProvider
+
+        class _Symmetric(EmbeddingProvider):
+            def __init__(self) -> None:
+                self.calls: list[list[str]] = []
+
+            def embed(self, texts: list[str]) -> list[list[float]]:
+                self.calls.append(texts)
+                return [[1.0] for _ in texts]
+
+            @property
+            def dimension(self) -> int:
+                return 1
+
+            @property
+            def provider_name(self) -> str:
+                return "symmetric"
+
+            @property
+            def model_name(self) -> str:
+                return "m"
+
+            @property
+            def context_length(self) -> int | None:
+                return None
+
+        provider = _Symmetric()
+        assert provider.embed_query(["q"]) == [[1.0]]
+        assert provider.calls == [["q"]]
+        assert provider.provider_variant == ""
+
+    @pytest.mark.parametrize("door", ["embed", "embed_query"])
+    def test_openai_sends_no_input_type_on_either_door(
+        self, monkeypatch: pytest.MonkeyPatch, door: str
+    ) -> None:
+        """OpenAI answers unknown request fields with HTTP 400, so neither door may add one."""
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
+        provider = OpenAIProvider(api_key="sk-test")
+        getattr(provider, door)(["hello"])
+
+        (kwargs,) = captured["create_calls"]
+        assert set(kwargs) == {"model", "input"}
+        assert provider.provider_variant == ""
+
+    @pytest.mark.parametrize("door", ["embed", "embed_query"])
+    def test_ollama_sends_no_input_type_on_either_door(
+        self, monkeypatch: pytest.MonkeyPatch, door: str
+    ) -> None:
+        """Ollama's OpenAI-compatible endpoint is equally strict about unknown fields."""
+        captured = _install_fake_openai(monkeypatch, vectors=[[0.1]])
+        provider = OllamaProvider(host="http://localhost:11434", model="bge-m3:latest")
+        getattr(provider, door)(["hello"])
+
+        (kwargs,) = captured["create_calls"]
+        assert set(kwargs) == {"model", "input"}
+        assert provider.provider_variant == ""
 
 
 def test_ollama_context_length_parses_api_show(monkeypatch):

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
+from markdown_vault_mcp.providers import EmbeddingProvider
 from markdown_vault_mcp.vector_index import VectorIndex, VectorIndexCompatibilityError
 
 if TYPE_CHECKING:
@@ -55,6 +56,69 @@ def _make_meta(path: str, heading: str | None = None) -> dict:
         "heading": heading,
         "content": f"Content for {path} section {heading}",
     }
+
+
+class _VariantProvider(EmbeddingProvider):
+    """Wrap a provider, overriding only its ``provider_variant`` token."""
+
+    def __init__(self, inner: MockEmbeddingProvider, variant: str) -> None:
+        self._inner = inner
+        self._variant = variant
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return self._inner.embed(texts)
+
+    @property
+    def provider_variant(self) -> str:
+        return self._variant
+
+    @property
+    def dimension(self) -> int:
+        return self._inner.dimension
+
+    @property
+    def provider_name(self) -> str:
+        return self._inner.provider_name
+
+    @property
+    def model_name(self) -> str:
+        return self._inner.model_name
+
+    @property
+    def context_length(self) -> int | None:
+        return self._inner.context_length
+
+
+class _DoorRecordingProvider(EmbeddingProvider):
+    """Wrap a provider, recording which embedding door each call came through."""
+
+    def __init__(self, inner: MockEmbeddingProvider) -> None:
+        self._inner = inner
+        self.doors: list[tuple[str, list[str]]] = []
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        self.doors.append(("embed", list(texts)))
+        return self._inner.embed(texts)
+
+    def embed_query(self, texts: list[str]) -> list[list[float]]:
+        self.doors.append(("embed_query", list(texts)))
+        return self._inner.embed(texts)
+
+    @property
+    def dimension(self) -> int:
+        return self._inner.dimension
+
+    @property
+    def provider_name(self) -> str:
+        return self._inner.provider_name
+
+    @property
+    def model_name(self) -> str:
+        return self._inner.model_name
+
+    @property
+    def context_length(self) -> int | None:
+        return self._inner.context_length
 
 
 # ---------------------------------------------------------------------------
@@ -912,3 +976,120 @@ class TestEmbedTextFormatToken:
         index.save(base)
         loaded = VectorIndex.load(base, mock_provider)
         assert loaded.count == 1
+
+
+class TestProviderVariantIdentity:
+    """The third identity component in the sidecar (#1135)."""
+
+    def test_variant_roundtrips_through_the_sidecar(
+        self, mock_provider: MockEmbeddingProvider, tmp_path: Path
+    ) -> None:
+        """A provider reporting a variant stamps it into ``index_metadata``."""
+        provider = _VariantProvider(mock_provider, "input_type")
+        index = VectorIndex(provider)
+        index.add(["text"], [_make_meta("a.md")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        payload = json.loads((tmp_path / "embeddings.json").read_text("utf-8"))
+        assert payload["index_metadata"]["provider_variant"] == "input_type"
+        assert VectorIndex.load(base, provider).count == 1
+
+    def test_default_variant_is_empty(
+        self, mock_provider: MockEmbeddingProvider, tmp_path: Path
+    ) -> None:
+        """A provider with one embedding space stamps the empty token."""
+        index = VectorIndex(mock_provider)
+        index.add(["text"], [_make_meta("a.md")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        payload = json.loads((tmp_path / "embeddings.json").read_text("utf-8"))
+        assert payload["index_metadata"]["provider_variant"] == ""
+
+    def test_untyped_sidecar_fails_the_check_for_a_variant_provider(
+        self, mock_provider: MockEmbeddingProvider, tmp_path: Path
+    ) -> None:
+        """The upgrade case: vectors written before the variant must re-embed.
+
+        Same provider, same model, but the stored vectors sit in the untyped
+        space, so the load must fail into the caller's rebuild path rather
+        than serve a mixed index.
+        """
+        index = VectorIndex(mock_provider)
+        index.add(["text"], [_make_meta("a.md")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+        json_path = tmp_path / "embeddings.json"
+        payload = json.loads(json_path.read_text("utf-8"))
+        del payload["index_metadata"]["provider_variant"]
+        json_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(VectorIndexCompatibilityError, match="variant"):
+            VectorIndex.load(base, _VariantProvider(mock_provider, "input_type"))
+
+    def test_absent_variant_key_still_loads_for_a_variantless_provider(
+        self, mock_provider: MockEmbeddingProvider, tmp_path: Path
+    ) -> None:
+        """Every pre-upgrade sidecar keeps loading: absent key reads as ``""``."""
+        index = VectorIndex(mock_provider)
+        index.add(["text"], [_make_meta("a.md")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+        json_path = tmp_path / "embeddings.json"
+        payload = json.loads(json_path.read_text("utf-8"))
+        del payload["index_metadata"]["provider_variant"]
+        json_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        assert VectorIndex.load(base, mock_provider).count == 1
+
+    def test_variant_change_reports_both_tokens(
+        self, mock_provider: MockEmbeddingProvider, tmp_path: Path
+    ) -> None:
+        """The error names stored and current variants, so the log explains the rebuild."""
+        index = VectorIndex(_VariantProvider(mock_provider, "old"))
+        index.add(["text"], [_make_meta("a.md")])
+        base = tmp_path / "embeddings"
+        index.save(base)
+
+        with pytest.raises(VectorIndexCompatibilityError) as excinfo:
+            VectorIndex.load(base, _VariantProvider(mock_provider, "new"))
+        assert "stored variant='old'" in str(excinfo.value)
+        assert "current variant='new'" in str(excinfo.value)
+
+
+class TestQueryEmbeddingDoor:
+    """``search`` embeds through the query door, ``add`` through the document one."""
+
+    def test_search_embeds_the_query_through_embed_query(
+        self, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        provider = _DoorRecordingProvider(mock_provider)
+        index = VectorIndex(provider)
+        index.add(["alpha", "beta"], [_make_meta("a.md"), _make_meta("b.md")])
+        provider.doors.clear()
+
+        index.search("alpha", limit=1)
+
+        assert provider.doors == [("embed_query", ["alpha"])]
+
+    def test_add_embeds_documents_through_embed(
+        self, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        provider = _DoorRecordingProvider(mock_provider)
+        VectorIndex(provider).add(["alpha"], [_make_meta("a.md")])
+
+        assert provider.doors == [("embed", ["alpha"])]
+
+    def test_search_by_path_reuses_stored_vectors(
+        self, mock_provider: MockEmbeddingProvider
+    ) -> None:
+        """Similarity from a stored document embeds nothing — neither door is used."""
+        provider = _DoorRecordingProvider(mock_provider)
+        index = VectorIndex(provider)
+        index.add(["alpha", "beta"], [_make_meta("a.md"), _make_meta("b.md")])
+        provider.doors.clear()
+
+        index.search_by_path("a.md", limit=1)
+
+        assert provider.doors == []


### PR DESCRIPTION
## Closes / Refs

Closes #1135

## What & why

Voyage's models are retrieval-tuned: the vendor asks callers to say whether
each text is a document or a query, and prepends a different retrieval prompt
to each. The provider ABC could not express that, so `VectorIndex.search`
embedded queries exactly as `IndexManager` embeds documents.

`EmbeddingProvider` now has two embedding doors. `embed` is the document side
(every existing call site was already document-side); `embed_query` is the
search side, and `VectorIndex.search` is its only caller. **Only `embed` stays
abstract** — `embed_query` is concrete and delegates to it — so a provider
whose model draws no distinction, and any subclass written before the split,
keeps embedding both sides identically with nothing to implement.
`VoyageProvider` overrides both, routing through a private `_embed` so the
dimension cache is filled once whichever side embeds first.

`input_type` reaches the wire as `extra_body`, and the shared transport omits
the field entirely unless a caller asks for it, so OpenAI and Ollama requests
stay exactly `{model, input}` — which #1169 pinned with a test because Voyage
answers unimplemented OpenAI fields (`dimensions`, `user`,
`encoding_format="float"`) with HTTP 400. That pin now reads
`{model, input, extra_body}` for Voyage only; two new tests assert the other
two providers still send exactly `{model, input}` on **both** doors.

### The one operator-visible consequence

Typed vectors sit in a different space from the untyped ones an existing
Voyage vault holds. So providers also report a `provider_variant` token
(`""` by default, `"input_type"` for Voyage) that joins provider/model as a
third identity component in the vector sidecar's `index_metadata`. An absent
key reads back as `""`, so every vault on the other three providers keeps
loading warm; an existing **Voyage** vault fails the identity check once on
first start after upgrade and takes the same `build_embeddings(force=True)`
self-heal a model change takes — one automatic re-embed pass, documented in
the embeddings guide.

I traced that path rather than assuming it: both `load_or_self_heal` callers
route a `VectorIndexCompatibilityError` to `BuildEmbeddings(force=True)`
(`managers/embeddings.py:355`, `indexing/coordinator.py:345`), and `force=True`
constructs a fresh empty `VectorIndex` before the cold build
(`managers/embeddings.py:503`). It does **not** take the convergence path,
which diffs on text and would have left the old untyped vectors in place —
i.e. the feature would have silently not taken for exactly the vaults it is for.

While there, the load-time identity comparison moved into
`_check_persisted_identity`; a third inline comparison in `VectorIndex.load`
was the growth #1169's own notes flagged as the `PLR0911` shape.

### Resolving the issue's open questions

1. **Is this a public-library-interface break?** No. The abstract set is
   unchanged, so a downstream `EmbeddingProvider` subclass stays instantiable
   and inherits symmetric behaviour; `tests/test_providers.py` pins that
   (`embed_query` / `provider_variant` are not in `__abstractmethods__`, and a
   subclass implementing only `embed` embeds both sides through it). Typed
   `feat`, not `feat!`. `EmbeddingProvider` is not in
   `tests/public_import_surface.txt`, so the root-surface guard is untouched.
   The honest caveat: a **duck-typed** provider — an object passed to
   `VectorIndex` that does not subclass the ABC — now needs `embed_query` and
   `provider_variant`. Three in-repo test doubles were exactly that shape and
   are converted to ABC subclasses in this PR, which is also what makes them
   the working proof of the compatibility claim above.
2. **Does the index side warrant sidecar invalidation?** Yes, and it is
   implemented as `provider_variant` above. Voyage's docs say vectors embedded
   with and without `input_type` "remain compatible", but a vault that
   re-embeds only changed notes would hold two prompt regimes indefinitely and
   rank them against each other, so the identity check takes the same posture
   as a model flip.

### Not `INDEX_SEMANTICS_VERSION`

`AGENTS.md` scopes that constant to how a note's stored **rows** derive from
its bytes. FTS rows are untouched here; the vector sidecar carries its own
identity mechanism, which is what this extends.

## What this PR deliberately does NOT do

- **Instruction-prefix asymmetry for local models (fastembed).** A different
  mechanism, explicitly out of scope in #1135; no issue filed, per the issue's
  own "only worth an issue if someone observes the need".
- **No configuration switch.** Typed embedding is how the `voyage` provider
  embeds, not a knob — a flag would only make the one-time re-embed optional
  at the price of a config surface nobody would flip. No new env var, so no
  wizard, `server.json`, or `config-contract` wiring.
- **No `_EMBEDDING_BATCH_SIZE` tuning** for remote providers — still the other
  follow-up named in #949/#950, still unfiled.
- **No live Voyage call.** The `openai` SDK is faked in-process throughout, so
  the tests pin that `input_type` reaches `embeddings.create` and that
  `extra_body` merges into the JSON body (verified against the installed SDK,
  `openai/_base_client.py:531`). That Voyage's server honours the field is a
  docs citation (docs.voyageai.com: accepted values `null` / `query` /
  `document`), not something CI can prove.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No commit carries `!`; see open question 1 above for why this is additive.

## Docs impact

- [ ] `README.md` — no env var, tool, or flag changed
- [x] `docs/` site pages — `guides/embeddings.md` (the asymmetry and the
      one-time re-embed), `api/providers.md` (the two doors)
- [x] `docs/design/` — `design.md` providers section: the two doors, why this
      was additive, the variant token, and why `INDEX_SEMANTICS_VERSION` is
      not the mechanism
- [x] Inline docstrings

## Verification

- `uv run pytest -q` — 3987 passed, 3 skipped
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run mypy src/ tests/` — clean (218 files)
- `diff-cover` vs `origin/main` — 100% patch coverage (25 changed lines, 0 missing)
- `scripts/structural_gate.sh` — 100%, 0 violations over 546 lines
- `vale` on both changed site pages — clean
- Mutation-checked: reverting `search` to `embed` fails
  `test_search_embeds_the_query_through_embed_query`; dropping
  `provider_variant` from the save payload fails all five
  `TestProviderVariantIdentity` tests.

---
_Generated by [Claude Code](https://claude.ai/code)_
