### PR TITLE
fix(okf): stamp generated.at and verified[].at as UTC instants

### DIFF
--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -363,7 +363,11 @@ and none of it is implied by vault declaration.
   OKF consumers should calibrate to that.
 - **Convention maintenance:** on successful writes, append a `log.md` entry
   (newest-first, `## YYYY-MM-DD` section, `**Update**:`-style bullet) and
-  refresh the affected folder's `index.md` listing. Both are guaranteed
+  refresh the affected folder's `index.md` listing. The section heading is
+  the server's *local* calendar day, as §9 has it and as a reader of the
+  log expects, while the same write's `generated.at` is a UTC instant
+  (#1372); around local midnight the two can name different days, which is
+  the two rules stating what they each mean, not a defect. Both are guaranteed
   versions of what the advisory layer asks the agent to do. Generated
   `index.md` content derives from the same data as `get_toc`.
   **Status:** shipped in phase 5b (see §9). Maintenance runs only for

--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -315,7 +315,9 @@ Everything here changes bytes or write outcomes; all of it is operator-gated
 and none of it is implied by vault declaration.
 
 - **Provenance stamping:** writes through `write`/`edit` set/update
-  `generated: {by, at}`. Actor string: authenticated identity when available
+  `generated: {by, at}`, `at` the UTC instant of the write in the spec's
+  example form (`2026-06-30T14:00:00Z`, a string; #1372). Actor string:
+  authenticated identity when available
   (`human:<subject>` via the existing access-token dependency), else
   `markdown-vault-mcp/<version>` as a tool actor. Existing `generated`
   values are overwritten (it describes the current bytes); `sources` are
@@ -326,7 +328,7 @@ and none of it is implied by vault declaration.
   body also invalidate (the spec ties verification to the concept, not the
   body alone); rename does not. This is the highest-value enforcement:
   it is exactly the invariant an advisory-only setup eventually misses.
-- **`okf_verify` tool:** appends `{by: human:<subject>, at}` to `verified`,
+- **`okf_verify` tool:** appends `{by: human:<subject>, at}` (`at` a UTC instant, #1372) to `verified`,
   promoting the note's tier. `destructiveHint=False`, `idempotentHint=False`.
 
   The authenticated subject is *whose token* is in play, not evidence that a

--- a/docs/design/reference/log.md
+++ b/docs/design/reference/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-09-07
 
+- `okf-v0.2.md`: the write-stamp departure removed for #1372 — `generated.at` and `verified[].at` are now UTC instants in the spec's example form, written as strings; the `generated`/`verified` claims gain their pins and the open offset question closes.
 - `okf-v0.2.md`: the staleness departure rewritten for #1373 — an instant with an offset is now compared as one, the bare date stays as a recorded lenience, an offset-less datetime is ignored; the August `stale_after` claim gains its pin.
 - Every page's `generated.at` and `verified[].at` rewritten from a bare date to the author instant of the commit that did the research or the refute (Codex on #1374: the OKF page documented the datetime rule and stamped itself with a date, as the template-owned skill's own template prescribes). `stale_after` stays a calendar date because `scripts/check_references.py` requires one; both raised upstream as fastmcp-server-template#603; the plugin's stale digest as claude-plugins#47. `okf-v0.2.md` gains the reserved-frontmatter departure (`ReservedFrontmatterPolicy`, #1174/#1175) and the bundle's own `stale_after` shape.
 

--- a/docs/design/reference/okf-v0.2.md
+++ b/docs/design/reference/okf-v0.2.md
@@ -108,10 +108,12 @@ months, not twelve.
   `generated.by` is required within `generated` and is an actor;
   `generated.at` is "an ISO 8601 datetime marking the content's last
   meaningful change". [source: spec] (§5.2) [source: spec-july] (§5.2)
+  [pins: tests/test_okf_write.py::TestApplyOkfWriteStamp::test_stamps_generated_on_a_note_without_frontmatter, tests/test_okf_write.py::TestApplyOkfWriteStamp::test_a_local_offset_instant_is_written_as_utc]
 - `verified` is "a list of verification events, each with `by` (an actor)
   and `at` (an ISO 8601 datetime)"; it "is independent of `generated.at`:
   content can change without re-confirmation, and facts can be re-confirmed
   without regeneration". [source: spec] (§5.2)
+  [pins: tests/test_okf_write.py::TestAppendOkfVerification::test_creates_verified_list_when_absent]
 - "A single verifier MAY be written as one `{ by, at }` mapping without
   the list dash. Consumers MUST treat a bare mapping as a one-element
   list" — restated as a consumer MUST in §11. [source: spec] (§5.2, §11)
@@ -161,7 +163,10 @@ months, not twelve.
   reference agent now keeps every frontmatter value as the string the
   author wrote. [source: pr-323] [observed: `yaml.safe_load` on
   `stale_after: 2026-09-23T00:00:00Z` yields a `datetime`, on the quoted
-  form a `str`; python-frontmatter uses the same loader]
+  form a `str`; python-frontmatter uses the same loader] The server's own
+  stamps are therefore written as strings, UTC with `Z`, the spec's example
+  form (#1372).
+  [pins: tests/test_okf_write.py::TestApplyOkfWriteStamp::test_the_stamp_is_a_quoted_string_not_a_yaml_timestamp]
 
 ### Provenance: `sources` (§5.1)
 
@@ -227,11 +232,6 @@ tree, 2026-09-07].
   datetime *without* an offset — allowed by neither text — is ignored.
   Decided in `docs/design/okf.md` § 3 (#1373).
   [pins: tests/test_okf.py::test_derive_stale, tests/test_okf.py::test_derive_stale_bare_date_uses_the_server_local_day]
-- **Write stamps are dates.** `apply_okf_write_stamp` and
-  `append_okf_verification` write `generated.at` and `verified[].at` as
-  `YYYY-MM-DD` (`today.isoformat()`), where both texts of v0.2 say "an ISO
-  8601 datetime" and the August text adds "with an explicit UTC offset".
-  #1372, filed from this page.
 - **`verified` is cleared on a content-changing write.** The spec keeps
   `verified` "independent of `generated.at`: content can change without
   re-confirmation"; the server's enforced write layer clears it so an
@@ -280,7 +280,5 @@ tree, 2026-09-07].
 
 - Attested Computations (§10) and the `sources[]` credibility signals
   (`usage_count`, `usage_window`): nothing here reads or writes them.
-- Whether `generated.at`, once written as a datetime, should carry the
-  server's local offset or UTC; the spec only requires an explicit offset.
 - The v0.1 fallbacks (`timestamp`, `# Citations`): the server neither reads
   nor migrates them, and no test covers a v0.1 bundle.

--- a/docs/guides/okf.md
+++ b/docs/guides/okf.md
@@ -97,14 +97,14 @@ The steps above keep a bundle conformant by convention. The enforced write layer
 
 With the layer on, and only while the vault is an active OKF bundle, every `write` and `edit` does two things to the note that lands:
 
-- **Stamps provenance.** The server writes `generated: {by, at}` describing the bytes it just saved. `at` is the write date. `by` is `human:<subject>` when the caller is authenticated, and a tool actor such as `markdown-vault-mcp/1.4.0` otherwise. Any existing `generated` value is replaced.
+- **Stamps provenance.** The server writes `generated: {by, at}` describing the bytes it just saved. `at` is the instant of the write, in UTC (`2026-09-07T05:32:29Z`), as the OKF spec requires of every timestamp. `by` is `human:<subject>` when the caller is authenticated, and a tool actor such as `markdown-vault-mcp/1.4.0` otherwise. Any existing `generated` value is replaced.
 - **Invalidates prior review.** A content change means an earlier human review no longer describes the current note, so the server clears `verified`. This fires on any content-changing write, including an edit that touches only a frontmatter line. A `rename` moves the file without changing its content, so it leaves both fields alone.
 
 The one-shot migration transforms above (`okf_convert_links`, `okf_generate_index`, `okf_seed_log`) are exempt: a mechanical rewrite does not re-stamp provenance or discard a human attestation.
 
 ### Recording a human review
 
-Enabling the layer also exposes the [`okf_verify`](../tools/index.md#okf_verify) tool. Call it on a note you have reviewed and it appends a `{by: human:<subject>, at}` entry to that note's `verified` list, which promotes the note's trust tier to `human-reviewed`. The verification write is exempt from the invalidation above, so attesting a note does not immediately clear the attestation you just added.
+Enabling the layer also exposes the [`okf_verify`](../tools/index.md#okf_verify) tool. Call it on a note you have reviewed and it appends a `{by: human:<subject>, at}` entry (`at` a UTC instant) to that note's `verified` list, which promotes the note's trust tier to `human-reviewed`. The verification write is exempt from the invalidation above, so attesting a note does not immediately clear the attestation you just added.
 
 One subtlety is worth understanding before you rely on the `human-reviewed` tier. The authenticated subject is *whose token* made the call, not proof that a person read the note. When an agent holds your token and attribution rests on the token alone, the model could promote a note to `human-reviewed` on its own, and the tier would mean nothing. `MARKDOWN_VAULT_MCP_OKF_VERIFY` controls how the tool guards against that. It applies only when `OKF_WRITE` is on. Setting it to a non-default value with the layer off is a configuration error, because the tool is hidden and the setting would have no effect.
 

--- a/docs/guides/okf.md
+++ b/docs/guides/okf.md
@@ -57,7 +57,7 @@ sources:
     id: handbook
 verified:
   - by: human:alex
-    at: 2026-08-01
+    at: "2026-08-01T09:14:00Z"
 ---
 ```
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -380,6 +380,17 @@ time without an offset is allowed by neither text and is ignored. What the
 spec says in each of its texts, with sources, is recorded in
 `docs/design/reference/okf-v0.2.md`.
 
+**Provenance stamps are instants.** The `generated.at` the server stamps
+on every content write, and the `verified[].at` that `okf_verify` appends,
+were bare dates where the OKF spec says "an ISO 8601 datetime" and, since
+its in-place amendment of 2026-08-21, one "with an explicit UTC offset"
+([#1372](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1372)).
+They are now UTC instants in the spec's own example form,
+`2026-09-07T05:32:29Z`, written as strings so the YAML emitter cannot
+re-spell them, and a bundle this server has written is accepted by a
+consumer that is strict about offsets. What the spec says in each of its
+texts, with sources, is in `docs/design/reference/okf-v0.2.md`.
+
 **A link with any URI scheme is external.** The external-link filter was an
 allowlist of four prefixes, so a `file:`, `ftp:`, `obsidian:` or `zotero:`
 destination was resolved against the source note's folder and reported as a
@@ -574,6 +585,12 @@ on your part:
   may lose one for a note whose `stale_after` carried a time but no
   offset (previously read as its date, now ignored). No stored rows
   change, so no rebuild.
+- **`generated.at` moves on every content write.** It is now the UTC
+  instant of the write rather than the date
+  ([#1372](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1372)),
+  so two writes of a note on one day no longer leave its frontmatter
+  byte-identical; on a git-backed vault each such write is its own commit,
+  as any content write already was.
 - **A Voyage vault also re-embeds once**, through a separate mechanism
   with a separate trigger: the provider's embedding behavior is part of the
   vector sidecar's identity, and asymmetric embedding changed it

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -581,7 +581,7 @@ Seed a folder's reserved `log.md` change history from the vault's git commit his
 
 #### `okf_verify`
 
-Attest a note as human-reviewed by appending a `{by: human:<subject>, at: <date>}` entry to its `verified` frontmatter list, promoting the note's trust tier to `human-reviewed`. Part of the [enforced write layer](../guides/okf.md#the-enforced-write-layer): registered only when `MARKDOWN_VAULT_MCP_OKF_WRITE` is enabled. The append itself does not clear `verified`; only content-changing writes do that.
+Attest a note as human-reviewed by appending a `{by: human:<subject>, at: <UTC instant>}` entry to its `verified` frontmatter list, promoting the note's trust tier to `human-reviewed`. Part of the [enforced write layer](../guides/okf.md#the-enforced-write-layer): registered only when `MARKDOWN_VAULT_MCP_OKF_WRITE` is enabled. The append itself does not clear `verified`; only content-changing writes do that.
 
 How the review is confirmed depends on [`MARKDOWN_VAULT_MCP_OKF_VERIFY`](../configuration.md):
 

--- a/src/markdown_vault_mcp/_okf_write.py
+++ b/src/markdown_vault_mcp/_okf_write.py
@@ -34,7 +34,7 @@ import logging
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from datetime import date
+from datetime import UTC, datetime
 from functools import lru_cache
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
@@ -185,6 +185,6 @@ def build_okf_write_enrich(
         if not detector.state().active:
             return text
         actor = intent.actor if intent is not None else default_actor
-        return apply_okf_write_stamp(text, actor=actor, today=date.today())
+        return apply_okf_write_stamp(text, actor=actor, now=datetime.now(UTC))
 
     return enrich

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -5,7 +5,7 @@ import base64
 import contextlib
 import logging
 from dataclasses import asdict
-from datetime import date
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -987,7 +987,7 @@ def register(mcp: FastMCP) -> None:
 
         Part of the OKF (Open Knowledge Format) enforced-write layer, available
         only when `MARKDOWN_VAULT_MCP_OKF_WRITE` is enabled. Appends a
-        `{by: human:<subject>, at: <date>}` entry to the note's `verified`
+        `{by: human:<subject>, at: <UTC instant>}` entry to the note's `verified`
         frontmatter list, promoting the note's trust tier to `human-reviewed`.
 
         How the review is confirmed depends on `MARKDOWN_VAULT_MCP_OKF_VERIFY`:
@@ -1029,7 +1029,7 @@ def register(mcp: FastMCP) -> None:
             raise ToolError(f"Note not found: {path}")
         verified_count = len(verified_entries(note.frontmatter)) + 1
         new_text = append_okf_verification(
-            note.content, subject=subject, today=date.today()
+            note.content, subject=subject, now=datetime.now(UTC)
         )
         # Verification attests to a specific set of bytes, so the read-modify-
         # write must be atomic: pass the read's etag as if_match so a concurrent

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -969,7 +969,13 @@ def okf_timestamp(now: _dt.datetime) -> str:
 
     Returns:
         The ISO 8601 text.
+
+    Raises:
+        ValueError: If *now* carries no offset — it would be read as the
+            host's local time and gain an offset the caller never stated.
     """
+    if now.tzinfo is None:
+        raise ValueError("okf_timestamp needs an aware datetime")
     return now.astimezone(_dt.UTC).replace(microsecond=0).isoformat()[:-6] + "Z"
 
 

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -954,39 +954,59 @@ def append_okf_log_entry(text: str | None, *, date: str, summary: str) -> str:
     return "\n".join(parts) + "\n"
 
 
-def apply_okf_write_stamp(text: str, *, actor: str, today: _dt.date) -> str:
+def okf_timestamp(now: _dt.datetime) -> str:
+    """Spell an instant the way OKF's timestamp-valued keys require.
+
+    UTC with the ``Z`` designator at seconds precision — the spec's own
+    example form (``2026-06-30T14:00:00Z``; ``docs/design/reference/okf-v0.2.md``,
+    "Trust"). One spelling for every deployment, and a *string*: a
+    ``datetime`` value would be re-dumped by the YAML emitter as
+    ``2026-06-30 14:00:00+00:00``, the corruption the spec's amendment names
+    (#1372).
+
+    Args:
+        now: The instant to spell, timezone-aware.
+
+    Returns:
+        The ISO 8601 text.
+    """
+    return now.astimezone(_dt.UTC).replace(microsecond=0).isoformat()[:-6] + "Z"
+
+
+def apply_okf_write_stamp(text: str, *, actor: str, now: _dt.datetime) -> str:
     """Stamp ``generated: {by, at}`` and clear ``verified`` on a note's frontmatter.
 
     The enforced-write layer's core transform (design §6). Operates on the final
     file text (frontmatter plus body), so it is uniform across the ``write``
     (frontmatter-param) and ``edit`` (raw-splice) paths. ``generated`` describes
-    the current bytes and is overwritten; ``verified`` is dropped because a
-    content change invalidates any prior attestation; ``sources`` and every other
-    field are untouched.
+    the current bytes and is overwritten with the instant of this write —
+    "the content's last meaningful change" — so it moves on every content
+    write; ``verified`` is dropped because a content change invalidates any
+    prior attestation; ``sources`` and every other field are untouched.
 
     Args:
         text: The full note file text (frontmatter and body).
         actor: The provenance actor — ``human:<subject>`` when authenticated,
             else a tool actor such as ``markdown-vault-mcp/<version>``.
-        today: The stamp date (server-local; ISO-formatted into ``at``).
+        now: The instant of the write, timezone-aware (spelled by
+            :func:`okf_timestamp`).
 
     Returns:
         The stamped file text, or *text* unchanged when the resulting frontmatter
-        is identical (a same-day, same-actor re-write of a note with no
-        ``verified``) — so an unchanged note keeps its exact bytes and YAML
-        formatting.
+        is identical (the same actor and instant, no ``verified``) — so a
+        repeated stamp keeps the note's exact bytes and YAML formatting.
     """
     post = fm.loads(text)
     meta: dict[str, Any] = dict(post.metadata)
     new_meta: dict[str, Any] = dict(meta)
-    new_meta["generated"] = {"by": actor, "at": today.isoformat()}
+    new_meta["generated"] = {"by": actor, "at": okf_timestamp(now)}
     new_meta.pop("verified", None)
     if new_meta == meta:
         return text
     return fm.dumps(fm.Post(post.content, **new_meta))
 
 
-def append_okf_verification(text: str, *, subject: str, today: _dt.date) -> str:
+def append_okf_verification(text: str, *, subject: str, now: _dt.datetime) -> str:
     """Append a ``human:<subject>`` entry to a note's ``verified`` list.
 
     The ``okf_verify`` tool's core transform (design §6): records an attributable
@@ -997,7 +1017,8 @@ def append_okf_verification(text: str, *, subject: str, today: _dt.date) -> str:
     Args:
         text: The full note file text (frontmatter and body).
         subject: The authenticated subject (without the ``human:`` prefix).
-        today: The verification date (server-local; ISO-formatted into ``at``).
+        now: The instant of the verification, timezone-aware (spelled by
+            :func:`okf_timestamp`).
 
     Returns:
         The note text with the appended verification.
@@ -1005,6 +1026,6 @@ def append_okf_verification(text: str, *, subject: str, today: _dt.date) -> str:
     post = fm.loads(text)
     meta: dict[str, Any] = dict(post.metadata)
     verified = list(verified_entries(meta))
-    verified.append({"by": f"{_HUMAN_ACTOR_PREFIX}{subject}", "at": today.isoformat()})
+    verified.append({"by": f"{_HUMAN_ACTOR_PREFIX}{subject}", "at": okf_timestamp(now)})
     meta["verified"] = verified
     return fm.dumps(fm.Post(post.content, **meta))

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -111,7 +111,7 @@ class TestApplyOkfWriteStamp:
         # A producer-defined key survives the round trip (OKF v0.2 §4.1).
         assert meta["x_custom"] == 1
 
-    def test_same_actor_same_day_re_stamp_is_idempotent(self) -> None:
+    def test_same_actor_same_instant_re_stamp_is_idempotent(self) -> None:
         # Once a note carries this exact actor/instant stamp and no verified,
         # re-stamping is a byte-for-byte no-op — its YAML formatting is frozen.
         once = apply_okf_write_stamp("# T\n\nBody.\n", actor="t/1", now=_NOW)
@@ -125,6 +125,15 @@ class TestApplyOkfWriteStamp:
         )
         out = apply_okf_write_stamp("# Note\n", actor="a/1", now=local)
         assert fm.loads(out).metadata["generated"]["at"] == _ISO
+
+    def test_a_naive_instant_is_refused(self) -> None:
+        # A naive value would be read as the host's local time and silently
+        # become an offset the caller never stated — the class of ambiguity
+        # the amendment exists to remove. Callers pass an aware instant.
+        with pytest.raises(ValueError, match="aware"):
+            apply_okf_write_stamp(
+                "# Note\n", actor="a/1", now=_dt.datetime(2026, 8, 9, 14, 30, 5)
+            )
 
     def test_the_stamp_is_a_quoted_string_not_a_yaml_timestamp(self) -> None:
         # A datetime value would be re-dumped as ``2026-08-09 14:30:05+00:00``,

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -16,6 +16,7 @@ Covers the four pieces of the frontmatter-enforcement phase:
 from __future__ import annotations
 
 import datetime as _dt
+import re
 from typing import TYPE_CHECKING, Any
 
 import frontmatter as fm
@@ -51,8 +52,17 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
-_TODAY = _dt.date(2026, 8, 9)
-_ISO = _TODAY.isoformat()
+_NOW = _dt.datetime(2026, 8, 9, 14, 30, 5, tzinfo=_dt.UTC)
+#: The stamp the spec's examples show: UTC, ``Z``, seconds (#1372).
+_ISO = "2026-08-09T14:30:05Z"
+_STAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def _assert_recent_utc_stamp(value: object) -> None:
+    """A live stamp is a UTC instant in the spec's form, written just now."""
+    assert isinstance(value, str) and _STAMP_RE.match(value), value
+    written = _dt.datetime.fromisoformat(value)
+    assert abs(_dt.datetime.now(_dt.UTC) - written) < _dt.timedelta(minutes=5)
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +72,7 @@ _ISO = _TODAY.isoformat()
 
 class TestApplyOkfWriteStamp:
     def test_stamps_generated_on_a_note_without_frontmatter(self) -> None:
-        out = apply_okf_write_stamp("# Note\n\nBody.\n", actor="a/1", today=_TODAY)
+        out = apply_okf_write_stamp("# Note\n\nBody.\n", actor="a/1", now=_NOW)
         post = fm.loads(out)
         assert post.metadata["generated"] == {"by": "a/1", "at": _ISO}
         assert "Body." in post.content
@@ -77,7 +87,7 @@ class TestApplyOkfWriteStamp:
             "---\n"
             "# T\n"
         )
-        out = apply_okf_write_stamp(text, actor="human:x", today=_TODAY)
+        out = apply_okf_write_stamp(text, actor="human:x", now=_NOW)
         meta = fm.loads(out).metadata
         assert "verified" not in meta
         assert meta["generated"] == {"by": "human:x", "at": _ISO}
@@ -95,20 +105,36 @@ class TestApplyOkfWriteStamp:
             "---\n"
             "# P\n"
         )
-        meta = fm.loads(apply_okf_write_stamp(text, actor="t/1", today=_TODAY)).metadata
+        meta = fm.loads(apply_okf_write_stamp(text, actor="t/1", now=_NOW)).metadata
         assert meta["type"] == "Playbook"
         assert meta["sources"] == [{"resource": "https://example.com/a", "id": "a"}]
         # A producer-defined key survives the round trip (OKF v0.2 §4.1).
         assert meta["x_custom"] == 1
 
     def test_same_actor_same_day_re_stamp_is_idempotent(self) -> None:
-        # Once a note carries this exact actor/date stamp and no verified,
+        # Once a note carries this exact actor/instant stamp and no verified,
         # re-stamping is a byte-for-byte no-op — its YAML formatting is frozen.
-        once = apply_okf_write_stamp("# T\n\nBody.\n", actor="t/1", today=_TODAY)
-        assert apply_okf_write_stamp(once, actor="t/1", today=_TODAY) == once
+        once = apply_okf_write_stamp("# T\n\nBody.\n", actor="t/1", now=_NOW)
+        assert apply_okf_write_stamp(once, actor="t/1", now=_NOW) == once
+
+    def test_a_local_offset_instant_is_written_as_utc(self) -> None:
+        # 16:30:05 at +02:00 is 14:30:05Z; the stamp carries one spelling
+        # for every deployment (OKF v0.2 §5 as amended 2026-08-21; #1372).
+        local = _dt.datetime(
+            2026, 8, 9, 16, 30, 5, tzinfo=_dt.timezone(_dt.timedelta(hours=2))
+        )
+        out = apply_okf_write_stamp("# Note\n", actor="a/1", now=local)
+        assert fm.loads(out).metadata["generated"]["at"] == _ISO
+
+    def test_the_stamp_is_a_quoted_string_not_a_yaml_timestamp(self) -> None:
+        # A datetime value would be re-dumped as ``2026-08-09 14:30:05+00:00``,
+        # the corruption the amendment names; a string stays as written.
+        out = apply_okf_write_stamp("# Note\n", actor="a/1", now=_NOW)
+        assert "at: '2026-08-09T14:30:05Z'" in out
+        assert isinstance(fm.loads(out).metadata["generated"]["at"], str)
 
     def test_human_actor_is_recorded_verbatim(self) -> None:
-        out = apply_okf_write_stamp("body\n", actor="human:peter", today=_TODAY)
+        out = apply_okf_write_stamp("body\n", actor="human:peter", now=_NOW)
         assert fm.loads(out).metadata["generated"]["by"] == "human:peter"
 
 
@@ -119,14 +145,14 @@ class TestApplyOkfWriteStamp:
 
 class TestAppendOkfVerification:
     def test_creates_verified_list_when_absent(self) -> None:
-        out = append_okf_verification("# N\n", subject="peter", today=_TODAY)
+        out = append_okf_verification("# N\n", subject="peter", now=_NOW)
         meta = fm.loads(out).metadata
         assert meta["verified"] == [{"by": "human:peter", "at": _ISO}]
 
     def test_appends_to_existing_list(self) -> None:
         text = "---\nverified:\n  - by: human:alice\n    at: 2026-01-01\n---\n# N\n"
         meta = fm.loads(
-            append_okf_verification(text, subject="peter", today=_TODAY)
+            append_okf_verification(text, subject="peter", now=_NOW)
         ).metadata
         # The pre-existing unquoted YAML date round-trips as a date object; the
         # appended entry carries the ISO string we wrote.
@@ -137,7 +163,7 @@ class TestAppendOkfVerification:
 
     def test_preserves_body_and_other_fields(self) -> None:
         text = "---\ntitle: T\n---\n# T\n\nBody line.\n"
-        out = append_okf_verification(text, subject="peter", today=_TODAY)
+        out = append_okf_verification(text, subject="peter", now=_NOW)
         post = fm.loads(out)
         assert post.metadata["title"] == "T"
         assert "Body line." in post.content
@@ -147,7 +173,7 @@ class TestAppendOkfVerification:
         # existing attestation must survive the append (#1357).
         text = "---\nverified:\n  by: human:alice\n  at: 2026-01-01\n---\n# N\n"
         meta = fm.loads(
-            append_okf_verification(text, subject="peter", today=_TODAY)
+            append_okf_verification(text, subject="peter", now=_NOW)
         ).metadata
         assert meta["verified"] == [
             {"by": "human:alice", "at": _dt.date(2026, 1, 1)},
@@ -158,7 +184,7 @@ class TestAppendOkfVerification:
         # A malformed scalar verified is treated as empty, not crashed on.
         text = "---\nverified: nonsense\n---\n# N\n"
         meta = fm.loads(
-            append_okf_verification(text, subject="peter", today=_TODAY)
+            append_okf_verification(text, subject="peter", now=_NOW)
         ).metadata
         assert meta["verified"] == [{"by": "human:peter", "at": _ISO}]
 
@@ -363,7 +389,7 @@ class TestInvalidationMatrix:
         meta = _meta(enforced_vault, "note.md")
         assert "verified" not in meta
         assert meta["generated"]["by"].startswith("markdown-vault-mcp/")
-        assert meta["generated"]["at"] == _dt.date.today().isoformat()
+        _assert_recent_utc_stamp(meta["generated"]["at"])
 
     def test_body_edit_clears_verified(self, enforced_vault: Vault) -> None:
         enforced_vault.writer.write("note.md", _VERIFIED_NOTE)
@@ -606,9 +632,9 @@ class TestOkfVerifyTrustAuth:
         meta = fm.loads(
             (trust_auth_env / "guides" / "playbook.md").read_text(encoding="utf-8")
         ).metadata
-        assert meta["verified"] == [
-            {"by": "human:peter", "at": _dt.date.today().isoformat()}
-        ]
+        (entry,) = meta["verified"]
+        assert entry["by"] == "human:peter"
+        _assert_recent_utc_stamp(entry["at"])
 
     async def test_missing_note_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("fastmcp_pvl_core.get_subject", lambda: "peter")
@@ -629,11 +655,11 @@ class TestOkfVerifyTrustAuth:
 
         real_append = writer_mod.append_okf_verification
 
-        def racing_append(text: str, *, subject: str, today: Any) -> str:
+        def racing_append(text: str, *, subject: str, now: Any) -> str:
             (trust_auth_env / "guides" / "playbook.md").write_text(
                 "---\ntitle: Raced\n---\n# Raced\n", encoding="utf-8"
             )
-            return real_append(text, subject=subject, today=today)
+            return real_append(text, subject=subject, now=now)
 
         monkeypatch.setattr(writer_mod, "append_okf_verification", racing_append)
         async with Client(make_server()) as client:
@@ -679,9 +705,9 @@ class TestOkfVerifyElicit:
         payload = _parse_tool_data(result)
         assert payload["verifier"] == "human:peter"
         assert payload["verified_count"] == 1
-        assert _verified_meta(enforced_env / "guides" / "playbook.md") == [
-            {"by": "human:peter", "at": _dt.date.today().isoformat()}
-        ]
+        (entry,) = _verified_meta(enforced_env / "guides" / "playbook.md")
+        assert entry["by"] == "human:peter"
+        _assert_recent_utc_stamp(entry["at"])
 
     async def test_no_auth_stamps_local_after_confirmation(self) -> None:
         # With no auth the elicitation — not the token — proves a human is


### PR DESCRIPTION
## Closes / Refs

Closes #1372. Refs #1373 (PR #1375, the read side — same `okf.py`, different functions; whichever merges second rebases its release-notes hunk), #1357, the reference page `docs/design/reference/okf-v0.2.md`.

## What & why

Both texts of OKF v0.2 define `generated.at` and `verified[].at` as "an ISO 8601 datetime"; the 2026-08-21 amendment adds "with an explicit UTC offset" and shows that a strict consumer rejects a bare date at write. The server stamped `today.isoformat()` — a bare date — in both places.

**Decision (on the issue):** UTC, `Z`, seconds precision, written as a *string* — the spec's own example form, `2026-09-07T05:32:29Z`. A string because a `datetime` value is re-dumped by the YAML emitter as `2026-06-30 14:00:00+00:00`, the corruption the amendment PR names. One helper, `okf_timestamp`, spells it for both writers; it refuses a naive value, since `astimezone` would silently read one as host-local time and invent an offset the caller never stated. `apply_okf_write_stamp` / `append_okf_verification` take `now` (aware); the enricher and `okf_verify` pass `datetime.now(UTC)`. The log's `## YYYY-MM-DD` headings stay the server's local day (§9, unchanged by the amendment) — recorded in `okf.md` § 6 as two rules meaning what they each say.

Accepted consequence, in the Upgrading notes: `generated.at` moves on every content write, which is what "the content's last meaningful change" means; the old once-per-actor-day stability was a side effect of the date form, never a recorded decision (the review read the feature commit and PR #984 to check).

## Conformance (executed by the review)

- `+02:00` input → `2026-09-07T05:32:29Z`; microseconds truncated; UTC unchanged; naive → `ValueError`.
- Raw text after stamping: `at: '2026-09-07T05:32:29Z'` (quoted); `frontmatter.loads` → `str`; re-`dumps` → identical. Same for `append_okf_verification`.
- Matches the accepted-row shape of the amendment's storage table; nothing we emit resembles its two rejected rows.

## What this PR deliberately does NOT do

- Read `generated.at` anywhere (nothing does), so no `INDEX_SEMANTICS_VERSION` bump and no reader change.
- Rewrite stamps already on disk; a bare-date stamp stays until the note is next written.
- Change the log heading to UTC.

## Self-review 23d97ede..36b30bd2

Charters: rules (incl. the import-surface guard — `okf` submodule names are not root-exported, no snapshot change), diff, comments, history, conformance (executed). Coverage: full; one read-only agent, the diff charter walked by me as well.

- `okf_timestamp` — important/verified — accepted a naive `datetime` and read it as host-local time (would stamp `03:32:29Z` for a naive `05:32:29` on this host). Resolved in `36b30bd2`: refused with `ValueError`, pinned.
- `docs/guides/okf.md` example frontmatter — minor — still showed `at: 2026-08-01` beside prose saying `at` is an instant; the only such example in `docs/`/`examples/` (swept). Resolved.
- Log heading (local day) vs stamp (UTC) can name different days around local midnight — minor — deliberate, now written down in `okf.md` § 6. Resolved.
- Test name still said "same day" for what is now a same-instant guard. Renamed.
- History: `git log -S"today.isoformat()"` → the feature commit and this one; no idempotency or anti-churn rationale was ever recorded, so nothing deliberate is weakened.

## Verification

- TDD: the pure-transform tests failed on the signature, then on the values; the naive-guard test failed before the guard.
- `uv run pytest`: 4529 passed, 3 skipped (round 1: OKF files 204 passed); ruff, mypy (232 files), pre-commit `--all-files` (Vale), structural gate 100%, `mkdocs build --strict` 0, `check_references.py` 0, client-surface budget test passes with the `<UTC instant>` docstring edit.
