### PR TITLE
docs: prepare release notes for v4.2.0

### DIFF
--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -1,6 +1,6 @@
 # 4.2
 
-<!-- notes-range-end: e24837818b579aec1959a8bc5607606e4649664d -->
+<!-- notes-range-end: 60111e3fb38efdf54b78bc6fc1f5ca9acc2ff883 -->
 
 <!-- RELEASE-SUMMARY v4.2.0 START -->
 This release is about trusting the git layer. On a git-backed vault, an
@@ -14,9 +14,12 @@ rejected SHA, vanished history) are fixed. GitLab-hosted vaults gain the
 push-triggered reindex GitHub vaults already had, Voyage vaults get better
 search relevance with nothing to configure, and server instructions now
 arrive in full on Claude Code instead of losing their tail to a 2,048-unit
-cap. Nothing breaks: no env var, tool, or library import changes meaning.
-Two one-time costs on first start after upgrade: every vault rebuilds its
-text index once, and a Voyage vault re-embeds once.
+cap. Seven link-extraction fixes reshape the link graph: broken-link counts
+drop, notes whose only links were embeds become orphans, and a duplicate-name
+`[[Note]]` resolves as Obsidian does. Nothing breaks: no env var, tool, or
+library import changes meaning. Two one-time costs on first start after
+upgrade: every vault rebuilds its text index once, and a Voyage vault
+re-embeds once.
 <!-- RELEASE-SUMMARY v4.2.0 END -->
 
 This is the first release since [4.1](4.1.md). Most of it happened in one
