### PR TITLE
fix(git): say why a push failed, at the level deployments run at

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -236,6 +236,7 @@ unparseable
 unpushed
 unqueued
 unsourced
+unsynced
 untyped
 uploader
 upsert

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3874,21 +3874,24 @@ path reports it.
   argument, and every call site passes it: the two in `PushScheduler`
   (deferred and startup) and `GitWriteStrategy._record_push`, which forwards
   `PushResult.hint`.
-- **Push attempts log at WARNING; pull-cycle detail stays at DEBUG.** #1287
-  moved the per-attempt lines to DEBUG to stop a per-cycle warning from
-  drowning the transition. The two legs repeat on different clocks, and that
-  is what decides the level. The pull loop runs on a timer: the
+- **A push attempt logs at the level of what caused it.** #1287 moved the
+  per-attempt lines to DEBUG to stop a per-cycle warning from drowning the
+  transition, and the rule that decides the level is whether the attempt
+  fired on a timer or on a cause. The pull loop runs on a timer: the
   conflict-resolution loop cap, the "conflict resolution failed" line, and
   the sibling-commit failure fire every cycle with no operator or caller
   action, which is how they drowned the transition in the reported incident,
-  and they stay at DEBUG. A push is a per-write idle timer
-  (`PushScheduler.schedule_push` arms `threading.Timer(push_delay_s)`), so a
-  rejected push repeats once per write burst, and that line is the only
-  evidence retries are still happening (#1330). Hiding it at DEBUG left an
-  operator on a deployment running at INFO unable to tell a clone still
-  retrying from one that had stopped, or to see what git said. Both push
-  paths (deferred and startup) log at WARNING with redacted stderr; the fetch
-  leg was already there. Two classes stay loud for their own reasons: an
+  and they stay at DEBUG. So does the pull loop's retry of a still-pending
+  push (#957), which `_pull_loop` marks with `do_push_safe(retry=True)`: a
+  push that keeps failing would otherwise warn once per tick, indefinitely.
+  An attempt a write (`schedule_push`'s idle timer), a `flush`, or startup
+  caused is one attempt per cause, so its rejection repeats once per burst of
+  writes, and that line is the evidence retries are still happening (#1330).
+  Hiding it at DEBUG left an operator on a deployment running at INFO unable
+  to tell a clone still retrying from one that had stopped, or to see what
+  git said. Those attempts log at WARNING with redacted stderr on the
+  deferred and the startup path; the fetch leg was already there. Two
+  classes stay loud for their own reasons: an
   unexpected exception on either path (a bug, not a cycle), and a failure
   that can leave the working tree inconsistent (`abort_in_progress_rebase`,
   `restore_upstream_paths`). The guidance the incident produced still holds:

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -3865,17 +3865,34 @@ path reports it.
   atomically. The strategy-wide lock is held across a whole fetch + merge, so
   reading health under it would make every write response block behind a
   pull.
-- **The log marks transitions.** Entering the state logs once at ERROR
-  (`git_remote_unsynced`), recovery once at INFO (`git_remote_resynced`). The
-  per-attempt lines behind the conditions moved to DEBUG, where they keep the
-  git stderr: the rejected push in `PushScheduler`, and on the pull side the
-  conflict-resolution loop cap, the "conflict resolution failed" line, and the
-  sibling-commit failure — the three that repeated every cycle in the reported
-  incident. Two classes stay loud: an unexpected exception on either path
-  (a bug, not a cycle), and a failure that can leave the working tree
-  inconsistent (`abort_in_progress_rebase`, `restore_upstream_paths`). The
-  repeating per-cycle warning is what let the incident run for hours
-  unnoticed.
+- **The log marks transitions, and the push attempts behind them.** Entering
+  the state logs once at ERROR (`git_remote_unsynced`), recovery once at INFO
+  (`git_remote_resynced`). The transition carries a `cause=` field (the git
+  stderr the outcome came with) because `push_failed` is the bucket every
+  unrecognised message lands in and names a state rather than a problem
+  (#1330). `SyncHealthTracker.push_failed` takes that detail as a second
+  argument, and every call site passes it: the two in `PushScheduler`
+  (deferred and startup) and `GitWriteStrategy._record_push`, which forwards
+  `PushResult.hint`.
+- **Push attempts log at WARNING; pull-cycle detail stays at DEBUG.** #1287
+  moved the per-attempt lines to DEBUG to stop a per-cycle warning from
+  drowning the transition. The two legs repeat on different clocks, and that
+  is what decides the level. The pull loop runs on a timer: the
+  conflict-resolution loop cap, the "conflict resolution failed" line, and
+  the sibling-commit failure fire every cycle with no operator or caller
+  action, which is how they drowned the transition in the reported incident,
+  and they stay at DEBUG. A push is a per-write idle timer
+  (`PushScheduler.schedule_push` arms `threading.Timer(push_delay_s)`), so a
+  rejected push repeats once per write burst, and that line is the only
+  evidence retries are still happening (#1330). Hiding it at DEBUG left an
+  operator on a deployment running at INFO unable to tell a clone still
+  retrying from one that had stopped, or to see what git said. Both push
+  paths (deferred and startup) log at WARNING with redacted stderr; the fetch
+  leg was already there. Two classes stay loud for their own reasons: an
+  unexpected exception on either path (a bug, not a cycle), and a failure
+  that can leave the working tree inconsistent (`abort_in_progress_rebase`,
+  `restore_upstream_paths`). The guidance the incident produced still holds:
+  alert on the transitions, not the attempts.
 
 Every vault-mutating write tool passes its result through
 `attach_remote_health`, which adds a `remote` object while the clone is

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -297,7 +297,7 @@ commits) reports `would_apply=false`. The push leg has no safe local
 
     - The pull **succeeds** (`pull.applied=true`,
       `pull.reason="conflicts_resolved_with_siblings"`).
-    - HEAD advances to the remote tip — the canonical path now reflects
+    - HEAD advances to the remote tip, so the canonical path now reflects
       the remote (remote wins).
     - The local versions that conflicted are preserved as
       `<basename>.conflict-mcp-<timestamp>.md` siblings on the same
@@ -356,16 +356,34 @@ once at `ERROR`:
 ERROR markdown_vault_mcp.git.health: git_remote_unsynced kind=push reason=non_fast_forward ...
 ```
 
-Recovery logs once at `INFO` (`git_remote_resynced`), carrying when the
-outage started. The per-attempt lines behind both conditions (a rejected
-push, and a pull that could not resolve the divergence) sit at `DEBUG`, where
-they keep the full git stderr for whoever is diagnosing the outage. Two kinds
-of failure stay loud, because neither is a cycle that repeats harmlessly: an
-unexpected exception on the push or resolve path, and a failure that can
-leave the working tree inconsistent (a rebase that would not abort, an
-upstream file that would not restore). Alert on the transition
-lines: a repeated warning every sync cycle is easy to scroll past, which is
-how the incident behind
+That line carries the cause alongside the reason code, because `push_failed`
+is the bucket every unrecognised git message lands in and names a state
+rather than a problem. Recovery logs once at `INFO`
+(`git_remote_resynced`), carrying when the outage started.
+
+**The attempts are visible too, at the default level.** A rejected push logs
+at `WARNING` with the git stderr that says why, on the deferred and the
+startup path alike, as does a fetch that could not reach the remote:
+
+```
+WARNING markdown_vault_mcp.git.push_scheduler: git_push_failed cmd=... returncode=1 stderr=remote: GitLab: You are not allowed to push code to protected branches on this project.
+```
+
+Credentials are redacted. These lines were at `DEBUG` until
+[#1330](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1330), which
+meant a deployment running at `INFO` saw the transition and nothing else.
+Because every retry was equally silent, it could not tell a clone that was
+still retrying from one that had stopped. A push is scheduled by a write, so
+this line repeats once per burst of writes, not on a timer, and it is the
+evidence the retries are happening. The per-cycle details of a divergence
+the resolver is working through do fire on a timer, and they stay at
+`DEBUG`. Two kinds of failure stay loud for their own reasons: an unexpected
+exception on the push or resolve path, and a failure that can leave the
+working tree inconsistent (a rebase that would not abort, an upstream file
+that would not restore).
+
+Alert on the transition lines rather than the per-attempt ones: a warning
+every sync cycle is easy to scroll past, which is how the incident behind
 [#1287](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1287) ran for
 hours before anyone noticed.
 

--- a/docs/guides/git-integration.md
+++ b/docs/guides/git-integration.md
@@ -373,11 +373,14 @@ Credentials are redacted. These lines were at `DEBUG` until
 [#1330](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1330), which
 meant a deployment running at `INFO` saw the transition and nothing else.
 Because every retry was equally silent, it could not tell a clone that was
-still retrying from one that had stopped. A push is scheduled by a write, so
-this line repeats once per burst of writes, not on a timer, and it is the
-evidence the retries are happening. The per-cycle details of a divergence
-the resolver is working through do fire on a timer, and they stay at
-`DEBUG`. Two kinds of failure stay loud for their own reasons: an unexpected
+still retrying from one that had stopped. The level follows what caused the
+attempt: a push that a write, a `git_sync` flush, or startup caused warns,
+so the line repeats once per burst of writes and is the evidence the
+retries are happening. The pull loop's own retry of a still-pending push
+fires on its timer, and that one stays at `DEBUG` (a warning per tick,
+indefinitely, is the line #1287 removed), as do the per-cycle details of a
+divergence the resolver is working through. Two kinds of failure stay loud
+for their own reasons: an unexpected
 exception on the push or resolve path, and a failure that can leave the
 working tree inconsistent (a rebase that would not abort, an upstream file
 that would not restore).

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -221,6 +221,22 @@ reporting the remote tip as its projected target, which had been triggering
 pointless full reindexes through the sync paths
 ([#1301](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1301)).
 
+The release candidate then showed the other half of the problem: the
+noticing worked, and the diagnosing did not. When a clone could not reach
+its remote, the only line in the log was that one transition, naming the
+generic `push_failed` bucket; git's own words sat at `DEBUG`, and
+deployments run at `INFO`
+([#1330](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1330)). An
+operator learned the vault was stranded but not why, and because every retry
+was equally silent, could not tell a clone that was still retrying from one
+that had stopped. The transition line now carries the cause alongside the
+reason code, and a rejected push logs at `WARNING` with the git stderr, on
+the deferred and the startup path alike. That is a deliberate step back from
+the quieting #1287 introduced, on one leg only: a push is scheduled by a
+write, so the line repeats once per burst of writes, whereas the pull-side
+detail that drowned the transition in the original incident fires on a
+timer and stays at `DEBUG`. Credentials are redacted as before.
+
 See "When the clone stops reaching its remote" in the
 [git integration guide](../guides/git-integration.md).
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -232,10 +232,12 @@ was equally silent, could not tell a clone that was still retrying from one
 that had stopped. The transition line now carries the cause alongside the
 reason code, and a rejected push logs at `WARNING` with the git stderr, on
 the deferred and the startup path alike. That is a deliberate step back from
-the quieting #1287 introduced, on one leg only: a push is scheduled by a
-write, so the line repeats once per burst of writes, whereas the pull-side
-detail that drowned the transition in the original incident fires on a
-timer and stays at `DEBUG`. Credentials are redacted as before.
+the quieting #1287 introduced, and it is bounded by what caused the attempt:
+a push that a write caused is one attempt per write, so the line repeats
+once per burst of writes, whereas the pull loop's timer-driven retry of a
+still-pending push, like the pull-side detail that drowned the transition
+in the original incident, stays at `DEBUG`. Credentials are redacted as
+before.
 
 See "When the clone stops reaching its remote" in the
 [git integration guide](../guides/git-integration.md).

--- a/src/markdown_vault_mcp/git/health.py
+++ b/src/markdown_vault_mcp/git/health.py
@@ -20,9 +20,11 @@ Two properties matter for how it is used:
 * **The log records transitions, not cycles.** Entering the unsynced state
   logs once at ERROR, with the cause git gave, and recovery once at INFO.
   The repeating per-cycle warning is what let the incident in #1287 run for
-  hours unnoticed.  Push attempts are the exception (#1330): a push is
-  scheduled by a write rather than by a timer, so its rejection line repeats
-  once per burst of writes and is the evidence that retries are happening.
+  hours unnoticed.  Push attempts that a write, a flush, or startup caused
+  are the exception (#1330): each is one attempt per cause, so its rejection
+  line repeats once per burst of writes and is the evidence that retries are
+  happening.  The pull loop's timer-driven retry of a pending push stays at
+  DEBUG for the same reason the pull-side lines do.
 """
 
 from __future__ import annotations
@@ -234,14 +236,14 @@ class SyncHealthTracker:
                 # trailing spaces; the log line is key=value pairs, so the
                 # cause is flattened onto one line and placed last, where it
                 # cannot split an earlier field.
-                cause = " ".join(detail.split()) if detail else "unavailable"
+                cause = " ".join(detail.split()) if detail else ""
                 logger.error(
                     "git_remote_unsynced kind=%s reason=%s "
                     "detail=writes are committed locally and are not reaching "
                     "the remote cause=%s",
                     kind,
                     reason,
-                    cause,
+                    cause or "unavailable",
                 )
             else:
                 logger.debug("git_remote_unsynced_also kind=%s reason=%s", kind, reason)

--- a/src/markdown_vault_mcp/git/health.py
+++ b/src/markdown_vault_mcp/git/health.py
@@ -69,6 +69,24 @@ _Kind = Literal["push", "pull"]
 _NON_FAST_FORWARD_MARKERS = ("non-fast-forward", "fetch first")
 
 
+def one_line(text: str) -> str:
+    """Collapse *text* onto one line for a ``key=value`` log record.
+
+    Git's stderr spans several lines and pads them with trailing spaces; a
+    line-oriented log collector reads the unprefixed continuation lines as
+    separate malformed entries, and a later ``key=`` field would land on the
+    last of them (#1330).
+
+    Args:
+        text: Redacted git stderr, or any multi-line detail.
+
+    Returns:
+        The words of *text* joined by single spaces; empty when *text* has
+        none.
+    """
+    return " ".join(text.split())
+
+
 def push_failure_reason(stderr: str) -> str:
     """Classify a failed ``git push`` from its stderr.
 
@@ -232,11 +250,9 @@ class SyncHealthTracker:
             self._reasons[kind] = reason
             self._recompute()
             if was_healthy:
-                # Git's stderr spans several lines and pads them with
-                # trailing spaces; the log line is key=value pairs, so the
-                # cause is flattened onto one line and placed last, where it
-                # cannot split an earlier field.
-                cause = " ".join(detail.split()) if detail else ""
+                # Placed last, where a cause that somehow kept a newline
+                # could not split an earlier field.
+                cause = one_line(detail) if detail else ""
                 logger.error(
                     "git_remote_unsynced kind=%s reason=%s "
                     "detail=writes are committed locally and are not reaching "

--- a/src/markdown_vault_mcp/git/health.py
+++ b/src/markdown_vault_mcp/git/health.py
@@ -18,8 +18,11 @@ Two properties matter for how it is used:
   across a whole fetch + merge, so reading health under it would make every
   write response block behind a pull.
 * **The log records transitions, not cycles.** Entering the unsynced state
-  logs once at ERROR and recovery once at INFO.  The repeating per-cycle
-  warning is what let the incident in #1287 run for hours unnoticed.
+  logs once at ERROR, with the cause git gave, and recovery once at INFO.
+  The repeating per-cycle warning is what let the incident in #1287 run for
+  hours unnoticed.  Push attempts are the exception (#1330): a push is
+  scheduled by a write rather than by a timer, so its rejection line repeats
+  once per burst of writes and is the evidence that retries are happening.
 """
 
 from __future__ import annotations
@@ -163,14 +166,18 @@ class SyncHealthTracker:
         """
         return self._snapshot
 
-    def push_failed(self, reason: str) -> None:
+    def push_failed(self, reason: str, detail: str | None = None) -> None:
         """Record a push that did not reach the remote.
 
         Args:
             reason: A ``PUSH_REASON_*`` code.  Codes that do not prove
                 commits are stranded are ignored (see :data:`_PUSH_CONDITIONS`).
+            detail: What git said, when the caller has it.  ``push_failed`` is
+                the generic bucket every unrecognised stderr lands in, so
+                without this the one transition line names a state and not a
+                cause (#1330).
         """
-        self._open("push", reason, _PUSH_CONDITIONS)
+        self._open("push", reason, _PUSH_CONDITIONS, detail=detail)
 
     def push_succeeded(self) -> None:
         """Record that local commits reached the remote."""
@@ -190,8 +197,22 @@ class SyncHealthTracker:
         """Record that the clone reconciled with the remote."""
         self._close("pull")
 
-    def _open(self, kind: _Kind, reason: str, conditions: frozenset[str]) -> None:
-        """Open the *kind* condition, logging the transition into it once."""
+    def _open(
+        self,
+        kind: _Kind,
+        reason: str,
+        conditions: frozenset[str],
+        *,
+        detail: str | None = None,
+    ) -> None:
+        """Open the *kind* condition, logging the transition into it once.
+
+        Args:
+            kind: ``"push"`` or ``"pull"``.
+            reason: The ``*_REASON_*`` code.
+            conditions: The codes that count as an outage for this kind.
+            detail: Optional cause text carried onto the transition line.
+        """
         if reason not in conditions:
             return
         with self._lock:
@@ -209,11 +230,18 @@ class SyncHealthTracker:
             self._reasons[kind] = reason
             self._recompute()
             if was_healthy:
+                # Git's stderr spans several lines and pads them with
+                # trailing spaces; the log line is key=value pairs, so the
+                # cause is flattened onto one line and placed last, where it
+                # cannot split an earlier field.
+                cause = " ".join(detail.split()) if detail else "unavailable"
                 logger.error(
                     "git_remote_unsynced kind=%s reason=%s "
-                    "detail=writes are committed locally and are not reaching the remote",
+                    "detail=writes are committed locally and are not reaching "
+                    "the remote cause=%s",
                     kind,
                     reason,
+                    cause,
                 )
             else:
                 logger.debug("git_remote_unsynced_also kind=%s reason=%s", kind, reason)

--- a/src/markdown_vault_mcp/git/push_scheduler.py
+++ b/src/markdown_vault_mcp/git/push_scheduler.py
@@ -118,17 +118,21 @@ class PushScheduler:
 
         The outcome itself is recorded by :meth:`do_push`, while the shared
         lock still orders it against every other push (PR #1300); this wrapper
-        only logs.  A rejected push logs at DEBUG, where it keeps the git stderr for
-        diagnosis: the tracker logs the transition into the failed state
-        once, instead of every cycle.  An *unexpected* exception is not that
-        routine event and stays at ERROR with its traceback — repeating it is
-        the point, since it means a bug on the push path rather than a remote
-        that has moved on.
+        only logs.  A rejected push logs at WARNING with the git stderr that
+        says why, matching what the pull leg already does for a failed fetch
+        (#1330).  It was at DEBUG, and deployments run at INFO, so an operator
+        saw the tracker's one transition line naming the generic
+        ``push_failed`` bucket and nothing about the cause — and, because
+        every retry was equally silent, no way to tell a clone that is still
+        retrying from one that stopped.  Repeating per attempt is the point
+        here: it is the only evidence the retries are happening.  An
+        *unexpected* exception stays at ERROR with its traceback, since it
+        means a bug on the push path rather than a remote that has moved on.
         """
         try:
             self.do_push()
         except subprocess.CalledProcessError as exc:
-            logger.debug(
+            logger.warning(
                 "git_push_failed cmd=%s returncode=%d stderr=%s",
                 exc.cmd,
                 exc.returncode,
@@ -161,12 +165,18 @@ class PushScheduler:
             try:
                 _push(git_root, self._token, self._username)
             except subprocess.CalledProcessError as exc:
-                self._health.push_failed(
-                    push_failure_reason(self._redact(exc.stderr or ""))
-                )
+                # The stderr travels with the reason: ``push_failed`` is the
+                # bucket every unrecognised message lands in, so the reason
+                # alone names a state and not a cause (#1330).
+                stderr = self._redact(exc.stderr or "")
+                self._health.push_failed(push_failure_reason(stderr), stderr.strip())
                 raise
-            except Exception:
-                self._health.push_failed(PUSH_REASON_PUSH_FAILED)
+            except Exception as exc:
+                # Redacted like the stderr arm: an exception raised while
+                # building the push command can echo the remote URL.
+                self._health.push_failed(
+                    PUSH_REASON_PUSH_FAILED, self._redact(str(exc)) or None
+                )
                 raise
             self._push_pending = False
             self._health.push_succeeded()
@@ -215,13 +225,18 @@ class PushScheduler:
                 _push(git_root, self._token, self._username)
             except subprocess.CalledProcessError as exc:
                 sanitized_stderr = self._redact(exc.stderr or "")
-                logger.debug(
+                # WARNING for the same reason as the deferred-push leg
+                # (#1330): a startup push that cannot reach the remote is the
+                # first evidence an operator gets, and DEBUG hid it.
+                logger.warning(
                     "git_startup_push_failed cmd=%s returncode=%d stderr=%s",
                     exc.cmd,
                     exc.returncode,
                     sanitized_stderr,
                 )
-                self._health.push_failed(push_failure_reason(sanitized_stderr))
+                self._health.push_failed(
+                    push_failure_reason(sanitized_stderr), sanitized_stderr.strip()
+                )
             else:
                 self._health.push_succeeded()
 

--- a/src/markdown_vault_mcp/git/push_scheduler.py
+++ b/src/markdown_vault_mcp/git/push_scheduler.py
@@ -27,7 +27,7 @@ from markdown_vault_mcp.git._run import (
     redact,
     resolve_tracking_ref,
 )
-from markdown_vault_mcp.git.health import push_failure_reason
+from markdown_vault_mcp.git.health import one_line, push_failure_reason
 from markdown_vault_mcp.git.types import PUSH_REASON_PUSH_FAILED
 
 if TYPE_CHECKING:
@@ -148,7 +148,7 @@ class PushScheduler:
                 "git_push_failed cmd=%s returncode=%d stderr=%s",
                 exc.cmd,
                 exc.returncode,
-                self._redact(exc.stderr or ""),
+                one_line(self._redact(exc.stderr or "")),
             )
         except Exception:
             logger.error("Git push failed", exc_info=True)
@@ -244,7 +244,7 @@ class PushScheduler:
                     "git_startup_push_failed cmd=%s returncode=%d stderr=%s",
                     exc.cmd,
                     exc.returncode,
-                    sanitized_stderr,
+                    one_line(sanitized_stderr),
                 )
                 self._health.push_failed(
                     push_failure_reason(sanitized_stderr), sanitized_stderr.strip()

--- a/src/markdown_vault_mcp/git/push_scheduler.py
+++ b/src/markdown_vault_mcp/git/push_scheduler.py
@@ -113,26 +113,38 @@ class PushScheduler:
                 self._timer.daemon = True
                 self._timer.start()
 
-    def do_push_safe(self) -> None:
+    def do_push_safe(self, *, retry: bool = False) -> None:
         """Push wrapper that catches and logs errors.
 
         The outcome itself is recorded by :meth:`do_push`, while the shared
         lock still orders it against every other push (PR #1300); this wrapper
-        only logs.  A rejected push logs at WARNING with the git stderr that
-        says why, matching what the pull leg already does for a failed fetch
-        (#1330).  It was at DEBUG, and deployments run at INFO, so an operator
-        saw the tracker's one transition line naming the generic
-        ``push_failed`` bucket and nothing about the cause — and, because
-        every retry was equally silent, no way to tell a clone that is still
-        retrying from one that stopped.  Repeating per attempt is the point
-        here: it is the only evidence the retries are happening.  An
-        *unexpected* exception stays at ERROR with its traceback, since it
+        only logs.  The level follows what caused the attempt (#1330):
+
+        * An attempt a write, a flush, or startup caused logs a rejection at
+          WARNING with the git stderr that says why, matching what the pull
+          leg already does for a failed fetch.  It was at DEBUG, and
+          deployments run at INFO, so an operator saw the tracker's one
+          transition line naming the generic ``push_failed`` bucket and
+          nothing about the cause.  Each write is one attempt, so this line
+          repeats once per burst of writes and is the evidence that retries
+          are happening.
+        * A *retry* — the pull loop re-attempting a still-pending push on
+          every tick (#957) — logs at DEBUG.  That attempt fires on a timer
+          with no caller action, and a warning per tick is the repeating
+          line that let the incident behind #1287 run unnoticed.
+
+        An *unexpected* exception stays at ERROR with its traceback, since it
         means a bug on the push path rather than a remote that has moved on.
+
+        Args:
+            retry: ``True`` when the attempt is the pull loop's timer-driven
+                retry rather than one a write, flush, or startup caused.
         """
         try:
             self.do_push()
         except subprocess.CalledProcessError as exc:
-            logger.warning(
+            logger.log(
+                logging.DEBUG if retry else logging.WARNING,
                 "git_push_failed cmd=%s returncode=%d stderr=%s",
                 exc.cmd,
                 exc.returncode,

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1250,11 +1250,16 @@ class GitWriteStrategy:
         order they ran (PR #1300).  Outcomes that say nothing about the remote
         (``dry_run_unsupported``, ``no_remote``) are passed on as-is; the
         tracker ignores them.
+
+        ``hint`` carries git's own words and travels with the reason: the
+        reason alone is the generic ``push_failed`` bucket for every stderr
+        that matches no known marker, which told an operator the vault was
+        stranded but not why (#1330).
         """
         if result.applied:
             self._health.push_succeeded()
         elif result.reason is not None:
-            self._health.push_failed(result.reason)
+            self._health.push_failed(result.reason, result.hint)
 
     def _record_pull(self, result: PullResult) -> None:
         """Report a pull outcome to the sync-health tracker.

--- a/src/markdown_vault_mcp/git/strategy.py
+++ b/src/markdown_vault_mcp/git/strategy.py
@@ -1251,10 +1251,11 @@ class GitWriteStrategy:
         (``dry_run_unsupported``, ``no_remote``) are passed on as-is; the
         tracker ignores them.
 
-        ``hint`` carries git's own words and travels with the reason: the
-        reason alone is the generic ``push_failed`` bucket for every stderr
-        that matches no known marker, which told an operator the vault was
-        stranded but not why (#1330).
+        ``hint`` travels with the reason (#1330): for ``push_failed`` it is
+        git's own redacted stderr, since that reason is the bucket for every
+        message matching no known marker and alone told an operator the vault
+        was stranded but not why; for ``non_fast_forward`` it is the recovery
+        instruction ``force_push`` composes, which already names the problem.
         """
         if result.applied:
             self._health.push_succeeded()
@@ -1631,9 +1632,10 @@ class GitWriteStrategy:
                 # Retry a pending push after the pull reconciled any
                 # non-fast-forward divergence via its rebase step (#957).
                 # PushScheduler.do_push's guard makes this a no-op when
-                # nothing is pending.
+                # nothing is pending. Marked as a retry so a push that keeps
+                # failing does not warn once per tick (#1330).
                 if self._enable_push:
-                    self._push_scheduler.do_push_safe()
+                    self._push_scheduler.do_push_safe(retry=True)
             except Exception:
                 logger.exception("Git pull loop tick failed")
             # Wait until the next interval, or stop early.

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2725,6 +2725,46 @@ class TestGitPullLoop:
 
         assert push_calls, "pull loop did not retry the pending push"
 
+    def test_pull_loop_retry_of_a_rejected_push_does_not_warn(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A timer-driven retry logs at DEBUG, not once per tick at WARNING (#1330)."""
+        import logging
+        import subprocess
+        import time
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        monkeypatch.setattr(strategy, "_ensure_git_root", lambda _p: tmp_path)
+        monkeypatch.setattr(
+            "markdown_vault_mcp.git.subprocess.run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            ),
+        )
+        monkeypatch.setattr(strategy, "sync_once", lambda _repo: True)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+        rejected = subprocess.CalledProcessError(
+            returncode=1, cmd=["git", "push", "origin"], stderr="pre-receive hook"
+        )
+
+        with (
+            patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=rejected),
+            caplog.at_level(logging.DEBUG, logger="markdown_vault_mcp.git"),
+        ):
+            strategy.start(repo_path=tmp_path, pull_interval_s=3600)
+            time.sleep(0.05)
+            strategy.stop()
+
+        attempts = [r for r in caplog.records if "git_push_failed" in r.message]
+        assert attempts, "pull loop did not retry the pending push"
+        assert {r.levelno for r in attempts} == {logging.DEBUG}
+
     def test_pull_loop_retries_after_non_ff_rebase(
         self,
         git_repo_pair: GitRepoPair,

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1114,8 +1114,9 @@ class TestTokenRedactionInLogs:
 
         with (
             patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=fake_exc),
-            # The per-attempt line sits at DEBUG since #1287: the transition
-            # into the unsynced state is what gets logged loudly, once.
+            # The per-attempt line moved to WARNING in #1330 — DEBUG was
+            # invisible at the level deployments run at, so an operator saw
+            # the transition into the unsynced state and never its cause.
             caplog.at_level(logging.DEBUG, logger="markdown_vault_mcp.git"),
         ):
             strategy._push_scheduler.do_push_safe()

--- a/tests/test_git_health.py
+++ b/tests/test_git_health.py
@@ -476,9 +476,9 @@ class _LockObservingTracker(SyncHealthTracker):
         self._observed_lock = lock
         self.held: list[bool] = []
 
-    def push_failed(self, reason: str) -> None:
+    def push_failed(self, reason: str, detail: str | None = None) -> None:
         self.held.append(self._observed_lock.locked())
-        super().push_failed(reason)
+        super().push_failed(reason, detail)
 
     def push_succeeded(self) -> None:
         self.held.append(self._observed_lock.locked())
@@ -568,3 +568,199 @@ class TestOutcomesAreRecordedUnderTheStrategyLock:
         strategy.force_pull()
 
         assert tracker.held == [True]
+
+
+# ---------------------------------------------------------------------------
+# A stranded clone says why, at the level deployments run at (#1330)
+# ---------------------------------------------------------------------------
+
+
+class TestPushFailureIsDiagnosable:
+    """What an operator can learn from the log when pushes stop landing.
+
+    Observed on a live vault: the only push-related line in the whole
+    container log was the transition into the unsynced state, naming the
+    generic ``push_failed`` bucket. Git's own words sat at DEBUG, and the
+    deployment ran at INFO.
+    """
+
+    @staticmethod
+    def _rejected() -> subprocess.CalledProcessError:
+        return subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "push", "origin"],
+            stderr=(
+                "remote: GitLab: You are not allowed to push code to "
+                "protected branches on this project."
+            ),
+        )
+
+    def test_the_per_attempt_line_carries_git_stderr_at_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=self._rejected(),
+            ),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        line = next(r for r in caplog.records if "git_push_failed" in r.message)
+        assert line.levelno == logging.WARNING
+        assert "protected branches" in line.getMessage()
+
+    def test_every_retry_logs_so_retrying_is_distinguishable_from_stopped(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The transition line fires once; the attempts are what repeat."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=self._rejected(),
+            ),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
+        ):
+            for _ in range(3):
+                strategy._push_pending = True
+                strategy._push_scheduler.do_push_safe()
+
+        assert len([r for r in caplog.records if "git_push_failed" in r.message]) == 3
+
+    def test_the_transition_line_names_the_cause_not_just_the_bucket(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``push_failed`` is the bucket every unrecognised stderr lands in."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=self._rejected(),
+            ),
+            caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        line = next(r for r in caplog.records if "git_remote_unsynced" in r.message)
+        assert "protected branches" in line.getMessage()
+
+    def test_the_cause_is_one_line_however_git_wrapped_it(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Git's stderr spans lines and pads them; a key=value line cannot."""
+        tracker = SyncHealthTracker()
+        stderr = (
+            "remote: GitLab: You are not allowed to push.        \n"
+            "To https://example.invalid/vault.git\n"
+            " ! [remote rejected] main -> main (pre-receive hook declined)"
+        )
+        with caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"):
+            tracker.push_failed(PUSH_REASON_PUSH_FAILED, stderr)
+
+        line = next(r for r in caplog.records if "git_remote_unsynced" in r.message)
+        message = line.getMessage()
+        assert "\n" not in message
+        assert message.endswith(
+            "cause=remote: GitLab: You are not allowed to push. "
+            "To https://example.invalid/vault.git "
+            "! [remote rejected] main -> main (pre-receive hook declined)"
+        )
+
+    def test_a_missing_cause_reads_as_unavailable_not_none(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An outcome with nothing to say still produces a readable line.
+
+        ``OSError()`` with no message makes ``str(exc)`` empty, which is the
+        shape ``_push_locked`` turns into a missing detail.
+        """
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=OSError(),
+            ),
+            caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        line = next(r for r in caplog.records if "git_remote_unsynced" in r.message)
+        assert "cause=unavailable" in line.getMessage()
+
+    def test_a_push_result_without_a_hint_reads_as_unavailable(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The interactive path forwards ``PushResult.hint``, which may be None."""
+        tracker = SyncHealthTracker()
+        with caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"):
+            tracker.push_failed(PUSH_REASON_PUSH_FAILED, None)
+
+        line = next(r for r in caplog.records if "git_remote_unsynced" in r.message)
+        assert "cause=unavailable" in line.getMessage()
+
+    def test_the_startup_push_logs_its_rejection_at_warning(
+        self, git_repo_pair: GitRepoPair, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """On a restart with unpushed commits, nothing was logged at INFO."""
+        (git_repo_pair.local_path / "unpushed.md").write_text("unpushed\n")
+        _run_git(git_repo_pair.local_path, "add", "unpushed.md")
+        _run_git(git_repo_pair.local_path, "commit", "-m", "unpushed")
+        strategy = GitWriteStrategy(
+            token=None, push_delay_s=0, repo_path=git_repo_pair.local_path
+        )
+        strategy._git_root = git_repo_pair.local_path
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=self._rejected(),
+            ),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.push_if_unpushed()
+
+        line = next(r for r in caplog.records if "git_startup_push_failed" in r.message)
+        assert line.levelno == logging.WARNING
+        assert "protected branches" in line.getMessage()
+        transition = next(
+            r for r in caplog.records if "git_remote_unsynced" in r.message
+        )
+        assert "protected branches" in transition.getMessage()
+
+    def test_the_token_is_still_redacted_at_the_new_level(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Raising the level must not raise a secret with it."""
+        secret = "glpat_secret_abc123"
+        strategy = GitWriteStrategy(token=secret, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+        exc = subprocess.CalledProcessError(
+            returncode=128,
+            cmd=["git", "push", "origin"],
+            stderr=f"fatal: authentication failed — token={secret}",
+        )
+
+        with (
+            patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=exc),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        text = " ".join(r.getMessage() for r in caplog.records)
+        assert secret not in text
+        assert "***" in text

--- a/tests/test_git_health.py
+++ b/tests/test_git_health.py
@@ -615,6 +615,31 @@ class TestPushFailureIsDiagnosable:
         assert line.levelno == logging.WARNING
         assert "protected branches" in line.getMessage()
 
+    def test_the_attempt_line_is_one_line_however_git_wrapped_it(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A line-oriented collector must not see continuation lines."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+        exc = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "push", "origin"],
+            stderr="remote: no.        \nTo https://example.invalid/v.git\n ! rejected",
+        )
+
+        with (
+            patch("markdown_vault_mcp.git.push_scheduler._push", side_effect=exc),
+            caplog.at_level(logging.WARNING, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe()
+
+        line = next(r for r in caplog.records if "git_push_failed" in r.message)
+        assert "\n" not in line.getMessage()
+        assert line.getMessage().endswith(
+            "stderr=remote: no. To https://example.invalid/v.git ! rejected"
+        )
+
     def test_every_retry_logs_so_retrying_is_distinguishable_from_stopped(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -767,6 +792,7 @@ class TestPushFailureIsDiagnosable:
         line = next(r for r in caplog.records if "git_startup_push_failed" in r.message)
         assert line.levelno == logging.WARNING
         assert "protected branches" in line.getMessage()
+        assert "\n" not in line.getMessage()
         transition = next(
             r for r in caplog.records if "git_remote_unsynced" in r.message
         )

--- a/tests/test_git_health.py
+++ b/tests/test_git_health.py
@@ -635,6 +635,37 @@ class TestPushFailureIsDiagnosable:
 
         assert len([r for r in caplog.records if "git_push_failed" in r.message]) == 3
 
+    def test_the_pull_loop_retry_of_a_pending_push_stays_at_debug(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A retry fires on the pull timer, so warning per tick is #1287 again."""
+        strategy = GitWriteStrategy(token=None, push_delay_s=0)
+        strategy._git_root = tmp_path
+        strategy._push_pending = True
+
+        with (
+            patch(
+                "markdown_vault_mcp.git.push_scheduler._push",
+                side_effect=self._rejected(),
+            ),
+            caplog.at_level(logging.DEBUG, logger="markdown_vault_mcp.git"),
+        ):
+            strategy._push_scheduler.do_push_safe(retry=True)
+
+        line = next(r for r in caplog.records if "git_push_failed" in r.message)
+        assert line.levelno == logging.DEBUG
+        assert "protected branches" in line.getMessage()
+
+    def test_a_whitespace_only_cause_reads_as_unavailable(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        tracker = SyncHealthTracker()
+        with caplog.at_level(logging.ERROR, logger="markdown_vault_mcp.git"):
+            tracker.push_failed(PUSH_REASON_PUSH_FAILED, "  \n ")
+
+        line = next(r for r in caplog.records if "git_remote_unsynced" in r.message)
+        assert line.getMessage().endswith("cause=unavailable")
+
     def test_the_transition_line_names_the_cause_not_just_the_bucket(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
## Closes / Refs

Closes #1330

## What & why

On a live 4.2.0-rc.0 vault whose pushes were being refused, the only push-related line in the container log was the one-time `git_remote_unsynced` transition, naming the generic `push_failed` bucket. Git's stderr sat at `DEBUG` in both `PushScheduler` paths, and deployments run at `INFO`. The operator learned the vault was stranded but not why, and could not tell a clone still retrying from one that had stopped.

Two changes, both on the push leg only (decision recorded on #1330 before coding, amended after review round 1 — see below):

1. **The transition line carries `cause=`.** `SyncHealthTracker.push_failed(reason, detail=None)`; every producer passes it — `PushScheduler._push_locked` (both arms, redacted), `PushScheduler.push_if_unpushed`, and `GitWriteStrategy._record_push` via `PushResult.hint`. The cause is flattened onto one line and placed last: git's stderr spans lines and pads them with trailing spaces, and the log format is `key=value` pairs.
2. **A push attempt logs at the level of what caused it.** An attempt a write (the debounce timer), a `git_sync` flush, or startup caused logs its rejection at `WARNING` with redacted stderr, as the fetch leg already does — one attempt per cause, so the line repeats once per burst of writes. The pull loop's timer-driven retry of a still-pending push (#957) passes `do_push_safe(retry=True)` and logs at `DEBUG`: a warning per tick, indefinitely, is the repeating line #1287 removed. The pull-side per-cycle lines stay at `DEBUG`.

Not done: a `remote_rejected` reason bucket (recorded on the issue as data, not a request); `cause` on the write result's `remote` key.

## Review round 1

- **Codex P2 — the pull loop retries a pending push every tick, so the WARNING repeated per pull interval.** Correct, and it invalidated the justification the first version of this PR gave ("once per write burst"): that held only for deployments without the pull loop. Brought to the owner as a change to the decision's basis; the owner chose "loud when caused, quiet on timer". Fixed in `579bd4f`: `do_push_safe(*, retry=False)`, `_pull_loop` passes `retry=True`; pinned by `test_the_pull_loop_retry_of_a_pending_push_stays_at_debug` (method) and `test_pull_loop_retry_of_a_rejected_push_does_not_warn` (through the real loop). Every statement of the mechanism — `health.py` module docstring, design.md, the git guide, the release note — is corrected.
- **Claude important — `_record_push` docstring overclaimed that `hint` is always git's words.** Correct: `force_push` composes a recovery instruction for `non_fast_forward`. Docstring scoped in `579bd4f`; the behaviour is kept, since that hint names the problem and the action.
- **Claude minor — whitespace-only `str(exc)` flattened to an empty `cause=`.** Fixed in `579bd4f` (the emptiness check now runs on the flattened string); pinned by `test_a_whitespace_only_cause_reads_as_unavailable`.

## Review round 2

- **Codex P2 — the per-attempt WARNING lines still emitted git's raw multi-line stderr.** Same class as the transition-line flattening. Fixed in 088681e: one helper, `one_line()` in `git/health.py`, used by the transition line and both attempt paths; pinned by `test_the_attempt_line_is_one_line_however_git_wrapped_it`. The fetch leg's pre-existing line has the same shape but is outside this diff.
- Claude: clean; the awareness note on the `git push exited non-zero` fallback hint is left as is.

## Probe (real git, refusing pre-receive hook, seeded remote, real pull loop at 0.3s; DEBUG shown so the retries are visible)

```
--- a write's deferred push (caused)
ERROR markdown_vault_mcp.git.health: git_remote_unsynced kind=push reason=push_failed detail=writes are committed locally and are not reaching the remote cause=remote: GitLab: You are not allowed to push code to protected branches on this project. To …/remote.git ! [remote rejected] main -> main (pre-receive hook declined) error: failed to push some refs to '…/remote.git'
WARNING markdown_vault_mcp.git.push_scheduler: git_push_failed cmd=['git', '-C', '…/work', 'push', 'origin'] returncode=1 stderr=remote: GitLab: You are not allowed to push code to protected branches on this project. To …/remote.git ! [remote rejected] main -> main (pre-receive hook declined) error: failed to push some refs to '…/remote.git'
--- real pull loop, ~3 ticks, push still pending
DEBUG markdown_vault_mcp.git.health: git_remote_still_unsynced kind=push reason=push_failed
DEBUG markdown_vault_mcp.git.push_scheduler: git_push_failed cmd=… stderr=remote: GitLab: You are not allowed to push code to protected branches on this project.
DEBUG … (×3)
```

At `INFO` an operator sees the transition with its cause and one WARNING per write; the retries are there at `DEBUG`.

## Self-review 874fd95..088681e

Charters: rules, diff, comments, history. Conformance: no normative content. Past-PRs: the closed #1341's findings are folded in (the `"unavailable"` fallback test now drives `OSError()` and `push_failed(reason, None)`).
Coverage: full.

- Round 0: `_push_locked`'s generic arm passed `str(exc)` unredacted (fixed); `health.py` module docstring said "transitions, not cycles" with no push-side qualification (fixed).
- Round 2 (`code-review` on the cumulative diff after 088681e): clean. Checked specifically: `flush()` is reached only from `close()`, a caused one-off attempt, so its WARNING is right; the "raw multi-line stderr in a key=value line" class is fully swept *within this diff* (all three lines share `one_line()`), and the ~15 pre-existing sites in `strategy.py` / `conflict.py` are enumerated in #1349 (Decay) rather than pulled into this PR.
- Round 1: the three findings above. Re-read the cumulative diff after fixing: "deferred and the startup path" is still the accurate description of the caused attempts; `flush()` goes through `do_push_safe()` without the flag, so a `git_sync` flush warns, as the guide says.

## Verification

- `uv run pytest -x -q` on `088681e`: 4294 passed, 3 skipped.
- ruff check/format, `mypy src/ tests/`, `scripts/structural_gate.sh` (0 violations), `pre-commit run --all-files` (Vale included): clean.
- Coverage of touched modules: `git/health.py` 100%; `push_scheduler.py` misses only the pre-existing "no remote ref" guards outside this diff.

## Docs impact

- [x] `docs/design/design.md` — sync-health section: `cause=` field, and the level rule (caused vs timer-driven) with the pull-loop retry named.
- [x] `docs/guides/git-integration.md` — the "sit at `DEBUG`" claim is now false; example `WARNING` line; the retry caveat. (One pre-existing Vale em-dash error in the same file fixed, since the hook lints whole changed files.)
- [x] `docs/releases/4.2.md` — paragraph in "A write that cannot leave the host says so".
- [x] `.vale/…/accept.txt` — `unsynced`, the product's own term.
- [ ] `README.md` — no config or tool surface changed.
- [x] Docstrings: `SyncHealthTracker.push_failed` / `_open`, `do_push_safe`, `push_if_unpushed`, `_record_push`, module docstring of `health.py`.

No commit carries `!` (`push_failed` and `do_push_safe` gained optional parameters; no operator surface or importable name changed meaning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RSxDv7WV6p6FD5kZ2h83U