### PR TITLE
fix(scanner): match links one paragraph at a time

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2005,10 +2005,15 @@ cross a blank line, and bounding the *input* rather than the *pattern* keeps
 the plain negated character classes: a bounded alternation in the pattern
 measured 7-8x slower on a long run of unmatched brackets, while the split
 measured ~100x faster than whole-document matching on multi-paragraph input.
-A blank line is recognised with any line ending CommonMark accepts (LF, CRLF,
-or a lone CR), and a bare `>` line
-counts as blank, since inside a block quote that is how a paragraph break is
-written. A destination class additionally excludes `\n`. The returned list stays
+The boundary is what CommonMark says ends a paragraph, as far as that can be
+told without tracking containers: a blank line, under any line ending CommonMark
+accepts (LF, CRLF, or a lone CR; nothing upstream normalises them) and written
+as a bare `>` inside a block quote; an ATX heading line; a thematic break line
+(each indented at most three spaces, since four make an indented line, which
+cannot interrupt a paragraph). A block quote or list item also interrupts a paragraph, but a `>` or `-` line
+with text is a *continuation* inside its own container, so splitting there
+would cut quoted and listed paragraphs apart, and those two stay unsplit. A
+destination class additionally excludes `\r` and `\n`. The returned list stays
 grouped by kind (inline, reference, wikilink), which callers index into. A
 paragraph with no blank lines is still matched as one unit, so the wikilink
 pattern's quadratic cost on such input is unchanged (#1343).

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2005,7 +2005,8 @@ cross a blank line, and bounding the *input* rather than the *pattern* keeps
 the plain negated character classes: a bounded alternation in the pattern
 measured 7-8x slower on a long run of unmatched brackets, while the split
 measured ~100x faster than whole-document matching on multi-paragraph input.
-A blank line is recognised with either line ending, and a bare `>` line
+A blank line is recognised with any line ending CommonMark accepts (LF, CRLF,
+or a lone CR), and a bare `>` line
 counts as blank, since inside a block quote that is how a paragraph break is
 written. A destination class additionally excludes `\n`. The returned list stays
 grouped by kind (inline, reference, wikilink), which callers index into. A

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2005,7 +2005,9 @@ cross a blank line, and bounding the *input* rather than the *pattern* keeps
 the plain negated character classes: a bounded alternation in the pattern
 measured 7-8x slower on a long run of unmatched brackets, while the split
 measured ~100x faster than whole-document matching on multi-paragraph input.
-A destination class additionally excludes `\n`. The returned list stays
+A blank line is recognised with either line ending, and a bare `>` line
+counts as blank, since inside a block quote that is how a paragraph break is
+written. A destination class additionally excludes `\n`. The returned list stays
 grouped by kind (inline, reference, wikilink), which callers index into. A
 paragraph with no blank lines is still matched as one unit, so the wikilink
 pattern's quadratic cost on such input is unchanged (#1343).

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1997,6 +1997,19 @@ Links are extracted from markdown content during `parse_note()` and stored in th
 - **Reference-style**: `[text][ref]` with `[ref]: path.md` definitions
 - **Wikilinks**: `[[path]]`, `[[path|alias]]`, `[[path#heading]]`
 
