### PR TITLE
fix(okf): stale_after as an instant with an offset, the bare date kept

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1383,7 +1383,9 @@ the spec itself says, dated and sourced, in
   `_server_tools/_common.py` mirroring `attach_conventions`): when active,
   `search` hits, whole-document `read`s, and `get_context` carry an `okf`
   key — `type` (when declared), `status` (absent ⇒ `stable` per spec),
-  `stale` (today on or after `stale_after`, server-local date), and
+  `stale` (a bare `stale_after` date: the server-local day has reached it;
+  an instant with an offset: `now >= stale_after`; an offset-less datetime
+  is ignored — #1357, #1373), and
   `trust_tier` (`human-reviewed` if any `verified[].by` has the `human:`
   prefix, else `machine-confirmed` if `verified` is non-empty, else
   `unverified`; a bare `verified` mapping is a one-element list, as the

--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -64,7 +64,8 @@ metadata but attaches no meaning to `type`, `status`, `stale_after`, `sources`,
   Actor convention `human:<id>` / `process:<id>` / `<tool>/<version>`.
   Derived tiers: **unverified → machine-confirmed → human-reviewed**.
 - **Lifecycle:** `status: draft|stable|deprecated` (default `stable`),
-  `stale_after: YYYY-MM-DD`.
+  `stale_after`: a `YYYY-MM-DD` date (the July 2026 text) or an ISO 8601
+  instant with an offset (the text since 2026-08-21).
 - **Bundle marker:** `okf_version: "0.2"` allowed only in the bundle-root
   `index.md` frontmatter.
 - **Reserved files:** `index.md` (progressive-disclosure directory listing)
@@ -158,9 +159,14 @@ server's ranking math — layer 1 surfaces signal and lets the agent judge.
 **Computed per-note properties** (derived at annotation time from the stored
 frontmatter blob; not persisted):
 
-- `staleness`: `stale` iff today ≥ `stale_after` (the spec's rule, date-only
-  comparison, server-local date — the named date is the first stale day,
-  #1357); absent field → not stale.
+- `staleness`: both texts of v0.2 honoured (#1357, #1373). A bare date is
+  stale from that server-local day on (the named date is the first stale
+  day); an instant with an offset is stale when `now >= stale_after`,
+  compared as instants; a datetime *without* an offset is allowed by neither
+  text and is ignored (treated as absent), as the 2026-08-21 amendment
+  asks; absent field → not stale. Accepting the bare date is a deliberate
+  lenience against the amended text's "ignore" — Obsidian authors write
+  dates, and the upstream issue behind the amendment is still open.
 - `trust_tier`: `human-reviewed` if any `verified[].by` has the `human:`
   prefix; else `machine-confirmed` if `verified` is non-empty (all
   verifiers non-human); else `unverified`. A bare `verified` mapping is
@@ -529,8 +535,9 @@ phase owns.
 - Trust-tier edge cases: `verified` entries by `process:` actors only —
   v0.2 tier language suggests machine-confirmed; confirm against SPEC.md
   examples before freezing the table.
-- `stale_after` timezone semantics (spec gives date only) — proposal:
-  server-local date, documented.
+- ~~`stale_after` timezone semantics~~ — settled by the spec's 2026-08-21
+  amendment and #1373: the value carries its own offset; a bare date is the
+  server-local day.
 - Whether `okf_export` should optionally include a generated bundle-root
   `index.md` when absent (spec allows synthesized indexes) — lean yes.
 - Community governance ("W3C Holon CG" / "DataBook" profile) is

--- a/docs/design/reference/log.md
+++ b/docs/design/reference/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-09-07
 
+- `okf-v0.2.md`: the staleness departure rewritten for #1373 — an instant with an offset is now compared as one, the bare date stays as a recorded lenience, an offset-less datetime is ignored; the August `stale_after` claim gains its pin.
 - Every page's `generated.at` and `verified[].at` rewritten from a bare date to the author instant of the commit that did the research or the refute (Codex on #1374: the OKF page documented the datetime rule and stamped itself with a date, as the template-owned skill's own template prescribes). `stale_after` stays a calendar date because `scripts/check_references.py` requires one; both raised upstream as fastmcp-server-template#603; the plugin's stale digest as claude-plugins#47. `okf-v0.2.md` gains the reserved-frontmatter departure (`ReservedFrontmatterPolicy`, #1174/#1175) and the bundle's own `stale_after` shape.
 
 ## 2026-09-06

--- a/docs/design/reference/okf-v0.2.md
+++ b/docs/design/reference/okf-v0.2.md
@@ -146,6 +146,7 @@ months, not twelve.
   `2026-06-30T14:00:00Z`", stated once in the §5 preamble; `stale_after` is
   "an absolute instant. A concept is stale when `now >= stale_after`".
   [source: spec] (§5, §5.5)
+  [pins: tests/test_okf.py::test_derive_stale]
 - The amendment's reason: a bare date "names a different instant in every
   timezone, so the same bundle can be stale in one office and fresh in
   another" (filed upstream as issue #242, still open). "Consumers are
@@ -216,17 +217,16 @@ months, not twelve.
 Behaviour lines are [observed: `okf.py`, `_okf_write.py` on the working
 tree, 2026-09-06].
 
-- **Staleness is a date comparison, on the July text.** `derive_stale`
-  compares `stale_after` to the server-local date, stale when the date is
-  on or before today (#1357, the July rule). Against the August text it is
-  lenient where the spec asks for strictness: a bare date is honoured
-  rather than ignored; a `datetime` value is truncated to its date, so its
-  offset is discarded (`2026-09-24T00:30:00+02:00`, which is
-  2026-09-23T22:30Z, reads as not stale on the 23rd); and a *quoted*
-  ISO datetime string (`'2026-09-23T00:00:00Z'`), which the amended
-  reference agent would accept, fails `date.fromisoformat` and is treated
-  as absent. Decided in `docs/design/okf.md` § 3 for the date rule; the
-  instant rule is #1373, filed from this page.
+- **Both texts' `stale_after` forms are honoured, and the bare date is
+  kept.** `derive_stale` compares an instant with an offset as an instant
+  (`now >= stale_after`, the August rule) and a bare date against the
+  server-local calendar day (the July rule, #1357). Against the August
+  text this is lenient on purpose: the amendment says to ignore an
+  offset-less value, but a bare date is what the July text prescribed and
+  what an Obsidian author writes, and upstream #242 is still open. A
+  datetime *without* an offset — allowed by neither text — is ignored.
+  Decided in `docs/design/okf.md` § 3 (#1373).
+  [pins: tests/test_okf.py::test_derive_stale, tests/test_okf.py::test_derive_stale_bare_date_uses_the_server_local_day]
 - **Write stamps are dates.** `apply_okf_write_stamp` and
   `append_okf_verification` write `generated.at` and `verified[].at` as
   `YYYY-MM-DD` (`today.isoformat()`), where both texts of v0.2 say "an ISO

--- a/docs/design/reference/okf-v0.2.md
+++ b/docs/design/reference/okf-v0.2.md
@@ -215,7 +215,7 @@ months, not twelve.
 ## Where this project departs from the subject
 
 Behaviour lines are [observed: `okf.py`, `_okf_write.py` on the working
-tree, 2026-09-06].
+tree, 2026-09-07].
 
 - **Both texts' `stale_after` forms are honoured, and the bare date is
   kept.** `derive_stale` compares an instant with an offset as an instant

--- a/docs/guides/okf.md
+++ b/docs/guides/okf.md
@@ -34,7 +34,7 @@ Check the current state at any time through the `okf` section of the `stats` too
 On a recognised bundle, the server reads a few OKF frontmatter families and surfaces them in `search`, `read`, and `get_context` results under an `okf` key:
 
 - **Type**: the free-text `type` field, such as `Playbook`, `Metric`, or `Reference`.
-- **Lifecycle**: `status` is one of `draft`, `stable`, or `deprecated`. A note with no `status` is treated as `stable`. `stale_after: YYYY-MM-DD` marks a note stale from that date on.
+- **Lifecycle**: `status` is one of `draft`, `stable`, or `deprecated`. A note with no `status` is treated as `stable`. `stale_after` marks a note stale from a date on (`2026-12-31`) or from an instant on (`2026-12-31T00:00:00Z`; the offset is required).
 - **Trust tier**: derived from the `verified` list (a single entry may be written as a bare mapping, per the spec). A note verified by a person (`by: human:...`) is `human-reviewed`; a note verified only by a process is `machine-confirmed`; an unverified note is `unverified`.
 - **Sources**: the `sources` provenance list, surfaced in full on `read` and as a count on search hits.
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -369,7 +369,16 @@ such a note replaced that mapping with its own entry, so the earlier
 attestation was lost. The `stale` flag, the `stale` filter, the `stats`
 stale count and ranking now turn stale on the named date; the trust tier,
 the `okf_verify` append and its `verified_count` all read a bare mapping as
-one entry.
+one entry. The spec itself moved while this was being fixed: on 2026-08-21
+its maintainer amended "Version 0.2" in place so that `stale_after` is
+"an absolute instant" with an offset, "stale when `now >= stale_after`"
+([#1373](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1373)).
+Both spellings now work: a bare date (`2026-12-31`) is stale from that
+server-local day on, and an instant (`2026-12-31T00:00:00Z`, the quoted
+form included) is stale from that moment on, with its offset respected. A
+time without an offset is allowed by neither text and is ignored. What the
+spec says in each of its texts, with sources, is recorded in
+`docs/design/reference/okf-v0.2.md`.
 
 **A link with any URI scheme is external.** The external-link filter was an
 allowlist of four prefixes, so a `file:`, `ftp:`, `obsidian:` or `zotero:`
@@ -553,12 +562,16 @@ on your part:
   `INDEX_SEMANTICS_VERSION` moved from 2 to 7. One rebuild covers all
   five; it is automatic, costs CPU and local IO proportional to vault size,
   and does not re-embed.
-- **A note becomes stale one day earlier.** `stale_after` is now the first
-  stale day rather than the last current one
+- **A note becomes stale one day earlier, and an instant is honoured.**
+  `stale_after` is now the first stale day rather than the last current
+  one
   ([#1357](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1357)),
-  so a note dated today flips to `stale: true` on upgrade; triage listings
-  built with `{"stale": "true"}` may gain an entry. No stored rows change,
-  so no rebuild.
+  so a note dated today flips to `stale: true` on upgrade; a note whose
+  `stale_after` was a quoted instant (`'2026-01-01T00:00:00Z'`), which the
+  server used to ignore, is now stale when that instant has passed
+  ([#1373](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1373)).
+  Triage listings built with `{"stale": "true"}` may gain entries. No
+  stored rows change, so no rebuild.
 - **A Voyage vault also re-embeds once**, through a separate mechanism
   with a separate trigger: the provider's embedding behavior is part of the
   vector sidecar's identity, and asymmetric embedding changed it

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -570,8 +570,10 @@ on your part:
   `stale_after` was a quoted instant (`'2026-01-01T00:00:00Z'`), which the
   server used to ignore, is now stale when that instant has passed
   ([#1373](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1373)).
-  Triage listings built with `{"stale": "true"}` may gain entries. No
-  stored rows change, so no rebuild.
+  Triage listings built with `{"stale": "true"}` may gain entries, and
+  may lose one for a note whose `stale_after` carried a time but no
+  offset (previously read as its date, now ignored). No stored rows
+  change, so no rebuild.
 - **A Voyage vault also re-embeds once**, through a separate mechanism
   with a separate trigger: the provider's embedding behavior is part of the
   vector sidecar's identity, and asymmetric embedding changed it

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -254,46 +254,83 @@ def derive_trust_tier(metadata: dict[str, Any]) -> str:
     return TRUST_UNVERIFIED
 
 
-def derive_stale(metadata: dict[str, Any], *, today: _dt.date) -> bool:
-    """Derive staleness from ``stale_after`` (date-only comparison).
+_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
-    The field reference's rule: "Stale when ``today >= stale_after``", so
-    the date named is the first stale day (#1357).
+
+def _aware_or_none(value: _dt.datetime, raw: Any) -> _dt.datetime | None:
+    """Keep an instant that carries an offset; drop one that does not."""
+    if value.tzinfo is None:
+        logger.debug("okf_stale_after_naive value=%r", raw)
+        return None
+    return value
+
+
+def _parse_stale_after(raw: Any) -> _dt.date | _dt.datetime | None:
+    """Read a ``stale_after`` value into the shape its text of v0.2 gives it.
+
+    Returns a ``date`` for the July text's calendar-day form, an aware
+    ``datetime`` for the August text's instant form, and ``None`` for
+    anything else — including a datetime without an offset, which neither
+    text allows and the amendment says to ignore (#1373).
+    """
+    if isinstance(raw, _dt.datetime):
+        return _aware_or_none(raw, raw)
+    if isinstance(raw, _dt.date):
+        return raw
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    try:
+        parsed = (
+            _dt.date.fromisoformat(text)
+            if _DATE_ONLY_RE.match(text)
+            else _dt.datetime.fromisoformat(text)
+        )
+    except ValueError:
+        logger.debug("okf_stale_after_invalid value=%r", raw)
+        return None
+    return _aware_or_none(parsed, raw) if isinstance(parsed, _dt.datetime) else parsed
+
+
+def derive_stale(metadata: dict[str, Any], *, now: _dt.datetime) -> bool:
+    """Derive staleness from ``stale_after``.
+
+    Both texts of OKF v0.2 are honoured (``docs/design/reference/okf-v0.2.md``,
+    "Lifecycle"): a calendar date is stale from that day on, judged by the
+    server-local day of *now* (the July rule, #1357); an instant with an
+    offset is stale when ``now >= stale_after`` (the August rule, #1373). A
+    datetime without an offset is ignored, as the amendment asks.
 
     Args:
         metadata: The note's frontmatter dict. ``stale_after`` may be a
-            ``date`` (YAML parses bare ISO dates) or a ``YYYY-MM-DD``
-            string; anything else is treated as absent.
-        today: The server-local date to compare against.
+            ``date`` or ``datetime`` (YAML parses bare timestamps) or their
+            ISO 8601 string spellings; anything else is treated as absent.
+        now: The current instant, timezone-aware. Its local calendar day is
+            what a bare date is compared against.
 
     Returns:
-        ``True`` iff ``stale_after`` parses and is on or before *today*.
+        ``True`` iff ``stale_after`` parses and *now* has reached it.
     """
-    raw = metadata.get("stale_after")
-    if isinstance(raw, _dt.datetime):
-        raw = raw.date()
-    if isinstance(raw, _dt.date):
-        return raw <= today
-    if isinstance(raw, str):
-        try:
-            return _dt.date.fromisoformat(raw.strip()) <= today
-        except ValueError:
-            logger.debug("okf_stale_after_invalid value=%r", raw)
-            return False
-    return False
+    boundary = _parse_stale_after(metadata.get("stale_after"))
+    if boundary is None:
+        return False
+    if isinstance(boundary, _dt.datetime):
+        return now >= boundary
+    return now.date() >= boundary
 
 
 def derive_annotation(
     metadata: dict[str, Any],
     *,
-    today: _dt.date | None = None,
+    now: _dt.datetime | None = None,
     include_sources: bool = False,
 ) -> dict[str, Any]:
     """Derive the ``okf`` read-annotation payload for one note.
 
     Args:
         metadata: The note's frontmatter dict (may be empty).
-        today: Server-local date for staleness; defaults to today.
+        now: The current instant for staleness, timezone-aware; defaults to
+            the server's local now.
         include_sources: When true (``read`` payloads), include the raw
             ``sources`` list; otherwise (search hits) include only
             ``sources_count``, and only when non-zero.
@@ -303,7 +340,7 @@ def derive_annotation(
         ``stale``, and ``trust_tier`` always; ``type`` only when present
         and non-empty; sources per *include_sources*.
     """
-    today = today or _dt.date.today()
+    now = now or _dt.datetime.now().astimezone()
     annotation: dict[str, Any] = {}
     note_type = metadata.get("type")
     if isinstance(note_type, str) and note_type.strip():
@@ -314,7 +351,7 @@ def derive_annotation(
         if isinstance(status, str) and status.strip()
         else OKF_STATUS_DEFAULT
     )
-    annotation["stale"] = derive_stale(metadata, today=today)
+    annotation["stale"] = derive_stale(metadata, now=now)
     annotation["trust_tier"] = derive_trust_tier(metadata)
     sources = metadata.get("sources")
     source_list = sources if isinstance(sources, list) else []
@@ -376,7 +413,7 @@ def matches_okf_filters(
     metadata: dict[str, Any],
     okf_filters: dict[str, str],
     *,
-    today: _dt.date | None = None,
+    now: _dt.datetime | None = None,
 ) -> bool:
     """Evaluate the OKF filter dimensions against one note's frontmatter.
 
@@ -389,7 +426,8 @@ def matches_okf_filters(
         metadata: The note's frontmatter dict (may be empty).
         okf_filters: The OKF-dimension subset of a ``filters`` dict —
             keys from :data:`OKF_FILTER_KEYS` only.
-        today: Server-local date for staleness; defaults to today.
+        now: The current instant for staleness, timezone-aware; defaults to
+            the server's local now.
 
     Returns:
         ``True`` when every given dimension matches.
@@ -397,7 +435,7 @@ def matches_okf_filters(
     Raises:
         ValueError: If a ``stale`` value is not a true/false spelling.
     """
-    annotation = derive_annotation(metadata, today=today)
+    annotation = derive_annotation(metadata, now=now)
     for key, value in okf_filters.items():
         if key == "stale":
             if annotation["stale"] is not parse_stale_filter(value):

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -26,6 +26,8 @@ from markdown_vault_mcp.okf import (
 )
 
 TODAY = dt.date(2026, 8, 7)
+#: The instant the staleness tests run at: 10:00 in a +02:00 zone on TODAY.
+NOW = dt.datetime(2026, 8, 7, 10, 0, tzinfo=dt.timezone(dt.timedelta(hours=2)))
 
 
 def _write_root_index(vault: Path, text: str) -> None:
@@ -168,20 +170,44 @@ def test_derive_trust_tier(metadata: dict, expected: str) -> None:
         ({"stale_after": dt.date(2026, 8, 8)}, False),
         ({"stale_after": "2026-08-07"}, True),
         ({"stale_after": dt.date(2027, 1, 1)}, False),
-        ({"stale_after": dt.datetime(2026, 1, 1, 12, 0)}, True),
         ({"stale_after": "2026-01-01"}, True),
         ({"stale_after": " 2026-01-01 "}, True),
         ({"stale_after": "not-a-date"}, False),
         ({"stale_after": 20260101}, False),
+        # An instant with an offset is compared as one (OKF v0.2 as amended
+        # 2026-08-21: "stale when now >= stale_after"; #1373). NOW is
+        # 2026-08-07T08:00:00Z.
+        ({"stale_after": dt.datetime(2026, 8, 7, 8, 0, tzinfo=dt.UTC)}, True),
+        ({"stale_after": dt.datetime(2026, 8, 7, 8, 1, tzinfo=dt.UTC)}, False),
+        ({"stale_after": "2026-08-07T08:00:00Z"}, True),
+        ({"stale_after": "2026-08-07T08:00:01Z"}, False),
+        ({"stale_after": "2026-08-07T10:00:00+02:00"}, True),
+        ({"stale_after": "2026-08-08T00:30:00+02:00"}, False),
+        # The offset decides, not the calendar day: 2026-08-07T02:00-08:00 is
+        # 10:00Z, two hours after NOW.
+        ({"stale_after": "2026-08-07T02:00:00-08:00"}, False),
+        # A time with no offset is allowed by neither text of v0.2 and the
+        # amendment says to ignore such a value: treated as absent.
+        ({"stale_after": dt.datetime(2026, 1, 1, 12, 0)}, False),
+        ({"stale_after": "2026-01-01T12:00:00"}, False),
     ],
 )
 def test_derive_stale(metadata: dict, expected: bool) -> None:
-    assert derive_stale(metadata, today=TODAY) is expected
+    assert derive_stale(metadata, now=NOW) is expected
+
+
+def test_derive_stale_bare_date_uses_the_server_local_day() -> None:
+    """A bare date is judged against now's local calendar day, not UTC's."""
+    # 2026-08-08T00:30 at +02:00 is still 2026-08-07 in UTC; the bare date
+    # 2026-08-08 is stale there because the server's day has turned.
+    now = dt.datetime(2026, 8, 8, 0, 30, tzinfo=dt.timezone(dt.timedelta(hours=2)))
+    assert derive_stale({"stale_after": dt.date(2026, 8, 8)}, now=now) is True
+    assert derive_stale({"stale_after": dt.date(2026, 8, 9)}, now=now) is False
 
 
 class TestDeriveAnnotation:
     def test_empty_metadata_defaults(self) -> None:
-        annotation = derive_annotation({}, today=TODAY)
+        annotation = derive_annotation({}, now=NOW)
         assert annotation == {
             "status": OKF_STATUS_DEFAULT,
             "stale": False,
@@ -196,7 +222,7 @@ class TestDeriveAnnotation:
                 "stale_after": "2020-01-01",
                 "verified": [{"by": "human:peter"}],
             },
-            today=TODAY,
+            now=NOW,
         )
         assert annotation == {
             "type": "Playbook",
@@ -206,21 +232,21 @@ class TestDeriveAnnotation:
         }
 
     def test_unknown_status_passes_through(self) -> None:
-        annotation = derive_annotation({"status": "archived"}, today=TODAY)
+        annotation = derive_annotation({"status": "archived"}, now=NOW)
         assert annotation["status"] == "archived"
 
     def test_non_string_type_omitted(self) -> None:
-        annotation = derive_annotation({"type": 5}, today=TODAY)
+        annotation = derive_annotation({"type": 5}, now=NOW)
         assert "type" not in annotation
 
     def test_blank_status_defaults(self) -> None:
-        annotation = derive_annotation({"status": "  "}, today=TODAY)
+        annotation = derive_annotation({"status": "  "}, now=NOW)
         assert annotation["status"] == OKF_STATUS_DEFAULT
 
     def test_search_mode_counts_sources(self) -> None:
         annotation = derive_annotation(
             {"sources": [{"resource": "https://a"}, {"resource": "https://b"}]},
-            today=TODAY,
+            now=NOW,
         )
         assert annotation["sources_count"] == 2
         assert "sources" not in annotation
@@ -228,14 +254,14 @@ class TestDeriveAnnotation:
     def test_read_mode_includes_sources(self) -> None:
         sources = [{"resource": "https://a", "id": "a"}]
         annotation = derive_annotation(
-            {"sources": sources}, today=TODAY, include_sources=True
+            {"sources": sources}, now=NOW, include_sources=True
         )
         assert annotation["sources"] == sources
         assert "sources_count" not in annotation
 
     def test_empty_or_malformed_sources_omitted(self) -> None:
         for metadata in ({"sources": []}, {"sources": "https://a"}):
-            annotation = derive_annotation(metadata, today=TODAY, include_sources=True)
+            annotation = derive_annotation(metadata, now=NOW, include_sources=True)
             assert "sources" not in annotation
             assert "sources_count" not in annotation
 
@@ -361,7 +387,7 @@ def test_matches_okf_filters(
 ) -> None:
     from markdown_vault_mcp.okf import matches_okf_filters
 
-    assert matches_okf_filters(metadata, okf_filters, today=TODAY) is expected
+    assert matches_okf_filters(metadata, okf_filters, now=NOW) is expected
 
 
 PLAYBOOK_NOTE = """---


### PR DESCRIPTION
## Closes / Refs

Closes #1373. Refs #1357 (the date-boundary fix this extends), #1372 (the write side, next PR), the reference page `docs/design/reference/okf-v0.2.md` (#1374).

## What & why

OKF v0.2 was amended in place on 2026-08-21: `stale_after` is "an absolute instant … stale when `now >= stale_after`", with an explicit offset, and the amendment asks consumers to ignore an offset-less value. #1357 had aligned the reader with the *July* text (a date, `today >= stale_after`), and a spec-conformant quoted instant (`'2026-01-01T00:00:00Z'`) was silently not stale.

**Decision (on the issue):** honour both texts, strict only where neither allows the value.

| `stale_after` | rule |
|---|---|
| bare date (YAML date or `YYYY-MM-DD` string) | stale from that server-local day on — the July rule, kept deliberately (Obsidian authors write dates; upstream #242 is still open) |
| instant with an offset (YAML timestamp, or a quoted ISO string, `Z` included) | stale when `now >= stale_after`, compared as instants |
| datetime without an offset | ignored, one debug line — allowed by neither text |

`derive_stale` takes an aware `now` instead of a date; `derive_annotation` / `matches_okf_filters` take `now` (no external caller passed `today`). No `INDEX_SEMANTICS_VERSION` bump: derived at annotation time. `docs/design/okf.md` § 10's open "timezone semantics" question closes with this.

## Conformance (executed by the review, `now = 2026-08-07T10:00+02:00` = 08:00Z)

| input | stale |
|---|---|
| `date(2026,8,7)` / `"2026-08-07"` / `date(2026,8,8)` | true / true / false |
| `"2026-08-07T08:00:00Z"` / `"…08:00:01Z"` | true / false |
| `"2026-08-07T02:00:00-08:00"` (= 10:00Z, later than now) | false — the offset decides, not the calendar day |
| `"2026-08-07 08:00:00Z"` (space separator, what PyYAML re-dumps) | true |
| `"2026-08-07T08:00:00"` / naive `datetime` | false (ignored) |
| PyYAML `stale_after: 2026-08-07T08:00:00Z` → aware `datetime` | true |

## What this PR deliberately does NOT do

- Write stamps as datetimes: #1372, next.
- Flag an offset-less datetime in `okf_validate`: it is ignored with a debug line; a finding type is not in this issue.
- Change the bundle's own reference pages, whose `stale_after` stays a calendar date because the template-owned checker requires one (fastmcp-server-template#603).

## Self-review 23d97ede..12e323d7

Charters: rules (incl. the logging standard for the two `logger.debug` lines), diff, comments, history, conformance (the matrix above, plus a YAML round trip and a JSON index round trip proving the SQL-backed stats/filter path agrees with the live path). Coverage: full; one read-only agent, the diff charter walked by me as well.

- `okf.py` `_parse_stale_after` — structural gate — eight returns; the offset check split into `_aware_or_none`. Resolved before the first push.
- `docs/releases/4.2.md` upgrade bullet — minor — said listings "may gain entries" but not that a note with an offset-less datetime (previously truncated to its date) now loses `stale: true`. Resolved in `12e323d7`.
- Reference page observation stamp still `2026-09-06` under a bullet describing today's code. Resolved in `12e323d7`.
- Recorded intent: #1371's three boundary cases survive verbatim; the one removed case (naive datetime → stale) is the deliberate flip. `20260101` / `2026-W32-5` strings, which 3.11's relaxed `date.fromisoformat` used to accept by accident, are now ignored — the decision scopes the string form to `YYYY-MM-DD`.

## Verification

- TDD: the extended parametrisation failed first (signature, then eight value rows).
- `uv run pytest --cov`: 4536 passed, 3 skipped; `okf.py` 100%.
- ruff, mypy (232 files), pre-commit `--all-files` (Vale), structural gate 100%, `mkdocs build --strict` 0, `check_references.py` 0.
