### PR TITLE
perf(git): ask the exclude rules about both sides of a rename at once

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2462,6 +2462,15 @@ file "not ignored", but `git add` still refuses to name a tracked file living
 under an ignored directory, so only `--no-index` predicts the rule the filter
 exists to satisfy.
 
+Both sides are asked in **one** call, not one each (#1250). `move_folder` fires
+a rename callback per moved file, so the probe count scales with the size of
+the moved subtree, and spawning the process costs more than matching the rules
+does. The paths go over `--stdin` with `-z`: `-z` is accepted only with
+`--stdin`, and the newline-delimited reply it would otherwise produce is
+ambiguous for a filename containing a newline. Git answers with the excluded
+subset, echoing each path back verbatim, and exit code 1 means "none of them"
+rather than a failure.
+
 Two consequences of that filter are load-bearing. A **tracked** path an exclude
 rule covers is still staged, with `git add -u` rather than `-A`: its deletion is
 real, dropping it would leave git serving content the vault no longer has there,

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2468,8 +2468,10 @@ the moved subtree, and spawning the process costs more than matching the rules
 does. The paths go over `--stdin` with `-z`: `-z` is accepted only with
 `--stdin`, and the newline-delimited reply it would otherwise produce is
 ambiguous for a filename containing a newline. Git answers with the excluded
-subset, echoing each path back verbatim, and exit code 1 means "none of them"
-rather than a failure.
+subset, echoing each path back verbatim. It defines exactly two exit codes —
+0 for "some of them" and 1 for "none" — so 1 is an ordinary negative reply and
+not a failure, while every other code is one, the negative code a signal
+produces included.
 
 Two consequences of that filter are load-bearing. A **tracked** path an exclude
 rule covers is still staged, with `git add -u` rather than `-A`: its deletion is

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1670,6 +1670,12 @@ def _ignored_paths(root: str, paths: Sequence[Path]) -> set[str]:
     **verbatim**, so the strings returned here compare equal to the strings
     that were sent.
 
+    Git defines exactly two answers: 0 for "some of them" and 1 for "none",
+    so 1 is an ordinary negative reply rather than a failure. Every other
+    code is a failure and is answered as "none excluded" — the negative code
+    POSIX reports for a signal included, which is why the guard tests
+    membership rather than ordering.
+
     Args:
         root: Git repository root, as a string.
         paths: Absolute paths to probe.
@@ -1686,14 +1692,17 @@ def _ignored_paths(root: str, paths: Sequence[Path]) -> set[str]:
         text=True,
         check=False,
     )
-    if result.returncode > 1:
-        # 1 means "none of them", which is the ordinary negative answer. Above
-        # that is a real failure; report no exclusions, exactly as the
-        # single-path probe did, and let the ``git add`` that follows surface
-        # the underlying problem with its own stderr. Warned rather than
-        # traced: when the paths turn out not to be excluded after all, that
-        # ``git add`` succeeds and this is the only record that the filter
-        # answered from a failure rather than from the exclude rules.
+    if result.returncode not in (0, 1):
+        # 0 and 1 are the two answers git defines — "some" and "none of them";
+        # 1 is the ordinary negative answer, not a failure. Anything else is,
+        # including the *negative* code POSIX reports for a signal, which an
+        # ordered ``> 1`` test would let through into the parse. Report no
+        # exclusions, exactly as the single-path probe did, and let the
+        # ``git add`` that follows surface the underlying problem with its own
+        # stderr. Warned rather than traced: when the paths turn out not to be
+        # excluded after all, that ``git add`` succeeds and this is the only
+        # record that the filter answered from a failure rather than from the
+        # exclude rules.
         logger.warning(
             "git_check_ignore_failed rc=%s stderr=%s",
             result.returncode,

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1693,16 +1693,10 @@ def _ignored_paths(root: str, paths: Sequence[Path]) -> set[str]:
         check=False,
     )
     if result.returncode not in (0, 1):