+**Paragraph-local matching (#1334)**: reference definitions are collected
+document-wide first (a definition lives wherever the author put it), then the
+code-stripped body is split on blank lines and inline links, reference usages
+and wikilinks are matched one paragraph at a time. CommonMark allows no link to
+cross a blank line, and bounding the *input* rather than the *pattern* keeps
+the plain negated character classes: a bounded alternation in the pattern
+measured 7-8x slower on a long run of unmatched brackets, while the split
+measured ~100x faster than whole-document matching on multi-paragraph input.
+A destination class additionally excludes `\n`. The returned list stays
+grouped by kind (inline, reference, wikilink), which callers index into. A
+paragraph with no blank lines is still matched as one unit, so the wikilink
+pattern's quadratic cost on such input is unchanged (#1343).
+
 **Exclusions**: links inside fenced code blocks (`` ``` ``) and inline code (`` ` ``)
 are not extracted. External destinations and pure anchors are skipped. "External"
 is decided by shape, not by allowlist (#1335): a destination carrying any URI

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -350,6 +350,19 @@ A single letter before the colon is still a Windows drive, not a scheme.
 Existing vaults rebuild their index once on first start after upgrade, so
 the stale rows go away.
 
+**A link no longer spans paragraphs.** The inline-link pattern let link
+text run across blank lines, so a stray `[` early in a document paired
+with a `](` thousands of characters later, indexing pages of prose as one
+link's text and whatever followed as its destination. On a vault of
+converted PDFs, `get_broken_links` returned several multi-kilobyte blobs of
+document text
+([#1334](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1334)).
+Links are now matched one paragraph at a time, as CommonMark bounds them;
+reference definitions are still found wherever the author put them. On
+realistic multi-paragraph input this is also about a hundred times faster
+than before on the bracket-heavy shapes that provoked it. Existing vaults
+rebuild once on first start after upgrade.
+
 ## Configuration and its documentation
 
 **The OIDC pages stopped steering readers into the wrong mode.** The 4.1

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -252,8 +252,9 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: schemed wikilink gained a ``.md`` suffix. Those rows are gone from a fresh
 #: parse; the bump rebuilds notes whose bytes never changed.
 #:
-#: Version 5 (#1334): no link crosses a blank line. Link extraction matches
-#: one paragraph at a time, so an unmatched ``[`` can no longer pair with a
+#: Version 5 (#1334): no link crosses a paragraph boundary (a blank line,
+#: an ATX heading, or a thematic break). Link extraction matches one
+#: paragraph at a time, so an unmatched ``[`` can no longer pair with a
 #: ``](`` paragraphs later and store pages of prose as one link's text and
 #: destination. Those rows are gone from a fresh parse; the bump rebuilds
 #: notes whose bytes never changed.

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -251,7 +251,13 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: ``obsidian:`` and the like were stored as vault-relative link rows, and a
 #: schemed wikilink gained a ``.md`` suffix. Those rows are gone from a fresh
 #: parse; the bump rebuilds notes whose bytes never changed.
-INDEX_SEMANTICS_VERSION = 4
+#:
+#: Version 5 (#1334): no link crosses a blank line. Link extraction matches
+#: one paragraph at a time, so an unmatched ``[`` can no longer pair with a
+#: ``](`` paragraphs later and store pages of prose as one link's text and
+#: destination. Those rows are gone from a fresh parse; the bump rebuilds
+#: notes whose bytes never changed.
+INDEX_SEMANTICS_VERSION = 5
 
 
 class ChunkingMeta(NamedTuple):

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -791,18 +791,41 @@ _RE_URI_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]+:")
 _RE_FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 # Inline code: matches single backtick spans (non-greedy, no newlines inside).
 _RE_INLINE_CODE = re.compile(r"`[^`\n]+`")
-# A blank line: the paragraph boundary CommonMark says no link may cross.
+# The paragraph boundary CommonMark says no link may cross.
 # Link extraction runs one paragraph at a time (#1334), so the negated
 # classes below are bounded by the split rather than by the pattern; a
 # bounded alternation inside the pattern measured 7-8x slower on a long run
 # of unmatched brackets, and matching per paragraph measured ~100x faster
-# than whole-document matching on multi-paragraph input. Nothing upstream
-# normalises line endings, so every ending CommonMark recognises (LF, CRLF,
-# and a lone CR) must bound a blank line; and inside a block quote a blank
-# line is written as a bare ``>``, which is a paragraph break in CommonMark
-# wherever it appears.
-_LINE_ENDING = r"(?:\r\n|\n|\r)"
-_RE_PARAGRAPH_BREAK = re.compile(rf"{_LINE_ENDING}[ \t>]*{_LINE_ENDING}")
+# than whole-document matching on multi-paragraph input.
+#
+# CommonMark ends a paragraph at a blank line, or where a block that may
+# interrupt a paragraph starts. The boundary below covers what can be told
+# without tracking containers: a blank line, under every line ending
+# CommonMark accepts (LF, CRLF, a lone CR; nothing upstream normalises
+# them) and written as a bare ``>`` inside a block quote; an ATX heading
+# line; a thematic break line. A block quote or list item also interrupts a
+# paragraph, but a ``>`` or ``-`` line with text is a *continuation* inside
+# its own container, so splitting there would cut quoted and listed
+# paragraphs apart; those stay unsplit.
+# A lone CR is an ending only when no LF follows, or CRLF would count twice.
+_LINE_ENDING = r"(?:\r\n|\n|\r(?!\n))"
+_BLANK_LINE = r"[ \t>]*"
+# What may precede a heading or a thematic break: block-quote markers, each
+# indented at most three spaces, then at most three spaces. Four spaces of
+# indentation make an indented line, which cannot interrupt a paragraph.
+_BLOCK_PREFIX = r"(?: {0,3}>)* {0,3}"
+_ATX_HEADING_LINE = rf"{_BLOCK_PREFIX}#{{1,6}}(?:[ \t][^\r\n]*)?"
+_THEMATIC_BREAK_LINE = (
+    rf"{_BLOCK_PREFIX}(?:-[ \t]*){{3,}}"
+    rf"|{_BLOCK_PREFIX}(?:\*[ \t]*){{3,}}"
+    rf"|{_BLOCK_PREFIX}(?:_[ \t]*){{3,}}"
+)
+# The trailing ending is a lookahead, so two boundary lines in a row (a
+# heading under a heading) each split.
+_RE_PARAGRAPH_BREAK = re.compile(
+    rf"{_LINE_ENDING}(?:{_BLANK_LINE}|{_ATX_HEADING_LINE}|{_THEMATIC_BREAK_LINE})"
+    rf"(?={_LINE_ENDING})"
+)
 # Inline markdown link: [text](target). The destination never spans a line.
 _RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)\r\n]+)\)")
 # Reference-style link usage: [text][ref] or [text][]
