### PR TITLE
chore: prepare release 4.2.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,39 @@ Narrative, rationale, and upgrade guidance live in
 
 <!-- version list -->
 
+## 4.2.0-rc.0 (2026-09-05)
+
+### Features
+
+- add VaultSettings so Vault construction is settings-first (#1224)
+- record skip tombstones so FTS absence means deleted (#1227)
+- push-triggered reindex for GitLab-hosted vaults (#1262)
+- embed queries and documents asymmetrically (#1270)
+- commit once per tool call, not once per file (#1265)
+- read a note at a revision, and name the one an overwrite replaced (#1288)
+
+### Bug Fixes
+
+- resolve commit identity at the tool edge so OIDC claims survive the dispatcher thread (#1226)
+- report every moved file to the write callback in move_folder (#1244)
+- adopt template v7 semantic roles (#1255)
+- enforce client-facing budgets (#1258)
+- adopt template v7.0.1 and de-fork the OIDC pages (#1260)
+- exclude reserved files from the stats OKF histograms (#1267)
+- scope the auto-commit's no-diff check to the operation's own paths (#1274)
+- commit the operation's own paths, not the whole index (#1275)
+- keep the file watcher when a webhook cannot deliver on this transport (#1277)
+- keep ProjectConfig importable under the generator's dep floor (#1279)
+- normalize attachment-extension spellings on the way in (#1280)
+- accept the object IDs a SHA-256 repository mints (#1286)
+- stop handing back non-ASCII note paths git octal-escaped (#1291)
+- stop attributing a previous note's commits to one that reused its name (#1298)
+- tell a caller when its write cannot leave the host (#1300)
+- stop predicting a fast-forward for a pull that would diverge (#1301)
+- treat a note's name as a name, not a glob, wherever git takes a pathspec (#1305)
+- follow a note's renames at the same threshold in every reader (#1302)
+- give a note renamed while resolving a merge its history back (#1314)
+
 ## 4.1.0 (2026-08-30)
 
 ### Features

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -1,8 +1,8 @@
-# Next release
+# 4.2
 
 <!-- notes-range-end: e24837818b579aec1959a8bc5607606e4649664d -->
 
-<!-- RELEASE-SUMMARY NEXT START -->
+<!-- RELEASE-SUMMARY v4.2.0 START -->
 This release is about trusting the git layer. On a git-backed vault, an
 agent can now undo an overwrite from the client: an overwriting `write`
 names the commit holding what it replaced, and `read` accepts a `revision`
@@ -17,7 +17,7 @@ arrive in full on Claude Code instead of losing their tail to a 2,048-unit
 cap. Nothing breaks: no env var, tool, or library import changes meaning.
 Two one-time costs on first start after upgrade: every vault rebuilds its
 text index once, and a Voyage vault re-embeds once.
-<!-- RELEASE-SUMMARY NEXT END -->
+<!-- RELEASE-SUMMARY v4.2.0 END -->
 
 This is the first release since [4.1](4.1.md). Most of it happened in one
 place, the git integration, pushed by two outside reports: a vault where one
@@ -424,3 +424,6 @@ on your part:
 This release is not the FastMCP 4 move: the template's v8 line and
 fastmcp-pvl-core 7 carry that migration, tracked for the next major as
 [#1271](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1271).
+
+<!-- PATCH-RELEASES-START -->
+<!-- PATCH-RELEASES-END -->

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -9,6 +9,7 @@ behind it.
 <!-- RELEASE-PAGES-START: newest series first; one list entry per page.
      Release Prepare inserts the new series entry directly below this
      comment when it promotes the staged notes. -->
+- [4.2](4.2.md)
 - [4.1](4.1.md)
 - [4.0](4.0.md).
 - [3.1](3.1.md) (released July 8, 2026). Backfilled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-vault-mcp"
-version = "4.1.0"
+version = "4.2.0-rc.0"
 description = "Generic markdown vault MCP with hybrid search"
 readme = "README.md"
 license = "MIT"  # project-owned — keep across copier updates

--- a/uv.lock
+++ b/uv.lock
@@ -1793,7 +1793,7 @@ wheels = [
 
 [[package]]
 name = "markdown-vault-mcp"
-version = "4.1.0"
+version = "4.2.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **4.2.0-rc.0** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

The deterministic promotion step checked that this PR carries release notes
under `docs/releases/`. Reviewers must compare the page's `notes-range-end`
with the release delta and verify that every meaningful behavior change is
covered. If meaningful behavior is missing, merge a normal notes PR into the
base branch and re-dispatch Release Prepare.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Features

- add VaultSettings so Vault construction is settings-first (#1224)
- record skip tombstones so FTS absence means deleted (#1227)
- push-triggered reindex for GitLab-hosted vaults (#1262)
- embed queries and documents asymmetrically (#1270)
- commit once per tool call, not once per file (#1265)
- read a note at a revision, and name the one an overwrite replaced (#1288)

## Bug Fixes

- resolve commit identity at the tool edge so OIDC claims survive the dispatcher thread (#1226)
- report every moved file to the write callback in move_folder (#1244)
- adopt template v7 semantic roles (#1255)
- enforce client-facing budgets (#1258)
- adopt template v7.0.1 and de-fork the OIDC pages (#1260)
- exclude reserved files from the stats OKF histograms (#1267)
- scope the auto-commit's no-diff check to the operation's own paths (#1274)
- commit the operation's own paths, not the whole index (#1275)
- keep the file watcher when a webhook cannot deliver on this transport (#1277)
- keep ProjectConfig importable under the generator's dep floor (#1279)
- normalize attachment-extension spellings on the way in (#1280)
- accept the object IDs a SHA-256 repository mints (#1286)
- stop handing back non-ASCII note paths git octal-escaped (#1291)
- stop attributing a previous note's commits to one that reused its name (#1298)
- tell a caller when its write cannot leave the host (#1300)
- stop predicting a fast-forward for a pull that would diverge (#1301)
- treat a note's name as a name, not a glob, wherever git takes a pathspec (#1305)
- follow a note's renames at the same threshold in every reader (#1302)
- give a note renamed while resolving a merge its history back (#1314)
