### PR TITLE
fix(okf): the maintained log.md stacks a frontmatter block per write

### DIFF
--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -467,11 +467,17 @@ carry. Both generators and the `OKF_WRITE` maintainer write through it:
   trade one defect for another.
 
 The `OKF_WRITE` maintainer needs this for a second reason: `_append_log` is a
-read-modify-write and `DocumentManager.read` returns the body without
-frontmatter, so the log's frontmatter has to be carried across the rewrite
-explicitly. Since the maintainer runs after *every* content write, the
-alternative is not a one-time gap but frontmatter stripped again after each
-save — including frontmatter an operator seeded by hand.
+read-modify-write, and `DocumentManager.read` returns the *whole file*,
+frontmatter included (`NoteContent.content`). The maintainer therefore drops
+the frontmatter from the text (`strip_reserved_frontmatter`) and carries it
+across the rewrite explicitly through `frontmatter=`. Since the maintainer
+runs after *every* content write, getting either half wrong compounds per
+save rather than once: not carrying it over stripped hand-seeded frontmatter
+again after each save (#1174); re-emitting it above text that still contained
+it stacked one more identical block per write (#1391). The strip drops the
+block that opens the text and nothing else: it never inspects the body, so a
+log quoting its own frontmatter as a sample keeps it, and the blocks a
+defective release already stacked stay where they are until #1403.
 
 ### Export
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -359,6 +359,17 @@ exempts from typing
 histograms now cover the same note population `okf_validate` audits, and
 reserved files are reported separately as `reserved_count`.
 
+**The maintained `log.md` no longer stacks a frontmatter block per write.**
+On a vault that requires frontmatter, the 4.1.0 fix that gave the generated
+`log.md` the fields the index gate demands re-emitted them above text that
+still contained them, so every enforced write added one more identical block
+to the top of the folder's log; one live folder had accumulated eighteen
+([#1391](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1391)). The
+append now drops the frontmatter from the text before carrying it across the
+rewrite. A log 4.1.0 already stacked stops growing; the blocks it accumulated
+stay in its body, which
+[#1403](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1403) covers.
+
 **OKF staleness, the single-verifier shorthand and the provenance stamps
 now follow the spec.** OKF v0.2 says a note is stale from its `stale_after`
 on, that consumers "must treat a bare mapping as a one-element list" for

--- a/src/markdown_vault_mcp/_okf_convention.py
+++ b/src/markdown_vault_mcp/_okf_convention.py
@@ -32,6 +32,7 @@ from markdown_vault_mcp.okf import (
     OKF_RESERVED_FILENAMES,
     ReservedFrontmatterPolicy,
     append_okf_log_entry,
+    strip_reserved_frontmatter,
 )
 
 if TYPE_CHECKING:
@@ -135,9 +136,11 @@ class ConventionMaintainer:
     def _append_log(self, folder: str, path: str, operation: WriteOperation) -> None:
         """Append a dated ``**Update**`` bullet to the folder's ``log.md``.
 
-        The read-modify-write splits frontmatter from body: ``read()`` hands
-        back the body alone, so the log's frontmatter has to be carried over
-        explicitly or the rewrite would strip it — including frontmatter an
+        The read-modify-write splits frontmatter from body. ``read()`` hands
+        back the *whole file*, so the frontmatter is dropped from the text
+        before the append and carried over through ``frontmatter=`` instead;
+        re-emitting it above text that still contained it stacked one block
+        per write (#1391), and not carrying it over stripped frontmatter an
         operator seeded by hand to satisfy ``required_frontmatter`` (#1174).
         """
         log_path = f"{folder}/log.md" if folder else "log.md"
@@ -150,7 +153,11 @@ class ConventionMaintainer:
             # re-enters this same re-entrant lock.
             with self._write_lock:
                 existing = self._doc_mgr.read(log_path)
-                text = existing.content if existing is not None else None
+                text = (
+                    strip_reserved_frontmatter(existing.content)
+                    if existing is not None
+                    else None
+                )
                 new_text = append_okf_log_entry(
                     text, date=self._today().isoformat(), summary=summary
                 )

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -899,6 +899,52 @@ def build_log_markdown(entries: Any) -> tuple[str, int, int]:
     return body, sum(len(v) for v in by_date.values()), len(order)
 
 
+def strip_reserved_frontmatter(text: str) -> str:
+    """Return the body of a reserved file's raw text, frontmatter dropped.
+
+    ``DocumentManager.read`` hands back the whole file, frontmatter included
+    (``NoteContent.content``), so a read-modify-write that re-emits the
+    frontmatter through ``frontmatter=`` has to drop it from the text first,
+    or every rewrite stacks one more block above the body (#1391).
+
+    The block is found by python-frontmatter's own format detection, which is
+    anchored at the start of the text, and removed by the matching handler's
+    ``split``. The remainder comes back as written: a second block, a
+    malformed one, a log quoting its own frontmatter as a sample, and an
+    indented first line all survive — the parser's parsed ``content`` would
+    have stripped the whitespace around the body, silently de-indenting a
+    leading code block. An empty block (``---`` immediately closed) is a
+    block: it carries no keys, but leaving it would put the re-emitted
+    frontmatter above it and stack exactly what this fix removes.
+
+    Two narrow rules, both the library's own:
+
+    - Only the newlines separating the block from the body are dropped.
+      The write re-inserts that separator, so keeping them would add a blank
+      line per write — the same growth in another guise.
+    - A block with no closing delimiter is not frontmatter, which is how
+      ``frontmatter.parse`` itself reads one.
+
+    Removing the blocks a defective release already stacked is #1403 and is
+    deliberately not done here: from inside this function such a block and a
+    quoted example are the same bytes.
+
+    Args:
+        text: The raw file text.
+
+    Returns:
+        The body, or *text* unchanged when it opens with no frontmatter block.
+    """
+    handler = fm.detect_format(text, fm.handlers)
+    if handler is None:
+        return text
+    try:
+        _, body = handler.split(text)
+    except ValueError:
+        return text
+    return str(body).lstrip("\n")
+
+
 def append_okf_log_entry(text: str | None, *, date: str, summary: str) -> str:
     """Append a dated bullet to an OKF ``log.md``, newest date section on top.
 
@@ -917,7 +963,8 @@ def append_okf_log_entry(text: str | None, *, date: str, summary: str) -> str:
     under a date — is preserved verbatim; only the one bullet is inserted.
 
     Args:
-        text: The current ``log.md`` file text, or ``None`` when absent.
+        text: The current ``log.md`` body — frontmatter already dropped, see
+            :func:`strip_reserved_frontmatter` — or ``None`` when absent.
         date: The ISO date (``YYYY-MM-DD``) of the entry's section.
         summary: The bullet text (without the leading ``- ``), e.g.
             ``"**Update**: wrote `guides/note.md`"``.

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -979,3 +979,71 @@ class TestReservedFrontmatterPolicy:
             title_field="heading", required_fields=("heading",)
         )
         assert policy.build(None, title="Log") == {"heading": "Log"}
+
+
+class TestStripReservedFrontmatter:
+    """The body of a reserved file's raw text, for the log read-modify-write (#1391)."""
+
+    def test_text_without_frontmatter_is_unchanged(self) -> None:
+        from markdown_vault_mcp.okf import strip_reserved_frontmatter
+
+        assert strip_reserved_frontmatter("# Log\n\n## 2026-09-07\n\n- x\n") == (
+            "# Log\n\n## 2026-09-07\n\n- x\n"
+        )
+
+    def test_the_opening_block_is_dropped(self) -> None:
+        from markdown_vault_mcp.okf import strip_reserved_frontmatter
+
+        out = strip_reserved_frontmatter("---\ntitle: Log\n---\n\n# Log\n\n- x\n")
+        assert out == "# Log\n\n- x\n"
+
+    @pytest.mark.parametrize(
+        "second",
+        [
+            "---\ntitle: Log\n---\n\n# Log\n",
+            "---\ntitle: Other\n---\n\n# Log\n",
+            "---\nfoo: [\n---\n\n# Log\n",
+            '{\n"not valid"\n}\n\n# Log\n',
+        ],
+        ids=["identical", "different", "malformed-yaml", "json-lookalike"],
+    )
+    def test_only_the_opening_block_is_dropped(self, second: str) -> None:
+        """Whatever follows is body: it is returned as written, never parsed.
+
+        A block the defect stacked is indistinguishable here from one a log
+        quotes on purpose, so neither is touched (#1403).
+        """
+        from markdown_vault_mcp.okf import strip_reserved_frontmatter
+
+        assert strip_reserved_frontmatter("---\ntitle: Log\n---\n\n" + second) == (
+            second
+        )
+
+    def test_an_empty_block_is_dropped(self) -> None:
+        """A block with no keys is still a block; leaving it would stack."""
+        from markdown_vault_mcp.okf import strip_reserved_frontmatter
+
+        assert strip_reserved_frontmatter("---\n---\n\n# Log\n\n- x\n") == (
+            "# Log\n\n- x\n"
+        )
+
+    def test_the_body_comes_back_as_written(self) -> None:
+        """The parser's own ``content`` would de-indent a leading code block."""
+        from markdown_vault_mcp.okf import strip_reserved_frontmatter
+
+        body = "    indented code\n\n# Log\n\n- x\n"
+        assert strip_reserved_frontmatter("---\ntitle: Log\n---\n\n" + body) == body
+
+    def test_an_unterminated_block_is_not_frontmatter(self) -> None:
+        from markdown_vault_mcp.okf import strip_reserved_frontmatter
+
+        text = "---\nnever closed\n\n# Log\n"
+        assert strip_reserved_frontmatter(text) == text
+
+    def test_an_interior_block_is_not_a_header(self) -> None:
+        """A log quoting its own frontmatter keeps its heading and history."""
+        from markdown_vault_mcp.okf import strip_reserved_frontmatter
+
+        body = "# Log\n\n## 2026-09-07\n\nSample:\n\n---\ntitle: Log\n---\n\n- after\n"
+        assert strip_reserved_frontmatter("---\ntitle: Log\n---\n\n" + body) == body
+        assert strip_reserved_frontmatter(body) == body

--- a/tests/test_okf_convention.py
+++ b/tests/test_okf_convention.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
+import frontmatter
 import pytest
 
 from markdown_vault_mcp._okf_convention import ConventionMaintainer
@@ -67,7 +68,12 @@ class _FakeDoc:
         if self.existing is None:
             return None
         body, metadata = self.existing
-        return type("N", (), {"content": body, "frontmatter": metadata})()
+        # Mirror the real ``DocumentManager.read``: ``NoteContent.content`` is
+        # the raw file text *including* its frontmatter block (#1391).
+        content = (
+            frontmatter.dumps(frontmatter.Post(body, **metadata)) if metadata else body
+        )
+        return type("N", (), {"content": content, "frontmatter": metadata})()
 
     def write(self, path: str, content: str, **kw: object) -> None:
         if self.raise_on_write:
@@ -155,10 +161,11 @@ class TestMaintainerFailureIsolation:
 class TestMaintainedLogFrontmatter:
     """The maintained ``log.md`` keeps satisfying the vault's index gate (#1174).
 
-    ``_append_log`` is a read-modify-write and ``read()`` returns the body
-    without frontmatter, so the log's frontmatter has to be carried across
-    the rewrite explicitly — the maintainer runs on *every* enforced write,
-    so getting this wrong strips it again after each save.
+    ``_append_log`` is a read-modify-write and ``read()`` returns the whole
+    file, frontmatter included. The frontmatter has to be dropped from the
+    text and carried across the rewrite explicitly — the maintainer runs on
+    *every* enforced write, so getting either half wrong compounds per save:
+    stripped again (#1174) or stacked again (#1391).
     """
 
     def test_unconfigured_vault_writes_no_frontmatter(self) -> None:
@@ -174,6 +181,17 @@ class TestMaintainedLogFrontmatter:
             "title": "Change history",
             "type": "log",
         }
+
+    def test_rewrite_body_carries_no_frontmatter_block(self) -> None:
+        """The read hands back the whole file; the body written back must not
+        still contain the block that ``frontmatter=`` re-emits (#1391)."""
+        m, doc, _ = _maintainer()
+        doc.existing = ("# Log\n", {"title": "Log"})
+        m.maintain("note.md", "write")
+        path, content = doc.writes[0]
+        assert path == "log.md"
+        assert content.startswith("# Log\n")
+        assert "---" not in content
 
     def test_required_field_is_seeded_on_a_fresh_log(self) -> None:
         m, doc, _ = _maintainer(
@@ -392,5 +410,56 @@ class TestUpkeepUnderRequiredFrontmatter:
             assert "wrote `guides/a.md`" in log.content
             assert "wrote `guides/b.md`" in log.content
             assert "guides/log.md" in {n.path for n in col.reader.list_documents()}
+            # Exactly one frontmatter block on disk, not one per write (#1391).
+            on_disk = (root / "guides" / "log.md").read_text(encoding="utf-8")
+            assert on_disk.count("title: Log") == 1
+            assert on_disk.startswith("---\ntitle: Log\n---\n")
+        finally:
+            col.close()
+
+    def test_an_empty_frontmatter_block_is_replaced_not_stacked_above(
+        self, tmp_path: Path
+    ) -> None:
+        """A hand-emptied block carries no keys but still occupies the top."""
+        root = tmp_path / "gated_vault_empty_fm"
+        (root / "guides").mkdir(parents=True)
+        (root / "index.md").write_text(_ROOT_INDEX, encoding="utf-8")
+        (root / "guides" / "log.md").write_text(
+            "---\n---\n\n# Log\n\n## 2026-09-06\n\n- **Update**: wrote `old.md`\n",
+            encoding="utf-8",
+        )
+        col = _build_vault(root, okf_write=True, required_frontmatter=["title"])
+        try:
+            col.writer.write("guides/a.md", "---\ntitle: A\n---\n# A\n")
+            wait_for_writer_drain(col)
+
+            on_disk = (root / "guides" / "log.md").read_text(encoding="utf-8")
+            assert on_disk.startswith("---\ntitle: Log\n---\n")
+            assert on_disk.count("---\n") == 2
+            assert "wrote `old.md`" in on_disk
+        finally:
+            col.close()
+
+    def test_an_already_stacked_log_stops_growing(self, tmp_path: Path) -> None:
+        """A vault that ran the defective release keeps the blocks it has.
+
+        The append adds no more; removing the accumulated ones is #1403.
+        """
+        root = tmp_path / "gated_vault_stacked"
+        (root / "guides").mkdir(parents=True)
+        (root / "index.md").write_text(_ROOT_INDEX, encoding="utf-8")
+        stacked = "---\ntitle: Log\n---\n\n" * 3 + (
+            "# Log\n\n## 2026-09-06\n\n- **Update**: wrote `guides/old.md`\n"
+        )
+        (root / "guides" / "log.md").write_text(stacked, encoding="utf-8")
+        col = _build_vault(root, okf_write=True, required_frontmatter=["title"])
+        try:
+            col.writer.write("guides/a.md", "---\ntitle: A\n---\n# A\n")
+            wait_for_writer_drain(col)
+
+            on_disk = (root / "guides" / "log.md").read_text(encoding="utf-8")
+            assert on_disk.count("title: Log") == 3
+            assert "wrote `guides/old.md`" in on_disk
+            assert "wrote `guides/a.md`" in on_disk
         finally:
             col.close()


### PR DESCRIPTION
## Closes / Refs

Closes #1391. Refs #1403 (the repair, deliberately not here).

## What & why

On a vault whose `log.md` carries frontmatter (a `required_frontmatter` seeding `title`, or a hand-seeded block), every enforced write under `OKF_WRITE` stacked one more identical frontmatter block above the folder log's body; one live folder had accumulated eighteen. The maintainer's read-modify-write treated `NoteContent.content` as the body alone, while `DocumentManager.read()` hands back the whole file, and then wrote it back with `frontmatter=` set.

The append now drops the block that opens the text before carrying the frontmatter across the rewrite, and does nothing else. The body is never parsed, so a log quoting its own frontmatter as a sample keeps it.

**Scope, deliberately narrowed after review.** Earlier revisions of this branch also healed files the defective releases had already stacked, by walking the body and deciding which blocks were "the same". Three review rounds each found a different edge in that decision, because from inside this function a stacked block and a block a log quotes on purpose are the same bytes. Separating them takes a rule about body content, which this fix does not invent. The repair is #1403, with the one signature that is provable: the defective code prepended a fixed serialisation, so a polluted file is that exact string repeated, which is a prefix test and not a parse. Until then a stacked log stops growing and keeps what it has, pinned by `test_an_already_stacked_log_stops_growing`.

## What this PR deliberately does NOT do

- Remove blocks already on disk: #1403.
- Touch `generate_index`, which rebuilds its body fresh and never shares this read-modify-write path.
- Add any parse of body text, which is what the narrowing is about.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before pushing.
- [x] No commit carries `!`.

## Docs impact

- [ ] `README.md` — no user-facing surface changed
- [x] `docs/` site pages — `docs/releases/4.2.md`, which now states the stacking stops and points at #1403 for the repair
- [x] `docs/design/` — `docs/design/okf.md` corrected: it said `read()` returns the body without frontmatter
- [x] Inline docstrings — `_append_log`, `strip_reserved_frontmatter`, `append_okf_log_entry`

No `INDEX_SEMANTICS_VERSION` bump: no stored-row derivation changed.

## Self-review c3020f8c..fc063e3d

Charters: rules, diff, comments, history, conformance (no normative content). Past-PRs charter skipped.
Coverage: full. `_okf_convention.py` 100%, `okf.py` 98% (the misses are unrelated functions).

### Round 4 (post-rewrite): two Codex P2 findings, both confirmed and fixed in fc063e3d

Both were about how the body is extracted, not about a body-content decision, and both reproduce:

- **Empty frontmatter block.** `---\n---` parses to empty metadata, so the truthiness guard returned the file unchanged and the seeded header landed above the block: two blocks, the exact defect. The block is now located with `frontmatter.detect_format` rather than by whether it carried keys.
- **Body normalisation.** Worse than reported: `loads().content` strips whitespace at both ends, so a leading four-space code block was silently de-indented, not merely trimmed. The body now comes from the handler's `split`, which returns the raw remainder.

The fix uses the library's two primitives for exactly the two things needed — where the block starts, where it ends — and adds two narrow rules, both the library's own: separator newlines are dropped (keeping them would add a blank line per write, verified stable over four consecutive writes), and an unterminated block is not frontmatter, which is how `frontmatter.parse` reads one. Three new unit tests plus a real-vault test for the empty-block case.

Outside this function and left alone: trailing blank lines are dropped by `frontmatter.dumps` on every write that passes `frontmatter=`, which predates this PR.

Clean at this scope. The three findings the earlier revisions carried — a docstring contradicting the read contract, a `JSONDecodeError` escaping a YAML-only catch, and an interior block being taken for a header — all belonged to the healing loop that this revision does not have. The first is fixed in the docstrings; the other two cannot arise, and `test_only_the_opening_block_is_dropped` pins both cases as body text along with the identical-block case that motivated the loop.

---
_Generated by [Claude Code](https://claude.ai/code)_