@@ -917,8 +940,9 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
     * **Wikilinks**: ``[[path]]`` or ``[[path|alias]]``
 
     Links inside fenced code blocks and inline code spans are ignored.
-    Matching runs one paragraph at a time, so no link crosses a blank line
-    (#1334); reference *definitions* are the exception and are collected
+    Matching runs one paragraph at a time, so no link crosses a paragraph
+    boundary: a blank line, an ATX heading, or a thematic break (#1334);
+    reference *definitions* are the exception and are collected
     document-wide. External destinations are skipped: any URI scheme (``https:``,
     ``mailto:``, ``file:``, ``obsidian:``, and so on, by shape rather than
     by allowlist, #1335) and protocol-relative ``//host`` targets. So are

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -797,10 +797,12 @@ _RE_INLINE_CODE = re.compile(r"`[^`\n]+`")
 # bounded alternation inside the pattern measured 7-8x slower on a long run
 # of unmatched brackets, and matching per paragraph measured ~100x faster
 # than whole-document matching on multi-paragraph input. Nothing upstream
-# normalises line endings, so a CRLF blank line must match too; and inside a
-# block quote a blank line is written as a bare ``>``, which is a paragraph
-# break in CommonMark wherever it appears.
-_RE_PARAGRAPH_BREAK = re.compile(r"\r?\n[ \t>]*\r?\n")
+# normalises line endings, so every ending CommonMark recognises (LF, CRLF,
+# and a lone CR) must bound a blank line; and inside a block quote a blank
+# line is written as a bare ``>``, which is a paragraph break in CommonMark
+# wherever it appears.
+_LINE_ENDING = r"(?:\r\n|\n|\r)"
+_RE_PARAGRAPH_BREAK = re.compile(rf"{_LINE_ENDING}[ \t>]*{_LINE_ENDING}")
 # Inline markdown link: [text](target). The destination never spans a line.
 _RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)\r\n]+)\)")
 # Reference-style link usage: [text][ref] or [text][]

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -795,11 +795,14 @@ _RE_INLINE_CODE = re.compile(r"`[^`\n]+`")
 # Link extraction runs one paragraph at a time (#1334), so the negated
 # classes below are bounded by the split rather than by the pattern; a
 # bounded alternation inside the pattern measured 7-8x slower on a long run
