### PR TITLE
fix(git): commit the operation's own paths, not the whole index

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2488,9 +2488,30 @@ git's own spelling of "the whole repository", returned only by the unscoped
 batch containing one widens its own check back to match, or a rename that
 reported no pathspec would be dropped from the check and its commit skipped.
 
-The commit itself is still repository-wide: `git commit` takes no pathspec, so
-a write that *does* have a diff of its own carries any unrelated staged work
-along with it (#1273).
+**Scoping the commit itself (#1273).** Scoping the decision left the act
+unscoped: `git commit` without a pathspec commits the **whole index**, so a
+write that *did* have a diff of its own still carried an operator's unrelated
+staged work into a commit titled after a vault write they never made.
+`_commit_staged` therefore takes the same pathspec and names it, making the
+commit *partial* — every other index entry is left where the operator put it.
+The unscoped legacy rename branch reports the empty pathspec and keeps the
+whole-index invocation, because `--only` with no paths is rejected outside
+`--amend` and that branch has no narrower truth to offer.
+
+A partial commit differs from the whole-index form in two ways, both accepted
+deliberately. It records the named paths' **working-tree** content rather than
+what was staged a moment earlier, so an external edit landing between the
+`git add` and the `git commit` is committed rather than left dirty — the
+repository ends up describing what is on disk, which is what the vault mirrors.
+And git refuses it outright while a merge is in progress
+(`cannot do a partial commit during a merge`), which is the better failure: the
+whole-index form would have swept the operator's entire in-progress merge into
+a `write: <note>` commit. The write is on disk, the `CalledProcessError` is
+logged, and the operator's own merge commit carries the staged file. A
+conflicted *rebase* — the state `resolve_conflicts_safely`'s defensive abort
+exists to clean up, and cannot always — is unaffected in the other direction: a
+partial commit succeeds there, where the whole-index form fails outright on
+"unmerged files".
 
 **Write identity: the `Principal` value (#1160, fixes #1218).** "Who is
 acting" is resolved **once, at the MCP tool edge**, into a frozen

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1890,6 +1890,7 @@ def _stage_and_commit(
         root,
         f"{operation}: {rel_path}",
         _CommitIdentity(commit_name, commit_email, author_name, author_email),
+        scope,
     )
 
     logger.info("Git: committed %s (%s)", rel_path, operation)
@@ -1927,8 +1928,9 @@ def _stage_and_commit_batch(
     Staging is per item, using the same scoped rules as a single write, so a
     batch never widens what gets swept in: a delete still stages only its own
     path, and a rename still stages exactly its two. Only the commit is shared,
-    and the no-diff check that guards it, which asks about the union of the
-    pathspecs the items reported (#1249).
+    along with the no-diff check that guards it and the pathspec the commit is
+    scoped to, both taken from the union of what the items reported
+    (#1249, #1273).
 
     A one-item batch delegates to :func:`_stage_and_commit` instead, so the
     commit subject stays that file's own path rather than becoming the
@@ -1985,12 +1987,13 @@ def _stage_and_commit_batch(
         return
 
     # Skip commit if staging produced no diff (e.g. rewriting identical bytes).
-    if _index_matches_head(root, [] if whole_repo else scope):
+    commit_scope = [] if whole_repo else scope
+    if _index_matches_head(root, commit_scope):
         logger.debug("git_batch_no_diff tool=%s", tool_name)
         return
 
     noun = "file" if staged == 1 else "files"
-    _commit_staged(root, f"{tool_name}: {staged} {noun}", identity)
+    _commit_staged(root, f"{tool_name}: {staged} {noun}", identity, commit_scope)
     logger.info("git_batch_committed tool=%s files=%s", tool_name, staged)
 
 
@@ -1998,17 +2001,43 @@ def _commit_staged(
     root: str,
     commit_msg: str,
     identity: _CommitIdentity,
+    pathspec: Sequence[str],
 ) -> None:
-    """Commit whatever is staged, under the resolved committer/author identity.
+    """Commit the operation's own paths, under the resolved identity.
 
     Extracted so the single-write and batched commit paths share one copy of
     the identity resolution; the sanitisation below is a commit-object header
     injection guard, and two copies could drift apart silently.
 
+    ``git commit`` without a pathspec commits the **whole index**, so a write
+    that had a diff of its own still carried an operator's unrelated staged
+    work into its commit and pushed it (#1273). Naming the operation's paths
+    makes it a *partial* commit, which leaves every other index entry alone.
+
+    Two consequences of a partial commit are deliberate:
+
+    - It records the named paths' **working-tree** content rather than what
+      was staged a moment ago. An external edit landing in that window is
+      committed instead of left dirty, and an external delete in that window
+      records a deletion — in both cases the repository ends up describing
+      what is actually on disk, which is what the vault is mirroring.
+    - Git refuses it outright while a merge is in progress
+      (``cannot do a partial commit during a merge``). That is the better
+      failure: the whole-index form would have swept the operator's entire
+      in-progress merge into a commit titled ``write: <note>``. The write is
+      on disk, the ``CalledProcessError`` is logged by the caller, and the
+      operator's own merge commit carries the staged file. A conflicted
+      *rebase* is not affected — a partial commit succeeds there, where the
+      whole-index form fails on "unmerged files".
+
     Args:
         root: Git repository root, as a string for ``git -C``.
         commit_msg: The commit subject.
         identity: Committer and author identity for the commit.
+        pathspec: The paths this operation staged. **Empty commits the whole
+            index**, matching git's own reading of an empty pathspec; only
+            the unscoped legacy rename branch produces it, and it has no
+            narrower truth to offer.
     """
     commit_name = identity.commit_name
     commit_email = identity.commit_email
@@ -2043,6 +2072,10 @@ def _commit_staged(
     if eff_author_name != san_commit_name or eff_author_email != san_commit_email:
         author_args = ["--author", f"{eff_author_name} <{eff_author_email}>"]
 
+    # ``--only`` with no paths is rejected outside ``--amend``, so the
+    # unscoped branch keeps the historic whole-index invocation.
+    scope_args = ["--only", "--", *pathspec] if pathspec else []
+
     subprocess.run(
         [
             "git",
@@ -2056,6 +2089,7 @@ def _commit_staged(
             "-m",
             commit_msg,
             *author_args,
+            *scope_args,
         ],
         capture_output=True,
         text=True,

--- a/tests/test_commit_scope.py
+++ b/tests/test_commit_scope.py
@@ -596,6 +596,35 @@ class TestBatchCommitsForReal:
         assert len(_subjects(repo)) == before
         assert _staged_paths(repo) == {"operator.md"}
 
+    def test_a_batch_commits_only_the_paths_it_wrote(self, tmp_path: Path) -> None:
+        """#1273: the shared commit still names the batch's own paths.
+
+        ``git commit`` without a pathspec commits the whole index, so an
+        operator's staged work rode along under this tool call's message.
+        """
+        import subprocess
+
+        repo = _repo(tmp_path)
+        (repo / "operator.md").write_text("# Theirs\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "--", str(repo / "operator.md")],
+            capture_output=True,
+            check=True,
+        )
+        strategy = self._strategy(repo)
+
+        for name in ("a.md", "b.md"):
+            (repo / name).write_text(f"# {name}\n", encoding="utf-8")
+        strategy.on_write_batch(
+            [(repo / name, "write", None, None) for name in ("a.md", "b.md")],
+            "okf_convert_links",
+        )
+        strategy.close()
+
+        assert _subjects(repo)[0] == "okf_convert_links: 2 files"
+        assert _files_in_head(repo) == {"a.md", "b.md"}
+        assert _staged_paths(repo) == {"operator.md"}
+
     def test_an_unscoped_rename_widens_the_batch_check_back_to_the_repository(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6453,18 +6453,20 @@ def _tracked_files(repo: Path) -> set[str]:
 
 
 # ---------------------------------------------------------------------------
-# scoped commit checks (#1249)
+# scoped commits (#1249, #1273)
 # ---------------------------------------------------------------------------
 
 
-class TestTheCommitCheckIsScopedToTheOperation:
-    """A write that stages nothing must not commit the operator's staged work.
+class TestCommitsAreScopedToTheOperation:
+    """An auto-commit carries the operation's own paths and nothing else.
 
+    Both halves of the decision used to be repository-wide.
     ``git diff --cached --quiet`` without a pathspec answers "does the index
     differ from HEAD anywhere", which is not the question a commit decision
-    asks. An operation whose own ``git add`` stages nothing then saw the
-    operator's deliberately-uncommitted work and committed it under the
-    operation's message.
+    asks (#1249); and ``git commit`` without a pathspec commits the whole
+    index, so even a write with a diff of its own swept an operator's
+    deliberately-uncommitted work into a commit titled after a vault write
+    they did not make (#1273).
     """
 
     @staticmethod
@@ -6494,6 +6496,81 @@ class TestTheCommitCheckIsScopedToTheOperation:
 
         assert _head(git_repo) == head_before
         assert _worktree_status(git_repo) == {"A  operator.md"}
+
+    def test_a_real_write_commits_only_its_own_path(self, git_repo: Path) -> None:
+        """#1273: a diff of its own is no licence to commit everything staged.
+
+        ``git commit`` without a pathspec commits the whole index, so the
+        operator's deliberately-uncommitted work rode along in a commit
+        titled after a vault write they did not make.
+        """
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        self._stage_operator_work(git_repo)
+
+        (git_repo / "vault-note.md").write_text("# Vault\n", encoding="utf-8")
+        _stage_and_commit(git_repo, git_repo / "vault-note.md", "write")
+
+        assert _commit_files(git_repo) == {"vault-note.md"}
+        assert _worktree_status(git_repo) == {"A  operator.md"}
+
+    def test_a_write_during_a_merge_commits_nothing(self, git_repo: Path) -> None:
+        """Git refuses a partial commit mid-merge, and that is the right failure.
+
+        The whole-index form would have swept the operator's in-progress
+        merge into a commit titled after a vault write. The strategy logs the
+        failure and leaves the merge alone.
+        """
+        import subprocess
+
+        strategy = GitWriteStrategy(
+            token=None,
+            repo_url=None,
+            managed=False,
+            enable_pull=False,
+            enable_push=False,
+            repo_path=git_repo,
+        )
+        try:
+            self._start_a_merge(git_repo)
+            head_before = _head(git_repo)
+
+            (git_repo / "vault-note.md").write_text("# Vault\n", encoding="utf-8")
+            strategy(git_repo / "vault-note.md", "# Vault\n", "write")
+        finally:
+            strategy.close()
+
+        assert _head(git_repo) == head_before
+        assert (git_repo / ".git" / "MERGE_HEAD").exists()
+        # The merge is still the operator's to finish.
+        assert (
+            subprocess.run(
+                ["git", "-C", str(git_repo), "rev-parse", "--verify", "MERGE_HEAD"],
+                capture_output=True,
+                check=False,
+            ).returncode
+            == 0
+        )
+
+    @staticmethod
+    def _start_a_merge(repo: Path) -> None:
+        """Leave the repository with ``MERGE_HEAD`` set and nothing committed."""
+        import subprocess
+
+        def _git(*args: str) -> None:
+            subprocess.run(
+                ["git", "-C", str(repo), *args], capture_output=True, check=True
+            )
+
+        _git("checkout", "-b", "side")
+        (repo / "side.md").write_text("# Side\n", encoding="utf-8")
+        _git("add", "-A")
+        _git("commit", "-m", "side")
+        _git("checkout", "-")
+        (repo / "trunk.md").write_text("# Trunk\n", encoding="utf-8")
+        _git("add", "-A")
+        _git("commit", "-m", "trunk")
+        _git("merge", "--no-commit", "--no-ff", "side")
 
     def test_a_real_write_still_commits(self, git_repo: Path) -> None:
         """The scoped check must not suppress a commit that has a diff of its own."""


### PR DESCRIPTION
## Closes / Refs

Closes #1273. Follows #1274, which scoped the commit *decision*.

## What & why

Scoping the decision left the act unscoped. `git commit` without a pathspec
commits the **whole index**, so a write that *did* have a diff of its own still
carried an operator's deliberately-uncommitted work into a commit titled after
a vault write they never made, and the deferred push shipped it:

```
$ git show --name-only --format=%s HEAD
write: vault-note.md

operator.md
vault-note.md
```

`_commit_staged` now takes the same pathspec `_index_matches_head` already
receives and names it, making the commit *partial* — every other index entry is
left where the operator put it. The unscoped legacy rename branch reports the
empty pathspec and keeps the whole-index invocation, because `--only` with no
paths is rejected outside `--amend` and that branch has no narrower truth to
offer.

**Two differences from the whole-index form, both accepted deliberately** and
both verified against real repositories before choosing this over a temporary
`GIT_INDEX_FILE`:

- A partial commit records the named paths' **working-tree** content rather
  than what was staged a moment earlier. An external edit landing between the
  `git add` and the `git commit` is committed rather than left dirty — the
  repository ends up describing what is on disk, which is what the vault
  mirrors.
- Git refuses it while a merge is in progress
  (`cannot do a partial commit during a merge`). That is the better failure,
  not a regression: the whole-index form would have swept the operator's entire
  in-progress merge into a `write: <note>` commit. The write is on disk, the
  `CalledProcessError` is logged, `schedule_push()` is skipped, and the
  operator's merge stays theirs. Pinned by
  `test_a_write_during_a_merge_commits_nothing`.

A conflicted **rebase** moves the other way: a partial commit *succeeds* there,
where the whole-index form fails outright on `Committing is not possible
because you have unmerged files`. That state is not hypothetical — the comment
on `_force_pull_rebase_fallback` says the defensive abort exists so "any
per-write commit path" does not trip over a leftover `rebase-merge`, and
`abort_in_progress_rebase` is allowed to fail.

## What this PR deliberately does NOT do

- **Does not touch `conflict.write_conflict_files`' pathspec-less commit.**
  Its `NOTE:` says the whole-index reach is intentional there — it also has to
  capture upstream content staged by the rebase's own merge — and it holds
  `_lock` for the same reason. Narrowing it would break conflict resolution.
- **Does not retry or defer the write refused mid-merge.** The file is on disk
  and staged; the operator's own merge commit carries it. Retrying would only
  hit the same refusal, and unstaging it would fight the operator's index.
- **Adds no configuration and changes no tool surface.**

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No commit carries `!`. `_commit_staged` is private and not re-exported;
      `_stage_and_commit`, which `git/__init__.py` re-exports for the historic
      import surface, keeps its signature.

## Docs impact

- [ ] `README.md` — no user-facing config, env var, or tool surface changed
- [ ] `docs/` site pages — same
- [x] `docs/design/` — the "still repository-wide (#1273)" paragraph #1274 left
      behind is replaced with the scoped commit and its two trade-offs
- [x] Inline docstrings — `_commit_staged` and `_stage_and_commit_batch`

## Test status

4,014 pass, 18 skip. Structural gate 100% (0 violations); `mypy` clean; patch
coverage 100% (`diff-cover` against `origin/main`).

Three new tests, each mutation-checked by dropping `--only` from the command:

- `test_a_real_write_commits_only_its_own_path` — the transcript above,
  inverted into an assertion;
- `test_a_batch_commits_only_the_paths_it_wrote` — the same on the batch path;
- `test_a_write_during_a_merge_commits_nothing` — the behaviour change a
  reviewer will ask about, pinned rather than described.

The existing `#1238` / `#1244` rename tests are the arbiter for whether
`--only` chokes on an ignored or tracked-but-ignored pathspec; they pass
unchanged.

## Self-review 5d1d8139..e99687a8

Charters: rules, diff, comments, history. Conformance charter: no schema, wire
format, or RFC-2119 prose in this diff. Past-PRs charter: the touched region's
only review history is #1274, authored here hours ago and merged clean.

No findings survived refutation. Two candidates struck:

- `--author` and `--only` in one `git commit` argv — refuted: git parses
  options before `--`, and the six identity tests in `tests/test_git.py` that
  assert on `--author` now run through the scoped path unchanged.
- `conflict.py:461` pathspec-less commit inconsistent with the new rule —
  struck as pre-existing on untouched lines, and its `NOTE:` documents the
  reach as intentional. Recorded above instead.

---
_Generated by [Claude Code](https://claude.ai/code)_
