### PR TITLE
fix(okf): stale on the stale_after date, and a bare verified mapping is one entry

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1382,10 +1382,12 @@ what is implemented today:
   `_server_tools/_common.py` mirroring `attach_conventions`): when active,
   `search` hits, whole-document `read`s, and `get_context` carry an `okf`
   key — `type` (when declared), `status` (absent ⇒ `stable` per spec),
-  `stale` (`stale_after` strictly before today, server-local date), and
+  `stale` (today on or after `stale_after`, server-local date), and
   `trust_tier` (`human-reviewed` if any `verified[].by` has the `human:`
   prefix, else `machine-confirmed` if `verified` is non-empty, else
-  `unverified`). Reads carry the full `sources` list; search hits carry
+  `unverified`; a bare `verified` mapping is a one-element list, as the
+  spec's single-verifier shorthand requires, at every site that reads
+  the field — tier, the `okf_verify` append and its count, #1357). Reads carry the full `sources` list; search hits carry
   `sources_count`. Section reads omit the key (no frontmatter to derive
   from). When inactive, no payload changes at all — the non-OKF baseline
   is byte-identical.

--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -153,11 +153,14 @@ server's ranking math — layer 1 surfaces signal and lets the agent judge.
 **Computed per-note properties** (derived at annotation time from the stored
 frontmatter blob; not persisted):
 
