### PR TITLE
docs(design): record the discovery-seed boundary as unverified, not tracked

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3108,8 +3108,8 @@ Instructions deliberately carry only concise discovery seeds, enforced facts,
 and the vault-wide OKF interpretation/editing rule. Tool descriptions own the
 detailed call contract. This reduces the overlap identified by #1257 without
 claiming that every repeated workflow sentence is safely removable: whether a
-tool-searching client needs a larger discovery seed remains an experiment and
-#1257 stays open for that evidence.
+tool-searching client needs a larger discovery seed remains unverified, and no
+evidence establishes where the floor is.
 
 **Client-facing surface budget**: `tests/test_client_surface_budget.py`
 constructs the maximal discoverable HTTP surface (read-write, summarization,


### PR DESCRIPTION
## Closes / Refs

Refs #1257 (closed manually as completed; this repoints the design record off it)

## What & why

`docs/design/design.md` asserted that #1257 "stays open for that evidence" for
the tool-searching-client discovery-seed experiment. #1257 is now closed as
completed: the overlap it measured was removed by #1258 (domain snippets
1,983 → 842 chars, with four of its six measured paragraphs reclassified out of
`WORKFLOWS` into `CAPABILITIES` / `INSTANCE`), and the residual question has no
observed symptom, so it belongs in the design record rather than an open ticket.

The caveat is kept; only the tracker claim is dropped. The neighbouring
past-tense reference — "the overlap identified by #1257" — is left alone: it
remains accurate against a closed issue.

## What this PR deliberately does NOT do

- File a successor issue for the experiment. No symptom, no owner, nothing
  compounding — that is the "constrain issues to decay that will compound" rule,
  not an oversight. A routing failure under a tool-searching client would be a
  fresh bug with its own evidence.
- Touch `_instructions.py`. Nothing in the current numbers argues for moving the
  seed in either direction.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] Any commit carrying `!` breaks an operator or library surface that existed
  at the **last stable release**. This PR carries no `!` commit.

### Self-review `0d8ca857..5115ba37`

Charters: rules, diff, adjacent commitments, history. Conformance charter
skipped — no formal schema or RFC-2119 prose in range. Past-PR-review charter
skipped. Coverage: full local diff.

One finding, found and fixed before pushing:

- `docs/design/design.md:3111` — important/verified — the first draft's closing
  clause read "no current measurement supports cutting the seed further", which
  contradicts the same sentence's first half. Evidence: that half explicitly
  declines to claim "that every repeated workflow sentence is safely removable",
  i.e. it concedes measurable overlap survives — and it does: the 200-char
  `CAPABILITIES` snippet still restates `search`'s "Omit 'mode'" rule. A
  redundancy measurement therefore does still exist and could be read as
  supporting a cut. Fix: narrowed the claim to what is actually true — "no
  evidence establishes where the floor is". Resolved in `5115ba37`.

Checked for other mirrors of the tracker claim across the repo (`git grep 1257`,
"stays open", "remains an experiment"): none outside the two design.md lines.

## Docs impact

- [x] `docs/design/` is the change.
- [x] `README.md` and `docs/` site pages reviewed; no change needed — the
  paragraph is internal design prose and states no operator-facing behaviour.
- [x] No code changed, so no docstrings are affected.

## Validation

- `uv run pre-commit run --files docs/design/design.md`: passed
- The three tests that read `design.md` (`test_config_wizard_spec`,
  `test_search_pipeline_integration`, `test_write_tool_enumeration`):
  30 passed
- Docs-only diff: no Python changed, so the structural gate has no diff to
  measure and Vale excludes `docs/design/` by design.

---
_Generated by [Claude Code](https://claude.ai/code)_
