### PR TITLE
fix(git): scope the auto-commit's no-diff check to the operation's own paths

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2467,10 +2467,30 @@ rule covers is still staged, with `git add -u` rather than `-A`: its deletion is
 real, dropping it would leave git serving content the vault no longer has there,
 and `-u` acts on tracked files only, so the exclude rules never apply to it.
 And when the filter leaves nothing at all to stage, `_stage_rename` reports that
-to its caller, which skips the commit rather than falling through — the
-`git diff --cached --quiet` check below it is repository-wide, so an operator's
-own staged work would otherwise be committed under the rename's message and
-pushed, the very leak this section exists to prevent.
+to its caller, which skips the commit rather than falling through — there is no
+pathspec to ask a diff check about when nothing was staged, and the historic
+repository-wide check would have committed an operator's own staged work under
+the rename's message and pushed it, the very leak this section exists to
+prevent.
+
+**Scoping the commit decision, not just the staging (#1249).** Staging being
+scoped was only half of it: `git diff --cached --quiet` without a pathspec
+answers "does the index differ from `HEAD` anywhere", which is not the question
+a commit decision asks. Whenever an operation's own `git add` ran but recorded
+nothing — a byte-identical write is the clearest case — that check saw an
+operator's deliberately-uncommitted work and committed it. `_stage_one`
+therefore returns **the pathspec it staged** rather than a boolean, and
+`_index_matches_head` asks the question scoped to it. The batched path unions
+its items' pathspecs. Two conventions carry the tri-state: `None` means nothing
+was staged and the caller must not commit at all, and an **empty** pathspec is
+git's own spelling of "the whole repository", returned only by the unscoped
+`old_path is None` rename branch whose staging really is repository-wide — a
+batch containing one widens its own check back to match, or a rename that
+reported no pathspec would be dropped from the check and its commit skipped.
+
+The commit itself is still repository-wide: `git commit` takes no pathspec, so
+a write that *does* have a diff of its own carries any unrelated staged work
+along with it (#1273).
 
 **Write identity: the `Principal` value (#1160, fixes #1218).** "Who is
 acting" is resolved **once, at the MCP tool edge**, into a frozen

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1810,7 +1810,7 @@ def _index_matches_head(root: str, pathspec: Sequence[str]) -> bool:
     The question a commit decision has to ask is "did this operation stage
     anything", not "does the index differ from HEAD anywhere". Asking the
     repository-wide form let an operation that staged nothing of its own —
-    a byte-identical write, a delete of an already-deleted path — see the
+    writing byte-identical content is the clearest way in — see the
     operator's deliberately-uncommitted staged work and commit it under the
     operation's message.
 

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1673,7 +1673,7 @@ def _is_ignored(root: str, path: Path) -> bool:
     return result.returncode == 0
 
 
-def _stage_rename(root: str, path: Path, old_path: Path | None) -> bool:
+def _stage_rename(root: str, path: Path, old_path: Path | None) -> list[str] | None:
     """Stage both sides of a rename without touching anything else (#894).
 
     ``git add -A`` over an explicit pathspec records the old path's
@@ -1704,10 +1704,12 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> bool:
             function fixes.
 
     Returns:
-        Whether anything was staged. ``False`` means both sides were ignored
-        and untrackable, so there is nothing for this operation to commit —
-        the caller must not fall through to a repository-wide diff check,
-        which would commit whatever the operator happened to have staged.
+        The pathspec that was staged, or ``None`` when both sides were ignored
+        and untrackable — there is then nothing for this operation to commit,
+        and the caller must not fall through to a diff check at all. An
+        **empty** list is git's own spelling of "the whole repository" and is
+        returned only by the unscoped *old_path is None* branch, whose
+        staging really is repository-wide.
     """
     if old_path is None:
         logger.debug("git_stage_rename_unscoped path=%s", path)
@@ -1723,7 +1725,7 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> bool:
             text=True,
             check=True,
         )
-        return True
+        return []
 
     pathspec: list[str] = []
     deletions: list[str] = []
@@ -1748,7 +1750,10 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> bool:
                 text=True,
                 check=True,
             )
-    return bool(deletions or pathspec)
+    staged = deletions + pathspec
+    if not staged:
+        return None
+    return staged
 
 
 def _stage_one(
@@ -1756,7 +1761,7 @@ def _stage_one(
     path: Path,
     operation: WriteOperation,
     old_path: Path | None,
-) -> bool:
+) -> list[str] | None:
     """Stage one write's paths, scoped to what that operation touched.
 
     Extracted so the single-write and batched commit paths stage identically;
@@ -1769,9 +1774,12 @@ def _stage_one(
         old_path: For a rename, the absolute path the file moved from.
 
     Returns:
-        ``False`` when a rename had nothing stageable, so the caller can bail
-        out rather than committing whatever else happened to be staged.
-        ``True`` otherwise.
+        The pathspec that was staged, for the caller to scope its
+        "did anything actually change" check to (#1249), or ``None`` when a
+        rename had nothing stageable — the caller must then bail out rather
+        than committing whatever else happened to be staged. An **empty**
+        list means the staging was repository-wide, which is git's own
+        spelling of the same pathspec.
     """
     if operation == "delete":
         # File already removed from disk; stage the deletion.
@@ -1782,9 +1790,10 @@ def _stage_one(
             check=True,
         )
     elif operation == "rename":
-        if not _stage_rename(root, path, old_path):
+        staged = _stage_rename(root, path, old_path)
+        if staged is None:
             logger.debug("git_stage_rename_noop path=%s", path)
-            return False
+        return staged
     else:
         subprocess.run(
             ["git", "-C", root, "add", "--", str(path)],
@@ -1792,7 +1801,34 @@ def _stage_one(
             text=True,
             check=True,
         )
-    return True
+    return [str(path)]
+
+
+def _index_matches_head(root: str, pathspec: Sequence[str]) -> bool:
+    """Return whether nothing is staged *within pathspec* (#1249).
+
+    The question a commit decision has to ask is "did this operation stage
+    anything", not "does the index differ from HEAD anywhere". Asking the
+    repository-wide form let an operation that staged nothing of its own —
+    a byte-identical write, a delete of an already-deleted path — see the
+    operator's deliberately-uncommitted staged work and commit it under the
+    operation's message.
+
+    Args:
+        root: Git repository root, as a string for ``git -C``.
+        pathspec: The paths the operation staged. **Empty means the whole
+            repository**, matching git's own reading of an empty pathspec;
+            only the unscoped legacy rename branch produces it.
+
+    Returns:
+        ``True`` when the index matches ``HEAD`` across *pathspec*, so there
+        is nothing for this operation to commit.
+    """
+    result = subprocess.run(
+        ["git", "-C", root, "diff", "--cached", "--quiet", "--", *pathspec],
+        capture_output=True,
+    )
+    return result.returncode == 0
 
 
 def _stage_and_commit(
@@ -1831,11 +1867,10 @@ def _stage_and_commit(
     """
     root = str(git_root)
 
-    if not _stage_one(root, path, operation, old_path):
-        # Nothing this operation touched is stageable. Returning here
-        # rather than falling through matters: the diff check below is
-        # repository-wide, so an operator's unrelated staged work would
-        # otherwise be committed under this rename's message and pushed.
+    scope = _stage_one(root, path, operation, old_path)
+    if scope is None:
+        # Nothing this operation touched is stageable, so there is no
+        # pathspec to ask about and nothing here to commit.
         return
 
     # Generate commit message from operation and relative path.
@@ -1845,11 +1880,7 @@ def _stage_and_commit(
         rel_path = path
 
     # Skip commit if staging produced no diff (e.g. writing identical content).
-    check_result = subprocess.run(
-        ["git", "-C", root, "diff", "--cached", "--quiet"],
-        capture_output=True,
-    )
-    if check_result.returncode == 0:
+    if _index_matches_head(root, scope):
         logger.debug(
             "Git: nothing staged for %s (%s), skipping commit", rel_path, operation
         )
@@ -1928,26 +1959,31 @@ def _stage_and_commit_batch(
 
     root = str(git_root)
     staged = 0
+    scope: list[str] = []
+    whole_repo = False
     for path, operation, old_path, _principal in items:
         try:
-            if _stage_one(root, path, operation, old_path):
-                staged += 1
+            item_scope = _stage_one(root, path, operation, old_path)
         except subprocess.CalledProcessError:
             # One unstageable path must not cost the rest of the batch its
             # commit — the files are already written to disk either way.
             logger.error(
                 "git_stage_failed path=%s op=%s", path, operation, exc_info=True
             )
+            continue
+        if item_scope is None:
+            continue
+        staged += 1
+        # An empty item scope is the unscoped legacy rename, which stages
+        # repository-wide; the batch's check can be no narrower than that.
+        whole_repo = whole_repo or not item_scope
+        scope.extend(item_scope)
     if staged == 0:
         logger.debug("git_batch_nothing_staged tool=%s count=%s", tool_name, len(items))
         return
 
     # Skip commit if staging produced no diff (e.g. rewriting identical bytes).
-    check_result = subprocess.run(
-        ["git", "-C", root, "diff", "--cached", "--quiet"],
-        capture_output=True,
-    )
-    if check_result.returncode == 0:
+    if _index_matches_head(root, [] if whole_repo else scope):
         logger.debug("git_batch_no_diff tool=%s", tool_name)
         return
 

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1926,7 +1926,9 @@ def _stage_and_commit_batch(
 
     Staging is per item, using the same scoped rules as a single write, so a
     batch never widens what gets swept in: a delete still stages only its own
-    path, and a rename still stages exactly its two. Only the commit is shared.
+    path, and a rename still stages exactly its two. Only the commit is shared,
+    and the no-diff check that guards it, which asks about the union of the
+    pathspecs the items reported (#1249).
 
     A one-item batch delegates to :func:`_stage_and_commit` instead, so the
     commit subject stays that file's own path rather than becoming the

--- a/tests/test_commit_scope.py
+++ b/tests/test_commit_scope.py
@@ -399,6 +399,19 @@ def _subjects(repo: Path) -> list[str]:
     return out.stdout.splitlines()
 
 
+def _staged_paths(repo: Path) -> set[str]:
+    """Paths whose index entry differs from HEAD."""
+    import subprocess
+
+    out = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--cached", "--name-only"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line for line in out.stdout.splitlines() if line}
+
+
 def _files_in_head(repo: Path) -> set[str]:
     import subprocess
 
@@ -541,6 +554,86 @@ class TestBatchCommitsForReal:
         strategy.close()
 
         assert len(_subjects(repo)) == before
+
+    def test_a_batch_that_stages_nothing_leaves_staged_work_alone(
+        self, tmp_path: Path
+    ) -> None:
+        """#1249: the batch's no-diff check must ask only about its own paths.
+
+        Repository-wide, it saw the operator's deliberately-uncommitted work
+        and committed it under this tool call's message.
+        """
+        import subprocess
+
+        repo = _repo(tmp_path)
+        (repo / "second.md").write_text("# Second\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "-A"], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "second"],
+            capture_output=True,
+            check=True,
+        )
+        (repo / "operator.md").write_text("# Theirs\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "--", str(repo / "operator.md")],
+            capture_output=True,
+            check=True,
+        )
+        strategy = self._strategy(repo)
+        before = len(_subjects(repo))
+
+        strategy.on_write_batch(
+            [
+                (repo / "note.md", "write", None, None),
+                (repo / "second.md", "write", None, None),
+            ],
+            "okf_convert_links",
+        )
+        strategy.close()
+
+        assert len(_subjects(repo)) == before
+        assert _staged_paths(repo) == {"operator.md"}
+
+    def test_an_unscoped_rename_widens_the_batch_check_back_to_the_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """A caller predating #894 stages repository-wide, so it reports no pathspec.
+
+        Narrowing the check to the paths the *other* items reported would then
+        miss the rename entirely and skip a commit that has to happen.
+        """
+        import subprocess
+
+        repo = _repo(tmp_path)
+        (repo / "second.md").write_text("# Second\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "-A"], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "second"],
+            capture_output=True,
+            check=True,
+        )
+        strategy = self._strategy(repo)
+        before = len(_subjects(repo))
+
+        (repo / "note.md").rename(repo / "moved.md")
+        strategy.on_write_batch(
+            [
+                (repo / "moved.md", "rename", None, None),
+                (repo / "second.md", "write", None, None),
+            ],
+            "move_folder",
+        )
+        strategy.close()
+
+        assert len(_subjects(repo)) == before + 1
+        # An empty staged set means both sides of the rename reached the
+        # commit, the departure as well as the arrival.
+        assert _staged_paths(repo) == set()
+        assert "moved.md" in _files_in_head(repo)
 
     def test_a_delete_in_a_batch_stages_its_own_removal(self, tmp_path: Path) -> None:
         repo = _repo(tmp_path)

--- a/tests/test_commit_scope.py
+++ b/tests/test_commit_scope.py
@@ -748,6 +748,37 @@ class TestBatchCommitsForReal:
 
         assert any("git_batch_failed" in r.message for r in caplog.records)
 
+    def test_an_ignored_rename_drops_out_of_the_batch(self, tmp_path: Path) -> None:
+        """Both sides ignored: nothing staged, so it neither errors nor counts."""
+        import subprocess
+
+        repo = _repo(tmp_path)
+        (repo / ".gitignore").write_text(".DS_Store\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "-A"], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "ignore"],
+            capture_output=True,
+            check=True,
+        )
+        strategy = self._strategy(repo)
+
+        (repo / "b").mkdir()
+        (repo / "b" / ".DS_Store").write_bytes(b"junk")
+        (repo / "kept.md").write_text("# Kept\n", encoding="utf-8")
+        strategy.on_write_batch(
+            [
+                (repo / "b" / ".DS_Store", "rename", repo / "a" / ".DS_Store", None),
+                (repo / "kept.md", "write", None, None),
+            ],
+            "move_folder",
+        )
+        strategy.close()
+
+        assert _subjects(repo)[0] == "move_folder: 1 file"
+        assert _files_in_head(repo) == {"kept.md"}
+
     def test_a_batch_where_nothing_stages_commits_nothing(self, tmp_path: Path) -> None:
         """Every path unstageable: no commit, and no crash."""
         repo = _repo(tmp_path)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6282,10 +6282,12 @@ class TestRenameStagingSkipsIgnoredPaths:
     ) -> None:
         """Codex P1: skipping the ``git add`` must skip the commit too.
 
-        The diff check in ``_stage_and_commit`` is repository-wide. With
-        nothing staged for this operation, it saw the operator's own staged
-        work and committed it under the rename's message — the exact class of
-        leak #894 exists to prevent, through a new door.
+        With nothing staged for this operation, ``_stage_and_commit`` used to
+        fall through to a repository-wide diff check, see the operator's own
+        staged work and commit it under the rename's message — the exact class
+        of leak #894 exists to prevent, through a new door. Bailing out is
+        still what happens here: there is no pathspec to scope a check to
+        when nothing was staged at all.
         """
         import subprocess
 
@@ -6448,3 +6450,58 @@ def _tracked_files(repo: Path) -> set[str]:
         check=True,
     )
     return {line for line in out.stdout.splitlines() if line.strip()}
+
+
+# ---------------------------------------------------------------------------
+# scoped commit checks (#1249)
+# ---------------------------------------------------------------------------
+
+
+class TestTheCommitCheckIsScopedToTheOperation:
+    """A write that stages nothing must not commit the operator's staged work.
+
+    ``git diff --cached --quiet`` without a pathspec answers "does the index
+    differ from HEAD anywhere", which is not the question a commit decision
+    asks. An operation whose own ``git add`` stages nothing then saw the
+    operator's deliberately-uncommitted work and committed it under the
+    operation's message.
+    """
+
+    @staticmethod
+    def _stage_operator_work(repo: Path) -> None:
+        """Leave a staged-but-uncommitted change of the operator's own behind."""
+        import subprocess
+
+        (repo / "operator.md").write_text("# Theirs\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "--", str(repo / "operator.md")],
+            capture_output=True,
+            check=True,
+        )
+
+    def test_a_byte_identical_write_leaves_staged_work_alone(
+        self, git_repo: Path
+    ) -> None:
+        """The staging succeeds and records nothing, so there is nothing to commit."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._stage_operator_work(git_repo)
+        head_before = _head(git_repo)
+
+        # README.md is already committed with exactly these bytes.
+        (git_repo / "README.md").write_text("# Test\n", encoding="utf-8")
+        _stage_and_commit(git_repo, git_repo / "README.md", "write")
+
+        assert _head(git_repo) == head_before
+        assert _worktree_status(git_repo) == {"A  operator.md"}
+
+    def test_a_real_write_still_commits(self, git_repo: Path) -> None:
+        """The scoped check must not suppress a commit that has a diff of its own."""
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        head_before = _head(git_repo)
+        (git_repo / "new.md").write_text("# New\n", encoding="utf-8")
+        _stage_and_commit(git_repo, git_repo / "new.md", "write")
+
+        assert _head(git_repo) != head_before
+        assert "new.md" in _commit_files(git_repo)


### PR DESCRIPTION
## Closes / Refs

Closes #1249

## What & why

`git diff --cached --quiet` without a pathspec answers "does the index differ
from `HEAD` anywhere", which is not the question a commit decision asks.
Whenever a write's own `git add` ran but recorded nothing — writing
byte-identical content is the clearest way in — the check saw an operator's
deliberately-uncommitted staged work and committed it under the write's
message, and the deferred push shipped it.

`_stage_one` now returns **the pathspec it staged** rather than a boolean, and
`_index_matches_head` asks the question scoped to it. Returning what staging
actually did, rather than recomputing a pathspec from the operation, keeps the
check exact: a rename that skipped an ignored or untracked side never names it,
so a force-added ignored file the operator happened to stage cannot leak in
through the check either.

Two conventions carry the tri-state, both spelled out in the docstrings:

- `None` — nothing was staged, so there is no pathspec to ask about and the
  caller must not commit at all. This is #1244's early return, unchanged.
- an **empty** pathspec — git's own spelling of "the whole repository",
  returned only by the unscoped `old_path is None` rename branch, whose
  staging really is repository-wide. #1249 says to leave that branch's
  behaviour alone, and this does.

**Both check sites are fixed, not just the one #1249 names.** The issue was
written against `_stage_and_commit` before #1265 landed; #1265 added a second
repository-wide check in `_stage_and_commit_batch`. A batch unions its items'
pathspecs, and widens back to the repository when any item reports the empty
one — otherwise an unscoped rename would drop out of the check entirely and
lose the commit it needs.

## What this PR deliberately does NOT do

- **Does not scope `git commit` itself:** #1273. `_commit_staged` invokes
  `git commit` with no pathspec, so a write that *does* have a diff of its own
  still carries any unrelated staged work into its commit. That is a different
  case from the one #1249 reports — the operation stages something there — and
  the substitute (`git commit -- <pathspec>`) reads the named paths from the
  working tree rather than the index and is refused during a merge, both of
  which touch the pull/rebase path. Filed with a verified repro transcript and
  milestoned v4.2.
- **Does not change the unscoped legacy rename branch.** Its staging is
  imprecise by construction (#894 is the issue that scoped the rest), so its
  check stays repository-wide to match, which is what #1249 asks for.
- **Adds no configuration and changes no tool surface.**

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No commit carries `!`. `_stage_rename` and `_stage_one` are private and
      not re-exported; `_stage_and_commit`, which `git/__init__.py` does
      re-export for the historic import surface, keeps its signature.

## Docs impact

- [ ] `README.md` — no user-facing config, env var, or tool surface changed
- [ ] `docs/` site pages — same
- [x] `docs/design/` — "Write + Git Integration" gains the scoping paragraph
      and states the residual `git commit` reach with its issue number
- [x] Inline docstrings — `_stage_rename`, `_stage_one`,
      `_stage_and_commit_batch`, plus the new `_index_matches_head`

## Test status

4,011 pass, 18 skip. Structural gate 100% (0 violations); `mypy` clean; patch
coverage 100% (`diff-cover` against `origin/main`).

Every new test was mutation-checked against the code it pins:

- forcing `_index_matches_head` back to the pathspec-less form fails
  `test_a_byte_identical_write_leaves_staged_work_alone` and
  `test_a_batch_that_stages_nothing_leaves_staged_work_alone`;
- dropping the batch's widening (`_index_matches_head(root, scope)`) fails
  `test_an_unscoped_rename_widens_the_batch_check_back_to_the_repository`,
  which is the regression that widening exists to prevent.

## Self-review c094ca5..3c1b6cb

Charters: rules, diff, comments, history. Conformance charter: no schema,
wire format, or RFC-2119 prose in this diff. Past-PRs charter skipped — the
touched region's review history is #1265, merged hours ago and authored here.

- `src/markdown_vault_mcp/git/strategy.py:1813` — important/verified — the new
  `_index_matches_head` docstring offered "a delete of an already-deleted
  path" as a second way to reach the check; that path never reaches it.
  Evidence: `git add -u -- a.md` on a path already deleted *and committed*
  exits 128, `fatal: pathspec 'a.md' did not match any files`, so the
  operation raises in staging. Fix: cite only the byte-identical write, which
  is reproduced in a test. Resolved in `15f2bb8d`.
- `src/markdown_vault_mcp/git/strategy.py:1929` — minor/verified —
  `_stage_and_commit_batch`'s docstring said "Only the commit is shared",
  which after this change also omits the shared no-diff check.
  Fix: name the union explicitly. Resolved in `3c1b6cbf`.

Nothing else survived refutation.

---
_Generated by [Claude Code](https://claude.ai/code)_