-- `staleness`: `stale` iff `stale_after` < today (date-only comparison,
-  server-local date); absent field → not stale.
+- `staleness`: `stale` iff today ≥ `stale_after` (the spec's rule, date-only
+  comparison, server-local date — the named date is the first stale day,
+  #1357); absent field → not stale.
 - `trust_tier`: `human-reviewed` if any `verified[].by` has the `human:`
   prefix; else `machine-confirmed` if `verified` is non-empty (all
-  verifiers non-human); else `unverified`. Exact tier algorithm lives in
+  verifiers non-human); else `unverified`. A bare `verified` mapping is
+  read as a one-element list (spec shorthand; `okf.verified_entries` is the
+  one reader, #1357). Exact tier algorithm lives in
   the field-mapping table (§1 spec-stability caveat) with table-driven
   tests.
 - `okf.status`: the raw `status` value, defaulted to `stable` when absent

--- a/docs/guides/okf.md
+++ b/docs/guides/okf.md
@@ -34,8 +34,8 @@ Check the current state at any time through the `okf` section of the `stats` too
 On a recognised bundle, the server reads a few OKF frontmatter families and surfaces them in `search`, `read`, and `get_context` results under an `okf` key:
 
 - **Type**: the free-text `type` field, such as `Playbook`, `Metric`, or `Reference`.
-- **Lifecycle**: `status` is one of `draft`, `stable`, or `deprecated`. A note with no `status` is treated as `stable`. `stale_after: YYYY-MM-DD` marks a note stale once that date passes.
-- **Trust tier**: derived from the `verified` list. A note verified by a person (`by: human:...`) is `human-reviewed`; a note verified only by a process is `machine-confirmed`; an unverified note is `unverified`.
+- **Lifecycle**: `status` is one of `draft`, `stable`, or `deprecated`. A note with no `status` is treated as `stable`. `stale_after: YYYY-MM-DD` marks a note stale from that date on.
+- **Trust tier**: derived from the `verified` list (a single entry may be written as a bare mapping, per the spec). A note verified by a person (`by: human:...`) is `human-reviewed`; a note verified only by a process is `machine-confirmed`; an unverified note is `unverified`.
 - **Sources**: the `sources` provenance list, surfaced in full on `read` and as a count on search hits.
 
 You can filter on these dimensions. `search` and `list_documents` accept `status`, `stale`, `trust_tier`, and `type` filters, so `{"stale": "true"}` or `{"status": "deprecated"}` builds a triage listing. See the [tools reference](../tools/index.md) for the full filter set.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -357,6 +357,20 @@ exempts from typing
 histograms now cover the same note population `okf_validate` audits, and
 reserved files are reported separately as `reserved_count`.
 
+**OKF staleness and the single-verifier shorthand now follow the spec.**
+The OKF v0.2 field reference says a note is "stale when `today >=
+stale_after`" and that consumers "must treat a bare mapping as a
+one-element list" for `verified`
+([#1357](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1357)).
+The server did neither: on the `stale_after` date itself it still reported
+the note current, and a note whose `verified` was written as a single
+mapping rather than a list read as `unverified`. Worse, `okf_verify` on
+such a note replaced that mapping with its own entry, so the earlier
+attestation was lost. The `stale` flag, the `stale` filter, `okf_validate`
+and ranking now turn stale on the named date; the trust tier, the
+`okf_verify` append and its `verified_count` all read a bare mapping as one
+entry.
+
 **A link with any URI scheme is external.** The external-link filter was an
 allowlist of four prefixes, so a `file:`, `ftp:`, `obsidian:` or `zotero:`
 destination was resolved against the source note's folder and reported as a
@@ -539,6 +553,12 @@ on your part:
   `INDEX_SEMANTICS_VERSION` moved from 2 to 7. One rebuild covers all
   five; it is automatic, costs CPU and local IO proportional to vault size,
   and does not re-embed.
+- **A note becomes stale one day earlier.** `stale_after` is now the first
+  stale day rather than the last current one
+  ([#1357](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1357)),
+  so a note dated today flips to `stale: true` on upgrade; triage listings
+  built with `{"stale": "true"}` may gain an entry. No stored rows change,
+  so no rebuild.
 - **A Voyage vault also re-embeds once**, through a separate mechanism
   with a separate trigger: the provider's embedding behavior is part of the
   vector sidecar's identity, and asymmetric embedding changed it

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -366,10 +366,10 @@ The server did neither: on the `stale_after` date itself it still reported
 the note current, and a note whose `verified` was written as a single
 mapping rather than a list read as `unverified`. Worse, `okf_verify` on
 such a note replaced that mapping with its own entry, so the earlier
-attestation was lost. The `stale` flag, the `stale` filter, `okf_validate`
-and ranking now turn stale on the named date; the trust tier, the
-`okf_verify` append and its `verified_count` all read a bare mapping as one
-entry.
+attestation was lost. The `stale` flag, the `stale` filter, the `stats`
+stale count and ranking now turn stale on the named date; the trust tier,
+the `okf_verify` append and its `verified_count` all read a bare mapping as
+one entry.
 
 **A link with any URI scheme is external.** The external-link filter was an
 allowlist of four prefixes, so a `file:`, `ftp:`, `obsidian:` or `zotero:`

--- a/examples/okf/prompts/okf-triage-stale.md
+++ b/examples/okf/prompts/okf-triage-stale.md
@@ -16,7 +16,7 @@ whole vault.
 Use the OKF filter dimensions (these work only on a detected bundle):
 
 - `list_documents(folder=<$folder or omit>, filters={"stale": "true"})` — notes
-  whose `stale_after` is in the past.
+  whose `stale_after` has arrived.
 - `list_documents(folder=<$folder or omit>, filters={"status": "deprecated"})` —
   notes explicitly retired.
 

--- a/examples/okf/prompts/okf-verify-note.md
+++ b/examples/okf/prompts/okf-verify-note.md
@@ -28,7 +28,7 @@ Check the claims against the note's own `sources` and against the vault:
 
 - Are the assertions still accurate?
 - Do the `sources` support them?
-- Is anything out of date (a past `stale_after`, superseded facts)?
+- Is anything out of date (a `stale_after` that has arrived, superseded facts)?
 
 If the note needs changes, make them first with `edit` / `write` and stop —
 a content change invalidates any prior verification, so verify only once the

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -83,7 +83,7 @@ def register(mcp: FastMCP) -> None:
                 bundle three keys carry OKF semantics: status ("draft"/
                 "stable"/"deprecated"; "stable" also matches notes without
                 a status field), stale ("true"/"false" — stale_after
-                passed), and trust_tier ("unverified"/"machine-confirmed"/
+                reached), and trust_tier ("unverified"/"machine-confirmed"/
                 "human-reviewed"); "type" filters normally, e.g.
                 {"type": "Playbook", "stale": "false"}.
             chunks_per_file: Maximum number of sections to return per file
@@ -119,7 +119,7 @@ def register(mcp: FastMCP) -> None:
             - okf (dict, optional): OKF read annotation — present only when
               the vault is an active OKF bundle. Carries ``type`` (when
               declared), ``status`` (defaults to "stable"), ``stale``
-              (bool, ``stale_after`` passed), ``trust_tier`` ("unverified" /
+              (bool, ``stale_after`` reached), ``trust_tier`` ("unverified" /
               "machine-confirmed" / "human-reviewed"), and
               ``sources_count`` (when the note cites sources).
             - sections (list[dict]): Up to ``chunks_per_file`` best-matching
@@ -323,7 +323,7 @@ def register(mcp: FastMCP) -> None:
                 fields match by membership. On an OKF bundle three keys
                 carry OKF semantics: status ("draft"/"stable"/"deprecated";
                 "stable" also matches notes without a status field), stale
-                ("true"/"false" — stale_after passed), and trust_tier
+                ("true"/"false" — stale_after reached), and trust_tier
                 ("unverified"/"machine-confirmed"/"human-reviewed"). Use
                 {"status": "deprecated"} or {"stale": "true"} to build
                 triage listings. Any filter excludes attachments (they

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -25,7 +25,11 @@ from markdown_vault_mcp.exceptions import (
     ConcurrentModificationError,
     EditConflictError,
 )
-from markdown_vault_mcp.okf import _HUMAN_ACTOR_PREFIX, append_okf_verification
+from markdown_vault_mcp.okf import (
+    _HUMAN_ACTOR_PREFIX,
+    append_okf_verification,
+    verified_entries,
+)
 from markdown_vault_mcp.utils import is_note
 from markdown_vault_mcp.utils.text import decode_utf8
 from markdown_vault_mcp.vault import Vault
@@ -1023,8 +1027,7 @@ def register(mcp: FastMCP) -> None:
         note = await asyncio.to_thread(vault.reader.read, path)
         if note is None:
             raise ToolError(f"Note not found: {path}")
-        prior = note.frontmatter.get("verified")
-        verified_count = (len(prior) if isinstance(prior, list) else 0) + 1
+        verified_count = len(verified_entries(note.frontmatter)) + 1
         new_text = append_okf_verification(
             note.content, subject=subject, today=date.today()
         )

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -202,13 +202,37 @@ class OkfDetector:
         return None
 
 
+def verified_entries(metadata: dict[str, Any]) -> list[Any]:
+    """Return a note's ``verified`` field as the list the spec defines.
+
+    The field reference allows a single verifier "as a bare mapping without
+    the list dash" and requires consumers to "treat a bare mapping as a
+    one-element list" (#1357). Every reader of ``verified`` goes through
+    here so the shorthand is honoured at each of them alike.
+
+    Args:
+        metadata: The note's frontmatter dict.
+
+    Returns:
+        The list as written, a bare mapping wrapped as one element, or an
+        empty list when the field is absent or of neither shape.
+    """
+    verified = metadata.get("verified")
+    if isinstance(verified, list):
+        return verified
+    if isinstance(verified, dict):
+        return [verified]
+    return []
+
+
 def derive_trust_tier(metadata: dict[str, Any]) -> str:
     """Derive a note's trust tier from its ``verified`` frontmatter.
 
     Per the design (§3): ``human-reviewed`` when any well-formed
     ``verified[].by`` carries the ``human:`` prefix; ``machine-confirmed``
     when ``verified`` is non-empty (all verifiers non-human); ``unverified``
-    otherwise. Malformed entries are ignored (permissive consumer).
+    otherwise. Malformed entries are ignored (permissive consumer); a bare
+    mapping is one entry (:func:`verified_entries`).
 
     Args:
         metadata: The note's frontmatter dict.
@@ -217,10 +241,7 @@ def derive_trust_tier(metadata: dict[str, Any]) -> str:
         One of :data:`TRUST_UNVERIFIED`, :data:`TRUST_MACHINE`,
         :data:`TRUST_HUMAN`.
     """
-    verified = metadata.get("verified")
-    if not isinstance(verified, list):
-        return TRUST_UNVERIFIED
-    entries = [entry for entry in verified if isinstance(entry, dict)]
+    entries = [entry for entry in verified_entries(metadata) if isinstance(entry, dict)]
     if any(
         str(entry.get("by", "")).startswith(_HUMAN_ACTOR_PREFIX) for entry in entries
     ):
@@ -233,6 +254,9 @@ def derive_trust_tier(metadata: dict[str, Any]) -> str:
 def derive_stale(metadata: dict[str, Any], *, today: _dt.date) -> bool:
     """Derive staleness from ``stale_after`` (date-only comparison).
 
+    The field reference's rule: "Stale when ``today >= stale_after``", so
+    the date named is the first stale day (#1357).
+
     Args:
         metadata: The note's frontmatter dict. ``stale_after`` may be a
             ``date`` (YAML parses bare ISO dates) or a ``YYYY-MM-DD``
@@ -240,16 +264,16 @@ def derive_stale(metadata: dict[str, Any], *, today: _dt.date) -> bool:
         today: The server-local date to compare against.
 
     Returns:
-        ``True`` iff ``stale_after`` parses and is strictly before *today*.
+        ``True`` iff ``stale_after`` parses and is on or before *today*.
     """
     raw = metadata.get("stale_after")
     if isinstance(raw, _dt.datetime):
         raw = raw.date()
     if isinstance(raw, _dt.date):
-        return raw < today
+        return raw <= today
     if isinstance(raw, str):
         try:
-            return _dt.date.fromisoformat(raw.strip()) < today
+            return _dt.date.fromisoformat(raw.strip()) <= today
         except ValueError:
             logger.debug("okf_stale_after_invalid value=%r", raw)
             return False
@@ -939,8 +963,7 @@ def append_okf_verification(text: str, *, subject: str, today: _dt.date) -> str:
     """
     post = fm.loads(text)
     meta: dict[str, Any] = dict(post.metadata)
-    existing = meta.get("verified")
-    verified = list(existing) if isinstance(existing, list) else []
+    verified = list(verified_entries(meta))
     verified.append({"by": f"{_HUMAN_ACTOR_PREFIX}{subject}", "at": today.isoformat()})
     meta["verified"] = verified
     return fm.dumps(fm.Post(post.content, **meta))

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -231,8 +231,8 @@ def derive_trust_tier(metadata: dict[str, Any]) -> str:
     Per the design (§3): ``human-reviewed`` when any well-formed
     ``verified[].by`` carries the ``human:`` prefix; ``machine-confirmed``
     when ``verified`` is non-empty (all verifiers non-human); ``unverified``
-    otherwise. Malformed entries are ignored (permissive consumer); a bare
-    mapping is one entry (:func:`verified_entries`).
+    otherwise. Entries that are not mappings are ignored (permissive
+    consumer); a bare mapping is one entry (:func:`verified_entries`).
 
     Args:
         metadata: The note's frontmatter dict.

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -148,6 +148,9 @@ class TestVaultIntegration:
             TRUST_HUMAN,
         ),
         ({"generated": {"by": "human:alice"}}, TRUST_UNVERIFIED),
+        # A bare mapping is a one-element list (field reference, #1357).
+        ({"verified": {"by": "human:alice", "at": "2026-01-01"}}, TRUST_HUMAN),
+        ({"verified": {"by": "process:ci"}}, TRUST_MACHINE),
     ],
 )
 def test_derive_trust_tier(metadata: dict, expected: str) -> None:
@@ -159,7 +162,11 @@ def test_derive_trust_tier(metadata: dict, expected: str) -> None:
     [
         ({}, False),
         ({"stale_after": dt.date(2026, 8, 6)}, True),
-        ({"stale_after": dt.date(2026, 8, 7)}, False),  # strictly before
+        # Stale when today >= stale_after (field reference, #1357): the
+        # date itself is the first stale day.
+        ({"stale_after": dt.date(2026, 8, 7)}, True),
+        ({"stale_after": dt.date(2026, 8, 8)}, False),
+        ({"stale_after": "2026-08-07"}, True),
         ({"stale_after": dt.date(2027, 1, 1)}, False),
         ({"stale_after": dt.datetime(2026, 1, 1, 12, 0)}, True),
         ({"stale_after": "2026-01-01"}, True),

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -151,7 +151,7 @@ class TestAppendOkfVerification:
             {"by": "human:peter", "at": _ISO},
         ]
 
-    def test_non_list_verified_is_replaced(self) -> None:
+    def test_scalar_verified_is_replaced(self) -> None:
         # A malformed scalar verified is treated as empty, not crashed on.
         text = "---\nverified: nonsense\n---\n# N\n"
         meta = fm.loads(

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -139,6 +139,18 @@ class TestAppendOkfVerification:
         assert post.metadata["title"] == "T"
         assert "Body line." in post.content
 
+    def test_a_bare_mapping_is_kept_as_the_first_entry(self) -> None:
+        # The spec's single-verifier shorthand is a one-element list; the
+        # existing attestation must survive the append (#1357).
+        text = "---\nverified:\n  by: human:alice\n  at: 2026-01-01\n---\n# N\n"
+        meta = fm.loads(
+            append_okf_verification(text, subject="peter", today=_TODAY)
+        ).metadata
+        assert meta["verified"] == [
+            {"by": "human:alice", "at": _dt.date(2026, 1, 1)},
+            {"by": "human:peter", "at": _ISO},
+        ]
+
     def test_non_list_verified_is_replaced(self) -> None:
         # A malformed scalar verified is treated as empty, not crashed on.
         text = "---\nverified: nonsense\n---\n# N\n"
@@ -625,6 +637,24 @@ class TestOkfVerifyTrustAuth:
             await wait_for_mcp_writer_drain(client)
             with pytest.raises(ToolError, match="changed since it was read"):
                 await client.call_tool("okf_verify", {"path": "guides/playbook.md"})
+
+    async def test_counts_a_bare_mapping_as_one(
+        self, trust_auth_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # verified_count is the list length after the append; a bare-mapping
+        # verified is one entry, not zero (#1357).
+        monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: "peter")
+        (trust_auth_env / "guides" / "playbook.md").write_text(
+            "---\nverified:\n  by: human:alice\n  at: 2026-01-01\n---\n# P\n",
+            encoding="utf-8",
+        )
+        async with Client(make_server()) as client:
+            await wait_for_mcp_writer_drain(client)
+            result = await client.call_tool(
+                "okf_verify", {"path": "guides/playbook.md"}
+            )
+            await wait_for_mcp_writer_drain(client)
+        assert _parse_tool_data(result)["verified_count"] == 2
 
 
 @pytest.mark.usefixtures("enforced_env")


### PR DESCRIPTION
## Closes / Refs

Closes #1357.

## What & why

The OKF v0.2 field reference says a note is "stale when `today >= stale_after`" and that consumers "must treat a bare mapping as a one-element list" for `verified`. The read layer did neither, and neither departure was deliberate — #968's body and commit say only "date comparison on `stale_after`", and `docs/design/okf.md` § 3 states strict-before with no rationale.

**Decision (on the issue):** follow the spec on both. The `verified` half is four sites, not two, and one of them loses data: `derive_trust_tier` (bare mapping read as `unverified`), `append_okf_verification` (a bare mapping was *replaced* by the new entry, dropping the existing attestation), the `okf_verify` tool's `verified_count` (bare mapping counted as 0), and the `derive_stale` boundary. One helper, `okf.verified_entries`, does the coercion so the readers cannot drift again. `okf_validate` computes no staleness (the decision comment said otherwise; corrected there) — the consumers are the `stale` annotation, the `stale` filter, `stats.okf.stale_count` and ranking, all through `derive_stale`, so there is no second boundary.

No `INDEX_SEMANTICS_VERSION` bump: staleness and tier are derived at annotation time from the stored frontmatter blob; no stored row changes.

## Breaking-change classification, made deliberately

`fix:`, not `fix!:`. AGENTS.md's refinement 1 ("if the old behaviour is gone, treat it as breaking") is aimed at a tool whose *contract* changes; this corrects a derived advisory field to the value the spec it implements defines, the same class as #1333 and #1334 changing what `get_broken_links` returns in this cycle, both `fix:`. What an operator sees: a note whose `stale_after` is today reads `stale: true` from upgrade day (the Upgrading section says so). If you read it the other way, retitling is enough.

## Conformance (executed, `today = 2026-09-06`)

| `stale_after` | stale |
|---|---|
| `2026-09-05` / `2026-09-06` / `2026-09-07` (date or string) | true / true / false |

| `verified` | tier | `okf_verify` result |
|---|---|---|
| `{by: human:alice, at: …}` (bare mapping) | human-reviewed | `[alice, peter]`, count 2 (was `[peter]`, count 1) |
| `{by: process:ci}` | machine-confirmed | prior kept, count 2 |
| `[…]`, scalar, absent | unchanged | unchanged |

## What this PR deliberately does NOT do

- Change how `verified: {}` / `[{}]` read (machine-confirmed, pre-existing for the list form; the docstring now says "entries that are not mappings are ignored", which is what the code does).
- Touch `stale_after` timezone semantics (server-local date; the open question in `okf.md` § 10 stands).

## Self-review c78cf215..c87017db

Charters: rules, diff, comments, history, conformance (executed matrices above). Coverage: full; one read-only agent ran rules/comments/history/conformance, the diff charter I walked myself.

- AGENTS.md breaking-change policy — important — the commit carried no `!` and no recorded reason; the classification above is the resolution, written down rather than left implicit.
- `docs/releases/4.2.md` — minor/verified — claimed `okf_validate` derives staleness; it does not (`stats` does). Resolved in `c87017db`, and the issue's decision comment corrected.
- `examples/okf/prompts/*` — minor — two prompt texts still said "in the past"; now "has arrived". Resolved in `c87017db`.
- `derive_trust_tier` docstring — minor — "malformed entries are ignored" overstated (only non-mapping entries are). Resolved. Test renamed to what it pins (`test_scalar_verified_is_replaced`).
- History: `git log -S` on both departures points only at #968; nothing was reverted.

## Verification

- TDD: six tests failed first (boundary ×2, bare-mapping tier ×2, append, tool count).
- `uv run pytest --cov`: 4527 passed, 3 skipped; `okf.py` and `_server_tools/writer.py` at 100%.
- ruff, mypy (232 files), pre-commit `--all-files` (Vale), structural gate 100%, `mkdocs build --strict` exit 0, client-surface budget test (the three "reached" edits fit: +2 chars in input schemas).
