### PR TITLE
fix(config): keep ProjectConfig importable under the generator's dep floor

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3299,6 +3299,43 @@ first-party prompt is a packaging defect.
 
 ## Configuration
 
+### The config import floor (#1259)
+
+Importing `markdown_vault_mcp.config` must succeed with only
+`fastmcp-pvl-core` and PyYAML installed. That is not a style preference: the
+template-owned `scripts/gen_config_surface.py` imports `ProjectConfig` to
+discover this project's domain env vars, and it runs from copier's
+`_migrations` under `uv run --no-project --with fastmcp-pvl-core --with
+pyyaml` — before any project virtualenv exists. Nothing else this project
+declares as a dependency is importable at that moment.
+
+A module-scope import that reaches further fails in a way that reads as
+someone else's bug. `_import_project_config` treats the `ModuleNotFoundError`
+as tolerable (a stderr warning, then `None`), so discovery yields zero domain
+vars; the mcpb install-screen `files:` guard then aborts the run with
+"names config vars that do not exist (check for a typo…)" — pointing at the
+install screen rather than at the import. That is how the weekly copier-update
+workflow failed twice in August 2026, invisibly to anyone running the
+generator locally: from inside the repository, `uv run --no-project` still
+resolves the project's own `.venv`, which has everything installed.
+
+So a domain module reachable from `ProjectConfig` puts any heavier import
+behind `TYPE_CHECKING` (annotations — `from __future__ import annotations` is
+on everywhere, so they never evaluate) plus a function-local import at the
+runtime use site. `config_sections/_assembly.py` → `markdown_vault_mcp.git`
+(the `GitWriteStrategy` construction in `_build_git_strategy`) is one such
+edge; `config_sections/vault_settings.py` → `markdown_vault_mcp.okf` (the
+`OKF_INDEXED_FIELDS` table in `effective_indexed_fields`) is another, and both
+reach `python-frontmatter`. Note that importing `markdown_vault_mcp.git.types`
+would not have helped: a submodule import executes the package `__init__`
+first, and that is where the chain to `frontmatter` runs — which is also why
+the git edge is the older of the two, and why it, not the OKF edge, is what
+the pre-`config_sections/` tree tripped over in August.
+
+`tests/test_config_import_floor.py` enforces the floor by importing
+`config` in a fresh interpreter and asserting it adds no third-party module
+beyond what `fastmcp_pvl_core` and `yaml` already pull in.
+
 ### Phase 1: Python API Only
 
 Configuration is the `Vault` constructor. No config files.

--- a/src/markdown_vault_mcp/config_sections/_assembly.py
+++ b/src/markdown_vault_mcp/config_sections/_assembly.py
@@ -11,6 +11,16 @@ chunk-cap heuristic, and the ``from_env`` field validators — lives here instea
 
 Imports only fastmcp_pvl_core, stdlib, and sibling domain modules (never
 ``config`` at runtime) so ``config.py`` can import these without a cycle.
