### PR TITLE
fix(git): stop predicting a fast-forward for a pull that would diverge

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3968,12 +3968,14 @@ Set `MARKDOWN_VAULT_MCP_GIT_LFS=false` for repos that do not use LFS, or when
   enables concurrent readers during index writes).
 - If `MARKDOWN_VAULT_MCP_GIT_LFS=true`, each pull tick that advanced `HEAD`
   ends with `git lfs pull` so LFS pointer files are resolved before reads and
-  indexing (a no-op tick that finds `HEAD` already up to date skips it).
+  indexing (a no-op tick with nothing to pull skips it: nothing arrived that
+  could carry a pointer).
 
 **Shared pull pipeline (#879)**: the periodic loop (`sync_once`) and the
 interactive `git_sync(direction='pull')` tool (`force_pull`) are thin entry
 points over one implementation, `GitWriteStrategy._pull_pipeline` (quiesce +
-lock → `git fetch origin` → resolve tracking ref → ff-only merge → rebase →
+lock → `git fetch origin` → resolve tracking ref → classify divergence →
+ff-only merge → rebase →
 Syncthing-style sibling conflict resolution → LFS pull). `force_pull` returns
 the pipeline's structured `PullResult` directly; `sync_once` adapts it to its
 historical bool (`applied and to_sha != from_sha`), pre-checks the tracking ref
@@ -3983,6 +3985,22 @@ contract. Unifying the two paths fixed the loop's diverged conflict handling:
 its post-abort upstream restore previously ran per-file `git checkout` with no
 failure handling, whereas the pipeline's `_restore_upstream_paths` drops paths
 whose restore failed instead of committing stale local content over them.
+
+**Divergence is classified before the pull, not after (#1292)**: the pipeline
+asks `git merge-base --is-ancestor` before it merges or predicts — the remote
+tip reachable from `HEAD` means there is nothing to pull, `HEAD` reachable
+from the remote tip means `merge --ff-only` can succeed. A dry run projects
+from that classification instead of assuming a fast-forward, so a diverged
+clone reports `fast_forward=False, reason="diverged"` rather than the clean
+fast-forward the real pull then refused; the real pull skips the merge it
+already knows cannot succeed and goes straight to the rebase path. The same
+classification corrected a clone that was only *ahead* — unpushed local
+commits, remote unmoved: it reported `to_sha=<remote tip>` for a pull that
+left `HEAD` where it was, which read as HEAD moving backwards and made
+`git_sync` reindex for a pull that moved nothing. A dry run still fetches
+without draining deferred writes, so its prediction describes the clone at
+fetch time: a pending write the real pull commits first can diverge after the
+projection was taken.
 
 **`enable_pull` gates every pull, not just the loop (#1128)**: the flag is
 `False` in unmanaged / commit-only mode, where the strategy exists only to

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -195,9 +195,14 @@ succeeded; otherwise `push` stays `null` and the LLM should inspect
 
 `dry_run=true` previews what a pull *would* do (useful for "is there
 anything new on origin?") without risking an in-conversation conflict.
-The push leg has no safe local "would this be accepted" probe, so a
-dry-run push always returns `applied=false` with
-`reason="dry_run_unsupported"`.
+The preview classifies the clone against the remote before predicting. A
+history that has moved on both locally and on the remote reports
+`fast_forward=false` with `reason="diverged"`, which is the signal that the
+real pull would rebase and may end in sibling resolution or fail outright.
+A clone with nothing to pull (up to date, or carrying only unpushed local
+commits) reports `would_apply=false`. The push leg has no safe local
+"would this be accepted" probe, so a dry-run push always returns
+`applied=false` with `reason="dry_run_unsupported"`.
 
 !!! info "Conflict outcome: Syncthing-style sibling resolution"
     When the pull would otherwise need an interactive merge, the server

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -649,7 +649,7 @@ history before continuing the conversation.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `direction` | `"pull"` \| `"push"` \| `"both"` | `"both"` | Which legs to run. `"both"` runs pull first, then push; if pull fails (`pull.applied=false`) the push leg is skipped and `push` stays `null` so a callable can inspect `pull.reason` before retrying. |
-| `dry_run` | bool | `false` | When `true`, the pull leg runs `git fetch` and reports what *would* happen (`would_apply: bool`, projected `to_sha`) without moving HEAD. The push leg has no safe local probe for "would the remote accept this," so a dry-run push is a no-op that returns `applied=false` with `reason="dry_run_unsupported"`. |
+| `dry_run` | bool | `false` | When `true`, the pull leg runs `git fetch` and reports what *would* happen (`would_apply: bool`, projected `to_sha`) without moving HEAD. A clone whose history has moved on alongside the remote gets `fast_forward=false` with `reason="diverged"` rather than a fast-forward the real pull could not perform. The push leg has no safe local probe for "would the remote accept this," so a dry-run push is a no-op that returns `applied=false` with `reason="dry_run_unsupported"`. |
 
 **Returns:** Dict with the following fields:
 
@@ -746,7 +746,8 @@ Push rejected as non-fast-forward:
 ```
 
 **`pull.reason` values** (set on every non-fast-forward outcome and on
-failures; `null` for clean fast-forwards and dry-runs):
+failures; `null` when the pull fast-forwards cleanly, has nothing to bring
+in, or is a dry run projecting a clean fast-forward):
 
 | Reason | Meaning | `applied` |
 |--------|---------|-----------|
@@ -756,6 +757,7 @@ failures; `null` for clean fast-forwards and dry-runs):
 | `"conflicts_resolved_with_siblings"` | Rebase hit real conflicts; resolved by accepting upstream and writing local versions as `.conflict-mcp-*` siblings (#232). `conflict_files` populated. | `true` |
 | `"conflict_resolution_failed"` | The conflict-resolution loop could not produce a recoverable working tree; rebase was aborted. HEAD did not move. | `false` |
 | `"non_fast_forward_with_conflicts"` | Rare catastrophic fallback when even the conflict-resolution path could not stabilise the working tree. HEAD did not move. | `false` |
+| `"diverged"` | **`dry_run=true` only.** Local and remote histories have both moved on, so the projected pull cannot fast-forward. The real call rebases and may end in `"rebased"`, `"conflicts_resolved_with_siblings"`, or a failure; a dry run reports the divergence rather than guessing which. | `false` |
 
 **`push.reason` values** (`null` on success including the
 already-up-to-date no-op):

--- a/src/markdown_vault_mcp/_server_tools/git.py
+++ b/src/markdown_vault_mcp/_server_tools/git.py
@@ -91,7 +91,11 @@ def _format_pull_dict(result: PullResult, dry_run: bool) -> dict[str, Any]:
     if result.conflict_files:
         pull_dict["conflict_files"] = list(result.conflict_files)
     if dry_run:
-        # SHA comparison: handles force_pull's up-to-date early-return cleanly.
+        # SHA comparison: handles the pull pipeline's nothing-to-pull return
+        # (up-to-date, or a clone that is only ahead) cleanly — both report
+        # ``to_sha == from_sha``.  On a ``diverged`` projection this is
+        # ``True`` because the real pull would do work, though the work is a
+        # rebase that mints its own SHAs rather than a move to ``to_sha``.
         pull_dict["would_apply"] = result.from_sha != result.to_sha
     return pull_dict
 
@@ -391,10 +395,12 @@ def register(mcp: FastMCP) -> None:
         ``pull.reason`` (and ``pull.conflict_files`` for conflict
         resolution) before retrying.
 
-        ``dry_run=True`` projects the would-be pull without moving HEAD.
-        Push has no safe dry-run (git provides no local probe for
-        "would the remote accept this"), so the push leg returns
-        ``applied=False`` with ``reason='dry_run_unsupported'``.
+        ``dry_run=True`` projects the would-be pull without moving HEAD,
+        reporting ``fast_forward=False`` with ``reason='diverged'`` when
+        the real pull could not fast-forward.  Push has no safe dry-run
+        (git provides no local probe for "would the remote accept this"),
+        so the push leg returns ``applied=False`` with
+        ``reason='dry_run_unsupported'``.
 
         Args:
             direction: ``"pull"``, ``"push"``, or ``"both"`` (default).
@@ -449,10 +455,10 @@ def register(mcp: FastMCP) -> None:
 
             # Short-circuit the push leg when the pull failed in 'both' mode
             # so we don't push on top of an unreconciled local clone.
-            # Excludes ``dry_run``: in dry-run mode ``applied`` is always
-            # ``False`` even on a healthy projection, so falling through is
-            # correct — the push leg's ``dry_run_unsupported`` reason then
-            # surfaces in the response, distinguishing a preview from a
+            # Excludes ``dry_run``: a projection reports ``applied=False``
+            # whenever it predicts work, so falling through is correct — the
+            # push leg's ``dry_run_unsupported`` reason then surfaces in the
+            # response, distinguishing a preview from a
             # real-pull-failed-push-skipped result.
             if direction == "both" and not pull_dict["applied"] and not dry_run:
                 # Refresh head_sha defensively (today's force_pull leaves

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -57,6 +57,7 @@ from markdown_vault_mcp.git.push_scheduler import PushScheduler
 from markdown_vault_mcp.git.types import (
     PULL_REASON_CONFLICT_RESOLUTION_FAILED,
     PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS,
+    PULL_REASON_DIVERGED,
     PULL_REASON_FETCH_FAILED,
     PULL_REASON_NO_REMOTE,
     PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS,
@@ -680,6 +681,101 @@ class GitWriteStrategy:
         """
         return run_git_capturing(git_root, *args, env=env)
 
+    def _is_ancestor(
+        self,
+        git_root: Path,
+        ancestor: str,
+        descendant: str,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> bool:
+        """Report whether *ancestor* is reachable from *descendant*.
+
+        ``git merge-base --is-ancestor`` answers by exit status: ``0`` yes,
+        ``1`` no.  That is the fast-forward test the pull pipeline needs —
+        ``merge --ff-only <remote>`` succeeds exactly when HEAD is an
+        ancestor of the remote tip — so a dry run can classify the
+        divergence without attempting the merge (#1292).
+
+        Args:
+            git_root: Working-tree root used for git ``-C``.
+            ancestor: Commit-ish that may be reachable from *descendant*.
+            descendant: Commit-ish to search back from.
+            env: Optional GIT_ASKPASS environment.  Both commits are local
+                objects here, so no network access is involved.
+
+        Returns:
+            ``True`` when *ancestor* is reachable from *descendant* (a SHA
+            is its own ancestor).  ``False`` when it is not, and also when
+            git answers with any other exit status — an unusable answer
+            must not read as "a fast-forward is available".
+        """
+        proc = self._run_git_capturing(
+            git_root, "merge-base", "--is-ancestor", ancestor, descendant, env=env
+        )
+        if proc.returncode not in (0, 1):
+            logger.warning(
+                "Git: `merge-base --is-ancestor %s %s` failed (exit %d): %s",
+                ancestor,
+                descendant,
+                proc.returncode,
+                self._redact((proc.stderr or "").strip()),
+            )
+            return False
+        return proc.returncode == 0
+
+    def _count_commits_behind(
+        self,
+        git_root: Path,
+        from_sha: str,
+        remote_sha: str,
+        *,
+        env: dict[str, str] | None = None,
+        log_prefix: str = "Git force_pull",
+    ) -> int:
+        """Count the commits *remote_sha* carries that *from_sha* does not.
+
+        On a clone that is purely behind, this is the number of commits
+        ``merge --ff-only`` would apply; on a diverged clone it is the
+        remote-only half of the divergence.
+
+        Args:
+            git_root: Working-tree root used for git ``-C``.
+            from_sha: Local HEAD SHA.
+            remote_sha: Remote-tracking tip SHA.
+            env: Optional GIT_ASKPASS environment.
+            log_prefix: Message prefix identifying the calling entry point.
+
+        Returns:
+            The commit count, or ``0`` when git answered with something no
+            ``int`` can hold — which is logged as a warning rather than
+            raised, so an unusable count does not fail an otherwise fine
+            pull.
+        """
+        commits_ahead = self._git(
+            git_root,
+            "rev-list",
+            "--count",
+            f"{from_sha}..{remote_sha}",
+            env=env,
+        ).strip()
+        try:
+            return int(commits_ahead)
+        except ValueError:
+            # ``rev-list --count`` is documented to print a single
+            # integer; if parsing fails, the underlying git call is
+            # broken in a way we should surface rather than silently
+            # report 0 commits.  Fall back to 0 but log loudly.
+            logger.warning(
+                "%s: could not parse commit count %r "
+                "from `git rev-list --count %s..%s`",
+                log_prefix,
+                commits_ahead,
+                from_sha,
+                remote_sha,
+            )
+            return 0
+
     def _tracking_ref(
         self, git_root: Path, env: dict[str, str] | None = None
     ) -> str | None:
@@ -713,9 +809,11 @@ class GitWriteStrategy:
         first and the merge runs on a clean tree (#571). Skipped under
         ``dry_run`` (which only fetches and never touches the working tree).
 
-        On ``ff-only`` failure (divergent history) the implementation
-        falls through to the same rebase + Syncthing-style sibling write
-        path used by :meth:`sync_once` (see
+        Divergent history is detected before the merge (``git merge-base
+        --is-ancestor``, #1292) and goes straight to the same rebase +
+        Syncthing-style sibling write path used by :meth:`sync_once`; a
+        working tree that refuses an otherwise available fast-forward
+        falls through to it too (see
         :func:`~markdown_vault_mcp.git.conflict.resolve_rebase_conflicts` and
         :func:`~markdown_vault_mcp.git.conflict.write_conflict_files`).  When
         the conflict-resolution
@@ -741,9 +839,11 @@ class GitWriteStrategy:
 
         Args:
             dry_run: When ``True``, runs ``git fetch`` and computes the
-                would-be pull without modifying HEAD.  Returns
-                ``applied=False`` with ``commits_pulled`` set to the count
-                that *would* have been pulled.
+                would-be pull without modifying HEAD.  A projection that
+                predicts work returns ``applied=False`` with
+                ``commits_pulled`` set to the count that *would* have been
+                pulled; one that finds nothing to pull returns the same
+                ``applied=True`` the real call would.
 
         Returns:
             :class:`PullResult` describing the operation.  See the
@@ -816,7 +916,7 @@ class GitWriteStrategy:
         dry_run: bool = False,
         log_prefix: str = "Git force_pull",
     ) -> PullResult:
-        """Run the shared fetch → ff-only → rebase → sibling pipeline.
+        """Run the shared fetch → classify → ff-only → rebase → sibling pipeline.
 
         The single implementation behind :meth:`force_pull` (interactive
         ``git_sync`` tool) and :meth:`sync_once` (periodic pull loop) —
@@ -831,8 +931,8 @@ class GitWriteStrategy:
         Args:
             git_root: Resolved working-tree root.
             env: The caller's git environment, cleaned up by the caller.
-            dry_run: Fetch and compute the would-be pull without touching
-                HEAD.
+            dry_run: Fetch and project the would-be pull from the same
+                classification the real pull acts on, without touching HEAD.
             log_prefix: Message prefix identifying the calling entry point
                 (``"Git force_pull"`` / ``"Git pull"``).
 
@@ -875,8 +975,16 @@ class GitWriteStrategy:
         if ref is None or remote_sha is None:
             return PullResult.head_unchanged_failure(from_sha, PULL_REASON_NO_REMOTE)
 
-        if remote_sha == from_sha:
-            # Already up to date — successful no-op (applied=True even on dry_run).
+        # Nothing to bring in: either the remote tip *is* HEAD, or it is an
+        # ancestor of HEAD because the clone carries unpushed local commits.
+        # ``merge --ff-only`` is a no-op success on both, so report HEAD as
+        # the SHA it stayed at — naming ``remote_sha`` there made a pull that
+        # moved nothing read as a pull that moved HEAD backwards, and made
+        # ``git_sync`` reindex for it (#1292).  The SHA equality short-circuit
+        # keeps the common case free of a subprocess.
+        if remote_sha == from_sha or self._is_ancestor(
+            git_root, remote_sha, from_sha, env=env
+        ):
             return PullResult(
                 applied=True,
                 fast_forward=True,
@@ -885,48 +993,46 @@ class GitWriteStrategy:
                 to_sha=from_sha,
             )
 
-        # Count commits between local and remote.  When the local
-        # branch is behind the remote this is the number of commits
-        # ``merge --ff-only`` would apply.
-        commits_ahead = self._git(
-            git_root,
-            "rev-list",
-            "--count",
-            f"{from_sha}..{remote_sha}",
-            env=env,
-        ).strip()
-        try:
-            commits_pulled = int(commits_ahead)
-        except ValueError:
-            # ``rev-list --count`` is documented to print a single
-            # integer; if parsing fails, the underlying git call is
-            # broken in a way we should surface rather than silently
-            # report 0 commits.  Fall back to 0 but log loudly.
-            logger.warning(
-                "%s: could not parse commit count %r "
-                "from `git rev-list --count %s..%s`",
-                log_prefix,
-                commits_ahead,
-                from_sha,
-                remote_sha,
-            )
-            commits_pulled = 0
+        commits_pulled = self._count_commits_behind(
+            git_root, from_sha, remote_sha, env=env, log_prefix=log_prefix
+        )
+
+        # Classify before predicting or merging: HEAD being an ancestor of the
+        # remote tip is exactly the condition ``merge --ff-only`` requires.
+        # A dry run that assumed fast-forward reported one for divergences the
+        # real pull then refused, which read as benign while writes stranded
+        # locally (#1292).
+        can_fast_forward = self._is_ancestor(git_root, from_sha, remote_sha, env=env)
 
         if dry_run:
-            # Heuristic: assume fast-forward.  Actual ff-ness is
-            # only known after attempting the merge; the conflict
-            # path below corrects this for non-dry-run calls.
             return PullResult(
                 applied=False,
-                fast_forward=True,
+                fast_forward=can_fast_forward,
                 commits_pulled=commits_pulled,
                 from_sha=from_sha,
                 to_sha=remote_sha,
+                reason=None if can_fast_forward else PULL_REASON_DIVERGED,
             )
 
-        # Attempt fast-forward merge first.  On divergence fall
-        # through to rebase + Syncthing-style sibling resolution,
-        # mirroring :meth:`sync_once`.
+        if not can_fast_forward:
+            # Histories diverged; ``merge --ff-only`` cannot succeed.  Go
+            # straight to rebase + Syncthing-style sibling resolution,
+            # mirroring :meth:`sync_once`.
+            logger.debug(
+                "%s: local and remote diverged, attempting rebase",
+                log_prefix,
+            )
+            return self._force_pull_rebase_fallback(
+                git_root=git_root,
+                env=env,
+                from_sha=from_sha,
+                ref=ref,
+                log_prefix=log_prefix,
+            )
+
+        # Fast-forward is available on the history; the merge can still fail
+        # on a working tree the fetch's new commits would overwrite, which
+        # falls through to the same rebase path.
         try:
             self._git(git_root, "merge", "--ff-only", remote_sha, env=env)
         except subprocess.CalledProcessError as ff_exc:
@@ -965,8 +1071,9 @@ class GitWriteStrategy:
     ) -> PullResult:
         """Attempt rebase + Syncthing-style sibling resolution.
 
-        Called by :meth:`_pull_pipeline` when ``merge --ff-only`` failed
-        because local and remote histories diverged.  Returns a
+        Called by :meth:`_pull_locked` when local and remote histories have
+        diverged, and when an available fast-forward was refused by the
+        working tree.  Returns a
         structured :class:`PullResult`; :meth:`sync_once` adapts it back
         to its historical bool (#879).
 
@@ -1349,7 +1456,7 @@ class GitWriteStrategy:
 
         Thin adapter over :meth:`_pull_pipeline` (#879) — the periodic
         pull loop and the interactive ``git_sync`` tool now share one
-        fetch → ff-only → rebase → sibling implementation, so the loop
+        fetch → classify → ff-only → rebase → sibling implementation, so the loop
         gets the pipeline's safe conflict handling: defensive rebase
         abort and an upstream restore that drops paths whose restore
         failed instead of committing stale local content over them.

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -715,7 +715,7 @@ class GitWriteStrategy:
         )
         if proc.returncode not in (0, 1):
             logger.warning(
-                "Git: `merge-base --is-ancestor %s %s` failed (exit %d): %s",
+                "git_merge_base_failed ancestor=%s descendant=%s exit=%d stderr=%s",
                 ancestor,
                 descendant,
                 proc.returncode,
@@ -1019,7 +1019,7 @@ class GitWriteStrategy:
             # straight to rebase + Syncthing-style sibling resolution,
             # mirroring :meth:`sync_once`.
             logger.debug(
-                "%s: local and remote diverged, attempting rebase",
+                "git_pull_diverged entry=%s action=rebase",
                 log_prefix,
             )
             return self._force_pull_rebase_fallback(

--- a/src/markdown_vault_mcp/git/types.py
+++ b/src/markdown_vault_mcp/git/types.py
@@ -18,6 +18,7 @@ PULL_REASON_NON_FAST_FORWARD_WITH_CONFLICTS = "non_fast_forward_with_conflicts"
 PULL_REASON_REBASED = "rebased"
 PULL_REASON_CONFLICTS_RESOLVED_WITH_SIBLINGS = "conflicts_resolved_with_siblings"
 PULL_REASON_CONFLICT_RESOLUTION_FAILED = "conflict_resolution_failed"
+PULL_REASON_DIVERGED = "diverged"
 
 PUSH_REASON_DRY_RUN_UNSUPPORTED = "dry_run_unsupported"
 PUSH_REASON_NO_REMOTE = "no_remote"
@@ -36,19 +37,23 @@ class PullResult:
 
     Attributes:
         applied: ``True`` when the pull was actually executed and HEAD was
-            moved (or was already up-to-date and required no work).
-            Also ``True`` when divergent history was resolved via the
-            Syncthing-style sibling write — HEAD advanced to the remote
-            and the local MCP versions were preserved as
+            moved, and when there was nothing to bring in — an up-to-date
+            clone, or one carrying only unpushed local commits — so no work
+            was required.  Also ``True`` when divergent history was resolved
+            via the Syncthing-style sibling write — HEAD advanced to the
+            remote and the local MCP versions were preserved as
             ``.conflict-mcp-*`` siblings (see ``conflict_files``).
-            ``False`` for ``dry_run`` calls and for failures that left
-            HEAD unchanged.
+            ``False`` for failures that left HEAD unchanged, and for a
+            ``dry_run`` predicting work: a dry run with nothing to pull
+            reports ``True``, since that answer is the same either way.
         fast_forward: ``True`` when the pull was (or would have been) a
             clean fast-forward.  ``False`` when divergent history
             required rebase + sibling writes, or when the operation
             failed.  Inspect ``reason`` and ``conflict_files`` to
             distinguish "applied via conflict resolution" from outright
-            failure.
+            failure.  A ``dry_run`` classifies the divergence before
+            predicting, so this is never ``True`` for a pull the real
+            call could not fast-forward (#1292).
         commits_pulled: Count of commits brought in.  Reliable on the
             fast-forward path (``reason is None`` and ``fast_forward=True``).
             On ``"rebased"`` and ``"conflicts_resolved_with_siblings"`` this
@@ -57,13 +62,21 @@ class PullResult:
             so the linear-history "commits pulled" count is not meaningful.
             Inspect ``from_sha != to_sha`` to detect that HEAD actually
             moved on those paths.  In ``dry_run`` mode this is the count
-            that *would* have been pulled.
+            of remote-only commits the pull would reconcile against —
+            on a diverged clone the real pull rebases and reports ``0``,
+            so the two disagree by design.
         from_sha: HEAD SHA before the pull.
         to_sha: HEAD SHA after the pull.  In ``dry_run`` mode this is the
-            SHA HEAD would have moved to.  When the pull failed and HEAD
-            did not move this equals ``from_sha``.
+            SHA HEAD would have moved to — on the ``"diverged"``
+            prediction, the remote tip the pull would reconcile against
+            rather than a SHA HEAD can reach, since the rebase mints new
+            commits.  When the pull failed and HEAD did not move this
+            equals ``from_sha``, as it does when there is nothing to
+            pull.
         reason: Diagnostic code describing the outcome.  ``None`` for
-            clean fast-forward pulls and dry-runs.  Otherwise one of:
+            clean fast-forward pulls, for pulls with nothing to bring in,
+            and for dry-runs predicting a clean fast-forward.  Otherwise
+            one of:
 
             * ``"fetch_failed"`` — ``git fetch origin`` exited non-zero
               (network error, auth failure, etc.); HEAD did not move.
@@ -93,6 +106,14 @@ class PullResult:
               move (``from_sha == to_sha``); (b) the rebase completed and
               HEAD advanced, but the sibling-files commit failed — HEAD
               has moved (``from_sha != to_sha``, ``applied=False``).
+            * ``"diverged"`` — **dry-run only**: local and remote
+              histories have both moved on, so the pull being predicted
+              cannot fast-forward.  The real call would rebase and fall
+              back to Syncthing-style sibling resolution, which may end
+              in ``"conflicts_resolved_with_siblings"``, ``"rebased"``,
+              or a failure — a dry run does not attempt the rebase, so
+              it reports the divergence rather than guessing which
+              (#1292).
 
             See module-level ``PULL_REASON_*`` constants for the
             string values.

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -294,7 +294,7 @@ class TestPullDivergenceClassification:
 
         assert result.fast_forward is False
         assert result.reason == "diverged"
-        assert any("--is-ancestor" in r.message for r in caplog.records)
+        assert any("git_merge_base_failed" in r.message for r in caplog.records)
 
 
 class TestForcePush:

--- a/tests/test_git_force_methods.py
+++ b/tests/test_git_force_methods.py
@@ -9,6 +9,7 @@ so the same setup can be reused by future tests for the higher-level
 from __future__ import annotations
 
 import logging
+import subprocess
 from typing import TYPE_CHECKING
 
 import pytest
@@ -113,6 +114,187 @@ class TestForcePull:
         assert result.applied is False  # dry-run reports prediction only
         assert result.commits_pulled == 1  # would pull 1 commit
         assert not (git_repo_pair.local_path / "drynew.md").exists()
+
+
+class TestPullDivergenceClassification:
+    """#1292: the pipeline classifies the clone before merging or predicting.
+
+    The reported incident: a dry-run pull answered ``fast_forward=True`` for a
+    divergence the real pull then refused, so an operator watching writes
+    strand locally read the clone as healthy.
+    """
+
+    @staticmethod
+    def _local_commit(repo: Path, file_name: str, body: str) -> None:
+        """Commit one file on the local clone without pushing it."""
+        (repo / file_name).write_text(body)
+        _run_git(repo, "add", file_name)
+        _run_git(repo, "commit", "-m", f"local commit: {file_name}")
+
+    def _diverged_strategy(
+        self, pair: GitRepoPair, clone_name: str
+    ) -> GitWriteStrategy:
+        """Move the remote and the local clone onto the same file."""
+        _seed_remote_commit(
+            pair,
+            clone_name=clone_name,
+            file_name="shared.md",
+            body="from remote\n",
+        )
+        self._local_commit(pair.local_path, "shared.md", "from local\n")
+        return GitWriteStrategy(
+            enable_pull=True, enable_push=False, repo_path=pair.local_path
+        )
+
+    def test_dry_run_on_a_diverged_clone_says_diverged(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """The projection reports the divergence instead of a fast-forward."""
+        strategy = self._diverged_strategy(git_repo_pair, "clone_diverged_dry")
+        head_before = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+
+        result = strategy.force_pull(dry_run=True)
+
+        assert result.fast_forward is False
+        assert result.reason == "diverged"
+        assert result.applied is False
+        # The remote-only commit is still counted: it is what the pull would
+        # reconcile against, even though the real pull rebases rather than
+        # fast-forwarding it in.
+        assert result.commits_pulled == 1
+        assert result.to_sha != result.from_sha
+        assert (
+            _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+            == head_before
+        )
+
+    def test_the_dry_run_prediction_holds_for_the_real_pull(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """The real pull on the same divergence also cannot fast-forward."""
+        strategy = self._diverged_strategy(git_repo_pair, "clone_diverged_real")
+
+        predicted = strategy.force_pull(dry_run=True)
+        actual = strategy.force_pull()
+
+        assert predicted.fast_forward is False
+        assert actual.fast_forward is predicted.fast_forward
+        # The real pull resolves the divergence rather than refusing it here;
+        # what the dry run promised is only that it would not be a
+        # fast-forward.
+        assert actual.reason == "conflicts_resolved_with_siblings"
+
+    def test_a_clone_that_is_only_ahead_pulls_nothing(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """Unpushed local commits leave HEAD alone — and are reported that way.
+
+        The remote tip is an ancestor of HEAD, so ``merge --ff-only`` is a
+        no-op success.  Reporting the remote tip as ``to_sha`` made a pull
+        that moved nothing look like a pull that moved HEAD backwards, which
+        is also what made ``git_sync`` reindex for it.
+        """
+        self._local_commit(git_repo_pair.local_path, "unpushed.md", "local\n")
+        strategy = GitWriteStrategy(
+            enable_pull=True, enable_push=False, repo_path=git_repo_pair.local_path
+        )
+        head = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+
+        result = strategy.force_pull()
+
+        assert result.applied is True
+        assert result.fast_forward is True
+        assert result.commits_pulled == 0
+        assert result.from_sha == head
+        assert result.to_sha == head
+        assert _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip() == head
+
+    def test_a_dry_run_on_a_clone_that_is_only_ahead_predicts_no_move(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """Same clone, projected: nothing to pull, so no SHA move to report."""
+        self._local_commit(git_repo_pair.local_path, "unpushed.md", "local\n")
+        strategy = GitWriteStrategy(
+            enable_pull=True, enable_push=False, repo_path=git_repo_pair.local_path
+        )
+
+        result = strategy.force_pull(dry_run=True)
+
+        assert result.fast_forward is True
+        assert result.reason is None
+        assert result.commits_pulled == 0
+        assert result.from_sha == result.to_sha
+
+    def test_an_available_fast_forward_can_still_fail_on_a_dirty_tree(
+        self, git_repo_pair: GitRepoPair
+    ) -> None:
+        """History says fast-forward; the working tree can still refuse it.
+
+        The classification only reads history, so the ``merge --ff-only``
+        attempt stays wrapped: an uncommitted edit to a file the incoming
+        commit also touches makes git refuse, and the pull falls back to the
+        rebase path (which cannot proceed on that tree either, leaving HEAD
+        where it was).
+        """
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_dirty_tree",
+            file_name="README.md",
+            body="remote edit\n",
+        )
+        (git_repo_pair.local_path / "README.md").write_text("uncommitted local\n")
+        strategy = GitWriteStrategy(
+            enable_pull=True, enable_push=False, repo_path=git_repo_pair.local_path
+        )
+        head = _run_git(git_repo_pair.local_path, "rev-parse", "HEAD").strip()
+
+        result = strategy.force_pull()
+
+        assert result.applied is False
+        assert result.reason == "conflict_resolution_failed"
+        assert result.from_sha == result.to_sha == head
+        # The uncommitted edit is still on disk — nothing was thrown away.
+        assert (
+            git_repo_pair.local_path / "README.md"
+        ).read_text() == "uncommitted local\n"
+
+    def test_an_unusable_ancestry_answer_does_not_promise_a_fast_forward(
+        self, git_repo_pair: GitRepoPair, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``merge-base`` failing outright must not read as "fast-forward".
+
+        Exit status is the whole answer, so any status other than 0 / 1
+        leaves the pipeline without one.  It then declines to promise the
+        fast-forward it cannot verify.
+        """
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_broken_mergebase",
+            file_name="seeded.md",
+            body="seeded\n",
+        )
+        strategy = GitWriteStrategy(
+            enable_pull=True, enable_push=False, repo_path=git_repo_pair.local_path
+        )
+        real_capturing = strategy._run_git_capturing
+
+        def _capturing(
+            git_root: Path, *args: str, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if args[:2] == ("merge-base", "--is-ancestor"):
+                return subprocess.CompletedProcess(
+                    args=["git", *args], returncode=128, stdout="", stderr="boom\n"
+                )
+            return real_capturing(git_root, *args, **kwargs)  # type: ignore[arg-type]
+
+        strategy._run_git_capturing = _capturing  # type: ignore[method-assign]
+
+        with caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"):
+            result = strategy.force_pull(dry_run=True)
+
+        assert result.fast_forward is False
+        assert result.reason == "diverged"
+        assert any("--is-ancestor" in r.message for r in caplog.records)
 
 
 class TestForcePush:

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -258,6 +258,94 @@ class TestGitSync:
         assert payload["push"]["applied"] is False
         assert payload["push"]["reason"] == "dry_run_unsupported", payload["push"]
 
+    async def test_dry_run_pull_on_a_diverged_clone_reports_diverged(
+        self, git_repo_pair: GitRepoPair, _git_managed_env: Path
+    ) -> None:
+        """#1292: the preview names the divergence the real pull would meet.
+
+        It previously answered ``fast_forward=true`` for a clone the real
+        pull could not fast-forward, so the reporter's stranded writes read
+        as a healthy clone on first inspection.
+        """
+        _seed_remote_commit(
+            git_repo_pair,
+            clone_name="clone_dry_diverged",
+            file_name="shared.md",
+            body="from remote\n",
+        )
+        (git_repo_pair.local_path / "shared.md").write_text("from local\n")
+        _run_git(git_repo_pair.local_path, "add", "shared.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "local edit")
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "git_sync", {"direction": "pull", "dry_run": True}
+            )
+
+        payload = _parse_tool_data(result)
+
+        assert payload["pull"]["fast_forward"] is False
+        assert payload["pull"]["reason"] == "diverged"
+        # The pull would still do work — it is the *kind* of work that the
+        # reason qualifies.
+        assert payload["pull"]["would_apply"] is True
+
+    async def test_dry_run_pull_with_only_unpushed_commits_would_apply_false(
+        self, git_repo_pair: GitRepoPair, _git_managed_env: Path
+    ) -> None:
+        """A clone that is only ahead has nothing to pull (#1292)."""
+        (git_repo_pair.local_path / "unpushed.md").write_text("local\n")
+        _run_git(git_repo_pair.local_path, "add", "unpushed.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "unpushed local commit")
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "git_sync", {"direction": "pull", "dry_run": True}
+            )
+
+        payload = _parse_tool_data(result)
+
+        assert payload["pull"]["would_apply"] is False
+        assert payload["pull"]["commits_pulled"] == 0
+        assert payload["pull"]["from_sha"] == payload["pull"]["to_sha"]
+
+    async def test_pull_with_only_unpushed_commits_does_not_reindex(
+        self,
+        git_repo_pair: GitRepoPair,
+        _git_managed_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A pull that moves nothing must not trigger a reindex (#1292).
+
+        The reindex is keyed on ``from_sha != to_sha``; naming the remote
+        tip as ``to_sha`` on a clone that is only ahead made every such
+        pull pause writes and rebuild the index for no new content.
+        """
+        from markdown_vault_mcp._server_tools import git as git_tools
+
+        calls: list[str] = []
+
+        async def _spy(_vault: Any, pull_dict: dict[str, Any]) -> None:
+            calls.append(pull_dict["to_sha"])
+
+        monkeypatch.setattr(git_tools, "_reindex_after_pull", _spy)
+
+        (git_repo_pair.local_path / "unpushed.md").write_text("local\n")
+        _run_git(git_repo_pair.local_path, "add", "unpushed.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "unpushed local commit")
+
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool("git_sync", {"direction": "pull"})
+
+        payload = _parse_tool_data(result)
+
+        assert payload["pull"]["applied"] is True
+        assert payload["pull"]["from_sha"] == payload["pull"]["to_sha"]
+        assert calls == []
+
     async def test_pull_conflict_returns_conflict_files(
         self, git_repo_pair: GitRepoPair, _git_managed_env: Path
     ) -> None:


### PR DESCRIPTION
## What this fixes

A dry-run `git_sync(direction="pull")` assumed the pull it modelled would
fast-forward. Against the reporter's diverged clone it answered
`fast_forward: true, would_apply: true` for a pull the real call then refused
with `conflict_resolution_failed` — so an operator watching writes strand
locally read the clone as benign on first inspection.

The pull pipeline now classifies the clone against the remote with
`git merge-base --is-ancestor` **before** it merges or predicts:

| Clone state | Dry run reports | Real pull |
|---|---|---|
| Up to date | `applied=true`, `would_apply=false` | no-op |
| Only ahead (unpushed commits) | `applied=true`, `would_apply=false` | no-op, HEAD unchanged |
| Behind | `fast_forward=true`, `commits_pulled=N` | `merge --ff-only` |
| Diverged | `fast_forward=false`, `reason="diverged"` | straight to rebase + sibling resolution |

A dry run projects from the same classification the real call acts on, so it
can no longer promise a fast-forward the real pull refuses. The real pull
skips the `merge --ff-only` it already knows cannot succeed. The attempt stays
wrapped in `try` because history saying "fast-forward" is not the whole answer:
a working tree with an uncommitted edit to an incoming file still refuses, and
falls back to the same rebase path.

The dry run does not predict *which* way the rebase ends — `rebased`,
`conflicts_resolved_with_siblings`, or a failure. It reports the divergence it
observed rather than guessing, which is what the reporter needed to see.

## Second fix, same lines: a clone that is only ahead

Unpushed local commits with the remote unmoved — the shape of the reported
deployment, where every push was being rejected. Both the dry run and the real
pull named the remote tip as `to_sha` for a pull that left HEAD exactly where
it was. That read as HEAD moving *backwards*, and because the reindex is keyed
on `from_sha != to_sha` it made every such pull rebuild the index for content
that never arrived — through `git_sync`, through the webhook handler, and
through the periodic loop (whose `sync_once` adapter is
`applied and to_sha != from_sha`). All three now see the no-op for what it is.

This was not in the issue; it surfaced while fixing the classification and
lives on the same lines, so it is fixed here with its own regression tests
rather than filed for later.

## The issue's open questions

- **`direction="push"` dry runs**: no gap. A dry-run push returns
  `applied=false, reason="dry_run_unsupported"` and contacts nothing — git has
  no local probe for "would the remote accept this", so there is no prediction
  to get wrong. No code change.
- **#467's `would_apply` SHA comparison**: adjacent but unaffected. It stays
  `from_sha != to_sha`; correcting `to_sha` on the only-ahead path is what
  makes it answer `false` there, which is what #467 wanted for the up-to-date
  case.

## Verification

Both defects were reproduced against the two-clone fixture before any code
changed, and all eight new tests were mutation-checked: with the fix reverted
they fail, with it in place they pass. Full suite 4211 passed, structural gate
100%, patch fully covered (the `merge --ff-only` failure branch, no longer
reachable via divergence, is now covered by a dirty-tree test).

## Self-review 84f94339..1676dd52

Charters: rules, diff, comments, history, conformance. Coverage: full;
single-agent (no subagent fan-out), no past-PR charter.

- `src/markdown_vault_mcp/git/types.py:45` — important/verified — `PullResult.applied`
  said "`False` for `dry_run` calls", which this change widens into a lie: a dry
  run with nothing to pull returns `True`.
  Evidence: `test_dry_run_pull_already_up_to_date_would_apply_false` asserts
  `payload["pull"]["applied"] is True`. Resolved in 1676dd52.
- `src/markdown_vault_mcp/git/strategy.py:841` — important/verified — `force_pull`'s
  own `dry_run` Args block carried the same unconditional "Returns `applied=False`"
  claim. Swept the class: `git grep "applied=False" src/ docs/ | grep -i dry` now
  returns only push-leg `dry_run_unsupported` text, which is accurate.
  Resolved in 1676dd52.
- `docs/design/design.md` — minor/verified — the LFS sentence said the tick skips
  `git lfs pull` when "HEAD is already up to date"; it now skips on any
  nothing-to-pull tick. Resolved in 1676dd52.

One deliberate choice, stated rather than changed:

- **`PULL_REASON_DIVERGED` is not re-exported** from `markdown_vault_mcp.git`.
  It follows `PULL_REASON_PULL_DISABLED` (#1128), the other recently added
  constant, which is also reachable only via `markdown_vault_mcp.git.types`.
  Exporting one and not the other would be the worse asymmetry.

## Review round (`598669de`)

Codex raised one P1: the two log calls this branch adds opened with a prose
prefix rather than the snake_case event name the logging standard requires.
I had justified them on module consistency; the rule is explicit and these
are new records, so they now conform — `git_merge_base_failed` and
`git_pull_diverged`.

The relocated `could not parse commit count` warning deliberately keeps its
wording: it is the same call moved into `_count_commits_behind`, not a new or
changed one, and two existing tests pin that text. Converting it would change
an operator-visible message unrelated to this fix.

Claude's review reported no bugs and no changes requested.

Not breaking: no operator surface changes, and the MCP tool surface gains a
reason value the client re-discovers on connect. The removed behaviour was a
misprediction, not a capability.

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RSxDv7WV6p6FD5kZ2h83U
