### PR TITLE
fix(scanner): treat a destination with any URI scheme as external

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1998,8 +1998,14 @@ Links are extracted from markdown content during `parse_note()` and stored in th
 - **Wikilinks**: `[[path]]`, `[[path|alias]]`, `[[path#heading]]`
 
 **Exclusions**: links inside fenced code blocks (`` ``` ``) and inline code (`` ` ``)
-are not extracted. External URLs (`http://`, `https://`, `mailto:`) and pure anchors
-are skipped. "Pure anchor" covers every spelling of a same-document reference:
+are not extracted. External destinations and pure anchors are skipped. "External"
+is decided by shape, not by allowlist (#1335): a destination carrying any URI
+scheme (`[A-Za-z][A-Za-z0-9+.-]+:`, so `https:`, `mailto:`, `file:`,
+`obsidian:`, `zotero:` alike) or the protocol-relative `//host` prefix, which has
+no scheme to detect. Two or more characters are required before the colon so a
+Windows drive (`C:/notes/x.md`) stays a path; the known cost is that a file
+name shaped like `draft:v2.md` reads as a scheme. The test applies at all three
+extraction sites, wikilinks included. "Pure anchor" covers every spelling of a same-document reference:
 `[text](#heading)`, a reference definition whose target starts with `#`, and the
 wikilink form `[[#heading]]` (issue #1107). The wikilink form was the exception
 until #1107: its fragment is split off before `.md` is appended, so the empty path

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -318,6 +318,17 @@ exempts from typing
 histograms now cover the same note population `okf_validate` audits, and
 reserved files are reported separately as `reserved_count`.
 
+**A link with any URI scheme is external.** The external-link filter was an
+allowlist of four prefixes, so a `file:`, `ftp:`, `obsidian:` or `zotero:`
+destination was resolved against the source note's folder and reported as a
+broken vault link, and a wikilink such as `[[https://example.com]]` was
+stored with `.md` appended
+([#1335](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1335)).
+The filter now recognises a scheme by its shape, at every extraction site.
+A single letter before the colon is still a Windows drive, not a scheme.
+Existing vaults rebuild their index once on first start after upgrade, so
+the stale rows go away.
+
 ## Configuration and its documentation
 
 **The OIDC pages stopped steering readers into the wrong mode.** The 4.1

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -245,7 +245,13 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: ``documents``. An index built by an older pipeline has no tombstones, so
 #: its row absences are ambiguous (skipped vs. deleted); the bump forces the
 #: one cold rebuild that materialises tombstones for existing skips.
-INDEX_SEMANTICS_VERSION = 3
+#:
+#: Version 4 (#1335): a destination carrying any URI scheme is external.
+#: The filter was an allowlist of four prefixes, so ``file:``, ``ftp:``,
+#: ``obsidian:`` and the like were stored as vault-relative link rows, and a
+#: schemed wikilink gained a ``.md`` suffix. Those rows are gone from a fresh
+#: parse; the bump rebuilds notes whose bytes never changed.
+INDEX_SEMANTICS_VERSION = 4
 
 
 class ChunkingMeta(NamedTuple):

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -775,7 +775,17 @@ def _resolve_title(
     return path.stem
 
 
-_EXTERNAL_URL_PREFIXES = ("http://", "https://", "mailto:", "//")
+# Protocol-relative URLs (``//host/path``) carry no scheme for
+# :data:`_RE_URI_SCHEME` to match, so they are named here.
+_EXTERNAL_URL_PREFIXES = ("//",)
+# A URI scheme, per RFC 3986, anchored at the start of a destination. Two or
+# more characters are required before the colon: a single letter is a Windows
+# drive (``C:/notes/topic.md``), which is a path and not a scheme (#1335).
+# Matching the *shape* rather than an allowlist of four prefixes is what keeps
+# ``file:``, ``ftp:``, ``obsidian:`` and ``zotero:`` out of vault-path
+# resolution. The known cost: a file name shaped like ``draft:v2.md`` reads
+# as a scheme too.
+_RE_URI_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]+:")
 
 # Fenced code block: matches ``` or ~~~ delimiters (with optional language tag).
 _RE_FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
@@ -792,6 +802,24 @@ _RE_REF_DEF = re.compile(r"^\s*\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
 _FOOTNOTE_LABEL_PREFIX = "^"
 # Wikilink: [[path]], [[path|alias]], or [[path\|alias]] (Obsidian table-cell escape)
 _RE_WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
+
+
+def _is_external_target(target: str) -> bool:
+    """Return whether a raw link destination points outside the vault.
+
+    A destination carrying a URI scheme names a resource somewhere else and is
+    not a vault-relative path, however unfamiliar the scheme (#1335).
+
+    Args:
+        target: Raw destination string as written in the document.
+
+    Returns:
+        ``True`` when *target* is external and should not be resolved as a
+        vault path.
+    """
+    return target.startswith(_EXTERNAL_URL_PREFIXES) or bool(
+        _RE_URI_SCHEME.match(target)
+    )
 
 
 def _strip_code_spans(content: str) -> str:
@@ -877,8 +905,10 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
     * **Wikilinks**: ``[[path]]`` or ``[[path|alias]]``
 
     Links inside fenced code blocks and inline code spans are ignored.
-    External URLs (``http://``, ``https://``, ``mailto:``) are skipped, as
-    are same-document anchors in every spelling — ``[text](#heading)``,
+    External destinations are skipped: any URI scheme (``https:``,
+    ``mailto:``, ``file:``, ``obsidian:``, and so on, by shape rather than
+    by allowlist, #1335) and protocol-relative ``//host`` targets. So are
+    same-document anchors in every spelling — ``[text](#heading)``,
     ``[text][ref]`` with a ``#`` target, and ``[[#heading]]``.
 
     Args:
@@ -910,7 +940,7 @@ def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
             continue
         text = m.group(1)
         raw_target = m.group(2).strip()
-        if any(raw_target.startswith(p) for p in _EXTERNAL_URL_PREFIXES):
+        if _is_external_target(raw_target):
             continue
         if raw_target.startswith("#"):
             # Pure anchor link — skip (points to a section in the same doc).
@@ -971,7 +1001,7 @@ def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
         raw_target = ref_defs.get(ref_key)
         if raw_target is None:
             continue
-        if any(raw_target.startswith(p) for p in _EXTERNAL_URL_PREFIXES):
+        if _is_external_target(raw_target):
             continue
         if raw_target.startswith("#"):
             continue
@@ -999,7 +1029,8 @@ def _extract_wikilinks(clean: str, source_path: str) -> list[LinkInfo]:
     for ``FTSIndex.resolve_vault_wikilinks()`` to resolve vault-wide.
 
     Fragment-only wikilinks (``[[#Heading]]``) are skipped, matching how
-    :func:`_extract_inline_links` treats ``[text](#heading)`` (#1107).
+    :func:`_extract_inline_links` treats ``[text](#heading)`` (#1107), and
+    so are targets carrying a URI scheme (#1335).
     """
     links: list[LinkInfo] = []
     for m in _RE_WIKILINK.finditer(clean):
@@ -1029,6 +1060,12 @@ def _extract_wikilinks(clean: str, source_path: str) -> list[LinkInfo]:
             # backlink counts. Appending ".md" to the empty path portion is
             # what used to store the literal target ".md", which cannot
             # exist and so was always reported broken (#1107).
+            continue
+
+        if _is_external_target(raw_path):
+            # [[https://example.com]] is a URL Obsidian renders as one; it
+            # used to gain a ``.md`` suffix and be stored as a vault target
+            # that could never exist (#1335).
             continue
 
         # raw_target for wikilinks: path portion before .md is appended,

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2149,3 +2149,57 @@ class TestAliasResolution:
         outlinks = idx.get_outlinks("source.md")
         assert outlinks[0]["target_path"] == "artificial-intelligence.md"
         assert outlinks[0]["fragment"] == "history"
+
+
+# ---------------------------------------------------------------------------
+# extract_links: any URI scheme is external (#1335)
+# ---------------------------------------------------------------------------
+
+
+class TestExternalUriSchemes:
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "file:///E:/Design/2026-001/Semicon",
+            "ftp://example.com/pub/doc.md",
+            "obsidian://open?vault=Notes&file=Topic",
+            "zotero://select/items/1_ABCD",
+            "tel:+31612345678",
+            "mailto:someone@example.com",
+            "https://example.com/page",
+        ],
+    )
+    def test_schemed_inline_target_is_external(self, target: str) -> None:
+        """Any URI scheme marks the destination external, not a vault path."""
+        assert extract_links(f"[x]({target})", "notes/deep/src.md") == []
+
+    def test_schemed_reference_target_is_external(self) -> None:
+        """The scheme test applies to reference definitions too."""
+        content = "[x][ref]\n\n[ref]: zotero://select/items/1_ABCD"
+        assert extract_links(content, "index.md") == []
+
+    def test_schemed_wikilink_target_is_external(self) -> None:
+        """A schemed wikilink target is not a vault path with ``.md`` appended."""
+        assert extract_links("[[https://example.com]]", "index.md") == []
+
+    def test_protocol_relative_target_is_still_external(self) -> None:
+        """``//host/path`` has no scheme to detect, so the prefix stays."""
+        assert extract_links("[x](//cdn.example.com/a.md)", "index.md") == []
+
+    def test_windows_drive_letter_is_not_a_scheme(self) -> None:
+        """A single letter before ``:`` is a drive letter, not a URI scheme."""
+        links = extract_links("[x](C:/notes/topic.md)", "index.md")
+        assert len(links) == 1
+        assert links[0].raw_target == "C:/notes/topic.md"
+
+    def test_plain_relative_target_still_resolves(self) -> None:
+        """A destination with no scheme is unaffected."""
+        links = extract_links("[x](../sibling.md)", "Journal/2024/today.md")
+        assert len(links) == 1
+        assert links[0].target_path == "Journal/sibling.md"
+
+    def test_a_colon_after_a_slash_is_not_a_scheme(self) -> None:
+        """The scheme is anchored at the start; a later colon is path data."""
+        links = extract_links("[x](notes/time: 10.md)", "index.md")
+        assert len(links) == 1
+        assert links[0].target_path == "notes/time: 10.md"


### PR DESCRIPTION
## Closes / Refs

Closes #1335

## What & why

The external-link filter was an allowlist of four prefixes (`http://`, `https://`, `mailto:`, `//`), so a link using any other scheme — `file:`, `ftp:`, `obsidian:`, `zotero:` — was resolved against the source note's folder and reported as a broken vault link; a schemed wikilink such as `[[https://example.com]]` gained a `.md` suffix. A scheme is now recognised by its RFC 3986 shape (`[A-Za-z][A-Za-z0-9+.-]+:`) at all three extraction sites. Two or more characters are required before the colon so a Windows drive (`C:/notes/x.md`) stays a path; `//` stays as an explicit prefix because a protocol-relative target has no scheme to detect. The known cost — a file name shaped like `draft:v2.md` reads as a scheme — is documented in the design doc rather than special-cased.

Stored link rows change for notes whose bytes did not, so `INDEX_SEMANTICS_VERSION` goes 3 → 4 with its own history note (#1124 rule). Decision recorded on #1335 before coding. The code is the `_is_external_target` shape from the closed #1339, applied on its own.

## Probe (library, vault built from the issue's inputs)

Source note contained the issue's `file:///E:/AJEB-Design/…` link, a `zotero://` link, `[[https://example.com]]`, `[sibling](sibling.md)`, and `[drive](C:/notes/topic.md)`:

```
outlink: sibling.md -> 3-Resources/EU & NL Policy/sibling.md exists= False
outlink: C:/notes/topic.md -> 3-Resources/EU & NL Policy/C:/notes/topic.md exists= False
broken: [('sibling.md', …), ('C:/notes/topic.md', …)]
```

The three schemed destinations no longer appear as vault links; the drive letter and the plain relative link still do. (The drive-letter link is a genuinely broken vault link in this vault, as it was before.)

## Self-review 11b0ada..c93435d

Charters: rules, diff, comments, history. Conformance: no normative content. Past-PRs: the closed #1339 drew no findings on this part of its diff.
Coverage: full.

- No blockers or importants survived refutation. Checked specifically: the wikilink test runs after the fragment split, so `[[https://example.com#s]]` is external and `[[note#https://x]]` is not; `_resolve_link_path`'s comment that `//`-prefixed targets never reach it still holds; the prefix tuple's only other users were the two call sites replaced here.

## Verification

- `uv run pytest -x -q`: 4256 passed, 19 skipped (16 are the wizard smoke tests skipping on a stale local `site/`; unrelated to this diff).
- ruff check/format, `mypy src/ tests/`, `scripts/structural_gate.sh` (0 violations), `pre-commit run --all-files` (Vale included): clean.

## Docs impact

- [x] `docs/design/design.md` — link-extraction exclusions now state the shape rule, the drive-letter floor, and the `draft:v2.md` cost.
- [x] `docs/releases/4.2.md` — paragraph in "Search and indexing", including the one-time rebuild.
- [ ] `README.md` / `docs/tools/index.md` — no tool contract change; neither enumerates the old prefixes.
- [x] Docstrings: `extract_links`, `_extract_wikilinks`, `_is_external_target`; `INDEX_SEMANTICS_VERSION` history note.

No commit carries `!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RSxDv7WV6p6FD5kZ2h83U