-# of unmatched brackets, and matching per paragraph measured ~90x faster than
-# whole-document matching on ordinary multi-paragraph markdown.
-_RE_PARAGRAPH_BREAK = re.compile(r"\n[ \t]*\n")
+# of unmatched brackets, and matching per paragraph measured ~100x faster
+# than whole-document matching on multi-paragraph input. Nothing upstream
+# normalises line endings, so a CRLF blank line must match too; and inside a
+# block quote a blank line is written as a bare ``>``, which is a paragraph
+# break in CommonMark wherever it appears.
+_RE_PARAGRAPH_BREAK = re.compile(r"\r?\n[ \t>]*\r?\n")
 # Inline markdown link: [text](target). The destination never spans a line.
-_RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)\n]+)\)")
+_RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)\r\n]+)\)")
 # Reference-style link usage: [text][ref] or [text][]
 _RE_REF_USAGE = re.compile(r"\[([^\]]*)\]\[([^\]]*)\]")
 # Reference definition: [ref]: target  (at start of line, optional leading whitespace)

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -791,8 +791,15 @@ _RE_URI_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]+:")
 _RE_FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 # Inline code: matches single backtick spans (non-greedy, no newlines inside).
 _RE_INLINE_CODE = re.compile(r"`[^`\n]+`")
-# Inline markdown link: [text](target)
-_RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+# A blank line: the paragraph boundary CommonMark says no link may cross.
+# Link extraction runs one paragraph at a time (#1334), so the negated
+# classes below are bounded by the split rather than by the pattern; a
+# bounded alternation inside the pattern measured 7-8x slower on a long run
+# of unmatched brackets, and matching per paragraph measured ~90x faster than
+# whole-document matching on ordinary multi-paragraph markdown.
+_RE_PARAGRAPH_BREAK = re.compile(r"\n[ \t]*\n")
+# Inline markdown link: [text](target). The destination never spans a line.
+_RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)\n]+)\)")
 # Reference-style link usage: [text][ref] or [text][]
 _RE_REF_USAGE = re.compile(r"\[([^\]]*)\]\[([^\]]*)\]")
 # Reference definition: [ref]: target  (at start of line, optional leading whitespace)
@@ -905,7 +912,9 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
     * **Wikilinks**: ``[[path]]`` or ``[[path|alias]]``
 
     Links inside fenced code blocks and inline code spans are ignored.
