### PR TITLE
fix(git): report a configured commit claim the token does not carry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,7 +205,7 @@
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # Git committer email for auto-commits.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
-# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.
+# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. A configured claim the token does not carry is reported once at WARNING and the static identity is used.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=
 # OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -374,7 +374,7 @@ starting points live under `examples/`: `obsidian-readonly.env`,
 | `MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S` | `30.0` | No | Seconds of write-idle time before pushing; 0 pushes only on shutdown. |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME` | `markdown-vault-mcp` | No | Git committer name for auto-commits; set this in Docker where git config user.name is empty. |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL` | `noreply@markdown-vault-mcp` | No | Git committer email for auto-commits. |
-| `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` | (none) | No | OIDC claim key used as the commit author name (such as name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. |
+| `MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM` | (none) | No | OIDC claim key used as the commit author name (such as name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. A configured claim the token does not carry is reported once at WARNING and the static identity is used. |
 | `MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM` | (none) | No | OIDC claim key used as the commit author email (such as email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim. |
 | `MARKDOWN_VAULT_MCP_GIT_LFS` | `true` | No | Run git lfs pull on startup to fetch LFS-tracked attachments; set to false for repos without LFS. |
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2578,6 +2578,17 @@ untouched. `GitWriteStrategy.__call__` consumes the Principal's
 identity); the `git/` package imports nothing from `fastmcp` (guard-tested),
 so non-MCP drivers supply a `Principal` instead of faking request context.
 
+A configured claim the token does not carry is reported, not just fallen
+back from (#1331). `_resolve_claim()` logs `git_commit_claim_unusable`
+once per process per `(field, key)` — naming the field, the key, and whether
+the claim was `absent`, `empty`, or `not_a_string` — and only for an
+authenticated caller, since with no token there is nothing to be missing.
+Per field rather than per key, because both fields may be configured to the
+same claim and each deserves its own line; the memory is cleared by
+`configure_identity_claims()`, so a reconfiguration gets a fresh answer. The
+startup warning in `git/strategy.py` is suppressed exactly when a claim *is*
+configured, which is why the signal lives at the resolution site.
+
 `resolve_mcp_principal()` is the **only** place the subject rules live
 (#1231) — `human:<subject>`, and the `"local"` sentinel counting as no human
 identity. `_okf_write.py` used to re-derive them in a fallback branch that

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -859,7 +859,7 @@
       "label": "Git Commit Name Claim",
       "type": "text",
       "var": "MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM",
-      "help": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.",
+      "help": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. A configured claim the token does not carry is reported once at WARNING and the static identity is used.",
       "advancedGroup": "Git sync"
     },
     {

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -157,6 +157,16 @@ background commit, so the commit author is the person who made the write.
 It also now agrees with the OKF provenance record for the same write, which
 was already stamped correctly.
 
+The release candidate found the other way the same claims fall back
+silently: the identity provider simply does not put them in the access
+token. That outcome looked exactly like a deployment that had never
+configured attribution, and the one nearby startup warning is suppressed
+precisely when a claim is configured
+([#1331](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1331)).
+The first authenticated write now reports the configured key and whether
+it was absent or empty, once per field per process; the commit still falls
+back to the static identity.
+
 ## A write that cannot leave the host says so
 
 The sharpest report of the cycle came from a production deployment.

--- a/examples/bearer-auth.env
+++ b/examples/bearer-auth.env
@@ -115,7 +115,7 @@ MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S=30.0
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # Git committer email for auto-commits.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
-# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.
+# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. A configured claim the token does not carry is reported once at WARNING and the static identity is used.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=
 # OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=

--- a/examples/oidc.env
+++ b/examples/oidc.env
@@ -129,7 +129,7 @@ MARKDOWN_VAULT_MCP_GIT_PUSH_DELAY_S=30.0
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # Git committer email for auto-commits.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
-# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.
+# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. A configured claim the token does not carry is reported once at WARNING and the static identity is used.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=
 # OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.
 MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -127,7 +127,7 @@
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME=markdown-vault-mcp
 # Git committer email for auto-commits.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL=noreply@markdown-vault-mcp
-# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write.
+# OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. A configured claim the token does not carry is reported once at WARNING and the static identity is used.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM=
 # OIDC claim key used as the commit author email (e.g. email); overrides GIT_COMMIT_EMAIL per request when an OIDC token is present. Resolved and carried the same way as the name claim.
 # MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM=

--- a/server.json
+++ b/server.json
@@ -350,7 +350,7 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM",
-          "description": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write."
+          "description": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. A configured claim the token does not carry is reported once at WARNING and the static identity is used."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM",
@@ -924,7 +924,7 @@
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_COMMIT_NAME_CLAIM",
-          "description": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write."
+          "description": "OIDC claim key used as the commit author name (e.g. name); overrides GIT_COMMIT_NAME per request when an OIDC token is present. The claim is resolved when the tool call arrives and carried to the background commit, so it applies on every write. A configured claim the token does not carry is reported once at WARNING and the static identity is used."
         },
         {
           "name": "MARKDOWN_VAULT_MCP_GIT_COMMIT_EMAIL_CLAIM",

--- a/src/markdown_vault_mcp/_identity.py
+++ b/src/markdown_vault_mcp/_identity.py
@@ -47,6 +47,13 @@ _LOCAL_SUBJECT = "local"
 _name_claim: str | None = None
 _email_claim: str | None = None
 
+#: ``(field, key)`` pairs already reported unusable, so the diagnostic below
+#: is one line per field per process rather than one per write. Keyed on the
+#: pair, not the key alone: both fields may be configured to the same claim,
+#: and each deserves its own line. Cleared whenever the configured keys
+#: change, so a reconfiguration gets a fresh answer.
+_warned_absent_claims: set[tuple[str, str]] = set()
+
 
 def configure_identity_claims(
     *, name_claim: str | None, email_claim: str | None
@@ -65,6 +72,7 @@ def configure_identity_claims(
     global _name_claim, _email_claim
     _name_claim = name_claim
     _email_claim = email_claim
+    _warned_absent_claims.clear()
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,6 +148,51 @@ def _claim_value(claims: dict[str, Any] | None, key: str | None) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _resolve_claim(
+    claims: dict[str, Any] | None, key: str | None, field: str
+) -> str | None:
+    """Read a configured claim, reporting once when it is not usable.
+
+    An operator who configures ``GIT_COMMIT_NAME_CLAIM`` has asked for
+    attribution deliberately. When the claim is not in the access token the
+    commit silently falls back to the static identity, which looks exactly
+    like a deployment that never configured it — and the one nearby startup
+    warning is suppressed precisely when a claim *is* configured (#1331).
+
+    Only fires for an authenticated caller: with no token there are no claims
+    to be missing, and the fallback is the intended behaviour.
+
+    Args:
+        claims: The token claims, or ``None`` when there is no token.
+        key: The configured claim key, or ``None`` when none is configured.
+        field: The identity field being resolved, for the log line.
+
+    Returns:
+        The claim value, or ``None`` when it is absent, empty, or not a
+        string; the log line says which.
+    """
+    value = _claim_value(claims, key)
+    if value is not None or key is None or claims is None:
+        return value
+    if (field, key) not in _warned_absent_claims:
+        _warned_absent_claims.add((field, key))
+        logger.warning(
+            "git_commit_claim_unusable field=%s claim=%s state=%s "
+            "detail=commits fall back to the static commit identity",
+            field,
+            key,
+            _claim_state(claims, key),
+        )
+    return None
+
+
+def _claim_state(claims: dict[str, Any], key: str) -> str:
+    """Name why a configured claim was unusable, for the diagnostic line."""
+    if key not in claims:
+        return "absent"
+    return "empty" if claims[key] == "" else "not_a_string"
+
+
 def resolve_mcp_principal() -> Principal:
     """Resolve the caller's :class:`Principal` from the MCP request context.
 
@@ -148,7 +201,9 @@ def resolve_mcp_principal() -> Principal:
     ``"local"`` sentinel makes a ``"human"`` principal; the sentinel or no
     subject makes a ``"local"`` one with ``subject=None``. Display name and
     email are read from the token claims using the keys registered via
-    :func:`configure_identity_claims` (non-empty strings only).
+    :func:`configure_identity_claims` (non-empty strings only); a configured
+    claim an authenticated caller's token does not carry is reported once
+    per process (#1331).
 
     Returns:
         The resolved principal. Never ``None`` — an unauthenticated caller
@@ -162,8 +217,8 @@ def resolve_mcp_principal() -> Principal:
 
     subject = get_subject()
     claims = get_claims()
-    display_name = _claim_value(claims, _name_claim)
-    email = _claim_value(claims, _email_claim)
+    display_name = _resolve_claim(claims, _name_claim, "display_name")
+    email = _resolve_claim(claims, _email_claim, "email")
     if subject and subject != _LOCAL_SUBJECT:
         return Principal(
             subject=subject, display_name=display_name, email=email, kind="human"

--- a/src/markdown_vault_mcp/config.py
+++ b/src/markdown_vault_mcp/config.py
@@ -664,7 +664,8 @@ class ProjectConfig:
                 "overrides GIT_COMMIT_NAME per request when an OIDC token is "
                 "present. The claim is resolved when the tool call arrives "
                 "and carried to the background commit, so it applies on "
-                "every write."
+                "every write. A configured claim the token does not carry "
+                "is reported once at WARNING and the static identity is used."
             ),
             "tags": ("git",),
             "wizard": {"group": "Git sync"},

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -14,6 +14,7 @@ pattern ``_okf_write`` uses).
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -225,3 +226,115 @@ class TestConfigureIdentityClaims:
     def test_module_state_is_set(self) -> None:
         configure_identity_claims(name_claim="a", email_claim="b")
         assert (_identity._name_claim, _identity._email_claim) == ("a", "b")
+
+
+# ---------------------------------------------------------------------------
+# A configured claim the token does not carry (#1331)
+# ---------------------------------------------------------------------------
+
+
+def _claim_lines(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """The claim diagnostic's records, matched on the event name."""
+    return [r for r in caplog.records if "git_commit_claim_unusable" in r.message]
+
+
+class TestAbsentCommitClaimIsReported:
+    """The silent half of #1331: a configured claim that never arrives.
+
+    The fallback itself is correct; what was missing is any signal that the
+    operator's configured attribution is inert. It looks identical to a
+    deployment that never configured it, and the one nearby startup warning
+    in ``git/strategy.py`` is suppressed exactly when a claim *is* configured.
+    """
+
+    def test_absent_claim_warns_once_and_falls_back(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            first = resolve_mcp_principal()
+            second = resolve_mcp_principal()
+        assert first.display_name is None
+        assert second.display_name is None
+        lines = _claim_lines(caplog)
+        assert len(lines) == 1, "one line per key per process, not one per write"
+        assert lines[0].args[-1] == "absent"
+
+    def test_an_empty_claim_is_reported_as_empty(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Present but empty has the same effect and a distinguishable cause."""
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"name": ""})
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert _claim_lines(caplog)[0].args[-1] == "empty"
+
+    def test_a_non_string_claim_is_reported_as_such(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"name": 123})
+        with caplog.at_level(logging.WARNING):
+            assert resolve_mcp_principal().display_name is None
+        assert _claim_lines(caplog)[0].args[-1] == "not_a_string"
+
+    def test_both_fields_are_reported_independently(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim="name", email_claim="email")
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert {r.args[0] for r in _claim_lines(caplog)} == {"display_name", "email"}
+
+    def test_both_fields_on_the_same_claim_are_both_reported(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dedup is per field, so a shared key cannot hide the second field."""
+        configure_identity_claims(name_claim="name", email_claim="name")
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert [r.args[0] for r in _claim_lines(caplog)] == ["display_name", "email"]
+
+    def test_a_present_claim_says_nothing(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"name": "Ada"})
+        with caplog.at_level(logging.WARNING):
+            assert resolve_mcp_principal().display_name == "Ada"
+        assert _claim_lines(caplog) == []
+
+    def test_an_unauthenticated_caller_says_nothing(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No token means no claims to be missing; the fallback is intended."""
+        configure_identity_claims(name_claim="name", email_claim=None)
+        _patch_context(monkeypatch, subject=None, claims=None)
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert _claim_lines(caplog) == []
+
+    def test_no_configured_claim_says_nothing(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure_identity_claims(name_claim=None, email_claim=None)
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            resolve_mcp_principal()
+        assert _claim_lines(caplog) == []
+
+    def test_reconfiguring_clears_the_warned_set(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reconfiguration is a new question and deserves a fresh answer."""
+        _patch_context(monkeypatch, subject="sub-1", claims={"sub": "sub-1"})
+        with caplog.at_level(logging.WARNING):
+            configure_identity_claims(name_claim="name", email_claim=None)
+            resolve_mcp_principal()
+            configure_identity_claims(name_claim="name", email_claim=None)
+            resolve_mcp_principal()
+        assert len(_claim_lines(caplog)) == 2


### PR DESCRIPTION
## Closes / Refs

Closes #1331

## What & why

On an OIDC deployment with `GIT_COMMIT_NAME_CLAIM` / `_EMAIL_CLAIM` configured, every commit was authored by the static fallback identity, and nothing at any level said why: the identity provider simply did not put those claims in the access token. The fallback is correct; what was missing is any signal that the operator's configured attribution is inert. The one nearby startup warning (`git/strategy.py:487`) is suppressed exactly when a claim *is* configured.

`resolve_mcp_principal` now resolves each configured claim through `_resolve_claim`, which logs `git_commit_claim_unusable field=… claim=… state=absent|empty|not_a_string` once per process per `(field, key)` — per field, so both fields configured to the same claim each get their line (the open finding from the closed #1341's review) — and only for an authenticated caller: with no token there is nothing to be missing. `configure_identity_claims` clears the memory, so a reconfiguration gets a fresh answer. Decision recorded on #1331 before coding.

Not done: the OKF provenance path (it stamps the subject via `get_subject()`, which is unaffected by the claim keys — that is why the issue saw `human:<subject>` next to a static commit author); the startup warning keeps its condition.

## Probe (`get_subject`/`get_claims` patched, three writes then an unauthenticated one)

```
WARNING markdown_vault_mcp._identity: git_commit_claim_unusable field=display_name claim=name state=absent detail=commits fall back to the static commit identity
WARNING markdown_vault_mcp._identity: git_commit_claim_unusable field=email claim=email state=empty detail=commits fall back to the static commit identity
principal: Principal(subject='9d8a647f', display_name=None, email=None, kind='human')
unauthenticated: Principal(subject=None, display_name=None, email=None, kind='local')
```

Two lines for three writes; none for the unauthenticated caller.

## Self-review 11b0ada..HEAD

Charters: rules, diff, comments, history. Conformance: no normative content. Past-PRs: the closed #1341's one open finding (dedup keyed on the claim alone) is fixed here with a test that configures both fields to the same key.
Coverage: full.

- No blockers or importants survived refutation.
- Minor, justified: two concurrent first writes can race on the `(field, key)` set and log the same pair twice. Benign duplicate; a lock for a once-per-process diagnostic is not worth its cost.

## Verification

- `uv run pytest -q`: 4252 passed, 19 skipped — 16 of the skips were `tests/test_config_wizard_smoke.py` skipping because the local `site/` was stale against the regenerated `wizard-spec.json`; after `mkdocs build` those 16 pass. The other 3 skips are the usual Python 3.13 symlink gates.
- ruff check/format, `mypy src/ tests/`, `scripts/structural_gate.sh` (0 violations), `pre-commit run --all-files` (Vale included), `scripts/gen_config_surface.py --check`: clean.

## Docs impact

- [x] `docs/design/design.md` — identity section: the diagnostic, its dedup key, and why it lives at the resolution site.
- [x] `docs/releases/4.2.md` — paragraph after the #1218 fix.
- [x] Config help for `GIT_COMMIT_NAME_CLAIM` gained one sentence; the generated surfaces (`docs/configuration.md`, `wizard-spec.json`, `.env.example`, `examples/*.env`, `packaging/env.example`, `server.json` descriptions) are regenerated from it. No version stamp changed.
- [ ] `README.md` — no config or tool surface changed.
- [x] Docstrings: `_resolve_claim`, `_claim_state`, `resolve_mcp_principal`.

No commit carries `!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RSxDv7WV6p6FD5kZ2h83U