### PR TITLE
fix(rename): say when update_links does not apply to an attachment

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1829,6 +1829,7 @@ class RenameResult:
     old_path: str
     new_path: str
     updated_links: int = 0  # number of source docs updated (update_links=True)
+    hint: str | None = None  # why nothing was rewritten (attachment, #1338)
 
 # --- Index types ---
 
@@ -2125,8 +2126,9 @@ itself resolves `[[Figure 1.png]]` to the file and shows it in its graph
 ([`reference/obsidian-markdown.md`](reference/obsidian-markdown.md),
 "Extension, non-markdown targets, embeds"); making attachments graph nodes
 here — resolution, `exists`, backlinks, rename-rewrite — is the v5 feature
-#1359. Until then `rename` of an attachment reports `updated_links: 0`
-with no signal; making it say that `update_links` does not apply is #1338.
+#1359. Until then `rename` of an attachment with `update_links=True`
+reports `updated_links: 0` with a `hint` saying the flag does not apply
+(#1338).
 
 Two consequences follow. The allowlist is now an input to what a note's
 stored rows are, so it is recorded as build provenance alongside
@@ -2483,7 +2485,13 @@ count reflects source documents successfully rewritten. Link style is
 preserved: vault-root-relative links are rewritten as vault-root-relative;
 source-directory-relative links (such as `../notes/target.md`) are rewritten
 with the correct new relative path from the source file's directory.
-`update_links` is silently ignored for attachments (non-`.md` files).
+`update_links` does not apply to attachments (non-`.md` files): the link
+graph is notes-only, so no reference to an attachment is tracked and there
+is nothing to rewrite. Passing the flag for an attachment sets
+`RenameResult.hint` saying so; `updated_links` stays `0`, and the MCP tool
+carries the `hint` key only when it is set (#1338). `move_folder` has no
+such flag and rewrites through its `.md`-only path map, so it needs no
+equivalent. Rewriting embeds on attachment rename is the v5 feature #1359.
 
 **`move_folder()` behavior**: a dedicated tool (not an overload of `rename`)
 that moves an entire folder subtree to a new prefix in one call. It is the

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -407,6 +407,18 @@ What this deliberately does not do is make attachments part of the graph:
 rewrites the embeds pointing at the renamed file are the v5 feature
 [#1359](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1359).
 
+**Renaming an attachment says when `update_links` does not apply.** The
+attachment branch of `rename` never read the flag, so a call that asked
+for a rewrite answered `updated_links: 0` and nothing else, and "the two
+halves of one documented parameter behave differently with no signal to
+the caller"
+([#1338](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1338)).
+The count was honest; the silence was the bug. The result now carries a
+`hint` when `update_links=true` is passed for an attachment: references to
+attachments are not tracked as links, so nothing was rewritten and the
+notes embedding the old path still name it. A note rename, or an attachment
+rename without the flag, carries no `hint` key at all.
+
 ## Configuration and its documentation
 
 **The OIDC pages stopped steering readers into the wrong mode.** The 4.1

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -503,8 +503,17 @@ Rename a document or attachment, or move it to a different folder. Parent direct
 |-----------|------|-------------|
 | `old_path` | string | Current relative path |
 | `new_path` | string | Target relative path. Fails if `new_path` already exists |
+| `if_match` | string | Optional etag from a previous `read`; the rename proceeds only if the file is unchanged since |
+| `update_links` | bool | Rewrite links in other notes that point to `old_path`. Pass `true` whenever renaming a note. Default `false` |
 
-**Returns:** `{"old_path": "drafts/idea.md", "new_path": "projects/idea.md"}`
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `old_path` | string | Source path (echoed back) |
+| `new_path` | string | Destination path (echoed back) |
+| `updated_links` | integer | Number of source documents whose links were rewritten |
+| `hint` | string | Present only when `update_links` was requested for an attachment: references to attachments are not tracked as links, so nothing was rewritten |
 
 ### `move_folder`
 

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -524,12 +524,13 @@ def register(mcp: FastMCP) -> None:
     ) -> dict[str, Any]:
         """Rename or move a document or attachment. When renaming a .md note,
         always pass update_links=True to rewrite links in other documents
-        that point to the old path — omitting this leaves those links broken.
+        that point to the old path.
 
         For .md documents: the file and its search index entries are updated
         immediately — do not call 'reindex' afterward.
-        For attachments: only the file is moved (no index update needed).
-        Parent directories for new_path are created automatically.
+        For attachments: only the file is moved; update_links does not apply
+        (attachment references are not tracked as links).
+        Parent directories are created automatically.
 
         Args:
             old_path: Current relative path (e.g. "drafts/idea.md"
@@ -549,6 +550,8 @@ def register(mcp: FastMCP) -> None:
         Returns:
             Dict with old_path (str), new_path (str), and updated_links (int)
             counting the number of source documents whose links were updated.
+            Carries hint (str) only when update_links was requested for an
+            attachment, saying why nothing was rewritten.
 
         Raises:
             DocumentNotFoundError: If old_path does not exist.
@@ -568,7 +571,11 @@ def register(mcp: FastMCP) -> None:
                 if_match=if_match,
                 update_links=update_links,
             )
-        return attach_remote_health(vault, asdict(result))
+        data = asdict(result)
+        # Absent, not null, when there is nothing to say — like `remote`.
+        if data["hint"] is None:
+            del data["hint"]
+        return attach_remote_health(vault, data)
 
     @mcp.tool(
         tags={"write"},

--- a/src/markdown_vault_mcp/facets/writer.py
+++ b/src/markdown_vault_mcp/facets/writer.py
@@ -306,6 +306,8 @@ class WriterFacet:
         Moves the file on disk and updates the FTS / vector indices.  When
         *update_links* is ``True``, all wikilinks and markdown links in other
         documents that pointed to *old_path* are rewritten to *new_path*.
+        For an attachment the flag does not apply (its references are not
+        tracked as links) and the result's ``hint`` says so.
 
         Args:
             old_path: Current relative path of the document or attachment.

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -83,6 +83,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Set as :attr:`~markdown_vault_mcp.types.RenameResult.hint` when
+#: ``update_links=True`` is passed for an attachment.  The link graph is
+#: notes-only — references to attachments are not tracked as links — so there
+#: is nothing to rewrite; a bare ``updated_links: 0`` hid that (#1338).
+_ATTACHMENT_UPDATE_LINKS_HINT = (
+    "update_links does not apply to attachments: references to attachments "
+    "are not tracked as links, so none were rewritten. Notes embedding the "
+    "old path still name it; edit them to point at the new path."
+)
+
 
 class DocumentManager:
     """Manages document CRUD, attachments, path validation, and backlinks.
@@ -1067,7 +1077,9 @@ class DocumentManager:
 
         When *update_links* is ``True`` and *old_path* is a ``.md`` document,
         every document that links to *old_path* is also updated so its links
-        point to *new_path*.
+        point to *new_path*.  For an attachment the flag does not apply —
+        references to attachments are not tracked as links — and the result's
+        *hint* says so instead of reporting a bare ``0`` (#1338).
 
         Args:
             old_path: Current relative document or attachment path.
@@ -1082,7 +1094,9 @@ class DocumentManager:
 
         Returns:
             :class:`~markdown_vault_mcp.types.RenameResult` with
-            *updated_links* counting source documents successfully updated.
+            *updated_links* counting source documents successfully updated,
+            and *hint* set when *update_links* was requested for an
+            attachment.
 
         Raises:
             ReadOnlyError: If the vault is read-only.
@@ -1096,6 +1110,7 @@ class DocumentManager:
         """
         self._check_writable()
         updated_links = 0
+        hint: str | None = None
         backlink_callbacks: list[tuple[Path, str]] = []
 
         with self._file_write_lock:
@@ -1135,6 +1150,8 @@ class DocumentManager:
             else:
                 old_abs, new_abs = self._artifacts.move(old_path, new_path, if_match)
                 callback_content = ""
+                if update_links:
+                    hint = _ATTACHMENT_UPDATE_LINKS_HINT
 
             self._notifier.fire_rename(new_abs, callback_content, old_abs)
             for src_abs, src_content in backlink_callbacks:
@@ -1144,6 +1161,7 @@ class DocumentManager:
             old_path=old_path,
             new_path=new_path,
             updated_links=updated_links,
+            hint=hint,
         )
 
     def _rewrite_one_source(

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -396,11 +396,15 @@ class RenameResult:
         old_path: Original relative path.
         new_path: New relative path after the rename.
         updated_links: Number of backlinks in other documents that were rewritten.
+        hint: Why no links were rewritten although ``update_links`` was
+            requested — set when the renamed file is an attachment, whose
+            references are not tracked as links (#1338). ``None`` otherwise.
     """
 
     old_path: str
     new_path: str
     updated_links: int = 0
+    hint: str | None = None
 
 
 @dataclass

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1549,18 +1549,57 @@ class TestRenameUpdateLinks:
         assert "(self_renamed.md)" in content
         assert "(self_link.md)" not in content
 
-    def test_update_links_ignored_for_attachments(self, rename_vault: Path) -> None:
-        """update_links=True is silently ignored when renaming a non-.md attachment."""
+    def test_update_links_on_attachment_says_it_does_not_apply(
+        self, rename_vault: Path
+    ) -> None:
+        """Renaming an embedded attachment with update_links=True sets ``hint``.
+
+        The embed is not a tracked link (#1333), so nothing is rewritten and
+        ``updated_links`` is honestly 0 — but the caller asked for a rewrite
+        and gets told why none happened instead of a bare zero (#1338).
+        """
+        (rename_vault / "Images").mkdir()
+        (rename_vault / "Images" / "pic.png").write_bytes(b"\x89PNG\r\n")
+        (rename_vault / "embedder.md").write_text("# N\n\n![[Images/pic.png]]\n")
+        col = Vault(
+            source_dir=rename_vault, read_only=False, attachment_extensions=["png"]
+        )
+        col.index.build_index()
+
+        result = col.writer.rename(
+            "Images/pic.png", "Images/renamed.png", update_links=True
+        )
+
+        assert result.updated_links == 0
+        assert result.hint is not None
+        assert "update_links" in result.hint
+        assert (rename_vault / "Images" / "renamed.png").is_file()
+        assert "![[Images/pic.png]]" in (rename_vault / "embedder.md").read_text()
+
+    def test_attachment_rename_without_update_links_has_no_hint(
+        self, rename_vault: Path
+    ) -> None:
+        """The hint answers a request that was made; no request, no hint."""
         (rename_vault / "image.png").write_bytes(b"\x89PNG\r\n")
         col = Vault(
             source_dir=rename_vault, read_only=False, attachment_extensions=["png"]
         )
         col.index.build_index()
 
-        result = col.writer.rename("image.png", "photo.png", update_links=True)
+        result = col.writer.rename("image.png", "photo.png")
 
         assert result.updated_links == 0
-        assert (rename_vault / "photo.png").is_file()
+        assert result.hint is None
+
+    def test_note_rename_has_no_hint(self, rename_vault: Path) -> None:
+        """The note branch honours update_links, so it never carries the hint."""
+        col = Vault(source_dir=rename_vault, read_only=False)
+        col.index.build_index()
+
+        result = col.writer.rename("target.md", "renamed.md", update_links=True)
+
+        assert result.updated_links > 0
+        assert result.hint is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1699,6 +1699,50 @@ class TestMCPWriteAttachment:
                 )
 
 
+class TestMCPRenameAttachment:
+    """MCP rename() on an attachment says when update_links does not apply."""
+
+    async def test_rename_attachment_with_update_links_carries_hint(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "rename",
+                {
+                    "old_path": "assets/image.png",
+                    "new_path": "assets/photo.png",
+                    "update_links": True,
+                },
+            )
+        data = result.data
+        assert data["new_path"] == "assets/photo.png"
+        assert data["updated_links"] == 0
+        assert "update_links" in data["hint"]
+
+    async def test_rename_attachment_without_update_links_omits_hint(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "rename",
+                {"old_path": "assets/image.png", "new_path": "assets/photo.png"},
+            )
+        assert "hint" not in result.data
+
+    async def test_rename_note_omits_hint(
+        self, _mcp_env_writable_with_attachments: Path
+    ) -> None:
+        server = make_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "rename",
+                {"old_path": "note.md", "new_path": "moved.md", "update_links": True},
+            )
+        assert "hint" not in result.data
+
+
 class TestAttachmentSizeCap:
     """Cap enforcement lives in the read/write MCP tools, not the vault library."""
 


### PR DESCRIPTION
## Closes / Refs

Closes #1338. Refs #1333 (the fix that made this reachable), #1359 (attachments as graph nodes, v5).

## What & why

`rename(old, new, update_links=True)` on an attachment answered `updated_links: 0` and nothing else. The attachment branch of `DocumentManager.rename` never read the flag, so — in the issue's words — "the two halves of one documented parameter behave differently with no signal to the caller". Since #1360 the link graph is notes-only, so the `0` is honest: no reference to an attachment is a tracked link, and there is nothing to rewrite. The silence was the bug.

**Decision (owner, 2026-09-05, quoted on the issue):** the attachment branch of `rename` *says* `update_links` does not apply instead of a silent `0`; rewriting embeds on attachment rename stays #1359.

- `RenameResult` gains `hint: str | None = None` (`types.py`). The attachment branch sets it only when `update_links=True` (`managers/document.py`): references to attachments are not tracked as links, so none were rewritten; notes embedding the old path still name it.
- The MCP `rename` result carries the `hint` key only when set — absent, not null — the same shape as the warn-only `remote` key and `PushResult.hint`.
- `updated_links` stays `0` for attachments; a note rename, or an attachment rename without the flag, has no `hint`.
- `move_folder` is unaffected: it has no `update_links` parameter and rewrites through its `.md`-only `md_map` (`_plan_folder_move`); attachments inside the moved prefix have had no tracked links since #1360. This closes the `[unverified]` in the report.

**Client-surface budget.** The `rename` description's added clause pushed the reviewed total to 58,064 > 58,000 (`tests/test_client_surface_budget.py`; input schemas sit at 27,594/27,600, so the `update_links` arg description could not grow). The description now carries "update_links does not apply (attachment references are not tracked as links)" and drops "— omitting this leaves those links broken", which the `update_links` arg description still says verbatim (both clauses came from #214's `05a757ca`; one of two duplicated warnings moved, none left the surface). `Returns:` text does not count toward the description (FastMCP keeps only the first text section) and is where the `hint` is documented. Total after: 57,991.

## Probe (library, the issue's exact inputs, `attachment_extensions=["png"]`)

```
rename result: RenameResult(old_path='Images/pic.png', new_path='Images/renamed.png', updated_links=0, hint='update_links does not apply to attachments: references to attachments are not tracked as links, so none were rewritten. Notes embedding the old path still name it; edit them to point at the new path.')
note body after: '# N\n\n![[Images/pic.png]]\n'
no-flag: RenameResult(old_path='Images/renamed.png', new_path='Images/pic.png', updated_links=0, hint=None)
```

Note branch, for contrast (`other.md` holds `[[note]]`):

```
note rename: RenameResult(old_path='note.md', new_path='moved.md', updated_links=1, hint=None)
other body after: 'See [[moved]].\n'
```

## What this PR deliberately does NOT do

- Rewrite embeds when an attachment is renamed, or resolve/backlink attachments: #1359.
- Change `updated_links` for attachments, or add a `hint` to `move_folder` (it has no flag to not-apply).
- Bump `INDEX_SEMANTICS_VERSION`: no stored row changes.

## Self-review 7aabfe66..9b01e083

Charters: rules, diff, comments, history. Conformance: no normative content. Past-PRs: not walked (the closed #1341 bundle's #1338 hunks were not consulted; the decision on the issue was the input).
Coverage: full. Comments and history ran as parallel read-only agents; rules and the diff charter I walked myself.

- `facets/writer.py` `WriterFacet.rename` docstring — minor/verified — still described `update_links` with no attachment carve-out; pre-existing since #1360 but the same class as the docstrings this PR changes, so swept here. Resolved in `9b01e083`.
- History: the deleted `test_update_links_ignored_for_attachments` (`68bb8870`) pinned observed behaviour, not a decision ("verifies update_links=True is silently ignored"); its two assertions survive in the replacement test. No prior `hint` on a write result was ever reverted. The `rename` description had never been budget-trimmed before.
- Rules, diff: clean.

## Verification

- TDD: three library tests and one tool test failed first (`AttributeError: 'RenameResult' object has no attribute 'hint'`, `KeyError: 'hint'`); the two "omits hint" tool tests guard the `None`-stripping and would fail on a bare `asdict`.
- `uv run pytest -x -q --cov=src/markdown_vault_mcp`: 4392 passed, 3 skipped; every changed line covered (`writer.py` 100%, `types.py` 100%, `document.py` misses are pre-existing lines).
- ruff check/format, mypy (231 files), pre-commit `--all-files` (Vale clean after two rewrites), `scripts/structural_gate.sh` (0 violations, 100%), `mkdocs build --strict` exit 0.
