### PR TITLE
fix(links): the wikilink tie-break is Obsidian's, observed on 1.13.7

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2301,8 +2301,17 @@ vault-wide resolution rules rather than relative path resolution:
   all documents are indexed, `FTSIndex.resolve_vault_wikilinks()` performs a
   bulk SQL UPDATE that resolves each unmatched wikilink target vault-wide:
   it searches for any document whose path equals the target or ends with
-  `/target`. When multiple candidates match, the shortest path (fewest path
-  components) wins. This mirrors Obsidian's tie-breaking rule.
+  `/target`. When several match, the tie-break is the one observed on
+  Obsidian 1.13.7 (#1350; the fixtures are on
+  [`reference/obsidian-markdown.md`](reference/obsidian-markdown.md), "The
+  tie-break"): **an exact vault path wins** (`[[Note]]` is `Note.md` at the
+  root, `[[b/Note]]` is `b/Note.md`, even over a match beside the source);
+  otherwise **a match in the source note's own folder** (an ancestor folder
+  counts for nothing); otherwise **the shortest path string** — not fewest
+  components, which the earlier text of this section claimed, and not
+  file-tree order. What Obsidian does when two candidates tie on length is
+  not observed; the resolver takes the lexicographically first of the
+  shortest, so the answer does not depend on index history.
 
 - **Explicit relative wikilinks** (`[[./note]]`, `[[../note]]`): the `./` or
   `../` prefix opts out of vault-wide resolution. These are resolved against
@@ -2316,7 +2325,9 @@ vault-wide resolution rules rather than relative path resolution:
   `alias` (string) frontmatter field. `[[AI]]` resolves to a
   document with `aliases: [AI, A.I.]` in its frontmatter. Alias matching
   is case-insensitive. When multiple documents share the same alias, the
-  shortest path wins. Path matches always take priority over alias matches.
+  path rule's tie-break applies by analogy (own folder, then shortest
+  path); Obsidian's own alias tie-break was not observed. Path matches
+  always take priority over alias matches.
 
 `resolve_vault_wikilinks()` is called automatically at the end of
 `IndexFacet.build_index()`, `IndexFacet.reindex()`, and every

--- a/docs/design/reference/index.md
+++ b/docs/design/reference/index.md
@@ -10,7 +10,7 @@ you are about to touch; a page past its `stale_after` is re-researched with
 the `researching-references` skill, never trusted. Trust tier and staleness
 follow OKF v0.2 (`generated`, `verified`, `stale_after`).
 
