### PR TITLE
fix(git): say why a push failed, why a claim is inert, and stop advising an unrelated note

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -236,6 +236,7 @@ unparseable
 unpushed
 unqueued
 unsourced
+unsynced
 untyped
 uploader
 upsert

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3848,17 +3848,31 @@ path reports it.
   atomically. The strategy-wide lock is held across a whole fetch + merge, so
   reading health under it would make every write response block behind a
   pull.
-- **The log marks transitions.** Entering the state logs once at ERROR
-  (`git_remote_unsynced`), recovery once at INFO (`git_remote_resynced`). The
-  per-attempt lines behind the conditions moved to DEBUG, where they keep the
-  git stderr: the rejected push in `PushScheduler`, and on the pull side the
-  conflict-resolution loop cap, the "conflict resolution failed" line, and the
-  sibling-commit failure — the three that repeated every cycle in the reported
-  incident. Two classes stay loud: an unexpected exception on either path
-  (a bug, not a cycle), and a failure that can leave the working tree
-  inconsistent (`abort_in_progress_rebase`, `restore_upstream_paths`). The
-  repeating per-cycle warning is what let the incident run for hours
-  unnoticed.
+- **The log marks transitions, and the push attempts behind them.** Entering
+  the state logs once at ERROR (`git_remote_unsynced`), recovery once at INFO
+  (`git_remote_resynced`). The transition carries a `cause=` field — the git
+  stderr the outcome came with — because `push_failed` is the bucket every
+  unrecognised message lands in and names a state rather than a problem
+  (#1330). `SyncHealthTracker.push_failed` takes that detail as a second
+  argument, and every call site passes it: the two in `PushScheduler`
+  (deferred and startup) and `GitWriteStrategy._record_push`, which forwards
+  `PushResult.hint`.
+- **Push attempts log at WARNING; pull-cycle detail stays at DEBUG.** #1287
+  moved the per-attempt lines to DEBUG to stop a per-cycle warning from
+  drowning the transition. That was right for the pull side — the
+  conflict-resolution loop cap, the "conflict resolution failed" line, and
+  the sibling-commit failure repeated every cycle in the reported incident,
+  and they stay at DEBUG. It was wrong for the push side (#1330): a rejected
+  push is the only evidence that retries are still happening, and hiding it
+  at DEBUG left an operator on a deployment running at INFO unable to
+  distinguish a clone that was still retrying from one that had stopped, or
+  to see what git said. Both push paths are back at WARNING with redacted
+  stderr; the fetch leg was already there. Two classes stay loud for their
+  own reasons: an unexpected exception on either path (a bug, not a cycle),
+  and a failure that can leave the working tree inconsistent
+  (`abort_in_progress_rebase`, `restore_upstream_paths`). The guidance the
+  incident produced still holds — alert on the transitions, not the
+  attempts.
 
 Every vault-mutating write tool passes its result through
 `attach_remote_health`, which adds a `remote` object while the clone is

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -356,16 +356,33 @@ once at `ERROR`:
 ERROR markdown_vault_mcp.git.health: git_remote_unsynced kind=push reason=non_fast_forward ...
 ```
 
-Recovery logs once at `INFO` (`git_remote_resynced`), carrying when the
-outage started. The per-attempt lines behind both conditions (a rejected
-push, and a pull that could not resolve the divergence) sit at `DEBUG`, where
-they keep the full git stderr for whoever is diagnosing the outage. Two kinds
-of failure stay loud, because neither is a cycle that repeats harmlessly: an
-unexpected exception on the push or resolve path, and a failure that can
-leave the working tree inconsistent (a rebase that would not abort, an
-upstream file that would not restore). Alert on the transition
-lines: a repeated warning every sync cycle is easy to scroll past, which is
-how the incident behind
+That line carries the cause alongside the reason code, because `push_failed`
+is the bucket every unrecognised git message lands in and names a state
+rather than a problem. Recovery logs once at `INFO`
+(`git_remote_resynced`), carrying when the outage started.
+
+**The attempts are visible too, at the default level.** A rejected push logs
+at `WARNING` with the git stderr that says why, on the deferred and the
+startup path alike, as does a fetch that could not reach the remote:
+
+```
+WARNING markdown_vault_mcp.git.push_scheduler: git_push_failed cmd=... returncode=1 stderr=remote: GitLab: You are not allowed to push code to protected branches on this project.
+```
+
+Credentials are redacted. These lines were at `DEBUG` until
+[#1330](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1330), which
+meant a deployment running at `INFO` saw the transition and nothing else —
+and, because every retry was equally silent, could not tell a clone that was
+still retrying from one that had stopped. Repetition is the point here: it is
+the evidence the retries are happening. Quieter still are the per-cycle
+details of a divergence the resolver is working through, which stay at
+`DEBUG`. Two kinds of failure stay loud for their own reasons: an unexpected
+exception on the push or resolve path, and a failure that can leave the
+working tree inconsistent (a rebase that would not abort, an upstream file
+that would not restore).
+
+Alert on the transition lines rather than the per-attempt ones: a warning
+every sync cycle is easy to scroll past, which is how the incident behind
 [#1287](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1287) ran for
 hours before anyone noticed.
 

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -297,7 +297,7 @@ commits) reports `would_apply=false`. The push leg has no safe local
 
     - The pull **succeeds** (`pull.applied=true`,
       `pull.reason="conflicts_resolved_with_siblings"`).
-    - HEAD advances to the remote tip — the canonical path now reflects
+    - HEAD advances to the remote tip, so the canonical path now reflects
       the remote (remote wins).
     - The local versions that conflicted are preserved as
       `<basename>.conflict-mcp-<timestamp>.md` siblings on the same
@@ -371,8 +371,8 @@ WARNING markdown_vault_mcp.git.push_scheduler: git_push_failed cmd=... returncod
 
 Credentials are redacted. These lines were at `DEBUG` until
 [#1330](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1330), which
-meant a deployment running at `INFO` saw the transition and nothing else —
-and, because every retry was equally silent, could not tell a clone that was
+meant a deployment running at `INFO` saw the transition and nothing else.
+Because every retry was equally silent, it could not tell a clone that was
 still retrying from one that had stopped. Repetition is the point here: it is
 the evidence the retries are happening. Quieter still are the per-cycle
 details of a divergence the resolver is working through, which stay at

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -332,10 +332,10 @@ the deferred and the startup path alike, and the transition line carries the
 cause alongside the reason code. Credentials are redacted as before.
 
 **A commit claim that never arrives is reported once.** Setting
-`GIT_COMMIT_NAME_CLAIM` or `_GIT_COMMIT_EMAIL_CLAIM` to a claim the identity
-provider does not put in the access token made every commit fall back to the
-static identity, silently, looking exactly like a deployment that had never
-configured attribution
+`MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` or `_EMAIL_CLAIM` to a claim the
+identity provider does not put in the access token made every commit fall
+back to the static identity, silently, looking exactly like a deployment
+that had never configured attribution
 ([#1331](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1331)). The
 first write reports the configured key and whether it was absent or empty,
 once per key, and only for an authenticated caller.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -318,6 +318,39 @@ exempts from typing
 histograms now cover the same note population `okf_validate` audits, and
 reserved files are reported separately as `reserved_count`.
 
+## Diagnosing a vault that stops replicating
+
+**A failed push now says what git said.** When a clone could not reach its
+remote, the only line in the log was the one-time transition into the
+unsynced state, naming the generic `push_failed` bucket; git's own words sat
+at `DEBUG`, and deployments run at `INFO`
+([#1330](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1330)). An
+operator learned the vault was stranded but not why, and because every retry
+was equally silent, could not tell a clone that was still retrying from one
+that had stopped. Push failures now log at `WARNING` with the git stderr, on
+the deferred and the startup path alike, and the transition line carries the
+cause alongside the reason code. Credentials are redacted as before.
+
+**A commit claim that never arrives is reported once.** Setting
+`GIT_COMMIT_NAME_CLAIM` or `_GIT_COMMIT_EMAIL_CLAIM` to a claim the identity
+provider does not put in the access token made every commit fall back to the
+static identity, silently, looking exactly like a deployment that had never
+configured attribution
+([#1331](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1331)). The
+first write reports the configured key and whether it was absent or empty,
+once per key, and only for an authenticated caller.
+
+**A revision read stops recommending an unrelated note.** `read(path,
+revision=)` correctly refuses when git records the note as a copy rather
+than a continuation, but the refusal then named the copy source as the thing
+to read
+([#1336](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1336)).
+That source is git's similarity match: two short notes sharing frontmatter
+scaffolding clear the threshold easily, and the documented next step after a
+revision read is to write the content back. The refusal still names what git
+found, and now points at `get_history` the way the neighbouring branch
+already did.
+
 ## Configuration and its documentation
 
 **The OIDC pages stopped steering readers into the wrong mode.** The 4.1

--- a/src/markdown_vault_mcp/_identity.py
+++ b/src/markdown_vault_mcp/_identity.py
@@ -47,6 +47,11 @@ _LOCAL_SUBJECT = "local"
 _name_claim: str | None = None
 _email_claim: str | None = None
 
+#: Claim keys already reported absent, so the diagnostic below is one line per
+#: key per process rather than one per write. Cleared whenever the configured
+#: keys change, so a reconfiguration gets a fresh answer.
+_warned_absent_claims: set[str] = set()
+
 
 def configure_identity_claims(
     *, name_claim: str | None, email_claim: str | None
@@ -65,6 +70,7 @@ def configure_identity_claims(
     global _name_claim, _email_claim
     _name_claim = name_claim
     _email_claim = email_claim
+    _warned_absent_claims.clear()
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,6 +146,44 @@ def _claim_value(claims: dict[str, Any] | None, key: str | None) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _resolve_claim(
+    claims: dict[str, Any] | None, key: str | None, field: str
+) -> str | None:
+    """Read a configured claim, reporting once when it is not usable.
+
+    An operator who configures ``GIT_COMMIT_NAME_CLAIM`` has asked for
+    attribution deliberately. When the claim is not in the access token the
+    commit silently falls back to the static identity, which looks exactly
+    like a deployment that never configured it — and the one nearby startup
+    warning is suppressed precisely when a claim *is* configured (#1331).
+
+    Only fires for an authenticated caller: with no token there are no claims
+    to be missing, and the fallback is the intended behaviour.
+
+    Args:
+        claims: The token claims, or ``None`` when there is no token.
+        key: The configured claim key, or ``None`` when none is configured.
+        field: The identity field being resolved, for the log line.
+
+    Returns:
+        The claim value, or ``None`` when it is absent, empty, or not a
+        string.
+    """
+    value = _claim_value(claims, key)
+    if value is not None or key is None or claims is None:
+        return value
+    if key not in _warned_absent_claims:
+        _warned_absent_claims.add(key)
+        logger.warning(
+            "git_commit_claim_unusable field=%s claim=%s state=%s "
+            "detail=commits fall back to the static commit identity",
+            field,
+            key,
+            "absent" if key not in claims else "empty",
+        )
+    return None
+
+
 def resolve_mcp_principal() -> Principal:
     """Resolve the caller's :class:`Principal` from the MCP request context.
 
@@ -162,8 +206,8 @@ def resolve_mcp_principal() -> Principal:
 
     subject = get_subject()
     claims = get_claims()
-    display_name = _claim_value(claims, _name_claim)
-    email = _claim_value(claims, _email_claim)
+    display_name = _resolve_claim(claims, _name_claim, "display_name")
+    email = _resolve_claim(claims, _email_claim, "email")
     if subject and subject != _LOCAL_SUBJECT:
         return Principal(
             subject=subject, display_name=display_name, email=email, kind="human"

--- a/src/markdown_vault_mcp/git/health.py
+++ b/src/markdown_vault_mcp/git/health.py
@@ -163,14 +163,18 @@ class SyncHealthTracker:
         """
         return self._snapshot
 
-    def push_failed(self, reason: str) -> None:
+    def push_failed(self, reason: str, detail: str | None = None) -> None:
         """Record a push that did not reach the remote.
 
         Args:
             reason: A ``PUSH_REASON_*`` code.  Codes that do not prove
                 commits are stranded are ignored (see :data:`_PUSH_CONDITIONS`).
+            detail: What git said, when the caller has it.  ``push_failed`` is
+                the generic bucket every unrecognised stderr lands in, so
+                without this the one transition line names a state and not a
+                cause (#1330).
         """
-        self._open("push", reason, _PUSH_CONDITIONS)
+        self._open("push", reason, _PUSH_CONDITIONS, detail=detail)
 
     def push_succeeded(self) -> None:
         """Record that local commits reached the remote."""
@@ -190,8 +194,22 @@ class SyncHealthTracker:
         """Record that the clone reconciled with the remote."""
         self._close("pull")
 
-    def _open(self, kind: _Kind, reason: str, conditions: frozenset[str]) -> None:
-        """Open the *kind* condition, logging the transition into it once."""
+    def _open(
+        self,
+        kind: _Kind,
+        reason: str,
+        conditions: frozenset[str],
+        *,
+        detail: str | None = None,
+    ) -> None:
+        """Open the *kind* condition, logging the transition into it once.
+
+        Args:
+            kind: ``"push"`` or ``"pull"``.
+            reason: The ``*_REASON_*`` code.
+            conditions: The codes that count as an outage for this kind.
+            detail: Optional cause text carried onto the transition line.
+        """
         if reason not in conditions:
             return
         with self._lock:
@@ -210,10 +228,11 @@ class SyncHealthTracker:
             self._recompute()
             if was_healthy:
                 logger.error(
-                    "git_remote_unsynced kind=%s reason=%s "
+                    "git_remote_unsynced kind=%s reason=%s cause=%s "
                     "detail=writes are committed locally and are not reaching the remote",
                     kind,
                     reason,
+                    detail or "unavailable",
                 )
             else:
                 logger.debug("git_remote_unsynced_also kind=%s reason=%s", kind, reason)

--- a/src/markdown_vault_mcp/git/push_scheduler.py
+++ b/src/markdown_vault_mcp/git/push_scheduler.py
@@ -118,17 +118,21 @@ class PushScheduler:
 
         The outcome itself is recorded by :meth:`do_push`, while the shared
         lock still orders it against every other push (PR #1300); this wrapper
-        only logs.  A rejected push logs at DEBUG, where it keeps the git stderr for
-        diagnosis: the tracker logs the transition into the failed state
-        once, instead of every cycle.  An *unexpected* exception is not that
-        routine event and stays at ERROR with its traceback — repeating it is
-        the point, since it means a bug on the push path rather than a remote
-        that has moved on.
+        only logs.  A rejected push logs at WARNING with the git stderr that
+        says why, matching what the pull leg already does for a failed fetch
+        (#1330).  It was at DEBUG, and deployments run at INFO, so an operator
+        saw the tracker's one transition line naming the generic
+        ``push_failed`` bucket and nothing about the cause — and, because
+        every retry was equally silent, no way to tell a clone that is still
+        retrying from one that stopped.  Repeating per attempt is the point
+        here: it is the only evidence the retries are happening.  An
+        *unexpected* exception stays at ERROR with its traceback, since it
+        means a bug on the push path rather than a remote that has moved on.
         """
         try:
             self.do_push()
         except subprocess.CalledProcessError as exc:
-            logger.debug(
+            logger.warning(
                 "git_push_failed cmd=%s returncode=%d stderr=%s",
                 exc.cmd,
                 exc.returncode,
@@ -161,12 +165,14 @@ class PushScheduler:
             try:
                 _push(git_root, self._token, self._username)
             except subprocess.CalledProcessError as exc:
-                self._health.push_failed(
-                    push_failure_reason(self._redact(exc.stderr or ""))
-                )
+                # The stderr travels with the reason: ``push_failed`` is the
+                # bucket every unrecognised message lands in, so the reason
+                # alone names a state and not a cause (#1330).
+                stderr = self._redact(exc.stderr or "")
+                self._health.push_failed(push_failure_reason(stderr), stderr.strip())
                 raise
-            except Exception:
-                self._health.push_failed(PUSH_REASON_PUSH_FAILED)
+            except Exception as exc:
+                self._health.push_failed(PUSH_REASON_PUSH_FAILED, str(exc) or None)
                 raise
             self._push_pending = False
             self._health.push_succeeded()
@@ -215,13 +221,18 @@ class PushScheduler:
                 _push(git_root, self._token, self._username)
             except subprocess.CalledProcessError as exc:
                 sanitized_stderr = self._redact(exc.stderr or "")
-                logger.debug(
+                # WARNING for the same reason as the deferred-push leg
+                # (#1330): a startup push that cannot reach the remote is the
+                # first evidence an operator gets, and DEBUG hid it.
+                logger.warning(
                     "git_startup_push_failed cmd=%s returncode=%d stderr=%s",
                     exc.cmd,
                     exc.returncode,
                     sanitized_stderr,
                 )
-                self._health.push_failed(push_failure_reason(sanitized_stderr))
+                self._health.push_failed(
+                    push_failure_reason(sanitized_stderr), sanitized_stderr.strip()
+                )
             else:
                 self._health.push_succeeded()
 

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -1722,11 +1722,20 @@ def _path_at_ref(raw: str, cur_rel: str, ref: str) -> str:
                 "'get_history' to find a revision this note actually has."
             )
         elif status.startswith("C") and paths[-1] == tracked:
+            # The copy source is git's similarity guess, not a note the caller
+            # asked about: two short notes sharing frontmatter scaffolding
+            # clear the rename threshold easily. Naming it as the thing to
+            # read invites restoring unrelated content, and the documented
+            # next step after a revision read is to write it back, so this
+            # branch points at 'get_history' the way the 'A' branch above
+            # does (#1336). The source is still named, because it is what
+            # git said and it explains the refusal.
             raise ValueError(
                 f"{tracked!r} appears as a copy of {paths[0]!r} rather than as a "
                 "continuation of it, so the note now at that path did not exist "
-                f"at that revision. Read {paths[0]!r} at {ref!r} instead if the "
-                "content you want is the one it was copied from."
+                "at that revision. The copy source is git's similarity match, "
+                "not necessarily related to what you asked for; use "
+                "'get_history' to find a revision this note actually has."
             )
         elif status[0] not in ("D", "M", "T") or paths[0] != tracked:
             raise ValueError(

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1250,11 +1250,16 @@ class GitWriteStrategy:
         order they ran (PR #1300).  Outcomes that say nothing about the remote
         (``dry_run_unsupported``, ``no_remote``) are passed on as-is; the
         tracker ignores them.
+
+        ``hint`` carries git's own words and travels with the reason: the
+        reason alone is the generic ``push_failed`` bucket for every stderr
+        that matches no known marker, which told an operator the vault was
+        stranded but not why (#1330).
         """
         if result.applied:
             self._health.push_succeeded()
         elif result.reason is not None:
-            self._health.push_failed(result.reason)
+            self._health.push_failed(result.reason, result.hint)
 
     def _record_pull(self, result: PullResult) -> None:
         """Report a pull outcome to the sync-health tracker.

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1114,8 +1114,9 @@ class TestTokenRedactionInLogs:
 
         with (
             patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=fake_exc),
-            # The per-attempt line sits at DEBUG since #1287: the transition
-            # into the unsynced state is what gets logged loudly, once.
+            # The per-attempt line moved to WARNING in #1330 — DEBUG was
+            # invisible at the level deployments run at, so an operator saw
+            # the transition into the unsynced state and never its cause.
             caplog.at_level(logging.DEBUG, logger="markdown_vault_mcp.git"),
         ):
             strategy._push_scheduler.do_push_safe()

--- a/tests/test_git_health.py
+++ b/tests/test_git_health.py
@@ -476,9 +476,9 @@ class _LockObservingTracker(SyncHealthTracker):
         self._observed_lock = lock
         self.held: list[bool] = []
 
-    def push_failed(self, reason: str) -> None:
+    def push_failed(self, reason: str, detail: str | None = None) -> None:
         self.held.append(self._observed_lock.locked())
-        super().push_failed(reason)
+        super().push_failed(reason, detail)
 
     def push_succeeded(self) -> None:
         self.held.append(self._observed_lock.locked())
@@ -568,3 +568,134 @@ class TestOutcomesAreRecordedUnderTheStrategyLock:
         strategy.force_pull()
 
         assert tracker.held == [True]
+
+
+# ---------------------------------------------------------------------------
+# A stranded clone says why, at the level deployments run at (#1330)
+# ---------------------------------------------------------------------------
+
+
+class TestPushFailureIsDiagnosable:
+    """What an operator can learn from the log when pushes stop landing.
+
+    Observed on a live vault: the only push-related line in the whole
+    container log was the transition into the unsynced state, naming the
+    generic ``push_failed`` bucket. Git's own words sat at DEBUG, and the
+    deployment ran at INFO.
+    """
+
+    @staticmethod
+    def _rejected() -> subprocess.CalledProcessError:
+        return subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "push", "origin"],
+            stderr=(
+                "remote: GitLab: You are not allowed to push code to "
+                "protected branches on this project."
+            ),
+        )
+
+    def test_the_per_attempt_line_carries_git_stderr_at_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=self._rejected(),
+            ),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        line = next(r for r in caplog.records if "git_push_failed" in r.message)
+        assert line.levelno == logging.WARNING
+        assert "protected branches" in line.getMessage()
+
+    def test_every_retry_logs_so_retrying_is_distinguishable_from_stopped(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The transition line fires once; the attempts are what repeat."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=self._rejected(),
+            ),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
+        ):
+            for _ in range(3):
+                strategy._push_pending = True
+                strategy._push_scheduler.do_push_safe()
+
+        assert len([r for r in caplog.records if "git_push_failed" in r.message]) == 3
+
+    def test_the_transition_line_names_the_cause_not_just_the_bucket(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``push_failed`` is the bucket every unrecognised stderr lands in."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=self._rejected(),
+            ),
+            caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        line = next(r for r in caplog.records if "git_remote_unsynced" in r.message)
+        assert "protected branches" in line.getMessage()
+
+    def test_a_missing_cause_reads_as_unavailable_not_none(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An outcome with no hint still produces a readable line."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=OSError("boom"),
+            ),
+            caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        line = next(r for r in caplog.records if "git_remote_unsynced" in r.message)
+        assert "cause=" in line.message
+        assert "None" not in line.getMessage()
+
+    def test_the_token_is_still_redacted_at_the_new_level(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Raising the level must not raise a secret with it."""
+        secret = "glpat_secret_abc123"
+        strategy = GitWriteStrategy(token=secret, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+        exc = subprocess.CalledProcessError(
+            returncode=128,
+            cmd=["git", "push", "origin"],
+            stderr=f"fatal: authentication failed — token={secret}",
+        )
+
+        with (
+            patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=exc),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        text = " ".join(r.getMessage() for r in caplog.records)
+        assert secret not in text
+        assert "***" in text

--- a/tests/test_git_revision.py
+++ b/tests/test_git_revision.py
@@ -865,6 +865,29 @@ class TestWalkRules:
 
         assert list(_iter_name_status("\x1eSHA\0\nR100\0only-one-path\0")) == []
 
+    def test_a_copy_refusal_does_not_send_the_caller_to_another_note(self) -> None:
+        """The copy source is git's similarity guess, not the caller's note.
+
+        Two short notes sharing frontmatter scaffolding clear the rename
+        threshold easily, so advising "read that one instead" invited
+        restoring unrelated content — and the documented next step after a
+        revision read is to write it back (#1336). The sibling ``A`` branch
+        already pointed at 'get_history'; this one now does too.
+        """
+        from markdown_vault_mcp.git.query import _path_at_ref
+
+        stream = "\x1eSHA\0\nC85\0unrelated.md\0note.md\0"
+        with pytest.raises(ValueError) as exc:
+            _path_at_ref(stream, "note.md", "abc123")
+
+        message = str(exc.value)
+        assert "get_history" in message
+        # The source is still named — it is what git said, and it is what
+        # explains the refusal — but it is not offered as a thing to read.
+        assert "unrelated.md" in message
+        assert "Read 'unrelated.md'" not in message
+        assert "similarity match" in message
+
     def test_edits_and_deletes_carry_the_identity_forward(self) -> None:
         """The walk survives the record classes that keep a note's identity."""
         from markdown_vault_mcp.git.query import _path_at_ref

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -14,6 +14,7 @@ pattern ``_okf_write`` uses).
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -225,3 +226,96 @@ class TestConfigureIdentityClaims:
     def test_module_state_is_set(self) -> None:
         configure_identity_claims(name_claim="a", email_claim="b")
         assert (_identity._name_claim, _identity._email_claim) == ("a", "b")
+
+
+# ---------------------------------------------------------------------------
+# A configured claim the token does not carry (#1331)
+# ---------------------------------------------------------------------------
+
+
+def _claim_lines(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """The claim diagnostic's records, matched on the event name."""
+    return [r for r in caplog.records if "git_commit_claim_unusable" in r.message]
+
+
+class TestAbsentCommitClaimIsReported:
+    """The silent half of #1331: a configured claim that never arrives.
+
+    The fallback itself is correct; what was missing is any signal that the
+    operator's configured attribution is inert. It looks identical to a
+    deployment that never configured it, and the one nearby startup warning
+    in ``git/strategy.py`` is suppressed exactly when a claim *is* configured.
+    """
+
+    def test_absent_claim_warns_once_and_falls_back(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            first = resolve_mcp_principal()
+            second = resolve_mcp_principal()
+        assert first.display_name is None
+        assert second.display_name is None
+        lines = _claim_lines(caplog)
+        assert len(lines) == 1, "one line per key per process, not one per write"
+        assert lines[0].args[-1] == "absent"
+
+    def test_an_empty_claim_is_reported_as_empty(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Present but empty has the same effect and a distinguishable cause."""
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"name": ""})
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert _claim_lines(caplog)[0].args[-1] == "empty"
+
+    def test_both_fields_are_reported_independently(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim="name", email_claim="email")
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert {r.args[0] for r in _claim_lines(caplog)} == {"display_name", "email"}
+
+    def test_a_present_claim_says_nothing(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"name": "Ada"})
+        with caplog.at_level(logging.WARNING):
+            assert resolve_mcp_principal().display_name == "Ada"
+        assert _claim_lines(caplog) == []
+
+    def test_an_unauthenticated_caller_says_nothing(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No token means no claims to be missing; the fallback is intended."""
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject=None, claims=None)
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert _claim_lines(caplog) == []
+
+    def test_no_configured_claim_says_nothing(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim=None, email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert _claim_lines(caplog) == []
+
+    def test_reconfiguring_clears_the_warned_set(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reconfiguration is a new question and deserves a fresh answer."""
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            configure_identity_claims(name_claim="name", email_claim=None)
+            resolve_mcp_principal()
+            configure_identity_claims(name_claim="name", email_claim=None)
+            resolve_mcp_principal()
+        assert len(_claim_lines(caplog)) == 2


### PR DESCRIPTION
## Closes / Refs

Closes #1330, closes #1331, closes #1336

## What & why

Three diagnostics found on a live 4.2.0-rc.0 vault. None changes what the
server *does*; each changes what an operator can find out when it stops
working. They are bundled because they were found in one session on one
subsystem and each is a few lines.

### A failed push logged no cause at the default level (#1330)

The git stderr sat at `DEBUG` in both `PushScheduler` paths, and deployments
run at `INFO`. The only push-related line in a whole container log was the
one-time transition into the unsynced state, naming `push_failed` — the
bucket every unrecognised message lands in. The operator learned the vault was
stranded and not why; and because every retry was equally silent, could not
tell a clone still retrying from one that had stopped.

Both paths (deferred and startup) now log at `WARNING` with redacted stderr,
matching what the fetch leg already did. Repetition is deliberate here: the
attempt line is the only evidence retries are happening. The transition line
gained a `cause=` field, so `SyncHealthTracker.push_failed` takes the detail
as a second argument and **every** call site passes it — the two in
`PushScheduler` and `GitWriteStrategy._record_push` forwarding
`PushResult.hint`.

**On reversing part of #1287.** That change moved these lines to `DEBUG` on
purpose, so a per-cycle warning would not drown the transition. That reasoning
holds for the pull side, whose loop-cap and resolution-failure lines repeated
every cycle in that incident — they stay at `DEBUG`. It does not hold for the
push side, where the attempt is the only evidence there is. The guidance the
incident produced (alert on transitions, not attempts) is restated in both
places that carry it rather than silently dropped.

### A configured commit claim the token does not carry fell back silently (#1331)

An operator who sets `GIT_COMMIT_NAME_CLAIM` has asked for attribution
deliberately. When the claim is not in the access token, every commit uses the
static identity and the outcome is indistinguishable from a deployment that
never configured it — and the one nearby startup warning is suppressed
*exactly* when a claim is configured. `_resolve_claim` reports the key once
per process, distinguishes absent from empty (the issue's open question), and
fires only for an authenticated caller, since with no token there is nothing
to be missing.

### A revision-read copy refusal advised reading an unrelated note (#1336)

The refusal is right; the advice was not. The copy source is git's similarity
match — two short notes sharing frontmatter scaffolding clear the threshold
easily — and the documented next step after a revision read is to write the
content back, so pointing at it invited restoring unrelated content. The
refusal still names what git found, and now points at `get_history` the way
the sibling `A` branch already did.

### Review round 1 (Codex, one P2 — real, fixed)

The release notes wrote `_GIT_COMMIT_EMAIL_CLAIM`, which is neither the
setting's real name nor this page's established shorthand, so a reader
following it would configure nothing. Corrected to the same form the earlier
mention on the page uses: the full
`MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` followed by the `_EMAIL_CLAIM`
suffix. Both verified against `config.py:1169-1170` rather than from memory,
and I swept the rest of the diff's prose for the same class (no other
occurrences).

## What this PR deliberately does NOT do

- **Change the rename threshold.** #1336 suspects `--find-renames=30` (from
  #1302) makes spurious `C` records likelier. Unverified, and lowering the
  threshold would trade this for missed lineage; the refusal text is the part
  that was wrong.
- **Touch the pull side's DEBUG lines.** #1287's reasoning still applies
  there; only the push side is reversed, and the design doc says why.
- **Report the claim gap on the OKF provenance path.** It resolves from the
  same `Principal` and #1331 flags it `[unverified]`; this PR covers the git
  identity path the issue is about.
- **Document remote-side push prerequisites**: #1337, a separate docs PR
  which depends on this one — it must tell operators how to see why a push
  was refused, and this change is that answer.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
      It caught a test double implementing the old `push_failed` signature
      (two failures, fixed), and the class of docs describing the changed log
      levels: `docs/guides/git-integration.md` and the design doc both
      asserted these lines "sit at `DEBUG`". Both swept in this PR rather than
      left for a reviewer.
- [x] No commit carries `!`. `SyncHealthTracker.push_failed` gained an
      optional second parameter; no operator surface or importable name
      changed meaning.

## Docs impact

- [ ] `README.md` — no config or tool surface changed.
- [x] `docs/` site pages — `docs/releases/4.2.md`, and
      `docs/guides/git-integration.md` (the log-level claim it made is now
      false; also one pre-existing Vale error the hook surfaced, since it
      lints whole changed files).
- [x] `docs/design/` — the sync-health section, including why #1287 is
      reversed on one side and kept on the other.
- [x] Inline docstrings — `do_push_safe`, `push_if_unpushed`,
      `SyncHealthTracker.push_failed` / `_open`, `_record_push`,
      `_resolve_claim`, and the `_path_at_ref` walk's rule list.
- [x] `.vale` vocabulary — `unsynced`, the product's own term, used in prose
      rather than only inside code spans.

---
_Generated by [Claude Code](https://claude.ai/code)_
