### PR TITLE
fix(scanner): resolve links the way markdown writes them

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -84,6 +84,7 @@ Authentik
 automations
 backlink
 backlinks
+basename
 basenames
 beartype
 binariness

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1998,8 +1998,22 @@ Links are extracted from markdown content during `parse_note()` and stored in th
 - **Wikilinks**: `[[path]]`, `[[path|alias]]`, `[[path#heading]]`
 
 **Exclusions**: links inside fenced code blocks (`` ``` ``) and inline code (`` ` ``)
-are not extracted. External URLs (`http://`, `https://`, `mailto:`) and pure anchors
-are skipped. "Pure anchor" covers every spelling of a same-document reference:
+are not extracted. External destinations and pure anchors are skipped.
+
+**A destination carrying any URI scheme is external.** The filter was an
+allowlist of four prefixes (`http://`, `https://`, `mailto:`, `//`) until
+#1335, so every other scheme fell through to vault-path resolution: a
+`file:///E:/…` link was joined against the source note's folder, collapsed to
+`file:/E:/…` by path normalisation, and reported broken — as were `ftp:`,
+`obsidian:` and `zotero:`, all of which appear in real vaults. The test is now
+the shape RFC 3986 gives a scheme, anchored at the start of the destination,
+requiring **two or more** characters before the colon: one letter is a Windows
+drive (`C:/notes/topic.md`), which is a path. `//` stays named explicitly
+because a protocol-relative URL has no scheme to match. The same test now
+guards wikilinks, where `[[https://example.com]]` had been storing
+`https://example.com.md`.
+
+"Pure anchor" covers every spelling of a same-document reference:
 `[text](#heading)`, a reference definition whose target starts with `#`, and the
 wikilink form `[[#heading]]` (issue #1107). The wikilink form was the exception
 until #1107: its fragment is split off before `.md` is appended, so the empty path
@@ -2021,6 +2035,20 @@ external-URL skip did not recognise it and the path resolver joined it against
 the source note's directory, collapsing `https://` to `https:/` in the stored
 `target_path`. Both halves of reference extraction now skip labels beginning
 with `^`.
+
+**No link spans a paragraph.** The inline-link regex bounded link text with
+`[^\]]*` and the destination with `[^)]+`, and both character classes match
+newlines (#1334). A single unmatched `[` therefore paired with a `](`
+thousands of characters later, indexing several paragraphs of prose as one
+link whose destination was whatever followed — including destinations
+containing literal newlines. Beyond the wrong rows, `get_broken_links` and
+`get_outlinks` returned those multi-kilobyte `link_text` values verbatim,
+making one call very expensive in an LLM context. The bound follows
+CommonMark: link text may contain a *soft* break but not a blank line
+(`(?:[^\]\n]|\n(?![ \t]*\n))*`), and a destination contains no newline at
+all. The same unbounded shape was swept from the reference-usage,
+reference-definition and wikilink regexes in the same change — a wikilink has
+no multi-line form in Obsidian either.
 
 **Path resolution for markdown links**: relative paths are resolved against the
 source document's directory. `../sibling.md` from `Journal/2024/today.md` resolves
@@ -2062,6 +2090,21 @@ vault-wide resolution rules rather than relative path resolution:
   the source document's directory at scan time, identical to markdown links.
 
 - `[[Note Title]]` appends `.md` → `Note Title.md` before resolution.
+
+- **Wikilinks to attachments** (`![[diagram.png]]`, Obsidian's embed syntax):
+  a target whose extension is in the configured attachment allowlist names
+  that attachment, and keeps its own extension. Appending `.md` produced
+  `diagram.png.md`, a target that cannot exist, so every image and PDF embed
+  was permanently in `get_broken_links` and inflated `broken_link_count`
+  (#1333). The decision has to happen at extraction time: attachments are not
+  indexed — `list_documents(include_attachments=True)` walks the filesystem —
+  so `resolve_vault_wikilinks()` has no rows to match against. This is why
+  `IndexManager` (and through it `parse_note` / `scan_directory`) carries the
+  allowlist. Under the `*` wildcard the suffix must additionally *look* like
+  an extension (`[A-Za-z0-9]{1,8}`), or the note title `Version 2.0 plan`
+  would read as a `0 plan` attachment. Whether an embed should be recorded as
+  a link at all — `_extract_inline_links` skips `![alt](src)` — is a separate
+  question, deliberately left open.
 
 - **Alias resolution**: When no path match is found,
   `resolve_vault_wikilinks()` also checks the `document_aliases` table.

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2096,15 +2096,41 @@ vault-wide resolution rules rather than relative path resolution:
   that attachment, and keeps its own extension. Appending `.md` produced
   `diagram.png.md`, a target that cannot exist, so every image and PDF embed
   was permanently in `get_broken_links` and inflated `broken_link_count`
-  (#1333). The decision has to happen at extraction time: attachments are not
-  indexed — `list_documents(include_attachments=True)` walks the filesystem —
-  so `resolve_vault_wikilinks()` has no rows to match against. This is why
-  `IndexManager` (and through it `parse_note` / `scan_directory`) carries the
-  allowlist. Under the `*` wildcard the suffix must additionally *look* like
-  an extension (`[A-Za-z0-9]{1,8}`), or the note title `Version 2.0 plan`
-  would read as a `0 plan` attachment. Whether an embed should be recorded as
-  a link at all — `_extract_inline_links` skips `![alt](src)` — is a separate
-  question, deliberately left open.
+  (#1333). This is why `IndexManager` (and through it `parse_note` /
+  `scan_directory`) carries the allowlist. Under the `*` wildcard the suffix
+  must additionally *look* like an extension (`[A-Za-z0-9]{1,8}`), or the
+  note title `Version 2.0 plan` would read as a `0 plan` attachment. Whether
+  an embed should be recorded as a link at all — `_extract_inline_links`
+  skips `![alt](src)` — is a separate question, deliberately left open.
+
+**Attachment targets need two stages, because attachments are not indexed.**
+`list_documents(include_attachments=True)` walks the filesystem; `documents`
+holds notes only. Extraction therefore cannot be the whole fix, and neither
+can `resolve_vault_wikilinks()`, which has no rows to match an attachment
+against. The layers split cleanly:
+
+- **Index truth stays index truth.** `FTSIndex.get_broken_links()` and
+  `count_broken_links()` answer "is this target an indexed document", which
+  is the only question the index can answer, and their docstrings say so.
+- **`LinkManager` overlays vault truth**, because `source_dir` is what it
+  holds that the index does not. `utils.attachment_target_exists()` is the
+  single shared predicate — non-`.md`, allowlisted, resolving inside the
+  vault, present on disk — applied by `get_broken_links` (filters the row
+  out), `get_outlinks` (ORs into `exists`), and `count_broken_links` (counts
+  the same rows through the same predicate, so `stats.broken_link_count`
+  cannot disagree with the list). It covers markdown links to attachments
+  (`[x](data/file.txt)`) as well as wikilink embeds — the same defect class.
+- **The two attachment tests are deliberately different.**
+  `_names_attachment` in the scanner decides whether to append `.md`, and
+  under the `*` wildcard requires an extension-*shaped* suffix so a dotted
+  note title stays a note. `attachment_target_exists` mirrors what `read`
+  will actually serve, where under the wildcard an extensionless `Makefile`
+  *is* an attachment — so it applies no shape guard. They answer different
+  questions and must not be unified.
+
+The filesystem check runs only for a target that is non-`.md` and
+allowlisted, so a vault whose broken links are all notes pays nothing beyond
+the query the index already ran.
 
 - **Alias resolution**: When no path match is found,
   `resolve_vault_wikilinks()` also checks the `document_aliases` table.

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2935,7 +2935,7 @@ pattern). Each tool is annotated with MCP `ToolAnnotations`:
 | `embeddings_status` | Check embedding provider status | `True` | `False` | `True` |
 | `get_backlinks` | Find documents that link to a path | `True` | `False` | `True` |
 | `get_outlinks` | Find links from a document (with exists flag) | `True` | `False` | `True` |
-| `get_broken_links` | Find links to non-existent documents | `True` | `False` | `True` |
+| `get_broken_links` | Find links whose target is not in the vault | `True` | `False` | `True` |
 | `get_similar` | Find semantically similar notes by path | `True` | `False` | `True` |
 | `get_toc` | Heading outline for a note or folder subtree | `True` | `False` | `True` |
 | `get_recent` | Get most recently modified notes | `True` | `False` | `True` |

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2097,18 +2097,33 @@ vault-wide resolution rules rather than relative path resolution:
   `diagram.png.md`, a target that cannot exist, so every image and PDF embed
   was permanently in `get_broken_links` and inflated `broken_link_count`
   (#1333). This is why `IndexManager` (and through it `parse_note` /
-  `scan_directory`) carries the allowlist. Under the `*` wildcard the suffix
-  must additionally *look* like an extension (`[A-Za-z0-9]{1,8}`), or the
-  note title `Version 2.0 plan` would read as a `0 plan` attachment. Whether
-  an embed should be recorded as a link at all — `_extract_inline_links`
-  skips `![alt](src)` — is a separate question, deliberately left open.
+  `scan_directory`) carries the allowlist. The classification rule itself is
+  described under the three stages below. Whether an embed should be
+  recorded as a link at all — `_extract_inline_links` skips `![alt](src)` —
+  is a separate question, deliberately left open.
 
-**Attachment targets need two stages, because attachments are not indexed.**
-`list_documents(include_attachments=True)` walks the filesystem; `documents`
-holds notes only. Extraction therefore cannot be the whole fix, and neither
-can `resolve_vault_wikilinks()`, which has no rows to match an attachment
-against. The layers split cleanly:
+**Attachment targets need three stages, because attachments are not
+indexed.** `list_documents(include_attachments=True)` walks the filesystem;
+`documents` holds notes only. Extraction alone therefore cannot be the fix,
+and the vault-wide resolver cannot find an attachment in rows that do not
+exist. The layers split as follows:
 
+- **Extraction classifies the name.** `utils.names_attachment()` decides
+  whether `.md` is appended. It is the *name*'s kind, not the file's
+  presence: a `.md` target is a note in every configuration, and otherwise
+  the suffix must be allowlisted — plus, under the `*` wildcard,
+  extension-*shaped* (`[A-Za-z0-9]{1,8}`), so the note title
+  `Version 2.0 plan` does not read as a `0 plan` attachment.
+- **Resolution asks the same predicate.** `resolve_vault_wikilinks()`
+  receives the attachment population (supplied by `IndexManager`, one walk
+  per pass) and matches it against the target *as written*, before the
+  `.md` note fallback. A target `names_attachment()` classifies as an
+  attachment stops there whether or not the file exists — otherwise a
+  missing `pic.png` gains `.md` and matches any note called `pic.png.md`,
+  reporting an existing link to something unrelated. Extraction made that
+  classification when it declined to append `.md`; resolution has to agree,
+  which is why one predicate serves both. Two stages disagreeing about what
+  a name *is* is the whole defect class here.
 - **Index truth stays index truth.** `FTSIndex.get_broken_links()` and
   `count_broken_links()` answer "is this target an indexed document", which
   is the only question the index can answer, and their docstrings say so.
@@ -2120,17 +2135,34 @@ against. The layers split cleanly:
   the same rows through the same predicate, so `stats.broken_link_count`
   cannot disagree with the list). It covers markdown links to attachments
   (`[x](data/file.txt)`) as well as wikilink embeds — the same defect class.
-- **The two attachment tests are deliberately different.**
-  `_names_attachment` in the scanner decides whether to append `.md`, and
-  under the `*` wildcard requires an extension-*shaped* suffix so a dotted
-  note title stays a note. `attachment_target_exists` mirrors what `read`
-  will actually serve, where under the wildcard an extensionless `Makefile`
-  *is* an attachment — so it applies no shape guard. They answer different
-  questions and must not be unified.
+
+**`names_attachment` and `attachment_target_exists` are deliberately
+different and must not be unified.** The first asks what a *name* is, and
+applies the wildcard shape guard. The second mirrors what `read` will
+actually serve, where under the wildcard an extensionless `Makefile` *is* an
+attachment — so it applies no shape guard. Different questions, different
+answers.
 
 The filesystem check runs only for a target that is non-`.md` and
 allowlisted, so a vault whose broken links are all notes pays nothing beyond
 the query the index already ran.
+
+**An attachment mutation re-resolves the graph.** Attachments carry no index
+rows, so `write_attachment`, and the attachment branches of `delete` and
+`rename`, mark the path dirty purely for the effect on resolution: the
+per-path step is a no-op for an unindexed file, and the
+`resolve_vault_wikilinks()` pass `process_dirty_paths` always ends with is
+the point. Without it an embed written before its file stayed unresolved
+until an unrelated write or a manual reindex.
+
+**The allowlist is build provenance.** Because extraction reads it, it is
+the first *content* setting to change how a note's rows derive from its
+bytes, so it rides in `ChunkingMeta` and is compared on warm restart.
+`canonical_attachment_extensions()` renders the default set as `""` (an
+index predating the key compares equal) and an *explicitly empty* allowlist
+as a distinct sentinel — the two are different configurations deriving
+different rows, and collapsing them let a switch between them keep serving
+the old interpretation.
 
 - **Alias resolution**: When no path match is found,
   `resolve_vault_wikilinks()` also checks the `document_aliases` table.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -318,6 +318,36 @@ exempts from typing
 histograms now cover the same note population `okf_validate` audits, and
 reserved files are reported separately as `reserved_count`.
 
+**Links resolve the way markdown writes them.** Four defects in link
+extraction were found together on a live vault and fixed together, because
+they share one stage of the pipeline and one rebuild.
+
+A stray unmatched `[` used to pair with a `](` thousands of characters
+later: neither the link text nor the destination was bounded to a
+paragraph, so whole pages of prose were indexed as one link, and
+`get_broken_links` returned those multi-kilobyte values verbatim — wrong
+data, and an expensive answer
+([#1334](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1334)).
+Links now follow CommonMark: text may wrap a line but not cross a blank
+one, and a destination never contains a newline.
+
+Obsidian's image and PDF embeds — `![[diagram.png]]` — were permanently
+broken links. The scanner appended `.md` to every wikilink target without
+one, so `diagram.png` was looked up as `diagram.png.md`, which cannot exist
+([#1333](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1333)). A
+target whose extension is in `ATTACHMENT_EXTENSIONS` now names that
+attachment. On the vault where this was found it accounted for roughly one
+broken link in eight.
+
+A destination carrying any URI scheme is now external. The filter was an
+allowlist of four prefixes, so `file:`, `ftp:`, `obsidian:` and `zotero:`
+links were resolved against the source note's folder and reported broken
+([#1335](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1335)). A
+single letter before the colon is still a Windows drive, not a scheme.
+
+Together these change how a note's stored link rows derive from its bytes,
+which is what the one-time index rebuild under Upgrading is for.
+
 ## Configuration and its documentation
 
 **The OIDC pages stopped steering readers into the wrong mode.** The 4.1
@@ -401,12 +431,19 @@ meaning; the operator surface only grew (two GitLab webhook variables,
 `INSTANCE_DESCRIPTION`). A few things do change behavior without any action
 on your part:
 
-- **The text index rebuilds once on first start.** Recording skip
-  tombstones changed how stored rows derive from a note's bytes, so
-  `INDEX_SEMANTICS_VERSION` moved from 2 to 3
-  ([#1227](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1227)).
-  The rebuild is automatic, costs CPU and local IO proportional to vault
-  size, and does not re-embed.
+- **The text index rebuilds once on first start.** Two changes in this
+  release alter how stored rows derive from a note's bytes — recording skip
+  tombstones
+  ([#1227](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1227)) and
+  the link-extraction fixes above — so `INDEX_SEMANTICS_VERSION` moved from
+  2 to 4. The rebuild is automatic, happens once regardless of how many
+  changes triggered it, costs CPU and local IO proportional to vault size,
+  and does not re-embed.
+- **Your broken-link count will drop, and some links will start
+  resolving.** That is the link-extraction fix landing, not data loss:
+  attachment embeds, schemed URLs and prose mis-read as links leave
+  `get_broken_links`, and backlinks appear for targets that never resolved
+  before.
 - **A Voyage vault also re-embeds once**, through a separate mechanism
   with a separate trigger: the provider's embedding behavior is part of the
   vector sidecar's identity, and asymmetric embedding changed it

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -343,6 +343,14 @@ ordinary `[x](data/file.txt)` markdown link. `stats.broken_link_count` is
 counted through the same check, so it agrees with what `get_broken_links`
 returns.
 
+Embeds resolve the way Obsidian writes them, by basename: `![[pic.png]]`
+finds the file wherever it lives, so a vault keeping its images in `assets/`
+or `Images/` needs no path-qualified embed. A note that happened to be named
+`pic.png.md` used to capture such an embed, and no longer does. Because link
+extraction now reads `ATTACHMENT_EXTENSIONS`, that setting is recorded with
+the index: changing it rebuilds once on the next start, so notes whose bytes
+never moved still pick up the new answer.
+
 A destination carrying any URI scheme is now external. The filter was an
 allowlist of four prefixes, so `file:`, `ftp:`, `obsidian:` and `zotero:`
 links were resolved against the source note's folder and reported broken

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -325,23 +325,23 @@ they share one stage of the pipeline and one rebuild.
 A stray unmatched `[` used to pair with a `](` thousands of characters
 later: neither the link text nor the destination was bounded to a
 paragraph, so whole pages of prose were indexed as one link, and
-`get_broken_links` returned those multi-kilobyte values verbatim — wrong
-data, and an expensive answer
+`get_broken_links` returned those multi-kilobyte values verbatim. That is
+wrong data, and an expensive answer
 ([#1334](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1334)).
 Links now follow CommonMark: text may wrap a line but not cross a blank
 one, and a destination never contains a newline.
 
-Obsidian's image and PDF embeds — `![[diagram.png]]` — were permanently
+Obsidian's image and PDF embeds (`![[diagram.png]]`) were permanently
 broken links, roughly one reported broken link in eight on the vault where
 this was found. The scanner appended `.md` to every wikilink target without
 one, and nothing downstream could recover: attachments are not indexed, so
 the index reported every link to one as pointing at a missing document
 ([#1333](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1333)). A
 link naming an allowlisted attachment that is present in the vault is now
-resolved against the same files `read` serves — as a wikilink embed or as an
-ordinary `[x](data/file.txt)` markdown link — and `stats.broken_link_count`
-is counted through the same check, so it agrees with what
-`get_broken_links` returns.
+resolved against the same files `read` serves, as a wikilink embed or as an
+ordinary `[x](data/file.txt)` markdown link. `stats.broken_link_count` is
+counted through the same check, so it agrees with what `get_broken_links`
+returns.
 
 A destination carrying any URI scheme is now external. The filter was an
 allowlist of four prefixes, so `file:`, `ftp:`, `obsidian:` and `zotero:`
@@ -436,10 +436,10 @@ meaning; the operator surface only grew (two GitLab webhook variables,
 on your part:
 
 - **The text index rebuilds once on first start.** Two changes in this
-  release alter how stored rows derive from a note's bytes — recording skip
+  release alter how stored rows derive from a note's bytes: recording skip
   tombstones
   ([#1227](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1227)) and
-  the link-extraction fixes above — so `INDEX_SEMANTICS_VERSION` moved from
+  the link-extraction fixes above, so `INDEX_SEMANTICS_VERSION` moved from
   2 to 4. The rebuild is automatic, happens once regardless of how many
   changes triggered it, costs CPU and local IO proportional to vault size,
   and does not re-embed.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -332,12 +332,16 @@ Links now follow CommonMark: text may wrap a line but not cross a blank
 one, and a destination never contains a newline.
 
 Obsidian's image and PDF embeds — `![[diagram.png]]` — were permanently
-broken links. The scanner appended `.md` to every wikilink target without
-one, so `diagram.png` was looked up as `diagram.png.md`, which cannot exist
+broken links, roughly one reported broken link in eight on the vault where
+this was found. The scanner appended `.md` to every wikilink target without
+one, and nothing downstream could recover: attachments are not indexed, so
+the index reported every link to one as pointing at a missing document
 ([#1333](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1333)). A
-target whose extension is in `ATTACHMENT_EXTENSIONS` now names that
-attachment. On the vault where this was found it accounted for roughly one
-broken link in eight.
+link naming an allowlisted attachment that is present in the vault is now
+resolved against the same files `read` serves — as a wikilink embed or as an
+ordinary `[x](data/file.txt)` markdown link — and `stats.broken_link_count`
+is counted through the same check, so it agrees with what
+`get_broken_links` returns.
 
 A destination carrying any URI scheme is now external. The filter was an
 allowlist of four prefixes, so `file:`, `ftp:`, `obsidian:` and `zotero:`

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -25,7 +25,7 @@ markdown-vault-mcp exposes MCP tools across several categories. Write tools are 
 | [`get_index_status`](#get_index_status) | Index Status | Read | Check background FTS build state (queryable / building / failed) |
 | [`get_backlinks`](#get_backlinks) | Backlinks | Read | Find all documents that link to a given document |
 | [`get_outlinks`](#get_outlinks) | Outlinks | Read | Find all links from a document, with existence check |
-| [`get_broken_links`](#get_broken_links) | Broken Links | Read | Find all links pointing to non-existent documents |
+| [`get_broken_links`](#get_broken_links) | Broken Links | Read | Find all links whose target is not in the vault |
 | [`get_similar`](#get_similar) | Similar Notes | Read | Find semantically similar notes by document path |
 | [`get_toc`](#get_toc) | Table of Contents | Read | Heading outline for a note or a folder subtree |
 | [`get_recent`](#get_recent) | Recent Notes | Read | Get the most recently modified notes |
@@ -823,11 +823,17 @@ Find all links from a document, with existence check.
 | `limit` | int | `null` | Maximum number of outlinks to return. Omitted (the default) returns all. |
 | `wait_for_pending_writes` | bool | `false` | Block until the IndexWriter drains before answering, then report freshness via `_meta.index_stale` (see the *Index freshness on read tools* note at the top of this page). |
 
-**Returns:** List of link targets with an `exists` field indicating whether the target document is in the vault. Each entry has `target_path`, `link_text`, `link_type`, `fragment`, `raw_target`, and `exists` fields. Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).
+**Returns:** List of link targets with an `exists` field indicating whether the target is present in the vault. A target counts as present when it is an indexed note, or an attachment on disk whose extension is in `ATTACHMENT_EXTENSIONS`. Attachments are not indexed, so `![[diagram.png]]` and `[x](data/file.txt)` resolve against the same files `read` serves. Each entry has `target_path`, `link_text`, `link_type`, `fragment`, `raw_target`, and `exists` fields. Index freshness is reported in `_meta.index_stale` (see the freshness note at the top of this page).
 
 ### `get_broken_links`
 
-Find all links across the vault pointing to non-existent documents.
+Find all links across the vault whose target is not in the vault.
+
+A link counts as broken when nothing is at its target path: neither an
+indexed note, nor an allowlisted attachment on disk. A wikilink embed such as
+`![[diagram.png]]` does not appear here when the file exists, even though
+attachments are never indexed. `stats.broken_link_count` is counted
+through the same test, so the two always agree.
 
 **Parameters:**
 

--- a/src/markdown_vault_mcp/_server_tools/graph.py
+++ b/src/markdown_vault_mcp/_server_tools/graph.py
@@ -155,7 +155,7 @@ def register(mcp: FastMCP) -> None:
             - link_type (str): One of "markdown", "wikilink", or "reference".
             - fragment (str | None): Heading anchor (e.g. "#section"), or null.
             - raw_target (str): Literal link target as written in the source.
-            - exists (bool): True if the target document is indexed.
+            - exists (bool): True if the target is in the vault.
 
             Index freshness is reported out-of-band in the response's
             ``_meta.index_stale`` field — True when the IndexWriter had
@@ -203,8 +203,8 @@ def register(mcp: FastMCP) -> None:
         Use this to audit link health across the vault. Call this when
         'stats' shows broken_link_count > 0, or after a 'rename' that did
         not use update_links=True, to see what links were left pointing to
-        the old path. A broken link means the target path does not match any
-        indexed document — the referenced note may have been deleted, renamed,
+        the old path. A broken link means nothing in the vault is at the
+        target path — the referenced note may have been deleted, renamed,
         or never created.
 
         Args:

--- a/src/markdown_vault_mcp/_server_tools/graph.py
+++ b/src/markdown_vault_mcp/_server_tools/graph.py
@@ -198,7 +198,7 @@ def register(mcp: FastMCP) -> None:
         wait_for_pending_writes: _WaitForPendingWrites = False,
         vault: Vault = Depends(get_vault),
     ) -> list[dict[str, Any]]:
-        """Find all links that point to non-existent documents (broken links).
+        """Find all links whose target is not in the vault (broken links).
 
         Use this to audit link health across the vault. Call this when
         'stats' shows broken_link_count > 0, or after a 'rename' that did

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -872,7 +872,7 @@ def register(mcp: FastMCP) -> None:
               - link_type (str): One of "markdown", "wikilink", or "reference".
               - fragment (str | None): Heading anchor (e.g. "#section"), or null.
               - raw_target (str): Literal link target as written in the source.
-              - exists (bool): True if the target document is indexed.
+              - exists (bool): True if the target is in the vault.
 
             - similar (list): Semantically similar notes, field-collapsed by
               file (chunks_per_file=1 for compact dossiers).  List of dicts,

--- a/src/markdown_vault_mcp/facets/graph.py
+++ b/src/markdown_vault_mcp/facets/graph.py
@@ -93,7 +93,8 @@ class GraphFacet:
         """Return all links from the given document to other documents.
 
         The ``exists`` field on each :class:`~markdown_vault_mcp.types.OutlinkInfo`
-        indicates whether the target document is currently indexed.
+        indicates whether the target is present in the vault — an indexed
+        note, or an allowlisted attachment on disk (#1333).
 
         Args:
             path: Relative path of the source document
@@ -114,6 +115,9 @@ class GraphFacet:
 
     def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
         """Return all links whose target does not exist in the vault.
+
+        A link naming an allowlisted attachment that is present on disk is
+        not broken, even though attachments are never indexed (#1333).
 
         Args:
             folder: If provided, restrict to source documents in this folder

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -49,7 +49,7 @@ from markdown_vault_mcp.types import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -217,6 +217,13 @@ _META_SEARCHABLE_FIELDS_KEY = "searchable_fields"
 # searchable_fields (which only shares its value when SEARCHABLE_FIELDS is
 # left to default to INDEXED_FIELDS).
 _META_INDEXED_FIELDS_KEY = "indexed_frontmatter_fields"
+#: Canonical attachment allowlist in force at build time. Link extraction
+#: consults it to tell a wikilink naming an attachment from one naming a note
+#: (#1333), which makes it the first *content* config to change how a note's
+#: stored rows derive from its bytes. Without it here, flipping
+#: ``ATTACHMENT_EXTENSIONS`` leaves an unchanged note's stale ``pic.png.md``
+#: link row in place until something else forces a rebuild.
+_META_ATTACHMENT_EXTENSIONS_KEY = "attachment_extensions"
 
 # Derived-content provenance: the version of this server's own parse-to-row
 # pipeline (#1124). Unlike every key above it, this records no operator input
@@ -274,6 +281,10 @@ class ChunkingMeta(NamedTuple):
         indexed_frontmatter_fields: Comma-joined canonical form of the
             frontmatter fields promoted to ``document_tags`` for structured
             filtering (default ``""`` — none configured).
+        attachment_extensions: Comma-joined canonical attachment allowlist in
+            force at build time (default ``""`` — the built-in set). Link
+            extraction consults it (#1333), so a change to it changes the
+            stored link rows.
         semantics_version: :data:`INDEX_SEMANTICS_VERSION` in force when the
             build ran (``0`` for an index written before the key existed).
     """
@@ -283,6 +294,7 @@ class ChunkingMeta(NamedTuple):
     title_field: str = "title"
     searchable_fields: str = ""
     indexed_frontmatter_fields: str = ""
+    attachment_extensions: str = ""
     semantics_version: int = 0
 
 
@@ -1272,6 +1284,7 @@ class FTSIndex:
         title_field: str = "title",
         searchable_fields: str = "",
         indexed_frontmatter_fields: str = "",
+        attachment_extensions: str = "",
     ) -> None:
         """Record the embedding/indexing provenance used for this build.
 
@@ -1303,6 +1316,10 @@ class FTSIndex:
             indexed_frontmatter_fields: Comma-joined canonical
                 structured-filter field list. The default (no fields) is
                 already the empty string.
+            attachment_extensions: Comma-joined canonical attachment
+                allowlist. The default set is stored as the empty string so a
+                pre-upgrade index reads back as "unchanged" rather than as a
+                spurious mismatch.
         """
         conn = self._conn()
         model_value = "" if model is None else model
@@ -1319,6 +1336,7 @@ class FTSIndex:
                 (_META_TITLE_FIELD_KEY, title_value),
                 (_META_SEARCHABLE_FIELDS_KEY, searchable_fields),
                 (_META_INDEXED_FIELDS_KEY, indexed_frontmatter_fields),
+                (_META_ATTACHMENT_EXTENSIONS_KEY, attachment_extensions),
                 (_META_INDEX_SEMANTICS_KEY, str(INDEX_SEMANTICS_VERSION)),
             ):
                 conn.execute(
@@ -1344,13 +1362,14 @@ class FTSIndex:
         conn = self._conn()
         with conn:
             rows = conn.execute(
-                "SELECT key, value FROM meta WHERE key IN (?, ?, ?, ?, ?, ?)",
+                "SELECT key, value FROM meta WHERE key IN (?, ?, ?, ?, ?, ?, ?)",
                 (
                     _META_EMBED_MODEL_KEY,
                     _META_MAX_CHUNK_CHARS_OVERRIDE_KEY,
                     _META_TITLE_FIELD_KEY,
                     _META_SEARCHABLE_FIELDS_KEY,
                     _META_INDEXED_FIELDS_KEY,
+                    _META_ATTACHMENT_EXTENSIONS_KEY,
                     _META_INDEX_SEMANTICS_KEY,
                 ),
             ).fetchall()
@@ -1373,6 +1392,7 @@ class FTSIndex:
             title_field=stored.get(_META_TITLE_FIELD_KEY) or "title",
             searchable_fields=stored.get(_META_SEARCHABLE_FIELDS_KEY) or "",
             indexed_frontmatter_fields=stored.get(_META_INDEXED_FIELDS_KEY) or "",
+            attachment_extensions=stored.get(_META_ATTACHMENT_EXTENSIONS_KEY) or "",
             semantics_version=semantics_version,
         )
 
@@ -1913,7 +1933,7 @@ class FTSIndex:
         return [dict(row) for row in cur.fetchall()]
 
     @_retry_on_locked
-    def resolve_vault_wikilinks(self) -> int:
+    def resolve_vault_wikilinks(self, *, attachment_paths: Sequence[str] = ()) -> int:
         """Resolve vault-wide wikilink ``target_path`` values against the document set.
 
         Obsidian resolves bare wikilinks (e.g. ``[[Note]]``) by searching the
@@ -1935,6 +1955,20 @@ class FTSIndex:
         that document.  This mirrors Obsidian's alias resolution behaviour
         (e.g. ``[[AI]]`` resolves to a document with ``aliases: [AI]``).
 
+        Attachments resolve here too, and are tried **first** (#1333).
+        ``![[pic.png]]`` is Obsidian's embed syntax and names a file, not a
+        note, so the ``.md`` append that follows would look for
+        ``pic.png.md`` — a path that cannot exist, unless some unrelated note
+        happens to carry that name, in which case the embed silently resolved
+        to it. Trying the attachment population against the target *as
+        written* fixes both: the common layout where the file lives in
+        ``assets/`` or ``Images/`` while the embed names only its basename,
+        and the mis-resolution onto a same-named note.
+
+        Attachments are not indexed, so the caller supplies their paths;
+        ``IndexManager`` passes the same population
+        ``list_documents(include_attachments=True)`` serves.
+
         Wikilinks with an explicit relative prefix (``./`` or ``../``) are
         skipped; they are resolved relative to the source document at scan time
         and do not participate in vault-wide resolution.
@@ -1947,6 +1981,11 @@ class FTSIndex:
 
         Uses ``substr``/``length`` comparisons instead of ``LIKE`` to avoid
         wildcard-escaping issues with filenames that contain ``%`` or ``_``.
+
+        Args:
+            attachment_paths: Vault-relative paths of the allowlisted
+                attachments on disk. Empty means "notes only", which is the
+                pre-#1333 behaviour.
 
         Returns:
             Number of link rows whose ``target_path`` was updated.
@@ -1997,15 +2036,20 @@ class FTSIndex:
                 stem = stem[: stem.index("#")]
             if not stem:
                 continue
-            # 2. Append .md if not already present.
-            search_target = stem if stem.lower().endswith(".md") else stem + ".md"
-
-            # Find the best match: exact path or suffix match, shortest wins.
+            # 2. An attachment is named as written — no .md is appended —
+            #    and is tried first so an embed never resolves onto a
+            #    same-named note (#1333).
             candidates = [
-                p
-                for p in doc_paths
-                if p == search_target or p.endswith("/" + search_target)
+                p for p in attachment_paths if p == stem or p.endswith("/" + stem)
             ]
+            # 3. Otherwise this names a note: append .md if not already there.
+            if not candidates:
+                search_target = stem if stem.lower().endswith(".md") else stem + ".md"
+                candidates = [
+                    p
+                    for p in doc_paths
+                    if p == search_target or p.endswith("/" + search_target)
+                ]
             if not candidates:
                 # Fallback: check if the stem matches a document alias.
                 # Use the raw stem (without .md) for alias matching.

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -298,6 +298,57 @@ class ChunkingMeta(NamedTuple):
     semantics_version: int = 0
 
 
+def _resolve_one_wikilink(
+    raw_target: str,
+    *,
+    attachment_paths: Sequence[str],
+    doc_paths: Sequence[str],
+    alias_map: dict[str, list[str]],
+) -> str | None:
+    """Resolve one wikilink's ``raw_target`` to a vault path, or ``None``.
+
+    The vault-wide half of Obsidian's wikilink semantics, extracted from
+    :meth:`FTSIndex.resolve_vault_wikilinks` so the caller stays a batch loop.
+    Three populations are consulted in order, and the shortest match wins in
+    each — Obsidian's own tie-break:
+
+    1. **Attachments, against the target as written.** ``![[pic.png]]`` names
+       a file, so no ``.md`` is appended. Tried first so an embed can never
+       resolve onto a note that happens to be called ``pic.png.md`` (#1333).
+    2. **Notes**, with ``.md`` appended when the target lacks it.
+    3. **Aliases**, matched on the raw stem.
+
+    Args:
+        raw_target: The wikilink target as written, fragment included.
+        attachment_paths: Vault-relative paths of allowlisted attachments.
+        doc_paths: Vault-relative paths of indexed documents.
+        alias_map: Lower-cased alias to the paths declaring it.
+
+    Returns:
+        The resolved vault-relative path, or ``None`` when nothing matches
+        (a genuinely broken link) or the target is fragment-only.
+    """
+    stem = raw_target
+    if "#" in stem:
+        stem = stem[: stem.index("#")]
+    if not stem:
+        return None
+
+    candidates = [p for p in attachment_paths if p == stem or p.endswith("/" + stem)]
+    if not candidates:
+        search_target = stem if stem.lower().endswith(".md") else stem + ".md"
+        candidates = [
+            p
+            for p in doc_paths
+            if p == search_target or p.endswith("/" + search_target)
+        ]
+    if not candidates:
+        candidates = alias_map.get(stem.lower(), [])
+    if not candidates:
+        return None
+    return min(candidates, key=len)
+
+
 def _escape_like(value: str) -> str:
     """Escape SQLite LIKE special characters in ``value``.
 
@@ -2029,37 +2080,13 @@ class FTSIndex:
         # Resolve each wikilink in Python, then batch-UPDATE.
         updates: list[tuple[str, int]] = []
         for row in rows:
-            # Derive the search filename from raw_target:
-            # 1. Strip any trailing fragment (#heading).
-            stem = row["raw_target"]
-            if "#" in stem:
-                stem = stem[: stem.index("#")]
-            if not stem:
-                continue
-            # 2. An attachment is named as written — no .md is appended —
-            #    and is tried first so an embed never resolves onto a
-            #    same-named note (#1333).
-            candidates = [
-                p for p in attachment_paths if p == stem or p.endswith("/" + stem)
-            ]
-            # 3. Otherwise this names a note: append .md if not already there.
-            if not candidates:
-                search_target = stem if stem.lower().endswith(".md") else stem + ".md"
-                candidates = [
-                    p
-                    for p in doc_paths
-                    if p == search_target or p.endswith("/" + search_target)
-                ]
-            if not candidates:
-                # Fallback: check if the stem matches a document alias.
-                # Use the raw stem (without .md) for alias matching.
-                alias_candidates = alias_map.get(stem.lower(), [])
-                if alias_candidates:
-                    candidates = alias_candidates
-            if not candidates:
-                continue  # Genuinely broken — no document matches.
-            new_path = min(candidates, key=len)
-            if new_path != row["target_path"]:
+            new_path = _resolve_one_wikilink(
+                row["raw_target"],
+                attachment_paths=attachment_paths,
+                doc_paths=doc_paths,
+                alias_map=alias_map,
+            )
+            if new_path is not None and new_path != row["target_path"]:
                 updates.append((new_path, row["id"]))
 
         with conn:

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -47,6 +47,7 @@ from markdown_vault_mcp.types import (
     SubtreeNote,
     TocEntry,
 )
+from markdown_vault_mcp.utils.content_kind import names_attachment
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -304,6 +305,7 @@ def _resolve_one_wikilink(
     attachment_paths: Sequence[str],
     doc_paths: Sequence[str],
     alias_map: dict[str, list[str]],
+    attachment_extensions: frozenset[str],
 ) -> str | None:
     """Resolve one wikilink's ``raw_target`` to a vault path, or ``None``.
 
@@ -313,16 +315,25 @@ def _resolve_one_wikilink(
     each — Obsidian's own tie-break:
 
     1. **Attachments, against the target as written.** ``![[pic.png]]`` names
-       a file, so no ``.md`` is appended. Tried first so an embed can never
-       resolve onto a note that happens to be called ``pic.png.md`` (#1333).
+       a file, so no ``.md`` is appended (#1333).
     2. **Notes**, with ``.md`` appended when the target lacks it.
     3. **Aliases**, matched on the raw stem.
+
+    A target that :func:`~markdown_vault_mcp.utils.names_attachment`
+    classifies as an attachment stops after step 1, whether or not the file
+    is there. The note steps would append ``.md`` and hand a *missing*
+    ``pic.png`` to any note called ``pic.png.md``, reporting an existing link
+    to an unrelated note where the honest answer is a broken one. Extraction
+    made that classification when it declined to append ``.md``, so
+    resolution has to agree with it — which is why both call one predicate.
 
     Args:
         raw_target: The wikilink target as written, fragment included.
         attachment_paths: Vault-relative paths of allowlisted attachments.
         doc_paths: Vault-relative paths of indexed documents.
         alias_map: Lower-cased alias to the paths declaring it.
+        attachment_extensions: The effective attachment allowlist, used to
+            reach the same verdict extraction reached.
 
     Returns:
         The resolved vault-relative path, or ``None`` when nothing matches
@@ -335,15 +346,15 @@ def _resolve_one_wikilink(
         return None
 
     candidates = [p for p in attachment_paths if p == stem or p.endswith("/" + stem)]
-    if not candidates:
+    if not candidates and not names_attachment(stem, attachment_extensions):
         search_target = stem if stem.lower().endswith(".md") else stem + ".md"
         candidates = [
             p
             for p in doc_paths
             if p == search_target or p.endswith("/" + search_target)
         ]
-    if not candidates:
-        candidates = alias_map.get(stem.lower(), [])
+        if not candidates:
+            candidates = alias_map.get(stem.lower(), [])
     if not candidates:
         return None
     return min(candidates, key=len)
@@ -1984,7 +1995,12 @@ class FTSIndex:
         return [dict(row) for row in cur.fetchall()]
 
     @_retry_on_locked
-    def resolve_vault_wikilinks(self, *, attachment_paths: Sequence[str] = ()) -> int:
+    def resolve_vault_wikilinks(
+        self,
+        *,
+        attachment_paths: Sequence[str] = (),
+        attachment_extensions: frozenset[str] | None = None,
+    ) -> int:
         """Resolve vault-wide wikilink ``target_path`` values against the document set.
 
         Obsidian resolves bare wikilinks (e.g. ``[[Note]]``) by searching the
@@ -2037,6 +2053,10 @@ class FTSIndex:
             attachment_paths: Vault-relative paths of the allowlisted
                 attachments on disk. Empty means "notes only", which is the
                 pre-#1333 behaviour.
+            attachment_extensions: The effective allowlist, so a target
+                classified as an attachment is not resolved onto a note when
+                the file is missing. ``None`` classifies nothing as an
+                attachment, matching an empty *attachment_paths*.
 
         Returns:
             Number of link rows whose ``target_path`` was updated.
@@ -2085,6 +2105,7 @@ class FTSIndex:
                 attachment_paths=attachment_paths,
                 doc_paths=doc_paths,
                 alias_map=alias_map,
+                attachment_extensions=attachment_extensions or frozenset(),
             )
             if new_path is not None and new_path != row["target_path"]:
                 updates.append((new_path, row["id"]))

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -245,7 +245,16 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: ``documents``. An index built by an older pipeline has no tombstones, so
 #: its row absences are ambiguous (skipped vs. deleted); the bump forces the
 #: one cold rebuild that materialises tombstones for existing skips.
-INDEX_SEMANTICS_VERSION = 3
+#:
+#: Version 4 (#1332, #1333, #1334, #1335): link extraction changed how a
+#: note's ``links`` rows are derived from its bytes. Links no longer span a
+#: blank line, destinations no longer contain a newline, any URI scheme marks
+#: a destination external, and a wikilink naming an allowlisted attachment
+#: keeps its own extension instead of gaining ``.md``. An index built by an
+#: older pipeline still holds the prose-spanning, schemed and ``.png.md``
+#: rows the old code produced, so the bump forces the one cold rebuild that
+#: replaces them.
+INDEX_SEMANTICS_VERSION = 4
 
 
 class ChunkingMeta(NamedTuple):

--- a/src/markdown_vault_mcp/indexing/coordinator.py
+++ b/src/markdown_vault_mcp/indexing/coordinator.py
@@ -61,6 +61,7 @@ class IndexWriteCoordinator:
         title_field: str = "title",
         searchable_fields: str = "",
         indexed_frontmatter_fields: str = "",
+        attachment_extensions: str = "",
     ) -> None:
         self._fts = fts
         self._index_path = index_path
@@ -85,6 +86,13 @@ class IndexWriteCoordinator:
         # short-circuit (#927) even when SEARCHABLE_FIELDS is explicitly
         # overridden and would otherwise stay unchanged.
         self._indexed_frontmatter_fields = indexed_frontmatter_fields
+        # Link-extraction provenance: the attachment allowlist decides whether
+        # a wikilink target gains ``.md`` or names an attachment (#1333), so a
+        # change to it changes stored link rows for notes whose bytes never
+        # moved. Hash-based reindexing would never re-parse those notes, so
+        # without this the warm restart would keep serving `pic.png.md`
+        # forever. Comma-joined canonical form ("" for the default set).
+        self._attachment_extensions = attachment_extensions
         self._readiness = ReadinessState()
         # Deprecated background-build thread bookkeeping (guarded by the
         # injected file-write lock, matching the former Vault locking).
@@ -252,6 +260,11 @@ class IndexWriteCoordinator:
                 "indexed_frontmatter_fields",
                 stored.indexed_frontmatter_fields,
                 self._indexed_frontmatter_fields,
+            ),
+            (
+                "attachment_extensions",
+                stored.attachment_extensions,
+                self._attachment_extensions,
             ),
             (
                 "index_semantics_version",

--- a/src/markdown_vault_mcp/interfaces.py
+++ b/src/markdown_vault_mcp/interfaces.py
@@ -282,7 +282,12 @@ class GraphStore(Protocol):
         """Return the number of notes nothing links to."""
         ...
 
-    def resolve_vault_wikilinks(self, *, attachment_paths: Sequence[str] = ()) -> int:
+    def resolve_vault_wikilinks(
+        self,
+        *,
+        attachment_paths: Sequence[str] = (),
+        attachment_extensions: frozenset[str] | None = None,
+    ) -> int:
         """Resolve stored wikilink targets to real paths.
 
         A write, unlike the rest of this protocol: link targets are only

--- a/src/markdown_vault_mcp/interfaces.py
+++ b/src/markdown_vault_mcp/interfaces.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Sequence
     from pathlib import Path
 
     from markdown_vault_mcp.fts_index import ChunkingMeta
@@ -204,6 +204,7 @@ class KeywordIndex(Protocol):
         title_field: str = "title",
         searchable_fields: str = "",
         indexed_frontmatter_fields: str = "",
+        attachment_extensions: str = "",
     ) -> None:
         """Record the settings the current rows were derived under.
 
@@ -281,7 +282,7 @@ class GraphStore(Protocol):
         """Return the number of notes nothing links to."""
         ...
 
-    def resolve_vault_wikilinks(self) -> int:
+    def resolve_vault_wikilinks(self, *, attachment_paths: Sequence[str] = ()) -> int:
         """Resolve stored wikilink targets to real paths.
 
         A write, unlike the rest of this protocol: link targets are only

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -790,8 +790,32 @@ class DocumentManager:
                 *path* already exists while no *if_match* is supplied.
             ValueError: If the path escapes the source directory or has an
                 extension not in the allowlist.
+
+        An attachment is never indexed, but the link graph resolves wikilink
+        embeds against the attachments present on disk (#1333), so adding one
+        changes what ``![[pic.png]]`` resolves to. Marking the path dirty
+        routes that through the writer's existing choke point: the per-path
+        step is a no-op for an unindexed file, and the
+        ``resolve_vault_wikilinks()`` pass it always ends with is the part
+        that matters.
         """
-        return self._artifacts.write(path, content, if_match)
+        result = self._artifacts.write(path, content, if_match)
+        self._mark_attachment_dirty(path)
+        return result
+
+    def _mark_attachment_dirty(self, *paths: str) -> None:
+        """Schedule a link-graph re-resolution after an attachment mutation.
+
+        Attachments carry no index rows of their own, so this exists purely
+        for its side effect on wikilink resolution (#1333). Without it, an
+        embed written before its attachment stays unresolved until something
+        else marks a path dirty or a reindex runs.
+
+        Args:
+            paths: The attachment paths that were added, removed, or moved.
+        """
+        if self._mark_paths_dirty is not None:
+            self._mark_paths_dirty(list(paths))
 
     def edit(
         self,
@@ -1045,6 +1069,7 @@ class DocumentManager:
                     self._mark_paths_dirty([path])
             else:
                 abs_path = self._artifacts.unlink(path, if_match)
+                self._mark_attachment_dirty(path)
 
             self._notifier.fire(abs_path, "", "delete")
 
@@ -1134,6 +1159,7 @@ class DocumentManager:
                     self._mark_paths_dirty(dirty)
             else:
                 old_abs, new_abs = self._artifacts.move(old_path, new_path, if_match)
+                self._mark_attachment_dirty(old_path, new_path)
                 callback_content = ""
 
             self._notifier.fire_rename(new_abs, callback_content, old_abs)

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -42,7 +41,11 @@ from markdown_vault_mcp.utils import (
     is_note,
     is_path_excluded,
 )
-from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS, iter_markdown_files
+from markdown_vault_mcp.utils.fs import (
+    GLOB_SYMLINK_KWARGS,
+    iter_markdown_files,
+    vault_relative_in_scope,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -178,8 +181,10 @@ class IndexManager:
 
         Attachments are not indexed, so vault-wide wikilink resolution cannot
         find them in ``documents`` and every embed read as broken (#1333).
-        This walks the source tree the way ``list_documents`` does, applying
-        the same exclusion rules, and runs once per resolution pass rather
+        The in-scope rule is shared with the listing path through
+        :func:`~markdown_vault_mcp.utils.fs.vault_relative_in_scope`, so the
+        attachments a vault *serves* and the attachments its links *resolve
+        against* cannot drift apart. Runs once per resolution pass rather
         than once per link.
 
         Returns:
@@ -193,16 +198,19 @@ class IndexManager:
             try:
                 if not abs_path.is_file():
                     continue
-                rel = abs_path.relative_to(self._source_dir).as_posix()
-            except (OSError, ValueError):
+            except OSError:
+                # A racing delete or an unreadable component: not a reason to
+                # fail the whole build.
                 continue
-            if is_note(rel) or not is_allowed_artifact(
-                rel, self._attachment_extensions
-            ):
+            rel = vault_relative_in_scope(
+                abs_path,
+                self._source_dir,
+                is_excluded=self._is_path_excluded,
+                log_context="_attachment_paths",
+            )
+            if rel is None or is_note(rel):
                 continue
-            if any(part.startswith(".") for part in PurePosixPath(rel).parts):
-                continue
-            if self._is_path_excluded(rel):
+            if not is_allowed_artifact(rel, self._attachment_extensions):
                 continue
             paths.append(rel)
         return sorted(paths)

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -35,13 +35,14 @@ from markdown_vault_mcp.scanner import (
 )
 from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult, SkippedFile
 from markdown_vault_mcp.utils import (
+    effective_attachment_extensions,
     is_note,
     is_path_excluded,
 )
 from markdown_vault_mcp.utils.fs import iter_markdown_files
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
     from markdown_vault_mcp.interfaces import KeywordGraphIndex, VectorStore
@@ -87,6 +88,8 @@ class IndexManager:
             force at build time, or ``None`` when the cap was derived from the
             model context. Recorded into FTS meta alongside the model as a
             stable warm-restart key (#649).
+        attachment_extensions: Configured attachment allowlist, consulted by
+            link extraction (``None`` = the default set).
         title_field: Frontmatter key consulted first when resolving document
             titles; threaded to every ``parse_note``/``scan_directory`` call
             and recorded into FTS meta as a warm-restart key.
@@ -118,6 +121,7 @@ class IndexManager:
         embed_model_name: str | None = None,
         max_chunk_chars_override: int | None = None,
         title_field: str = "title",
+        attachment_extensions: Sequence[str] | None = None,
         embed_text_builder: EmbedTextBuilder | None = None,
         embedding_batch_size: int = _EMBEDDING_BATCH_SIZE,
     ) -> None:
@@ -136,6 +140,13 @@ class IndexManager:
         self._embed_model_name = embed_model_name
         self._max_chunk_chars_override = max_chunk_chars_override
         self._title_field = title_field
+        # Link extraction needs the allowlist to tell a wikilink naming an
+        # attachment ([[diagram.png]]) from one naming a note (#1333).
+        # Resolved once here: attachments are not indexed, so the decision
+        # cannot be deferred to resolve_vault_wikilinks().
+        self._attachment_extensions = effective_attachment_extensions(
+            attachment_extensions
+        )
         self._embed_builder = embed_text_builder or EmbedTextBuilder()
         # Composed vector-lifecycle collaborator (#1157). The shared path
         # helpers are injected as callables (per the #736 precedent) so the
@@ -432,6 +443,7 @@ class IndexManager:
                 exclude_patterns=self._exclude_patterns,
                 on_skip=_collect_skip,
                 title_field=self._title_field,
+                attachment_extensions=self._attachment_extensions,
             )
         )
 
@@ -706,6 +718,7 @@ class IndexManager:
                 self._chunk_strategy,
                 rel_path=path,
                 title_field=self._title_field,
+                attachment_extensions=self._attachment_extensions,
                 required_frontmatter=self._required_frontmatter,
                 log_context="reindex",
             )
@@ -928,6 +941,7 @@ class IndexManager:
                             self._source_dir,
                             self._chunk_strategy,
                             title_field=self._title_field,
+                            attachment_extensions=self._attachment_extensions,
                         )
                         missing = [
                             k

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -35,11 +36,13 @@ from markdown_vault_mcp.scanner import (
 )
 from markdown_vault_mcp.types import IndexStats, ParsedNote, ReindexResult, SkippedFile
 from markdown_vault_mcp.utils import (
+    canonical_attachment_extensions,
     effective_attachment_extensions,
+    is_allowed_artifact,
     is_note,
     is_path_excluded,
 )
-from markdown_vault_mcp.utils.fs import iter_markdown_files
+from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS, iter_markdown_files
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -169,6 +172,40 @@ class IndexManager:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _attachment_paths(self) -> list[str]:
+        """Vault-relative paths of the allowlisted attachments on disk.
+
+        Attachments are not indexed, so vault-wide wikilink resolution cannot
+        find them in ``documents`` and every embed read as broken (#1333).
+        This walks the source tree the way ``list_documents`` does, applying
+        the same exclusion rules, and runs once per resolution pass rather
+        than once per link.
+
+        Returns:
+            Sorted vault-relative POSIX paths, or an empty list when nothing
+            is allowlisted.
+        """
+        if not self._attachment_extensions:
+            return []
+        paths: list[str] = []
+        for abs_path in self._source_dir.rglob("*", **GLOB_SYMLINK_KWARGS):
+            try:
+                if not abs_path.is_file():
+                    continue
+                rel = abs_path.relative_to(self._source_dir).as_posix()
+            except (OSError, ValueError):
+                continue
+            if is_note(rel) or not is_allowed_artifact(
+                rel, self._attachment_extensions
+            ):
+                continue
+            if any(part.startswith(".") for part in PurePosixPath(rel).parts):
+                continue
+            if self._is_path_excluded(rel):
+                continue
+            paths.append(rel)
+        return sorted(paths)
 
     def _is_path_excluded(self, path: str) -> bool:
         """Check whether *path* matches any configured exclude pattern.
@@ -494,7 +531,7 @@ class IndexManager:
         skipped = len(candidates) - len(notes)
 
         # Resolve vault-wide wikilinks now that all documents are indexed.
-        self._fts.resolve_vault_wikilinks()
+        self._fts.resolve_vault_wikilinks(attachment_paths=self._attachment_paths())
 
         # Record skipped files (excluded, missing frontmatter, unparseable)
         # in tracker state too, so the first reindex() — including the boot
@@ -556,6 +593,9 @@ class IndexManager:
             title_field=self._title_field,
             searchable_fields=",".join(self._embed_builder.searchable_fields),
             indexed_frontmatter_fields=",".join(self._indexed_frontmatter_fields),
+            attachment_extensions=canonical_attachment_extensions(
+                self._attachment_extensions
+            ),
         )
         return IndexStats(
             documents_indexed=len(notes) - errored,
@@ -655,7 +695,7 @@ class IndexManager:
             vectors.save(embeddings_path)
 
         # Re-resolve vault-wide wikilinks.
-        self._fts.resolve_vault_wikilinks()
+        self._fts.resolve_vault_wikilinks(attachment_paths=self._attachment_paths())
 
         # Rebuild tracker state from current FTS index contents.
         state_notes: list[ParsedNote] = [
@@ -1016,7 +1056,9 @@ class IndexManager:
         finally:
             # Always restore link-graph consistency, even on per-path failures.
             try:
-                self._fts.resolve_vault_wikilinks()
+                self._fts.resolve_vault_wikilinks(
+                    attachment_paths=self._attachment_paths()
+                )
             except Exception:
                 logger.exception("process_dirty_paths: resolve_vault_wikilinks failed")
 

--- a/src/markdown_vault_mcp/managers/index.py
+++ b/src/markdown_vault_mcp/managers/index.py
@@ -539,7 +539,10 @@ class IndexManager:
         skipped = len(candidates) - len(notes)
 
         # Resolve vault-wide wikilinks now that all documents are indexed.
-        self._fts.resolve_vault_wikilinks(attachment_paths=self._attachment_paths())
+        self._fts.resolve_vault_wikilinks(
+            attachment_paths=self._attachment_paths(),
+            attachment_extensions=self._attachment_extensions,
+        )
 
         # Record skipped files (excluded, missing frontmatter, unparseable)
         # in tracker state too, so the first reindex() — including the boot
@@ -703,7 +706,10 @@ class IndexManager:
             vectors.save(embeddings_path)
 
         # Re-resolve vault-wide wikilinks.
-        self._fts.resolve_vault_wikilinks(attachment_paths=self._attachment_paths())
+        self._fts.resolve_vault_wikilinks(
+            attachment_paths=self._attachment_paths(),
+            attachment_extensions=self._attachment_extensions,
+        )
 
         # Rebuild tracker state from current FTS index contents.
         state_notes: list[ParsedNote] = [
@@ -1065,7 +1071,8 @@ class IndexManager:
             # Always restore link-graph consistency, even on per-path failures.
             try:
                 self._fts.resolve_vault_wikilinks(
-                    attachment_paths=self._attachment_paths()
+                    attachment_paths=self._attachment_paths(),
+                    attachment_extensions=self._attachment_extensions,
                 )
             except Exception:
                 logger.exception("process_dirty_paths: resolve_vault_wikilinks failed")

--- a/src/markdown_vault_mcp/managers/link.py
+++ b/src/markdown_vault_mcp/managers/link.py
@@ -21,12 +21,15 @@ from markdown_vault_mcp.types import (
     OutlinkInfo,
 )
 from markdown_vault_mcp.utils import (
+    attachment_target_exists,
+    effective_attachment_extensions,
     fts_row_to_note_info,
     normalize_folder,
     validate_path,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from markdown_vault_mcp.interfaces import KeywordGraphIndex
@@ -40,11 +43,41 @@ class LinkManager:
     Args:
         fts: The FTS index to query.
         source_dir: Absolute path to the vault root directory.
+        attachment_extensions: Configured attachment allowlist (``None`` = the
+            default set), used to overlay vault truth on the index's answer
+            for links that target attachments (#1333).
     """
 
-    def __init__(self, fts: KeywordGraphIndex, source_dir: Path) -> None:
+    def __init__(
+        self,
+        fts: KeywordGraphIndex,
+        source_dir: Path,
+        attachment_extensions: Sequence[str] | None = None,
+    ) -> None:
         self._fts = fts
         self._source_dir = source_dir
+        self._attachment_extensions = effective_attachment_extensions(
+            attachment_extensions
+        )
+
+    def _target_is_present_attachment(self, target: str) -> bool:
+        """Return whether *target* names an attachment file the vault holds.
+
+        The index answers "is this an indexed document", and attachments are
+        not indexed, so every link to one read as broken (#1333). This is the
+        one place the link queries consult the filesystem to complete that
+        answer; see
+        :func:`~markdown_vault_mcp.utils.attachment_target_exists`.
+
+        Args:
+            target: Stored vault-relative link target.
+
+        Returns:
+            ``True`` when the target is an allowlisted attachment on disk.
+        """
+        return attachment_target_exists(
+            target, self._source_dir, self._attachment_extensions
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -116,7 +149,8 @@ class LinkManager:
 
         The ``exists`` field on each
         :class:`~markdown_vault_mcp.types.OutlinkInfo` indicates whether the
-        target document is currently indexed.
+        target is present in the vault — an indexed note, or an allowlisted
+        attachment on disk (attachments are not indexed, #1333).
 
         Args:
             path: Relative path of the source document
@@ -139,7 +173,8 @@ class LinkManager:
                 link_text=row["link_text"],
                 link_type=row["link_type"],
                 fragment=row["fragment"],
-                exists=bool(row["target_exists"]),
+                exists=bool(row["target_exists"])
+                or self._target_is_present_attachment(row["target_path"]),
                 raw_target=row["raw_target"],
             )
             for row in rows
@@ -147,6 +182,10 @@ class LinkManager:
 
     def get_broken_links(self, *, folder: str | None = None) -> list[BrokenLinkInfo]:
         """Return all links whose target does not exist in the vault.
+
+        The index's own answer covers indexed notes only; a link naming an
+        allowlisted attachment that is present on disk is not broken, and is
+        filtered out here (#1333).
 
         Args:
             folder: If provided, restrict to source documents in this folder
@@ -169,7 +208,30 @@ class LinkManager:
                 raw_target=row["raw_target"],
             )
             for row in rows
+            if not self._target_is_present_attachment(row["target_path"])
         ]
+
+    def count_broken_links(self) -> int:
+        """Return the number of broken links, matching :meth:`get_broken_links`.
+
+        Counted from the same rows and through the same attachment overlay, so
+        ``stats.broken_link_count`` cannot disagree with the list a caller
+        gets back (#1333). ``KeywordGraphIndex.count_broken_links`` remains the
+        index-truth counterpart and does not apply the overlay.
+
+        A filesystem check runs only for a target that is non-``.md`` and
+        allowlisted, so a vault whose broken links are all notes pays nothing
+        beyond the query the index already ran.
+
+        Returns:
+            Number of links whose target is in neither the index nor the
+            vault's attachments.
+        """
+        return sum(
+            1
+            for row in self._fts.get_broken_links()
+            if not self._target_is_present_attachment(row["target_path"])
+        )
 
     def get_orphan_notes(self) -> list[NoteInfo]:
         """Return all documents with no inbound or outbound links.

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -1449,7 +1449,17 @@ class SearchManager:
             indexed_frontmatter_fields=list(self._indexed_frontmatter_fields),
             attachment_extensions=attachment_extensions,
             link_count=self._fts.count_links(),
-            broken_link_count=self._fts.count_broken_links(),
+            # Through LinkManager when wired (the production path): attachments
+            # are not indexed, so the index-level count disagrees with the list
+            # get_broken_links() returns (#1333). The raw count is the correct
+            # fallback for a SearchManager built without one — it is then the
+            # only answer available, and it matches the FTS rows that same
+            # caller would read.
+            broken_link_count=(
+                self._link_manager.count_broken_links()
+                if self._link_manager is not None
+                else self._fts.count_broken_links()
+            ),
             orphan_count=self._fts.count_orphans(),
         )
 

--- a/src/markdown_vault_mcp/managers/search.py
+++ b/src/markdown_vault_mcp/managers/search.py
@@ -14,6 +14,7 @@ import json
 import logging
 import mimetypes
 import sqlite3
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from markdown_vault_mcp.embed_text import is_embeddable
@@ -80,7 +81,10 @@ from markdown_vault_mcp.utils import (
     normalize_folder,
     validate_path,
 )
-from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS
+from markdown_vault_mcp.utils.fs import (
+    GLOB_SYMLINK_KWARGS,
+    vault_relative_in_scope,
+)
 
 if TYPE_CHECKING:
     import builtins
@@ -1309,31 +1313,21 @@ class SearchManager:
                 attachments.append(info)
         return attachments
 
-    def _attachment_rel_path(self, abs_path: Path) -> Path | None:
+    def _attachment_rel_path(self, abs_path: Path) -> str | None:
         """Vault-relative path of *abs_path*, or ``None`` when out of scope.
 
         Out of scope: outside ``source_dir``, any dot-prefixed path
         component, or a match against the configured exclude patterns
-        (mirrors ``scan_directory`` behaviour).
+        (mirrors ``scan_directory`` behaviour). The rule itself lives in
+        :func:`~markdown_vault_mcp.utils.fs.vault_relative_in_scope`, shared
+        with the link layer's attachment scan so the two cannot drift.
         """
-        try:
-            # rglob yields paths anchored at the unresolved self._source_dir;
-            # using .resolve() here would mismatch when source_dir is itself
-            # a symlink and silently drop every attachment.
-            rel = abs_path.relative_to(self._source_dir)
-        except ValueError as exc:
-            logger.warning(
-                "_list_attachments: skipping %s — outside source_dir (%s)",
-                abs_path,
-                exc,
-            )
-            return None
-        # Skip files where any path component starts with ".".
-        if any(part.startswith(".") for part in rel.parts):
-            return None
-        if self._is_path_excluded(rel.as_posix()):
-            return None
-        return rel
+        return vault_relative_in_scope(
+            abs_path,
+            self._source_dir,
+            is_excluded=self._is_path_excluded,
+            log_context="_list_attachments",
+        )
 
     def _attachment_info(
         self,
@@ -1365,17 +1359,17 @@ class SearchManager:
             or not is_allowed_artifact_suffix(suffix, exts)
         ):
             return None
-        rel = self._attachment_rel_path(abs_path)
-        if rel is None:
-            return None
         # POSIX spelling throughout: `str(Path)` yields OS separators, so on
         # Windows this produced `docs\\api` where the index, the exclusion
         # check above, and a normalized `folder` argument all use `docs/api`
-        # — nested attachments then matched nothing.
-        rel_path = rel.as_posix()
+        # — nested attachments then matched nothing. The shared scope helper
+        # returns the POSIX spelling directly.
+        rel_path = self._attachment_rel_path(abs_path)
+        if rel_path is None:
+            return None
         if pattern and not fnmatch.fnmatch(rel_path, pattern):
             return None
-        rel_folder = rel.parent.as_posix()
+        rel_folder = PurePosixPath(rel_path).parent.as_posix()
         if rel_folder == ".":
             rel_folder = ""
         if folder is not None and not folder_matches(rel_folder, folder):

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -15,8 +15,8 @@ import yaml
 from markdown_vault_mcp.hashing import compute_etag
 from markdown_vault_mcp.types import Chunk, LinkInfo, ParsedNote, SkippedFile
 from markdown_vault_mcp.utils.content_kind import (
-    artifact_suffix,
     effective_attachment_extensions,
+    names_attachment,
 )
 from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS, iter_markdown_files
 from markdown_vault_mcp.utils.text import decode_utf8
@@ -788,24 +788,29 @@ _EXTERNAL_URL_PREFIXES = ("//",)
 # Matching the *shape* rather than an allowlist of four prefixes is what keeps
 # `file:`, `ftp:`, `obsidian:` and `zotero:` out of vault-path resolution.
 _RE_URI_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]+:")
-# An extension-shaped suffix: what a file type looks like, used only under the
-# ``*`` attachment wildcard (see :func:`_names_attachment`).
-_RE_EXTENSION_SHAPE = re.compile(r"[A-Za-z0-9]{1,8}")
-
 # Fenced code block: matches ``` or ~~~ delimiters (with optional language tag).
 _RE_FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 # Inline code: matches single backtick spans (non-greedy, no newlines inside).
 _RE_INLINE_CODE = re.compile(r"`[^`\n]+`")
-# Link *text*, bounded to one paragraph. CommonMark permits a soft break inside
-# link text but not a blank line, so a newline is allowed only when it is not
-# followed by another (#1334). Without this an unmatched ``[`` pairs with a
-# ``](`` thousands of characters later and indexes whole pages of prose as a
-# link — wrong data, and a multi-kilobyte value on every outlink result.
-_TEXT_SPAN = r"(?:[^\]\n]|\n(?![ \t]*\n))*"
-# Inline markdown link: [text](target). A destination never contains a newline.
-_RE_INLINE_LINK = re.compile(rf"\[({_TEXT_SPAN})\]\(([^)\n]+)\)")
+# A blank line: the paragraph boundary CommonMark says no link may cross.
+# Extraction splits on this and matches within one paragraph at a time, which
+# is what bounds a link rather than the regexes themselves (#1334).
+#
+# Splitting first, rather than teaching each regex to stop at a blank line,
+# is deliberate on two counts. The bounded alternation it replaced
+# (``(?:[^\]\n]|\n(?![ \t]*\n))*``) was correct but roughly seven times
+# slower than a plain negated class on the pathological input this defect is
+# about — a long run of unmatched ``[`` — because CPython's engine pays for
+# the alternation on every backtrack step. Splitting keeps the plain class
+# *and* shrinks the quadratic backtracking window from the whole document to
+# one paragraph, so it is faster than the code this defect was found in.
+_RE_PARAGRAPH_BREAK = re.compile(r"\n[ \t]*\n")
+# Inline markdown link: [text](target). Matched within one paragraph, so
+# ``[^\]]*`` cannot cross a blank line. A destination never contains a
+# newline in any case: CommonMark does not allow one.
+_RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)\n]+)\)")
 # Reference-style link usage: [text][ref] or [text][]
-_RE_REF_USAGE = re.compile(rf"\[({_TEXT_SPAN})\]\[({_TEXT_SPAN})\]")
+_RE_REF_USAGE = re.compile(r"\[([^\]]*)\]\[([^\]]*)\]")
 # Reference definition: [ref]: target  (at start of line, optional leading whitespace)
 _RE_REF_DEF = re.compile(r"^\s*\[([^\]\n]+)\]:\s*(.+)$", re.MULTILINE)
 # Markdown footnotes ([^label] / [^label]: body) differ from reference-style
@@ -832,35 +837,6 @@ def _is_external_target(target: str) -> bool:
     return target.startswith(_EXTERNAL_URL_PREFIXES) or bool(
         _RE_URI_SCHEME.match(target)
     )
-
-
-def _names_attachment(target: str, extensions: frozenset[str]) -> bool:
-    """Return whether a wikilink target names an attachment rather than a note.
-
-    Used to decide whether ``.md`` should be appended: ``[[diagram.png]]``
-    names the attachment that ``read`` already serves, and appending ``.md``
-    produced a target that cannot exist, so every Obsidian image embed was
-    reported broken (#1333).
-
-    Args:
-        target: Wikilink target with any fragment already split off.
-        extensions: The effective attachment allowlist, as returned by
-            :func:`~markdown_vault_mcp.utils.content_kind.effective_attachment_extensions`.
-
-    Returns:
-        ``True`` when *target* carries an extension naming an attachment.
-    """
-    suffix = artifact_suffix(target)
-    if not suffix:
-        # No extension at all — a note name in every configuration.
-        return False
-    if "*" in extensions:
-        # The wildcard means "every non-.md file", which says nothing about
-        # which *suffixes* are file types. Taken literally it would read the
-        # note title ``Version 2.0 plan`` as a ``0 plan`` attachment, so under
-        # the wildcard the suffix must also look like an extension.
-        return _RE_EXTENSION_SHAPE.fullmatch(suffix) is not None
-    return suffix in extensions
 
 
 def _strip_code_spans(content: str) -> str:
@@ -950,6 +926,9 @@ def extract_links(
     * **Reference-style**: ``[text][ref]`` with ``[ref]: path.md``
     * **Wikilinks**: ``[[path]]`` or ``[[path|alias]]``
 
+    Matching runs one paragraph at a time, so no link crosses a blank line;
+    reference *definitions* are the exception and are collected document-wide.
+
     Links inside fenced code blocks and inline code spans are ignored. A
     destination carrying any URI scheme (``https:``, ``file:``, ``obsidian:``
     …) is external and skipped, as are same-document anchors in every
@@ -974,11 +953,19 @@ def extract_links(
         if attachment_extensions is None
         else attachment_extensions
     )
-    return [
-        *_extract_inline_links(clean, source_path),
-        *_extract_reference_links(clean, source_path),
-        *_extract_wikilinks(clean, source_path, extensions),
-    ]
+    # Definitions are document-wide; every other match is paragraph-local,
+    # which is what stops a link crossing a blank line (#1334).
+    ref_defs = _collect_reference_definitions(clean)
+    inline: list[LinkInfo] = []
+    reference: list[LinkInfo] = []
+    wiki: list[LinkInfo] = []
+    for paragraph in _RE_PARAGRAPH_BREAK.split(clean):
+        inline.extend(_extract_inline_links(paragraph, source_path))
+        reference.extend(_extract_reference_links(paragraph, source_path, ref_defs))
+        wiki.extend(_extract_wikilinks(paragraph, source_path, extensions))
+    # Grouped by kind rather than interleaved by position, preserving the
+    # order callers saw when each extractor ran over the whole document.
+    return [*inline, *reference, *wiki]
 
 
 def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
@@ -1013,21 +1000,23 @@ def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
     return links
 
 
-def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
-    """Extract reference-style ``[text][ref]`` links from code-stripped content.
+def _collect_reference_definitions(clean: str) -> dict[str, str]:
+    """Collect ``[ref]: path.md`` definitions from code-stripped content.
 
-    Collects the ``[ref]: path.md`` definitions first (optional CommonMark
-    titles stripped), then resolves each usage; an empty ``[ref]`` falls
-    back to the link text per CommonMark shortcut semantics. Destinations
-    carrying a URI scheme and pure anchors are skipped.
+    Read from the whole document rather than per paragraph: a definition
+    lives wherever the author put it, usually far from the usages it serves,
+    so this is the one part of extraction that is not paragraph-local.
 
-    Markdown footnotes are skipped on both halves: a footnote definition
-    (``[^label]: body``) is prose, not a link target, and two adjacent
-    footnote references (``[^a][^b]``) are not one reference-style link
-    (#1104).
+    Optional CommonMark titles are stripped. A footnote definition
+    (``[^label]: body``) is prose, not a link target, and storing it resolved
+    whatever the footnote said as a vault path (#1104).
+
+    Args:
+        clean: Code-stripped markdown body.
+
+    Returns:
+        Lower-cased reference key to its raw target.
     """
-    links: list[LinkInfo] = []
-    # Collect reference definitions first.
     ref_defs: dict[str, str] = {}
     for m in _RE_REF_DEF.finditer(clean):
         ref_key = m.group(1).strip().lower()
@@ -1039,7 +1028,29 @@ def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
         # Strip optional CommonMark title: "...", '...', or (...)
         ref_target = re.sub(r'\s+(?:"[^"]*"|\'[^\']*\'|\([^)]*\))\s*$', "", ref_target)
         ref_defs[ref_key] = ref_target
+    return ref_defs
 
+
+def _extract_reference_links(
+    clean: str, source_path: str, ref_defs: dict[str, str]
+) -> list[LinkInfo]:
+    """Extract reference-style ``[text][ref]`` usages from one paragraph.
+
+    An empty ``[ref]`` falls back to the link text per CommonMark shortcut
+    semantics. Destinations carrying a URI scheme and pure anchors are
+    skipped, as are footnote references: two adjacent ones (``[^a][^b]``) are
+    not one ``[text][ref]`` pair (#1104).
+
+    Args:
+        clean: One paragraph of code-stripped markdown.
+        source_path: Relative POSIX path of the source document.
+        ref_defs: Definitions collected document-wide by
+            :func:`_collect_reference_definitions`.
+
+    Returns:
+        List of :class:`~markdown_vault_mcp.types.LinkInfo` objects.
+    """
+    links: list[LinkInfo] = []
     for m in _RE_REF_USAGE.finditer(clean):
         text = m.group(1)
         ref = m.group(2).strip() or text  # empty [ref] falls back to link text
@@ -1136,7 +1147,7 @@ def _extract_wikilinks(
 
         # Wikilinks naming a note get ".md" appended; one naming an attachment
         # already carries the extension that identifies it (#1333).
-        if not raw_path.lower().endswith(".md") and not _names_attachment(
+        if not raw_path.lower().endswith(".md") and not names_attachment(
             raw_path, attachment_extensions
         ):
             raw_path = raw_path + ".md"

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -14,6 +14,10 @@ import yaml
 
 from markdown_vault_mcp.hashing import compute_etag
 from markdown_vault_mcp.types import Chunk, LinkInfo, ParsedNote, SkippedFile
+from markdown_vault_mcp.utils.content_kind import (
+    artifact_suffix,
+    effective_attachment_extensions,
+)
 from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS, iter_markdown_files
 from markdown_vault_mcp.utils.text import decode_utf8
 
@@ -775,23 +779,88 @@ def _resolve_title(
     return path.stem
 
 
-_EXTERNAL_URL_PREFIXES = ("http://", "https://", "mailto:", "//")
+# Protocol-relative URLs (``//host/path``) carry no scheme for
+# :data:`_RE_URI_SCHEME` to match, so they are named here.
+_EXTERNAL_URL_PREFIXES = ("//",)
+# A URI scheme, per RFC 3986, anchored at the start of a destination. Two or
+# more characters are required before the colon: a single letter is a Windows
+# drive (``C:/notes/topic.md``), which is a path and not a scheme (#1335).
+# Matching the *shape* rather than an allowlist of four prefixes is what keeps
+# `file:`, `ftp:`, `obsidian:` and `zotero:` out of vault-path resolution.
+_RE_URI_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]+:")
+# An extension-shaped suffix: what a file type looks like, used only under the
+# ``*`` attachment wildcard (see :func:`_names_attachment`).
+_RE_EXTENSION_SHAPE = re.compile(r"[A-Za-z0-9]{1,8}")
 
 # Fenced code block: matches ``` or ~~~ delimiters (with optional language tag).
 _RE_FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 # Inline code: matches single backtick spans (non-greedy, no newlines inside).
 _RE_INLINE_CODE = re.compile(r"`[^`\n]+`")
-# Inline markdown link: [text](target)
-_RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+# Link *text*, bounded to one paragraph. CommonMark permits a soft break inside
+# link text but not a blank line, so a newline is allowed only when it is not
+# followed by another (#1334). Without this an unmatched ``[`` pairs with a
+# ``](`` thousands of characters later and indexes whole pages of prose as a
+# link — wrong data, and a multi-kilobyte value on every outlink result.
+_TEXT_SPAN = r"(?:[^\]\n]|\n(?![ \t]*\n))*"
+# Inline markdown link: [text](target). A destination never contains a newline.
+_RE_INLINE_LINK = re.compile(rf"\[({_TEXT_SPAN})\]\(([^)\n]+)\)")
 # Reference-style link usage: [text][ref] or [text][]
-_RE_REF_USAGE = re.compile(r"\[([^\]]*)\]\[([^\]]*)\]")
+_RE_REF_USAGE = re.compile(rf"\[({_TEXT_SPAN})\]\[({_TEXT_SPAN})\]")
 # Reference definition: [ref]: target  (at start of line, optional leading whitespace)
-_RE_REF_DEF = re.compile(r"^\s*\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
+_RE_REF_DEF = re.compile(r"^\s*\[([^\]\n]+)\]:\s*(.+)$", re.MULTILINE)
 # Markdown footnotes ([^label] / [^label]: body) differ from reference-style
 # links by exactly this character, and both reference regexes match them.
 _FOOTNOTE_LABEL_PREFIX = "^"
-# Wikilink: [[path]], [[path|alias]], or [[path\|alias]] (Obsidian table-cell escape)
-_RE_WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
+# Wikilink: [[path]], [[path|alias]], or [[path\|alias]] (Obsidian table-cell
+# escape). Neither half spans a line — Obsidian has no multi-line wikilink.
+_RE_WIKILINK = re.compile(r"\[\[([^\]|\n]+)(?:\|([^\]\n]+))?\]\]")
+
+
+def _is_external_target(target: str) -> bool:
+    """Return whether a raw link destination points outside the vault.
+
+    A destination carrying a URI scheme names a resource somewhere else and is
+    not a vault-relative path, however unfamiliar the scheme (#1335).
+
+    Args:
+        target: Raw destination string as written in the document.
+
+    Returns:
+        ``True`` when *target* is external and should not be resolved as a
+        vault path.
+    """
+    return target.startswith(_EXTERNAL_URL_PREFIXES) or bool(
+        _RE_URI_SCHEME.match(target)
+    )
+
+
+def _names_attachment(target: str, extensions: frozenset[str]) -> bool:
+    """Return whether a wikilink target names an attachment rather than a note.
+
+    Used to decide whether ``.md`` should be appended: ``[[diagram.png]]``
+    names the attachment that ``read`` already serves, and appending ``.md``
+    produced a target that cannot exist, so every Obsidian image embed was
+    reported broken (#1333).
+
+    Args:
+        target: Wikilink target with any fragment already split off.
+        extensions: The effective attachment allowlist, as returned by
+            :func:`~markdown_vault_mcp.utils.content_kind.effective_attachment_extensions`.
+
+    Returns:
+        ``True`` when *target* carries an extension naming an attachment.
+    """
+    suffix = artifact_suffix(target)
+    if not suffix:
+        # No extension at all — a note name in every configuration.
+        return False
+    if "*" in extensions:
+        # The wildcard means "every non-.md file", which says nothing about
+        # which *suffixes* are file types. Taken literally it would read the
+        # note title ``Version 2.0 plan`` as a ``0 plan`` attachment, so under
+        # the wildcard the suffix must also look like an extension.
+        return _RE_EXTENSION_SHAPE.fullmatch(suffix) is not None
+    return suffix in extensions
 
 
 def _strip_code_spans(content: str) -> str:
@@ -867,7 +936,12 @@ def _resolve_link_path(target: str, source_rel: str) -> tuple[str, str | None]:
     return resolved_str, fragment
 
 
-def extract_links(content: str, source_path: str) -> list[LinkInfo]:
+def extract_links(
+    content: str,
+    source_path: str,
+    *,
+    attachment_extensions: frozenset[str] | None = None,
+) -> list[LinkInfo]:
     """Extract all links from a markdown document body.
 
     Handles three link formats:
@@ -876,32 +950,42 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
     * **Reference-style**: ``[text][ref]`` with ``[ref]: path.md``
     * **Wikilinks**: ``[[path]]`` or ``[[path|alias]]``
 
-    Links inside fenced code blocks and inline code spans are ignored.
-    External URLs (``http://``, ``https://``, ``mailto:``) are skipped, as
-    are same-document anchors in every spelling — ``[text](#heading)``,
-    ``[text][ref]`` with a ``#`` target, and ``[[#heading]]``.
+    Links inside fenced code blocks and inline code spans are ignored. A
+    destination carrying any URI scheme (``https:``, ``file:``, ``obsidian:``
+    …) is external and skipped, as are same-document anchors in every
+    spelling — ``[text](#heading)``, ``[text][ref]`` with a ``#`` target, and
+    ``[[#heading]]``. No link spans a blank line, and no destination contains
+    a newline.
 
     Args:
         content: Markdown body text (frontmatter already stripped).
         source_path: Relative POSIX path of the source document, used for
             resolving relative link targets (e.g. ``"Journal/2024/today.md"``).
+        attachment_extensions: Configured attachment allowlist, used to tell a
+            wikilink naming an attachment (``[[diagram.png]]``) from one naming
+            a note. ``None`` uses the default set.
 
     Returns:
         List of :class:`~markdown_vault_mcp.types.LinkInfo` objects.
     """
     clean = _strip_code_spans(content)
+    extensions = (
+        effective_attachment_extensions(None)
+        if attachment_extensions is None
+        else attachment_extensions
+    )
     return [
         *_extract_inline_links(clean, source_path),
         *_extract_reference_links(clean, source_path),
-        *_extract_wikilinks(clean, source_path),
+        *_extract_wikilinks(clean, source_path, extensions),
     ]
 
 
 def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
     """Extract inline ``[text](path.md)`` links from code-stripped content.
 
-    Skips image links (``![alt](src)``), external URLs, and pure anchor
-    links (``#section`` within the same document).
+    Skips image links (``![alt](src)``), destinations carrying any URI
+    scheme, and pure anchor links (``#section`` within the same document).
     """
     links: list[LinkInfo] = []
     for m in _RE_INLINE_LINK.finditer(clean):
@@ -910,7 +994,7 @@ def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
             continue
         text = m.group(1)
         raw_target = m.group(2).strip()
-        if any(raw_target.startswith(p) for p in _EXTERNAL_URL_PREFIXES):
+        if _is_external_target(raw_target):
             continue
         if raw_target.startswith("#"):
             # Pure anchor link — skip (points to a section in the same doc).
@@ -934,8 +1018,8 @@ def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
 
     Collects the ``[ref]: path.md`` definitions first (optional CommonMark
     titles stripped), then resolves each usage; an empty ``[ref]`` falls
-    back to the link text per CommonMark shortcut semantics. External URLs
-    and pure anchors are skipped.
+    back to the link text per CommonMark shortcut semantics. Destinations
+    carrying a URI scheme and pure anchors are skipped.
 
     Markdown footnotes are skipped on both halves: a footnote definition
     (``[^label]: body``) is prose, not a link target, and two adjacent
@@ -971,7 +1055,7 @@ def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
         raw_target = ref_defs.get(ref_key)
         if raw_target is None:
             continue
-        if any(raw_target.startswith(p) for p in _EXTERNAL_URL_PREFIXES):
+        if _is_external_target(raw_target):
             continue
         if raw_target.startswith("#"):
             continue
@@ -989,7 +1073,9 @@ def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
     return links
 
 
-def _extract_wikilinks(clean: str, source_path: str) -> list[LinkInfo]:
+def _extract_wikilinks(
+    clean: str, source_path: str, attachment_extensions: frozenset[str]
+) -> list[LinkInfo]:
     """Extract ``[[path]]`` / ``[[path|alias]]`` wikilinks from content.
 
     Handles the Obsidian table-cell pipe escape (#731), fragment splitting
@@ -999,7 +1085,15 @@ def _extract_wikilinks(clean: str, source_path: str) -> list[LinkInfo]:
     for ``FTSIndex.resolve_vault_wikilinks()`` to resolve vault-wide.
 
     Fragment-only wikilinks (``[[#Heading]]``) are skipped, matching how
-    :func:`_extract_inline_links` treats ``[text](#heading)`` (#1107).
+    :func:`_extract_inline_links` treats ``[text](#heading)`` (#1107), as are
+    schemed targets, which name something outside the vault (#1335).
+
+    Args:
+        clean: Code-stripped markdown body.
+        source_path: Relative POSIX path of the source document.
+        attachment_extensions: Effective attachment allowlist, consulted to
+            decide whether a target names an attachment rather than a note
+            (#1333).
     """
     links: list[LinkInfo] = []
     for m in _RE_WIKILINK.finditer(clean):
@@ -1031,12 +1125,20 @@ def _extract_wikilinks(clean: str, source_path: str) -> list[LinkInfo]:
             # exist and so was always reported broken (#1107).
             continue
 
+        if _is_external_target(raw_path):
+            # A schemed target ([[https://example.com]]) is not a vault path,
+            # and appending ".md" to one produced a target that cannot exist.
+            continue
+
         # raw_target for wikilinks: path portion before .md is appended,
         # with fragment re-attached so the original [[Note#section]] is preserved.
         wikilink_raw_target = raw_path + ("#" + fragment if fragment else "")
 
-        # Wikilinks without .md extension: append it.
-        if not raw_path.lower().endswith(".md"):
+        # Wikilinks naming a note get ".md" appended; one naming an attachment
+        # already carries the extension that identifies it (#1333).
+        if not raw_path.lower().endswith(".md") and not _names_attachment(
+            raw_path, attachment_extensions
+        ):
             raw_path = raw_path + ".md"
 
         # Obsidian vault-wide resolution semantics:
@@ -1069,6 +1171,7 @@ def parse_note(
     chunk_strategy: ChunkStrategy | None = None,
     *,
     title_field: str = "title",
+    attachment_extensions: frozenset[str] | None = None,
 ) -> ParsedNote:
     """Parse a single markdown file into a ParsedNote.
 
@@ -1083,6 +1186,10 @@ def parse_note(
             :class:`HeadingChunker`.
         title_field: Frontmatter key consulted first when resolving the
             document title (see :func:`_resolve_title`).
+        attachment_extensions: Effective attachment allowlist, consulted only
+            by link extraction (see :func:`extract_links`). ``None`` uses the
+            default set — correct for a caller that reads the parsed
+            frontmatter, chunks or hash and ignores ``links``.
 
     Returns:
         A :class:`~markdown_vault_mcp.types.ParsedNote` instance.
@@ -1115,7 +1222,7 @@ def parse_note(
     rel_str = rel_path.as_posix()
 
     chunks = chunk_strategy.chunk(body, metadata)
-    links = extract_links(body, rel_str)
+    links = extract_links(body, rel_str, attachment_extensions=attachment_extensions)
     # Measured here rather than summed from `chunks`: overlap duplicates text
     # across chunk boundaries, so a sum would over-count multi-chunk notes.
     content_chars = len(body)
@@ -1168,6 +1275,7 @@ def parse_note_categorized(
     *,
     rel_path: str,
     title_field: str = "title",
+    attachment_extensions: frozenset[str] | None = None,
     required_frontmatter: list[str] | None = None,
     log_context: str = "scan",
 ) -> ParsedNote | CategorizedSkip | None:
@@ -1196,6 +1304,8 @@ def parse_note_categorized(
         rel_path: Vault-relative POSIX path, used for the ``SkippedFile``
             and log messages.
         title_field: Frontmatter key consulted first for the title.
+        attachment_extensions: Effective attachment allowlist, forwarded to
+            :func:`parse_note` for link extraction.
         required_frontmatter: Frontmatter keys that must be present.
         log_context: Prefix identifying the calling pipeline in logs.
 
@@ -1204,7 +1314,13 @@ def parse_note_categorized(
         deterministic skip, or ``None`` for a transient I/O failure.
     """
     try:
-        note = parse_note(abs_path, source_dir, chunk_strategy, title_field=title_field)
+        note = parse_note(
+            abs_path,
+            source_dir,
+            chunk_strategy,
+            title_field=title_field,
+            attachment_extensions=attachment_extensions,
+        )
     except UnicodeDecodeError as exc:
         logger.warning(
             "%s: skipping %s — cannot decode as UTF-8 (%s)",
@@ -1259,6 +1375,7 @@ def scan_directory(
     chunk_strategy: ChunkStrategy | None = None,
     on_skip: Callable[[SkippedFile], None] | None = None,
     title_field: str = "title",
+    attachment_extensions: frozenset[str] | None = None,
 ) -> Iterator[ParsedNote]:
     """Discover and parse all markdown files under ``source_dir``.
 
@@ -1290,6 +1407,8 @@ def scan_directory(
             transient ``OSError`` skips (self-healing). ``None`` (default)
             preserves the historical behaviour of silently skipping such
             files (#775).
+        attachment_extensions: Effective attachment allowlist, forwarded to
+            link extraction.
         title_field: Frontmatter key consulted first when resolving each
             document's title; passed through to :func:`parse_note`.
 
@@ -1335,6 +1454,7 @@ def scan_directory(
             chunk_strategy,
             rel_path=rel_posix,
             title_field=title_field,
+            attachment_extensions=attachment_extensions,
             required_frontmatter=required_frontmatter,
             log_context="scan",
         )

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -588,7 +588,9 @@ class OutlinkInfo:
         link_type: Link syntax: ``"markdown"``, ``"wikilink"``, or ``"reference"``.
         fragment: Heading anchor if present.
         raw_target: The unresolved link target exactly as written.
-        exists: ``True`` if the target document exists in the vault.
+        exists: ``True`` if the target is present in the vault — an
+            indexed note, or an attachment on disk whose extension is
+            allowlisted (attachments are not indexed, #1333).
     """
 
     target_path: str

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -174,6 +174,58 @@ def validate_history_path(
     return resolve_inside(path, source_dir)
 
 
+def attachment_target_exists(
+    target: str, source_dir: Path, attachment_extensions: frozenset[str]
+) -> bool:
+    """Return whether a link target names an attachment present in the vault.
+
+    Attachments are not indexed — ``list_documents(include_attachments=True)``
+    walks the filesystem — so the index alone cannot tell a link to
+    ``Images/pic.png`` from a link to a note that does not exist. This is the
+    vault-truth overlay the link queries apply on top of the index-truth
+    answer (#1333).
+
+    The test mirrors what ``read`` will actually serve: non-``.md``,
+    allowlisted, and present on disk. It deliberately does **not** apply the
+    extension-shape guard that
+    :func:`~markdown_vault_mcp.scanner._names_attachment` uses — that one
+    decides whether to append ``.md`` at extraction time and must not read an
+    extensionless note title as a file type, whereas under the ``*`` wildcard
+    ``read`` really does serve an extensionless ``Makefile``, so this
+    predicate must too.
+
+    Lives here rather than in ``utils.content_kind`` for two reasons: it
+    touches the filesystem, and it is not the ``is_attachment`` helper that
+    module's docstring deliberately declines to provide. That one would be a
+    routing test wearing a misleading name; this one is a link-graph
+    question — "is there something at this target" — composed at the one
+    place that has ``source_dir`` to answer it.
+
+    Args:
+        target: Stored vault-relative link target.
+        source_dir: Absolute vault root.
+        attachment_extensions: The effective attachment allowlist.
+
+    Returns:
+        ``True`` when *target* is an allowlisted attachment that exists inside
+        the vault. ``False`` for a note, a non-allowlisted extension, a path
+        escaping the vault, or a file that is not there.
+    """
+    if is_note(target) or not is_allowed_artifact(target, attachment_extensions):
+        return False
+    try:
+        abs_path = resolve_inside(target, source_dir)
+    except (OSError, RuntimeError, ValueError):
+        # ValueError: traversal outside the vault. OSError/RuntimeError: a
+        # symlink loop or unreadable component reached by resolve()
+        # (RuntimeError on Python < 3.13).
+        return False
+    try:
+        return abs_path.is_file()
+    except OSError:
+        return False
+
+
 def validate_history_dir(path: str, source_dir: Path) -> Path:
     """Resolve a vault-relative *directory* path for read-only git-history queries.
 
@@ -207,6 +259,7 @@ __all__ = [
     "CHAR_SUBS",
     "apply_link_replacement",
     "artifact_suffix",
+    "attachment_target_exists",
     "build_position_map",
     "compute_new_raw_target",
     "effective_attachment_extensions",

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -13,6 +13,7 @@ from markdown_vault_mcp.utils.content_kind import (
     is_allowed_artifact,
     is_allowed_artifact_suffix,
     is_note,
+    names_attachment,
 )
 
 if TYPE_CHECKING:
@@ -272,6 +273,7 @@ __all__ = [
     "is_allowed_artifact_suffix",
     "is_note",
     "is_path_excluded",
+    "names_attachment",
     "normalize_text",
     "resolve_inside",
     "validate_history_dir",

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from markdown_vault_mcp.utils.content_kind import (
     artifact_suffix,
+    canonical_attachment_extensions,
     effective_attachment_extensions,
     has_md_suffix,
     is_allowed_artifact,
@@ -261,6 +262,7 @@ __all__ = [
     "artifact_suffix",
     "attachment_target_exists",
     "build_position_map",
+    "canonical_attachment_extensions",
     "compute_new_raw_target",
     "effective_attachment_extensions",
     "find_closest_match",

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -190,7 +190,7 @@ def attachment_target_exists(
     The test mirrors what ``read`` will actually serve: non-``.md``,
     allowlisted, and present on disk. It deliberately does **not** apply the
     extension-shape guard that
-    :func:`~markdown_vault_mcp.scanner._names_attachment` uses — that one
+    :func:`~markdown_vault_mcp.utils.names_attachment` uses — that one
     decides whether to append ``.md`` at extraction time and must not read an
     extensionless note title as a file type, whereas under the ``*`` wildcard
     ``read`` really does serve an extensionless ``Makefile``, so this

--- a/src/markdown_vault_mcp/utils/content_kind.py
+++ b/src/markdown_vault_mcp/utils/content_kind.py
@@ -51,6 +51,7 @@ a bare wikilink, stripping it for a label).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -67,6 +68,7 @@ __all__ = [
     "is_allowed_artifact",
     "is_allowed_artifact_suffix",
     "is_note",
+    "names_attachment",
 ]
 
 
@@ -176,6 +178,16 @@ def effective_attachment_extensions(
     return frozenset(ext for ext in normalized if ext)
 
 
+#: An extension-shaped suffix: what a file type looks like, used only under
+#: the ``*`` attachment wildcard (see :func:`names_attachment`).
+_RE_EXTENSION_SHAPE = re.compile(r"[A-Za-z0-9]{1,8}")
+
+#: Provenance rendering of an *explicitly empty* attachment allowlist,
+#: distinct from the empty string the default set renders as (see
+#: :func:`canonical_attachment_extensions`).
+_NO_EXTENSIONS = "(none)"
+
+
 def canonical_attachment_extensions(extensions: frozenset[str]) -> str:
     """Return the allowlist's canonical string form, for build provenance.
 
@@ -190,13 +202,64 @@ def canonical_attachment_extensions(extensions: frozenset[str]) -> str:
     and must compare equal to a default-configured server rather than
     forcing a spurious rebuild on every such deployment.
 
+    An *explicitly empty* allowlist renders as :data:`_NO_EXTENSIONS`, not as
+    ``""``. The two are different configurations that derive different rows —
+    with nothing allowlisted, ``[[pic.png]]`` is a note reference and stores
+    ``pic.png.md`` — so collapsing them onto one value let a switch between
+    them keep the warm index and serve the previous interpretation forever.
+    The sentinel is not a possible rendering of a real allowlist: an
+    extension is configured without its dot, so no member can contain
+    parentheses.
+
     Args:
         extensions: The effective allowlist, as returned by
             :func:`effective_attachment_extensions`.
 
     Returns:
-        ``""`` for the default set, else the sorted members comma-joined.
+        ``""`` for the default set, :data:`_NO_EXTENSIONS` for an explicitly
+        empty one, else the sorted members comma-joined.
     """
     if extensions == DEFAULT_ATTACHMENT_EXTENSIONS:
         return ""
+    if not extensions:
+        return _NO_EXTENSIONS
     return ",".join(sorted(extensions))
+
+
+def names_attachment(target: str, extensions: frozenset[str]) -> bool:
+    """Return whether a wikilink target names an attachment rather than a note.
+
+    Shared by extraction (which decides whether to append ``.md``) and by
+    vault-wide resolution (which must not fall back to the note population
+    for a target this classifies as an attachment). Both stages have to
+    reach the same verdict, or a target classified one way at write time is
+    resolved the other way at query time — which is how a missing
+    ``pic.png`` came to resolve onto an unrelated ``pic.png.md`` note.
+
+    Distinct from
+    :func:`~markdown_vault_mcp.utils.attachment_target_exists`, deliberately:
+    that one mirrors what ``read`` will serve and applies no shape guard,
+    because under the ``*`` wildcard ``read`` really does serve an
+    extensionless ``Makefile``. This one decides a *name*'s kind, where the
+    same wildcard must not read the note title ``Version 2.0 plan`` as a
+    ``0 plan`` attachment.
+
+    Args:
+        target: Wikilink target with any fragment already split off.
+        extensions: The effective attachment allowlist, as returned by
+            :func:`~markdown_vault_mcp.utils.content_kind.effective_attachment_extensions`.
+
+    Returns:
+        ``True`` when *target* carries an extension naming an attachment.
+    """
+    suffix = artifact_suffix(target)
+    if not suffix:
+        # No extension at all — a note name in every configuration.
+        return False
+    if "*" in extensions:
+        # The wildcard means "every non-.md file", which says nothing about
+        # which *suffixes* are file types. Taken literally it would read the
+        # note title ``Version 2.0 plan`` as a ``0 plan`` attachment, so under
+        # the wildcard the suffix must also look like an extension.
+        return _RE_EXTENSION_SHAPE.fullmatch(suffix) is not None
+    return suffix in extensions

--- a/src/markdown_vault_mcp/utils/content_kind.py
+++ b/src/markdown_vault_mcp/utils/content_kind.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "artifact_suffix",
+    "canonical_attachment_extensions",
     "effective_attachment_extensions",
     "has_md_suffix",
     "is_allowed_artifact",
@@ -173,3 +174,29 @@ def effective_attachment_extensions(
         return DEFAULT_ATTACHMENT_EXTENSIONS
     normalized = (ext.strip().lstrip(".").lower() for ext in attachment_extensions)
     return frozenset(ext for ext in normalized if ext)
+
+
+def canonical_attachment_extensions(extensions: frozenset[str]) -> str:
+    """Return the allowlist's canonical string form, for build provenance.
+
+    Link extraction consults the allowlist to tell a wikilink naming an
+    attachment from one naming a note (#1333), which makes it the first
+    *content* setting to change how a note's stored rows derive from its
+    bytes. The index therefore records it, and a warm restart compares it,
+    the way it already does for ``title_field`` and the curated field lists.
+
+    The default set is deliberately rendered as the empty string rather than
+    its members: an index built before this key existed reads back ``""``,
+    and must compare equal to a default-configured server rather than
+    forcing a spurious rebuild on every such deployment.
+
+    Args:
+        extensions: The effective allowlist, as returned by
+            :func:`effective_attachment_extensions`.
+
+    Returns:
+        ``""`` for the default set, else the sorted members comma-joined.
+    """
+    if extensions == DEFAULT_ATTACHMENT_EXTENSIONS:
+        return ""
+    return ",".join(sorted(extensions))

--- a/src/markdown_vault_mcp/utils/content_kind.py
+++ b/src/markdown_vault_mcp/utils/content_kind.py
@@ -251,7 +251,17 @@ def names_attachment(target: str, extensions: frozenset[str]) -> bool:
 
     Returns:
         ``True`` when *target* carries an extension naming an attachment.
+        Always ``False`` for a ``.md`` target.
     """
+    if has_md_suffix(target):
+        # A ``.md`` target is a note in every configuration, including under
+        # the ``*`` wildcard, where ``md`` would otherwise be an
+        # extension-shaped suffix that matches everything. Extraction reaches
+        # this verdict by short-circuiting before it asks; saying it here too
+        # is what lets resolution ask the same question and get the same
+        # answer, instead of classifying an explicit ``[[note.md]]`` as an
+        # attachment and refusing to resolve it.
+        return False
     suffix = artifact_suffix(target)
     if not suffix:
         # No extension at all — a note name in every configuration.

--- a/src/markdown_vault_mcp/utils/fs.py
+++ b/src/markdown_vault_mcp/utils/fs.py
@@ -195,3 +195,49 @@ def iter_markdown_files(
         for filename in filenames:
             if is_note(filename):
                 yield base / filename
+
+
+def vault_relative_in_scope(
+    abs_path: Path,
+    source_dir: Path,
+    *,
+    is_excluded: Callable[[str], bool],
+    log_context: str = "attachment scan",
+) -> str | None:
+    """Vault-relative POSIX path of *abs_path*, or ``None`` when out of scope.
+
+    The shared in-scope rule for the attachment population: a file is out of
+    scope when it sits outside *source_dir*, when any path component is
+    dot-prefixed, or when it matches the configured exclude patterns. Mirrors
+    ``scan_directory`` so the attachments a vault serves and the attachments
+    its links resolve against are the same set.
+
+    Deliberately does **not** resolve symlinks: ``rglob`` yields paths
+    anchored at the unresolved *source_dir*, and resolving here would
+    mismatch when *source_dir* is itself a symlink and silently drop every
+    attachment.
+
+    Args:
+        abs_path: A path yielded by walking *source_dir*.
+        source_dir: The vault root, unresolved.
+        is_excluded: Predicate over the vault-relative POSIX path, supplied
+            by the caller because the exclude patterns live on its config.
+        log_context: Prefix naming the calling scan in the warning logged
+            when *abs_path* is outside *source_dir*.
+
+    Returns:
+        The vault-relative POSIX path, or ``None`` when out of scope.
+    """
+    try:
+        rel = abs_path.relative_to(source_dir)
+    except ValueError as exc:
+        logger.warning(
+            "%s: skipping %s — outside source_dir (%s)", log_context, abs_path, exc
+        )
+        return None
+    if any(part.startswith(".") for part in rel.parts):
+        return None
+    rel_posix = rel.as_posix()
+    if is_excluded(rel_posix):
+        return None
+    return rel_posix

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -595,6 +595,7 @@ class Vault:
             embed_model_name=self._embed_model_name,
             max_chunk_chars_override=self._max_chunk_chars_override,
             title_field=self._title_field,
+            attachment_extensions=self._attachment_extensions,
             embed_text_builder=self._embed_builder,
             embedding_batch_size=self._embedding_batch_size,
         )

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -47,6 +47,12 @@ from markdown_vault_mcp.scanner import (
     WholeDocumentChunker,
 )
 from markdown_vault_mcp.tracker import ChangeTracker
+from markdown_vault_mcp.utils.content_kind import (
+    canonical_attachment_extensions as _canonical_attachment_extensions,
+)
+from markdown_vault_mcp.utils.content_kind import (
+    effective_attachment_extensions as _effective_attachment_extensions,
+)
 from markdown_vault_mcp.write_callback import WriteCallbackDispatcher
 
 if TYPE_CHECKING:
@@ -617,6 +623,9 @@ class Vault:
             title_field=self._title_field,
             searchable_fields=",".join(self._searchable_frontmatter_fields),
             indexed_frontmatter_fields=",".join(self._indexed_frontmatter_fields),
+            attachment_extensions=_canonical_attachment_extensions(
+                _effective_attachment_extensions(self._attachment_extensions)
+            ),
         )
         # 3. SearchManager (receives IndexManager callbacks via constructor)
         self._search_mgr = SearchManager(

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -564,7 +564,11 @@ class Vault:
         from markdown_vault_mcp.managers.search import SearchManager
 
         # 1. LinkManager (no deps)
-        self._link_mgr = LinkManager(fts=self._fts, source_dir=self._source_dir)
+        self._link_mgr = LinkManager(
+            fts=self._fts,
+            source_dir=self._source_dir,
+            attachment_extensions=self._attachment_extensions,
+        )
         # 1b. GitQueryManager (git history/diff/revision reads; needs
         #     git_strategy + source_dir + the note read cap)
         self._git_query_mgr = GitQueryManager(

--- a/tests/test_index_coordinator.py
+++ b/tests/test_index_coordinator.py
@@ -16,6 +16,10 @@ from markdown_vault_mcp.indexing import IndexWriteCoordinator, ProcessDirtyPaths
 from markdown_vault_mcp.managers.index import IndexManager
 from markdown_vault_mcp.scanner import HeadingChunker
 from markdown_vault_mcp.tracker import ChangeTracker
+from markdown_vault_mcp.utils import (
+    canonical_attachment_extensions,
+    effective_attachment_extensions,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -32,6 +36,7 @@ def make_coordinator(
     title_field: str = "title",
     searchable_fields: tuple[str, ...] = (),
     indexed_frontmatter_fields: tuple[str, ...] = (),
+    attachment_extensions: tuple[str, ...] | None = None,
 ) -> IndexWriteCoordinator:
     """Build a wired coordinator over a tmp vault (mirrors Vault wiring)."""
     from markdown_vault_mcp.embed_text import EmbedTextBuilder
@@ -55,6 +60,9 @@ def make_coordinator(
         exclude_patterns=None,
         required_frontmatter=None,
         indexed_frontmatter_fields=list(indexed_frontmatter_fields),
+        attachment_extensions=(
+            None if attachment_extensions is None else list(attachment_extensions)
+        ),
         get_vectors=lambda: holder["v"],
         set_vectors=lambda v: holder.__setitem__("v", v),
         embed_model_name=embed_model_name,
@@ -72,6 +80,11 @@ def make_coordinator(
         title_field=title_field,
         searchable_fields=",".join(searchable_fields),
         indexed_frontmatter_fields=",".join(indexed_frontmatter_fields),
+        attachment_extensions=canonical_attachment_extensions(
+            effective_attachment_extensions(
+                None if attachment_extensions is None else list(attachment_extensions)
+            )
+        ),
     )
 
 
@@ -1150,5 +1163,70 @@ def test_default_curated_knobs_keep_warm_restart(tmp_path: Path) -> None:
     try:
         assert coord2._chunking_meta_matches() is True
         assert coord2.build_index().chunks_indexed == 0
+    finally:
+        coord2.close(timeout=5)
+
+
+def test_changing_the_attachment_allowlist_rejects_the_warm_restart(
+    tmp_path: Path,
+) -> None:
+    """The allowlist decides link rows, so a change to it stales them.
+
+    Hash-based reindexing never re-parses a note whose bytes did not move, so
+    an unchanged ``[[data.csv]]`` would keep the ``data.csv.md`` target it was
+    built with after ``csv`` became allowlisted (#1333, review round 1).
+    """
+    db = tmp_path / "index.db"
+    (tmp_path / "a.md").write_text("# A\n\n[[data.csv]]\n", encoding="utf-8")
+    coord = make_coordinator(tmp_path, db=db, attachment_extensions=("png",))
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+
+    coord2 = make_coordinator(tmp_path, db=db, attachment_extensions=("png", "csv"))
+    try:
+        assert coord2._chunking_meta_matches() is False
+    finally:
+        coord2.close(timeout=5)
+
+
+def test_an_unchanged_allowlist_keeps_the_warm_restart(tmp_path: Path) -> None:
+    """The guard must not force a rebuild on every restart."""
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, db=db, attachment_extensions=("png",))
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+
+    coord2 = make_coordinator(tmp_path, db=db, attachment_extensions=("png",))
+    try:
+        assert coord2._chunking_meta_matches() is True
+    finally:
+        coord2.close(timeout=5)
+
+
+def test_a_default_allowlist_matches_an_index_predating_the_key(
+    tmp_path: Path,
+) -> None:
+    """An absent key reads back as "", which is what the default renders as."""
+    db = tmp_path / "index.db"
+    coord = make_coordinator(tmp_path, db=db)
+    try:
+        coord.build_index()
+    finally:
+        coord.close(timeout=5)
+
+    conn = sqlite3.connect(db)
+    try:
+        with conn:
+            conn.execute("DELETE FROM meta WHERE key = 'attachment_extensions'")
+    finally:
+        conn.close()
+
+    coord2 = make_coordinator(tmp_path, db=db)
+    try:
+        assert coord2._chunking_meta_matches() is True
     finally:
         coord2.close(timeout=5)

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2149,3 +2149,137 @@ class TestAliasResolution:
         outlinks = idx.get_outlinks("source.md")
         assert outlinks[0]["target_path"] == "artificial-intelligence.md"
         assert outlinks[0]["fragment"] == "history"
+
+
+# ---------------------------------------------------------------------------
+# extract_links: paragraph bounding (#1334)
+# ---------------------------------------------------------------------------
+
+
+class TestLinkSpanBounding:
+    def test_stray_bracket_does_not_pair_across_a_blank_line(self) -> None:
+        """An unmatched ``[`` cannot pair with a ``](`` in a later paragraph."""
+        content = "See item [3 below.\n\nAnother paragraph.\n\nAn image: [x](pic.md)"
+        links = extract_links(content, "index.md")
+        assert [lnk.link_text for lnk in links] == ["x"]
+        assert links[0].target_path == "pic.md"
+
+    def test_link_text_may_span_a_soft_break(self) -> None:
+        """CommonMark allows a single newline inside link text."""
+        links = extract_links("[wrapped\ntext](note.md)", "index.md")
+        assert len(links) == 1
+        assert links[0].link_text == "wrapped\ntext"
+
+    def test_destination_never_contains_a_newline(self) -> None:
+        """A ``](`` whose closing paren is paragraphs away is not a link."""
+        content = "[text](.\n2. The programme has objectives:\n3. (a)"
+        assert extract_links(content, "index.md") == []
+
+    def test_reference_usage_does_not_span_a_blank_line(self) -> None:
+        """``[text][ref]`` is bounded the same way inline link text is."""
+        content = "A stray [bracket.\n\nProse.\n\n[real][ref]\n\n[ref]: b.md"
+        links = extract_links(content, "index.md")
+        assert [lnk.link_text for lnk in links] == ["real"]
+
+    def test_wikilink_target_never_spans_a_newline(self) -> None:
+        """``[[`` on one line and ``]]`` on another is not a wikilink."""
+        assert extract_links("[[stray\n\nprose]]", "index.md") == []
+
+
+# ---------------------------------------------------------------------------
+# extract_links: URI schemes (#1335)
+# ---------------------------------------------------------------------------
+
+
+class TestExternalUriSchemes:
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "file:///E:/Design/2026-001/Semicon",
+            "ftp://example.com/pub/doc.md",
+            "obsidian://open?vault=Notes&file=Topic",
+            "zotero://select/items/1_ABCD",
+            "tel:+31612345678",
+        ],
+    )
+    def test_schemed_inline_target_is_external(self, target: str) -> None:
+        """Any URI scheme marks the destination external, not a vault path."""
+        assert extract_links(f"[x]({target})", "notes/deep/src.md") == []
+
+    def test_schemed_reference_target_is_external(self) -> None:
+        """The scheme test applies to reference definitions too."""
+        content = "[x][ref]\n\n[ref]: zotero://select/items/1_ABCD"
+        assert extract_links(content, "index.md") == []
+
+    def test_schemed_wikilink_target_is_external(self) -> None:
+        """A schemed wikilink target is not a vault path with ``.md`` appended."""
+        assert extract_links("[[https://example.com]]", "index.md") == []
+
+    def test_windows_drive_letter_is_not_a_scheme(self) -> None:
+        """A single letter before ``:`` is a drive letter, not a URI scheme."""
+        links = extract_links("[x](C:/notes/topic.md)", "index.md")
+        assert len(links) == 1
+        assert links[0].raw_target == "C:/notes/topic.md"
+
+    def test_plain_relative_target_still_resolves(self) -> None:
+        """A destination with no scheme is unaffected."""
+        links = extract_links("[x](../sibling.md)", "Journal/2024/today.md")
+        assert len(links) == 1
+        assert links[0].target_path == "Journal/sibling.md"
+
+
+# ---------------------------------------------------------------------------
+# extract_links: wikilinks to attachments (#1333)
+# ---------------------------------------------------------------------------
+
+
+class TestWikilinkAttachments:
+    def test_allowlisted_extension_does_not_get_md_appended(self) -> None:
+        """``![[diagram.png]]`` names the attachment, not ``diagram.png.md``."""
+        links = extract_links(
+            "![[Images/wachtpost.png]]",
+            "index.md",
+            attachment_extensions=frozenset({"png", "pdf"}),
+        )
+        assert len(links) == 1
+        assert links[0].target_path == "Images/wachtpost.png"
+        assert links[0].raw_target == "Images/wachtpost.png"
+
+    def test_non_allowlisted_extension_still_gets_md_appended(self) -> None:
+        """An extension outside the allowlist keeps the note-name behaviour."""
+        links = extract_links(
+            "[[Report v2.final]]",
+            "index.md",
+            attachment_extensions=frozenset({"png"}),
+        )
+        assert links[0].target_path == "Report v2.final.md"
+
+    def test_bare_wikilink_still_gets_md_appended(self) -> None:
+        """A target with no extension is a note in every configuration."""
+        links = extract_links(
+            "[[My Note]]", "index.md", attachment_extensions=frozenset({"*"})
+        )
+        assert links[0].target_path == "My Note.md"
+
+    def test_wildcard_allows_any_extension_shaped_suffix(self) -> None:
+        """Under ``*`` every plausible file extension names an attachment."""
+        links = extract_links(
+            "[[assets/flow.drawio]]",
+            "index.md",
+            attachment_extensions=frozenset({"*"}),
+        )
+        assert links[0].target_path == "assets/flow.drawio"
+
+    def test_wildcard_does_not_treat_a_dotted_title_as_an_extension(self) -> None:
+        """``Version 2.0 plan`` is a note title, not a ``0 plan`` attachment."""
+        links = extract_links(
+            "[[Version 2.0 plan]]",
+            "index.md",
+            attachment_extensions=frozenset({"*"}),
+        )
+        assert links[0].target_path == "Version 2.0 plan.md"
+
+    def test_attachment_wikilink_keeps_its_fragment_behaviour(self) -> None:
+        """A default call (no allowlist) uses the default attachment set."""
+        links = extract_links("[[notes/pic.png]]", "index.md")
+        assert links[0].target_path == "notes/pic.png"

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2479,3 +2479,169 @@ class TestAttachmentAllowlistIsProvenance:
         col = Vault(source_dir=src)
         col.index.build_index()
         assert col._fts.get_chunking_meta().attachment_extensions == ""
+
+
+# ---------------------------------------------------------------------------
+# Review round 2: the three gaps the round-1 fixes left (#1333)
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyAllowlistIsDistinctProvenance:
+    """An explicitly empty allowlist is not the default set.
+
+    They derive different rows — with nothing allowlisted `[[pic.png]]` is a
+    note reference storing `pic.png.md` — so rendering both as `""` let a
+    switch between them keep the warm index and serve the old interpretation.
+    """
+
+    def test_empty_and_default_render_differently(self) -> None:
+        from markdown_vault_mcp.utils import (
+            canonical_attachment_extensions,
+            effective_attachment_extensions,
+        )
+
+        default = canonical_attachment_extensions(effective_attachment_extensions(None))
+        empty = canonical_attachment_extensions(effective_attachment_extensions([]))
+        assert default == ""
+        assert empty != default
+
+    def test_a_literal_none_extension_does_not_collide(self) -> None:
+        """The sentinel must not be a renderable allowlist."""
+        from markdown_vault_mcp.utils import (
+            canonical_attachment_extensions,
+            effective_attachment_extensions,
+        )
+
+        empty = canonical_attachment_extensions(effective_attachment_extensions([]))
+        literal = canonical_attachment_extensions(
+            effective_attachment_extensions(["none"])
+        )
+        assert empty != literal
+
+    def test_the_empty_allowlist_is_recorded_with_the_build(
+        self, tmp_path: Path
+    ) -> None:
+        src = tmp_path / "vault"
+        src.mkdir()
+        (src / "n.md").write_text("# N\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=[])
+        col.index.build_index()
+        assert col._fts.get_chunking_meta().attachment_extensions != ""
+
+
+class TestMissingAttachmentStaysBroken:
+    """A target classified as an attachment must not resolve onto a note.
+
+    Extraction declined to append `.md`, so resolution has to agree. Falling
+    through handed a *missing* `pic.png` to any note called `pic.png.md`,
+    reporting an existing link to an unrelated note.
+    """
+
+    def test_a_missing_attachment_does_not_resolve_to_a_same_named_note(
+        self, tmp_path: Path
+    ) -> None:
+        src = tmp_path / "vault"
+        src.mkdir()
+        (src / "pic.png.md").write_text("# unrelated\n", encoding="utf-8")
+        (src / "note.md").write_text("![[pic.png]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png"])
+        col.index.build_index()
+        (outlink,) = col.graph.get_outlinks("note.md")
+        assert outlink.target_path == "pic.png"
+        assert outlink.exists is False
+
+    def test_the_resolver_refuses_the_note_fallback_directly(self) -> None:
+        from markdown_vault_mcp.fts_index import _resolve_one_wikilink
+
+        assert (
+            _resolve_one_wikilink(
+                "pic.png",
+                attachment_paths=[],
+                doc_paths=["pic.png.md"],
+                alias_map={},
+                attachment_extensions=frozenset({"png"}),
+            )
+            is None
+        )
+
+    def test_a_note_target_still_uses_the_note_population(self) -> None:
+        """The guard must not disable ordinary note resolution."""
+        from markdown_vault_mcp.fts_index import _resolve_one_wikilink
+
+        assert (
+            _resolve_one_wikilink(
+                "Topic",
+                attachment_paths=[],
+                doc_paths=["notes/Topic.md"],
+                alias_map={},
+                attachment_extensions=frozenset({"png"}),
+            )
+            == "notes/Topic.md"
+        )
+
+    def test_aliases_still_resolve_for_note_targets(self) -> None:
+        from markdown_vault_mcp.fts_index import _resolve_one_wikilink
+
+        assert (
+            _resolve_one_wikilink(
+                "AI",
+                attachment_paths=[],
+                doc_paths=[],
+                alias_map={"ai": ["notes/Artificial Intelligence.md"]},
+                attachment_extensions=frozenset({"png"}),
+            )
+            == "notes/Artificial Intelligence.md"
+        )
+
+
+class TestAttachmentWritesReResolve:
+    """Adding an attachment changes what an existing embed resolves to.
+
+    Attachment writes carry no index rows, so nothing scheduled a resolver
+    pass and `![[pic.png]]` written before its file stayed unresolved until
+    an unrelated write or a manual reindex.
+    """
+
+    @staticmethod
+    def _vault(tmp_path: Path) -> Vault:
+        src = tmp_path / "vault"
+        (src / "assets").mkdir(parents=True)
+        (src / "note.md").write_text("# N\n\n![[pic.png]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png"], read_only=False)
+        col.index.build_index()
+        return col
+
+    def test_writing_the_attachment_resolves_the_waiting_embed(
+        self, tmp_path: Path
+    ) -> None:
+        col = self._vault(tmp_path)
+        assert col.graph.get_outlinks("note.md")[0].exists is False
+
+        col._doc_mgr.write_attachment("assets/pic.png", b"\x89PNG\r\n\x1a\n")
+        wait_for_writer_drain(col)
+
+        (outlink,) = col.graph.get_outlinks("note.md")
+        assert outlink.target_path == "assets/pic.png"
+        assert outlink.exists is True
+
+    def test_deleting_the_attachment_un_resolves_it(self, tmp_path: Path) -> None:
+        col = self._vault(tmp_path)
+        col._doc_mgr.write_attachment("assets/pic.png", b"\x89PNG\r\n\x1a\n")
+        wait_for_writer_drain(col)
+        assert col.graph.get_outlinks("note.md")[0].exists is True
+
+        col._doc_mgr.delete("assets/pic.png")
+        wait_for_writer_drain(col)
+        assert col.graph.get_outlinks("note.md")[0].exists is False
+
+    def test_renaming_the_attachment_follows_it(self, tmp_path: Path) -> None:
+        col = self._vault(tmp_path)
+        col._doc_mgr.write_attachment("assets/pic.png", b"\x89PNG\r\n\x1a\n")
+        wait_for_writer_drain(col)
+
+        col._doc_mgr.rename("assets/pic.png", "img/pic.png")
+        wait_for_writer_drain(col)
+
+        (outlink,) = col.graph.get_outlinks("note.md")
+        assert outlink.target_path == "img/pic.png"
+        assert outlink.exists is True

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2425,6 +2425,30 @@ class TestAttachmentWikilinksResolveVaultWide:
         col.index.build_index()
         assert col.graph.get_outlinks("note.md")[0].target_path == "a/pic.png"
 
+    def test_an_empty_allowlist_resolves_no_attachments(self, tmp_path: Path) -> None:
+        """Nothing allowlisted means the scan is skipped entirely."""
+        src = tmp_path / "vault"
+        (src / "assets").mkdir(parents=True)
+        (src / "assets" / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (src / "note.md").write_text("![[pic.png]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=[])
+        col.index.build_index()
+        (broken,) = col.graph.get_broken_links()
+        assert broken.target_path == "pic.png.md"
+
+    def test_an_unreadable_entry_is_skipped_not_raised(self, tmp_path: Path) -> None:
+        """A racing delete or an unreadable component must not fail the build."""
+        src = tmp_path / "vault"
+        (src / "assets").mkdir(parents=True)
+        (src / "assets" / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (src / "note.md").write_text("![[pic.png]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png"])
+        from pathlib import Path as _RuntimePath
+
+        with patch.object(_RuntimePath, "is_file", side_effect=OSError("vanished")):
+            paths = col._index_mgr._attachment_paths()
+        assert paths == []
+
 
 # ---------------------------------------------------------------------------
 # The allowlist is build provenance (#1333, review round 1)

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2283,3 +2283,79 @@ class TestWikilinkAttachments:
         """A default call (no allowlist) uses the default attachment set."""
         links = extract_links("[[notes/pic.png]]", "index.md")
         assert links[0].target_path == "notes/pic.png"
+
+
+# ---------------------------------------------------------------------------
+# Attachment targets are vault truth, not index truth (#1333)
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentLinkTargets:
+    """A link to an on-disk attachment is not broken, at every surface.
+
+    Attachments are never indexed, so the FTS answer alone reports every one
+    of them broken. These pin the LinkManager overlay that completes it.
+    """
+
+    @staticmethod
+    def _vault(tmp_path: Path, body: str) -> Vault:
+        src = tmp_path / "vault"
+        (src / "Images").mkdir(parents=True)
+        (src / "Images" / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (src / "note.md").write_text(body, encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png"])
+        col.index.build_index()
+        return col
+
+    def test_wikilink_embed_of_present_attachment_is_not_broken(
+        self, tmp_path: Path
+    ) -> None:
+        """The #1333 reproduction, end to end."""
+        col = self._vault(tmp_path, "# Note\n\n![[Images/pic.png]]\n")
+        assert col.graph.get_broken_links() == []
+        (outlink,) = col.graph.get_outlinks("note.md")
+        assert outlink.target_path == "Images/pic.png"
+        assert outlink.exists is True
+
+    def test_stats_count_agrees_with_the_list(self, tmp_path: Path) -> None:
+        """broken_link_count and get_broken_links read the same population."""
+        col = self._vault(tmp_path, "# Note\n\n![[Images/pic.png]]\n\n[[Nowhere]]\n")
+        assert col.reader.stats().broken_link_count == len(col.graph.get_broken_links())
+        assert col.reader.stats().broken_link_count == 1
+
+    def test_inline_link_to_present_attachment_is_not_broken(
+        self, tmp_path: Path
+    ) -> None:
+        """The same overlay covers markdown links, not only wikilinks."""
+        col = self._vault(tmp_path, "# Note\n\n[pic](Images/pic.png)\n")
+        assert col.graph.get_broken_links() == []
+
+    def test_missing_attachment_is_still_broken(self, tmp_path: Path) -> None:
+        """The allowlist alone does not excuse a file that is not there."""
+        col = self._vault(tmp_path, "# Note\n\n![[Images/gone.png]]\n")
+        (broken,) = col.graph.get_broken_links()
+        assert broken.target_path == "Images/gone.png"
+
+    def test_non_allowlisted_extension_is_still_broken(self, tmp_path: Path) -> None:
+        """An extension outside the allowlist keeps note semantics."""
+        src = tmp_path / "vault"
+        src.mkdir()
+        (src / "data.csv").write_text("a,b\n", encoding="utf-8")
+        (src / "note.md").write_text("[[data.csv]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png"])
+        col.index.build_index()
+        (broken,) = col.graph.get_broken_links()
+        assert broken.target_path == "data.csv.md"
+
+    def test_traversal_target_is_never_resolved_outside_the_vault(
+        self, tmp_path: Path
+    ) -> None:
+        """A target escaping the vault stays broken even if the file exists."""
+        (tmp_path / "outside.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        # A bare wikilink is stored verbatim — it never passes through the
+        # clamping in _resolve_link_path — so this is the one spelling that
+        # reaches the overlay carrying real ``..`` segments.
+        col = self._vault(tmp_path, "# Note\n\n[[Images/../../outside.png]]\n")
+        (broken,) = col.graph.get_broken_links()
+        assert broken.target_path == "Images/../../outside.png"
+        assert all(o.exists is False for o in col.graph.get_outlinks("note.md"))

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2359,3 +2359,99 @@ class TestAttachmentLinkTargets:
         (broken,) = col.graph.get_broken_links()
         assert broken.target_path == "Images/../../outside.png"
         assert all(o.exists is False for o in col.graph.get_outlinks("note.md"))
+
+
+# ---------------------------------------------------------------------------
+# Attachment wikilinks resolve vault-wide (#1333, review round 1)
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentWikilinksResolveVaultWide:
+    """Obsidian's embeds name a file, and usually only its basename.
+
+    Extraction alone left `![[pic.png]]` stored as `pic.png` while the file
+    lived in `assets/`, so it stayed broken; and because the vault-wide
+    resolver appended `.md` to every target, a same-named note could capture
+    the embed outright.
+    """
+
+    @staticmethod
+    def _vault(tmp_path: Path, *, decoy: bool) -> Vault:
+        src = tmp_path / "vault"
+        (src / "assets").mkdir(parents=True)
+        (src / "assets" / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        if decoy:
+            (src / "pic.png.md").write_text("# unrelated\n", encoding="utf-8")
+        (src / "note.md").write_text("# N\n\n![[pic.png]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png"])
+        col.index.build_index()
+        return col
+
+    def test_bare_embed_resolves_to_the_file_in_its_folder(
+        self, tmp_path: Path
+    ) -> None:
+        col = self._vault(tmp_path, decoy=False)
+        (outlink,) = col.graph.get_outlinks("note.md")
+        assert outlink.target_path == "assets/pic.png"
+        assert outlink.exists is True
+        assert col.graph.get_broken_links() == []
+
+    def test_a_same_named_note_does_not_capture_the_embed(self, tmp_path: Path) -> None:
+        """`pic.png.md` is what the .md append used to look for."""
+        col = self._vault(tmp_path, decoy=True)
+        (outlink,) = col.graph.get_outlinks("note.md")
+        assert outlink.target_path == "assets/pic.png"
+
+    def test_note_wikilinks_still_resolve_vault_wide(self, tmp_path: Path) -> None:
+        """The attachment branch must not shadow ordinary note resolution."""
+        src = tmp_path / "vault"
+        (src / "notes").mkdir(parents=True)
+        (src / "notes" / "Topic.md").write_text("# T\n", encoding="utf-8")
+        (src / "hub.md").write_text("[[Topic]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png"])
+        col.index.build_index()
+        (outlink,) = col.graph.get_outlinks("hub.md")
+        assert outlink.target_path == "notes/Topic.md"
+        assert outlink.exists is True
+
+    def test_shortest_path_wins_among_attachments(self, tmp_path: Path) -> None:
+        """Obsidian's tie-break, applied to the attachment population too."""
+        src = tmp_path / "vault"
+        (src / "a" / "b").mkdir(parents=True)
+        (src / "a" / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (src / "a" / "b" / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (src / "note.md").write_text("![[pic.png]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png"])
+        col.index.build_index()
+        assert col.graph.get_outlinks("note.md")[0].target_path == "a/pic.png"
+
+
+# ---------------------------------------------------------------------------
+# The allowlist is build provenance (#1333, review round 1)
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentAllowlistIsProvenance:
+    """Link extraction reads the allowlist, so a change to it stales the rows.
+
+    Hash-based reindexing never re-parses a note whose bytes did not move, so
+    without the allowlist in the recorded provenance an unchanged
+    `[[data.csv]]` kept its `data.csv.md` row after `csv` was allowlisted.
+    """
+
+    def test_the_allowlist_is_recorded_with_the_build(self, tmp_path: Path) -> None:
+        src = tmp_path / "vault"
+        src.mkdir()
+        (src / "n.md").write_text("# N\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["png", "PDF"])
+        col.index.build_index()
+        assert col._fts.get_chunking_meta().attachment_extensions == "pdf,png"
+
+    def test_the_default_set_is_recorded_as_empty(self, tmp_path: Path) -> None:
+        """So an index built before this key existed compares equal."""
+        src = tmp_path / "vault"
+        src.mkdir()
+        (src / "n.md").write_text("# N\n", encoding="utf-8")
+        col = Vault(source_dir=src)
+        col.index.build_index()
+        assert col._fts.get_chunking_meta().attachment_extensions == ""

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2564,6 +2564,46 @@ class TestMissingAttachmentStaysBroken:
             is None
         )
 
+    def test_an_explicit_md_wikilink_resolves_under_the_wildcard(self) -> None:
+        """A ``.md`` target is a note in every configuration.
+
+        Under ``*`` every extension-shaped suffix names an attachment, and
+        ``md`` is one — so classifying by suffix alone made an explicit
+        ``[[note.md]]`` unresolvable. Extraction never hit that, because it
+        short-circuits on the ``.md`` before asking; the two stages have to
+        agree, so the predicate answers it the same way.
+        """
+        from markdown_vault_mcp.fts_index import _resolve_one_wikilink
+
+        assert (
+            _resolve_one_wikilink(
+                "note.md",
+                attachment_paths=[],
+                doc_paths=["notes/note.md"],
+                alias_map={},
+                attachment_extensions=frozenset({"*"}),
+            )
+            == "notes/note.md"
+        )
+
+    def test_an_md_target_is_never_an_attachment(self) -> None:
+        from markdown_vault_mcp.utils import names_attachment
+
+        assert names_attachment("note.md", frozenset({"*"})) is False
+        assert names_attachment("note.MD", frozenset({"*"})) is False
+        assert names_attachment("diagram.png", frozenset({"*"})) is True
+
+    def test_an_explicit_md_wikilink_resolves_end_to_end(self, tmp_path: Path) -> None:
+        src = tmp_path / "vault"
+        (src / "notes").mkdir(parents=True)
+        (src / "notes" / "note.md").write_text("# N\n", encoding="utf-8")
+        (src / "hub.md").write_text("[[note.md]]\n", encoding="utf-8")
+        col = Vault(source_dir=src, attachment_extensions=["*"])
+        col.index.build_index()
+        (outlink,) = col.graph.get_outlinks("hub.md")
+        assert outlink.target_path == "notes/note.md"
+        assert outlink.exists is True
+
     def test_a_note_target_still_uses_the_note_population(self) -> None:
         """The guard must not disable ordinary note resolution."""
         from markdown_vault_mcp.fts_index import _resolve_one_wikilink

--- a/tests/test_utils_attachment_target_exists.py
+++ b/tests/test_utils_attachment_target_exists.py
@@ -47,7 +47,7 @@ class TestAttachmentTargetExists:
     def test_wildcard_serves_an_extensionless_file(self, vault: Path) -> None:
         """No extension-shape guard here: ``read`` serves this under ``*``.
 
-        This is the deliberate asymmetry with ``scanner._names_attachment``,
+        This is the deliberate asymmetry with ``names_attachment``,
         which does apply a shape guard because it answers a different
         question (whether to append ``.md`` at extraction time).
         """

--- a/tests/test_utils_attachment_target_exists.py
+++ b/tests/test_utils_attachment_target_exists.py
@@ -1,0 +1,83 @@
+"""Tests for :func:`markdown_vault_mcp.utils.attachment_target_exists` (#1333).
+
+The vault-truth half of link resolution: the index knows only about notes, so
+this is what tells a link to an on-disk attachment from a link to nothing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from markdown_vault_mcp.utils import attachment_target_exists
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    """A vault root holding one attachment, one note, and one extensionless file."""
+    root = tmp_path / "vault"
+    (root / "Images").mkdir(parents=True)
+    (root / "Images" / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    (root / "note.md").write_text("# Note\n", encoding="utf-8")
+    (root / "Makefile").write_text("all:\n", encoding="utf-8")
+    return root
+
+
+class TestAttachmentTargetExists:
+    def test_allowlisted_attachment_on_disk(self, vault: Path) -> None:
+        assert attachment_target_exists("Images/pic.png", vault, frozenset({"png"}))
+
+    def test_allowlisted_but_absent(self, vault: Path) -> None:
+        assert not attachment_target_exists(
+            "Images/gone.png", vault, frozenset({"png"})
+        )
+
+    def test_present_but_not_allowlisted(self, vault: Path) -> None:
+        assert not attachment_target_exists("Images/pic.png", vault, frozenset({"pdf"}))
+
+    def test_a_note_is_never_an_attachment(self, vault: Path) -> None:
+        """Even with ``md`` allowlisted — the note branch owns those."""
+        assert not attachment_target_exists("note.md", vault, frozenset({"md", "png"}))
+
+    def test_wildcard_serves_an_extensionless_file(self, vault: Path) -> None:
+        """No extension-shape guard here: ``read`` serves this under ``*``.
+
+        This is the deliberate asymmetry with ``scanner._names_attachment``,
+        which does apply a shape guard because it answers a different
+        question (whether to append ``.md`` at extraction time).
+        """
+        assert attachment_target_exists("Makefile", vault, frozenset({"*"}))
+
+    def test_directory_is_not_a_file(self, vault: Path) -> None:
+        (vault / "Images.png").mkdir()
+        assert not attachment_target_exists("Images.png", vault, frozenset({"png"}))
+
+    def test_traversal_outside_the_vault_is_refused(self, vault: Path) -> None:
+        """The file exists one level up; the guard must still say no."""
+        (vault.parent / "outside.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        assert not attachment_target_exists(
+            "Images/../../outside.png", vault, frozenset({"png"})
+        )
+
+    def test_unresolvable_path_is_refused_not_raised(self, vault: Path) -> None:
+        """A symlink loop raises OSError (RuntimeError on Python < 3.13)."""
+        with patch(
+            "markdown_vault_mcp.utils.resolve_inside",
+            side_effect=OSError("Too many levels of symbolic links"),
+        ):
+            assert not attachment_target_exists(
+                "Images/pic.png", vault, frozenset({"png"})
+            )
+
+    def test_unstattable_file_is_refused_not_raised(self, vault: Path) -> None:
+        """``is_file()`` can itself raise on an unreadable path component."""
+        target = vault / "Images" / "pic.png"
+        with patch.object(type(target), "is_file", side_effect=OSError("EACCES")):
+            assert not attachment_target_exists(
+                "Images/pic.png", vault, frozenset({"png"})
+            )


### PR DESCRIPTION
## Closes / Refs

Closes #1333, closes #1334, closes #1335

## What & why

Three link-extraction defects found together during the 4.2.0-rc.0 live test.
They share one pipeline stage and one index rebuild, so they are fixed
together rather than in three PRs that each force a rebuild.

- **#1334** — `[^\]]*` and `[^)]+` both match newlines, so an unmatched `[`
  paired with a `](` thousands of characters later and indexed pages of prose
  as one link. `get_broken_links` returned those multi-kilobyte values
  verbatim. Link text is now bounded the way CommonMark bounds it (a soft
  break is allowed, a blank line is not) and a destination never contains a
  newline. The same unbounded shape is swept from the reference-usage,
  reference-definition and wikilink regexes in the same commit.
- **#1333** — `![[diagram.png]]` gained a `.md` suffix. A wikilink target
  whose extension is allowlisted now names that attachment.
- **#1335** — the external filter was an allowlist of four prefixes, so
  `file:`, `ftp:`, `obsidian:` and `zotero:` were resolved as vault paths.
  The test is now the shape RFC 3986 gives a scheme, requiring two or more
  characters before the colon so a Windows drive stays a path.

`INDEX_SEMANTICS_VERSION` 3 → 4 in the same commit, per the #1124 rule.

### #1333 needed two stages, not one

The local review caught this before the push, and it reshaped the diff.
Fixing extraction alone moves the broken target from `Images/pic.png.md` to
`Images/pic.png` **without un-breaking it**: attachments are never indexed,
so `get_broken_links` — whose predicate is "not in `documents_live`" — still
reports every link to one. The index cannot answer the question; only
something holding `source_dir` can.

So the layers split: `FTSIndex` keeps answering index truth, and
`LinkManager` overlays vault truth through one shared predicate
(`utils.attachment_target_exists`) applied at all three surfaces —
`get_broken_links` filters the row, `get_outlinks` ORs into `exists`, and a
new `LinkManager.count_broken_links` counts the same rows through the same
predicate so `stats.broken_link_count` cannot disagree with the list. This
also un-breaks ordinary markdown links to attachments (`[x](data/file.txt)`),
which is the same defect class; there is a test pinning that as deliberate.

The two attachment tests are deliberately **not** unified, and the docstrings
say so: `_names_attachment` decides the `.md` append and under the `*`
wildcard requires an extension-*shaped* suffix (or the note title
`Version 2.0 plan` reads as a `0 plan` attachment), while
`attachment_target_exists` mirrors what `read` actually serves, where under
the wildcard an extensionless `Makefile` *is* an attachment.

### Review round 1 (Codex, three P1s — all real, all fixed)

**Embeds resolve by basename now.** `![[pic.png]]` with the file at
`assets/pic.png` was still broken: extraction stored `pic.png`, and
`resolve_vault_wikilinks()` searched only indexed documents after appending
`.md`. Worse, a note named `pic.png.md` captured the embed outright.
Verified both with a probe before fixing. The resolver now tries the
attachment population against the target *as written* before the `.md`
fallback, so one rule fixes both, and Obsidian's shortest-path tie-break
applies to attachments too. `IndexManager` supplies that population once per
resolution pass, not per link. This also made the resolver exceed the
complexity ceiling, so the per-link rule is extracted to
`_resolve_one_wikilink` rather than suppressed.

**The allowlist is now build provenance.** Link extraction reads
`ATTACHMENT_EXTENSIONS`, which makes it the first *content* setting to change
how a note's rows derive from its bytes — and hash-based reindexing never
re-parses an unchanged note, so flipping it left `[[data.csv]]` on a stale
`data.csv.md` row. It rides in `ChunkingMeta` and is compared on warm
restart, like `title_field`. The default set records as `""` so an index
predating the key compares equal instead of rebuilding every deployment once
for nothing.

**The published tool reference stated the old contract.** I swept the source
docstrings and design.md when `exists` changed meaning and missed
`docs/tools/index.md`. Swept the whole class this round: the tool page, the
summary table, both tool docstrings, and the design.md facet table.

**One more, from the Repowise health gate.** It flagged duplication, and was
right about the substance: `IndexManager._attachment_paths` (added in this
round) reimplemented the scope rule `SearchManager._attachment_rel_path`
already owned. Two copies of it is exactly the drift this PR exists to
prevent — the attachments a vault *serves* and the ones its links *resolve
against* must be one set. `utils.fs.vault_relative_in_scope` is now the
single rule and both call it.

The gate is advisory (not in the required set) and still reports a
regression, which is a composite over pre-existing signals on the files this
change necessarily touches: `FTSIndex` is a 53-method god class, and
`fts_index.py` / `managers/index.py` / `scanner.py` each carry 14–28
prior-defect and co-change-scatter findings that predate this PR. Those are
refactor-later debt, not something to bundle here.

## What this PR deliberately does NOT do

- **Rewrite embeds when an attachment is renamed**: #1338. `rename(...,
  update_links=True)` on an attachment returns `updated_links: 0` and always
  has — the note and attachment branches of `DocumentManager.rename` differ.
  It was invisible before this PR because no link row ever pointed at an
  attachment path. Verified with a probe, filed with the reproduction, in the
  v4.2 milestone.
- **Index attachments as `documents` rows.** That would remove the need for
  the overlay, and is a much larger change to the index contract.
- **Decide whether an embed should be a link at all.** `_extract_inline_links`
  skips `![alt](src)` while `_extract_wikilinks` records `![[...]]`. #1333's
  open question; left as-is so this PR changes resolution, not the population.
- **Percent-decoded destinations**: #1332, deliberately its own PR — it
  reaches the rename link-rewrite path and has its own design decisions.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
      It found the #1333 blocker described above; the range was re-reviewed
      after the fix reshaped the diff.
- [x] No commit carries `!`. Nothing here breaks an operator or library
      surface: `extract_links`, `parse_note`, `scan_directory` and
      `LinkManager.__init__` all gained keyword parameters with defaults that
      preserve the previous call shape.

## Docs impact

- [ ] `README.md` — no user-facing config or tool surface changed.
- [x] `docs/` site pages — `docs/releases/4.2.md` (the behaviour change and
      the one-time rebuild under Upgrading).
- [x] `docs/design/` — the link-extraction section: the paragraph bound, the
      scheme test, and the two-stage attachment story with the deliberate
      asymmetry between the two predicates.
- [x] Inline docstrings — `extract_links`, `parse_note`,
      `parse_note_categorized`, `scan_directory`, `_extract_inline_links`,
      `_extract_reference_links`, `_extract_wikilinks`, `OutlinkInfo.exists`,
      `GraphFacet.get_outlinks` / `get_broken_links`, and the two MCP tool
      docstrings (kept at a near-zero character delta for the client-surface
      budget).

---
_Generated by [Claude Code](https://claude.ai/code)_
