### PR TITLE
docs(reference): OKF v0.2 page, in both texts of the spec

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1367,8 +1367,9 @@ ones).
 
 The vault can declare itself an [OKF (Open Knowledge Format)](https://github.com/GoogleCloudPlatform/knowledge-catalog)
 bundle via an `okf_version` field in the root `index.md` frontmatter. The
-full design (trust model, later phases) lives in `docs/design/okf.md`;
-what is implemented today:
+full design (trust model, later phases) lives in `docs/design/okf.md`; what
+the spec itself says, dated and sourced, in
+[`reference/okf-v0.2.md`](reference/okf-v0.2.md). What is implemented today:
 
 - **Detection** (`okf.py::OkfDetector`): a pure disk-I/O probe in the
   `ConventionsResolver` mold — no index coupling, works pre-clone, and a

--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -13,6 +13,11 @@ proposals — tracking issue
 ([`GoogleCloudPlatform/knowledge-catalog` → `okf/SPEC.md`](https://github.com/GoogleCloudPlatform/knowledge-catalog),
 Apache 2.0; announced 2026-06-12 on the
 [Google Cloud blog](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing)).
+What the spec actually says, with sources, dates and the in-place amendment
+of 2026-08-21 (every timestamp an ISO 8601 datetime with an offset;
+`stale_after` an instant), is the reference page
+[`reference/okf-v0.2.md`](reference/okf-v0.2.md); the departures this
+document decides are listed there.
 
 This document is the authoritative design for OKF support. As phases land,
 the relevant subsections graduate into `design.md` alongside the features

--- a/docs/design/reference/commonmark-gfm.md
+++ b/docs/design/reference/commonmark-gfm.md
@@ -6,10 +6,10 @@ subject_version: "0.31.2"
 valid_for: "CommonMark 0.31.x; GFM as published at accessed date"
 generated:
   by: process:researching-references
-  at: 2026-09-06
+  at: 2026-09-06T12:14:49+02:00
 verified:
   - by: process:researching-references-refute
-    at: 2026-09-06
+    at: 2026-09-06T12:14:49+02:00
 stale_after: 2027-09-06
 status: stable
 sources:

--- a/docs/design/reference/git-history-queries.md
+++ b/docs/design/reference/git-history-queries.md
@@ -6,10 +6,10 @@ subject_version: "git-scm.com manual pages ('last updated in' 2.42.0–2.55.0; p
 valid_for: "git 2.x"
 generated:
   by: process:researching-references
-  at: 2026-09-06
+  at: 2026-09-06T12:14:49+02:00
 verified:
   - by: process:researching-references-refute
-    at: 2026-09-06
+    at: 2026-09-06T13:18:18+02:00
 stale_after: 2027-03-06
 status: stable
 sources:

--- a/docs/design/reference/git-push-and-remotes.md
+++ b/docs/design/reference/git-push-and-remotes.md
@@ -6,10 +6,10 @@ subject_version: "git-scm.com manual pages ('last updated in' 2.42.0–2.55.0; p
 valid_for: "git 2.x"
 generated:
   by: process:researching-references
-  at: 2026-09-06
+  at: 2026-09-06T12:14:49+02:00
 verified:
   - by: process:researching-references-refute
-    at: 2026-09-06
+    at: 2026-09-06T13:18:18+02:00
 stale_after: 2027-03-06
 status: stable
 sources:

--- a/docs/design/reference/git-staging-and-commits.md
+++ b/docs/design/reference/git-staging-and-commits.md
@@ -6,10 +6,10 @@ subject_version: "git-scm.com manual pages ('last updated in' 2.42.0–2.55.0; p
 valid_for: "git 2.x"
 generated:
   by: process:researching-references
-  at: 2026-09-06
+  at: 2026-09-06T12:14:49+02:00
 verified:
   - by: process:researching-references-refute
-    at: 2026-09-06
+    at: 2026-09-06T13:18:18+02:00
 stale_after: 2027-03-06
 status: stable
 sources:

--- a/docs/design/reference/index.md
+++ b/docs/design/reference/index.md
@@ -1,7 +1,5 @@
 ---
 okf_version: "0.2"
-title: External-behaviour references
-description: OKF v0.2 bundle of dated, sourced references on how things outside this repository behave
 ---
 
 # External-behaviour references
@@ -16,4 +14,5 @@ follow OKF v0.2 (`generated`, `verified`, `stale_after`).
 - [CommonMark and GitHub Flavored Markdown](/commonmark-gfm.md): line endings, paragraph boundaries, link and reference grammar, code spans and fences, the #1334 decision table. Read before any regex in `scanner.py`.
 - [Git push, credentials and remotes](/git-push-and-remotes.md): push refusals and their wording, `--porcelain`, askpass and `GIT_TERMINAL_PROMPT`, URL forms, `safe.directory`, `symbolic-ref` and `origin/HEAD`. Read before `git/health.py`, `git/push_scheduler.py`, `git/_run.py`, `git/bootstrap.py`, or the repository-discovery part of `git/conflict.py`.
 - [Git staging, commits and rebase state](/git-staging-and-commits.md): pathspec magic, `add`/`check-ignore`, `commit --only` and identity, ancestry and fast-forward, rebase state on disk and conflict markers. Read before `git/strategy.py`, `git/conflict.py`, or the pathspec part of `git/_run.py`.
+- [Open Knowledge Format v0.2](/okf-v0.2.md): frontmatter families, trust tiers, `stale_after` in both texts of v0.2 (date in July, instant with offset since 2026-08-21), reserved files, links, conformance; the timestamp departures. Read before `okf.py`, `_okf_write.py`, `_okf_convention.py` or `okf_bundle.py`.
 - [Git history and revision queries](/git-history-queries.md): `log -z`/`--name-status` framing, `--follow` and rename detection, `--since`/`--until` date semantics, `ls-tree -l`, symlink blobs, LFS pointers. Read before `git/query.py`.

--- a/docs/design/reference/log.md
+++ b/docs/design/reference/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-09-06
 
+- `okf-v0.2.md` created from `okf/SPEC.md` at commit 62432a09 and the July 2026 text it amended (Codex on #1371: #1357 changed runtime semantics on a digest of the spec with no reference page behind it). Records that the spec's timestamp contract moved in place on 2026-08-21 (`stale_after` is an instant, every timestamp carries an offset) while the header stayed 0.2; departures on staleness and write stamps recorded and filed as #1373 and #1372; the root `index.md` trimmed to `okf_version` only, which §8 requires and the plugin validator enforced.
 - `commonmark-gfm.md`: the `_RE_INLINE_LINK` and reference-link departure entries re-observed after #1334 (per-region matching, LF normalisation, no line ending in a destination); the decision table's "Now" column filled in from `_paragraph_regions`, with "dep." for the two deliberate departures and "no, by choice" for the rows left unhonoured; pointer to the design-doc rationale added.
 - `obsidian-markdown.md`: the `.md`-append and embed entries updated for #1333 (attachment references are not links; note embeds still are); the departure recorded as a deliberate notes-only carve-out pointing at #1359; test pins added; the stale "without decoding" departure note corrected to the #1332 behaviour.
 - Bundle created: `obsidian-markdown.md`, `commonmark-gfm.md`, `git-cli.md` migrated from the first reference contract to OKF v0.2 (`generated`, `verified`, `stale_after`, `sources[].resource`); the refute pass on each page recorded as a `process:` verification.

--- a/docs/design/reference/log.md
+++ b/docs/design/reference/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-09-07
+
+- Every page's `generated.at` and `verified[].at` rewritten from a bare date to the author instant of the commit that did the research or the refute (Codex on #1374: the OKF page documented the datetime rule and stamped itself with a date, as the template-owned skill's own template prescribes). `stale_after` stays a calendar date because `scripts/check_references.py` requires one; both raised upstream as fastmcp-server-template#603; the plugin's stale digest as claude-plugins#47. `okf-v0.2.md` gains the reserved-frontmatter departure (`ReservedFrontmatterPolicy`, #1174/#1175) and the bundle's own `stale_after` shape.
+
 ## 2026-09-06
 
 - `okf-v0.2.md` created from `okf/SPEC.md` at commit 62432a09 and the July 2026 text it amended (Codex on #1371: #1357 changed runtime semantics on a digest of the spec with no reference page behind it). Records that the spec's timestamp contract moved in place on 2026-08-21 (`stale_after` is an instant, every timestamp carries an offset) while the header stayed 0.2; departures on staleness and write stamps recorded and filed as #1373 and #1372; the root `index.md` trimmed to `okf_version` only, which §8 requires and the plugin validator enforced.

--- a/docs/design/reference/obsidian-markdown.md
+++ b/docs/design/reference/obsidian-markdown.md
@@ -6,10 +6,10 @@ subject_version: "1.14 (help pages state a version only for properties: 1.4 / 1.
 valid_for: "Obsidian 1.x"
 generated:
   by: process:researching-references
-  at: 2026-09-06
+  at: 2026-09-06T12:14:49+02:00
 verified:
   - by: process:researching-references-refute
-    at: 2026-09-06
+    at: 2026-09-06T12:14:49+02:00
 stale_after: 2027-03-06
 status: stable
 sources:

--- a/docs/design/reference/okf-v0.2.md
+++ b/docs/design/reference/okf-v0.2.md
@@ -41,9 +41,11 @@ on the word of a digest of the spec rather than the spec itself; this page
 reads the spec, and finds that the spec has moved since that digest was
 made. The document still calls itself "Version 0.2", but its text was
 amended in place on 2026-08-21 [source: pr-323]; where the July and August
-texts differ, both are recorded. The spec's own authors describe it as
-"early-stage" and "a starting point" [source: spec], so its `stale_after`
-here is six months, not twelve.
+texts differ, both are recorded. The spec calls its field one that "is
+evolving quickly" and keeps a "Considered and deferred" list for the next
+revision [source: spec] (§1, §12), it was amended without a version bump,
+and the repository carries no tags, so this page's `stale_after` is six
+months, not twelve.
 
 ## Scope
 
@@ -98,7 +100,7 @@ here is six months, not twelve.
 - Producers "MAY include any additional keys"; consumers "SHOULD preserve
   unknown keys when round-tripping and MUST NOT reject documents with
   unrecognized fields". [source: spec] (§4.1)
-  [pins: tests/test_okf_write.py::TestApplyOkfWriteStamp::test_preserves_sources_and_other_fields]
+  [pins: tests/test_okf_write.py::TestApplyOkfWriteStamp::test_preserves_sources_and_other_fields, tests/test_okf.py::TestOkfAudit::test_mixed_vault_report]
 
 ### Trust: `generated`, `verified`, tiers (§5.2, §5.3, §7)
 
@@ -162,11 +164,14 @@ here is six months, not twelve.
 
 ### Provenance: `sources` (§5.1)
 
-- `sources` is a list of `{ id, resource, title, author, usage_count,
-  last_modified }` entries; per-claim attribution is a markdown footnote
-  whose label is a `sources[].id`, "keyed rather than positional".
-  [source: spec] (§5.1)
+- `sources` is a list of entries in which `resource` is "REQUIRED within an
+  entry" and `id`, `title`, `author`, `usage_count` and `last_modified` are
+  optional; the server passes the list through on reads and counts it on
+  search hits. [source: spec] (§5.1)
   [pins: tests/test_okf.py::TestDeriveAnnotation::test_read_mode_includes_sources, tests/test_okf.py::TestDeriveAnnotation::test_search_mode_counts_sources]
+- Per-claim attribution is a markdown footnote whose label is a
+  `sources[].id`, "keyed rather than positional". Nothing here depends on
+  it. [source: spec] (§5.1)
 
 ### Links and paths (§6)
 
@@ -190,10 +195,14 @@ here is six months, not twelve.
   does not understand the declared version "SHOULD attempt best-effort
   consumption rather than refusing the bundle". [source: spec] (§12)
   [pins: tests/test_okf.py::TestOkfDetector::test_unknown_version_warns_once_and_detects, tests/test_okf.py::TestOkfDetector::test_unquoted_yaml_scalar_version]
-- v0.2 supersedes v0.1 with two breaking renames: `timestamp` →
-  `generated.at` (consumers MAY fall back to `timestamp`), and the body
-  `# Citations` list → `sources`. Everything else is carried forward
-  unchanged. [source: spec] (§13)
+- v0.2 supersedes v0.1 with two breaking renames — `timestamp` →
+  `generated.at` (consumers MAY fall back to `timestamp`) and the body
+  `# Citations` list → `sources` — plus the additive families this page
+  documents: `sources`, `generated`/`verified`, `status`/`stale_after`, the
+  `Attested Computation` type and the actor convention. Bundle structure,
+  reserved filenames, the required `type`, the recommended keys,
+  cross-linking, index and log files and the permissive conformance rule
+  are "carried forward unchanged". [source: spec] (§13)
 - The 2026-08-21 timestamp amendment changed the text of "Version 0.2"
   without a version bump: the header still reads 0.2, `okf_version: "0.2"`
   still declares it, and the repository carries no tags. [observed:

--- a/docs/design/reference/okf-v0.2.md
+++ b/docs/design/reference/okf-v0.2.md
@@ -1,0 +1,256 @@
+---
+type: Reference
+title: Open Knowledge Format v0.2
+description: What the OKF v0.2 spec requires of a bundle and its consumers (frontmatter families, trust tiers, staleness, reserved files, links, conformance), as published in July 2026 and as amended in place on 2026-08-21
+subject_version: "0.2 (spec commit 62432a09, 2026-08-21)"
+valid_for: "OKF 0.2 as amended 2026-08-21; re-research on any later commit to okf/SPEC.md or a 0.3 draft"
+generated:
+  by: process:researching-references
+  at: 2026-09-06
+verified:
+  - by: process:researching-references-refute
+    at: 2026-09-06
+stale_after: 2027-03-06
+status: stable
+sources:
+  - id: spec
+    title: Open Knowledge Format (OKF), Version 0.2, okf/SPEC.md at commit 62432a09 (2026-08-21)
+    resource: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/62432a0954/okf/SPEC.md
+    accessed: 2026-09-06
+  - id: spec-july
+    title: Open Knowledge Format (OKF), Version 0.2, okf/SPEC.md at commit 3fcbb9f8 (2026-07-24, the text v0.2 was published with)
+    resource: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/3fcbb9f828/okf/SPEC.md
+    accessed: 2026-09-06
+  - id: pr-323
+    title: knowledge-catalog PR #323, "okf: make every timestamp an ISO 8601 datetime with an explicit offset" (merged 2026-08-21)
+    resource: https://github.com/GoogleCloudPlatform/knowledge-catalog/pull/323
+    accessed: 2026-09-06
+  - id: issue-242
+    title: knowledge-catalog issue #242, "stale_after comparison has no timezone anchor, so staleness depends on where a bundle is read" (open)
+    resource: https://github.com/GoogleCloudPlatform/knowledge-catalog/issues/242
+    accessed: 2026-09-06
+---
+
+# Open Knowledge Format v0.2
+
+What the OKF specification (`okf/SPEC.md` in
+`GoogleCloudPlatform/knowledge-catalog`) requires of a bundle and of a
+consumer, scoped to the fields and files this server reads, writes, audits
+and ranks on. Written after #1357, which corrected two read-layer departures
+on the word of a digest of the spec rather than the spec itself; this page
+reads the spec, and finds that the spec has moved since that digest was
+made. The document still calls itself "Version 0.2", but its text was
+amended in place on 2026-08-21 [source: pr-323]; where the July and August
+texts differ, both are recorded. The spec's own authors describe it as
+"early-stage" and "a starting point" [source: spec], so its `stale_after`
+here is six months, not twelve.
+
+## Scope
+
+- Covers: bundle structure and reserved filenames (§3), concept
+  frontmatter (§4.1), the provenance/trust/lifecycle families (§5), the
+  actor convention (§7), links and paths (§6), index and log files (§8, §9),
+  conformance and versioning (§11–§13).
+- Does not cover: Attested Computations (§10) and per-source credibility
+  signals (`usage_count`, `usage_window`, §5.1) — nothing here reads them;
+  the v0.3 proposal.
+- Depended on by: `src/markdown_vault_mcp/okf.py` (detection, annotations,
+  filters, ranking weights, the audit, index/log builders, write stamps),
+  `_okf_write.py` and `_okf_convention.py` (write-side stamping and log
+  maintenance), `okf_bundle.py` (export), `_server_tools/reader.py` and
+  `writer.py` (the `okf_*` tools); `docs/design/okf.md` decides what this
+  project does with these rules.
+
+## Claims
+
+### Bundle structure and reserved files (§3, §8, §9)
+
+- A bundle is a directory tree of markdown files; structure is the
+  producer's choice. `index.md` and `log.md` "have defined meaning at any
+  level of the hierarchy and MUST NOT be used for concept documents"; every
+  other `.md` file is a concept. [source: spec] (§3.1)
+  [pins: tests/test_okf.py::TestOkfAudit::test_mixed_vault_report]
+- There is no tag file format; a consumer wanting a tag view synthesises it
+  from frontmatter. [source: spec] (§3.1)
+- An `index.md` "MAY appear in any directory"; index files "contain no
+  frontmatter, with one exception: a bundle-root `index.md` MAY carry an
+  `okf_version` key". The body is sections of `* [Title](url) - description`
+  entries; producers MAY generate one, consumers MAY synthesise one when
+  none is present. [source: spec] (§8, §12)
+  [pins: tests/test_okf.py::TestOkfDetector::test_declared_auto_active, tests/test_okf.py::TestBuildIndexMarkdown::test_entries_with_and_without_description]
+- A `log.md` MAY appear at any level; it is "a flat list of date-grouped
+  entries, newest first"; "Date headings MUST use ISO 8601 `YYYY-MM-DD`
+  form"; the leading bold word of an entry is a convention, not a
+  requirement. [source: spec] (§9)
+  [pins: tests/test_okf.py::TestBuildLogMarkdown::test_groups_by_date_newest_first, tests/test_okf.py::TestAppendOkfLogEntry::test_inserts_new_day_section_on_top]
+- The August amendment left the log's date headings alone: "`## 2026-05-22`
+  groups a day's entries and is not a field value." [source: pr-323]
+
+### Concept frontmatter (§4.1)
+
+- `type` is "the only always-required key; a concept carrying just `type`
+  is fully conformant". Values are not registered; "consumers MUST tolerate
+  unknown types gracefully". [source: spec] (§4.1)
+  [pins: tests/test_okf.py::TestOkfAudit::test_mixed_vault_report]
+- `title`, `description`, `resource` and `tags` are recommended; a consumer
+  "MAY derive a title from the filename" when `title` is absent.
+  [source: spec] (§4.1)
+- Producers "MAY include any additional keys"; consumers "SHOULD preserve
+  unknown keys when round-tripping and MUST NOT reject documents with
+  unrecognized fields". [source: spec] (§4.1)
+  [pins: tests/test_okf_write.py::TestApplyOkfWriteStamp::test_preserves_sources_and_other_fields]
+
+### Trust: `generated`, `verified`, tiers (§5.2, §5.3, §7)
+
+- `generated: { by, at }` records how the current content was produced;
+  `generated.by` is required within `generated` and is an actor;
+  `generated.at` is "an ISO 8601 datetime marking the content's last
+  meaningful change". [source: spec] (§5.2) [source: spec-july] (§5.2)
+- `verified` is "a list of verification events, each with `by` (an actor)
+  and `at` (an ISO 8601 datetime)"; it "is independent of `generated.at`:
+  content can change without re-confirmation, and facts can be re-confirmed
+  without regeneration". [source: spec] (§5.2)
+- "A single verifier MAY be written as one `{ by, at }` mapping without
+  the list dash. Consumers MUST treat a bare mapping as a one-element
+  list" — restated as a consumer MUST in §11. [source: spec] (§5.2, §11)
+  [pins: tests/test_okf.py::test_derive_trust_tier, tests/test_okf_write.py::TestAppendOkfVerification::test_a_bare_mapping_is_kept_as_the_first_entry, tests/test_okf_write.py::TestOkfVerifyTrustAuth::test_counts_a_bare_mapping_as_one]
+- Tiers, lowest to highest: no `verified` key ⇒ unverified; "`verified` by
+  non-`human:` actors only ⇒ machine-confirmed"; "`verified` by a
+  `human:<id>` actor ⇒ human-reviewed". "Trust tiers are advisory signals,
+  not access control." [source: spec] (§5.3)
+  [pins: tests/test_okf.py::test_derive_trust_tier]
+- Actors: `<producer>/<version>` for agents and tools, `human:<id>` for a
+  person, `process:<id>` for an automated process; "producers MUST use
+  [`human:`] for hand-authored or human-confirmed content" because
+  consumers key trust off that prefix. [source: spec] (§7)
+  [pins: tests/test_okf_write.py::TestActorResolution::test_tool_actor_format, tests/test_okf_write.py::TestApplyOkfWriteStamp::test_human_actor_is_recorded_verbatim]
+- The spec says nothing about a tier for a `verified` entry that carries no
+  `by`, or an empty list; "non-`human:` actors only" reads naturally as
+  machine-confirmed for `[{}]`, which is what the server does.
+  [unverified] A spec-maintainer answer or a reference-agent fixture would
+  settle it.
+
+### Lifecycle: `status` and `stale_after` (§5.4, §5.5)
+
+- `status` is `draft | stable | deprecated`; "Absent `status` ⇒ `stable`";
+  `deprecated` is "kept for links and history; no longer current".
+  [source: spec] (§5.4)
+  [pins: tests/test_okf.py::TestDeriveAnnotation::test_empty_metadata_defaults, tests/test_okf.py::TestDeriveAnnotation::test_unknown_status_passes_through]
+- **July text:** `stale_after` is "an absolute date (`YYYY-MM-DD`). A
+  concept is stale when `today >= stale_after`". [source: spec-july] (§5.5)
+  [pins: tests/test_okf.py::test_derive_stale]
+- **August text:** "Every timestamp-valued key in OKF is an ISO 8601
+  datetime with an explicit UTC offset, for example
+  `2026-06-30T14:00:00Z`", stated once in the §5 preamble; `stale_after` is
+  "an absolute instant. A concept is stale when `now >= stale_after`".
+  [source: spec] (§5, §5.5)
+- The amendment's reason: a bare date "names a different instant in every
+  timezone, so the same bundle can be stale in one office and fresh in
+  another" (filed upstream as issue #242, still open). "Consumers are
+  expected to be strict rather than lenient about a value that arrives
+  without an offset: a midnight-UTC fallback would quietly reintroduce the
+  disagreement this change exists to remove. The reference agent ignores
+  such a value, and the demo's storage layer rejects it outright."
+  [source: pr-323] [source: issue-242]
+- The amendment also records that PyYAML's YAML 1.1 loader coerces
+  `2026-06-30T14:00:00Z` into a `datetime` and dumps it back as
+  `2026-06-30 14:00:00+00:00`, corrupting `generated.at` on rewrite; the
+  reference agent now keeps every frontmatter value as the string the
+  author wrote. [source: pr-323] [observed: `yaml.safe_load` on
+  `stale_after: 2026-09-23T00:00:00Z` yields a `datetime`, on the quoted
+  form a `str`; python-frontmatter uses the same loader]
+
+### Provenance: `sources` (§5.1)
+
+- `sources` is a list of `{ id, resource, title, author, usage_count,
+  last_modified }` entries; per-claim attribution is a markdown footnote
+  whose label is a `sources[].id`, "keyed rather than positional".
+  [source: spec] (§5.1)
+  [pins: tests/test_okf.py::TestDeriveAnnotation::test_read_mode_includes_sources, tests/test_okf.py::TestDeriveAnnotation::test_search_mode_counts_sources]
+
+### Links and paths (§6)
+
+- Concepts link with "standard markdown links" in two forms: absolute
+  (bundle-relative, beginning with `/`, "the **recommended** form") and
+  relative. Wikilinks are not among them. [source: spec] (§6.1)
+  [pins: tests/test_okf.py::TestConvertWikilinks::test_basic_and_aliased_and_skipped, tests/test_okf.py::TestConvertWikilinks::test_markdown_links_untouched]
+- "Consumers MUST tolerate broken links: a link whose target does not exist
+  in the bundle is not malformed". [source: spec] (§6.1)
+
+### Conformance and versioning (§11, §12, §13)
+
+- A bundle is conformant when every non-reserved `.md` file has parseable
+  frontmatter with a non-empty `type`, and every reserved file present
+  follows §8/§9. Consumers MUST NOT reject a bundle for missing optional
+  fields, unknown types, unknown keys, broken links or missing `index.md`.
+  [source: spec] (§11)
+  [pins: tests/test_okf.py::TestOkfAudit::test_mixed_vault_report]
+- `okf_version: "0.2"` MAY be declared in the bundle-root `index.md`, "the
+  only place frontmatter is permitted in an `index.md`"; a consumer that
+  does not understand the declared version "SHOULD attempt best-effort
+  consumption rather than refusing the bundle". [source: spec] (§12)
+  [pins: tests/test_okf.py::TestOkfDetector::test_unknown_version_warns_once_and_detects, tests/test_okf.py::TestOkfDetector::test_unquoted_yaml_scalar_version]
+- v0.2 supersedes v0.1 with two breaking renames: `timestamp` →
+  `generated.at` (consumers MAY fall back to `timestamp`), and the body
+  `# Citations` list → `sources`. Everything else is carried forward
+  unchanged. [source: spec] (§13)
+- The 2026-08-21 timestamp amendment changed the text of "Version 0.2"
+  without a version bump: the header still reads 0.2, `okf_version: "0.2"`
+  still declares it, and the repository carries no tags. [observed:
+  `gh api repos/GoogleCloudPlatform/knowledge-catalog/tags` is empty; the
+  commit list for `okf/SPEC.md` is 2026-06-12, 2026-07-24 ×2, 2026-08-21]
+  So a bundle declaring 0.2 may follow either text, and a consumer cannot
+  tell which from the declaration.
+
+## Where this project departs from the subject
+
+Behaviour lines are [observed: `okf.py`, `_okf_write.py` on the working
+tree, 2026-09-06].
+
+- **Staleness is a date comparison, on the July text.** `derive_stale`
+  compares `stale_after` to the server-local date, stale when the date is
+  on or before today (#1357, the July rule). Against the August text it is
+  lenient where the spec asks for strictness: a bare date is honoured
+  rather than ignored; a `datetime` value is truncated to its date, so its
+  offset is discarded (`2026-09-24T00:30:00+02:00`, which is
+  2026-09-23T22:30Z, reads as not stale on the 23rd); and a *quoted*
+  ISO datetime string (`'2026-09-23T00:00:00Z'`), which the amended
+  reference agent would accept, fails `date.fromisoformat` and is treated
+  as absent. Decided in `docs/design/okf.md` § 3 for the date rule; the
+  instant rule is #1373, filed from this page.
+- **Write stamps are dates.** `apply_okf_write_stamp` and
+  `append_okf_verification` write `generated.at` and `verified[].at` as
+  `YYYY-MM-DD` (`today.isoformat()`), where both texts of v0.2 say "an ISO
+  8601 datetime" and the August text adds "with an explicit UTC offset".
+  #1372, filed from this page.
+- **`verified` is cleared on a content-changing write.** The spec keeps
+  `verified` "independent of `generated.at`: content can change without
+  re-confirmation"; the server's enforced write layer clears it so an
+  attestation cannot outlive the bytes it attested. Deliberate; decided in
+  `docs/design/okf.md` § 6.
+  [pins: tests/test_okf_write.py::TestInvalidationMatrix::test_body_write_clears_verified_and_stamps, tests/test_okf_write.py::TestInvalidationMatrix::test_rename_preserves_verified]
+- **Reserved files are exempt from the `type` rule in the audit and the
+  stats** (#1251, #962). The spec's conformance rule 2 applies to "every
+  frontmatter block", but reserved files carry none by §8, so exempting
+  them is the spec's own consequence rather than a departure.
+- **Ranking downweights** deprecated (×0.5), stale (×0.75) and reserved
+  (×0.5) notes when a bundle is detected. The spec keeps `status` and
+  staleness as advisory annotations and says nothing about ranking; trust
+  tiers are deliberately *not* boosted, matching "advisory signals, not
+  access control". Decided in `docs/design/okf.md` § 5.
+- **Wikilinks are reported, not rejected.** The audit lists notes that
+  contain wikilinks as informational, and `okf_convert_links` rewrites them
+  to root-relative markdown links at export; a bundle with wikilinks is
+  still served. The spec names only markdown links (§6.1) but does not
+  forbid other syntax.
+- **`okf_version` accepted values** are `0.1` and `0.2`; any other declared
+  version warns once and is still detected (§12's best-effort rule).
+
+## Not covered
+
+- Attested Computations (§10) and the `sources[]` credibility signals
+  (`usage_count`, `usage_window`): nothing here reads or writes them.
+- Whether `generated.at`, once written as a datetime, should carry the
+  server's local offset or UTC; the spec only requires an explicit offset.
+- The v0.1 fallbacks (`timestamp`, `# Citations`): the server neither reads
+  nor migrates them, and no test covers a v0.1 bundle.

--- a/docs/design/reference/okf-v0.2.md
+++ b/docs/design/reference/okf-v0.2.md
@@ -6,10 +6,10 @@ subject_version: "0.2 (spec commit 62432a09, 2026-08-21)"
 valid_for: "OKF 0.2 as amended 2026-08-21; re-research on any later commit to okf/SPEC.md or a 0.3 draft"
 generated:
   by: process:researching-references
-  at: 2026-09-06
+  at: 2026-09-06T21:59:57+02:00
 verified:
   - by: process:researching-references-refute
-    at: 2026-09-06
+    at: 2026-09-06T22:11:28+02:00
 stale_after: 2027-03-06
 status: stable
 sources:
@@ -242,6 +242,27 @@ tree, 2026-09-06].
   stats** (#1251, #962). The spec's conformance rule 2 applies to "every
   frontmatter block", but reserved files carry none by §8, so exempting
   them is the spec's own consequence rather than a departure.
+- **A generated reserved file carries frontmatter when the operator requires
+  it.** §8 allows frontmatter in an `index.md` only for the bundle root's
+  `okf_version`, and none in `log.md`. With `required_frontmatter`
+  configured, the server's own `index.md` / `log.md` generators
+  (`ReservedFrontmatterPolicy` in `okf.py`) seed the configured keys — the
+  title field with the file's title, any other as `null` — because a
+  generated file with no frontmatter would fail the same index gate the
+  server enforces and vanish from `search` and `list_documents` (#1174,
+  #1175). Existing keys, including the root `okf_version`, are preserved;
+  `okf_version` is never synthesised into a folder index. With nothing
+  required, the files are written body-only as §8 and §9 have them.
+  Deliberate; decided in `docs/design/okf.md`, "Generated reserved files
+  and the index gate".
+  [pins: tests/test_okf.py::TestReservedFrontmatterPolicy::test_title_field_is_seeded_with_the_derived_title, tests/test_okf.py::TestReservedFrontmatterPolicy::test_other_required_fields_are_seeded_as_null, tests/test_okf.py::TestReservedFrontmatterPolicy::test_existing_frontmatter_is_preserved_unconfigured]
+- **This bundle's own `stale_after` is a calendar date.** The
+  template-owned `scripts/check_references.py` requires
+  `stale_after` to be `YYYY-MM-DD` and reads `verified` only as a list, both
+  the July text's shape; the pages' `generated.at` / `verified[].at` are
+  offset datetimes as both texts require. Filed upstream as
+  pvliesdonk/fastmcp-server-template#603; the plugin digest #1357 followed
+  is pvliesdonk/claude-plugins#47.
 - **Ranking downweights** deprecated (×0.5), stale (×0.75) and reserved
   (×0.5) notes when a bundle is detected. The spec keeps `status` and
   staleness as advisory annotations and says nothing about ranking; trust

--- a/src/markdown_vault_mcp/_okf_convention.py
+++ b/src/markdown_vault_mcp/_okf_convention.py
@@ -1,5 +1,8 @@
 """OKF enforced-write convention maintenance (#964, design §6 phase 5b).
 
+The ``index.md`` / ``log.md`` shapes maintained here are the spec's §8 and §9,
+recorded in ``docs/design/reference/okf-v0.2.md``.
+
 After a successful enforced content write (``write`` / ``edit``), the server
 keeps the affected folder's reserved files current: it appends a dated bullet
 to that folder's ``log.md`` and refreshes its ``index.md`` listing. These are

--- a/src/markdown_vault_mcp/_okf_write.py
+++ b/src/markdown_vault_mcp/_okf_write.py
@@ -10,6 +10,10 @@ a contextvar: ``asyncio.to_thread`` copies the current context into its worker, 
 a value set around the ``to_thread`` call is visible to the enricher. This mirrors
 ``fastmcp_pvl_core``'s own ``_current_auth_mode`` contextvar.
 
+What the spec requires of the ``generated`` / ``verified`` stamps written here
+(actor convention, timestamp form) is in ``docs/design/reference/okf-v0.2.md``;
+the stamps' departure from it is #1372.
+
 Actor resolution rules (design §6):
 
 - ``human:<subject>`` when an authenticated subject is present.

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -1,7 +1,10 @@
 """OKF (Open Knowledge Format) support: detection and read-side annotations.
 
 OKF (`GoogleCloudPlatform/knowledge-catalog`, ``okf/SPEC.md``) is a bundle
-convention over markdown-with-frontmatter. This module implements phase 1 of
+convention over markdown-with-frontmatter. What the spec says — in both texts
+of "Version 0.2", since it was amended in place on 2026-08-21 — is recorded
+with sources and dates in ``docs/design/reference/okf-v0.2.md``; read it
+before changing a rule here. This module implements phase 1 of
 `docs/design/okf.md`: the vault-side detection probe (``okf_version`` declared
 in the bundle-root ``index.md``) and the pure derivation of per-note read
 annotations (``type`` / ``status`` / staleness / trust tier).

--- a/src/markdown_vault_mcp/okf_bundle.py
+++ b/src/markdown_vault_mcp/okf_bundle.py
@@ -1,5 +1,8 @@
 """OKF bundle export (#963): build a conformant bundle zip from live vault state.
 
+"Conformant" is the spec's §11, recorded with the link and reserved-file rules
+in ``docs/design/reference/okf-v0.2.md``.
+
 Phase 4 of ``docs/design/okf.md`` §7, and the export half of the migration
 story that :mod:`markdown_vault_mcp.managers.okf_migrate` began. The build
 **never mutates the vault**: it reads the notes and attachments in scope,

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -91,12 +91,15 @@ class TestApplyOkfWriteStamp:
             "sources:\n"
             "  - resource: https://example.com/a\n"
             "    id: a\n"
+            "x_custom: 1\n"
             "---\n"
             "# P\n"
         )
         meta = fm.loads(apply_okf_write_stamp(text, actor="t/1", today=_TODAY)).metadata
         assert meta["type"] == "Playbook"
         assert meta["sources"] == [{"resource": "https://example.com/a", "id": "a"}]
+        # A producer-defined key survives the round trip (OKF v0.2 §4.1).
+        assert meta["x_custom"] == 1
 
     def test_same_actor_same_day_re_stamp_is_idempotent(self) -> None:
         # Once a note carries this exact actor/date stamp and no verified,


### PR DESCRIPTION
## Closes / Refs

Refs #1357 (Codex's P1 on #1371: the fix changed runtime semantics on the OKF spec's word with no reference page behind it). Refs #1372, #1373 — the two observations this page surfaced, filed from it.

## What & why

AGENTS.md: "A bug rooted in an external behaviour closes with a reference entry, not only a design-doc narrative." #1357 closed on a *digest* of the spec (the open-knowledge-format plugin's field reference), and `docs/design/reference/` had no OKF page. This adds `okf-v0.2.md` under the `researching-references` skill: claims from the spec itself (`okf/SPEC.md`, commit `62432a09`), every quote at its section, pins to the tests that honour each claim, and the departures.

**What the spec turned out to say.** The document still calls itself "Version 0.2", but its maintainer amended it in place on 2026-08-21 (knowledge-catalog PR #323): "Every timestamp-valued key in OKF is an ISO 8601 datetime with an explicit UTC offset", and `stale_after` is "an absolute instant. A concept is stale when `now >= stale_after`" — where the July text (the one the digest and #1357 follow) said "an absolute date (`YYYY-MM-DD`)" and `today >= stale_after`. The repository carries no tags, so a bundle declaring `0.2` may follow either text. The page records both, and the amendment's own rationale (a bare date "names a different instant in every timezone"; consumers "are expected to be strict rather than lenient about a value that arrives without an offset").

**Departures recorded, two of them new:**
- Staleness is compared as a date (July rule); against the August text a quoted conformant instant is silently ignored and an offset is discarded → **#1373**.
- Write stamps (`generated.at`, `verified[].at`) are bare dates; both texts say "an ISO 8601 datetime" → **#1372**.
- Deliberate and already decided in `docs/design/okf.md`: `verified` cleared on content writes; ranking downweights; wikilinks reported not rejected; reserved files exempt from the `type` audit.

**Bundle hygiene.** The plugin's own `validate_okf.py` reported the reference bundle NOT conformant on `main`: the root `index.md` carried `title`/`description`, which §8 forbids ("index files contain no frontmatter, with one exception: … `okf_version`"). Trimmed; the bundle now validates (0 errors). `check_references.py` and `tests/test_reference_docs.py` read only `okf_version` from it.

Pointers added from `okf.py`, `_okf_write.py`, `_okf_convention.py`, `okf_bundle.py`, `docs/design/okf.md` and `design.md`'s OKF section; `index.md` and `log.md` entries.

## Self-review 2fcfa994..dcbbf06c

Charters: the skill's refute pass (every `[source:]` quote re-found at its section in the fetched sources, every `[observed:]` re-run, every `[pins:]` test body read, every departure line re-executed against HEAD), plus rules, comments, history. Coverage: full; the refute pass ran as an independent read-only agent, which is the point of it.

- `okf-v0.2.md` preamble — blocker/verified — "early-stage" and "a starting point" were attributed to the spec; neither phrase is in it (the second is from the v0.1 announcement blog, and I had it from the plugin skill's description — the secondary-source trap the skill names). Replaced with §1/§12 wording that is verbatim. Resolved in `dcbbf06c`.
- §13 claim — important/verified — "everything else is carried forward unchanged" dropped the spec's own scoping parenthetical and read as if v0.1 already had the trust/lifecycle families. Rewritten from §13.2. Resolved.
- `[pins:]` on the unknown-keys claim — important/verified — the pinned test asserted only spec-defined keys survive; it now writes and asserts an arbitrary `x_custom` key. Resolved.
- `sources` claim — minor — `resource` is REQUIRED within an entry; now said. The footnote-label half is marked as not depended on. Resolved.
- Module pointers were on `okf.py` only; added to the three other depending modules. Resolved.
- 21 other pinned tests read and confirmed to assert their claim; all remaining quotes verbatim; July/August attribution confirmed by diffing the two commits (the three §5 lines are the only change).

## Review round 1 (Codex P2 ×2, Claude clean), resolved in `27991a86`

- **The page's own stamps were bare dates** while documenting the datetime rule. Swept as the class: every page in the bundle had them, because the template-owned skill's `reference-template.md` prescribes `at: <YYYY-MM-DD>`. All six pages now carry the author instant of their research/refute commit as `generated.at` / `verified[].at`. `stale_after` deliberately stays a calendar date: the template-owned `check_references.py` rejects a datetime there and reads `verified` only as a list — filed upstream as pvliesdonk/fastmcp-server-template#603 and recorded on the page as the bundle's own departure. The plugin digest #1357 followed is stale for the same reason: pvliesdonk/claude-plugins#47.
- **Reserved-frontmatter exception** (`ReservedFrontmatterPolicy`, #1174/#1175): recorded as a deliberate departure from §8/§9 with the decision pointer and three pins.
- Claude's readability nit on the `index.md` bullet order: left as is (the list is grouped by module, not alphabetical); not worth a diff line.

## Verification

`scripts/check_references.py` exit 0 (28 source, 3 observed, 1 unverified, 16 pins); plugin `validate_okf.py docs/design/reference` conformant; `tests/test_reference_docs.py` 2 passed; OKF tests 177 passed; ruff, mypy, pre-commit, structural gate 100%, `mkdocs build --strict` 0.