-        # 0 and 1 are the two answers git defines — "some" and "none of them";
-        # 1 is the ordinary negative answer, not a failure. Anything else is,
-        # including the *negative* code POSIX reports for a signal, which an
-        # ordered ``> 1`` test would let through into the parse. Report no
-        # exclusions, exactly as the single-path probe did, and let the
-        # ``git add`` that follows surface the underlying problem with its own
-        # stderr. Warned rather than traced: when the paths turn out not to be
-        # excluded after all, that ``git add`` succeeds and this is the only
-        # record that the filter answered from a failure rather than from the
-        # exclude rules.
+        # Warned rather than traced: when the paths turn out not to be excluded
+        # after all, the ``git add`` that follows succeeds and this line is the
+        # only record that the filter answered from a failure rather than from
+        # the exclude rules. See the docstring for why the test is membership.
         logger.warning(
             "git_check_ignore_failed rc=%s stderr=%s",
             result.returncode,

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1690,8 +1690,11 @@ def _ignored_paths(root: str, paths: Sequence[Path]) -> set[str]:
         # 1 means "none of them", which is the ordinary negative answer. Above
         # that is a real failure; report no exclusions, exactly as the
         # single-path probe did, and let the ``git add`` that follows surface
-        # the underlying problem with its own stderr.
-        logger.debug(
+        # the underlying problem with its own stderr. Warned rather than
+        # traced: when the paths turn out not to be excluded after all, that
+        # ``git add`` succeeds and this is the only record that the filter
+        # answered from a failure rather than from the exclude rules.
+        logger.warning(
             "git_check_ignore_failed rc=%s stderr=%s",
             result.returncode,
             (result.stderr or "").strip(),

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1648,8 +1648,13 @@ def _is_tracked(root: str, path: Path) -> bool:
     return bool(result.stdout.strip())
 
 
-def _is_ignored(root: str, path: Path) -> bool:
-    """Return whether git's exclude rules would refuse to add *path*.
+def _ignored_paths(root: str, paths: Sequence[Path]) -> set[str]:
+    """Return which of *paths* git's exclude rules would refuse to add.
+
+    Asked once for every path rather than once per path (#1250):
+    :func:`_stage_rename` needs the answer for both sides of a rename, and
+    ``move_folder`` fires it once per moved file, so process spawn — not the
+    rule matching — dominates a large reorganization.
 
     ``--no-index`` is deliberate. Without it ``git check-ignore`` answers
     "not ignored" for anything already in the index, but ``git add`` refuses
@@ -1657,20 +1662,42 @@ def _is_ignored(root: str, path: Path) -> bool:
     is tracked* — so the default answer would not match the rule this probe
     exists to predict.
 
+    The paths go over ``--stdin`` with ``-z`` rather than as arguments:
+    ``-z`` is accepted *only* with ``--stdin`` (``git`` exits with
+    ``fatal: -z only makes sense with --stdin`` otherwise), and the
+    newline-delimited reply it would otherwise produce is ambiguous for a
+    filename containing a newline. Git echoes each ignored path back
+    **verbatim**, so the strings returned here compare equal to the strings
+    that were sent.
+
     Args:
         root: Git repository root, as a string.
-        path: Absolute path to probe.
+        paths: Absolute paths to probe.
 
     Returns:
-        ``True`` when the path matches an exclude rule.
+        The subset of ``str(path)`` values matching an exclude rule.
     """
+    if not paths:
+        return set()
     result = subprocess.run(
-        ["git", "-C", root, "check-ignore", "--no-index", "-q", "--", str(path)],
+        ["git", "-C", root, "check-ignore", "--no-index", "-z", "--stdin"],
+        input="".join(f"{path}\0" for path in paths),
         capture_output=True,
         text=True,
         check=False,
     )
-    return result.returncode == 0
+    if result.returncode > 1:
+        # 1 means "none of them", which is the ordinary negative answer. Above
+        # that is a real failure; report no exclusions, exactly as the
+        # single-path probe did, and let the ``git add`` that follows surface
+        # the underlying problem with its own stderr.
+        logger.debug(
+            "git_check_ignore_failed rc=%s stderr=%s",
+            result.returncode,
+            (result.stderr or "").strip(),
+        )
+        return set()
+    return {entry for entry in result.stdout.split("\0") if entry}
 
 
 def _stage_rename(root: str, path: Path, old_path: Path | None) -> list[str] | None:
@@ -1727,17 +1754,18 @@ def _stage_rename(root: str, path: Path, old_path: Path | None) -> list[str] | N
         )
         return []
 
+    ignored = _ignored_paths(root, (old_path, path))
     pathspec: list[str] = []
     deletions: list[str] = []
     if not _is_tracked(root, old_path):
         logger.debug("git_stage_rename_old_untracked old_path=%s", old_path)
-    elif _is_ignored(root, old_path):
+    elif str(old_path) in ignored:
         logger.debug("git_stage_rename_old_tracked_but_ignored old_path=%s", old_path)
         deletions.append(str(old_path))
     else:
         pathspec.append(str(old_path))
 
-    if _is_ignored(root, path):
+    if str(path) in ignored:
         logger.debug("git_stage_rename_new_ignored path=%s", path)
     else:
         pathspec.append(str(path))

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6582,3 +6582,154 @@ class TestCommitsAreScopedToTheOperation:
 
         assert _head(git_repo) != head_before
         assert "new.md" in _commit_files(git_repo)
+
+
+# ---------------------------------------------------------------------------
+# batched exclude probe (#1250)
+# ---------------------------------------------------------------------------
+
+
+class TestTheExcludeProbeIsAskedOnce:
+    """Both sides of a rename are one ``check-ignore`` call, not two.
+
+    ``move_folder`` fires a rename callback per moved file, so the probe count
+    scales with subtree size and process spawn dominates the rule matching.
+    """
+
+    @staticmethod
+    def _seed(repo: Path) -> None:
+        """Commit a note, a ``.gitignore``, and a tracked file inside ``cache/``."""
+        (repo / ".gitignore").write_text(".DS_Store\ncache/\n", encoding="utf-8")
+        (repo / "note.md").write_text("# Note\n", encoding="utf-8")
+        legacy = repo / "cache" / "legacy.md"
+        legacy.parent.mkdir()
+        legacy.write_text("# Legacy\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "."], capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "-f", "--", str(legacy)],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "seed"],
+            capture_output=True,
+            check=True,
+        )
+
+    @staticmethod
+    def _count_check_ignore(repo: Path, old: Path, new: Path) -> int:
+        """Run one rename through the strategy, counting ``check-ignore`` spawns."""
+        from unittest import mock
+
+        from markdown_vault_mcp.git import _stage_and_commit
+
+        real_run = subprocess.run
+        calls = 0
+
+        def _counting(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal calls
+            if isinstance(cmd, list) and "check-ignore" in cmd:
+                calls += 1
+            return real_run(cmd, *args, **kwargs)
+
+        with mock.patch("markdown_vault_mcp.git.strategy.subprocess.run", _counting):
+            _stage_and_commit(repo, new, "rename", old_path=old)
+        return calls
+
+    def test_an_ordinary_rename_probes_once(self, git_repo: Path) -> None:
+        """Neither side is excluded, and the answer for both costs one call."""
+        self._seed(git_repo)
+
+        old_abs = git_repo / "note.md"
+        new_abs = git_repo / "moved.md"
+        old_abs.rename(new_abs)
+
+        assert self._count_check_ignore(git_repo, old_abs, new_abs) == 1
+        assert _commit_files(git_repo) == {"note.md", "moved.md"}
+
+    def test_one_call_answers_for_both_sides_at_once(self, git_repo: Path) -> None:
+        """The awkward case: old tracked-but-ignored, new ignored, one probe.
+
+        Batching must not lose the per-path resolution — the deletion is still
+        recorded and the ignored destination still stays out of the repository.
+        """
+        self._seed(git_repo)
+
+        old_abs = git_repo / "cache" / "legacy.md"
+        new_abs = git_repo / "cache" / "moved.md"
+        old_abs.rename(new_abs)
+
+        assert self._count_check_ignore(git_repo, old_abs, new_abs) == 1
+        assert _commit_files(git_repo) == {"cache/legacy.md"}
+        assert "cache/moved.md" not in _tracked_files(git_repo)
+
+
+class TestTheExcludeProbeItself:
+    """``_ignored_paths`` reports a subset, keyed by the strings it was given."""
+
+    def test_it_reports_only_the_excluded_paths(self, git_repo: Path) -> None:
+        """A mixed batch comes back as the excluded subset, verbatim."""
+        from markdown_vault_mcp.git.strategy import _ignored_paths
+
+        (git_repo / ".gitignore").write_text("cache/\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(git_repo), "add", "."], capture_output=True, check=True
+        )
+
+        excluded = git_repo / "cache" / "junk.md"
+        kept = git_repo / "note.md"
+
+        assert _ignored_paths(str(git_repo), (excluded, kept)) == {str(excluded)}
+
+    def test_a_tracked_file_under_an_ignored_directory_still_counts(
+        self, git_repo: Path
+    ) -> None:
+        """``--no-index`` is load-bearing: ``git add`` refuses it even so.
+
+        The index-aware default would call this file "not ignored", and the
+        staging that trusts the answer would then fail its whole invocation.
+        """
+        from markdown_vault_mcp.git.strategy import _ignored_paths
+
+        (git_repo / ".gitignore").write_text("cache/\n", encoding="utf-8")
+        legacy = git_repo / "cache" / "legacy.md"
+        legacy.parent.mkdir()
+        legacy.write_text("# Legacy\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(git_repo), "add", "-f", "--", str(legacy)],
+            capture_output=True,
+            check=True,
+        )
+
+        assert _ignored_paths(str(git_repo), (legacy,)) == {str(legacy)}
+
+    def test_no_paths_asks_git_nothing(self, git_repo: Path) -> None:
+        """The empty batch is answered without a subprocess."""
+        from unittest import mock
+
+        from markdown_vault_mcp.git.strategy import _ignored_paths
+
+        with mock.patch("markdown_vault_mcp.git.strategy.subprocess.run") as run_mock:
+            assert _ignored_paths(str(git_repo), ()) == set()
+        run_mock.assert_not_called()
+
+    def test_a_failing_probe_reports_no_exclusions(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Exit 1 means "none"; above that is a failure, answered the same way.
+
+        Reporting an exclusion nobody asked for would drop a real path from
+        the staging pathspec; reporting none lets the ``git add`` that follows
+        fail loudly with git's own stderr.
+        """
+        from markdown_vault_mcp.git.strategy import _ignored_paths
+
+        not_a_repo = tmp_path / "plain"
+        not_a_repo.mkdir()
+
+        with caplog.at_level(logging.DEBUG):
+            assert _ignored_paths(str(not_a_repo), (not_a_repo / "x.md",)) == set()
+
+        assert any("git_check_ignore_failed" in r.message for r in caplog.records)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6722,14 +6722,16 @@ class TestTheExcludeProbeItself:
 
         Reporting an exclusion nobody asked for would drop a real path from
         the staging pathspec; reporting none lets the ``git add`` that follows
-        fail loudly with git's own stderr.
+        fail loudly with git's own stderr — and when the paths were not
+        excluded after all, that ``git add`` succeeds and the warning is the
+        only record that the answer came from a failure.
         """
         from markdown_vault_mcp.git.strategy import _ignored_paths
 
         not_a_repo = tmp_path / "plain"
         not_a_repo.mkdir()
 
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.WARNING):
             assert _ignored_paths(str(not_a_repo), (not_a_repo / "x.md",)) == set()
 
         assert any("git_check_ignore_failed" in r.message for r in caplog.records)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6735,3 +6735,29 @@ class TestTheExcludeProbeItself:
             assert _ignored_paths(str(not_a_repo), (not_a_repo / "x.md",)) == set()
 
         assert any("git_check_ignore_failed" in r.message for r in caplog.records)
+
+    def test_a_signalled_probe_is_a_failure_too(
+        self, git_repo: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A killed probe reports a negative code, which no ``> 1`` test catches.
+
+        It would fall through to parsing the empty reply as "none excluded" —
+        the same safe answer, but reached silently, losing the one record that
+        the filter answered from a failure.
+        """
+        from unittest import mock
+
+        from markdown_vault_mcp.git.strategy import _ignored_paths
+
+        killed = subprocess.CompletedProcess(
+            args=["git", "check-ignore"], returncode=-9, stdout="", stderr=""
+        )
+        with (
+            mock.patch(
+                "markdown_vault_mcp.git.strategy.subprocess.run", return_value=killed
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            assert _ignored_paths(str(git_repo), (git_repo / "x.md",)) == set()
+
+        assert any("git_check_ignore_failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Closes / Refs

Closes #1250

## What & why

`_stage_rename` probed `git check-ignore` once per path. `move_folder` fires a
rename callback per moved file, so the probe count scales with the size of the
moved subtree, and spawning the process costs more than matching the rules
does.

`_ignored_paths` replaces `_is_ignored` with a plural shape: one invocation,
the excluded subset back. Per renamed file that takes the worst case from four
`git` processes to three, and — because the old-path exclude probe sat behind
an `elif` on `_is_tracked` — the best case from three to three, never worse.

**Why `--stdin -z` rather than passing both paths as arguments.** `-z` is
accepted *only* with `--stdin`; the argument form exits with
`fatal: -z only makes sense with --stdin`. Without `-z` the reply is
newline-delimited, which is ambiguous for a filename containing a newline. Git
echoes each ignored path back **verbatim**, so the strings returned compare
equal to the strings that were sent — verified for absolute and relative input
alike before relying on it.

**Exit codes.** 1 means "none of them" and is the ordinary negative answer, not
a failure. Above that is a failure, and it answers "none excluded" exactly as
the single-path probe did — reporting an exclusion nobody asked for would drop
a real path from the staging pathspec, while reporting none lets the `git add`
that follows fail loudly with git's own stderr.

One behaviour does change, deliberately: that failure is now **warned** rather
than swallowed. The old probe discarded any non-zero return code silently, so
when the paths turned out not to be excluded after all, the `git add` succeeded
and nothing recorded that the filter had answered from a failure rather than
from the exclude rules.

`--no-index` is unchanged and still load-bearing — the index-aware default
calls a tracked file under an ignored directory "not ignored" while `git add`
still refuses it. It is now pinned at the probe itself, not only through the
staging that trusts it.

## What this PR deliberately does NOT do

- **Does not batch `_is_tracked`.** #1250 scopes itself to the two exclude
  probes; `_is_tracked` is asked once per rename already, and folding it in
  would mean reconciling `ls-files` output with `check-ignore` output in one
  place for no further saving.
- **Does not change what gets staged or committed.** The four
  tracked/ignored quadrants `TestRenameStagingSkipsIgnoredPaths` pins are
  untouched, and that class passes unedited — which #1250 asks for explicitly.
- **Does not batch across renames.** The callback boundary is one file; the
  saving here is within a single rename, not across a `move_folder`.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No commit carries `!`. `_is_ignored` and `_ignored_paths` are private and
      not re-exported; the public import surface is unchanged.

`perf:` is the honest type here — no user-visible behaviour changes, and per
`AGENTS.md` it cuts no release and reaches no changelog entry. Retitle to
`fix:` if you read the new warning as worth a patch release on its own.

## Docs impact

- [ ] `README.md` — no user-facing config, env var, or tool surface changed
- [ ] `docs/` site pages — same
- [x] `docs/design/` — the exclude-probe paragraph gains the batching, the
      `--stdin -z` reasoning, and the exit-code convention
- [x] Inline docstrings — `_ignored_paths` carries the rationale `_is_ignored`
      had, plus what is new

## Test status

4,020 pass, 18 skip. Structural gate 100% (0 violations); `mypy` clean; patch
coverage 100% (`diff-cover` against `origin/main`).

Six new tests in two classes. The two that pin the saving count
`check-ignore` spawns through a real `_stage_and_commit` rename, and are
mutation-checked: restoring two separate `_ignored_paths` calls fails both.
The other four pin the probe itself — the mixed batch, the tracked-under-an-
ignored-directory case that `--no-index` exists for, the empty batch that asks
git nothing, and the failing probe that warns and reports no exclusions.

## Self-review 77b5b81..3583bf3

Charters: rules, diff, comments, history. Conformance charter: no schema, wire
format, or RFC-2119 prose in this diff. Past-PRs charter: the region's review
history is #1274 and #1275, both authored here today.

One finding, found and fixed during the review:

- `src/markdown_vault_mcp/git/strategy.py:1690` — important/verified — the
  probe failure was logged at `DEBUG`, invisible at the default level.
  Evidence: the `logging-standard` skill's level table assigns "degraded but
  continuing: API errors with fallback" to `WARNING`, and this is exactly that
  — with the aggravating detail that the fallback can succeed silently.
  Fix: raise to `WARNING`. Resolved in `3583bf3a`.

One candidate struck: redacting the probe's stderr through `redact()`, as the
network-facing helpers do. Refuted — `check-ignore` contacts no remote and
takes no credential, `redact(text, None)` is a documented no-op, and calling it
would imply a leak path that does not exist here.

---
_Generated by [Claude Code](https://claude.ai/code)_
