### PR TITLE
docs(git): state what the remote must permit, and how to read a refusal

### DIFF
--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -68,6 +68,35 @@ Behavior:
 - If `SOURCE_DIR` is empty at startup, the server clones `GIT_REPO_URL` into it.
 - If `SOURCE_DIR` is already a git repo, the server verifies `origin` matches `GIT_REPO_URL`.
 - Each write tool call is committed (see [What a commit covers](#what-a-commit-covers)); the accumulated commits are pushed after the configured idle delay.
+
+### What the remote must permit
+
+`GIT_USERNAME` and `GIT_TOKEN` decide who the server authenticates *as*. They
+say nothing about what that identity is allowed to do, and a token that
+authenticates perfectly can still be refused at push time. Both conditions
+below are ordinary first-run states rather than mistakes, and neither
+is visible from the credentials.
+
+**The token needs push access to the branch the vault tracks.** A read-only
+token clones and pulls without complaint, so a vault can run for hours,
+committing locally, before anything reveals that nothing is replicating.
+
+**A protected default branch refuses the push.** GitLab protected branches,
+GitHub branch protection, and GitHub rulesets all reject a push that does not
+meet their conditions, whatever the token's own scopes say. Either grant the
+token's identity permission to push to that branch, or point the vault at a
+branch it may write:
+
+- GitLab: Settings → Repository → Protected branches, or use a token whose
+  role is listed under **Allowed to push and merge**.
+- GitHub: Settings → Branches (or Rules → Rulesets); a bypass entry for the
+  app or account behind the token.
+
+The symptom is the same either way: writes succeed, `read` serves them back,
+and the commits accumulate in the clone without reaching the remote. See
+[When the clone stops reaching its remote](#when-the-clone-stops-reaching-its-remote)
+for what that looks like, and the next section for how to read the actual git
+error.
 - Periodic pull uses fast-forward-only updates.
 
 Two mechanisms sit alongside the periodic loop, both described below: a
@@ -230,6 +259,24 @@ Use `direction="pull"` or `direction="push"` to skip a leg. In
 `direction="both"` mode the push leg only runs when the pull leg
 succeeded; otherwise `push` stays `null` and the LLM should inspect
 `pull.reason` (and `pull.conflict_files`) before retrying.
+
+**`git_sync(direction="push")` is how you see why a push was refused.** It
+runs a real push and returns the remote's own words in `push.hint`:
+
+```
+remote: GitLab: You are not allowed to push code to protected branches on this project.
+```
+
+That is the fastest route from "the vault is not replicating" to the sentence
+that names the cause, and it is worth reaching for before inspecting the
+container or reproducing the push by hand.
+
+Do not substitute `git push --dry-run` for it. A dry-run push negotiates with
+the remote but never runs its pre-receive hooks, which is where a protected
+branch does its rejecting, so it reports success against a remote that would
+refuse the real push. This is also why a `dry_run=true` `git_sync` returns
+`applied=false` with `reason="dry_run_unsupported"` on the push leg rather
+than a prediction: there is no honest local answer to give.
 
 `dry_run=true` previews what a pull *would* do (useful for "is there
 anything new on origin?") without risking an in-conversation conflict.

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -95,8 +95,9 @@ branch it may write:
 The symptom is the same either way: writes succeed, `read` serves them back,
 and the commits accumulate in the clone without reaching the remote. See
 [When the clone stops reaching its remote](#when-the-clone-stops-reaching-its-remote)
-for what that looks like, and the next section for how to read the actual git
-error.
+for what that looks like, and
+[Manual sync](#manual-sync-git_sync-tool) for the one call that returns the
+remote's actual refusal message.
 - Periodic pull uses fast-forward-only updates.
 
 Two mechanisms sit alongside the periodic loop, both described below: a

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -356,6 +356,17 @@ same type. This only widens what is accepted; no working configuration
 changes meaning. Library callers passing `attachment_extensions=` get the
 same normalization.
 
+**The git guide now says what the remote must permit.** It documented which
+credentials to configure but not what the token had to be allowed to do, so
+two ordinary first-run conditions each cost a long detour before the real git
+error was found: a read-only token, and a protected default branch that
+refused the push
+([#1337](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1337)). The
+managed-git section now states both prerequisites and points at
+`git_sync(direction="push")` as the call that returns the remote's own
+refusal message, with a note on why `git push --dry-run` is not a substitute
+for it.
+
 ## For library consumers
 
 `Vault` construction is now settings-first: a `VaultSettings` object


### PR DESCRIPTION
## Closes / Refs

Closes #1337

## What & why

The guide gave `GIT_REPO_URL` / `GIT_USERNAME` / `GIT_TOKEN` and a
per-provider username table. Together those say who the server authenticates
*as*, and nothing about what that identity is allowed to do. Bringing a vault
up against a corporate GitLab hit two remote-side refusals in a row; both are
ordinary first-run conditions, and each cost a long detour before the actual
git error was found.

Two additions:

- **What the remote must permit** (managed-mode section): the token needs push
  access to the tracked branch, and protected branches or rulesets refuse
  independently of the token's own scopes. Where to look on GitLab and GitHub,
  and the symptom both share — writes succeed, `read` serves them back, and
  commits accumulate in a clone that is not replicating.
- **`git_sync(direction="push")` is the diagnostic route** (`git_sync`
  section): it runs a real push and returns the remote's own sentence in
  `push.hint`. With the reason `git push --dry-run` is *not* a substitute: a
  dry-run push negotiates with the remote but never runs its pre-receive
  hooks, which is exactly where a protected branch rejects, so it reports
  success against a remote that would refuse the real push. That also explains
  why a `dry_run` `git_sync` returns `dry_run_unsupported` on the push leg
  rather than a prediction.

The dry-run point is the one worth reading closely: it is the trap that
produced the detour, and the guide previously stated the `dry_run_unsupported`
behavior without saying why it exists.

## What this PR deliberately does NOT do

- **Say anything about what the log now contains.** #1330's fix (PR #1341,
  open) makes the push failure log its cause at `WARNING`, and #1341 carries
  the guide edit describing that. Keeping it out of here means this diff is
  reviewable against `main` on its own, with no claim that is only true once
  another PR lands. The two edits touch different sections of the same file;
  whichever merges second may need a trivial rebase.
- **Enumerate Bitbucket's protection model.** The issue raises it as an open
  question. GitLab and GitHub are the two verified against; the general
  statement covers the rest without inventing per-provider UI paths.
- **Document the `fetch_failed` webhook path.** #1337 flags it `[unverified]`
  and routes it to #1330 as a log-detail question rather than a docs one.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
      Checked specifically for forward references to #1341's behavior (none),
      and verified the `push.hint` field name against
      `git/types.py:214` and the tool reference rather than from memory.
- [x] `mkdocs build --strict` passes; the new cross-reference anchor resolves.
- [x] No commit carries `!`. Documentation only; no code changed.

## Docs impact

- [ ] `README.md` — the deployment prerequisites belong in the git guide.
- [x] `docs/` site pages — `docs/guides/git-integration.md` and
      `docs/releases/4.2.md`.
- [ ] `docs/design/` — no design decision changed; this documents behavior
      that already existed.
- [ ] Inline docstrings — no code touched.

---
_Generated by [Claude Code](https://claude.ai/code)_
