### PR TITLE
fix(links): resolve and rewrite percent-encoded link destinations

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2040,17 +2040,25 @@ ordering rules matter:
 - **The fragment splits before the decode.** An encoded `%23` is a literal
   `#` in the file name; decoding first would read it as the fragment marker
   and truncate the target.
-- **Two escapes are refused rather than decoded**, because decoding them
-  would invent a target that resolves. An encoded separator (`%2F`) stays
-  encoded: it is path *data*, so `dir%2Fnote.md` names one file that cannot
-  exist, and decoding it would point the link at the unrelated note actually
-  at `dir/note.md`, complete with a false backlink and a rename that rewrites
-  it. An escape that is not valid UTF-8 (`bad%FF.md`) leaves the whole
-  destination undecoded, because `unquote`'s default replacement decoding
-  substitutes U+FFFD — inventing a name, and collapsing distinct malformed
-  sequences onto one target so several broken links could share a false
-  backlink. `decode_link_target` in `utils/links.py` is the single decoder,
-  shared by extraction and by the rename-shape comparison.
+- **Two escapes name no possible file, and the link is not recorded at all.**
+  An encoded separator (`%2F`) is path *data*, so `dir%2Fnote.md` names one
+  path segment containing a slash. An escape that is not valid UTF-8
+  (`bad%FF.md`) names bytes that are not a UTF-8 name. `decode_link_target`
+  in `utils/links.py` returns `None` for both, and the extractors skip the
+  link.
+
+  Returning the *raw* spelling instead is not a refusal, which is the trap
+  here: the raw spelling is itself a valid path, so a vault containing a file
+  literally called `dir%2Fnote.md` matched it and gained a backlink from a
+  destination that names nothing. Decoding is no better in the other
+  direction — it points the link at the unrelated note actually at
+  `dir/note.md`. A file genuinely called `dir%2Fnote.md` is reached by
+  encoding the percent (`dir%252Fnote.md`), which decodes here without being
+  refused.
+
+  `decode_link_target` is the single decoder, shared by extraction and by the
+  rename-shape comparison; a destination it refuses is treated by the latter
+  as written, since there is no encoding convention to preserve.
 - **`raw_target` keeps the spelling as written**, because it is what
   `apply_link_replacement` searches for in the file. Only `target_path` is
   decoded.

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2040,6 +2040,17 @@ ordering rules matter:
 - **The fragment splits before the decode.** An encoded `%23` is a literal
   `#` in the file name; decoding first would read it as the fragment marker
   and truncate the target.
+- **Two escapes are refused rather than decoded**, because decoding them
+  would invent a target that resolves. An encoded separator (`%2F`) stays
+  encoded: it is path *data*, so `dir%2Fnote.md` names one file that cannot
+  exist, and decoding it would point the link at the unrelated note actually
+  at `dir/note.md`, complete with a false backlink and a rename that rewrites
+  it. An escape that is not valid UTF-8 (`bad%FF.md`) leaves the whole
+  destination undecoded, because `unquote`'s default replacement decoding
+  substitutes U+FFFD — inventing a name, and collapsing distinct malformed
+  sequences onto one target so several broken links could share a false
+  backlink. `decode_link_target` in `utils/links.py` is the single decoder,
+  shared by extraction and by the rename-shape comparison.
 - **`raw_target` keeps the spelling as written**, because it is what
   `apply_link_replacement` searches for in the file. Only `target_path` is
   decoded.

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2029,6 +2029,37 @@ to `Journal/sibling.md`. A leading slash makes the target vault-root-relative
 document's location — this is OKF's recommended link style. Traversal above the
 vault root clamps to root.
 