@@ -61,13 +64,18 @@ beyond recognition, the revision is off the current history), the read
 **fails rather than returning content**, because the next thing a caller
 does with the result is write it back. The
 [tools reference](../tools/index.md#reading-an-earlier-revision) lists every
-refusal case. In the same spirit, `previous_revision` is absent whenever no
+refusal case. Every refusal, including the one where git records the note
+as a copy of another, ends by pointing at `get_history`; none suggests
+reading a different note, because the copy source is only git's similarity
+match. In the same spirit, `previous_revision` is absent whenever no
 commit provably holds the replaced content, such as a brand-new note or a
 vault without git.
 
-Requires a git-backed vault; revision reads cover `.md` notes. No `restore`
-tool ships with this, deliberately: the read/write round trip above is the
-restore, and it keeps the caller in charge of what gets written.
+Requires a git-backed vault; revision reads cover `.md` notes and do not go
+through LFS. No `restore` tool ships with this, deliberately: the read/write
+round trip above is the restore, and it keeps the caller in charge of what
+gets written. See "Getting an overwritten note back" in the
+[git integration guide](../guides/git-integration.md).
 
 ## History that describes the right note
 
@@ -109,17 +117,6 @@ The end state is uniform: `get_history`, `get_diff`, and the new
 `read(revision=)` all identify a note the same way, with the same rename
 following, the same threshold, and the same lineage boundary at the note's
 creation.
-
-One refusal message changed after the release candidate. `read(path,
-revision=)` correctly refuses when git records the note as a copy rather
-than a continuation, but the refusal then named the copy source as the thing
-to read
-([#1336](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1336)).
-That source is git's similarity match (in the case that surfaced this, an
-unrelated note that merely shared frontmatter scaffolding), and the
-documented next step after a revision read is to write the content back. The
-refusal still names what git found, and now points at `get_history` the way
-the neighbouring refusal already did.
 
 ## One commit per tool call
 
@@ -168,15 +165,16 @@ background commit, so the commit author is the person who made the write.
 It also now agrees with the OKF provenance record for the same write, which
 was already stamped correctly.
 
-The release candidate found the other way the same claims fall back
-silently: the identity provider simply does not put them in the access
-token. That outcome looked exactly like a deployment that had never
-configured attribution, and the one nearby startup warning is suppressed
-precisely when a claim is configured
+The same claims also fall back silently when the identity provider does
+not put them in the access token at all. That outcome looked exactly like a
+deployment that had never configured attribution (the only trace was a
+`DEBUG` line), and the one nearby startup warning is suppressed precisely
+when a claim is configured
 ([#1331](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1331)).
 The first authenticated write now reports the configured key and whether
 it was absent or empty, once per field per process; the commit still falls
-back to the static identity.
+back to the static identity. See "What a commit covers" in the
+[git integration guide](../guides/git-integration.md).
 
 ## A write that cannot leave the host says so
 
@@ -202,9 +200,15 @@ The write still succeeded and the commit is real; the key tells the caller
 it is committed locally only, so an agent knows to keep its own copy and
 alert its user. When there is nothing to report, the key is absent rather
 than null.
-The log marks the transition once (`git_remote_unsynced`, and
-`git_remote_resynced` on recovery) instead of repeating the failure every
-push cycle. Writes are warned, never refused; the same report asked for a
+The log marks the transition once (`git_remote_unsynced` at `ERROR`,
+carrying git's own words as `cause=`, and `git_remote_resynced` on
+recovery). A push that a write, a `git_sync` flush, or startup caused logs
+its rejection once at `WARNING` with the redacted git stderr, so the line
+repeats once per burst of writes and shows the retries are happening; the
+pull loop's timer-driven retry of a still-pending push stays at `DEBUG`, as
+does the per-cycle detail of a divergence the resolver is working through
+([#1330](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1330)).
+Writes are warned, never refused; the same report asked for a
 configurable block, which is tracked separately as
 [#1299](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1299).
 
@@ -221,28 +225,10 @@ reporting the remote tip as its projected target, which had been triggering
 pointless full reindexes through the sync paths
 ([#1301](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1301)).
 
-The release candidate then showed the other half of the problem: the
-noticing worked, and the diagnosing did not. When a clone could not reach
-its remote, the only line in the log was that one transition, naming the
-generic `push_failed` bucket; git's own words sat at `DEBUG`, and
-deployments run at `INFO`
-([#1330](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1330)). An
-operator learned the vault was stranded but not why, and because every retry
-was equally silent, could not tell a clone that was still retrying from one
-that had stopped. The transition line now carries the cause alongside the
-reason code, and a rejected push logs at `WARNING` with the git stderr, on
-the deferred and the startup path alike. That is a deliberate step back from
-the quieting #1287 introduced, and it is bounded by what caused the attempt:
-a push that a write caused is one attempt per write, so the line repeats
-once per burst of writes, whereas the pull loop's timer-driven retry of a
-still-pending push, like the pull-side detail that drowned the transition
-in the original incident, stays at `DEBUG`. Credentials are redacted as
-before.
-
-The same deployment then found the pull side's own blind spot, and fixed
-it. When another writer pushed while the instance held local commits, the
-clone "stops syncing" while every write kept "returning success" and the
-log showed a conflict-resolution loop that "exceeded 50 iterations" (the
+The pull side had a blind spot of its own, found and fixed by the same
+deployment. When another writer pushed while the instance held local commits, the
+clone "stops syncing" while every `write` and `edit` "returns success" and
+the log showed a conflict-resolution loop that "exceeded 50 iterations" (the
 reporter's words in
 [#1362](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1362)).
 There was no conflict: the pull pipeline's `git rebase` ran with no
@@ -373,39 +359,32 @@ exempts from typing
 histograms now cover the same note population `okf_validate` audits, and
 reserved files are reported separately as `reserved_count`.
 
-**OKF staleness and the single-verifier shorthand now follow the spec.**
-The OKF v0.2 field reference says a note is "stale when `today >=
-stale_after`" and that consumers "must treat a bare mapping as a
-one-element list" for `verified`
-([#1357](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1357)).
-The server did neither: on the `stale_after` date itself it still reported
-the note current, and a note whose `verified` was written as a single
-mapping rather than a list read as `unverified`. Worse, `okf_verify` on
-such a note replaced that mapping with its own entry, so the earlier
-attestation was lost. The `stale` flag, the `stale` filter, the `stats`
-stale count and ranking now turn stale on the named date; the trust tier,
-the `okf_verify` append and its `verified_count` all read a bare mapping as
-one entry. The spec itself moved while this was being fixed: on 2026-08-21
-its maintainer amended "Version 0.2" in place so that `stale_after` is
-"an absolute instant" with an offset, "stale when `now >= stale_after`"
-([#1373](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1373)).
-Both spellings now work: a bare date (`2026-12-31`) is stale from that
-server-local day on, and an instant (`2026-12-31T00:00:00Z`, the quoted
-form included) is stale from that moment on, with its offset respected. A
-time without an offset is allowed by neither text and is ignored. What the
-spec says in each of its texts, with sources, is recorded in
-`docs/design/reference/okf-v0.2.md`.
-
-**Provenance stamps are instants.** The `generated.at` the server stamps
-on every content write, and the `verified[].at` that `okf_verify` appends,
-were bare dates where the OKF spec says "an ISO 8601 datetime" and, since
-its in-place amendment of 2026-08-21, one "with an explicit UTC offset"
-([#1372](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1372)).
-They are now UTC instants in the spec's own example form,
-`2026-09-07T05:32:29Z`, written as strings so the YAML emitter cannot
-re-spell them, and a bundle this server has written is accepted by a
-consumer that is strict about offsets. What the spec says in each of its
-texts, with sources, is in `docs/design/reference/okf-v0.2.md`.
+**OKF staleness, the single-verifier shorthand and the provenance stamps
+now follow the spec.** OKF v0.2 says a note is stale from its `stale_after`
+on, that consumers "must treat a bare mapping as a one-element list" for
+`verified`, and that `generated.at` and `verified[].at` are "an ISO 8601
+datetime"; the spec was amended in place on 2026-08-21 to make every such
+timestamp one "with an explicit UTC offset" and `stale_after` "an absolute
+instant"
+([#1357](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1357),
+[#1373](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1373),
+[#1372](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1372)).
+The server departed on all three. A note was reported current on its
+`stale_after` date, and a quoted instant (`'2026-01-01T00:00:00Z'`) was
+ignored altogether. A `verified` written as a single mapping read as
+`unverified`, and `okf_verify` on such a note replaced that mapping with its
+own entry, losing the earlier attestation. And both stamps were bare dates,
+which a consumer strict about offsets rejects. Now both `stale_after`
+spellings work: a bare date (`2026-12-31`) is stale from that server-local
+day on, and an instant (`2026-12-31T00:00:00Z`, quoted or not) is stale
+from that moment on, with its offset respected; a time without an offset is
+allowed by neither text of the spec and is ignored. The `stale` flag, the
+`stale` filter, the `stats` stale count and ranking all agree. A bare
+`verified` mapping is one entry for the trust tier, the `okf_verify` append
+and its `verified_count`. And every stamp the server writes is a UTC instant
+in the spec's example form, `2026-09-07T05:32:29Z`, written as a string so
+the YAML emitter cannot re-spell it; stamps already on disk are left as they
+are until the note is next written.
 
 **A link with any URI scheme is external.** The external-link filter was an
 allowlist of four prefixes, so a `file:`, `ftp:`, `obsidian:` or `zotero:`
@@ -447,7 +426,9 @@ the vault, about 12 of one vault's 90 reported broken links in one case
 The link graph is now notes-only: a reference whose target has an
 allowlisted extension is not a link, in any of the three link spellings and
 whether or not it is an embed, the way image links `![alt](src)` always
-were. A note whose only links were embeds is now an orphan in
+were. Under the `*` wildcard a suffix counts as an extension only when it
+holds a letter, so `[[Python 3.12]]` and `[[Version 2.0 plan]]` stay notes.
+A note whose only links were embeds is now an orphan in
 `get_orphan_notes` and `stats.orphan_count`, which is what it was to the
 note graph all along. The attachment allowlist has become an input to the index, so
 changing `MARKDOWN_VAULT_MCP_ATTACHMENT_EXTENSIONS` rebuilds it once on the
@@ -467,12 +448,13 @@ several multi-kilobyte blobs of document prose"
 ([#1334](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1334)).
 Links are now matched inside one paragraph at a time, with the boundaries
 taken from the CommonMark spec row by row (a blank line in any line-ending
-spelling, a bare `>`, a thematic break, a heading, a quote line, a list
-item), and a destination never contains a line ending. A link written *on* a
-heading, quote or list line still counts, as does a link whose text
-soft-breaks onto the next line. Three limits are deliberate. The scanner
-tracks no open quotes, items or fences, so a nested item indented four or
-more spaces is continuation text. Every numbered-list marker starts a new
+spelling, a bare `>`, a thematic break, an underline heading, a heading, a
+line that opens or deepens a block quote, a list item), and a destination
+never contains a line ending. A link written *on* a heading, quote or list
+line still counts, as does a link whose text soft-breaks onto the next
+line. Three limits were chosen rather than met. The scanner tracks no open
+quotes, items or fences, so a nested item indented four or more spaces is
+continuation text. Every numbered-list marker starts a new
 paragraph, not only `1.`, because converted PDFs are numbered lists and a
 stray `[` in one item must not pair into the next. And a destination
 wrapped onto its own line inside the parentheses is not accepted, because
@@ -494,21 +476,23 @@ escapes and entity references) and decoded before it is resolved, in
 reference definitions as well as inline links; an attachment written in
 any of these spellings is excluded from the link graph like the literal
 one. A rename keeps the form the author used, so `<my note.md>` becomes
-`<new name.md>`. One limit is deliberate: parentheses balance to three
-levels, the depth the spec's own examples reach. Existing vaults rebuild
-once on first start after upgrade.
+`<new name.md>`; only a new name containing `#`, `<` or `>` gains a
+backslash escape, so it cannot be misread as a fragment. One new limit is
+deliberate: parentheses balance to three levels, the depth the spec's own
+examples reach. Existing vaults rebuild once on first start after upgrade.
 
 **A duplicate note name resolves the way Obsidian resolves it.** When
 several notes share a name, a bare `[[Note]]` picked the shortest path
 everywhere, and the design doc claimed a different rule (fewest path
-components); neither was Obsidian's, and neither had a source. The
-maintainer ran the discriminating fixture on Obsidian 1.13.7
+components); neither had a source, and only the design doc's was wrong
+outright. The maintainer ran the discriminating fixture on Obsidian 1.13.7
 ([#1350](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1350)):
 an exact vault path wins, otherwise a note in the linking note's own
 folder, otherwise the shortest path. The resolver now does the same, so a
 `[[Note]]` written beside a same-named note points at that neighbour, as it
-does in Obsidian; the reference page records the fixture and its output.
-Existing vaults rebuild once on first start after upgrade.
+does in Obsidian, and a tie between equally short candidates now falls the
+same way on a cold build and an incremental one. Existing vaults rebuild
+once on first start after upgrade.
 
 **Renaming an attachment says when `update_links` does not apply.** The
 attachment branch of `rename` never read the flag, so a call that asked
@@ -563,10 +547,12 @@ same normalization.
 **The git guide now says what the remote must permit.** It documented which
 credentials to configure but not what the token had to be allowed to do, so
 two ordinary first-run conditions each cost a long detour before the real git
-error was found: a read-only token, and a protected default branch that
-refused the push
+error was found: a protected default branch that refused the push, and a
+clone with no usable token, whose fetches failed
 ([#1337](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1337)). The
-managed-git section now states both prerequisites and points at
+managed-git section now states both prerequisites (push access to the
+tracked branch, and a branch protection that refuses regardless of the
+token's scopes) and points at
 `git_sync(direction="push")` as the call that returns the remote's own
 refusal message, with a note on why `git push --dry-run` is not a substitute
 for it.
@@ -621,9 +607,16 @@ on your part:
   ([#1353](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1353)),
   and the wikilink tie-break observed on Obsidian
   ([#1350](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1350)).
-  `INDEX_SEMANTICS_VERSION` moved from 2 to 9. One rebuild covers all
-  seven; it is automatic, costs CPU and local IO proportional to vault size,
-  and does not re-embed.
+  `INDEX_SEMANTICS_VERSION` moved from 2 to 9 (the values between never
+  shipped; a vault on 4.2.0-rc.0 holds 3 and rebuilds once more). One
+  rebuild covers all seven; it is automatic, costs CPU and local IO
+  proportional to vault size, and does not re-embed. Expect the link graph
+  to change on it: `get_broken_links` and `stats.broken_link_count` drop
+  (attachment embeds, schemed URLs and stray-bracket prose leave, encoded
+  and CommonMark-spelled links now resolve), `get_orphan_notes` and
+  `stats.orphan_count` can gain notes whose only links were embeds, and in
+  a vault with duplicate note names a bare `[[Note]]` can re-point to the
+  note beside it, as it does in Obsidian.
 - **A note becomes stale one day earlier, and an instant is honoured.**
   `stale_after` is now the first stale day rather than the last current
   one
@@ -639,9 +632,14 @@ on your part:
 - **`generated.at` moves on every content write.** It is now the UTC
   instant of the write rather than the date
   ([#1372](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1372)),
-  so two writes of a note on one day no longer leave its frontmatter
-  byte-identical; on a git-backed vault each such write is its own commit,
-  as any content write already was.
+  so a rewrite of unchanged content, which used to leave the file
+  byte-identical when the same actor wrote it on the same day, now changes
+  the stamp and, on a git-backed vault, produces a commit. Stamps already
+  on disk stay bare dates until the note is next written.
+- **Two `fix(release)` entries in the changelog**
+  ([#1327](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1327),
+  [#1329](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1329)) are
+  repairs to the release pipeline itself, with no runtime effect.
 - **A Voyage vault also re-embeds once**, through a separate mechanism
   with a separate trigger: the provider's embedding behavior is part of the
   vector sidecar's identity, and asymmetric embedding changed it


### PR DESCRIPTION
## Release notes refresh for v4.2.0 (rc.1)

Mode `refresh-known-target`, stable identity v4.2.0, previous stable `v4.1.0`. Incremental research of the page's watermark range `e2483781..60111e3f` (32 commits; compare API), commits → PRs → closing issues through the API, three per-theme research briefs (git integration; links and the scanner; OKF and docs commits), written from the briefs. Compare: https://github.com/pvliesdonk/markdown-vault-mcp/compare/v4.1.0...60111e3f

### What changed on the page, and why

**Net delta applied** (the owner's rule: fixes to things introduced *for* this release are the feature as shipped, not bug fixes):
- #1336 (`read(revision=)` copy refusal) — same-cycle (#1288 is the only commit with the message); its paragraph is gone and one sentence sits in "Undo an overwrite".
- #1330 (push-failure cause) — same-cycle: v4.1.0 logged the stderr at ERROR every pull tick, #1300 quieted it, #1345 set the shipped level. The journey paragraph is gone; the #1287 section's log sentence now states the shipped rule.
- #1357/#1373/#1372 (OKF) — all three defects verified live at v4.1.0 (`okf.py` lines 249, 221/939, 913/940 at the tag) — but #1373 supersedes half of #1357 inside the range; the two paragraphs narrating that sequence are now one end-state paragraph.
- #1320 (guide docs) folded as two guide pointers; #1327/#1329 (`fix(release)`) are pipeline repairs with no runtime effect — one clause under Upgrading so the changelog's Bug Fixes entries are not a mystery.

**Corrections the briefs found** (each traced to the issue/PR/code):
- #1337 paragraph named "a read-only token" as one of the two first-run detours; the issue's two conditions were a protected branch and a clone with no usable token whose fetches failed.
- #1362 quote "returning success" was not verbatim; the issue says "returns success".
- #1331 paragraph narrated discovery ("The release candidate found…"); now states the case.
- #1334 boundary list omitted the setext underline and said "a quote line" where the shipped rule is "a line that opens or deepens a block quote".
- #1353: "One limit is deliberate" → "One new limit"; the rename escape exception (`#`, `<`, `>`) added, since it qualifies "a rename keeps the form the author used".
- #1350: "neither was Obsidian's" overclaimed — the code had the first and last of Obsidian's three rules; and the equal-length tie is now stable across cold and incremental builds.
- #1333: the wildcard letter rule (`[[Python 3.12]]` stays a note) added.
- `generated.at` Upgrading bullet's consequence sentence said nothing changed; now names the same-content rewrite that gains a commit.

**Added:** the link-graph reshaping on the rebuild (broken-link counts drop, embed-only notes become orphans, duplicate-name `[[Note]]` re-points) in the summary and the Upgrading rebuild bullet — seven fixes change what `get_broken_links`, `stats` and `get_orphan_notes` say, and a reader who triages on those numbers needs it before first start; "the values between never shipped; a vault on 4.2.0-rc.0 holds 3 and rebuilds once more".

Watermark moved to `60111e3f`.

### Evidence

Every inline link on the page is the evidence for its claim. Quotes re-checked verbatim against their sources by the briefs: #1287, #1292, #1264/#1265 (`mikebronner`, CONTRIBUTOR), #1137, #1362 (`FoundationOperations`, CONTRIBUTOR; fixed), #1333 ("Roughly 12 of this vault's 90…", not quoted, numbers match), #1334 (two quotes verbatim except a lowercased initial), #1338 (verbatim), OKF spec quotes verbatim on `docs/design/reference/okf-v0.2.md`. Numbers on the page: 2,596 / 3,918 (#1264), ~2,000 (#1334 JSON), 12/90 (#1333), Obsidian 1.13.7 (#1350), 2 → 9.

### Breaking-change classification

None. `tests/public_import_surface.txt` is unchanged v4.1.0..HEAD; no env var or tool changed meaning; the OKF `today=`→`now=` signatures are submodule-level, not root-importable. Consistent with every commit in the range (no `!`).

### Docs staleness candidates

- `docs/guides/git-integration.md:372` — "These lines were at `DEBUG` until #1330" describes an rc-only state no stable release had. [unverified whether worth changing; the sentence is true for rc.0 readers]
- `docs/guides/docker.md` did not change in range; its `GIT_COMMIT_NAME`/`_EMAIL` advice is still accurate — not a candidate.

### Left out

- Nothing unsourced was needed. The `docs/design/reference/` commits (#1352, #1356, #1374, #1385) and #1386 are contributor-facing and are not on the page.
