### PR TITLE
chore(release): merge release/4.1 into main so v4.1.0 is in main's ancestry

### DIFF
--- a/.claude-plugin/plugin/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-vault-mcp",
   "description": "Generic markdown vault MCP with hybrid search",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "Peter van Liesdonk"
   },

--- a/.claude-plugin/plugin/.mcp.json
+++ b/.claude-plugin/plugin/.mcp.json
@@ -3,7 +3,7 @@
     "command": "uvx",
     "args": [
       "--from",
-      "markdown-vault-mcp[all]==4.0.0",
+      "markdown-vault-mcp[all]==4.1.0",
       "markdown-vault-mcp",
       "serve"
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ Narrative, rationale, and upgrade guidance live in
 
 <!-- version list -->
 
+## 4.1.0 (2026-08-30)
+
+### Features
+
+- Voyage embedding provider and the WRITE_PROTECT_EXISTING guard (#1169)
+- expose note size on the enumeration surfaces (#1171)
+- adopt template v6.0.0 and compose via pvl-core 5 (#1192)
+- ✨ Resolve the default search mode from what the vault can serve. (#1189)
+
+### Bug Fixes
+
+- v4.1 bug sweep — rename staging, webhook gating, blank query, changelog (#1163)
+- drop the pygments pins, which held the lock on the broken release (#1166)
+- make the template-conformance gate actually render (#1191)
+- let @claude review actually run a review (#1194)
+- give generated reserved files the frontmatter the index gate requires (#1196)
+- declare the font origins the SPA actually loads (#1199)
+- validate default_search_mode at the constructor boundary too (#1206)
+- give the release index the marker form the promotion matches (#1212)
+
 ## 4.1.0-rc.0 (2026-08-29)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-vault-mcp"
-version = "4.1.0-rc.0"
+version = "4.1.0"
 description = "Generic markdown vault MCP with hybrid search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pvliesdonk/markdown-vault-mcp",
   "title": "Markdown Vault MCP",
   "description": "Generic markdown vault MCP with hybrid search",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "websiteUrl": "https://pvliesdonk.github.io/markdown-vault-mcp/",
   "repository": {
     "url": "https://github.com/pvliesdonk/markdown-vault-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "markdown-vault-mcp",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -475,7 +475,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v4.0.0",
+      "identifier": "ghcr.io/pvliesdonk/markdown-vault-mcp:v4.1.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{--port}/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -1790,7 +1790,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "4.1.0rc0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Closes / Refs

Closes #1322. Refs pvliesdonk/fastmcp-server-template#587, #588.

## What & why

**Merge this PR with "Create a merge commit", not squash.** The ancestry is the deliverable: a squash would keep the 7-line stamp diff and throw away the reason for it.

`v4.1.0` was released from `release/4.1`. The port PR #1228 carried the changelog section only, so on `main` knope still saw `v4.0.0` as the last release: Release Prepare computed `4.1.0-rc.1` and failed in the notes promotion (run 33948056893); with `override_version` it re-listed every 4.1.0 entry under 4.2.0 (#1321, closed).

This branch is `main` plus a `--no-ff` merge of `release/4.1`, whose single unique commit is the 4.1.0 prepare commit that `v4.1.0` tags. Tree diff against `main`: the five version stamps (`pyproject.toml`, `uv.lock`, `server.json`, `plugin.json`, `.mcp.json`) to `4.1.0`, nothing else. `CHANGELOG.md` conflicted (both sides added the 4.1.0 section) and is resolved to `main`'s content.

Verified locally with `knope prepare-release --dry-run --prerelease-label rc` on this head: `Using commits since tag v4.1.0` → `4.2.0-rc.0`, changelog section = exactly the 25 post-4.1.0 PRs. On plain `main` the same dry run says `Using commits since tag v4.0.0`.

## What this PR deliberately does NOT do

- No content change beyond the stamps; `docs/releases/` and `CHANGELOG.md` text stay as on `main`.
- Does not fix the workflow guard (#587) or make the template's port job do this itself (#588).

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No commit carries `!`.

## Self-review db0c6997..cc33185c

Charters: rules, diff, comments, history. Conformance: no normative content. Past-PRs: skipped.
Coverage: full for the four run charters. No findings. Verified: manifests in lockstep at 4.1.0 (gate 7); `tests/test_release_flow_contract.py` 62 passed; `v4.1.0` is an ancestor of the head.

## Docs impact

- [ ] `README.md` — no change needed
- [ ] `docs/` site pages — no change needed
- [ ] `docs/design/` — no change needed
- [ ] Inline docstrings — no code

---
_Generated by [Claude Code](https://claude.ai/code)_
