### PR TITLE
fix(okf): okf_validate reports index.md frontmatter the spec forbids

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1451,7 +1451,10 @@ the spec itself says, dated and sourced, in
   patterns double as the audit whitelist. Findings carry a count plus up
   to 20 example paths and come in three severities — conformance
   (missing ``type``, unparseable frontmatter, ``okf_version`` outside the
-  bundle root), advisory (unknown ``status`` vocabulary, ``log.md``
+  bundle root, an ``index.md`` carrying frontmatter §8 does not allow —
+  ``index_frontmatter``, #1396 — where an empty or unparseable block counts
+  and the vault's own ``required_frontmatter`` fields are tolerated),
+  advisory (unknown ``status`` vocabulary, ``log.md``
   heading shape, missing root ``index.md``), informational (wikilink
   usage, missing recommended fields). Reserved files are exempt from the
   ``type`` rule. The tool is registered with an ``okf`` tag and hidden
@@ -2910,7 +2913,13 @@ file does not abort the scan.
 
 **UTF-8 BOM normalization (#673).** All vault-markdown reads strip a leading
 UTF-8 BOM via `utils.text.read_text_utf8` (path → str) and `decode_utf8`
-(bytes → str), both using the `utf-8-sig` codec. The scanner hashes the raw
+(bytes → str), both using the `utf-8-sig` codec. Three capped readers open
+their own file handle rather than going through those helpers — the OKF
+audit, the OKF detection probe, and the conventions resolver — and pass the
+same codec for the same reason (#1396): a BOM in front of an opening
+delimiter hides the frontmatter from every parser, which left a declared
+bundle inactive, a typed note counted as untyped, and a convention file's
+raw YAML handed to the agent as guidance. The scanner hashes the raw
 on-disk bytes (BOM included) but decodes the text without the BOM, so a
 BOM-prefixed file's frontmatter parses and is indexed correctly. Writes are
 plain `utf-8` (no BOM), so the vault normalizes to no-BOM: a BOM-prefixed file

--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -260,9 +260,24 @@ during migration it is a progress meter:
 
 - Per-rule counts + capped example lists: notes missing parseable
   frontmatter; notes missing non-empty `type`; unknown `status` values;
-  `okf_version` outside bundle root; reserved-file convention violations
-  (structural only — `log.md` heading shape, root `index.md` presence:
-  advisory findings, since the spec tolerates their absence).
+  `okf_version` outside bundle root; `index.md` frontmatter the spec does
+  not allow (`index_frontmatter`: any key but `okf_version` on the root,
+  any key on a folder index — the fields the vault's own
+  `required_frontmatter` gate seeds are tolerated as the accepted #1174
+  departure; the git conflict resolver's `conflict_with` injection is the
+  motivating case, #1396). Presence is detected separately from content, so
+  a block carrying no keys is reported, as is one that does not parse —
+  which nothing else would report, a reserved file returning before the note
+  rules run. A block counts only once it is *closed*, so a `---` opening a
+  body-only index is the thematic break it looks like. Presence and content
+  are read from one normalised string, since the parser strips before it
+  detects and the two would otherwise disagree about a block behind a blank
+  line, and the audit's own read strips a BOM like every other vault read
+  (#673), which it did not before. A folder index declaring `okf_version` is
+  reported twice, here and as `misplaced`: deliberate, the two findings say
+  different things about it. Reserved-file convention violations (structural
+  only — `log.md` heading shape, root `index.md` presence: advisory
+  findings, since the spec tolerates their absence).
 - Informational (non-conformance) counts: wikilink usage (matters at export
   only), notes lacking recommended fields.
 - Summary ratio ("N of M notes conformant") + the same exclude patterns as

--- a/docs/design/reference/okf-v0.2.md
+++ b/docs/design/reference/okf-v0.2.md
@@ -79,7 +79,7 @@ months, not twelve.
   `okf_version` key". The body is sections of `* [Title](url) - description`
   entries; producers MAY generate one, consumers MAY synthesise one when
   none is present. [source: spec] (§8, §12)
-  [pins: tests/test_okf.py::TestOkfDetector::test_declared_auto_active, tests/test_okf.py::TestBuildIndexMarkdown::test_entries_with_and_without_description]
+  [pins: tests/test_okf.py::TestOkfDetector::test_declared_auto_active, tests/test_okf.py::TestBuildIndexMarkdown::test_entries_with_and_without_description, tests/test_okf.py::TestAuditIndexFrontmatter::test_frontmatter_on_a_folder_index_is_flagged]
 - A `log.md` MAY appear at any level; it is "a flat list of date-grouped
   entries, newest first"; "Date headings MUST use ISO 8601 `YYYY-MM-DD`
   form"; the leading bold word of an entry is a convention, not a
@@ -252,7 +252,9 @@ tree, 2026-09-07].
   server enforces and vanish from `search` and `list_documents` (#1174,
   #1175). Existing keys, including the root `okf_version`, are preserved;
   `okf_version` is never synthesised into a folder index. With nothing
-  required, the files are written body-only as §8 and §9 have them.
+  required, the files are written body-only as §8 and §9 have them. The
+  audit reports any other key on an `index.md` as `index_frontmatter` and
+  tolerates exactly the seeded ones (#1396).
   Deliberate; decided in `docs/design/okf.md`, "Generated reserved files
   and the index gate".
   [pins: tests/test_okf.py::TestReservedFrontmatterPolicy::test_title_field_is_seeded_with_the_derived_title, tests/test_okf.py::TestReservedFrontmatterPolicy::test_other_required_fields_are_seeded_as_null, tests/test_okf.py::TestReservedFrontmatterPolicy::test_existing_frontmatter_is_preserved_unconfigured]

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -370,6 +370,17 @@ rewrite. A log 4.1.0 already stacked stops growing; the blocks it accumulated
 stay in its body, which
 [#1403](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1403) covers.
 
+**`okf_validate` now reports `index.md` frontmatter the spec forbids.**
+The field reference allows no frontmatter on an index except `okf_version`
+on the bundle root, but the audit never looked: a root index that had picked
+up extra keys audited clean, and the `conflict_with` marker the git conflict
+resolver writes is one such key
+([#1396](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1396)). A
+new `index_frontmatter` finding lists such files, including one whose block
+is empty or does not parse. The fields the vault's own `required_frontmatter`
+setting seeds into generated indexes are tolerated, since the server wrote
+them on purpose.
+
 **OKF staleness, the single-verifier shorthand and the provenance stamps
 now follow the spec.** OKF v0.2 says a note is stale from its `stale_after`
 on, that consumers "must treat a bare mapping as a one-element list" for

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -309,7 +309,7 @@ Audit the vault's [OKF (Open Knowledge Format)](https://github.com/GoogleCloudPl
 
 No parameters.
 
-**Returns:** Report object with the detection state (`mode`, `declared_version`, `active`), the progress ratio (`total_notes`, `conformant_notes`), `root_index_missing` (bool), and per-rule findings that each carry `count` and up to 20 `examples` paths. Conformance findings: `missing_type`, `unparseable_frontmatter`, `misplaced_okf_version`. Advisory: `unknown_status`, `log_heading_shape`. Informational: `wikilink_files`, `missing_recommended`. Reserved files (`index.md`, `log.md`) are exempt from the `type` rule.
+**Returns:** Report object with the detection state (`mode`, `declared_version`, `active`), the progress ratio (`total_notes`, `conformant_notes`), `root_index_missing` (bool), and per-rule findings that each carry `count` and up to 20 `examples` paths. Conformance findings: `missing_type`, `unparseable_frontmatter`, `misplaced_okf_version`, `index_frontmatter` (an `index.md` carrying frontmatter the spec does not allow: any key but the bundle root's `okf_version`, beyond the fields your own `MARKDOWN_VAULT_MCP_REQUIRED_FIELDS` makes the server seed; a block that is empty or does not parse counts). Advisory: `unknown_status`, `log_heading_shape`. Informational: `wikilink_files`, `missing_recommended`. Reserved files (`index.md`, `log.md`) are exempt from the `type` rule.
 
 ## Index Management
 

--- a/examples/okf/prompts/okf-migrate-vault.md
+++ b/examples/okf/prompts/okf-migrate-vault.md
@@ -16,7 +16,9 @@ any write.
 
 Call `okf_validate`. Report the conformance ratio (`conformant_notes` of
 `total_notes`) and the per-rule findings — notes missing a `type`, unparseable
-frontmatter, unknown `status` values, misplaced `okf_version`. This reads from
+frontmatter, unknown `status` values, misplaced `okf_version`, and an
+`index.md` carrying frontmatter the spec does not allow
+(`index_frontmatter`). This reads from
 disk and works before anything is declared, so use it to decide where to start.
 
 ## Step 2: Declare

--- a/src/markdown_vault_mcp/_server_tools/reader.py
+++ b/src/markdown_vault_mcp/_server_tools/reader.py
@@ -1016,7 +1016,10 @@ def register(mcp: FastMCP) -> None:
 
         Findings come in three severities. Conformance (spec violations):
         notes missing a non-empty 'type', notes with unparseable
-        frontmatter, and 'okf_version' declared outside the root index.md.
+        frontmatter, 'okf_version' declared outside the root index.md, and
+        index.md files carrying frontmatter the spec does not allow (any
+        key but the root's 'okf_version', beyond the vault's own
+        required-frontmatter fields; an empty or unparseable block counts).
         Advisory (tolerated but worth fixing): 'status' values outside
         draft/stable/deprecated, log.md files whose '##' headings are not
         YYYY-MM-DD dates, and a missing root index.md. Informational (not
@@ -1030,8 +1033,8 @@ def register(mcp: FastMCP) -> None:
             state); 'total_notes' and 'conformant_notes' (the progress
             ratio); per-rule findings each carrying 'count' and up to 20
             'examples' paths ('missing_type', 'unparseable_frontmatter',
-            'misplaced_okf_version', 'unknown_status', 'log_heading_shape',
-            'wikilink_files', 'missing_recommended'); and
+            'misplaced_okf_version', 'index_frontmatter', 'unknown_status',
+            'log_heading_shape', 'wikilink_files', 'missing_recommended'); and
             'root_index_missing' (bool).
         """
         report = await asyncio.to_thread(vault.reader.okf_validate)

--- a/src/markdown_vault_mcp/conventions.py
+++ b/src/markdown_vault_mcp/conventions.py
@@ -197,7 +197,11 @@ class ConventionsResolver:
         rel = f"{folder}/{self._filename}" if folder else self._filename
         file_path = self._source_dir / rel
         try:
-            with file_path.open(encoding="utf-8") as fh:
+            # ``utf-8-sig`` like every other vault-markdown read (#673): a
+            # BOM in front of the opening delimiter hides the frontmatter
+            # from the parser, and the stripper below would then hand the
+            # raw YAML to the agent as convention text.
+            with file_path.open(encoding="utf-8-sig") as fh:
                 raw = fh.read(_MAX_READ_CHARS)
         except FileNotFoundError:
             return None

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -183,7 +183,11 @@ class OkfDetector:
         """
         file_path = self._source_dir / _ROOT_INDEX
         try:
-            with file_path.open(encoding="utf-8") as fh:
+            # ``utf-8-sig`` for the reason the audit's own read gives (#673):
+            # a BOM in front of the opening delimiter hides the block from
+            # every parser, and here that would leave a declared bundle
+            # undeclared and inactive.
+            with file_path.open(encoding="utf-8-sig") as fh:
                 raw = fh.read(_MAX_READ_CHARS)
         except FileNotFoundError:
             return None
@@ -460,7 +464,9 @@ class OkfAuditReport:
     Degrees, not verdicts: during a migration the audit is a progress
     meter, so partial conformance is first-class. ``conformance`` findings
     violate the spec's single hard rule (parseable frontmatter with a
-    non-empty ``type``) or its placement rule for ``okf_version``;
+    non-empty ``type``), its placement rule for ``okf_version``, or its
+    no-frontmatter rule for ``index.md`` (§8, recorded in
+    ``docs/design/reference/okf-v0.2.md``);
     ``advisories`` are tolerated-by-spec deviations worth fixing;
     ``informational`` entries are not deviations at all (wikilinks only
     matter at export; recommended fields are optional).
@@ -482,6 +488,18 @@ class OkfAuditReport:
             not ``YYYY-MM-DD`` dates (advisory).
         root_index_missing: Whether the bundle-root ``index.md`` is absent
             (advisory; consumers must tolerate it).
+        index_frontmatter: ``index.md`` files carrying frontmatter the spec
+            does not allow — any key but ``okf_version`` on the bundle root,
+            any key at all on a folder index — beyond the fields the vault's
+            own ``required_frontmatter`` gate seeds (#1174), which are the
+            server's accepted departure (#1396). A block that carries no keys
+            or does not parse counts: it is still a block, and an unparseable
+            one is reported nowhere else, since a reserved file returns before
+            the note rules run. A folder index declaring ``okf_version`` is
+            reported here *and* under ``misplaced_okf_version`` — deliberate,
+            because the two say different things about it (frontmatter where
+            none belongs; the declaration in the wrong place) and an operator
+            may filter on either.
         wikilink_files: Notes containing wikilinks (informational; only
             matters at export).
         missing_recommended: Notes lacking a recommended ``title`` or
@@ -501,6 +519,7 @@ class OkfAuditReport:
     root_index_missing: bool
     wikilink_files: OkfFinding
     missing_recommended: OkfFinding
+    index_frontmatter: OkfFinding
 
 
 class _FindingAccumulator:
@@ -529,6 +548,7 @@ class _AuditCounters:
         self.misplaced = _FindingAccumulator(cap)
         self.unknown_status = _FindingAccumulator(cap)
         self.log_shape = _FindingAccumulator(cap)
+        self.index_frontmatter = _FindingAccumulator(cap)
         self.wikilinks = _FindingAccumulator(cap)
         self.missing_recommended = _FindingAccumulator(cap)
         self.total = 0
@@ -537,6 +557,36 @@ class _AuditCounters:
 
 
 _LOG_HEADING_RE = re.compile(r"^## (\d{4}-\d{2}-\d{2})\s*$")
+
+
+def _opens_with_frontmatter(text: str) -> bool:
+    """Whether *text* opens with a frontmatter block, parseable or not.
+
+    Detection is anchored at the start of the text, so a fenced example
+    further down is not mistaken for one. Presence is asked separately from
+    content because an empty or unparseable block yields no keys, and the
+    audit has to tell "no block" from "a block saying nothing".
+
+    The block must be *closed*: an opening delimiter alone is a Markdown
+    thematic break, and detection reads only that first line. The handler's
+    ``split`` supplies the rest of the answer, raising when the block never
+    closes — which is how ``frontmatter.parse`` itself reads one. A closed
+    block whose YAML is malformed still counts, since ``split`` succeeds and
+    only the load fails.
+
+    Expects the same normalised text the parse is given
+    (:func:`_audit_file`). ``frontmatter.parse`` strips before it detects, so
+    on raw text a file whose block sits behind a blank line is frontmatter to
+    the parser and no block at all to this check.
+    """
+    handler = fm.detect_format(text, fm.handlers)
+    if handler is None:
+        return False
+    try:
+        handler.split(text)
+    except ValueError:
+        return False
+    return True
 
 
 def _log_headings_conform(body: str) -> bool:
@@ -549,9 +599,16 @@ def _log_headings_conform(body: str) -> bool:
 
 
 def _read_capped(file_path: Path, rel: str) -> str | None:
-    """Read up to :data:`_MAX_READ_CHARS` of *file_path*, ``None`` on error."""
+    """Read up to :data:`_MAX_READ_CHARS` of *file_path*, ``None`` on error.
+
+    ``utf-8-sig``, so a leading BOM is stripped as every other vault read
+    strips one (#673, ``utils.text.read_text_utf8``). Reading these files as
+    plain ``utf-8`` left the BOM in front of the opening delimiter, where no
+    parser sees frontmatter: a BOM-prefixed note was counted as untyped and a
+    BOM-prefixed ``index.md`` hid whatever its block carried.
+    """
     try:
-        with file_path.open(encoding="utf-8") as fh:
+        with file_path.open(encoding="utf-8-sig") as fh:
             return fh.read(_MAX_READ_CHARS)
     except (OSError, UnicodeDecodeError):
         logger.debug("okf_audit_read_failed path=%s", rel, exc_info=True)
@@ -580,15 +637,30 @@ def _evaluate_note(
         acc.missing_recommended.add(rel)
 
 
-def _audit_file(rel: str, raw: str, acc: _AuditCounters) -> None:
-    """Classify one markdown file and update the audit counters."""
+def _audit_file(
+    rel: str, raw: str, acc: _AuditCounters, tolerated_index_keys: frozenset[str]
+) -> None:
+    """Classify one markdown file and update the audit counters.
+
+    Args:
+        rel: Vault-relative path.
+        raw: The file text (capped, BOM already stripped by the read).
+        acc: The run's counters.
+        tolerated_index_keys: Frontmatter keys an ``index.md`` may carry
+            without a finding, beyond the root's ``okf_version``: the fields
+            the vault's own gate seeds into generated reserved files.
+    """
+    # One string for the parse and the presence check below: the parse strips
+    # before it detects a block, so on raw text a block behind a blank line is
+    # frontmatter to one and absent to the other.
+    text = raw.strip()
     try:
-        post = fm.loads(raw)
+        post = fm.loads(text)
         metadata: dict[str, Any] = dict(post.metadata)
         body = post.content
         parse_ok = True
     except yaml.YAMLError:
-        metadata, body, parse_ok = {}, raw, False
+        metadata, body, parse_ok = {}, text, False
 
     name = rel.rsplit("/", 1)[-1]
     if rel == _ROOT_INDEX:
@@ -598,6 +670,18 @@ def _audit_file(rel: str, raw: str, acc: _AuditCounters) -> None:
     if name in OKF_RESERVED_FILENAMES:
         if name == "log.md" and not _log_headings_conform(body):
             acc.log_shape.add(rel)
+        if name == "index.md" and _opens_with_frontmatter(text):
+            allowed = tolerated_index_keys | (
+                {"okf_version"} if rel == _ROOT_INDEX else frozenset()
+            )
+            keys = set(metadata)
+            # A block the spec does not sanction, in any of three shapes: it
+            # carries a key that is not allowed here, it carries none at all
+            # (still a block, and nothing justifies it), or it does not parse
+            # — which no other rule would report, since a reserved file
+            # returns before the note rules run.
+            if not parse_ok or not keys or keys - allowed:
+                acc.index_frontmatter.add(rel)
         return
 
     acc.total += 1
@@ -613,6 +697,7 @@ def audit_bundle(
     exclude_patterns: list[str] | None = None,
     detector: OkfDetector | None = None,
     example_cap: int = 20,
+    reserved_frontmatter: ReservedFrontmatterPolicy | None = None,
 ) -> OkfAuditReport:
     """Audit the vault's OKF conformance from disk (design §4; #962).
 
@@ -630,6 +715,10 @@ def audit_bundle(
         detector: Optional detection probe for reporting mode/version
             state; ``None`` reports an inactive, mode-``"off"``-like state.
         example_cap: Maximum example paths kept per finding.
+        reserved_frontmatter: The vault's reserved-file frontmatter policy;
+            the fields it seeds are tolerated on ``index.md`` files
+            (``index_frontmatter``). ``None`` tolerates nothing but the
+            root's ``okf_version``.
 
     Returns:
         The audit report. Empty or missing vault directories yield an
@@ -645,6 +734,11 @@ def audit_bundle(
     )
     excludes = list(exclude_patterns or [])
     acc = _AuditCounters(example_cap)
+    tolerated = (
+        reserved_frontmatter.seeded_fields
+        if reserved_frontmatter is not None
+        else frozenset()
+    )
     paths = (
         sorted(
             p.relative_to(source_dir).as_posix()
@@ -658,7 +752,7 @@ def audit_bundle(
             continue
         raw = _read_capped(source_dir / rel, rel)
         if raw is not None:
-            _audit_file(rel, raw, acc)
+            _audit_file(rel, raw, acc, tolerated)
 
     return OkfAuditReport(
         mode=state.mode,
@@ -674,6 +768,7 @@ def audit_bundle(
         root_index_missing=not acc.root_index_seen,
         wikilink_files=acc.wikilinks.finding(),
         missing_recommended=acc.missing_recommended.finding(),
+        index_frontmatter=acc.index_frontmatter.finding(),
     )
 
 
@@ -795,7 +890,9 @@ class ReservedFrontmatterPolicy:
     ``missing_frontmatter`` skip, so the bundle's own navigation and change
     history disappear from ``search`` and ``list_documents`` while staying
     readable from disk (#1174, #1175). The generators consult this policy so
-    what they write satisfies the gate the same server enforces.
+    what they write satisfies the gate the same server enforces, and the
+    audit consults it so those seeded keys are not reported back to the
+    operator as a defect (:attr:`seeded_fields`, #1396).
 
     The policy is deliberately *conditional*. With no required fields
     configured a reserved file needs no frontmatter to be indexed, and
@@ -812,6 +909,17 @@ class ReservedFrontmatterPolicy:
 
     title_field: str = "title"
     required_fields: tuple[str, ...] = ()
+
+    @property
+    def seeded_fields(self) -> frozenset[str]:
+        """The keys :meth:`build` seeds into a generated reserved file.
+
+        Exactly the configured required fields — ``title_field`` only when
+        it is among them. The audit tolerates these on ``index.md`` files
+        (#1396): they are the server's own accepted departure from the
+        spec's no-frontmatter rule, not a defect to report to the operator.
+        """
+        return frozenset(self.required_fields)
 
     def build(
         self, existing: Mapping[str, Any] | None, *, title: str

--- a/src/markdown_vault_mcp/vault.py
+++ b/src/markdown_vault_mcp/vault.py
@@ -716,6 +716,8 @@ class Vault:
             title_field=self._title_field,
             required_fields=tuple(self._required_frontmatter or ()),
         )
+        # The audit tolerates what this policy seeds (#1396).
+        self._reserved_frontmatter = reserved_frontmatter
         self._okf_migrate = OkfMigrationManager(
             doc_mgr=self._doc_mgr,
             link_mgr=self._link_mgr,
@@ -841,6 +843,7 @@ class Vault:
             self._source_dir,
             exclude_patterns=self._exclude_patterns,
             detector=self._okf,
+            reserved_frontmatter=self._reserved_frontmatter,
         )
 
     @property

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -207,3 +207,16 @@ class TestVaultDerivedExclusion:
             assert col.conventions.enabled is False
         finally:
             col.close()
+
+
+def test_a_bom_prefixed_conventions_file_still_strips_its_frontmatter(
+    tmp_path: Path,
+) -> None:
+    """Vault-markdown reads strip a BOM (#673); this one did not."""
+    from markdown_vault_mcp.conventions import ConventionsResolver
+
+    (tmp_path / "_conventions.md").write_text(
+        "\ufeff---\ntitle: Rules\n---\nRoot rules.\n", encoding="utf-8"
+    )
+    entries = ConventionsResolver(tmp_path, "_conventions.md").for_path("note.md")
+    assert entries[0].content.strip() == "Root rules."

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.conftest import wait_for_writer_drain
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -637,8 +639,21 @@ class TestOkfAudit:
         assert report.unknown_status.examples == ("guides/odd-status.md",)
         assert report.log_heading_shape.examples == ("junk/log.md",)
         assert report.root_index_missing is False
+        assert report.index_frontmatter.count == 0
         assert report.wikilink_files.examples == ("guides/untyped.md",)
         assert report.missing_recommended.count >= 3
+
+    def test_a_bom_prefixed_note_is_read_as_typed(self, tmp_path: Path) -> None:
+        """The audit read its files as plain utf-8, so a BOM hid the type."""
+        from markdown_vault_mcp.okf import audit_bundle
+
+        (tmp_path / "note.md").write_text(
+            "\ufeff---\ntype: Note\ntitle: N\ndescription: d\n---\n# N\n",
+            encoding="utf-8",
+        )
+        report = audit_bundle(tmp_path)
+        assert report.missing_type.count == 0
+        assert report.conformant_notes == 1
 
     def test_exclude_patterns_whitelist(self, tmp_path: Path) -> None:
         from markdown_vault_mcp.okf import audit_bundle
@@ -1047,3 +1062,194 @@ class TestStripReservedFrontmatter:
         body = "# Log\n\n## 2026-09-07\n\nSample:\n\n---\ntitle: Log\n---\n\n- after\n"
         assert strip_reserved_frontmatter("---\ntitle: Log\n---\n\n" + body) == body
         assert strip_reserved_frontmatter(body) == body
+
+
+class TestAuditIndexFrontmatter:
+    """``index.md`` frontmatter the spec does not allow is a finding (#1396).
+
+    The field reference: "No frontmatter, with exactly one exception: a
+    bundle-root ``index.md`` may carry ``okf_version``." The fields the
+    vault's own ``required_frontmatter`` gate seeds (#1174) are the server's
+    accepted departure and are tolerated; anything else is reported.
+    """
+
+    def test_root_index_with_only_okf_version_is_clean(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        assert audit_bundle(tmp_path).index_frontmatter.count == 0
+
+    def test_extra_key_on_the_root_index_is_flagged(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(
+            tmp_path,
+            '---\nokf_version: "0.2"\nconflict_with: index.conflict-mcp-x.md\n---\n'
+            "# Bundle\n",
+        )
+        assert audit_bundle(tmp_path).index_frontmatter.examples == ("index.md",)
+
+    def test_frontmatter_on_a_folder_index_is_flagged(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text(
+            "---\ntitle: guides\n---\n# guides\n", encoding="utf-8"
+        )
+        assert audit_bundle(tmp_path).index_frontmatter.examples == ("guides/index.md",)
+
+    def test_gate_seeded_fields_are_tolerated(self, tmp_path: Path) -> None:
+        """What the server itself writes under the gate is not a finding."""
+        from markdown_vault_mcp.okf import ReservedFrontmatterPolicy, audit_bundle
+
+        _write_root_index(
+            tmp_path, '---\nokf_version: "0.2"\ntitle: Bundle\n---\n# Bundle\n'
+        )
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text(
+            "---\ntitle: guides\n---\n# guides\n", encoding="utf-8"
+        )
+        policy = ReservedFrontmatterPolicy(required_fields=("title",))
+        report = audit_bundle(tmp_path, reserved_frontmatter=policy)
+        assert report.index_frontmatter.count == 0
+
+    def test_a_seeded_field_does_not_excuse_an_extra_key(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.okf import ReservedFrontmatterPolicy, audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text(
+            "---\ntitle: guides\nconflict_with: x.md\n---\n# guides\n",
+            encoding="utf-8",
+        )
+        policy = ReservedFrontmatterPolicy(required_fields=("title",))
+        report = audit_bundle(tmp_path, reserved_frontmatter=policy)
+        assert report.index_frontmatter.examples == ("guides/index.md",)
+
+    def test_an_empty_block_is_flagged(self, tmp_path: Path) -> None:
+        """A block with no keys is still frontmatter, which §8 does not allow."""
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text(
+            "---\n---\n\n# guides\n", encoding="utf-8"
+        )
+        assert audit_bundle(tmp_path).index_frontmatter.examples == ("guides/index.md",)
+
+    def test_an_empty_block_on_the_root_is_flagged(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, "---\n---\n\n# Bundle\n")
+        assert audit_bundle(tmp_path).index_frontmatter.examples == ("index.md",)
+
+    def test_unparseable_index_frontmatter_is_flagged(self, tmp_path: Path) -> None:
+        """Reserved files skip the note rules, so nothing else would report it."""
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text(
+            "---\ntitle: [\n---\n\n# guides\n", encoding="utf-8"
+        )
+        report = audit_bundle(tmp_path)
+        assert report.index_frontmatter.examples == ("guides/index.md",)
+        assert report.unparseable_frontmatter.count == 0
+
+    def test_an_index_without_a_block_is_clean(self, tmp_path: Path) -> None:
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text("# guides\n", encoding="utf-8")
+        assert audit_bundle(tmp_path).index_frontmatter.count == 0
+
+    def test_a_folder_index_declaring_okf_version_reports_both_rules(
+        self, tmp_path: Path
+    ) -> None:
+        """Deliberate overlap: the two findings say different things about it."""
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text(
+            '---\nokf_version: "0.2"\n---\n\n# guides\n', encoding="utf-8"
+        )
+        report = audit_bundle(tmp_path)
+        assert report.misplaced_okf_version.examples == ("guides/index.md",)
+        assert report.index_frontmatter.examples == ("guides/index.md",)
+
+    def test_a_bom_does_not_hide_the_declaration(self, tmp_path: Path) -> None:
+        """The detector reads the root index too, and under the same contract."""
+        from markdown_vault_mcp.okf import OkfDetector, audit_bundle
+
+        _write_root_index(tmp_path, '\ufeff---\nokf_version: "0.2"\n---\n# Bundle\n')
+        report = audit_bundle(tmp_path, detector=OkfDetector(tmp_path, mode="auto"))
+        assert report.declared_version == "0.2"
+        assert report.active is True
+
+    def test_a_thematic_break_is_not_a_block(self, tmp_path: Path) -> None:
+        """``---`` opening a body-only index is a horizontal rule, not a block."""
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text(
+            "---\n# guides\n\n- [a](/guides/a.md)\n", encoding="utf-8"
+        )
+        assert audit_bundle(tmp_path).index_frontmatter.count == 0
+
+    def test_leading_blank_lines_do_not_hide_a_block(self, tmp_path: Path) -> None:
+        """The parser strips before it detects; presence must see what it sees."""
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "index.md").write_text(
+            "\n\n---\nconflict_with: x.md\n---\n\n# guides\n", encoding="utf-8"
+        )
+        assert audit_bundle(tmp_path).index_frontmatter.examples == ("guides/index.md",)
+
+    def test_a_bom_does_not_hide_a_block(self, tmp_path: Path) -> None:
+        """Vault reads strip a leading BOM (#673); the audit reads the same way."""
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(
+            tmp_path,
+            '\ufeff---\nokf_version: "0.2"\nconflict_with: x.md\n---\n# Bundle\n',
+        )
+        assert audit_bundle(tmp_path).index_frontmatter.examples == ("index.md",)
+
+    def test_log_frontmatter_is_not_a_finding(self, tmp_path: Path) -> None:
+        """The spec's log section imposes no frontmatter rule."""
+        from markdown_vault_mcp.okf import audit_bundle
+
+        _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n# Bundle\n')
+        (tmp_path / "log.md").write_text(
+            "---\ntitle: Log\n---\n# Log\n\n## 2026-09-07\n\n- x\n", encoding="utf-8"
+        )
+        assert audit_bundle(tmp_path).index_frontmatter.count == 0
+
+    def test_vault_passes_its_own_gate_policy(self, tmp_path: Path) -> None:
+        """A gated vault's generated indexes audit clean through the facade."""
+        from markdown_vault_mcp.vault import Vault
+
+        root = tmp_path / "vault"
+        (root / "guides").mkdir(parents=True)
+        _write_root_index(root, '---\nokf_version: "0.2"\ntitle: Root\n---\n# Root\n')
+        col = Vault(
+            source_dir=root,
+            read_only=False,
+            okf_mode="on",
+            okf_write=True,
+            required_frontmatter=["title"],
+        )
+        try:
+            col.index.build_index()
+            col.writer.write("guides/a.md", "---\ntitle: A\n---\n# A\n")
+            wait_for_writer_drain(col)
+            assert (root / "guides" / "index.md").read_text().startswith("---\ntitle:")
+            assert col.reader.okf_validate().index_frontmatter.count == 0
+        finally:
+            col.close()


### PR DESCRIPTION
## Closes / Refs

Closes #1396

## What & why

The OKF field reference allows no frontmatter on an `index.md` except `okf_version` on the bundle root, but the audit behind `okf_validate` only recorded that the root index was seen and read no other key, so a root index carrying extra keys audited clean. The motivating case is the `conflict_with` marker the git conflict resolver injects (#1395).

A new conformance finding, `index_frontmatter`, lists `index.md` files whose keys go beyond the root's `okf_version`. The fields the vault's own `required_frontmatter` gate seeds into generated reserved files (#1174) are tolerated: the vault hands its `ReservedFrontmatterPolicy` to the audit, and the policy's new `seeded_fields` property names exactly what its `build()` emits, so what the server writes on purpose is never reported back as a defect while any other key still is.

Design call, disclosed for review: on a vault with no `required_frontmatter`, a hand-authored `title` on the root `index.md` is now reported, because the server did not seed it and the spec forbids it. `log.md` is out of scope; the spec's log section imposes no frontmatter rule (test `test_log_frontmatter_is_not_a_finding`).

## What this PR deliberately does NOT do

- Stop the conflict resolver from injecting the keys in the first place: #1395
- Regenerate `index.md` after non-write changes: #1392
- Change the tool's severity model or add a write-time gate (rejected in `docs/design/okf.md` §6).

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create` (report below).
- [x] No commit carries `!`. `OkfAuditReport` gains a required field, but the type is not on the public import surface and the MCP return dict only gains a key.

## Docs impact

- [ ] `README.md` — no user-facing surface changed
- [x] `docs/` site pages — `docs/releases/4.2.md` gains the paragraph; `docs/tools/index.md` lists the new finding in the returned schema; `examples/okf/prompts/okf-migrate-vault.md` lists it in the shipped migration prompt
- [x] `docs/design/` — `docs/design/design.md` conformance-audit paragraph; `docs/design/okf.md` §4 audit bullet; `docs/design/reference/okf-v0.2.md` pins the new test on the §8 row and notes the audit in the departure row
- [x] Inline docstrings — `okf_validate`, `OkfAuditReport`, `audit_bundle`, `_audit_file`, `ReservedFrontmatterPolicy`

No `INDEX_SEMANTICS_VERSION` bump: no stored-row derivation changed.

## Review round 1 — three findings, all addressed in 10c925e5

- `docs/design/design.md`, `docs/tools/index.md` — blocker/verified — the new finding was documented in the OKF design page and the release notes but not in the authoritative audit paragraph or the public tool schema. Both updated, and the repository swept for other mirrors of the findings list.
- `src/markdown_vault_mcp/okf.py` — important/verified — an `index.md` whose block was empty or unparseable audited clean, because the rule read parsed keys only; the unparseable case was reported nowhere else, a reserved file returning before the note rules run. Presence is now detected separately from content with `frontmatter.detect_format`, and the finding fires on an out-of-place key, no keys, or a failed parse. Four new tests.
- Overlap between `misplaced_okf_version` and `index_frontmatter` on a folder index — kept deliberately, now documented in the attribute docstring and `docs/design/okf.md`, and pinned by a test. The two findings say different things about the same file and an operator may filter on either; suppressing the older one would change pre-existing behaviour, outside this fix.

## Review round 2 — three findings, all addressed in 2d519333

Two shared a root cause: presence was read from the raw text while the parse normalises first, so the two disagreed inside one function. They now read one normalised string.

- `src/markdown_vault_mcp/okf.py` — important/verified — a block behind a leading blank line was frontmatter to the parse and absent to the presence check, so the file audited clean. Reported by Claude as non-blocking; fixed rather than deferred, since it is the same silent pass this PR exists to close.
- `src/markdown_vault_mcp/okf.py` (`_read_capped`) — important/verified — the audit read files as plain `utf-8` against the repository's documented `utf-8-sig` contract (#673), so a BOM sat in front of the opening delimiter. Broader than the new finding: it also counted a BOM-prefixed note as untyped, before this PR. Fixed at the read, one test each.
- `examples/okf/prompts/okf-migrate-vault.md` — important/verified — the shipped migration prompt enumerates the findings and omitted the new one. My round-1 sweep grepped identifiers and this file lists them in prose, so it did not match. Redone by phrase: it is the only closed enumeration in the repository.

## Review round 3 — three findings, all addressed in d307b616

- `src/markdown_vault_mcp/okf.py` — important/verified — a body-only `index.md` opening with `---` as a thematic break was reported as carrying frontmatter, because detection reads only that first line. A block now counts only once it is closed; a closed block with malformed YAML still counts, so round 2's case is unaffected. New test.
- `docs/design/okf.md` — important — the round-2 edit spliced the byte-order-mark clause into the middle of another sentence, leaving its continuation dangling. Rewritten as separate sentences and re-read end to end rather than in the diff. Not Vale-linted, so nothing in CI would have caught it.
- `examples/okf/prompts/okf-migrate-vault.md` — minor — rewrapped, along with one over-long line the same splice left behind.

## Self-review c3020f8c..HEAD

Charters: rules, diff, comments, history, conformance (the §8 rule is quoted from the project's reference page and pinned there). Past-PRs charter skipped.
Coverage: full, single-agent sequential.

- `src/markdown_vault_mcp/okf.py` (`OkfAuditReport` docstring) — important — still said conformance findings come only from the `type` rule or the `okf_version` placement rule after the diff added a third. Resolved in the amended commit.
- `src/markdown_vault_mcp/okf.py` (`ReservedFrontmatterPolicy` docstring) — minor — named only its writers after the audit became a reader. Resolved in the amended commit.

---
_Generated by [Claude Code](https://claude.ai/code)_
