### PR TITLE
docs: INDEX_SEMANTICS_VERSION bumps once per release, not per fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ If a conflict marker appears in a copier-update bot PR, the conflict itself ofte
 - Hybrid search: Reciprocal Rank Fusion (RRF)
 - Tool semantics: mirror Claude Code Read/Write/Edit patterns
 - Library is sync; MCP layer uses `asyncio.to_thread()`
-- Indexing is hash-based, so an unchanged file is never re-parsed: any change to how a note's stored rows are derived from its bytes (link extraction, chunking, tag/alias/heading derivation) must bump `INDEX_SEMANTICS_VERSION` in `fts_index.py` in the same commit, or deployed vaults keep serving the rows the old code produced (#1124)
+- Indexing is hash-based, so an unchanged file is never re-parsed: any change to how a note's stored rows are derived from its bytes (link extraction, chunking, tag/alias/heading derivation) must be covered by an `INDEX_SEMANTICS_VERSION` bump in `fts_index.py`, or deployed vaults keep serving the rows the old code produced (#1124). The bump is **once per release** (#1365): if no stable or rc tag contains the commit that set the current value, the value already covers the next release — extend its history note with the new change instead of bumping again (`git tag --contains <that commit>` empty → no bump). The edge channel is not a release for this purpose. A redundant bump is harmless, not a defect
 - Full decision log in `docs/design/design.md` appendix
 - How the outside world behaves (Obsidian's dialect, CommonMark/GFM, git) is recorded in dated, sourced references under `docs/design/reference/` (an OKF v0.2 bundle; start at its `index.md`); read the relevant page before touching `scanner.py`, `fts_index.py` link resolution, or `git/`, and re-research rather than trust a page past its `stale_after`
 <!-- DOMAIN-END -->

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -717,9 +717,16 @@ Two methods manage the index:
   every upgrade that fixes how those rows are derived. That is what #1124
   observed after the link-extraction fixes in #1104 / #1107: new notes got
   the corrected extraction, every pre-existing note kept its wrong link
-  rows, and no tool exposed a way to force the re-parse. The constant is
-  bumped in the same commit as any change that makes unchanged bytes yield
-  different stored rows; `_chunking_meta_matches` compares it like every
+  rows, and no tool exposed a way to force the re-parse. Any change that
+  makes unchanged bytes yield different stored rows is covered by a bump of
+  the constant, landed in the same commit — but **one bump per release**
+  (#1365): a deployment can only hold a value a stable or rc release
+  shipped, so when no such tag contains the commit that set the current
+  value, that value already covers the next release and the new change
+  joins its history note instead of bumping again (the v4.2 cycle went
+  3 → 9 before this rule; 4 through 8 never shipped and are kept as history).
+  The edge channel is not a release for this purpose, and a redundant bump
+  is harmless. `_chunking_meta_matches` compares the value like every
   other key, so the first start after such an upgrade rejects the
   short-circuit and cold-rebuilds once. An index written before the key
   existed reads back as `0` and rebuilds on the same rule; a corrupted or

--- a/src/markdown_vault_mcp/fts_index.py
+++ b/src/markdown_vault_mcp/fts_index.py
@@ -241,12 +241,24 @@ _META_INDEX_SEMANTICS_KEY = "index_semantics_version"
 #: Current version of the parse-to-row pipeline whose output is stored in the
 #: index (link extraction, chunk boundaries, tag/alias/heading derivation).
 #:
-#: **Bump this in the same commit** as any change that makes an unchanged file
-#: yield different stored rows. The bump is what converts such a fix into a
-#: fix operators actually receive: on the next start, the warm-restart
-#: short-circuit is rejected and every file is re-parsed once. Changes that
-#: only affect how stored rows are *queried* or *rendered* (ranking, snippets,
-#: response shaping) need no bump — nothing on disk went stale.
+#: Any change that makes an unchanged file yield different stored rows must
+#: be covered by a bump of this value — landed in the same commit, since the
+#: bump is what converts such a fix into a fix operators actually receive:
+#: on the next start, the warm-restart short-circuit is rejected and every
+#: file is re-parsed once. Changes that only affect how stored rows are
+#: *queried* or *rendered* (ranking, snippets, response shaping) need no
+#: bump — nothing on disk went stale.
+#:
+#: **One bump per release** (#1365). A deployment can only ever hold a value
+#: that shipped in a stable or rc release, so bumping on every merged fix
+#: manufactures values nobody can be at (4 through 8 below never shipped;
+#: they are kept as history). Before bumping, check whether the commit that
+#: set the current value is contained in a stable or rc tag
+#: (``git tag --contains <sha>``): if it is not, the current value already
+#: covers the next release — add the change to that version's note instead.
+#: The edge channel does not count as a release here. A redundant bump is
+#: harmless (one extra rebuild that would have happened anyway), so this is
+#: a should, not a must.
 #:
 #: Version 3 (#1129): skipped files became part of the stored row set —
 #: every surfaced deterministic skip now writes a tombstone row into


### PR DESCRIPTION
## Closes / Refs

Closes #1365.

## What & why

The rule as written ("bump in the same commit as any change to stored rows") produced 3 → 9 inside one release cycle, six values no deployment can hold. The owner's policy (on the issue): **one bump per release** — before bumping, check whether the commit that set the current value is contained in a stable or rc tag; if not, the value already covers the next release and the change joins its history note. A *should*, not a *must*: a redundant bump is one extra rebuild that would have happened anyway. The edge channel is not a release for this purpose; rc releases are. The current value stays at 9 and versions 4–8 stay as history notes.

Stated in the three places the rule lives: `AGENTS.md` (Key Design Decisions), the constant's docstring in `fts_index.py`, and `design.md` § Derived-content invalidation.

## What this PR deliberately does NOT do

- Rewind the constant or collapse the 4–8 notes: no deployment benefits, and the notes are the record.
- Add a mechanical check: the `git tag --contains` test is a one-liner for the author; a CI gate would need to know the release model's tag set and is not worth its false positives.

## Verification

Docs and a docstring only. ruff, pre-commit (Vale on `AGENTS.md`), `mkdocs build --strict` 0, `tests/test_fts_index.py` + `tests/test_commit_conventions.py` 95 passed. Rebased on `origin/main` before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RSxDv7WV6p6FD5kZ2h83U