-- [Obsidian markdown dialect and link resolution](/obsidian-markdown.md): wikilinks, embeds, aliases, tags, the resolution tie-break question (#1350). Read before `scanner.py` wikilink extraction or `fts_index.py` resolution.
+- [Obsidian markdown dialect and link resolution](/obsidian-markdown.md): wikilinks, embeds, aliases, tags, the resolution tie-break as observed on 1.13.7 (#1350). Read before `scanner.py` wikilink extraction or `fts_index.py` resolution.
 - [CommonMark and GitHub Flavored Markdown](/commonmark-gfm.md): line endings, paragraph boundaries, link and reference grammar, code spans and fences, the #1334 decision table. Read before any regex in `scanner.py`.
 - [Git push, credentials and remotes](/git-push-and-remotes.md): push refusals and their wording, `--porcelain`, askpass and `GIT_TERMINAL_PROMPT`, URL forms, `safe.directory`, `symbolic-ref` and `origin/HEAD`. Read before `git/health.py`, `git/push_scheduler.py`, `git/_run.py`, `git/bootstrap.py`, or the repository-discovery part of `git/conflict.py`.
 - [Git staging, commits and rebase state](/git-staging-and-commits.md): pathspec magic, `add`/`check-ignore`, `commit --only` and identity, ancestry and fast-forward, rebase state on disk and conflict markers. Read before `git/strategy.py`, `git/conflict.py`, or the pathspec part of `git/_run.py`.

--- a/docs/design/reference/log.md
+++ b/docs/design/reference/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-09-07
 
+- `obsidian-markdown.md`: the #1350 tie-break fixture run by the maintainer on Obsidian 1.13.7 through `getFirstLinkpathDest`; the tie-break section rewritten from `[unverified]` to the observed three rules (exact vault path, own folder, shortest path string) with the fixture and pins; the relative-wikilink and path-suffix rows settled by the same run; departure entries updated.
 - `commonmark-gfm.md`: the `_RE_INLINE_LINK`, reference-definition and `apply_link_replacement` departure entries re-observed after #1353 (destination parsed by §6.3's grammar, entities by §2.5's rule; the three-level parenthesis cap recorded as the deliberate departure); pins added.
 - `okf-v0.2.md`: the write-stamp departure removed for #1372 — `generated.at` and `verified[].at` are now UTC instants in the spec's example form, written as strings; the `generated`/`verified` claims gain their pins and the open offset question closes.
 - `okf-v0.2.md`: the staleness departure rewritten for #1373 — an instant with an offset is now compared as one, the bare date stays as a recorded lenience, an offset-less datetime is ignored; the August `stale_after` claim gains its pin.

--- a/docs/design/reference/obsidian-markdown.md
+++ b/docs/design/reference/obsidian-markdown.md
@@ -2,7 +2,7 @@
 type: Reference
 title: Obsidian markdown dialect and link resolution
 description: "Obsidian desktop (1.x): wikilink syntax, link resolution, aliases, and the Obsidian-only syntax that shares characters with links"
-subject_version: "1.14 (help pages state a version only for properties: 1.4 / 1.9)"
+subject_version: "1.14 (help pages state a version only for properties: 1.4 / 1.9); link resolution observed on 1.13.7"
 valid_for: "Obsidian 1.x"
 generated:
   by: process:researching-references
@@ -245,9 +245,11 @@ name a version only for properties (1.4 deprecates `alias`/`tag`/`cssclass`,
   spellings exist in Obsidian's model, but the help never shows one inside
   `[[ ]]`. [source: api-dts]
   [pins: tests/test_links.py::TestExtractWikilinks::test_wikilink_explicit_relative_resolved_against_source]
-- Whether `[[../note]]` resolves relative to the source note or is treated as
-  a literal name is [unverified]. Fixture: `a/x.md` containing `[[../y]]`
-  with `y.md` at root, then `resolvedLinks`.
+- `[[../note]]` resolves relative to the source note: `a/x.md` containing
+  `[[../y]]` with `y.md` at root resolved to `y.md`.
+  [observed: Obsidian 1.13.7, `getFirstLinkpathDest("../y", "a/x.md")`,
+  2026-09-07]
+  [pins: tests/test_links_wikilink_tie_break.py::TestVault1RootPresent::test_a_relative_wikilink_resolves_against_the_source]
 - Resolution is a "best match": `getFirstLinkpathDest(linkpath, sourcePath)`
   is documented only as "Get the best match for a linkpath"; the `sourcePath`
   parameter is present but its role is not described. [source: api-dts]
@@ -258,10 +260,13 @@ name a version only for properties (1.4 deprecates `alias`/`tag`/`cssclass`,
   path to the linked file"), "Relative path to file" ("Uses a path relative
   to the current file") and "Absolute path in vault" ("Uses the full path
   from the vault root"). [source: api-dts] [source: help-settings]
-- The design doc's "ends with `/target`" suffix match is not documented by
-  Obsidian; the help shows only full vault-root paths. Whether `[[b/Note]]`
-  resolves `a/b/Note.md` is [unverified]. Fixture: `a/b/Note.md` only, a note
-  containing `[[b/Note]]`, then `unresolvedLinks`.
+- The "ends with `/target`" suffix match is not documented by Obsidian; the
+  help shows only full vault-root paths. It is real: `[[b/Note]]` resolved
+  to `a/b/Note.md` while no `b/Note.md` existed, and to `b/Note.md` once
+  one did (rule 1 of the tie-break below).
+  [observed: Obsidian 1.13.7, `getFirstLinkpathDest("b/Note", "suffix.md")`,
+  2026-09-07]
+  [pins: tests/test_links_wikilink_tie_break.py::TestVault1RootPresent::test_a_path_suffix_matches_when_no_exact_path_exists]
 
 #### The tie-break (#1350)
 
@@ -272,21 +277,34 @@ name a version only for properties (1.4 deprecates `alias`/`tag`/`cssclass`,
 - What it leaves open: how `getFirstLinkpathDest` picks among several files
   that all match an ambiguous bare name typed by hand or left behind by a
   later duplicate. Neither "shortest path", "fewest components", "closest to
-  the source", nor "first in file-tree order" appears in any source read;
-  the `sourcePath` parameter hints that the source note's location may
-  matter. [unverified]
-- The project's two rules (code `min(candidates, key=len)`, design doc
-  "fewest path components") both claim to mirror Obsidian, and neither can be
-  sourced. The pinned tests use fixtures where the two rules agree
-  (`a/Note.md` vs `a/b/Note.md`; `javascript.md` vs
-  `deep/nested/javascript.md`), so they do not discriminate.
-  [pins: tests/test_links.py::TestResolveVaultWikilinks::test_bare_wikilink_shortest_path_wins, tests/test_links.py::TestAliasResolution::test_alias_resolution_shortest_path_wins]
-- A settling fixture, in one vault: `Note.md` at root, `zzzz/Note.md` (one
-  component, longer string), `a/b/Note.md` (two components, shorter string),
-  and a source note containing `[[Note]]` at root, in `zzzz/`, and in `a/b/`;
-  `resolvedLinks` then shows (1) whether root wins, (2) with `Note.md`
-  removed, whether string length or depth decides, and (3) whether the
-  source note's folder changes the answer.
+  the source", nor "first in file-tree order" appears in any source read.
+  [source: api-dts]
+- Observed instead, on Obsidian 1.13.7, by the maintainer in a scratch vault
+  through `app.metadataCache.getFirstLinkpathDest(link, sourcePath)` in the
+  developer console (2026-09-07; the console output is quoted verbatim on
+  issue #1350). Fixture: `Note.md`, `zzzz/Note.md`, `a/b/Note.md`; sources
+  `src-root.md`, `zzzz/src-zzzz.md`, `a/b/src-ab.md`, each `[[Note]]`; then
+  root `Note.md` deleted; then `b/Note.md`, `aaaaaaaa/Note.md` and
+  `zzzz/deep/src-deep.md` added; then `a/b/src-ab-path.md` holding
+  `[[b/Note]]`. Three rules, in order:
+  1. **An exact vault path wins.** With root `Note.md` present, `[[Note]]`
+     resolved to `Note.md` from all three sources, including from `a/b/`
+     beside `a/b/Note.md`; `[[b/Note]]` resolved to `b/Note.md` from
+     `a/b/`, over the own-folder suffix match `a/b/Note.md`.
+  2. **Otherwise the source note's own folder wins**: with root gone,
+     `zzzz/src-zzzz.md` → `zzzz/Note.md` (over the shorter `b/Note.md`),
+     `a/b/src-ab.md` → `a/b/Note.md`. An ancestor folder counts for
+     nothing: `zzzz/deep/src-deep.md` → `b/Note.md`.
+  3. **Otherwise the shortest path string wins**: `src-root.md` →
+     `a/b/Note.md` (11 characters) over `zzzz/Note.md` (12; so not fewest
+     components), and → `b/Note.md` over `a/b/Note.md` once `b/Note.md`
+     existed (so not file-tree order).
+  [observed: Obsidian 1.13.7, the fixture above, `getFirstLinkpathDest`]
+  [pins: tests/test_links_wikilink_tie_break.py::TestVault1RootPresent::test_the_exact_root_path_wins_from_every_folder, tests/test_links_wikilink_tie_break.py::TestVault2RootDeleted::test_own_folder_then_shortest_string, tests/test_links_wikilink_tie_break.py::TestVault3MoreCandidates::test_shortest_string_not_tree_order_and_no_ancestor_preference, tests/test_links_wikilink_tie_break.py::TestVault4ExactPathBeatsOwnFolder::test_an_exact_path_beats_the_own_folder_suffix_match]
+- Not observed: what breaks a tie between two candidates of equal length
+  and equal folder standing, and whether aliases share this tie-break.
+  [unverified] Two `Note.md` files in two sibling folders of equal name
+  length, and two notes declaring the same alias, would settle both.
 
 ### Case, aliases, properties
 
@@ -411,19 +429,21 @@ Each entry names the function and the design section that decides it.
   ("The link graph is notes-only").
 - `_extract_wikilinks`: no `![[` discrimination, so a note embed is a link.
   Not modelled; the help defines embeds as a distinct syntax.
-- `_extract_wikilinks`: `./` and `../` opt-out is a project convention; the
-  help shows no relative wikilink form. Unverifiable.
-- `FTSIndex.resolve_vault_wikilinks`: suffix match "ends with `/stem.md`" is
-  wider than the help's vault-root folder paths. Unverifiable.
-- `FTSIndex.resolve_vault_wikilinks`: `min(candidates, key=len)` versus the
-  design doc's "fewest path components" — #1350 open; neither is sourced,
-  and Obsidian only documents the *writing* rule (shortest unique path).
-  design.md § Link Extraction (Wikilink resolution).
+- `_extract_wikilinks`: `./` and `../` resolve against the source note, as
+  observed (`[[../y]]`, above); the help shows no relative wikilink form.
+- `FTSIndex.resolve_vault_wikilinks`: suffix match "ends with `/stem.md`"
+  matches what was observed (`[[b/Note]]` → `a/b/Note.md`).
+- `FTSIndex.resolve_vault_wikilinks`: the tie-break is the observed
+  three-rule one (exact path, own folder, shortest string) since #1350;
+  the design doc's earlier "fewest path components" was wrong. Equal-length
+  ties and the alias tie-break remain [unverified] and follow the same rule
+  by analogy. design.md § Link Extraction (Wikilink resolution).
 - `FTSIndex.resolve_vault_wikilinks`: path matching case-sensitive — #235
   asked for case-insensitivity; Obsidian's behaviour is unverified.
 - `FTSIndex.resolve_vault_wikilinks` / `_insert_aliases`: `[[Alias]]` as a
-  target, case-insensitive alias match, path-beats-alias, shortest path among
-  alias holders — all project rules; the help documents aliases only as
+  target, case-insensitive alias match, path-beats-alias, the path rule's
+  tie-break among alias holders (own folder, then shortest) — all project
+  rules; the help documents aliases only as
   suggestion entries that expand to `[[Note|Alias]]`. Unverifiable.
 - `_insert_aliases`: honours the scalar `alias` key that Obsidian deprecated
   in 1.4 and dropped in 1.9. Wider than current Obsidian; harmless for
@@ -445,9 +465,9 @@ Each entry names the function and the design section that decides it.
 
 ## Not covered
 
-- Everything marked `[unverified]` above; the single most valuable fixture is
-  the #1350 vault (three `Note.md` files, three source folders) read through
-  `metadataCache.resolvedLinks`.
+- Everything marked `[unverified]` above; the #1350 tie-break fixture was
+  run on 2026-09-07 and is recorded above, and the same console session is
+  the cheapest way to settle the rest (#1358).
 - Block-fragment links (`[[note#^id]]`): stored as a plain fragment, no test.
 - Embeds of notes (`![[Note]]`) as distinct from links: the scanner treats
   both as links; whether Obsidian's graph does is unknown.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -482,6 +482,18 @@ one. A rename keeps the form the author used, so `<my note.md>` becomes
 levels, the depth the spec's own examples reach. Existing vaults rebuild
 once on first start after upgrade.
 
+**A duplicate note name resolves the way Obsidian resolves it.** When
+several notes share a name, a bare `[[Note]]` picked the shortest path
+everywhere, and the design doc claimed a different rule (fewest path
+components); neither was Obsidian's, and neither had a source. The
+maintainer ran the discriminating fixture on Obsidian 1.13.7
+([#1350](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1350)):
+an exact vault path wins, otherwise a note in the linking note's own
+folder, otherwise the shortest path. The resolver now does the same, so a
+`[[Note]]` written beside a same-named note points at that neighbour, as it
+does in Obsidian; the reference page records the fixture and its output.
+Existing vaults rebuild once on first start after upgrade.
+
 **Renaming an attachment says when `update_links` does not apply.** The
 attachment branch of `rename` never read the flag, so a call that asked
 for a rewrite answered `updated_links: 0` and nothing else, and "the two
@@ -577,7 +589,7 @@ meaning; the operator surface only grew (two GitLab webhook variables,
 `INSTANCE_DESCRIPTION`). A few things do change behavior without any action
 on your part:
 
-- **The text index rebuilds once on first start.** Six changes in this
+- **The text index rebuilds once on first start.** Seven changes in this
   release alter how stored rows derive from a note's bytes: skip
   tombstones
   ([#1227](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1227)),
@@ -589,10 +601,12 @@ on your part:
   ([#1333](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1333)),
   links bounded to one paragraph
   ([#1334](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1334)),
-  and destinations read in every CommonMark spelling
-  ([#1353](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1353)).
-  `INDEX_SEMANTICS_VERSION` moved from 2 to 8. One rebuild covers all
-  six; it is automatic, costs CPU and local IO proportional to vault size,
+  destinations read in every CommonMark spelling
+  ([#1353](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1353)),
+  and the wikilink tie-break observed on Obsidian
+  ([#1350](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1350)).
+  `INDEX_SEMANTICS_VERSION` moved from 2 to 9. One rebuild covers all
+  seven; it is automatic, costs CPU and local IO proportional to vault size,
   and does not re-embed.
 - **A note becomes stale one day earlier, and an instant is honoured.**
   `stale_after` is now the first stale day rather than the last current

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -287,7 +287,13 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: ``note.md "title"``) and never resolved; the bump rebuilds notes whose
 #: bytes never changed so those rows gain their targets, and drops the ones
 #: that turn out to name attachments (#1333).
-INDEX_SEMANTICS_VERSION = 8
+#:
+#: Version 9 (#1350): the wikilink tie-break is Obsidian's, observed — an
+#: exact vault path, else the source note's own folder, else the shortest
+#: path string. A vault holding duplicate note names resolved a bare
+#: ``[[Note]]`` to the shortest path everywhere; the bump re-resolves the
+#: rows whose source sits beside a same-named note, which now win.
+INDEX_SEMANTICS_VERSION = 9
 
 
 class ChunkingMeta(NamedTuple):
@@ -401,6 +407,28 @@ def _derive_folder(path: str) -> str:
     # PurePosixPath('.') means no parent directory.
     folder = parent.as_posix()
     return "" if folder == "." else folder
+
+
+def _pick_wikilink_candidate(candidates: list[str], source_path: str) -> str:
+    """Tie-break among several documents matching one wikilink.
+
+    Observed on Obsidian 1.13.7 (#1350): once no exact vault path matches,
+    a candidate in the source note's own folder wins — an ancestor folder
+    counts for nothing — and otherwise the shortest path *string* does (not
+    fewest components, not file-tree order). Two candidates of equal length
+    and standing were not observed; the lexicographically first is taken so
+    the answer does not depend on index history.
+
+    Args:
+        candidates: Vault-relative paths of the matching documents.
+        source_path: Vault-relative path of the note holding the link.
+
+    Returns:
+        The chosen candidate.
+    """
+    source_dir = source_path.rpartition("/")[0]
+    own_folder = [p for p in candidates if p.rpartition("/")[0] == source_dir]
+    return min(own_folder or candidates, key=lambda p: (len(p), p))
 
 
 class FTSIndex:
@@ -1961,12 +1989,14 @@ class FTSIndex:
     def resolve_vault_wikilinks(self) -> int:
         """Resolve vault-wide wikilink ``target_path`` values against the document set.
 
-        Obsidian resolves bare wikilinks (e.g. ``[[Note]]``) by searching the
-        entire vault for a document whose filename matches, picking the shortest
-        path (fewest path components) when multiple candidates exist.  Wikilinks
-        with an explicit path (e.g. ``[[folder/Note]]``) are resolved to any
-        document whose path ends with ``folder/Note.md``, again preferring the
-        shortest match.
+        Obsidian resolves a bare wikilink (``[[Note]]``) by searching the
+        whole vault for a document whose name matches, and a path-qualified
+        one (``[[folder/Note]]``) against any document whose path ends with
+        ``folder/Note.md``. When several match, the tie-break is the one
+        observed on Obsidian 1.13.7 (#1350; ``docs/design/reference/
+        obsidian-markdown.md``, "The tie-break"): an exact vault path wins;
+        otherwise a match in the source note's own folder; otherwise the
+        shortest path string.
 
         Resolution anchors on ``raw_target`` (the original wikilink text as
         written) rather than the current ``target_path``.  This ensures
@@ -1978,7 +2008,9 @@ class FTSIndex:
         ``document_aliases`` table — if a document declares an ``aliases``
         frontmatter field containing the wikilink stem, the link resolves to
         that document.  This mirrors Obsidian's alias resolution behaviour
-        (e.g. ``[[AI]]`` resolves to a document with ``aliases: [AI]``).
+        (e.g. ``[[AI]]`` resolves to a document with ``aliases: [AI]``); the
+        tie-break among several is the path rule's, by analogy — Obsidian's
+        own alias tie-break was not observed.
 
         Wikilinks with an explicit relative prefix (``./`` or ``../``) are
         skipped; they are resolved relative to the source document at scan time
@@ -2003,6 +2035,7 @@ class FTSIndex:
             r["path"]
             for r in conn.execute("SELECT path FROM documents_live").fetchall()
         ]
+        doc_paths_set = set(doc_paths)
 
         # Build alias → document path mapping for fallback resolution.
         # Case-insensitive: Obsidian alias matching is case-insensitive.
@@ -2014,7 +2047,7 @@ class FTSIndex:
             """
         ).fetchall()
         # Map lowercased alias to list of document paths (multiple docs could
-        # share an alias; pick shortest path like the path-based resolution).
+        # share an alias; the path rule's tie-break applies).
         alias_map: dict[str, list[str]] = {}
         for ar in alias_rows:
             alias_map.setdefault(ar["alias"].lower(), []).append(ar["path"])
@@ -2024,11 +2057,12 @@ class FTSIndex:
         # resolved at scan time and must not be overwritten.
         rows = conn.execute(
             """
-            SELECT id, raw_target, target_path
-            FROM links
-            WHERE link_type = 'wikilink'
-              AND raw_target NOT LIKE './%'
-              AND raw_target NOT LIKE '../%'
+            SELECT l.id, l.raw_target, l.target_path, d.path AS source_path
+            FROM links l
+            JOIN documents d ON d.id = l.source_id
+            WHERE l.link_type = 'wikilink'
+              AND l.raw_target NOT LIKE './%'
+              AND l.raw_target NOT LIKE '../%'
             """
         ).fetchall()
 
@@ -2045,21 +2079,19 @@ class FTSIndex:
             # 2. Append .md if not already present.
             search_target = stem if stem.lower().endswith(".md") else stem + ".md"
 
-            # Find the best match: exact path or suffix match, shortest wins.
-            candidates = [
-                p
-                for p in doc_paths
-                if p == search_target or p.endswith("/" + search_target)
-            ]
-            if not candidates:
-                # Fallback: check if the stem matches a document alias.
-                # Use the raw stem (without .md) for alias matching.
-                alias_candidates = alias_map.get(stem.lower(), [])
-                if alias_candidates:
-                    candidates = alias_candidates
-            if not candidates:
-                continue  # Genuinely broken — no document matches.
-            new_path = min(candidates, key=len)
+            # An exact vault path wins outright (rule 1); the suffix matches
+            # and the alias fallback go through the tie-break (rules 2, 3).
+            if search_target in doc_paths_set:
+                new_path = search_target
+            else:
+                candidates = [p for p in doc_paths if p.endswith("/" + search_target)]
+                if not candidates:
+                    # Fallback: check if the stem matches a document alias.
+                    # Use the raw stem (without .md) for alias matching.
+                    candidates = alias_map.get(stem.lower(), [])
+                if not candidates:
+                    continue  # Genuinely broken — no document matches.
+                new_path = _pick_wikilink_candidate(candidates, row["source_path"])
             if new_path != row["target_path"]:
                 updates.append((new_path, row["id"]))
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2129,11 +2129,15 @@ class TestAliasResolution:
         assert col.reader.stats().broken_link_count == 0
 
     def test_alias_resolution_shortest_path_wins(self) -> None:
-        """When multiple documents share an alias, shortest path wins."""
+        """When multiple documents share an alias, shortest path wins.
+
+        The source sits in a folder holding no alias candidate, so the
+        own-folder rule (#1350) stays out of it and length decides.
+        """
         idx = FTSIndex(":memory:")
         notes = [
             make_note(
-                path="source.md",
+                path="src/source.md",
                 links=[
                     LinkInfo(
                         target_path="JS.md",
@@ -2157,7 +2161,7 @@ class TestAliasResolution:
         idx.build_from_notes(notes)
         idx.resolve_vault_wikilinks()
 
-        outlinks = idx.get_outlinks("source.md")
+        outlinks = idx.get_outlinks("src/source.md")
         assert outlinks[0]["target_path"] == "javascript.md"
 
     def test_alias_with_fragment(self) -> None:

--- a/tests/test_links_wikilink_tie_break.py
+++ b/tests/test_links_wikilink_tie_break.py
@@ -1,0 +1,161 @@
+"""The wikilink tie-break is Obsidian's, observed (#1350).
+
+When several documents match a bare or path-qualified wikilink, the code
+picked the shortest path string and the design doc said fewest path
+components; neither was sourced, and the pinned fixtures agreed on both.
+The maintainer ran the reference page's discriminating fixture on Obsidian
+1.13.7 (``app.metadataCache.getFirstLinkpathDest``); the four vaults below
+are that run, verbatim, and the rule they fix is:
+
+1. an exact vault path wins (``[[Note]]`` is ``Note.md`` at the root,
+   ``[[b/Note]]`` is ``b/Note.md``), even over the source's own folder;
+2. otherwise a match in the source note's own folder wins — an ancestor
+   folder counts for nothing;
+3. otherwise the shortest path string wins: not fewest components, not
+   file-tree order.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from markdown_vault_mcp.vault import Vault
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(vault: Path, rel: str, body: str) -> None:
+    path = vault / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _target(col: Vault, source: str) -> str:
+    outlinks = col.graph.get_outlinks(source)
+    assert len(outlinks) == 1, outlinks
+    return outlinks[0].target_path
+
+
+@pytest.fixture
+def vault_1(tmp_path: Path) -> Path:
+    """Root ``Note.md`` present; the observed answer is root from everywhere."""
+    vault = tmp_path / "vault"
+    for rel, body in {
+        "Note.md": "root\n",
+        "zzzz/Note.md": "zzzz\n",
+        "a/b/Note.md": "a-b\n",
+        "src-root.md": "[[Note]]\n",
+        "zzzz/src-zzzz.md": "[[Note]]\n",
+        "a/b/src-ab.md": "[[Note]]\n",
+        "y.md": "y\n",
+        "a/x.md": "[[../y]]\n",
+        "suffix.md": "[[b/Note]]\n",
+    }.items():
+        _write(vault, rel, body)
+    return vault
+
+
+class TestVault1RootPresent:
+    def test_the_exact_root_path_wins_from_every_folder(self, vault_1: Path) -> None:
+        col = Vault(source_dir=vault_1)
+        col.index.build_index()
+        try:
+            assert _target(col, "src-root.md") == "Note.md"
+            assert _target(col, "zzzz/src-zzzz.md") == "Note.md"
+            # Even from a/b/, where a/b/Note.md sits beside the source.
+            assert _target(col, "a/b/src-ab.md") == "Note.md"
+        finally:
+            col.close()
+
+    def test_a_relative_wikilink_resolves_against_the_source(
+        self, vault_1: Path
+    ) -> None:
+        col = Vault(source_dir=vault_1)
+        col.index.build_index()
+        try:
+            assert _target(col, "a/x.md") == "y.md"
+        finally:
+            col.close()
+
+    def test_a_path_suffix_matches_when_no_exact_path_exists(
+        self, vault_1: Path
+    ) -> None:
+        col = Vault(source_dir=vault_1)
+        col.index.build_index()
+        try:
+            assert _target(col, "suffix.md") == "a/b/Note.md"
+        finally:
+            col.close()
+
+
+class TestVault2RootDeleted:
+    def test_own_folder_then_shortest_string(self, vault_1: Path) -> None:
+        (vault_1 / "Note.md").unlink()
+        col = Vault(source_dir=vault_1)
+        col.index.build_index()
+        try:
+            # No own-folder match at the root: shortest string, and it is
+            # a/b/Note.md (11) over zzzz/Note.md (12) — not fewest components.
+            assert _target(col, "src-root.md") == "a/b/Note.md"
+            # Own folder beats the shorter string.
+            assert _target(col, "zzzz/src-zzzz.md") == "zzzz/Note.md"
+            assert _target(col, "a/b/src-ab.md") == "a/b/Note.md"
+        finally:
+            col.close()
+
+
+class TestVault3MoreCandidates:
+    def test_shortest_string_not_tree_order_and_no_ancestor_preference(
+        self, vault_1: Path
+    ) -> None:
+        (vault_1 / "Note.md").unlink()
+        _write(vault_1, "b/Note.md", "b\n")
+        _write(vault_1, "aaaaaaaa/Note.md", "aaaaaaaa\n")
+        _write(vault_1, "zzzz/deep/src-deep.md", "[[Note]]\n")
+        col = Vault(source_dir=vault_1)
+        col.index.build_index()
+        try:
+            # b/Note.md (9) is the shortest string; a/b/Note.md would be
+            # tree order; aaaaaaaa/Note.md would be fewest components.
+            assert _target(col, "src-root.md") == "b/Note.md"
+            assert _target(col, "zzzz/src-zzzz.md") == "zzzz/Note.md"
+            # zzzz/ is an ancestor of the source, and that counts for nothing.
+            assert _target(col, "zzzz/deep/src-deep.md") == "b/Note.md"
+            assert _target(col, "a/b/src-ab.md") == "a/b/Note.md"
+        finally:
+            col.close()
+
+
+class TestVault4ExactPathBeatsOwnFolder:
+    def test_an_exact_path_beats_the_own_folder_suffix_match(
+        self, vault_1: Path
+    ) -> None:
+        (vault_1 / "Note.md").unlink()
+        _write(vault_1, "b/Note.md", "b\n")
+        _write(vault_1, "a/b/src-ab-path.md", "[[b/Note]]\n")
+        col = Vault(source_dir=vault_1)
+        col.index.build_index()
+        try:
+            assert _target(col, "a/b/src-ab-path.md") == "b/Note.md"
+            assert _target(col, "suffix.md") == "b/Note.md"
+        finally:
+            col.close()
+
+
+class TestAliasesShareTheTieBreak:
+    """By analogy, not observed: own folder, then shortest path."""
+
+    def test_own_folder_alias_wins(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        _write(vault, "short.md", "---\naliases: [AI]\n---\n# S\n")
+        _write(vault, "topic/long-name.md", "---\naliases: [AI]\n---\n# L\n")
+        _write(vault, "topic/src.md", "See [[AI]].\n")
+        col = Vault(source_dir=vault)
+        col.index.build_index()
+        try:
+            assert _target(col, "topic/src.md") == "topic/long-name.md"
+        finally:
+            col.close()


### PR DESCRIPTION
## Closes / Refs

Closes #1350. Refs #1358 (the other `[unverified]` Obsidian rows; two of them settled by the same console session), #1365 (`INDEX_SEMANTICS_VERSION` 8 → 9 under the rule as written).

## What & why

When several notes matched a bare `[[Note]]`, the resolver took the shortest path string and the design doc said fewest path components; neither was sourced, and the pinned fixtures agreed on both. The maintainer ran the reference page's discriminating fixture on **Obsidian 1.13.7** through `app.metadataCache.getFirstLinkpathDest` (console output verbatim on the issue). Obsidian's rule, in order:

1. **An exact vault path wins** — `[[Note]]` is `Note.md` at the root, `[[b/Note]]` is `b/Note.md`, even over a match beside the source.
2. **Otherwise the source note's own folder wins**; an ancestor folder counts for nothing (`zzzz/deep/` → `b/Note.md`).
3. **Otherwise the shortest path string** — `a/b/Note.md` over `zzzz/Note.md` (so not fewest components), `b/Note.md` over `a/b/Note.md` (so not tree order).

The resolver already had rules 1 and 3 by construction (an exact match is the shortest candidate; `min(key=len)`); it lacked rule 2, which needs the source document's folder — `resolve_vault_wikilinks` now joins the source path and `_pick_wikilink_candidate` applies own-folder-then-shortest to suffix matches and to the alias fallback (by analogy; Obsidian's alias tie-break was not observed). An equal-length tie, also not observed, is now the lexicographically first of the shortest, so the answer no longer depends on index history (it used to follow rowid order — a cold build and an incremental one could disagree).

The same run settled two more `[unverified]` rows: `[[../y]]` resolves against the source note; `[[b/Note]]` matches `a/b/Note.md` by path suffix when no exact `b/Note.md` exists.

Docs: the reference page's tie-break section is rewritten from `[unverified]` to `[observed: Obsidian 1.13.7]` with the fixture and pins; `design.md`'s "fewest path components" replaced; release notes; `INDEX_SEMANTICS_VERSION` 8 → 9 (resolution results are stored rows; a vault with duplicate names re-resolves the sources that sit beside a same-named note).

## Tests

`tests/test_links_wikilink_tie_break.py` reproduces the four Obsidian vaults verbatim — all 14 observed output lines have an assertion — plus the stable-tie rule and the alias analogy. `test_alias_resolution_shortest_path_wins`'s source moved into a folder holding no candidate so it still tests rule 3 rather than passing through rule 2.

## What this PR deliberately does NOT do

- Verify the alias tie-break or the equal-length tie in Obsidian (both marked `[unverified]` on the page with the fixture that would settle them).
- Touch case sensitivity of matching (#235) or the remaining #1358 rows.

## Self-review f4579a3f..a0ea1165

Charters: rules, diff, comments, history, conformance (vault 3 rebuilt in a temp dir and diffed line by line against the maintainer's console output; the equal-length tie run across three creation orders and one incremental reindex). Coverage: full; one read-only agent, the resolver hunk walked by me as well.

- `design.md` / `_pick_wikilink_candidate` — low/verified — the prose said an equal-length tie takes "the first in index order", which is rowid order and flips between a cold and an incremental build (shown: `aa/` on every cold build, `bb/` after `reindex()`); the v9 rebuild would itself have flipped such ties. Resolved: lexicographic among the shortest, pinned by a build-then-reindex test.
- Reference page departures — low — still said "shortest path among alias holders". Resolved.
- `test_alias_resolution_shortest_path_wins` — low — passed through the own-folder branch (root source, root candidate), so no alias test exercised rule 3. Resolved: source moved into `src/`.
- Confirmed clean: the `JOIN documents` (not `documents_live`) is right — a tombstone has no `links` rows and `ON DELETE CASCADE` leaves no orphans; a root source's `""` folder matches only root alias candidates, which is correct; the rule was introduced in `bc418355` (#233) "matching Obsidian's resolution rules" with no Obsidian source ever cited.

## Verification

- TDD: the own-folder cases (vaults 2 and 3) and the alias analogy failed first; rules 1 and 3 passed already, as predicted.
- `uv run pytest`: 4611 passed, 3 skipped (pre-amend; the amend added one test and a doc line, 159 link tests re-run).
- ruff, mypy (234 files), pre-commit `--all-files` (Vale), structural gate 100%, `mkdocs build --strict` 0, `check_references.py` 0.
