### PR TITLE
fix(scanner): match a link inside one paragraph, never across a boundary

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2081,6 +2081,52 @@ a destination whose new name would need escaping to parse. The other CommonMark
 destination spellings (pointy brackets, backslash escapes, balanced
 parentheses, titles, entities) are a separate defect, #1353.
 
+**A link is matched inside one paragraph, never across a boundary (#1334).**
+The three patterns used to run over the whole code-stripped body, and their
+negated character classes admit line endings, so a stray unmatched `[` paired
+with a `](` paragraphs later and stored pages of prose as `link_text` — several
+multi-kilobyte blobs per `get_broken_links` call on a vault of converted PDFs.
+The body is now walked line by line into *regions* and each of inline links,
+reference usages and wikilinks is matched one region at a time; reference
+*definitions* stay document-wide, since they live wherever the author put
+them. The returned list keeps its grouped order (inline, reference, wikilink).
+Which lines end a paragraph is taken row by row from
+[`reference/commonmark-gfm.md`](reference/commonmark-gfm.md) ("Paragraph
+boundaries the scanner should honour"), and the walk is *line shape only* — no
+open-quote, open-item or open-fence state:
+
+- **Separators** (end the region, carry nothing): a blank or whitespace-only
+  line, a bare `>` marker, a thematic break, a setext underline.
+- **A heading** (`#`–`######` plus space, up to three leading spaces) is a
+  region by itself, so a link written on the heading line survives — the
+  second attempt (#1348) split on the heading and silently dropped
+  `## See also: [[Related]]` edges.
+- **Openers** (start a region that includes the line): a quote line with text,
+  unless the line before was one too (consecutive quote lines are one
+  paragraph); a bullet item; an ordered item.
+- Everything else is continuation text, as the spec has it for indented code,
+  `[r]: x.md` lines, HTML type-7 tags, table rows and lazy continuations.
+
+The patterns themselves keep their plain negated classes — the region bounds
+them — because a bounded alternation measured 7–8x slower on adversarial
+input (#1339); the inline destination class additionally excludes a line
+ending, since a destination never contains one. Line endings are normalised
+(`\r\n` and lone `\r` → `\n`) once before anything is matched, the way
+python-frontmatter already normalises CRLF on ingestion, so a CR-only note's
+reference definitions are found too. Two deliberate departures from the spec
+table: *every* ordered marker opens a region, not only `1.` (§5.2 Ex. 304 makes
+`2. text` after prose continuation text, but converted PDFs are numbered lists
+and a stray `[` in one item must not pair into the next — a link whose text
+soft-breaks onto a `2. ` line is the pinned cost); and a destination wrapped
+onto its own line inside the parentheses (`[a](\nx.md\n)`, legal in §6.3) is
+not recognised, since that shape is exactly what the defect produced. Not
+honoured, by choice: HTML block openers, GFM table delimiter rows, unclosed
+fences (a `_strip_code_spans` matter), and a nested item indented four or more
+spaces (continuation by the shape rule; the under-split is bounded by the next
+honoured boundary). The quadratic cost of the wikilink pattern *inside* one
+region with no boundaries is #1343 and is unchanged. `INDEX_SEMANTICS_VERSION`
+6 → 7 drops the stray-bracket rows on upgrade.
+
 **Exclusions**: links inside fenced code blocks (`` ``` ``) and inline code (`` ` ``)
 are not extracted. External destinations and pure anchors are skipped. "External"
 is decided by shape, not by allowlist (#1335): a destination carrying any URI

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2093,17 +2093,27 @@ them. The returned list keeps its grouped order (inline, reference, wikilink).
 Which lines end a paragraph is taken row by row from
 [`reference/commonmark-gfm.md`](reference/commonmark-gfm.md) ("Paragraph
 boundaries the scanner should honour"), and the walk is *line shape only* — no
-open-quote, open-item or open-fence state:
+open-item or open-fence state, and no quote state beyond what the line itself
+carries. The block-quote prefix (`>`, `> >`, up to three leading spaces each)
+is stripped and its depth counted *before* the shape is read, so a blank line
+inside a quote — which is spelled `>` or `>>`, not as whitespace — and a
+break, heading or item inside a quote are what they are (the review finding
+that closed the second attempt's round on Codex's `>` case, generalised):
 
 - **Separators** (end the region, carry nothing): a blank or whitespace-only
-  line, a bare `>` marker, a thematic break, a setext underline.
+  line, a bare quote marker at any depth, a thematic break, a setext
+  underline.
 - **A heading** (`#`–`######` plus space, up to three leading spaces) is a
   region by itself, so a link written on the heading line survives — the
   second attempt (#1348) split on the heading and silently dropped
   `## See also: [[Related]]` edges.
-- **Openers** (start a region that includes the line): a quote line with text,
-  unless the line before was one too (consecutive quote lines are one
-  paragraph); a bullet item; an ordered item.
+- **Openers** (start a region that includes the line): a bullet item; an
+  ordered item; a line whose quote depth is greater than the line before
+  (a block quote interrupts a paragraph, §5.1), while a line at the same or a
+  shallower depth continues it (consecutive `> ` lines are one paragraph;
+  `> > a` then `> b` is Ex. 233's lazy continuation). Known cost, pinned: a
+  quote line after an *unquoted* lazy continuation line (`> a`, `b`, `> c`)
+  opens a new region, which the spec would not.
 - Everything else is continuation text, as the spec has it for indented code,
   `[r]: x.md` lines, HTML type-7 tags, table rows and lazy continuations.
 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2112,15 +2112,20 @@ that closed the second attempt's round on Codex's `>` case, generalised):
   (a block quote interrupts a paragraph, §5.1), while a line at the same or a
   shallower depth continues it (consecutive `> ` lines are one paragraph;
   `> > a` then `> b` is Ex. 233's lazy continuation). Known cost, pinned: a
-  quote line after an *unquoted* lazy continuation line (`> a`, `b`, `> c`)
-  opens a new region, which the spec would not.
+  line whose depth grows again after such a lazy line (`> a`, `b`, `> c`; or
+  `> > a`, `> b`, `> > c`) opens a new region, which the spec would not.
 - Everything else is continuation text, as the spec has it for indented code,
   `[r]: x.md` lines, HTML type-7 tags, table rows and lazy continuations.
 
 The patterns themselves keep their plain negated classes — the region bounds
 them — because a bounded alternation measured 7–8x slower on adversarial
-input (#1339); the inline destination class additionally excludes a line
-ending, since a destination never contains one. Line endings are normalised
+input (#1339); the inline destination class and the wikilink target class
+additionally exclude a line ending, since a destination never contains one
+(a name with one names no file). Code is stripped in two steps around the
+split: fenced blocks before it, both fences anchored to a line start so three
+backticks in prose cannot swallow the blank line after them; inline spans per
+region after it, so a span filling a whole line does not leave a blank line
+for the walker to split on. Line endings are normalised
 (`\r\n` and lone `\r` → `\n`) once before anything is matched, the way
 python-frontmatter already normalises CRLF on ingestion, so a CR-only note's
 reference definitions are found too. Two deliberate departures from the spec
@@ -2131,7 +2136,7 @@ soft-breaks onto a `2. ` line is the pinned cost); and a destination wrapped
 onto its own line inside the parentheses (`[a](\nx.md\n)`, legal in §6.3) is
 not recognised, since that shape is exactly what the defect produced. Not
 honoured, by choice: HTML block openers, GFM table delimiter rows, unclosed
-fences (a `_strip_code_spans` matter), and a nested item indented four or more
+fences (a `_strip_fenced_code` matter), and a nested item indented four or more
 spaces (continuation by the shape rule; the under-split is bounded by the next
 honoured boundary). The quadratic cost of the wikilink pattern *inside* one
 region with no boundaries is #1343 and is unchanged. `INDEX_SEMANTICS_VERSION`

--- a/docs/design/reference/commonmark-gfm.md
+++ b/docs/design/reference/commonmark-gfm.md
@@ -361,7 +361,8 @@ Behaviour lines are [observed: `extract_links`, `_strip_code_spans`,
   (`[a [b] c](x.md)` missed, `[a [b c](x.md)` links `b c`); `\[` ignored;
   escapes and entities kept raw; links inside HTML blocks and fence info
   strings extracted. Right: images by `!` lookbehind; `[a] (x.md)` rejected.
-  Decided in `docs/design/design.md` § Link Extraction, pending #1334.
+  Decided in `docs/design/design.md` § Link Extraction; the destination
+  spellings are #1353.
 - `_RE_REF_USAGE` / `_RE_REF_DEF` in `_extract_reference_links` —
   **partial.** Right: full and collapsed forms, title stripping,
   document-wide definitions, footnotes excluded. Wrong: shortcut `[label]`
@@ -433,12 +434,12 @@ regression).
 | Blank line, CRLF (`\r\n\r\n`) | §2.1 | yes | yes | `\r\n` | none; already LF on the `parse_note` path |
 | Blank line, lone CR (`\r\r`) | §2.1 | yes | yes | `\r` | none |
 | Whitespace-only line (spaces/tabs) | §2.1 | yes | yes | `   ` | none |
-| Bare quote marker line | §5.1 Ex. 244 | yes (`^ {0,3}>[ \t]*$`) | yes | `>` | none |
+| Bare quote marker line | §5.1 Ex. 244 | yes (`^ {0,3}>[ \t]*$`) | yes, at any depth (`>>`, `> >`) | `>` | none |
 | ATX heading | §4.2 | yes (`^ {0,3}#{1,6}([ \t]\|$)`) | yes, own region | `## See [t](n.md)` | **is a link** (inline content) |
 | Thematic break | §4.1 | yes | yes | `***` | none possible |
 | Setext underline (`===`/`---`) | §4.3 | yes, but it turns the *preceding* lines into a heading | yes | `---` after text | preceding lines' links stay links |
 | Fence opener, 3+ backticks or tildes | §4.5 | opener yes; the closer needs length and character | only if closed | ```` ```py ```` | info string: **not a link** |
-| Block quote line with text | §5.1 Ex. 245 | yes | yes, unless the line before is one too | `> see [t](n.md)` | **is a link** (paragraph in the quote) |
+| Block quote line with text | §5.1 Ex. 245 | yes | yes, when the quote depth grows | `> see [t](n.md)` | **is a link** (paragraph in the quote) |
 | Bullet item `-`/`+`/`*` + space | §5.3 Ex. 303 | yes | yes | `- see [t](n.md)` | **is a link** |
 | Ordered item `1.`/`1)` + space | §5.2 rule 1 | yes | yes | `1. see [t](n.md)` | **is a link** |
 | Ordered item not starting at 1 | §5.2 Ex. 304 | not a boundary | dep.: opens a region | `2. text` | continuation text |
@@ -459,4 +460,7 @@ as separators; each is spec-backed continuation text and deserves a test
 that the link survives. The decision taken on #1334 (2026-09-06) and its
 rationale for each "no, by choice" and "dep." cell is recorded in
 `docs/design/design.md`, "Link Extraction"; the "Now" column is what
-`_paragraph_regions` does since that change.
+`_paragraph_regions` does since that change. The quote prefix is stripped
+before a line's shape is read, so every row above applies inside a block
+quote too (`> ***`, `> # h`, `> - item`), and the "Link on the line" column
+holds there as well.

--- a/docs/design/reference/commonmark-gfm.md
+++ b/docs/design/reference/commonmark-gfm.md
@@ -347,9 +347,14 @@ Behaviour lines are [observed: `extract_links`, `_strip_code_spans`,
 - `_RE_INLINE_CODE` — **partial.** Single backtick, single line only: a span
   with a line ending inside is not stripped; a double-backtick span is
   stripped by accident when it holds no inner backtick.
-- `_RE_INLINE_LINK` in `_extract_inline_links` — **wrong** on #1334: text
-  and destination match across line endings, blank lines and every
-  interrupting block, since `[^\]]` and `[^)]` admit `\n` and `\r`.
+- `_RE_INLINE_LINK` in `_extract_inline_links` — **right** on the #1334
+  boundaries the decision table below marks honoured, since 2026-09-06:
+  each pattern runs inside one paragraph region (`_paragraph_regions`,
+  line-shape only) and the destination class excludes `\n`; line endings
+  are normalised to `\n` first. A destination wrapped onto its own line
+  inside the parentheses (§6.3, one line ending allowed) is not recognised
+  — a deliberate departure, pinned. [observed: `extract_links`, 2026-09-06]
+  [pins: tests/test_links_paragraph_bounds.py::TestSeparators::test_a_stray_bracket_does_not_cross_it, tests/test_links_paragraph_bounds.py::TestOpeners::test_a_link_on_the_line_survives, tests/test_links_paragraph_bounds.py::TestIssueReproduction::test_a_destination_on_its_own_line_is_the_known_cost]
   **Partial** elsewhere: no `<dest>` form (stored as `<x y.md>`); no title
   (stored as `x.md "t"`); no balanced parentheses (`x(1).md` stored as
   `x(1`); spaces in destinations accepted; no bracket balancing
@@ -364,8 +369,10 @@ Behaviour lines are [observed: `extract_links`, `_strip_code_spans`,
   case-folded (`[ẞ]`/`[ss]` miss) and whitespace is not collapsed; a
   4-space-indented definition accepted, one inside `> ` rejected; trailing
   garbage kept in the target; `<x y.md>` kept with brackets; label text may
-  span a blank line; on a CR-only file `$` never matches, so no definition
-  is found (`[t][r]\r[r]: x.md\r` → no links).
+  span a blank line. A usage's text no longer spans a blank line, and the
+  CR-only miss is gone: line endings are normalised before `_RE_REF_DEF`
+  runs, so `[t][r]\r[r]: x.md\r` links (#1334). [observed: `extract_links`,
+  2026-09-06]
 - `_RE_URI_SCHEME` in `_is_external_target` — **right** against
   CommonMark's scheme (2+ characters, letter then `[A-Za-z0-9+.-]`), minus
   the 32 cap, plus `//host`; narrower than RFC 3986 by design (#1335).
@@ -395,49 +402,53 @@ Behaviour lines are [observed: `extract_links`, `_strip_code_spans`,
 
 ## Not covered
 
-- No test asserts a paragraph-boundary behaviour of `extract_links` (blank
-  line in any spelling, bare `>`, heading, thematic break, list marker, HTML
-  block) or a link *on* a boundary line; #1334's next attempt builds them
-  from the table below.
+- `tests/test_links_paragraph_bounds.py` pins one case per row of the table
+  below (a stray `[` across the boundary, a link *on* it, one link across
+  each continuation kind) since #1334; the HTML-block rows are the only ones
+  with no test, since the scanner does not honour them.
+- Whether `parse_note` should normalise a lone CR is settled by #1334:
+  `extract_links` normalises CRLF and CR to LF itself, so the question no
+  longer reaches the parser.
 - No test covers `<dest>` destinations, inline titles, balanced parentheses,
   nested brackets, `\[`, shortcut references, first-definition precedence,
   whitespace-collapsed labels, definitions in quotes, or CR-only files; the
   departures above are observed, not pinned.
-- Whether `parse_note` should normalise a lone CR as python-frontmatter
-  normalises CRLF is a design question, not a spec one.
 
 ## Paragraph boundaries the scanner should honour
 
 Decision table for #1334, one row per way a paragraph ends. "Container-free"
 means detectable from the line alone, without tracking open quotes, items
 or fences. "Now" is whether `extract_links` on the working tree stops a
-`[`…`](…)` match there (observed 2026-09-06). "Link on the line" is what the
-spec does with a link written on the boundary line itself — what a
-`re.split` that discards the separator loses (the #1348 regression).
+`[`…`](…)` match there (observed 2026-09-06, after #1334: "yes" where the
+row is honoured, "no" where the decision on the issue leaves it a
+continuation line, and "dep." for the two deliberate departures). "Link on
+the line" is what the spec does with a link written on the boundary line
+itself — what a `re.split` that discards the separator loses (the #1348
+regression).
 
 | Boundary | Spec | Container-free | Now | Example line | Link on the line |
 | --- | --- | --- | --- | --- | --- |
 | End of document / container | §4.8 | yes | yes | — | — |
-| Blank line, LF | §2.1, §4.8 | yes | no | empty line | none possible |
-| Blank line, CRLF (`\r\n\r\n`) | §2.1 | yes | no | `\r\n` | none; already LF on the `parse_note` path |
-| Blank line, lone CR (`\r\r`) | §2.1 | yes | no | `\r` | none |
-| Whitespace-only line (spaces/tabs) | §2.1 | yes | no | `   ` | none |
-| Bare quote marker line | §5.1 Ex. 244 | yes (`^ {0,3}>[ \t]*$`) | no | `>` | none |
-| ATX heading | §4.2 | yes (`^ {0,3}#{1,6}([ \t]\|$)`) | no | `## See [t](n.md)` | **is a link** (inline content) |
-| Thematic break | §4.1 | yes | no | `***` | none possible |
-| Setext underline (`===`/`---`) | §4.3 | yes, but it turns the *preceding* lines into a heading | no | `---` after text | preceding lines' links stay links |
+| Blank line, LF | §2.1, §4.8 | yes | yes | empty line | none possible |
+| Blank line, CRLF (`\r\n\r\n`) | §2.1 | yes | yes | `\r\n` | none; already LF on the `parse_note` path |
+| Blank line, lone CR (`\r\r`) | §2.1 | yes | yes | `\r` | none |
+| Whitespace-only line (spaces/tabs) | §2.1 | yes | yes | `   ` | none |
+| Bare quote marker line | §5.1 Ex. 244 | yes (`^ {0,3}>[ \t]*$`) | yes | `>` | none |
+| ATX heading | §4.2 | yes (`^ {0,3}#{1,6}([ \t]\|$)`) | yes, own region | `## See [t](n.md)` | **is a link** (inline content) |
+| Thematic break | §4.1 | yes | yes | `***` | none possible |
+| Setext underline (`===`/`---`) | §4.3 | yes, but it turns the *preceding* lines into a heading | yes | `---` after text | preceding lines' links stay links |
 | Fence opener, 3+ backticks or tildes | §4.5 | opener yes; the closer needs length and character | only if closed | ```` ```py ```` | info string: **not a link** |
-| Block quote line with text | §5.1 Ex. 245 | yes | no | `> see [t](n.md)` | **is a link** (paragraph in the quote) |
-| Bullet item `-`/`+`/`*` + space | §5.3 Ex. 303 | yes | no | `- see [t](n.md)` | **is a link** |
-| Ordered item `1.`/`1)` + space | §5.2 rule 1 | yes | no | `1. see [t](n.md)` | **is a link** |
-| Ordered item not starting at 1 | §5.2 Ex. 304 | not a boundary | — | `2. text` | continuation text |
+| Block quote line with text | §5.1 Ex. 245 | yes | yes, unless the line before is one too | `> see [t](n.md)` | **is a link** (paragraph in the quote) |
+| Bullet item `-`/`+`/`*` + space | §5.3 Ex. 303 | yes | yes | `- see [t](n.md)` | **is a link** |
+| Ordered item `1.`/`1)` + space | §5.2 rule 1 | yes | yes | `1. see [t](n.md)` | **is a link** |
+| Ordered item not starting at 1 | §5.2 Ex. 304 | not a boundary | dep.: opens a region | `2. text` | continuation text |
 | Empty list item | §5.2 Ex. 285 | not a boundary (a lone `-` is a setext underline) | — | `*` | — |
-| HTML block type 1–5 opener | §4.6 | yes (fixed prefixes) | no | `<!-- note -->` | raw: **not a link** |
-| HTML block type 6 opener | §4.6 | yes (tag list) | no | `<div>` | raw until a blank line: **not a link** |
+| HTML block type 1–5 opener | §4.6 | yes (fixed prefixes) | no, by choice | `<!-- note -->` | raw: **not a link** |
+| HTML block type 6 opener | §4.6 | yes (tag list) | no, by choice | `<div>` | raw until a blank line: **not a link** |
 | HTML block type 7 | §4.6 Ex. 187 | not a boundary | — | `<span>` | continuation text |
 | Indented code (4+ spaces) | §4.4 Ex. 223 | not a boundary | — | `    text` | continuation text |
 | Link reference definition | §4.7 Ex. 213 | not a boundary | — | `[r]: x.md` | continuation text (a definition only after a blank line or block) |
-| GFM table header + delimiter | GFM §4.10 | needs two lines | no | `\| a \|` / `\|---\|` | cells: **are links** |
+| GFM table header + delimiter | GFM §4.10 | needs two lines | no, by choice | `\| a \|` / `\|---\|` | cells: **are links** |
 | Soft break (single line ending) | §6.8 | — | not a boundary | `[a` / `b](x.md)` | one link across it |
 
 Two consequences. Four boundary kinds carry inline content on the boundary
@@ -445,4 +456,7 @@ line (ATX heading, quote line, list opener, table row): a splitter must hand
 that line to the extractors as its own region or it repeats #1348. The rows
 marked "not a boundary" are the ones a line-shape regex is tempted to treat
 as separators; each is spec-backed continuation text and deserves a test
-that the link survives.
+that the link survives. The decision taken on #1334 (2026-09-06) and its
+rationale for each "no, by choice" and "dep." cell is recorded in
+`docs/design/design.md`, "Link Extraction"; the "Now" column is what
+`_paragraph_regions` does since that change.

--- a/docs/design/reference/commonmark-gfm.md
+++ b/docs/design/reference/commonmark-gfm.md
@@ -62,7 +62,7 @@ Python 3.13.
   extended autolinks; GitHub footnotes.
 - Does not cover: emphasis, rendering, Obsidian wikilinks/embeds/callouts.
 - Depended on by: `src/markdown_vault_mcp/scanner.py` (`extract_links`,
-  `_extract_inline_links`, `_extract_reference_links`, `_strip_code_spans`,
+  `_extract_inline_links`, `_extract_reference_links`, `_strip_fenced_code`,
   `_scan_headings`, `extract_section`, `HeadingChunker._budget_split`),
   `src/markdown_vault_mcp/utils/links.py` (`apply_link_replacement`);
   `docs/design/design.md` § Link Extraction, § Chunking Strategy.
@@ -334,19 +334,23 @@ Python 3.13.
 ## Where this project departs from the subject
 
 Each inventoried assumption, by function, judged right / partial / wrong.
-Behaviour lines are [observed: `extract_links`, `_strip_code_spans`,
+Behaviour lines are [observed: `extract_links`, `_strip_fenced_code`,
 `_HEADING_RE` on the working tree, 2026-09-06].
 
-- `_RE_FENCED_CODE` in `_strip_code_spans` — **partial.** Right: backtick
-  and tilde fences. Wrong: not line-anchored (`` x ``` y … z ``` w `` in
-  prose is stripped); length ignored (a 4-backtick block "closes" at 3);
-  character ignored (a backtick block "closes" at `~~~`); an unclosed fence
-  is not stripped, so its links are extracted; `` `` `` on a line is
-  treated as a fence. Indented code, info strings, fences under list/quote
-  indentation are not modelled.
-- `_RE_INLINE_CODE` — **partial.** Single backtick, single line only: a span
-  with a line ending inside is not stripped; a double-backtick span is
-  stripped by accident when it holds no inner backtick.
+- `_RE_FENCED_CODE` in `_strip_fenced_code` — **partial.** Right: backtick
+  and tilde fences; both fences anchored to a line start after indentation
+  or quote markers, so `` x ``` y … z ``` w `` in prose is no longer
+  stripped and a backtick block no longer "closes" at `~~~` (#1334, since
+  2026-09-06). Wrong: length ignored (a 4-backtick block "closes" at 3); an
+  unclosed fence is not stripped, so its links are extracted. Indented code
+  and info strings are not modelled. [observed: `_strip_fenced_code`,
+  2026-09-06]
+- `_RE_INLINE_CODE` in `_strip_inline_code` — **partial.** A backtick run
+  and a closing run on one line, stripped per paragraph region after the
+  split so a span filling a whole line does not read as a blank line
+  (#1334). A span with a line ending inside is not stripped; a
+  double-backtick span holding an inner backtick is stripped up to that
+  backtick. [observed: `_strip_inline_code`, 2026-09-06]
 - `_RE_INLINE_LINK` in `_extract_inline_links` — **right** on the #1334
   boundaries the decision table below marks honoured, since 2026-09-06:
   each pattern runs inside one paragraph region (`_paragraph_regions`,
@@ -405,8 +409,11 @@ Behaviour lines are [observed: `extract_links`, `_strip_code_spans`,
 
 - `tests/test_links_paragraph_bounds.py` pins one case per row of the table
   below (a stray `[` across the boundary, a link *on* it, one link across
-  each continuation kind) since #1334; the HTML-block rows are the only ones
-  with no test, since the scanner does not honour them.
+  each continuation kind) since #1334. Untested rows: the HTML-block rows
+  (not honoured), end of document (trivial), and the link reference
+  definition, whose boundary behaviour is unobservable — the definition's
+  own brackets end any link text, so nothing can pair across it either way
+  (pinned as such).
 - Whether `parse_note` should normalise a lone CR is settled by #1334:
   `extract_links` normalises CRLF and CR to LF itself, so the question no
   longer reaches the parser.

--- a/docs/design/reference/log.md
+++ b/docs/design/reference/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-09-06
 
+- `commonmark-gfm.md`: the `_RE_INLINE_LINK` and reference-link departure entries re-observed after #1334 (per-region matching, LF normalisation, no line ending in a destination); the decision table's "Now" column filled in from `_paragraph_regions`, with "dep." for the two deliberate departures and "no, by choice" for the rows left unhonoured; pointer to the design-doc rationale added.
 - `obsidian-markdown.md`: the `.md`-append and embed entries updated for #1333 (attachment references are not links; note embeds still are); the departure recorded as a deliberate notes-only carve-out pointing at #1359; test pins added; the stale "without decoding" departure note corrected to the #1332 behaviour.
 - Bundle created: `obsidian-markdown.md`, `commonmark-gfm.md`, `git-cli.md` migrated from the first reference contract to OKF v0.2 (`generated`, `verified`, `stale_after`, `sources[].resource`); the refute pass on each page recorded as a `process:` verification.
 - `git-cli.md` (37 KB, one page for every module in `git/`) split by consumer module into `git-push-and-remotes.md`, `git-staging-and-commits.md` and `git-history-queries.md`; claims and markers moved verbatim, each page declaring only the sources its body cites; the original deleted.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -407,6 +407,26 @@ What this deliberately does not do is make attachments part of the graph:
 rewrites the embeds pointing at the renamed file are the v5 feature
 [#1359](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1359).
 
+**A stray `[` no longer turns pages of prose into a link.** The inline-link
+pattern let link text run across paragraph boundaries, so an unmatched `[`
+early in a note paired with a `](` thousands of characters later. In the
+report, "one entry's *destination* contains literal newlines," a second
+entry's link text spanned "[~2,000 further characters spanning many
+paragraphs]," and "a single `get_broken_links` call on this vault returned
+several multi-kilobyte blobs of document prose"
+([#1334](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1334)).
+Links are now matched inside one paragraph at a time, with the boundaries
+taken from the CommonMark spec row by row (a blank line in any line-ending
+spelling, a bare `>`, a thematic break, a heading, a quote line, a list
+item), and a destination never contains a line ending. A link written *on* a
+heading, quote or list line still counts, as does a link whose text
+soft-breaks onto the next line. Two limits are deliberate. The scanner
+tracks no open quotes, items or fences, so a nested item indented four or
+more spaces is continuation text. And a destination wrapped onto its own
+line inside the parentheses is not accepted, because that shape is what the
+converted-PDF defect produced. Existing vaults rebuild once on first start
+after upgrade.
+
 **Renaming an attachment says when `update_links` does not apply.** The
 attachment branch of `rename` never read the flag, so a call that asked
 for a rewrite answered `updated_links: 0` and nothing else, and "the two
@@ -502,7 +522,7 @@ meaning; the operator surface only grew (two GitLab webhook variables,
 `INSTANCE_DESCRIPTION`). A few things do change behavior without any action
 on your part:
 
-- **The text index rebuilds once on first start.** Four changes in this
+- **The text index rebuilds once on first start.** Five changes in this
   release alter how stored rows derive from a note's bytes: skip
   tombstones
   ([#1227](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1227)),
@@ -510,10 +530,12 @@ on your part:
   ([#1335](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1335)),
   percent-decoded destinations
   ([#1332](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1332)),
-  and attachment references leaving the link graph
-  ([#1333](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1333)).
-  `INDEX_SEMANTICS_VERSION` moved from 2 to 6. One rebuild covers all
-  four; it is automatic, costs CPU and local IO proportional to vault size,
+  attachment references leaving the link graph
+  ([#1333](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1333)),
+  and links bounded to one paragraph
+  ([#1334](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1334)).
+  `INDEX_SEMANTICS_VERSION` moved from 2 to 7. One rebuild covers all
+  five; it is automatic, costs CPU and local IO proportional to vault size,
   and does not re-embed.
 - **A Voyage vault also re-embeds once**, through a separate mechanism
   with a separate trigger: the provider's embedding behavior is part of the

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -420,12 +420,14 @@ taken from the CommonMark spec row by row (a blank line in any line-ending
 spelling, a bare `>`, a thematic break, a heading, a quote line, a list
 item), and a destination never contains a line ending. A link written *on* a
 heading, quote or list line still counts, as does a link whose text
-soft-breaks onto the next line. Two limits are deliberate. The scanner
+soft-breaks onto the next line. Three limits are deliberate. The scanner
 tracks no open quotes, items or fences, so a nested item indented four or
-more spaces is continuation text. And a destination wrapped onto its own
-line inside the parentheses is not accepted, because that shape is what the
-converted-PDF defect produced. Existing vaults rebuild once on first start
-after upgrade.
+more spaces is continuation text. Every numbered-list marker starts a new
+paragraph, not only `1.`, because converted PDFs are numbered lists and a
+stray `[` in one item must not pair into the next. And a destination
+wrapped onto its own line inside the parentheses is not accepted, because
+that shape is what the converted-PDF defect produced. Existing vaults
+rebuild once on first start after upgrade.
 
 **Renaming an attachment says when `update_links` does not apply.** The
 attachment branch of `rename` never read the flag, so a call that asked

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -272,7 +272,14 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: ``[img](pic.png)`` a ``pic.png`` row, both broken by construction since
 #: attachments are never indexed; the bump drops those rows from notes whose
 #: bytes never changed.
-INDEX_SEMANTICS_VERSION = 6
+#:
+#: Version 7 (#1334): a link is matched inside one paragraph region and a
+#: destination never contains a line ending. A stray ``[`` used to pair with
+#: a ``](`` paragraphs later, storing pages of prose as ``link_text`` and
+#: whatever followed as a broken target; the bump drops those rows, and
+#: records the links on heading, quote and list lines that the regions now
+#: bound correctly, for notes whose bytes never changed.
+INDEX_SEMANTICS_VERSION = 7
 
 
 class ChunkingMeta(NamedTuple):

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -799,10 +799,17 @@ _EXTERNAL_URL_PREFIXES = ("//",)
 # as a scheme too.
 _RE_URI_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]+:")
 
-# Fenced code block: matches ``` or ~~~ delimiters (with optional language tag).
-_RE_FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
-# Inline code: matches single backtick spans (non-greedy, no newlines inside).
-_RE_INLINE_CODE = re.compile(r"`[^`\n]+`")
+# Fenced code block: a ``` or ~~~ run opening a line (after indentation or
+# quote markers), with an optional info string, closed by the same run
+# opening a later line. Anchoring both fences to a line start is what keeps
+# three backticks in running prose from swallowing the blank line after
+# them, which would let a stray ``[`` pair across it (#1334); a same-line
+# multi-backtick span is a code span, matched by _RE_INLINE_CODE.
+_RE_FENCED_CODE = re.compile(
+    r"^[ \t>]*(```|~~~)[^\n]*\n.*?^[ \t>]*\1", re.DOTALL | re.MULTILINE
+)
+# Inline code: a backtick run and its closing run on one line.
+_RE_INLINE_CODE = re.compile(r"`+[^`\n]+`+")
 # Inline markdown link: [text](target). The text keeps the plain negated
 # class — a soft break inside link text is legal — and is bounded by the
 # paragraph region it is matched in (#1334); the destination excludes a line
@@ -815,8 +822,10 @@ _RE_REF_DEF = re.compile(r"^\s*\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
 # Markdown footnotes ([^label] / [^label]: body) differ from reference-style
 # links by exactly this character, and both reference regexes match them.
 _FOOTNOTE_LABEL_PREFIX = "^"
-# Wikilink: [[path]], [[path|alias]], or [[path\|alias]] (Obsidian table-cell escape)
-_RE_WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
+# Wikilink: [[path]], [[path|alias]], or [[path\|alias]] (Obsidian table-cell
+# escape). The target excludes a line ending: a name carrying one names no
+# file, and the row it stored was broken by construction (#1334).
+_RE_WIKILINK = re.compile(r"\[\[([^\]|\n]+)(?:\|([^\]]+))?\]\]")
 
 # Line shapes at which a paragraph ends, each decidable from the line alone
 # (no container state beyond the quote depth read off the line itself). The
@@ -898,8 +907,8 @@ def _line_shape(line: str, previous_depth: int) -> tuple[str, int]:
 
     Args:
         line: One LF-terminated line, without its ending.
-        previous_depth: Quote depth of the line before, ``0`` at a region
-            start.
+        previous_depth: Quote depth of the line before, ``0`` on the first
+            line of the body.
 
     Returns:
         ``(shape, depth)`` with *shape* one of the four module constants.
@@ -950,20 +959,37 @@ def _paragraph_regions(clean: str) -> Iterator[str]:
         yield "\n".join(lines)
 
 
-def _strip_code_spans(content: str) -> str:
-    """Remove fenced and inline code spans from markdown content.
+def _strip_fenced_code(content: str) -> str:
+    """Remove fenced code blocks from LF-normalised markdown content.
 
-    This prevents links inside code examples from being extracted.
+    Fences are block-level, so they go before the body is split into
+    paragraph regions; a fence ends the paragraph before it (§4.5), and the
+    line its removal leaves behind is blank, which is the right boundary.
 
     Args:
-        content: Raw markdown body text.
+        content: Body text with line endings normalised.
 
     Returns:
-        Content with fenced and inline code regions replaced by empty strings.
+        *content* with every closed fenced block replaced by nothing.
     """
-    content = _RE_FENCED_CODE.sub("", content)
-    content = _RE_INLINE_CODE.sub("", content)
-    return content
+    return _RE_FENCED_CODE.sub("", content)
+
+
+def _strip_inline_code(region: str) -> str:
+    """Remove inline code spans from one paragraph region.
+
+    Runs *after* the region split, not before: a span that fills a whole
+    line (`` `code` `` on its own) would otherwise leave an empty line
+    behind, and the walker would read that as a blank line and split the
+    paragraph the span sits in (#1334).
+
+    Args:
+        region: One paragraph region.
+
+    Returns:
+        *region* with every inline code span replaced by nothing.
+    """
+    return _RE_INLINE_CODE.sub("", region)
 
 
 def _resolve_link_path(
@@ -1078,7 +1104,7 @@ def extract_links(
     Returns:
         List of :class:`~markdown_vault_mcp.types.LinkInfo` objects.
     """
-    clean = _strip_code_spans(_normalise_line_endings(content))
+    body = _strip_fenced_code(_normalise_line_endings(content))
     extensions = (
         effective_attachment_extensions(None)
         if attachment_extensions is None
@@ -1087,12 +1113,15 @@ def extract_links(
     # Definitions live wherever the author put them, so they are collected
     # over the whole body; usages, inline links and wikilinks are matched one
     # paragraph region at a time so nothing pairs across a boundary (#1334).
-    # The result stays grouped by kind — callers index into it.
-    ref_defs = _collect_reference_definitions(clean)
+    # Inline code is stripped per region, after the split, so that a span
+    # filling a whole line does not read as a blank line. The result stays
+    # grouped by kind — callers index into it.
+    ref_defs = _collect_reference_definitions(_strip_inline_code(body))
     inline: list[LinkInfo] = []
     reference: list[LinkInfo] = []
     wiki: list[LinkInfo] = []
-    for region in _paragraph_regions(clean):
+    for raw_region in _paragraph_regions(body):
+        region = _strip_inline_code(raw_region)
         inline.extend(_extract_inline_links(region, source_path, extensions))
         reference.extend(
             _extract_reference_links(region, ref_defs, source_path, extensions)

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -803,8 +803,11 @@ _RE_URI_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]+:")
 _RE_FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 # Inline code: matches single backtick spans (non-greedy, no newlines inside).
 _RE_INLINE_CODE = re.compile(r"`[^`\n]+`")
-# Inline markdown link: [text](target)
-_RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+# Inline markdown link: [text](target). The text keeps the plain negated
+# class — a soft break inside link text is legal — and is bounded by the
+# paragraph region it is matched in (#1334); the destination excludes a line
+# ending outright, since a destination never contains one.
+_RE_INLINE_LINK = re.compile(r"\[([^\]]*)\]\(([^)\n]+)\)")
 # Reference-style link usage: [text][ref] or [text][]
 _RE_REF_USAGE = re.compile(r"\[([^\]]*)\]\[([^\]]*)\]")
 # Reference definition: [ref]: target  (at start of line, optional leading whitespace)
@@ -814,6 +817,30 @@ _RE_REF_DEF = re.compile(r"^\s*\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
 _FOOTNOTE_LABEL_PREFIX = "^"
 # Wikilink: [[path]], [[path|alias]], or [[path\|alias]] (Obsidian table-cell escape)
 _RE_WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
+
+# Line shapes at which a paragraph ends, each decidable from the line alone
+# (no container state). The rows come from
+# ``docs/design/reference/commonmark-gfm.md``, "Paragraph boundaries the
+# scanner should honour"; which rows are honoured, and the two departures,
+# are the decision on #1334. A separator carries no link content and is
+# dropped; a heading is a region by itself; a quote line with text or a list
+# item opens a region that includes the line, so links written on such a
+# line survive (the #1348 regression stated as a requirement).
+_RE_LINE_SEPARATOR = re.compile(
+    r"^(?:"
+    r"[ \t]*"  # blank or whitespace-only (§2.1, §4.8)
+    r"| {0,3}>[ \t]*"  # bare quote marker (§5.1 Ex. 244)
+    r"| {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})"  # break (§4.1)
+    r"| {0,3}(?:=+|-+)[ \t]*"  # setext underline (§4.3)
+    r")$"
+)
+_RE_LINE_ATX_HEADING = re.compile(r"^ {0,3}#{1,6}(?:[ \t]|$)")
+_RE_LINE_QUOTE = re.compile(r"^ {0,3}>")
+# Bullet or ordered item with content. Every ordered marker opens a region,
+# not only ``1.`` — §5.2 Ex. 304 makes ``2. text`` after prose continuation
+# text, but converted PDFs are numbered lists and a stray ``[`` in one item
+# must not pair into the next; the split soft-break link is the known cost.
+_RE_LINE_LIST_ITEM = re.compile(r"^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+\S")
 
 
 def _is_external_target(target: str) -> bool:
@@ -832,6 +859,69 @@ def _is_external_target(target: str) -> bool:
     return target.startswith(_EXTERNAL_URL_PREFIXES) or bool(
         _RE_URI_SCHEME.match(target)
     )
+
+
+def _normalise_line_endings(content: str) -> str:
+    """Rewrite CRLF and lone CR line endings as LF.
+
+    CommonMark treats all three spellings as a line ending (§2.1).
+    python-frontmatter already rewrites CRLF on the ``parse_note`` path, so
+    only a CR-only note and direct callers ever see the other two; doing it
+    here once means every pattern below reasons about ``\\n`` alone
+    (#1334).
+
+    Args:
+        content: Raw markdown body text.
+
+    Returns:
+        *content* with every line ending spelled ``\\n``.
+    """
+    return content.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _paragraph_regions(clean: str) -> Iterator[str]:
+    """Split code-stripped, LF-normalised content into paragraph regions.
+
+    A region is the run of lines inside which a link may span a soft break;
+    a stray ``[`` in one region cannot pair with a ``](`` in the next. The
+    walk is line-shape only (see :data:`_RE_LINE_SEPARATOR` and friends):
+    it tracks no open quotes, items or fences, so a nested item indented four
+    or more spaces is continuation text and a quote line is one paragraph
+    with the quote line before it.
+
+    Args:
+        clean: Body text with code removed and line endings normalised.
+
+    Yields:
+        Each region's lines joined with ``\\n``, in document order.
+    """
+    lines: list[str] = []
+    previous_was_quote = False
+    for line in clean.split("\n"):
+        if _RE_LINE_SEPARATOR.match(line):
+            if lines:
+                yield "\n".join(lines)
+                lines = []
+            previous_was_quote = False
+            continue
+        if _RE_LINE_ATX_HEADING.match(line):
+            if lines:
+                yield "\n".join(lines)
+                lines = []
+            yield line
+            previous_was_quote = False
+            continue
+        is_quote = _RE_LINE_QUOTE.match(line) is not None
+        opens = (is_quote and not previous_was_quote) or (
+            _RE_LINE_LIST_ITEM.match(line) is not None
+        )
+        if opens and lines:
+            yield "\n".join(lines)
+            lines = []
+        lines.append(line)
+        previous_was_quote = is_quote
+    if lines:
+        yield "\n".join(lines)
 
 
 def _strip_code_spans(content: str) -> str:
@@ -962,32 +1052,42 @@ def extract_links(
     Returns:
         List of :class:`~markdown_vault_mcp.types.LinkInfo` objects.
     """
-    clean = _strip_code_spans(content)
+    clean = _strip_code_spans(_normalise_line_endings(content))
     extensions = (
         effective_attachment_extensions(None)
         if attachment_extensions is None
         else attachment_extensions
     )
-    return [
-        *_extract_inline_links(clean, source_path, extensions),
-        *_extract_reference_links(clean, source_path, extensions),
-        *_extract_wikilinks(clean, source_path, extensions),
-    ]
+    # Definitions live wherever the author put them, so they are collected
+    # over the whole body; usages, inline links and wikilinks are matched one
+    # paragraph region at a time so nothing pairs across a boundary (#1334).
+    # The result stays grouped by kind — callers index into it.
+    ref_defs = _collect_reference_definitions(clean)
+    inline: list[LinkInfo] = []
+    reference: list[LinkInfo] = []
+    wiki: list[LinkInfo] = []
+    for region in _paragraph_regions(clean):
+        inline.extend(_extract_inline_links(region, source_path, extensions))
+        reference.extend(
+            _extract_reference_links(region, ref_defs, source_path, extensions)
+        )
+        wiki.extend(_extract_wikilinks(region, source_path, extensions))
+    return [*inline, *reference, *wiki]
 
 
 def _extract_inline_links(
-    clean: str, source_path: str, attachment_extensions: frozenset[str]
+    region: str, source_path: str, attachment_extensions: frozenset[str]
 ) -> list[LinkInfo]:
-    """Extract inline ``[text](path.md)`` links from code-stripped content.
+    """Extract inline ``[text](path.md)`` links from one paragraph region.
 
     Skips image links (``![alt](src)``), external URLs, pure anchor links
     (``#section`` within the same document), and destinations naming an
     attachment (#1333).
     """
     links: list[LinkInfo] = []
-    for m in _RE_INLINE_LINK.finditer(clean):
+    for m in _RE_INLINE_LINK.finditer(region):
         # Skip image links: ![alt](src) shares the same bracket syntax.
-        if m.start() > 0 and clean[m.start() - 1] == "!":
+        if m.start() > 0 and region[m.start() - 1] == "!":
             continue
         text = m.group(1)
         raw_target = m.group(2).strip()
@@ -1016,23 +1116,21 @@ def _extract_inline_links(
     return links
 
 
-def _extract_reference_links(
-    clean: str, source_path: str, attachment_extensions: frozenset[str]
-) -> list[LinkInfo]:
-    """Extract reference-style ``[text][ref]`` links from code-stripped content.
+def _collect_reference_definitions(clean: str) -> dict[str, str]:
+    """Collect ``[ref]: path.md`` definitions from the whole document body.
 
-    Collects the ``[ref]: path.md`` definitions first (optional CommonMark
-    titles stripped), then resolves each usage; an empty ``[ref]`` falls
-    back to the link text per CommonMark shortcut semantics. External URLs,
-    pure anchors, and definitions naming an attachment (#1333) are skipped.
+    Definitions apply document-wide and commonly sit far from the usages
+    they serve, so they are gathered over the full body rather than per
+    paragraph region (#1334). Optional CommonMark titles are stripped. A
+    footnote definition (``[^label]: body``) is prose, not a link target,
+    and is skipped (#1104).
 
-    Markdown footnotes are skipped on both halves: a footnote definition
-    (``[^label]: body``) is prose, not a link target, and two adjacent
-    footnote references (``[^a][^b]``) are not one reference-style link
-    (#1104).
+    Args:
+        clean: Body text with code removed and line endings normalised.
+
+    Returns:
+        Lower-cased label to raw target; a later definition wins.
     """
-    links: list[LinkInfo] = []
-    # Collect reference definitions first.
     ref_defs: dict[str, str] = {}
     for m in _RE_REF_DEF.finditer(clean):
         ref_key = m.group(1).strip().lower()
@@ -1044,8 +1142,27 @@ def _extract_reference_links(
         # Strip optional CommonMark title: "...", '...', or (...)
         ref_target = re.sub(r'\s+(?:"[^"]*"|\'[^\']*\'|\([^)]*\))\s*$', "", ref_target)
         ref_defs[ref_key] = ref_target
+    return ref_defs
 
-    for m in _RE_REF_USAGE.finditer(clean):
+
+def _extract_reference_links(
+    region: str,
+    ref_defs: dict[str, str],
+    source_path: str,
+    attachment_extensions: frozenset[str],
+) -> list[LinkInfo]:
+    """Extract reference-style ``[text][ref]`` links from one paragraph region.
+
+    Resolves each usage against *ref_defs* (see
+    :func:`_collect_reference_definitions`); an empty ``[ref]`` falls back
+    to the link text per CommonMark shortcut semantics. External URLs, pure
+    anchors, and definitions naming an attachment (#1333) are skipped.
+
+    Two adjacent footnote references (``[^a][^b]``) are not one
+    reference-style link and are skipped (#1104).
+    """
+    links: list[LinkInfo] = []
+    for m in _RE_REF_USAGE.finditer(region):
         text = m.group(1)
         ref = m.group(2).strip() or text  # empty [ref] falls back to link text
         if text.startswith(_FOOTNOTE_LABEL_PREFIX) or ref.startswith(
@@ -1083,9 +1200,9 @@ def _extract_reference_links(
 
 
 def _extract_wikilinks(
-    clean: str, source_path: str, attachment_extensions: frozenset[str]
+    region: str, source_path: str, attachment_extensions: frozenset[str]
 ) -> list[LinkInfo]:
-    """Extract ``[[path]]`` / ``[[path|alias]]`` wikilinks from content.
+    """Extract ``[[path]]`` / ``[[path|alias]]`` wikilinks from one region.
 
     Handles the Obsidian table-cell pipe escape (#731), fragment splitting
     before the ``.md`` append, and Obsidian vault-wide resolution
@@ -1100,7 +1217,7 @@ def _extract_wikilinks(
     the embed marker does not change what the target names.
     """
     links: list[LinkInfo] = []
-    for m in _RE_WIKILINK.finditer(clean):
+    for m in _RE_WIKILINK.finditer(region):
         raw_path = m.group(1).strip()
         # Obsidian escapes the alias pipe as `\|` in table cells, so the target
         # keeps a trailing `\` (#731). Strip it BEFORE wikilink_raw_target is

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -819,23 +819,25 @@ _FOOTNOTE_LABEL_PREFIX = "^"
 _RE_WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
 
 # Line shapes at which a paragraph ends, each decidable from the line alone
-# (no container state). The rows come from
-# ``docs/design/reference/commonmark-gfm.md``, "Paragraph boundaries the
-# scanner should honour"; which rows are honoured, and the two departures,
-# are the decision on #1334. A separator carries no link content and is
-# dropped; a heading is a region by itself; a quote line with text or a list
-# item opens a region that includes the line, so links written on such a
-# line survive (the #1348 regression stated as a requirement).
+# (no container state beyond the quote depth read off the line itself). The
+# rows come from ``docs/design/reference/commonmark-gfm.md``, "Paragraph
+# boundaries the scanner should honour"; which rows are honoured, and the
+# departures, are the decision on #1334. The block-quote prefix is stripped
+# before a line's shape is read, so ``>>``, ``> ***`` and ``> # h`` are what
+# they are inside the quote (Codex on #1348: a blank line inside a quote is
+# spelled with the marker). A separator carries no link content and is
+# dropped; a heading is a region by itself; a list item, or a line whose
+# quote depth grew, opens a region that includes the line, so links written
+# on such a line survive (the #1348 regression stated as a requirement).
+_RE_LINE_QUOTE_PREFIX = re.compile(r"^(?: {0,3}>[ \t]?)+")
 _RE_LINE_SEPARATOR = re.compile(
     r"^(?:"
-    r"[ \t]*"  # blank or whitespace-only (§2.1, §4.8)
-    r"| {0,3}>[ \t]*"  # bare quote marker (§5.1 Ex. 244)
+    r"[ \t]*"  # blank or whitespace-only (§2.1, §4.8); a bare `>` after the strip
     r"| {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})"  # break (§4.1)
     r"| {0,3}(?:=+|-+)[ \t]*"  # setext underline (§4.3)
     r")$"
 )
 _RE_LINE_ATX_HEADING = re.compile(r"^ {0,3}#{1,6}(?:[ \t]|$)")
-_RE_LINE_QUOTE = re.compile(r"^ {0,3}>")
 # Bullet or ordered item with content. Every ordered marker opens a region,
 # not only ``1.`` — §5.2 Ex. 304 makes ``2. text`` after prose continuation
 # text, but converted PDFs are numbered lists and a stray ``[`` in one item
@@ -879,15 +881,50 @@ def _normalise_line_endings(content: str) -> str:
     return content.replace("\r\n", "\n").replace("\r", "\n")
 
 
+_SEPARATOR = "separator"
+_HEADING = "heading"
+_OPENER = "opener"
+_CONTINUATION = "continuation"
+
+
+def _line_shape(line: str, previous_depth: int) -> tuple[str, int]:
+    """Classify one line for :func:`_paragraph_regions`.
+
+    The block-quote prefix is stripped first and its depth counted, so the
+    shape rules read the content *inside* the quote. A line opens a region
+    when it is a list item or when its quote depth grew — a block quote
+    interrupts a paragraph (§5.1), while a line at the same or a shallower
+    depth is the paragraph continuing (Ex. 233's lazy continuation).
+
+    Args:
+        line: One LF-terminated line, without its ending.
+        previous_depth: Quote depth of the line before, ``0`` at a region
+            start.
+
+    Returns:
+        ``(shape, depth)`` with *shape* one of the four module constants.
+    """
+    prefix = _RE_LINE_QUOTE_PREFIX.match(line)
+    depth = prefix.group(0).count(">") if prefix else 0
+    inner = line[prefix.end() :] if prefix else line
+    if _RE_LINE_SEPARATOR.match(inner):
+        return _SEPARATOR, depth
+    if _RE_LINE_ATX_HEADING.match(inner):
+        return _HEADING, depth
+    if depth > previous_depth or _RE_LINE_LIST_ITEM.match(inner):
+        return _OPENER, depth
+    return _CONTINUATION, depth
+
+
 def _paragraph_regions(clean: str) -> Iterator[str]:
     """Split code-stripped, LF-normalised content into paragraph regions.
 
     A region is the run of lines inside which a link may span a soft break;
     a stray ``[`` in one region cannot pair with a ``](`` in the next. The
-    walk is line-shape only (see :data:`_RE_LINE_SEPARATOR` and friends):
-    it tracks no open quotes, items or fences, so a nested item indented four
-    or more spaces is continuation text and a quote line is one paragraph
-    with the quote line before it.
+    walk reads line shapes only (see :func:`_line_shape`): it tracks no open
+    items or fences and no quote state beyond the depth on the line itself,
+    so a nested item indented four or more spaces is continuation text and a
+    quote line following a lazy continuation line opens a new region.
 
     Args:
         clean: Body text with code removed and line endings normalised.
@@ -896,30 +933,19 @@ def _paragraph_regions(clean: str) -> Iterator[str]:
         Each region's lines joined with ``\\n``, in document order.
     """
     lines: list[str] = []
-    previous_was_quote = False
+    previous_depth = 0
     for line in clean.split("\n"):
-        if _RE_LINE_SEPARATOR.match(line):
-            if lines:
-                yield "\n".join(lines)
-                lines = []
-            previous_was_quote = False
+        shape, previous_depth = _line_shape(line, previous_depth)
+        if shape is _CONTINUATION:
+            lines.append(line)
             continue
-        if _RE_LINE_ATX_HEADING.match(line):
-            if lines:
-                yield "\n".join(lines)
-                lines = []
-            yield line
-            previous_was_quote = False
-            continue
-        is_quote = _RE_LINE_QUOTE.match(line) is not None
-        opens = (is_quote and not previous_was_quote) or (
-            _RE_LINE_LIST_ITEM.match(line) is not None
-        )
-        if opens and lines:
+        if lines:
             yield "\n".join(lines)
             lines = []
-        lines.append(line)
-        previous_was_quote = is_quote
+        if shape is _HEADING:
+            yield line
+        elif shape is _OPENER:
+            lines.append(line)
     if lines:
         yield "\n".join(lines)
 

--- a/tests/test_links_paragraph_bounds.py
+++ b/tests/test_links_paragraph_bounds.py
@@ -1,0 +1,285 @@
+"""A link does not span a paragraph boundary (#1334).
+
+The inline-link, reference-usage and wikilink patterns used to run over the
+whole code-stripped body, so a stray ``[`` paired with a ``](`` paragraphs
+later and indexed pages of prose as link text. Extraction now walks the body
+line by line into regions and matches inside each region; reference
+*definitions* stay document-wide.
+
+Every case below is a row of the decision table in
+``docs/design/reference/commonmark-gfm.md`` ("Paragraph boundaries the
+scanner should honour"): a stray ``[`` across the boundary pairs with
+nothing, a link written *on* a content-carrying boundary line survives, and
+a spec continuation line does not split a link. The two deliberate
+departures (every ordered marker opens a region; line endings are
+normalised) are pinned here as the known cost, not hidden.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from markdown_vault_mcp.scanner import extract_links
+
+SRC = "notes/source.md"
+
+
+def targets(content: str) -> list[str]:
+    """Return the raw targets extracted from *content*, in order."""
+    return [link.raw_target for link in extract_links(content, SRC)]
+
+
+def texts(content: str) -> list[str]:
+    """Return the link texts extracted from *content*, in order."""
+    return [link.link_text for link in extract_links(content, SRC)]
+
+
+# ---------------------------------------------------------------------------
+# The issue's reproduction
+# ---------------------------------------------------------------------------
+
+
+class TestIssueReproduction:
+    """The report's inputs, exactly."""
+
+    def test_a_stray_bracket_does_not_pair_with_a_later_image(self) -> None:
+        content = (
+            "See item [3 below.\n\nSome other paragraph.\n\n"
+            "An image: ![Image](images/pic.png)\n"
+        )
+        assert extract_links(content, SRC) == []
+
+    def test_a_stray_bracket_does_not_pair_with_a_later_link(self) -> None:
+        content = (
+            "See item [3 below.\n\nSome other paragraph.\n\nA link: [Image](other.md)\n"
+        )
+        assert texts(content) == ["Image"]
+
+    def test_a_destination_never_contains_a_line_ending(self) -> None:
+        content = "the [Regulation](.\n2. The Specific Programme has:\n3. (a)\n"
+        assert extract_links(content, SRC) == []
+
+    def test_a_destination_on_its_own_line_is_the_known_cost(self) -> None:
+        # CommonMark allows one line ending inside the parentheses around a
+        # destination (§6.3); the scanner does not, since the same shape is
+        # what the converted-PDF defect produced. Pinned, not hidden.
+        assert extract_links("[a](\nnote.md\n)", SRC) == []
+
+
+# ---------------------------------------------------------------------------
+# Separators: a stray ``[`` before, ``](x.md)`` after, nothing pairs
+# ---------------------------------------------------------------------------
+
+
+SEPARATORS = {
+    "blank line": "\n\n",
+    "whitespace-only line": "\n \t \n",
+    "bare quote marker": "\n>\n",
+    "bare quote marker with trailing space": "\n> \n",
+    "thematic break stars": "\n***\n",
+    "thematic break dashes": "\n---\n",
+    "thematic break underscores": "\n_ _ _\n",
+    "setext underline equals": "\n===\n",
+    "setext underline single dash": "\n-\n",
+    "atx heading": "\n## Heading\n",
+    "atx heading indented three spaces": "\n   # Heading\n",
+    "empty atx heading": "\n#\n",
+}
+
+
+class TestSeparators:
+    """Boundary lines that carry no link content of their own."""
+
+    @pytest.mark.parametrize("separator", SEPARATORS.values(), ids=SEPARATORS)
+    def test_a_stray_bracket_does_not_cross_it(self, separator: str) -> None:
+        content = f"See [item{separator}after: [real](note.md)"
+        assert texts(content) == ["real"]
+
+    @pytest.mark.parametrize("separator", SEPARATORS.values(), ids=SEPARATORS)
+    def test_a_reference_usage_does_not_cross_it(self, separator: str) -> None:
+        content = f"See [item{separator}after: [real][r]\n\n[r]: note.md\n"
+        assert texts(content) == ["real"]
+
+    @pytest.mark.parametrize("separator", SEPARATORS.values(), ids=SEPARATORS)
+    def test_a_wikilink_does_not_cross_it(self, separator: str) -> None:
+        content = f"See [[item{separator}after: [[real]]"
+        assert targets(content) == ["real"]
+
+
+# ---------------------------------------------------------------------------
+# Openers: the line starts a new region and keeps its own links
+# ---------------------------------------------------------------------------
+
+
+OPENERS = {
+    "quote line with text": "> ",
+    "bullet dash": "- ",
+    "bullet plus": "+ ",
+    "bullet star": "* ",
+    "ordered dot": "1. ",
+    "ordered paren": "1) ",
+    "ordered not starting at one": "2. ",
+}
+
+
+class TestOpeners:
+    """Boundary lines that carry inline content: the #1348 requirement."""
+
+    @pytest.mark.parametrize("marker", OPENERS.values(), ids=OPENERS)
+    def test_a_stray_bracket_does_not_cross_it(self, marker: str) -> None:
+        content = f"See [item\n{marker}after: [real](note.md)"
+        assert texts(content) == ["real"]
+
+    @pytest.mark.parametrize("marker", OPENERS.values(), ids=OPENERS)
+    def test_a_link_on_the_line_survives(self, marker: str) -> None:
+        content = f"intro\n{marker}see [target](note.md)\nbody"
+        assert targets(content) == ["note.md"]
+
+    def test_a_link_on_a_heading_line_survives(self) -> None:
+        # The exact input the second attempt lost (#1348).
+        assert targets("intro\n# See [target](note.md)\nbody") == ["note.md"]
+
+    def test_a_wikilink_on_a_heading_line_survives(self) -> None:
+        content = "Some text.\n## Related: [[other note]]\n\nBody [link2](x.md)."
+        assert targets(content) == ["x.md", "other note"]
+
+    def test_a_heading_is_a_region_by_itself(self) -> None:
+        # A stray ``[`` on the heading line pairs with nothing below it.
+        assert texts("# Stray [here\nbody [real](note.md)") == ["real"]
+
+    def test_the_ordered_marker_departure_is_the_known_cost(self) -> None:
+        # §5.2 Ex. 304 makes ``2. text`` after prose continuation text; the
+        # scanner opens a region on every ordered marker so a stray ``[`` in
+        # one converted-PDF list item cannot pair into the next. The link
+        # split here is the price, pinned so it is a decision and not a bug.
+        assert extract_links("[a\n2. b](note.md)", SRC) == []
+
+
+# ---------------------------------------------------------------------------
+# Continuation lines: the spec keeps the paragraph going, so does the scanner
+# ---------------------------------------------------------------------------
+
+
+CONTINUATIONS = {
+    "soft break": "b",
+    "indented four spaces": "    b",
+    "html type-7 tag": "<span>b</span>",
+    "empty bullet item": "*",
+    "table-looking row": "| b |",
+    "bullet indented four spaces": "    - b",
+}
+
+
+class TestContinuations:
+    """Rows the table marks 'not a boundary': one link across the break."""
+
+    @pytest.mark.parametrize("line", CONTINUATIONS.values(), ids=CONTINUATIONS)
+    def test_one_link_survives_across_it(self, line: str) -> None:
+        content = f"[a\n{line}](note.md)"
+        assert targets(content) == ["note.md"]
+
+    def test_consecutive_quote_lines_are_one_paragraph(self) -> None:
+        assert targets("> [a\n> b](note.md)") == ["note.md"]
+
+    def test_a_lazy_continuation_of_a_quote_is_the_same_paragraph(self) -> None:
+        assert targets("> [a\nb](note.md)") == ["note.md"]
+
+    def test_an_indented_continuation_of_an_item_is_the_same_paragraph(
+        self,
+    ) -> None:
+        assert targets("- [a\n  b](note.md)") == ["note.md"]
+
+    def test_a_second_item_is_a_new_region(self) -> None:
+        assert extract_links("- [a\n- b](note.md)", SRC) == []
+
+    def test_a_quote_interrupts_a_paragraph(self) -> None:
+        assert extract_links("[a\n> b](note.md)", SRC) == []
+
+    def test_table_cells_keep_their_links(self) -> None:
+        content = "| a | b |\n|---|---|\n| [t](n.md) | [[w]] |\n"
+        assert targets(content) == ["n.md", "w"]
+
+
+# ---------------------------------------------------------------------------
+# Reference definitions stay document-wide
+# ---------------------------------------------------------------------------
+
+
+class TestReferenceDefinitionsAreDocumentWide:
+    def test_a_definition_after_a_blank_line_resolves_an_earlier_usage(
+        self,
+    ) -> None:
+        assert targets("See [t][r].\n\n[r]: note.md\n") == ["note.md"]
+
+    def test_a_definition_before_a_blank_line_resolves_a_later_usage(
+        self,
+    ) -> None:
+        assert targets("[r]: note.md\n\nSee [t][r].\n") == ["note.md"]
+
+    def test_a_definition_in_another_region_kind_still_resolves(self) -> None:
+        content = "# Heading\n\n[r]: note.md\n\n- See [t][r].\n"
+        assert targets(content) == ["note.md"]
+
+    def test_a_usage_text_does_not_cross_a_blank_line(self) -> None:
+        content = "[stray\n\n[t][r]\n\n[r]: note.md\n"
+        assert texts(content) == ["t"]
+
+
+# ---------------------------------------------------------------------------
+# Line endings
+# ---------------------------------------------------------------------------
+
+
+class TestLineEndings:
+    """CRLF and lone CR are line endings (§2.1); the scanner normalises them."""
+
+    @pytest.mark.parametrize("nl", ["\r\n", "\r"], ids=["crlf", "cr"])
+    def test_a_blank_line_in_any_spelling_is_a_boundary(self, nl: str) -> None:
+        content = f"See [item{nl}{nl}after: [real](note.md){nl}"
+        assert texts(content) == ["real"]
+
+    @pytest.mark.parametrize("nl", ["\r\n", "\r"], ids=["crlf", "cr"])
+    def test_a_heading_in_any_spelling_is_a_boundary(self, nl: str) -> None:
+        content = f"See [item{nl}## Heading{nl}after: [real](note.md){nl}"
+        assert texts(content) == ["real"]
+
+    @pytest.mark.parametrize("nl", ["\r\n", "\r"], ids=["crlf", "cr"])
+    def test_a_reference_definition_is_found_in_any_spelling(self, nl: str) -> None:
+        content = f"See [t][r].{nl}{nl}[r]: note.md{nl}"
+        assert targets(content) == ["note.md"]
+
+    def test_link_text_carries_no_carriage_return(self) -> None:
+        assert texts("[a\r\nb](note.md)") == ["a\nb"]
+
+    def test_a_destination_never_contains_a_carriage_return(self) -> None:
+        assert extract_links("[a](note\r.md)", SRC) == []
+
+
+# ---------------------------------------------------------------------------
+# What is preserved
+# ---------------------------------------------------------------------------
+
+
+class TestPreserved:
+    def test_the_result_stays_grouped_by_kind(self) -> None:
+        content = "[[w]] then [a](x.md) then [t][r]\n\n[r]: y.md\n\n[b](z.md) [[v]]"
+        assert [link.link_type for link in extract_links(content, SRC)] == [
+            "markdown",
+            "markdown",
+            "reference",
+            "wikilink",
+            "wikilink",
+        ]
+
+    def test_a_soft_break_inside_link_text_is_kept(self) -> None:
+        assert texts("[first\nsecond](note.md)") == ["first\nsecond"]
+
+    def test_an_image_at_the_start_of_a_region_is_still_an_image(self) -> None:
+        assert extract_links("intro\n\n![alt](pic.md)", SRC) == []
+
+    def test_a_link_whose_text_holds_a_fence_is_bounded_by_the_fence(
+        self,
+    ) -> None:
+        # Fenced code is stripped before regions are formed, as before.
+        content = "[a\n\n```\n[b](c.md)\n```\n\nd](note.md)"
+        assert extract_links(content, SRC) == []

--- a/tests/test_links_paragraph_bounds.py
+++ b/tests/test_links_paragraph_bounds.py
@@ -76,6 +76,10 @@ SEPARATORS = {
     "whitespace-only line": "\n \t \n",
     "bare quote marker": "\n>\n",
     "bare quote marker with trailing space": "\n> \n",
+    "nested bare quote marker": "\n>>\n",
+    "spaced nested bare quote marker": "\n> >\n",
+    "thematic break inside a quote": "\n> ***\n",
+    "setext underline inside a quote": "\n> ---\n",
     "thematic break stars": "\n***\n",
     "thematic break dashes": "\n---\n",
     "thematic break underscores": "\n_ _ _\n",
@@ -106,6 +110,35 @@ class TestSeparators:
         assert targets(content) == ["real"]
 
 
+QUOTED_SEPARATORS = {
+    "bare marker": ">",
+    "bare marker with trailing space": "> ",
+    "nested bare marker": ">>",
+    "spaced nested bare marker": "> >",
+    "thematic break inside the quote": "> ***",
+    "setext underline inside the quote": "> ---",
+    "heading inside the quote": "> ## Heading",
+}
+
+
+class TestSeparatorsInsideAQuote:
+    """The same boundaries, with quoted prose on both sides (#1348, Codex)."""
+
+    @pytest.mark.parametrize("line", QUOTED_SEPARATORS.values(), ids=QUOTED_SEPARATORS)
+    def test_a_stray_bracket_does_not_cross_it(self, line: str) -> None:
+        content = f"> See [item\n{line}\n> after: [real](note.md)"
+        assert texts(content) == ["real"]
+
+    @pytest.mark.parametrize("line", QUOTED_SEPARATORS.values(), ids=QUOTED_SEPARATORS)
+    def test_a_wikilink_does_not_cross_it(self, line: str) -> None:
+        content = f"> See [[item\n{line}\n> after: [[real]]"
+        assert targets(content) == ["real"]
+
+    def test_the_nested_quote_from_the_second_attempt_review(self) -> None:
+        content = ">> See item [3.\n>>\n>> More prose.\n>>\n>> A link: [x](note.md)\n"
+        assert texts(content) == ["x"]
+
+
 # ---------------------------------------------------------------------------
 # Openers: the line starts a new region and keeps its own links
 # ---------------------------------------------------------------------------
@@ -113,6 +146,9 @@ class TestSeparators:
 
 OPENERS = {
     "quote line with text": "> ",
+    "nested quote line with text": ">> ",
+    "bullet item inside a quote": "> - ",
+    "ordered item inside a quote": "> 1. ",
     "bullet dash": "- ",
     "bullet plus": "+ ",
     "bullet star": "* ",
@@ -142,6 +178,23 @@ class TestOpeners:
     def test_a_wikilink_on_a_heading_line_survives(self) -> None:
         content = "Some text.\n## Related: [[other note]]\n\nBody [link2](x.md)."
         assert targets(content) == ["x.md", "other note"]
+
+    def test_a_link_on_a_heading_inside_a_quote_survives(self) -> None:
+        assert targets("> intro\n> # See [target](note.md)\n> body") == ["note.md"]
+
+    def test_a_heading_inside_a_quote_is_a_region_by_itself(self) -> None:
+        assert texts("> # Stray [here\n> body [real](note.md)") == ["real"]
+
+    def test_a_second_item_inside_a_quote_is_a_new_region(self) -> None:
+        assert extract_links("> - [a\n> - b](note.md)", SRC) == []
+
+    def test_a_deeper_quote_interrupts_the_paragraph(self) -> None:
+        assert extract_links("> [a\n> > b](note.md)", SRC) == []
+
+    def test_a_shallower_quote_line_is_a_lazy_continuation(self) -> None:
+        # §5.1: the paragraph inside the inner quote continues on the
+        # less-nested line, so one link spans it.
+        assert targets("> > [a\n> b](note.md)") == ["note.md"]
 
     def test_a_heading_is_a_region_by_itself(self) -> None:
         # A stray ``[`` on the heading line pairs with nothing below it.
@@ -183,6 +236,12 @@ class TestContinuations:
 
     def test_a_lazy_continuation_of_a_quote_is_the_same_paragraph(self) -> None:
         assert targets("> [a\nb](note.md)") == ["note.md"]
+
+    def test_a_quote_line_after_a_lazy_line_is_the_known_cost(self) -> None:
+        # §5.1: ``> a`` / ``b`` / ``> c`` is one paragraph. The walk keeps no
+        # open-quote state, only the depth read off each line, so the third
+        # line's depth grows from 0 and it opens a new region. Pinned.
+        assert extract_links("> [a\nb\n> c](note.md)", SRC) == []
 
     def test_an_indented_continuation_of_an_item_is_the_same_paragraph(
         self,

--- a/tests/test_links_paragraph_bounds.py
+++ b/tests/test_links_paragraph_bounds.py
@@ -342,3 +342,22 @@ class TestPreserved:
         # Fenced code is stripped before regions are formed, as before.
         content = "[a\n\n```\n[b](c.md)\n```\n\nd](note.md)"
         assert extract_links(content, SRC) == []
+
+    def test_a_whole_line_code_span_does_not_split_the_link(self) -> None:
+        # Stripping the span must not turn its line into a blank line.
+        assert targets("[a\n`code`\nb](note.md)") == ["note.md"]
+
+    def test_a_definition_line_cannot_be_spanned_by_any_link(self) -> None:
+        # The table's "link reference definition" row has no observable
+        # boundary behaviour: the definition's own brackets end any link
+        # text, so nothing can pair across it either way.
+        assert targets("[a\n[r]: x.md\nb](note.md)") == []
+
+    def test_backticks_in_prose_do_not_swallow_a_blank_line(self) -> None:
+        # A fence opens at the start of a line (§4.5); three backticks in
+        # running prose are not one, so the blank line below stays a boundary.
+        assert extract_links("a [stray ```\n\nfoo``` ](x.md)", SRC) == []
+
+    def test_a_wikilink_target_never_contains_a_line_ending(self) -> None:
+        # A target with a line ending names no file; it is not a link.
+        assert extract_links("see [[a\nb]] here", SRC) == []


### PR DESCRIPTION
## Closes / Refs

Closes #1334. Refs #1343 (the wikilink pattern's cost inside one region, untouched), #1365 (the per-fix `INDEX_SEMANTICS_VERSION` bump, filed during this work; this PR follows the current rule and bumps 6 → 7).

## What & why

The three link patterns ran over the whole code-stripped body, and their negated classes admit line endings, so a stray unmatched `[` paired with a `](` paragraphs later and stored pages of prose as `link_text` — "a single `get_broken_links` call on this vault returned several multi-kilobyte blobs of document prose" (the issue). Two earlier attempts (#1339, #1348) each fixed the reported input and then lost one review round per further spelling of "where does a paragraph end", the last of which deleted links written *on* heading lines.

This attempt started from the research step those closures asked for: [`docs/design/reference/commonmark-gfm.md`](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/docs/design/reference/commonmark-gfm.md), "Paragraph boundaries the scanner should honour" (22 rows, each with a spec section), the **decision on the issue** (which rows are honoured, by what mechanism, the deliberate departures), and a test file built row by row from that table *before* the extraction code changed.

**Mechanism.** `_paragraph_regions` walks the LF-normalised, fence-stripped body line by line into regions, reading each line's *shape* after stripping its block-quote prefix and counting the depth: separators (blank or whitespace-only at any quote depth, thematic break, setext underline) end a region and carry nothing; an ATX heading is a region by itself; a bullet or ordered item, or a line whose quote depth grew, opens a region that includes the line, so links written on such lines survive. Everything else is continuation text, as the spec has it. Inline links, reference usages and wikilinks are then matched **one region at a time** with the plain negated classes unchanged (the bounded alternation measured 7–8x slower on #1339); inline code is stripped per region *after* the split; reference definitions stay document-wide; the result keeps its grouped order. The inline destination class and the wikilink target class exclude a line ending. Line endings are normalised once (`\r\n`, `\r` → `\n`) the way python-frontmatter already does for CRLF on ingestion, which also closes the CR-only reference-definition miss the reference page recorded.

**Deliberate departures, each pinned by a test as the known cost** (`docs/design/design.md`, "Link Extraction"): every ordered marker opens a region, not only `1.` (Ex. 304; converted PDFs are numbered lists); a destination wrapped onto its own line inside the parentheses is not recognised (that shape is what the defect produced); a quote line whose depth grows again after a lazy continuation line opens a region (no open-quote state). Not honoured, by choice: HTML block openers, GFM table delimiter rows, unclosed fences, nested items indented four or more spaces.

## Probe (the issue's input, through `extract_links`)

```
See item [3 below.\n\nSome other paragraph.\n\nA link: [Image](other.md)   ->  texts == ["Image"]
the [Regulation](.\n2. The Specific Programme has:\n3. (a)\n            ->  []
intro\n# See [target](note.md)\nbody   (the #1348 regression input)       ->  ["note.md"]
>> See item [3.\n>>\n>> More prose.\n>>\n>> A link: [x](note.md)   (Codex, #1348) ->  texts == ["x"]
```

Timing, the three #1348 inputs, this machine, best of 3 (`main` = `252e1c78`):

```
100 paragraphs x 400 '['  (39 KB)     main 27.606s   branch  0.289s
single 16 KB run of '[', no blanks    main  4.404s   branch  4.325s   (#1343, unchanged by design)
462 KB of prose with links            main  0.081s   branch  0.109s
```

## What this PR deliberately does NOT do

- Track container state (open quotes, items, fences): nested items indented 4+ spaces and a quote resumed after an unquoted lazy line are pinned costs, stated in the design doc and the reference table.
- Touch the wikilink pattern's quadratic term inside one region: #1343.
- Parse the other CommonMark destination spellings, bracket balancing, or unclosed fences: #1353 and the reference page's "partial" entries, unchanged.
- Decide #1365: it bumps `INDEX_SEMANTICS_VERSION` under the rule as written today.

## Self-review, two rounds, 252e1c78..141cbf0d

Charters: rules, diff, comments, history, past-PRs (#1339, #1348 every reviewer concern re-checked). Conformance: no normative content. Coverage: full; comments/history/past-PRs and the round-2 diff pass ran as read-only agents, the round-1 diff charter and both probing passes I ran myself.

**Round 1** (on `d6287ab3`):
- `scanner.py` `_RE_LINE_SEPARATOR` — important/verified — a blank line inside a *nested* quote (`>>`, `> >`) was not a separator, so the original defect survived for quoted content; Codex's #1348 finding one level down, and a class, not an instance: every shape rule read the raw line, so `> ***`, `> # h`, `> - item` were misread too. Resolved in `9561424f`: the quote prefix is stripped and its depth counted before the shape is read; a line opens when its depth grows. Pinned by `TestSeparatorsInsideAQuote` (the review's exact input included) and the quote cases in `TestOpeners`; amendment posted on the issue.
- `commonmark-gfm.md` — minor — a "pending #1334" clause survived next to "right on #1334". Resolved.
- Past-PR concerns from #1339/#1348: all five #1348 review-round inputs pinned and passing; #1339's regex-performance concern addressed in the direction that review named; every prior fix at the touched sites (#1104, #1107, #731, #1335, #1332, #1333) verified intact; no legacy test passes by coincidence.

**Round 2** (on `9561424f`):
- `scanner.py` `_strip_code_spans` — important/verified — a whole-line inline code span stripped to an empty line, which the walker read as a blank line and split a spec-legal link (`[a\n`code`\nb](note.md)` was an edge on `main` and would have been dropped by the v7 rebuild). Again a class: nothing may change a line's shape before the walker sees it. Resolved in `141cbf0d`: fences anchored to a line start and stripped before the split (which also stops three backticks in prose from swallowing the blank line after them), inline spans stripped per region after it. Pinned by `test_a_whole_line_code_span_does_not_split_the_link` and `test_backticks_in_prose_do_not_swallow_a_blank_line`.
- `scanner.py` `_RE_WIKILINK` — minor/verified — the target class still admitted `\n`, contradicting "a destination never contains a line ending". Resolved; pinned.
- Docs, minor: `_line_shape` docstring described a reset the walker does not do; the release note named two deliberate limits and omitted the ordered-marker one; the reference overstated row coverage (the definition row is unobservable — its own brackets end any link text — now pinned as such). All resolved in `141cbf0d`.

Two rounds each surfaced a class; per the review skill's convergence rule the third pass is this PR's reviewers, by the owner's call.

## Verification

- TDD: 59 of the 86 table-derived tests failed on `main` (the passes were continuation rows and grouped order — guards); each round's tests failed before its fix (14 and 3).
- `uv run pytest --cov`: 4521 passed, 3 skipped; every changed scanner line covered (misses are pre-existing `_resolve_link_path` lines).
- ruff, mypy (232 files), pre-commit `--all-files` (Vale), `scripts/structural_gate.sh` (100%), `mkdocs build --strict` exit 0, `tests/test_reference_docs.py` (pin markers resolve).
