### PR TITLE
chore(release): port the v4.1.0 version stamps to main

### DIFF
--- a/.claude-plugin/plugin/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-vault-mcp",
   "description": "Generic markdown vault MCP with hybrid search",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "Peter van Liesdonk"
   },

--- a/.claude-plugin/plugin/.mcp.json
+++ b/.claude-plugin/plugin/.mcp.json
@@ -3,7 +3,7 @@
     "command": "uvx",
     "args": [
       "--from",
-      "markdown-vault-mcp[all]==4.0.0",
+      "markdown-vault-mcp[all]==4.1.0",
       "markdown-vault-mcp",
       "serve"
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-vault-mcp"
-version = "4.1.0-rc.0"
+version = "4.1.0"
 description = "Generic markdown vault MCP with hybrid search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pvliesdonk/markdown-vault-mcp",
   "title": "Markdown Vault MCP",
   "description": "Generic markdown vault MCP with hybrid search",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "websiteUrl": "https://pvliesdonk.github.io/markdown-vault-mcp/",
   "repository": {
     "url": "https://github.com/pvliesdonk/markdown-vault-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "markdown-vault-mcp",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -489,7 +489,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v4.0.0",
+      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v4.1.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{--port}/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -1793,7 +1793,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "4.1.0rc0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Closes / Refs

Closes #1322. Refs pvliesdonk/fastmcp-server-template#587, pvliesdonk/fastmcp-server-template#588.

## What & why

v4.1.0 was cut from `release/4.1`; the port-bookkeeping PR #1228 carried the changelog section only, so main's version stamps never learned about the release: `pyproject.toml` and `uv.lock` said `4.1.0-rc.0`, and `server.json` plus the two Claude plugin manifests still said `4.0.0`. Release Prepare on main therefore computed `4.1.0-rc.1` (run 33948056893) and failed in the notes promotion; with `override_version` it re-listed all of 4.1.0's changelog entries (PR #1321, closed).

This is the "land a version-stamp port to main first" remedy the workflow's own guard names. `pyproject.toml` is set to `4.1.0` by hand; `uv.lock`, `server.json`, `plugin.json` and `.mcp.json` come from `scripts/stamp_manifests.py 4.1.0`, the same script a stable release PR runs. Seven lines, stamps only. The three manifests now carry the latest stable, as AGENTS.md gate 7 requires.

## What this PR deliberately does NOT do

- Does not touch `CHANGELOG.md` (the 4.1.0 section is already on main from #1228) or `docs/releases/`.
- Does not make the `v4.1.0` tag reachable from main; whether the stamps alone are enough for knope to anchor the next changelog range after 4.1.0 is unverified and shows on the next Release Prepare dispatch.
- Does not change the template workflow; the guard and range problems are filed upstream (#587, #588).

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No commit carries `!`.

## Self-review db0c6997..1a4e98e4

Charters: rules, diff, comments, history. Conformance: no normative content. Past-PRs: skipped.
Coverage: full for the four run charters.

No findings. Verified: manifest lockstep (all three at 4.1.0), `tests/test_release_flow_contract.py` 62 passed, pyproject version line history is knope's prepare commits only.

## Docs impact

- [ ] `README.md` — no change needed
- [ ] `docs/` site pages — no change needed
- [ ] `docs/design/` — no change needed
- [ ] Inline docstrings — no code

---
_Generated by [Claude Code](https://claude.ai/code)_