+**A markdown destination is a URL, so its percent-escapes are decoded.**
+`[x](/probe/b%5B1%5D.md)` names `probe/b[1].md`, and percent-encoding is the
+canonical way to write a destination containing `[`, `]`, spaces or
+parentheses — exactly the note names #1303 / #1305 taught the git layer to
+handle. Nothing decoded them, so the encoded spelling resolved to nothing,
+produced no backlink, and was skipped by a link-updating rename (#1332). Two
+ordering rules matter:
+
+- **The fragment splits before the decode.** An encoded `%23` is a literal
+  `#` in the file name; decoding first would read it as the fragment marker
+  and truncate the target.
+- **`raw_target` keeps the spelling as written**, because it is what
+  `apply_link_replacement` searches for in the file. Only `target_path` is
+  decoded.
+
+**Wikilinks are not decoded.** Obsidian writes wikilink targets literally, so
+`%20` in one is part of the name; decoding would break a note genuinely
+carrying a `%`. This is the one place the two link families deliberately
+disagree, and `_resolve_link_path` takes a `decode_percent` flag rather than
+guessing.
+
+**A rewrite keeps the spelling, not just the shape.** `compute_new_raw_target`
+detects a link's shape by comparing its destination to `old_path`, which is
+never encoded — so an encoded root-relative link never compared equal and fell
+into the relative-to-source branch, coming back rewritten as a relative link.
+That is the #1105 fidelity defect reached by a second route. The comparison is
+now made against the decoded destination, and the replacement is re-encoded
+(`quote`, `safe="/"`) only when the original was encoded. No encoding is
+introduced where the author used none, which also means a rename cannot repair
+a destination whose new name would need escaping to parse.
+
 **Fragment handling**: `path.md#heading` splits into `target_path=path.md` and
 `fragment=heading`. The fragment is preserved on `LinkInfo` but the target path
 is stored without it.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -318,6 +318,20 @@ exempts from typing
 histograms now cover the same note population `okf_validate` audits, and
 reserved files are reported separately as `reserved_count`.
 
+**Percent-encoded links resolve to the notes they name.** Writing a
+destination as `[x](/probe/b%5B1%5D.md)` is the canonical way to point at a
+note whose name contains `[`, `]`, a space or parentheses, and nothing
+decoded it
+([#1332](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1332)). The
+link reported broken, contributed no backlink, and a rename with
+`update_links=True` skipped it, so renaming the target left the link
+pointing at a path that no longer existed while reporting success. Both
+spellings of a name now resolve to the same note, both count as backlinks,
+and both are rewritten by a rename. A destination the author wrote encoded
+stays encoded when it is rewritten; one written literally stays literal.
+Wikilink targets are left alone, because Obsidian writes those literally and
+a `%` in one belongs to the name.
+
 ## Configuration and its documentation
 
 **The OIDC pages stopped steering readers into the wrong mode.** The 4.1
@@ -401,12 +415,15 @@ meaning; the operator surface only grew (two GitLab webhook variables,
 `INSTANCE_DESCRIPTION`). A few things do change behavior without any action
 on your part:
 
-- **The text index rebuilds once on first start.** Recording skip
-  tombstones changed how stored rows derive from a note's bytes, so
-  `INDEX_SEMANTICS_VERSION` moved from 2 to 3
-  ([#1227](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1227)).
-  The rebuild is automatic, costs CPU and local IO proportional to vault
-  size, and does not re-embed.
+- **The text index rebuilds once on first start.** Two changes in this
+  release alter how stored rows derive from a note's bytes: recording skip
+  tombstones
+  ([#1227](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1227)) and
+  decoding percent-escaped link destinations
+  ([#1332](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1332)),
+  so `INDEX_SEMANTICS_VERSION` moved from 2 to 4. The rebuild is automatic,
+  happens once regardless of how many changes triggered it, costs CPU and
+  local IO proportional to vault size, and does not re-embed.
 - **A Voyage vault also re-embeds once**, through a separate mechanism
   with a separate trigger: the provider's embedding behavior is part of the
   vector sidecar's identity, and asymmetric embedding changed it

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -330,10 +330,11 @@ spellings of a name now resolve to the same note, both count as backlinks,
 and both are rewritten by a rename. A destination the author wrote encoded
 stays encoded when it is rewritten; one written literally stays literal.
 Wikilink targets are left alone, because Obsidian writes those literally and
-a `%` in one belongs to the name. Two escapes stay untouched on purpose: an
-encoded slash, which is part of a name rather than a folder boundary, and an
-escape that is not valid UTF-8. Decoding either would point a link at some
-existing note it never named.
+a `%` in one belongs to the name. Two destinations are refused rather than
+resolved, because they name no file that can exist. An encoded slash is part
+of a name, not a folder boundary. An escape that is not valid UTF-8 names no
+UTF-8 name. Neither is recorded as a link. To point at a file whose name
+really does contain a percent, encode the percent itself.
 
 ## Configuration and its documentation
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -330,7 +330,10 @@ spellings of a name now resolve to the same note, both count as backlinks,
 and both are rewritten by a rename. A destination the author wrote encoded
 stays encoded when it is rewritten; one written literally stays literal.
 Wikilink targets are left alone, because Obsidian writes those literally and
-a `%` in one belongs to the name.
+a `%` in one belongs to the name. Two escapes stay untouched on purpose: an
+encoded slash, which is part of a name rather than a folder boundary, and an
+escape that is not valid UTF-8. Decoding either would point a link at some
+existing note it never named.
 
 ## Configuration and its documentation
 

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -245,7 +245,12 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: ``documents``. An index built by an older pipeline has no tombstones, so
 #: its row absences are ambiguous (skipped vs. deleted); the bump forces the
 #: one cold rebuild that materialises tombstones for existing skips.
-INDEX_SEMANTICS_VERSION = 3
+#:
+#: Version 4 (#1332): a markdown or reference destination is percent-decoded
+#: before it is resolved, so a link written ``b%5B1%5D.md`` now stores the
+#: target ``b[1].md`` it always named. An index built by an older pipeline
+#: holds the undecoded target, which matches no document.
+INDEX_SEMANTICS_VERSION = 4
 
 
 class ChunkingMeta(NamedTuple):

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -248,8 +248,11 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #:
 #: Version 4 (#1332): a markdown or reference destination is percent-decoded
 #: before it is resolved, so a link written ``b%5B1%5D.md`` now stores the
-#: target ``b[1].md`` it always named. An index built by an older pipeline
-#: holds the undecoded target, which matches no document.
+#: target ``b[1].md`` it always named, and a destination whose escapes name
+#: no possible file (``dir%2Fnote.md``, ``bad%FF.md``) stores no row at all.
+#: An index built by an older pipeline holds the undecoded target for the
+#: first, and a row for the second that can match a file coincidentally
+#: named the same as the escape sequence.
 INDEX_SEMANTICS_VERSION = 4
 
 

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -813,7 +813,7 @@ def _strip_code_spans(content: str) -> str:
 
 def _resolve_link_path(
     target: str, source_rel: str, *, decode_percent: bool = False
-) -> tuple[str, str | None]:
+) -> tuple[str, str | None] | None:
     """Resolve a raw link target against the source document's directory.
 
     Splits off any fragment identifier (``#heading``), resolves the path
@@ -832,7 +832,10 @@ def _resolve_link_path(
     Returns:
         A ``(resolved_path, fragment)`` tuple where ``resolved_path`` is the
         vault-relative POSIX path with forward slashes and ``fragment`` is the
-        heading identifier or ``None``.
+        heading identifier or ``None``. ``None`` in place of the tuple when
+        the destination carries an escape naming no possible file, in which
+        case the caller records no link at all — see
+        :func:`~markdown_vault_mcp.utils.links.decode_link_target`.
     """
     # Split fragment BEFORE decoding: an encoded ``%23`` is a literal ``#`` in
     # the file name, and decoding first would read it as the fragment marker
@@ -844,10 +847,13 @@ def _resolve_link_path(
         target = target[:idx]
 
     if decode_percent:
-        # An encoded separator stays encoded and an invalid-UTF-8 escape
-        # leaves the target undecoded, so neither invents a resolvable name;
-        # see :func:`~markdown_vault_mcp.utils.links.decode_link_target`.
-        target = decode_link_target(target)
+        decoded = decode_link_target(target)
+        if decoded is None:
+            # Names no possible file. Returning the raw spelling instead
+            # would resolve it against a vault that happens to contain a
+            # file called that, which is a different file.
+            return None
+        target = decoded
 
     if not target:
         # Link with only a fragment — points to the source document itself.
@@ -930,9 +936,10 @@ def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
         if raw_target.startswith("#"):
             # Pure anchor link — skip (points to a section in the same doc).
             continue
-        resolved, fragment = _resolve_link_path(
-            raw_target, source_path, decode_percent=True
-        )
+        resolution = _resolve_link_path(raw_target, source_path, decode_percent=True)
+        if resolution is None:
+            continue
+        resolved, fragment = resolution
         links.append(
             LinkInfo(
                 target_path=resolved,
@@ -992,9 +999,10 @@ def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
             continue
         if raw_target.startswith("#"):
             continue
-        resolved, fragment = _resolve_link_path(
-            raw_target, source_path, decode_percent=True
-        )
+        resolution = _resolve_link_path(raw_target, source_path, decode_percent=True)
+        if resolution is None:
+            continue
+        resolved, fragment = resolution
         links.append(
             LinkInfo(
                 target_path=resolved,
@@ -1065,7 +1073,13 @@ def _extract_wikilinks(clean: str, source_path: str) -> list[LinkInfo]:
         # FTSIndex.resolve_vault_wikilinks() can resolve them vault-wide
         # against the full indexed document set.
         if raw_path.startswith("./") or raw_path.startswith("../"):
-            resolved, path_fragment = _resolve_link_path(raw_path, source_path)
+            resolution = _resolve_link_path(raw_path, source_path)
+            if resolution is None:  # pragma: no cover - decode_percent=False
+                # Only a refused percent-escape yields None, and wikilinks
+                # are never decoded (Obsidian writes their targets
+                # literally), so this branch is unreachable from here.
+                continue
+            resolved, path_fragment = resolution
             fragment = fragment or path_fragment
         else:
             resolved = raw_path

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -8,6 +8,7 @@ import re
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from urllib.parse import unquote
 
 import frontmatter
 import yaml
@@ -810,7 +811,9 @@ def _strip_code_spans(content: str) -> str:
     return content
 
 
-def _resolve_link_path(target: str, source_rel: str) -> tuple[str, str | None]:
+def _resolve_link_path(
+    target: str, source_rel: str, *, decode_percent: bool = False
+) -> tuple[str, str | None]:
     """Resolve a raw link target against the source document's directory.
 
     Splits off any fragment identifier (``#heading``), resolves the path
@@ -821,18 +824,29 @@ def _resolve_link_path(target: str, source_rel: str) -> tuple[str, str | None]:
         target: Raw target string from the link (may include ``#fragment``).
         source_rel: Relative POSIX path of the source document
             (e.g. ``"Journal/2024/today.md"``).
+        decode_percent: Whether to percent-decode the path portion. True for
+            markdown and reference links, whose destination CommonMark
+            defines as a URL; False for wikilinks, which Obsidian writes
+            literally (#1332).
 
     Returns:
         A ``(resolved_path, fragment)`` tuple where ``resolved_path`` is the
         vault-relative POSIX path with forward slashes and ``fragment`` is the
         heading identifier or ``None``.
     """
-    # Split fragment.
+    # Split fragment BEFORE decoding: an encoded ``%23`` is a literal ``#`` in
+    # the file name, and decoding first would read it as the fragment marker
+    # and truncate the target (#1332).
     fragment: str | None = None
     if "#" in target:
         idx = target.index("#")
         fragment = target[idx + 1 :] or None
         target = target[:idx]
+
+    if decode_percent:
+        # unquote leaves a ``%`` that begins no valid escape alone, so a note
+        # genuinely named "50% off.md" survives a round trip.
+        target = unquote(target)
 
     if not target:
         # Link with only a fragment — points to the source document itself.
@@ -915,7 +929,9 @@ def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
         if raw_target.startswith("#"):
             # Pure anchor link — skip (points to a section in the same doc).
             continue
-        resolved, fragment = _resolve_link_path(raw_target, source_path)
+        resolved, fragment = _resolve_link_path(
+            raw_target, source_path, decode_percent=True
+        )
         links.append(
             LinkInfo(
                 target_path=resolved,
@@ -975,7 +991,9 @@ def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
             continue
         if raw_target.startswith("#"):
             continue
-        resolved, fragment = _resolve_link_path(raw_target, source_path)
+        resolved, fragment = _resolve_link_path(
+            raw_target, source_path, decode_percent=True
+        )
         links.append(
             LinkInfo(
                 target_path=resolved,

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -8,7 +8,6 @@ import re
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-from urllib.parse import unquote
 
 import frontmatter
 import yaml
@@ -16,6 +15,7 @@ import yaml
 from markdown_vault_mcp.hashing import compute_etag
 from markdown_vault_mcp.types import Chunk, LinkInfo, ParsedNote, SkippedFile
 from markdown_vault_mcp.utils.fs import GLOB_SYMLINK_KWARGS, iter_markdown_files
+from markdown_vault_mcp.utils.links import decode_link_target
 from markdown_vault_mcp.utils.text import decode_utf8
 
 if TYPE_CHECKING:
@@ -844,9 +844,10 @@ def _resolve_link_path(
         target = target[:idx]
 
     if decode_percent:
-        # unquote leaves a ``%`` that begins no valid escape alone, so a note
-        # genuinely named "50% off.md" survives a round trip.
-        target = unquote(target)
+        # An encoded separator stays encoded and an invalid-UTF-8 escape
+        # leaves the target undecoded, so neither invents a resolvable name;
+        # see :func:`~markdown_vault_mcp.utils.links.decode_link_target`.
+        target = decode_link_target(target)
 
     if not target:
         # Link with only a fragment — points to the source document itself.

--- a/src/markdown_vault_mcp/utils/__init__.py
+++ b/src/markdown_vault_mcp/utils/__init__.py
@@ -21,6 +21,7 @@ from markdown_vault_mcp.utils.fts import fts_row_to_note_info
 from markdown_vault_mcp.utils.links import (
     apply_link_replacement,
     compute_new_raw_target,
+    decode_link_target,
 )
 from markdown_vault_mcp.utils.text import (
     CHAR_SUBS,
@@ -209,6 +210,7 @@ __all__ = [
     "artifact_suffix",
     "build_position_map",
     "compute_new_raw_target",
+    "decode_link_target",
     "effective_attachment_extensions",
     "find_closest_match",
     "fts_row_to_note_info",

--- a/src/markdown_vault_mcp/utils/links.py
+++ b/src/markdown_vault_mcp/utils/links.py
@@ -25,37 +25,41 @@ _QUOTE_SAFE = "/"
 _RE_ENCODED_SEPARATOR = re.compile(r"%2[Ff]")
 
 
-def decode_link_target(target: str) -> str:
-    """Percent-decode a link destination without changing its structure.
+def decode_link_target(target: str) -> str | None:
+    """Percent-decode a link destination, or refuse it.
 
     CommonMark defines a markdown destination as a URL, so its escapes name
-    the same file the literal spelling does (#1332). Two escapes are refused
-    rather than decoded, because decoding them would invent a target:
+    the same file the literal spelling does (#1332). Two escapes name no file
+    at all, and are refused rather than decoded:
 
-    * **An encoded separator** (``%2F``) stays encoded. It is path *data*,
-      not a path separator, so a target carrying one names a file that cannot
-      exist and must resolve to nothing rather than to the note whose real
-      path the decode would spell.
-    * **An escape sequence that is not valid UTF-8** (``bad%FF.md``) leaves
-      the whole destination undecoded. ``unquote`` would otherwise substitute
-      U+FFFD, which invents a name — and collapses distinct malformed
-      sequences onto one target, so several broken links could all acquire
-      the same false backlink.
+    * **An encoded separator** (``%2F``). It is path *data*, not a path
+      separator, so the destination names one path segment containing a
+      slash — which no file can be called.
+    * **An escape sequence that is not valid UTF-8** (``bad%FF.md``). It
+      names bytes that are not a UTF-8 name. ``unquote`` would substitute
+      U+FFFD, inventing one, and collapse distinct malformed sequences onto
+      it.
+
+    Refusing returns ``None`` rather than the raw string, because the raw
+    string is itself a valid path: a vault containing a file literally called
+    ``dir%2Fnote.md`` would otherwise match it, giving a destination that
+    names nothing a resolved target and a backlink to an unrelated note. A
+    file genuinely called that is reached by encoding the percent
+    (``dir%252Fnote.md``), which decodes here without being refused.
 
     Args:
         target: The destination's path portion, fragment already split off.
 
     Returns:
-        The decoded path, or *target* unchanged when it carries an escape
-        that is not valid UTF-8.
+        The decoded path, or ``None`` when the destination carries an escape
+        that names no possible file.
     """
+    if _RE_ENCODED_SEPARATOR.search(target):
+        return None
     try:
-        return "%2F".join(
-            unquote(part, errors="strict")
-            for part in _RE_ENCODED_SEPARATOR.split(target)
-        )
+        return unquote(target, errors="strict")
     except UnicodeDecodeError:
-        return target
+        return None
 
 
 def compute_new_raw_target(
@@ -113,7 +117,9 @@ def compute_new_raw_target(
         # one — the same fidelity defect as #1105, reached by a different
         # route (#1332). Decode for the comparison; re-encode the answer only
         # if the author was encoding.
-        decoded_path_part = decode_link_target(raw_path_part)
+        # A refused destination names no file, so there is no encoding
+        # convention to preserve: treat it as written.
+        decoded_path_part = decode_link_target(raw_path_part) or raw_path_part
         was_encoded = decoded_path_part != raw_path_part
 
         if raw_path_part.startswith("/"):

--- a/src/markdown_vault_mcp/utils/links.py
+++ b/src/markdown_vault_mcp/utils/links.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 import os.path as osp
 import re
 from pathlib import Path
+from urllib.parse import quote, unquote
+
+#: Characters left unescaped when re-encoding a destination that the author
+#: already wrote percent-encoded. Only ``/`` — it is the path separator, and
+#: encoding it would change the link's structure rather than its spelling.
+_QUOTE_SAFE = "/"
 
 
 def compute_new_raw_target(
@@ -37,7 +43,9 @@ def compute_new_raw_target(
 
     Returns:
         The replacement raw_target string to write into the source file,
-        written in the same shape the original used.
+        written in the same shape *and the same spelling* the original used:
+        a destination the author percent-encoded is re-encoded, one written
+        literally stays literal (#1105, #1332).
     """
     if link_type == "wikilink":
         # Determine whether the original wikilink included the .md extension.
@@ -57,9 +65,19 @@ def compute_new_raw_target(
         # way, but silently converting one spelling to another undoes a
         # vault's OKF link conformance on any rename or folder move (#1105).
         raw_path_part = raw_target.split("#")[0]
+        # The shape test below compares the destination to old_path, and
+        # old_path is never encoded. Comparing the encoded spelling therefore
+        # never matched, so a root-relative encoded link fell into the
+        # relative-to-source branch and came back rewritten as a relative
+        # one — the same fidelity defect as #1105, reached by a different
+        # route (#1332). Decode for the comparison; re-encode the answer only
+        # if the author was encoding.
+        decoded_path_part = unquote(raw_path_part)
+        was_encoded = decoded_path_part != raw_path_part
+
         if raw_path_part.startswith("/"):
             new_path_part = "/" + new_path
-        elif source_path and old_path and raw_path_part != old_path:
+        elif source_path and old_path and decoded_path_part != old_path:
             # Relative-to-source link: compute the correct new relative path so
             # cross-directory links continue to resolve after the rename.
             source_dir = str(Path(source_path).parent)
@@ -68,6 +86,8 @@ def compute_new_raw_target(
             new_path_part = new_rel.replace("\\", "/")
         else:
             new_path_part = new_path
+        if was_encoded:
+            new_path_part = quote(new_path_part, safe=_QUOTE_SAFE)
         return new_path_part + ("#" + fragment if fragment else "")
 
 

--- a/src/markdown_vault_mcp/utils/links.py
+++ b/src/markdown_vault_mcp/utils/links.py
@@ -1,7 +1,8 @@
-"""Link-update helpers for file rename operations.
+"""Link target helpers: decoding, replacement computation, substitution.
 
-These functions compute replacement link targets and apply substitutions
-in file content when a note is renamed within the vault.
+:func:`decode_link_target` is shared with link extraction; the rest compute
+replacement link targets and apply substitutions in file content when a note
+is renamed within the vault.
 """
 
 from __future__ import annotations
@@ -15,6 +16,46 @@ from urllib.parse import quote, unquote
 #: already wrote percent-encoded. Only ``/`` — it is the path separator, and
 #: encoding it would change the link's structure rather than its spelling.
 _QUOTE_SAFE = "/"
+
+#: An encoded path separator. ``%2F`` is deliberately *not* decoded: a
+#: percent-escaped reserved character is data, not structure, so decoding it
+#: would turn ``dir%2Fnote.md`` — which names one impossible file — into a
+#: link to the unrelated note at ``dir/note.md``, complete with a false
+#: backlink and a rename that rewrites it.
+_RE_ENCODED_SEPARATOR = re.compile(r"%2[Ff]")
+
+
+def decode_link_target(target: str) -> str:
+    """Percent-decode a link destination without changing its structure.
+
+    CommonMark defines a markdown destination as a URL, so its escapes name
+    the same file the literal spelling does (#1332). Two escapes are refused
+    rather than decoded, because decoding them would invent a target:
+
+    * **An encoded separator** (``%2F``) stays encoded. It is path *data*,
+      not a path separator, so a target carrying one names a file that cannot
+      exist and must resolve to nothing rather than to the note whose real
+      path the decode would spell.
+    * **An escape sequence that is not valid UTF-8** (``bad%FF.md``) leaves
+      the whole destination undecoded. ``unquote`` would otherwise substitute
+      U+FFFD, which invents a name — and collapses distinct malformed
+      sequences onto one target, so several broken links could all acquire
+      the same false backlink.
+
+    Args:
+        target: The destination's path portion, fragment already split off.
+
+    Returns:
+        The decoded path, or *target* unchanged when it carries an escape
+        that is not valid UTF-8.
+    """
+    try:
+        return "%2F".join(
+            unquote(part, errors="strict")
+            for part in _RE_ENCODED_SEPARATOR.split(target)
+        )
+    except UnicodeDecodeError:
+        return target
 
 
 def compute_new_raw_target(
@@ -72,7 +113,7 @@ def compute_new_raw_target(
         # one — the same fidelity defect as #1105, reached by a different
         # route (#1332). Decode for the comparison; re-encode the answer only
         # if the author was encoding.
-        decoded_path_part = unquote(raw_path_part)
+        decoded_path_part = decode_link_target(raw_path_part)
         was_encoded = decoded_path_part != raw_path_part
 
         if raw_path_part.startswith("/"):

--- a/src/markdown_vault_mcp/utils/links.py
+++ b/src/markdown_vault_mcp/utils/links.py
@@ -17,11 +17,13 @@ from urllib.parse import quote, unquote
 #: encoding it would change the link's structure rather than its spelling.
 _QUOTE_SAFE = "/"
 
-#: An encoded path separator. ``%2F`` is deliberately *not* decoded: a
-#: percent-escaped reserved character is data, not structure, so decoding it
-#: would turn ``dir%2Fnote.md`` — which names one impossible file — into a
-#: link to the unrelated note at ``dir/note.md``, complete with a false
-#: backlink and a rename that rewrites it.
+#: An encoded path separator, which makes a destination unresolvable rather
+#: than merely undecoded. A percent-escaped reserved character is data, not
+#: structure, so ``dir%2Fnote.md`` names one path segment containing a slash.
+#: Decoding it would point the link at the unrelated note at ``dir/note.md``;
+#: keeping the raw spelling would point it at a file literally called
+#: ``dir%2Fnote.md``. Both are files the destination does not name, so
+#: :func:`decode_link_target` refuses it outright.
 _RE_ENCODED_SEPARATOR = re.compile(r"%2[Ff]")
 
 
@@ -116,9 +118,9 @@ def compute_new_raw_target(
         # relative-to-source branch and came back rewritten as a relative
         # one — the same fidelity defect as #1105, reached by a different
         # route (#1332). Decode for the comparison; re-encode the answer only
-        # if the author was encoding.
-        # A refused destination names no file, so there is no encoding
-        # convention to preserve: treat it as written.
+        # if the author was encoding. A refused destination names no file, so
+        # there is no encoding convention to preserve and it is compared as
+        # written — such a link is never stored, so this arm is defensive.
         decoded_path_part = decode_link_target(raw_path_part) or raw_path_part
         was_encoded = decoded_path_part != raw_path_part
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2227,6 +2227,12 @@ class TestPercentEncodedTargets:
         """
         assert extract_links("[x](bad%FF.md)", "hub.md") == []
 
+    def test_a_reference_definition_can_be_refused_too(self) -> None:
+        """The refusal applies wherever a destination is decoded, not only
+        to inline links."""
+        content = "[x][ref]\n\n[ref]: dir%2Fnote.md"
+        assert extract_links(content, "hub.md") == []
+
     def test_a_doubly_encoded_percent_still_reaches_its_file(self) -> None:
         """A file genuinely named ``dir%2Fnote.md`` is linked by encoding the
         percent, and that destination is decoded rather than refused."""

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2269,3 +2269,11 @@ class TestRenameRewritesEncodedLinks:
         body = (tmp_path / "vault" / "hub.md").read_text(encoding="utf-8")
         assert "[encoded](/probe/c%5B2%5D.md)" in body
         assert "[literal](/probe/c[2].md)" in body
+
+    def test_move_folder_rewrites_encoded_links_too(self, tmp_path: Path) -> None:
+        """rename and move_folder share one rewrite path, so both are fixed."""
+        col = self._vault(tmp_path)
+        col.writer.move_folder("probe", "moved")
+        body = (tmp_path / "vault" / "hub.md").read_text(encoding="utf-8")
+        assert "[encoded](/moved/b%5B1%5D.md)" in body
+        assert "[literal](/moved/b[1].md)" in body

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2149,3 +2149,123 @@ class TestAliasResolution:
         outlinks = idx.get_outlinks("source.md")
         assert outlinks[0]["target_path"] == "artificial-intelligence.md"
         assert outlinks[0]["fragment"] == "history"
+
+
+# ---------------------------------------------------------------------------
+# extract_links: percent-encoded destinations (#1332)
+# ---------------------------------------------------------------------------
+
+
+class TestPercentEncodedTargets:
+    """A markdown destination is a URL, so its escapes name the same file.
+
+    Percent-encoding is the canonical way to write a destination containing
+    ``[``, ``]``, spaces or parentheses, which is exactly the population
+    #1303 / #1305 taught the git layer to handle.
+    """
+
+    def test_encoded_brackets_resolve_to_the_named_note(self) -> None:
+        """The #1332 reproduction."""
+        links = extract_links("[x](/probe/b%5B1%5D.md)", "hub.md")
+        assert links[0].target_path == "probe/b[1].md"
+
+    def test_raw_target_keeps_the_spelling_as_written(self) -> None:
+        """raw_target is what a rewrite must find in the file."""
+        links = extract_links("[x](/probe/b%5B1%5D.md)", "hub.md")
+        assert links[0].raw_target == "/probe/b%5B1%5D.md"
+
+    def test_encoded_space_resolves(self) -> None:
+        links = extract_links("[x](notes/my%20note.md)", "hub.md")
+        assert links[0].target_path == "notes/my note.md"
+
+    def test_encoded_and_literal_spellings_agree(self) -> None:
+        """Both spellings of one name resolve to the same target."""
+        content = "[a](/p/b%5B1%5D.md)\n\n[b](/p/b[1].md)\n"
+        targets = {lnk.target_path for lnk in extract_links(content, "hub.md")}
+        assert targets == {"p/b[1].md"}
+
+    def test_encoded_fragment_separator_is_not_a_fragment(self) -> None:
+        """``%23`` is a literal ``#`` in the name, not the fragment marker."""
+        links = extract_links("[x](notes/C%23-guide.md)", "hub.md")
+        assert links[0].target_path == "notes/C#-guide.md"
+        assert links[0].fragment is None
+
+    def test_a_real_fragment_still_splits(self) -> None:
+        links = extract_links("[x](notes/my%20note.md#sec)", "hub.md")
+        assert links[0].target_path == "notes/my note.md"
+        assert links[0].fragment == "sec"
+
+    def test_reference_definitions_decode_too(self) -> None:
+        content = "[x][ref]\n\n[ref]: /p/b%5B1%5D.md"
+        assert extract_links(content, "hub.md")[0].target_path == "p/b[1].md"
+
+    def test_a_lone_percent_is_left_alone(self) -> None:
+        """``%`` that begins no valid escape is a literal character."""
+        links = extract_links("[x](notes/50%25%20off.md)", "hub.md")
+        assert links[0].target_path == "notes/50% off.md"
+
+    def test_wikilinks_are_not_decoded(self) -> None:
+        """Obsidian writes wikilink targets literally; it never encodes them.
+
+        Decoding them would break a note genuinely named with a ``%``.
+        """
+        links = extract_links("[[notes/100%20plan]]", "hub.md")
+        assert links[0].target_path == "notes/100%20plan.md"
+
+
+# ---------------------------------------------------------------------------
+# A link-updating rename reaches encoded destinations too (#1332)
+# ---------------------------------------------------------------------------
+
+
+class TestRenameRewritesEncodedLinks:
+    """The half of #1332 that silently left a link dangling.
+
+    Before the fix ``rename(update_links=True)`` reported ``updated_links: 1``
+    on a note carrying both spellings: it rewrote the literal one and skipped
+    the encoded one, which then pointed at a path that no longer existed.
+    """
+
+    @staticmethod
+    def _vault(tmp_path: Path) -> Vault:
+        src = tmp_path / "vault"
+        (src / "probe").mkdir(parents=True)
+        (src / "probe" / "b[1].md").write_text("# B\n", encoding="utf-8")
+        (src / "hub.md").write_text(
+            "[encoded](/probe/b%5B1%5D.md)\n\n[literal](/probe/b[1].md)\n",
+            encoding="utf-8",
+        )
+        col = Vault(source_dir=src, read_only=False)
+        col.index.build_index()
+        return col
+
+    def test_both_spellings_resolve_and_backlink(self, tmp_path: Path) -> None:
+        col = self._vault(tmp_path)
+        outlinks = col.graph.get_outlinks("hub.md")
+        assert {o.target_path for o in outlinks} == {"probe/b[1].md"}
+        assert all(o.exists for o in outlinks)
+        assert len(col.graph.get_backlinks("probe/b[1].md")) == 2
+
+    def test_rename_rewrites_both_spellings(self, tmp_path: Path) -> None:
+        col = self._vault(tmp_path)
+        result = col.writer.rename("probe/b[1].md", "probe/b2.md", update_links=True)
+        assert result.updated_links == 1  # one source note
+        body = (tmp_path / "vault" / "hub.md").read_text(encoding="utf-8")
+        assert "b%5B1%5D" not in body
+        assert "b[1]" not in body
+        assert body.count("/probe/b2.md") == 2
+
+    def test_rename_into_a_name_needing_escapes_keeps_the_spelling(
+        self, tmp_path: Path
+    ) -> None:
+        """The encoded link stays encoded; the literal one stays literal.
+
+        No encoding is introduced where the author used none — that is the
+        #1105 rule, and it is why a rename cannot repair a destination whose
+        new name would need escaping to parse. Out of scope here.
+        """
+        col = self._vault(tmp_path)
+        col.writer.rename("probe/b[1].md", "probe/c[2].md", update_links=True)
+        body = (tmp_path / "vault" / "hub.md").read_text(encoding="utf-8")
+        assert "[encoded](/probe/c%5B2%5D.md)" in body
+        assert "[literal](/probe/c[2].md)" in body

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2204,34 +2204,34 @@ class TestPercentEncodedTargets:
         links = extract_links("[x](notes/50%25%20off.md)", "hub.md")
         assert links[0].target_path == "notes/50% off.md"
 
-    def test_an_encoded_separator_is_data_not_structure(self) -> None:
-        """``%2F`` names one impossible file, not a path with a folder in it.
+    def test_an_encoded_separator_records_no_link(self) -> None:
+        """``%2F`` names one path segment containing a slash: no such file.
 
-        Decoding it would resolve the link to the unrelated note actually at
-        ``dir/note.md``, giving it a false backlink and letting a rename
-        rewrite it (review round 1).
+        Decoding it would resolve to the unrelated note actually at
+        ``dir/note.md``; keeping the raw spelling would resolve to a file
+        literally called ``dir%2Fnote.md``. Both are a different file from
+        the one the destination names, which is none.
         """
-        links = extract_links("[x](dir%2Fnote.md)", "hub.md")
-        assert links[0].target_path == "dir%2Fnote.md"
+        assert extract_links("[x](dir%2Fnote.md)", "hub.md") == []
 
     def test_an_encoded_separator_does_not_collide_with_a_real_note(self) -> None:
         content = "[a](dir%2Fnote.md)\n\n[b](dir/note.md)\n"
         targets = [lnk.target_path for lnk in extract_links(content, "hub.md")]
-        assert targets == ["dir%2Fnote.md", "dir/note.md"]
+        assert targets == ["dir/note.md"]
 
-    def test_an_invalid_utf8_escape_leaves_the_target_undecoded(self) -> None:
-        """``unquote`` would substitute U+FFFD, inventing a name.
+    def test_an_invalid_utf8_escape_records_no_link(self) -> None:
+        """The escaped bytes are not a UTF-8 name, so they name no file.
 
-        Distinct malformed sequences would also collapse onto that one
-        target, so several broken links could share a false backlink.
+        ``unquote`` would substitute U+FFFD, inventing one and collapsing
+        distinct malformed sequences onto it.
         """
-        links = extract_links("[x](bad%FF.md)", "hub.md")
-        assert links[0].target_path == "bad%FF.md"
+        assert extract_links("[x](bad%FF.md)", "hub.md") == []
 
-    def test_distinct_malformed_escapes_stay_distinct(self) -> None:
-        content = "[a](bad%FF.md)\n\n[b](bad%FE.md)\n"
-        targets = {lnk.target_path for lnk in extract_links(content, "hub.md")}
-        assert targets == {"bad%FF.md", "bad%FE.md"}
+    def test_a_doubly_encoded_percent_still_reaches_its_file(self) -> None:
+        """A file genuinely named ``dir%2Fnote.md`` is linked by encoding the
+        percent, and that destination is decoded rather than refused."""
+        links = extract_links("[x](dir%252Fnote.md)", "hub.md")
+        assert links[0].target_path == "dir%2Fnote.md"
 
     def test_valid_multibyte_escapes_still_decode(self) -> None:
         """Strict decoding must not reject legitimate non-ASCII names."""
@@ -2311,3 +2311,55 @@ class TestRenameRewritesEncodedLinks:
         body = (tmp_path / "vault" / "hub.md").read_text(encoding="utf-8")
         assert "[encoded](/moved/b%5B1%5D.md)" in body
         assert "[literal](/moved/b[1].md)" in body
+
+
+# ---------------------------------------------------------------------------
+# A refused destination resolves to nothing, even against a same-spelled file
+# (#1332, review round 2)
+# ---------------------------------------------------------------------------
+
+
+class TestRefusedDestinationsResolveToNothing:
+    """The raw spelling is itself a valid path, so returning it is not a refusal.
+
+    A vault can contain a file literally called ``dir%2Fnote.md``. Reaching it
+    means encoding the percent (``dir%252Fnote.md``); the single-encoded
+    destination names a path segment containing a slash, which is a different
+    thing — and no thing at all.
+    """
+
+    @staticmethod
+    def _vault(tmp_path: Path) -> Vault:
+        src = tmp_path / "vault"
+        src.mkdir()
+        (src / "dir%2Fnote.md").write_text("# literal\n", encoding="utf-8")
+        (src / "bad%FF.md").write_text("# literal\n", encoding="utf-8")
+        (src / "hub.md").write_text(
+            "[a](dir%2Fnote.md)\n\n[b](bad%FF.md)\n", encoding="utf-8"
+        )
+        col = Vault(source_dir=src)
+        col.index.build_index()
+        return col
+
+    def test_neither_refused_destination_becomes_an_outlink(
+        self, tmp_path: Path
+    ) -> None:
+        assert self._vault(tmp_path).graph.get_outlinks("hub.md") == []
+
+    def test_neither_same_spelled_file_gains_a_backlink(self, tmp_path: Path) -> None:
+        col = self._vault(tmp_path)
+        assert col.graph.get_backlinks("dir%2Fnote.md") == []
+        assert col.graph.get_backlinks("bad%FF.md") == []
+
+    def test_the_doubly_encoded_spelling_does_reach_the_file(
+        self, tmp_path: Path
+    ) -> None:
+        src = tmp_path / "vault"
+        src.mkdir()
+        (src / "dir%2Fnote.md").write_text("# literal\n", encoding="utf-8")
+        (src / "hub.md").write_text("[a](dir%252Fnote.md)\n", encoding="utf-8")
+        col = Vault(source_dir=src)
+        col.index.build_index()
+        (outlink,) = col.graph.get_outlinks("hub.md")
+        assert outlink.target_path == "dir%2Fnote.md"
+        assert outlink.exists is True

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2204,6 +2204,40 @@ class TestPercentEncodedTargets:
         links = extract_links("[x](notes/50%25%20off.md)", "hub.md")
         assert links[0].target_path == "notes/50% off.md"
 
+    def test_an_encoded_separator_is_data_not_structure(self) -> None:
+        """``%2F`` names one impossible file, not a path with a folder in it.
+
+        Decoding it would resolve the link to the unrelated note actually at
+        ``dir/note.md``, giving it a false backlink and letting a rename
+        rewrite it (review round 1).
+        """
+        links = extract_links("[x](dir%2Fnote.md)", "hub.md")
+        assert links[0].target_path == "dir%2Fnote.md"
+
+    def test_an_encoded_separator_does_not_collide_with_a_real_note(self) -> None:
+        content = "[a](dir%2Fnote.md)\n\n[b](dir/note.md)\n"
+        targets = [lnk.target_path for lnk in extract_links(content, "hub.md")]
+        assert targets == ["dir%2Fnote.md", "dir/note.md"]
+
+    def test_an_invalid_utf8_escape_leaves_the_target_undecoded(self) -> None:
+        """``unquote`` would substitute U+FFFD, inventing a name.
+
+        Distinct malformed sequences would also collapse onto that one
+        target, so several broken links could share a false backlink.
+        """
+        links = extract_links("[x](bad%FF.md)", "hub.md")
+        assert links[0].target_path == "bad%FF.md"
+
+    def test_distinct_malformed_escapes_stay_distinct(self) -> None:
+        content = "[a](bad%FF.md)\n\n[b](bad%FE.md)\n"
+        targets = {lnk.target_path for lnk in extract_links(content, "hub.md")}
+        assert targets == {"bad%FF.md", "bad%FE.md"}
+
+    def test_valid_multibyte_escapes_still_decode(self) -> None:
+        """Strict decoding must not reject legitimate non-ASCII names."""
+        links = extract_links("[x](notes/caf%C3%A9.md)", "hub.md")
+        assert links[0].target_path == "notes/café.md"
+
     def test_wikilinks_are_not_decoded(self) -> None:
         """Obsidian writes wikilink targets literally; it never encodes them.
 

--- a/tests/test_utils_links_percent.py
+++ b/tests/test_utils_links_percent.py
@@ -154,14 +154,20 @@ class TestComputeNewRawTargetEncoded:
 class TestDecodeLinkTarget:
     """The shared decoder's two refusals (review round 1)."""
 
-    def test_an_encoded_separator_survives_decoding(self) -> None:
-        assert decode_link_target("dir%2Fnote.md") == "dir%2Fnote.md"
+    def test_an_encoded_separator_is_refused(self) -> None:
+        """Returning the raw string would match a file literally named that,
+        which is a different file from the one the destination names."""
+        assert decode_link_target("dir%2Fnote.md") is None
 
-    def test_a_lowercase_encoded_separator_is_canonicalised(self) -> None:
-        assert decode_link_target("a%2fb.md") == "a%2Fb.md"
+    def test_a_lowercase_encoded_separator_is_refused_too(self) -> None:
+        assert decode_link_target("a%2fb.md") is None
 
-    def test_an_invalid_utf8_escape_leaves_the_whole_target(self) -> None:
-        assert decode_link_target("bad%FF.md") == "bad%FF.md"
+    def test_an_invalid_utf8_escape_is_refused(self) -> None:
+        assert decode_link_target("bad%FF.md") is None
+
+    def test_a_doubly_encoded_percent_is_not_refused(self) -> None:
+        """How a file genuinely named ``dir%2Fnote.md`` is reached."""
+        assert decode_link_target("dir%252Fnote.md") == "dir%2Fnote.md"
 
     def test_ordinary_escapes_decode(self) -> None:
         assert decode_link_target("probe/b%5B1%5D.md") == "probe/b[1].md"

--- a/tests/test_utils_links_percent.py
+++ b/tests/test_utils_links_percent.py
@@ -1,0 +1,156 @@
+"""Rename rewrites of percent-encoded link targets (#1332).
+
+An encoded destination and its literal spelling name the same file, so a
+link-updating rename must find and rewrite both. Before #1332 it rewrote
+only the literal one and left the encoded link pointing at a path that no
+longer existed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from markdown_vault_mcp.utils import apply_link_replacement, compute_new_raw_target
+
+
+class TestComputeNewRawTargetEncoded:
+    def test_root_relative_encoded_target_is_recognised(self) -> None:
+        """The encoded spelling must compare equal to old_path, not fall
+        through to the relative-to-source branch."""
+        assert (
+            compute_new_raw_target(
+                "markdown",
+                "probe/b%5B1%5D.md",
+                None,
+                "probe/b2.md",
+                source_path="hub.md",
+                old_path="probe/b[1].md",
+            )
+            == "probe/b2.md"
+        )
+
+    def test_root_relative_encoded_target_from_a_subfolder_source(self) -> None:
+        """The shape test compares raw_target to old_path, so an encoded
+        target never matched and fell into the relative-to-source branch.
+
+        From a root-level source that branch coincidentally produces the
+        right string; from a subfolder it converts a root-relative link into
+        a relative one, which is the fidelity defect #1105 was about.
+        """
+        assert (
+            compute_new_raw_target(
+                "markdown",
+                "probe/b%5B1%5D.md",
+                None,
+                "probe/b2.md",
+                source_path="sub/hub.md",
+                old_path="probe/b[1].md",
+            )
+            == "probe/b2.md"
+        )
+
+    def test_leading_slash_encoded_target_keeps_its_shape(self) -> None:
+        assert (
+            compute_new_raw_target(
+                "markdown",
+                "/probe/b%5B1%5D.md",
+                None,
+                "probe/b2.md",
+                source_path="hub.md",
+                old_path="probe/b[1].md",
+            )
+            == "/probe/b2.md"
+        )
+
+    def test_a_new_name_needing_escapes_is_re_encoded(self) -> None:
+        """The author wrote an encoded destination; the rewrite keeps that
+        convention rather than emitting raw brackets into a URL slot."""
+        assert (
+            compute_new_raw_target(
+                "markdown",
+                "/probe/b%5B1%5D.md",
+                None,
+                "probe/c[2].md",
+                source_path="hub.md",
+                old_path="probe/b[1].md",
+            )
+            == "/probe/c%5B2%5D.md"
+        )
+
+    def test_an_unencoded_target_is_still_written_literally(self) -> None:
+        """No encoding is introduced where the author used none (#1105)."""
+        assert (
+            compute_new_raw_target(
+                "markdown",
+                "probe/b[1].md",
+                None,
+                "probe/c[2].md",
+                source_path="hub.md",
+                old_path="probe/b[1].md",
+            )
+            == "probe/c[2].md"
+        )
+
+    def test_fragment_is_preserved(self) -> None:
+        assert (
+            compute_new_raw_target(
+                "markdown",
+                "/p/my%20note.md",
+                "sec",
+                "p/renamed.md",
+                source_path="hub.md",
+                old_path="p/my note.md",
+            )
+            == "/p/renamed.md#sec"
+        )
+
+    def test_relative_to_source_encoded_target(self) -> None:
+        """A genuinely relative encoded link still gets a relative answer."""
+        assert (
+            compute_new_raw_target(
+                "markdown",
+                "../p/my%20note.md",
+                None,
+                "p/renamed.md",
+                source_path="sub/hub.md",
+                old_path="p/my note.md",
+            )
+            == "../p/renamed.md"
+        )
+
+    @pytest.mark.parametrize("link_type", ["markdown", "reference"])
+    def test_both_url_shaped_link_types(self, link_type: str) -> None:
+        assert (
+            compute_new_raw_target(
+                link_type,
+                "/p/a%20b.md",
+                None,
+                "p/c.md",
+                source_path="hub.md",
+                old_path="p/a b.md",
+            )
+            == "/p/c.md"
+        )
+
+    def test_wikilinks_are_untouched_by_the_encoding_rule(self) -> None:
+        """A wikilink target is a literal name; ``%20`` is part of it."""
+        assert (
+            compute_new_raw_target(
+                "wikilink",
+                "notes/100%20plan",
+                None,
+                "notes/renamed.md",
+                source_path="hub.md",
+                old_path="notes/100%20plan.md",
+            )
+            == "notes/renamed"
+        )
+
+
+class TestApplyReplacementEncoded:
+    def test_the_encoded_occurrence_is_rewritten_in_place(self) -> None:
+        content = "See [x](/probe/b%5B1%5D.md) and [y](/probe/other.md)\n"
+        out = apply_link_replacement(
+            content, "markdown", "/probe/b%5B1%5D.md", "/probe/b2.md"
+        )
+        assert out == "See [x](/probe/b2.md) and [y](/probe/other.md)\n"

--- a/tests/test_utils_links_percent.py
+++ b/tests/test_utils_links_percent.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 import pytest
 
-from markdown_vault_mcp.utils import apply_link_replacement, compute_new_raw_target
+from markdown_vault_mcp.utils import (
+    apply_link_replacement,
+    compute_new_raw_target,
+    decode_link_target,
+)
 
 
 class TestComputeNewRawTargetEncoded:
@@ -144,6 +148,43 @@ class TestComputeNewRawTargetEncoded:
                 old_path="notes/100%20plan.md",
             )
             == "notes/renamed"
+        )
+
+
+class TestDecodeLinkTarget:
+    """The shared decoder's two refusals (review round 1)."""
+
+    def test_an_encoded_separator_survives_decoding(self) -> None:
+        assert decode_link_target("dir%2Fnote.md") == "dir%2Fnote.md"
+
+    def test_a_lowercase_encoded_separator_is_canonicalised(self) -> None:
+        assert decode_link_target("a%2fb.md") == "a%2Fb.md"
+
+    def test_an_invalid_utf8_escape_leaves_the_whole_target(self) -> None:
+        assert decode_link_target("bad%FF.md") == "bad%FF.md"
+
+    def test_ordinary_escapes_decode(self) -> None:
+        assert decode_link_target("probe/b%5B1%5D.md") == "probe/b[1].md"
+
+    def test_a_lone_percent_is_left_alone(self) -> None:
+        assert decode_link_target("50%25 off.md") == "50% off.md"
+
+
+class TestComputeNewRawTargetRefusals:
+    """A target the decoder refuses must not be treated as encoded."""
+
+    def test_an_encoded_separator_target_is_not_re_encoded(self) -> None:
+        """It never decoded, so there is no encoding convention to preserve."""
+        assert (
+            compute_new_raw_target(
+                "markdown",
+                "dir%2Fnote.md",
+                None,
+                "p/renamed.md",
+                source_path="hub.md",
+                old_path="dir%2Fnote.md",
+            )
+            == "p/renamed.md"
         )
 
 


### PR DESCRIPTION
## Closes / Refs

Closes #1332

## What & why

CommonMark defines a markdown destination as a URL, so `%5B` and `[` name the
same file. Nothing in `src/` decoded them, so `[x](/probe/b%5B1%5D.md)`
resolved to nothing, produced no backlink, and was skipped by a link-updating
rename — which reported success while leaving the link pointing at a path that
no longer existed. Percent-encoding is the canonical spelling for a
destination containing `[`, `]`, a space or parentheses, so this affects
exactly the note names #1303 / #1305 taught the git layer to handle.

**Extraction.** Two ordering rules the fix depends on, both pinned by tests:

- The fragment splits **before** the decode. An encoded `%23` is a literal `#`
  in the file name; decoding first would read it as the fragment marker and
  truncate the target.
- `raw_target` keeps the spelling as written, because it is the string
  `apply_link_replacement` searches for in the file. Only `target_path` is
  decoded.

**Wikilinks are deliberately not decoded.** Obsidian writes those targets
literally, so a `%` in one belongs to the name. `_resolve_link_path` takes a
`decode_percent` flag rather than guessing which family it is serving; this is
the one place the two link families disagree, and the test says so.

**The rename half needed its own fix, and it is the less obvious one.**
`compute_new_raw_target` detects a link's shape by comparing its destination
to `old_path`, which is never encoded. An encoded root-relative link therefore
never compared equal and fell into the relative-to-source branch, coming back
rewritten as a *relative* link — the #1105 fidelity defect reached by a second
route. From a root-level source that branch happens to produce the right
string, which is why the regression test uses a subfolder source. The
comparison now runs against the decoded destination, and the replacement is
re-encoded (`quote`, `safe="/"`) only when the original was encoded.

`rename` and `move_folder` both funnel through `_rewrite_link_sources`, so one
fix covers both; a test pins that rather than leaving it to be rediscovered.

`INDEX_SEMANTICS_VERSION` 3 → 4 in the same commit, per the #1124 rule.

> **Note on the version number:** #1339 (in review) also bumps it to 4. Whichever
> merges second needs a rebase to 5, with its history note appended rather than
> replacing the other's. Flagging it because a silent resolution would drop one
> of the two rebuild reasons from the constant's documented history.

### Review round 1 (Codex, two P2s — both real, both fixed)

Both findings were the same shape, and both were right: `unquote` will
happily produce a name the author never wrote, and that invented name can
match a real note.

**`%2F` no longer decodes.** It is path *data*, not a path separator, so
`dir%2Fnote.md` names one file that cannot exist. Decoding it pointed the
link at the unrelated note actually at `dir/note.md` — false backlink, and a
link-updating rename would rewrite it. It stays encoded, so the target
resolves to nothing.

**Decoding is strict.** `unquote`'s default replacement decoding turned
`bad%FF.md` into `bad�.md`, and collapsed distinct malformed sequences
onto that same target, so several unrelated broken links could acquire one
false backlink. A destination carrying an escape that is not valid UTF-8 is
now left undecoded.

Both refusals live in one shared `decode_link_target`, used by extraction and
by the rename shape comparison so the two cannot drift, with the reasoning in
its docstring. Nine tests cover both refusals, that valid multibyte escapes
still decode, and that distinct malformed sequences stay distinct.

### Review round 2 (Codex, one P2 — real, fixed)

Returning the *raw* spelling was not a refusal. The raw spelling is itself a
valid path, so a vault containing a file literally called `dir%2Fnote.md`
matched it: `get_outlinks` reported `exists=True` and that file gained a
backlink — from a destination that names no file at all. Reproduced against a
built vault before and after.

`decode_link_target` now returns `None` for both refused escapes and the
extractors record no link. A file genuinely called `dir%2Fnote.md` is reached
by encoding the percent (`dir%252Fnote.md`), which decodes without being
refused; there is a test for that, since it is the spelling the refusal pushes
an author toward.

### Self-review before this push

Two findings, both fixed in `2b8de3b`:

- The `INDEX_SEMANTICS_VERSION` 4 note described only the decode. A refused
  destination now stores no row at all, and an older index holds one that can
  match a file coincidentally named the same as the escape sequence — which is
  exactly what the version guards.
- The `_RE_ENCODED_SEPARATOR` comment still read "`%2F` is deliberately *not*
  decoded", implying the raw spelling is preserved. Preserving it was the
  defect.

Patch coverage also showed the refusal untested on the reference-link path;
covered.

## What this PR deliberately does NOT do

- **Introduce encoding where the author used none.** That is the #1105 rule,
  and it means a rename still cannot repair a destination whose *new* name
  would need escaping to parse — renaming into `c(2).md` writes literal parens
  into a `(...)` slot. Pre-existing, unchanged, and called out in the test's
  docstring so it is not mistaken for an endorsement.
- **Decode wikilink targets.** Deliberate, per above.
- **Percent-decode anywhere outside link resolution.** The git pathspec layer
  has its own literal-pathspec handling (#1303 / #1305); nothing here touches
  it.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
      Charter findings: `move_folder` shares the rewrite path (verified, now
      tested); `okf.py`'s `raw_target` use is wikilink-only and unaffected;
      no adjacent docstring contradicted (`LinkInfo.raw_target` still means
      "exactly as written", which the fix preserves on purpose).
- [x] No commit carries `!`. `_resolve_link_path` is private;
      `compute_new_raw_target` keeps its signature and its documented contract
      ("the same shape the original used"), now honoured in one more case.

## Docs impact

- [ ] `README.md` — no user-facing config or tool surface changed.
- [x] `docs/` site pages — `docs/releases/4.2.md`.
- [x] `docs/design/` — the link-extraction section: the decode, the two
      ordering rules, the wikilink exception, and the spelling-preserving
      rewrite.
- [x] Inline docstrings — `_resolve_link_path` and `compute_new_raw_target`.

---
_Generated by [Claude Code](https://claude.ai/code)_
