### PR TITLE
fix(git): stop advising an unrelated note when a revision read refuses a copy

### DIFF
--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -110,6 +110,17 @@ The end state is uniform: `get_history`, `get_diff`, and the new
 following, the same threshold, and the same lineage boundary at the note's
 creation.
 
+One refusal message changed after the release candidate. `read(path,
+revision=)` correctly refuses when git records the note as a copy rather
+than a continuation, but the refusal then named the copy source as the thing
+to read
+([#1336](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1336)).
+That source is git's similarity match (in the case that surfaced this, an
+unrelated note that merely shared frontmatter scaffolding), and the
+documented next step after a revision read is to write the content back. The
+refusal still names what git found, and now points at `get_history` the way
+the neighbouring refusal already did.
+
 ## One commit per tool call
 
 This one arrived from the field.

--- a/src/markdown_vault_mcp/git/query.py
+++ b/src/markdown_vault_mcp/git/query.py
@@ -1722,11 +1722,20 @@ def _path_at_ref(raw: str, cur_rel: str, ref: str) -> str:
                 "'get_history' to find a revision this note actually has."
             )
         elif status.startswith("C") and paths[-1] == tracked:
+            # The copy source is git's similarity match, not a note the caller
+            # asked about: in the case that surfaced this (#1336) it was an
+            # unrelated note that merely shared frontmatter scaffolding.
+            # Naming it as the thing to read invites restoring unrelated
+            # content, and the documented next step after a revision read is
+            # to write it back, so this branch points at 'get_history' the
+            # way the 'A' branch above does. The source is still named,
+            # because it is what git said and it explains the refusal.
             raise ValueError(
                 f"{tracked!r} appears as a copy of {paths[0]!r} rather than as a "
                 "continuation of it, so the note now at that path did not exist "
-                f"at that revision. Read {paths[0]!r} at {ref!r} instead if the "
-                "content you want is the one it was copied from."
+                "at that revision. The copy source is git's similarity match, "
+                "not necessarily related to what you asked for; use "
+                "'get_history' to find a revision this note actually has."
             )
         elif status[0] not in ("D", "M", "T") or paths[0] != tracked:
             raise ValueError(

--- a/tests/test_git_revision.py
+++ b/tests/test_git_revision.py
@@ -865,6 +865,28 @@ class TestWalkRules:
 
         assert list(_iter_name_status("\x1eSHA\0\nR100\0only-one-path\0")) == []
 
+    def test_a_copy_refusal_does_not_send_the_caller_to_another_note(self) -> None:
+        """The copy source is git's similarity guess, not the caller's note.
+
+        Advising "read that one instead" invited restoring unrelated
+        content — the documented next step after a revision read is to
+        write it back (#1336). The sibling ``A`` branch already pointed at
+        'get_history'; this one now does too.
+        """
+        from markdown_vault_mcp.git.query import _path_at_ref
+
+        stream = "\x1eSHA\0\nC85\0unrelated.md\0note.md\0"
+        with pytest.raises(ValueError) as exc:
+            _path_at_ref(stream, "note.md", "abc123")
+
+        message = str(exc.value)
+        assert "get_history" in message
+        # The source is still named — it is what git said, and it is what
+        # explains the refusal — but it is not offered as a thing to read.
+        assert "unrelated.md" in message
+        assert "Read 'unrelated.md'" not in message
+        assert "similarity match" in message
+
     def test_edits_and_deletes_carry_the_identity_forward(self) -> None:
         """The walk survives the record classes that keep a note's identity."""
         from markdown_vault_mcp.git.query import _path_at_ref


### PR DESCRIPTION
## Closes / Refs

Closes #1336

## What & why

`read(path, revision=)` refuses correctly when git records the note as a copy rather than a continuation, but the `C` branch of `_path_at_ref` then advised reading the copy source. That source is git's similarity match — in the observed case an unrelated note — and the documented next step after a revision read is to write the content back, so the advice invited restoring unrelated content. The refusal still names what git found (it explains the refusal) and now ends the way the sibling `A` branch already did: use `get_history`.

Decision recorded on #1336 before coding. Not done, deliberately: the rename threshold (`--find-renames=30`) is untouched — the cause of the spurious `C` record is unverified, and lowering it would trade this for missed lineage.

## Self-review 11b0ada..0aba481

Charters: rules, diff, comments, history. Conformance: no normative content. Past-PRs: skipped (single message change; no prior review threads on this branch of `query.py`).
Coverage: full.

- `git/query.py`, `tests/test_git_revision.py`, `docs/releases/4.2.md` — important/verified — the comment, test docstring and release note stated the *cause* of the spurious copy record ("clear the rename threshold easily") as fact; #1336 marks that cause `[unverified]`. Resolved in `0aba481`: all three now state only what was observed.

## Verification

- `uv run pytest -x -q`: 4260 passed, 3 skipped (pre-amend run; the amend changed prose only, `tests/test_git_revision.py -k copy_refusal` re-run: 1 passed).
- `ruff check --fix` → `ruff format` → `ruff format --check`: clean. `mypy src/ tests/`: clean.
- `scripts/structural_gate.sh`: 0 violations. `pre-commit run --all-files`: all passed (Vale included).

## Docs impact

- [x] `docs/releases/4.2.md` — paragraph in "History that describes the right note".
- [ ] `README.md` / `docs/tools/index.md` — no contract change; the refusal list there does not quote the message. `grep -rn "copied from\|appears as a copy" docs/ README.md` finds no mirror.
- [ ] `docs/design/` — no mirror of the message.
- [x] Inline comment on the branch says why.

No commit carries `!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RSxDv7WV6p6FD5kZ2h83U