+
+Module-scope imports here are also bound by the config import floor: every
+module reachable from ``ProjectConfig`` at import time must resolve with only
+``fastmcp-pvl-core`` and PyYAML installed, because the template's
+``scripts/gen_config_surface.py`` imports ``ProjectConfig`` under
+``uv run --no-project`` with exactly those two, before any project
+virtualenv exists (#1259). Anything reaching a further third-party package —
+``markdown_vault_mcp.git`` reaches ``python-frontmatter``, for one — belongs
+in ``TYPE_CHECKING`` plus a function-local import at the use site.
+``tests/test_config_import_floor.py`` enforces this.
 """
 
 from __future__ import annotations
@@ -25,10 +35,10 @@ from fastmcp_pvl_core import parse_bool as _parse_bool
 from markdown_vault_mcp._identity import configure_identity_claims
 from markdown_vault_mcp.config_sections.vault_settings import VaultSettings
 from markdown_vault_mcp.exceptions import ConfigurationError
-from markdown_vault_mcp.git import GitWriteStrategy
 
 if TYPE_CHECKING:
     from markdown_vault_mcp.config import ProjectConfig
+    from markdown_vault_mcp.git import GitWriteStrategy
     from markdown_vault_mcp.providers import EmbeddingProvider
     from markdown_vault_mcp.summarizer import Summarizer
     from markdown_vault_mcp.types import WriteCallback
@@ -127,6 +137,12 @@ def _build_git_strategy(
     ``enable_sync`` toggles both pull and push together — every call site enables
     or disables them in lockstep.
     """
+    # Imported here rather than at module scope: `markdown_vault_mcp.git`
+    # reaches `python-frontmatter` transitively, and every module reachable
+    # from `ProjectConfig` at import time must resolve under the
+    # config-surface generator's dependency floor (see the module docstring).
+    from markdown_vault_mcp.git import GitWriteStrategy
+
     git = config.git
     # The claim kwargs below no longer drive claim extraction — they inform
     # only the startup identity warning. Registration with the identity layer

--- a/src/markdown_vault_mcp/config_sections/vault_settings.py
+++ b/src/markdown_vault_mcp/config_sections/vault_settings.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING
 
-from markdown_vault_mcp.okf import OKF_INDEXED_FIELDS
-
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
@@ -220,6 +218,11 @@ class VaultSettings:
         Returns:
             The effective field list (possibly empty, never ``None``).
         """
+        # Imported here rather than at module scope: `markdown_vault_mcp.okf`
+        # imports `python-frontmatter`, which is outside the config import
+        # floor this module is bound by (see `_assembly`'s module docstring).
+        from markdown_vault_mcp.okf import OKF_INDEXED_FIELDS
+
         fields = list(self.indexed_frontmatter_fields or [])
         if okf_active:
             fields.extend(key for key in OKF_INDEXED_FIELDS if key not in fields)

--- a/tests/test_config_import_floor.py
+++ b/tests/test_config_import_floor.py
@@ -1,0 +1,89 @@
+"""Guard: importing `ProjectConfig` must stay inside the generator's dep floor.
+
+The template-owned `scripts/gen_config_surface.py` imports this project's
+`markdown_vault_mcp.config` to discover its domain env vars, and it does so
+under `uv run --no-project --with fastmcp-pvl-core --with pyyaml` — copier's
+tasks run before any project virtualenv exists, so the generator bootstraps
+with exactly those two distributions and nothing else the project declares.
+
+That makes "the import closure of `markdown_vault_mcp.config`" a real
+contract, not an implementation detail. Break it and the failure is quiet in
+the wrong direction: `_import_project_config` treats the `ModuleNotFoundError`
+as tolerable (warning, `None`), the domain-var set comes back empty, and only
+the *next* step — the mcpb install-screen `files:` guard, which names domain
+vars — turns that into `exit 1`. The weekly copier-update workflow failed that
+way twice before #1259, while a local run stayed green because `uv run
+--no-project` still resolves the repo's own `.venv` from inside the repo.
+
+The check runs in a subprocess because the pytest session has already imported
+most of the package: only a fresh interpreter can observe what importing
+`config` alone pulls in. `fastmcp_pvl_core` and `yaml` are imported first, so
+whatever they legitimately drag in forms the baseline and the assertion is
+about what `config` adds *beyond* the floor. A module the bootstrap does
+install but core happens to import lazily would surface here as a false
+positive; the fix for that one is to name it in the probe's baseline, not to
+relax the assertion.
+
+Fixing a real violation means moving the offending import out of module
+scope — `TYPE_CHECKING` for annotations, a function-local import at the use
+site for runtime use. `config_sections/_assembly.py` does both for
+`markdown_vault_mcp.git`, and `config_sections/vault_settings.py` does the
+latter for `markdown_vault_mcp.okf`.
+
+Sibling guard, deliberately separate: `test_package_imports.py` pins that the
+package *root* stays light, which is about surviving coverage.py's
+find_spec-then-purge cycle (#665, #903). Same subprocess technique, different
+contract — that one bounds `import markdown_vault_mcp`, this one bounds
+`import markdown_vault_mcp.config`, and neither implies the other.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+#: Imports `fastmcp_pvl_core` and `yaml` to establish the dependency floor,
+#: then reports the third-party top-level modules that importing
+#: `markdown_vault_mcp.config` adds on top of it. Underscore-prefixed names
+#: are interpreter internals (`_frozen_importlib_external` and friends), not
+#: distributions.
+_PROBE = """
+import json
+import sys
+
+import fastmcp_pvl_core  # noqa: F401
+import yaml  # noqa: F401
+
+baseline = set(sys.modules)
+import markdown_vault_mcp.config  # noqa: F401
+
+added = {name.split(".")[0] for name in set(sys.modules) - baseline}
+print(json.dumps(sorted(
+    name for name in added
+    if not name.startswith("_")
+    and name not in sys.stdlib_module_names
+    and name != "markdown_vault_mcp"
+)))
+"""
+
+
+def test_config_import_adds_no_third_party_beyond_the_floor() -> None:
+    """`markdown_vault_mcp.config` imports under core + PyYAML alone."""
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    assert result.returncode == 0, f"the probe interpreter failed:\n{result.stderr}"
+
+    extra = json.loads(result.stdout.splitlines()[-1])
+    assert extra == [], (
+        "importing markdown_vault_mcp.config reaches third-party packages the "
+        f"config-surface generator does not install: {extra}. Move the import "
+        "to TYPE_CHECKING (annotations) or into the function that uses it "
+        "(runtime) — see this module's docstring and #1259."
+    )


### PR DESCRIPTION
## Closes / Refs

Closes #1259

## What & why

`scripts/gen_config_surface.py` imports `markdown_vault_mcp.config` to discover
this project's domain env vars, and it runs from copier's `_migrations` under
`uv run --no-project --with fastmcp-pvl-core --with pyyaml` — before any project
virtualenv exists. Two module-scope imports reached `python-frontmatter` from
there: `config_sections/_assembly.py` → `markdown_vault_mcp.git` (whose package
`__init__` pulls in `git.strategy` → `git.conflict`) and
`config_sections/vault_settings.py` → `markdown_vault_mcp.okf`. Both now sit
behind `TYPE_CHECKING` plus a function-local import at the use site.

`markdown_vault_mcp.git.types` would not have been a fix: a submodule import
runs the package `__init__` first, which is where the chain to `frontmatter`
lives.

**Reproduced, before and after.** Running the workflow's exact failing
invocation from a directory outside the repository (from inside it,
`uv run --no-project` still resolves the project's own `.venv`, which is why
this was invisible locally):

```
$ env -u VIRTUAL_ENV -u PYTHONPATH uv run --no-project \
    --with fastmcp-pvl-core --with pyyaml python <repo>/scripts/gen_config_surface.py --check
```

| | before | after |
|-|-|-|
| stderr | `WARNING: importing markdown_vault_mcp.config failed: ModuleNotFoundError: No module named 'frontmatter'` | — |
| vars collected | 45 | 118 |
| mcpb `files:` guard | `ERROR: … names config vars that do not exist` | passes |
| exit | 1 | 0 |

**The 24 August failure is now accounted for.** #1259 left that one
unreconstructed, since `config_sections/` did not exist yet. Walking the import
closure of the pre-#1224 tree (`94414470`) shows `frontmatter` reachable through
the same `_assembly` → `git` → `strategy` → `conflict` edge this PR removes, so
both August failures share one cause.

Incidental: the closure drops from 105 first-party modules to 16, so a
downstream consumer importing `markdown_vault_mcp.config` no longer pays for the
git and OKF subsystems either.

`tests/test_config_import_floor.py` pins the contract by importing `config` in a
fresh interpreter and asserting it adds no third-party module beyond what
`fastmcp_pvl_core` and `yaml` already pull in. It was mutation-checked:
restoring either import at module scope fails it with the offending package
named.

## What this PR deliberately does NOT do

- **Does not touch `scripts/gen_config_surface.py`.** It is template-owned and
  ships byte-identical to every project; softening the mcpb `files:` guard would
  trade a loud abort for an install screen silently missing every domain var.
- **Does not fix the upstream diagnostic.** The generator's message named the
  install screen when the cause was the import it had just tolerated, which is
  what made two CI failures cost this much investigation. That is template-owned
  and filed as pvliesdonk/fastmcp-server-template#562; this PR fixes only the
  import chain, which is domain-owned and would still be worth fixing whatever
  upstream decides. (pvliesdonk/fastmcp-server-template#525 records the same
  symptom and is closed `NOT_PLANNED`; that disposition is not a ruling on the
  substance, so #562 does not lean on it.)
- **Does not trigger `copier-update.yml`.** The end-to-end proof is the next
  scheduled run; dispatching it would open an auto-PR the maintainer prefers to
  handle interactively (#1259 comment).
- **Does not change runtime behaviour.** `effective_indexed_fields` and
  `_build_git_strategy` do exactly what they did; only the import site moved.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] Any commit carrying `!` breaks an operator or library surface that
      existed at the **last stable release** — no `!` here. Nothing importable
      is removed: `GitWriteStrategy` and `OKF_INDEXED_FIELDS` stay exported from
      their defining modules; only two incidental re-export names disappear from
      a private (`_assembly`) and an internal module namespace.

## Docs impact

- [ ] `README.md` — no operator-facing change (no new env var, tool, or flag)
- [ ] `docs/` site pages — same
- [x] `docs/design/` — new "The config import floor (#1259)" section under
      Configuration, recording why the floor exists, how it fails, and the
      `TYPE_CHECKING` + function-local rule
- [x] Inline docstrings — `_assembly.py`'s module docstring states the floor;
      both moved imports carry a one-line reason at the use site

---
_Generated by [Claude Code](https://claude.ai/code)_