-    External destinations are skipped: any URI scheme (``https:``,
+    Matching runs one paragraph at a time, so no link crosses a blank line
+    (#1334); reference *definitions* are the exception and are collected
+    document-wide. External destinations are skipped: any URI scheme (``https:``,
     ``mailto:``, ``file:``, ``obsidian:``, and so on, by shape rather than
     by allowlist, #1335) and protocol-relative ``//host`` targets. So are
     same-document anchors in every spelling — ``[text](#heading)``,
@@ -920,11 +929,16 @@ def extract_links(content: str, source_path: str) -> list[LinkInfo]:
         List of :class:`~markdown_vault_mcp.types.LinkInfo` objects.
     """
     clean = _strip_code_spans(content)
-    return [
-        *_extract_inline_links(clean, source_path),
-        *_extract_reference_links(clean, source_path),
-        *_extract_wikilinks(clean, source_path),
-    ]
+    ref_defs = _collect_reference_definitions(clean)
+    inline: list[LinkInfo] = []
+    reference: list[LinkInfo] = []
+    wiki: list[LinkInfo] = []
+    for paragraph in _RE_PARAGRAPH_BREAK.split(clean):
+        inline.extend(_extract_inline_links(paragraph, source_path))
+        reference.extend(_extract_reference_links(paragraph, source_path, ref_defs))
+        wiki.extend(_extract_wikilinks(paragraph, source_path))
+    # Grouped by kind, as before the split: callers index into this list.
+    return [*inline, *reference, *wiki]
 
 
 def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
@@ -959,33 +973,53 @@ def _extract_inline_links(clean: str, source_path: str) -> list[LinkInfo]:
     return links
 
 
-def _extract_reference_links(clean: str, source_path: str) -> list[LinkInfo]:
-    """Extract reference-style ``[text][ref]`` links from code-stripped content.
+def _collect_reference_definitions(clean: str) -> dict[str, str]:
+    """Collect ``[ref]: path.md`` definitions from code-stripped content.
 
-    Collects the ``[ref]: path.md`` definitions first (optional CommonMark
-    titles stripped), then resolves each usage; an empty ``[ref]`` falls
-    back to the link text per CommonMark shortcut semantics. External URLs
-    and pure anchors are skipped.
+    Read from the whole document rather than per paragraph: a definition
+    lives wherever the author put it, usually far from the usages it serves,
+    so this is the one part of extraction that is not paragraph-local.
 
-    Markdown footnotes are skipped on both halves: a footnote definition
-    (``[^label]: body``) is prose, not a link target, and two adjacent
-    footnote references (``[^a][^b]``) are not one reference-style link
-    (#1104).
+    Optional CommonMark titles are stripped. A footnote definition
+    (``[^label]: body``) is prose, not a link target, and storing it resolved
+    whatever the footnote said as a vault path (#1104).
+
+    Args:
+        clean: Code-stripped markdown body.
+
+    Returns:
+        Lower-cased reference key to its raw target.
     """
-    links: list[LinkInfo] = []
-    # Collect reference definitions first.
     ref_defs: dict[str, str] = {}
     for m in _RE_REF_DEF.finditer(clean):
         ref_key = m.group(1).strip().lower()
         if ref_key.startswith(_FOOTNOTE_LABEL_PREFIX):
-            # Footnote definition: the body is prose, so storing it as a
-            # target resolved whatever the footnote said as a vault path.
             continue
         ref_target = m.group(2).strip()
         # Strip optional CommonMark title: "...", '...', or (...)
         ref_target = re.sub(r'\s+(?:"[^"]*"|\'[^\']*\'|\([^)]*\))\s*$', "", ref_target)
         ref_defs[ref_key] = ref_target
+    return ref_defs
 
+
+def _extract_reference_links(
+    clean: str, source_path: str, ref_defs: dict[str, str]
+) -> list[LinkInfo]:
+    """Extract reference-style ``[text][ref]`` usages from one paragraph.
+
+    Resolves each usage against *ref_defs*; an empty ``[ref]`` falls back to
+    the link text per CommonMark shortcut semantics. External destinations
+    and pure anchors are skipped.
+
+    Two adjacent footnote references (``[^a][^b]``) are not one
+    reference-style link (#1104).
+
+    Args:
+        clean: One code-stripped paragraph.
+        source_path: Relative POSIX path of the source document.
+        ref_defs: Definitions from :func:`_collect_reference_definitions`.
+    """
+    links: list[LinkInfo] = []
     for m in _RE_REF_USAGE.finditer(clean):
         text = m.group(1)
         ref = m.group(2).strip() or text  # empty [ref] falls back to link text

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2152,6 +2152,66 @@ class TestAliasResolution:
 
 
 # ---------------------------------------------------------------------------
+# extract_links: no link crosses a blank line (#1334)
+# ---------------------------------------------------------------------------
+
+
+class TestLinkSpanBounding:
+    def test_stray_bracket_does_not_pair_across_a_blank_line(self) -> None:
+        """An unmatched ``[`` cannot pair with a ``](`` in a later paragraph."""
+        content = "See item [3 below.\n\nAnother paragraph.\n\nAn image: [x](pic.md)"
+        links = extract_links(content, "index.md")
+        assert [lnk.link_text for lnk in links] == ["x"]
+        assert links[0].target_path == "pic.md"
+
+    def test_the_issue_shape_indexes_no_prose(self) -> None:
+        """The reported case: a stray ``[`` followed pages later by an image."""
+        content = (
+            "See item [3 below.\n\nSome other paragraph.\n\n"
+            "An image: ![Image](images/pic.png)"
+        )
+        assert extract_links(content, "index.md") == []
+
+    def test_link_text_may_span_a_soft_break(self) -> None:
+        """CommonMark allows a single newline inside link text."""
+        links = extract_links("[wrapped\ntext](note.md)", "index.md")
+        assert len(links) == 1
+        assert links[0].link_text == "wrapped\ntext"
+
+    def test_destination_never_contains_a_newline(self) -> None:
+        """A ``](`` whose closing paren is lines away is not a link."""
+        content = "[text](.\n2. The programme has objectives:\n3. (a)"
+        assert extract_links(content, "index.md") == []
+
+    def test_a_blank_line_with_trailing_whitespace_still_separates(self) -> None:
+        """Editors leave spaces on blank lines; the boundary must survive them."""
+        content = "A stray [bracket.\n   \nA real [x](pic.md)"
+        assert [lnk.link_text for lnk in extract_links(content, "index.md")] == ["x"]
+
+    def test_reference_usage_does_not_span_a_blank_line(self) -> None:
+        """``[text][ref]`` is bounded the same way inline link text is."""
+        content = "A stray [bracket.\n\nProse.\n\n[real][ref]\n\n[ref]: b.md"
+        links = extract_links(content, "index.md")
+        assert [lnk.link_text for lnk in links] == ["real"]
+
+    def test_reference_definition_far_from_its_usage_still_resolves(self) -> None:
+        """Definitions are document-wide; only usages are paragraph-local."""
+        content = "Intro [one][a] and [two][b].\n\nBody.\n\n[a]: a.md\n[b]: b.md"
+        links = extract_links(content, "index.md")
+        assert [lnk.target_path for lnk in links] == ["a.md", "b.md"]
+
+    def test_wikilink_target_never_spans_a_blank_line(self) -> None:
+        """``[[`` in one paragraph and ``]]`` in the next is not a wikilink."""
+        assert extract_links("[[stray\n\nprose]]", "index.md") == []
+
+    def test_result_order_stays_grouped_by_kind(self) -> None:
+        """Inline, then reference, then wikilinks, whatever their position."""
+        content = "[[w]] then [r][ref] then [i](i.md)\n\n[ref]: r.md"
+        kinds = [lnk.link_type for lnk in extract_links(content, "index.md")]
+        assert kinds == ["markdown", "reference", "wikilink"]
+
+
+# ---------------------------------------------------------------------------
 # extract_links: any URI scheme is external (#1335)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2188,6 +2188,25 @@ class TestLinkSpanBounding:
         content = "A stray [bracket.\n   \nA real [x](pic.md)"
         assert [lnk.link_text for lnk in extract_links(content, "index.md")] == ["x"]
 
+    def test_a_crlf_blank_line_is_a_paragraph_break(self) -> None:
+        """Nothing upstream normalises line endings; Windows notes keep CRLF."""
+        content = "See item [3 below.\r\n\r\nProse.\r\n\r\nAn image: [x](pic.md)"
+        links = extract_links(content, "index.md")
+        assert [lnk.link_text for lnk in links] == ["x"]
+        assert links[0].target_path == "pic.md"
+
+    def test_a_bare_quote_marker_line_is_a_paragraph_break(self) -> None:
+        """Inside a block quote a blank line is written as ``>`` alone."""
+        content = "> See [3.\n>\n> More prose.\n>\n> A real [x](pic.md)"
+        links = extract_links(content, "index.md")
+        assert [lnk.link_text for lnk in links] == ["x"]
+
+    def test_a_quoted_line_with_text_is_not_a_break(self) -> None:
+        """Only a bare marker is blank; ``> text`` continues the paragraph."""
+        links = extract_links("[wrapped\n> text](note.md)", "index.md")
+        assert len(links) == 1
+        assert links[0].link_text == "wrapped\n> text"
+
     def test_reference_usage_does_not_span_a_blank_line(self) -> None:
         """``[text][ref]`` is bounded the same way inline link text is."""
         content = "A stray [bracket.\n\nProse.\n\n[real][ref]\n\n[ref]: b.md"

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2201,6 +2201,35 @@ class TestLinkSpanBounding:
         links = extract_links(content, "index.md")
         assert [lnk.link_text for lnk in links] == ["x"]
 
+    def test_an_atx_heading_ends_the_paragraph_before_it(self) -> None:
+        """A heading interrupts a paragraph even with no blank line."""
+        content = "See item [3 below.\n## Heading\ntext [x](pic.md)"
+        assert [lnk.link_text for lnk in extract_links(content, "index.md")] == ["x"]
+
+    def test_a_heading_under_a_heading_still_splits(self) -> None:
+        """Each boundary line splits, not only the first of two."""
+        content = "[a\n# H [\n## H2\nb](p.md)"
+        assert extract_links(content, "index.md") == []
+
+    def test_a_hash_without_a_space_is_not_a_heading(self) -> None:
+        """``#hash`` is text; only ``#`` plus space (or end of line) is a heading."""
+        links = extract_links("[wrapped\n#tag text](note.md)", "index.md")
+        assert len(links) == 1
+
+    @pytest.mark.parametrize("rule", ["---", "* * *", "___", "- - -"])
+    def test_a_thematic_break_ends_the_paragraph_before_it(self, rule: str) -> None:
+        content = f"See item [3 below.\n{rule}\ntext [x](pic.md)"
+        assert [lnk.link_text for lnk in extract_links(content, "index.md")] == ["x"]
+
+    def test_an_indented_hash_line_is_a_continuation_not_a_heading(self) -> None:
+        """Four spaces of indent cannot interrupt a paragraph in CommonMark."""
+        links = extract_links("[wrapped\n    # still text](note.md)", "index.md")
+        assert len(links) == 1
+
+    def test_two_dashes_are_not_a_thematic_break(self) -> None:
+        links = extract_links("[wrapped\n--\ntext](note.md)", "index.md")
+        assert len(links) == 1
+
     def test_a_bare_quote_marker_line_is_a_paragraph_break(self) -> None:
         """Inside a block quote a blank line is written as ``>`` alone."""
         content = "> See [3.\n>\n> More prose.\n>\n> A real [x](pic.md)"

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2195,6 +2195,12 @@ class TestLinkSpanBounding:
         assert [lnk.link_text for lnk in links] == ["x"]
         assert links[0].target_path == "pic.md"
 
+    def test_a_lone_cr_blank_line_is_a_paragraph_break(self) -> None:
+        """CommonMark counts a lone carriage return as a line ending too."""
+        content = "See item [3 below.\r\rProse.\r\rAn image: [x](pic.md)"
+        links = extract_links(content, "index.md")
+        assert [lnk.link_text for lnk in links] == ["x"]
+
     def test_a_bare_quote_marker_line_is_a_paragraph_break(self) -> None:
         """Inside a block quote a blank line is written as ``>`` alone."""
         content = "> See [3.\n>\n> More prose.\n>\n> A real [x](pic.md)"


### PR DESCRIPTION
## Closes / Refs

Closes #1334

## What & why

`[^\]]*` and `[^)]+` both match newlines, so an unmatched `[` early in a note paired with a `](` thousands of characters later and stored pages of prose as one link's text, with whatever followed as its destination. On a vault of converted PDFs, `get_broken_links` returned several multi-kilobyte blobs of document text verbatim.

CommonMark allows no link to cross a blank line, so the bound now lives in the input rather than the pattern (decision recorded on #1334 before coding): `_collect_reference_definitions` reads the whole document first (a definition lives wherever the author put it), then `extract_links` splits the code-stripped body on blank lines and matches inline links, reference usages and wikilinks per paragraph. The plain negated classes stay — a bounded alternation in the pattern measured 7–8x slower on adversarial input in the closed #1339 — and the destination class excludes `\n`. The returned list stays grouped by kind, which callers index into.

`INDEX_SEMANTICS_VERSION` 4 → 5 with its own history note. #1343 (the wikilink pattern's quadratic cost on a paragraph with *no* blank lines) is unchanged and stays open — the last measurement below is that case.

## Review round 1

- **Claude, important — a CRLF blank line never matched, so the fix no-oped on Windows-authored notes.** Reproduced; nothing upstream normalises line endings. Fixed in ae19fdb: the boundary is `\r?\n[ \t>]*\r?\n` and the destination class excludes `\r` as well. Pinned by `test_a_crlf_blank_line_is_a_paragraph_break`.
- **Codex P2 — a blank line inside a block quote is a bare `>`, which the boundary read as content.** Fixed in the same pattern (`>` admitted in the blank-line class; a quoted line with text still continues the paragraph). Pinned by two tests.
- Nit: 90x vs 100x reconciled to ~100x (measured 99x).

## Review round 2

- **Codex P2 — a CR-only note's blank line is `\r\r`, which the boundary still required `\n` for.** Fixed in 7e292fd6: the boundary is built from a line-ending group (`(?:\r\n|\n|\r)`) on each side, so every ending CommonMark accepts bounds a blank line. Pinned by `test_a_lone_cr_blank_line_is_a_paragraph_break`.

## Review round 3 — the class swept

Rounds 1–2 each added one spelling of the same boundary. c7b0ed6 enumerates the class instead: a paragraph ends at a blank line (any of LF / CRLF / lone CR; whitespace-only or a bare `>` inside a quote), an ATX heading line, or a thematic break line, the latter two indented at most three spaces (four make an indented line, which cannot interrupt a paragraph); consecutive boundary lines each split. Block quotes and list items also interrupt a paragraph but a `>`/`-` line with text is a continuation inside its own container, so those stay unsplit — stated in the design note. All cases pinned in `TestLinkSpanBounding`; docstrings that said "blank line" now say "paragraph boundary".

## Measured (`extract_links`, this machine, `main` vs this branch)

```
100 paragraphs x 400 '[' (40 KB)              main  31.636s   branch   0.295s
single 16 KB run of '[', no blank lines       main   4.462s   branch   4.464s
500 KB of ordinary prose with links           main   0.083s   branch   0.102s
```
(re-measured on c7b0ed6, the final boundary)

## Probe (library, vault built from the issue's shape)

Note with `[Article 3 below.` (stray `[`), two paragraphs of prose, `![Image](images/image_000123.png)`, and one real `[link](other.md)`:

```
broken: 'link' -> 'other.md'
```

Before this change the same note produced one link whose text ran from the stray `[` to the image.

## Self-review 874fd95..c7b0ed66

Charters: rules, diff, comments, history. Conformance: no normative content. Past-PRs: the closed #1339's round-1 finding (the alternation's cost) is what shaped this; its follow-up shape is reused.
Coverage: full.

- Round 3 (`code-review` on the cumulative diff): the `extract_links` docstring, the semantics-version note and the lead comment still said "blank line" after the boundary widened — fixed in c7b0ed6; the heading/break prefix accepted any indent while CommonMark allows three spaces — fixed and pinned.
- Rounds 0–2: no blockers or importants survived refutation. Checked specifically: the image skip (`clean[m.start()-1] == "!"`) still works per paragraph, since a `!` cannot precede a paragraph's first character across a blank line; no code outside `scanner.py` uses the internals whose signatures changed; the blank-line regex tolerates trailing whitespace on the blank line (pinned by a test, since editors leave it).

## Verification

- `uv run pytest -x -q` on `7e292fd6`: 4295 passed, 3 skipped.
- ruff check/format, `mypy src/ tests/`, `scripts/structural_gate.sh` (0 violations), `pre-commit run --all-files` (Vale included): clean.

## Docs impact

- [x] `docs/design/design.md` — new "Paragraph-local matching" paragraph in the link-extraction section, including the measurements' shape and the #1343 boundary.
- [x] `docs/releases/4.2.md` — paragraph in "Search and indexing".
- [ ] `README.md` / `docs/tools/index.md` — no tool contract change.
- [x] Docstrings: `extract_links`, `_collect_reference_definitions`, `_extract_reference_links`; `INDEX_SEMANTICS_VERSION` history note.

No commit carries `!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RSxDv7WV6p6FD5kZ2h83U