### PR TITLE
fix(okf): the maintained log.md stacks a frontmatter block per write

### DIFF
--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -467,11 +467,23 @@ carry. Both generators and the `OKF_WRITE` maintainer write through it:
   trade one defect for another.
 
 The `OKF_WRITE` maintainer needs this for a second reason: `_append_log` is a
-read-modify-write and `DocumentManager.read` returns the body without
-frontmatter, so the log's frontmatter has to be carried across the rewrite
-explicitly. Since the maintainer runs after *every* content write, the
+read-modify-write, so the log's frontmatter has to be carried across the
+rewrite explicitly. Since the maintainer runs after *every* content write, the
 alternative is not a one-time gap but frontmatter stripped again after each
 save — including frontmatter an operator seeded by hand.
+
+The split is the maintainer's own work, and getting it backwards is #1391.
+`DocumentManager.read` returns the *whole file* in `NoteContent.content`,
+block included, while `DocumentManager.write` puts a `frontmatter=` mapping
+above the body it is handed. Feeding the read text straight back therefore
+serialises a second block above the one still in it, once per write; a live
+folder accumulated eighteen. `scanner.strip_frontmatter_block` takes the
+block off first, delegating detection to `python-frontmatter` so it agrees
+with `parse_note` about where the block ends, and returning the remainder
+unnormalised. Only the block that *opens* the text comes off: an identical
+block further down is body, because separating "stacked by the defect" from
+"quoted on purpose" needs a rule about body content that this layer does not
+have. Repairing files the defective releases already stacked is #1403.
 
 ### Export
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -386,6 +386,22 @@ in the spec's example form, `2026-09-07T05:32:29Z`, written as a string so
 the YAML emitter cannot re-spell it; stamps already on disk are left as they
 are until the note is next written.
 
+**A maintained `log.md` stops collecting frontmatter blocks.** With
+`OKF_WRITE` on and a `required_frontmatter` configured, every write into a
+folder added one more identical `---\ntitle: Log\n---` block to the top of
+that folder's `log.md`; one live folder had accumulated eighteen
+([#1391](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1391)). The
+per-write log append reads the file, adds its bullet and writes it back with
+the frontmatter carried across. But the read hands back the whole file, block
+included, and the write puts the carried block above whatever body it is
+given. The append now takes the opening block off the text first, so the file
+keeps exactly one however many writes the folder receives. Nothing reported
+the defect because the bullets were always correct and the file stayed
+indexed throughout. Blocks a 4.1.0 or 4.2.0-rc.0 vault already wrote stay
+where they are, in the body: removing them means telling a stacked block
+apart from one a log quotes on purpose, and that is
+[#1403](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1403).
+
 **A link with any URI scheme is external.** The external-link filter was an
 allowlist of four prefixes, so a `file:`, `ftp:`, `obsidian:` or `zotero:`
 destination was resolved against the source note's folder and reported as a

--- a/src/markdown_vault_mcp/_okf_convention.py
+++ b/src/markdown_vault_mcp/_okf_convention.py
@@ -33,6 +33,7 @@ from markdown_vault_mcp.okf import (
     ReservedFrontmatterPolicy,
     append_okf_log_entry,
 )
+from markdown_vault_mcp.scanner import strip_frontmatter_block
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -135,10 +136,14 @@ class ConventionMaintainer:
     def _append_log(self, folder: str, path: str, operation: WriteOperation) -> None:
         """Append a dated ``**Update**`` bullet to the folder's ``log.md``.
 
-        The read-modify-write splits frontmatter from body: ``read()`` hands
-        back the body alone, so the log's frontmatter has to be carried over
-        explicitly or the rewrite would strip it — including frontmatter an
-        operator seeded by hand to satisfy ``required_frontmatter`` (#1174).
+        The read-modify-write splits frontmatter from body itself. ``read()``
+        hands back the *whole file*, block included, while ``write()`` puts a
+        ``frontmatter=`` mapping above the body it is given — so the block has
+        to come off the text before the append and be carried across as the
+        mapping, or the log grows one more identical block per write (#1391).
+        Carrying it across at all is #1174: frontmatter an operator seeded by
+        hand to satisfy ``required_frontmatter`` must survive the rewrite, or
+        the vault's own change history stops being indexed.
         """
         log_path = f"{folder}/log.md" if folder else "log.md"
         verb = _OPERATION_VERB.get(operation, operation)
@@ -150,9 +155,13 @@ class ConventionMaintainer:
             # re-enters this same re-entrant lock.
             with self._write_lock:
                 existing = self._doc_mgr.read(log_path)
-                text = existing.content if existing is not None else None
+                body = (
+                    strip_frontmatter_block(existing.content)
+                    if existing is not None
+                    else None
+                )
                 new_text = append_okf_log_entry(
-                    text, date=self._today().isoformat(), summary=summary
+                    body, date=self._today().isoformat(), summary=summary
                 )
                 self._doc_mgr.write(
                     log_path,

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -917,13 +917,18 @@ def append_okf_log_entry(text: str | None, *, date: str, summary: str) -> str:
     under a date — is preserved verbatim; only the one bullet is inserted.
 
     Args:
-        text: The current ``log.md`` file text, or ``None`` when absent.
+        text: The current ``log.md`` **body**, frontmatter excluded, or
+            ``None`` when the log does not exist yet. A caller holding raw
+            file text takes the block off first
+            (:func:`~markdown_vault_mcp.scanner.strip_frontmatter_block`):
+            the result is written back as a body, so a block left in it is
+            serialised under a second one (#1391).
         date: The ISO date (``YYYY-MM-DD``) of the entry's section.
         summary: The bullet text (without the leading ``- ``), e.g.
             ``"**Update**: wrote `guides/note.md`"``.
 
     Returns:
-        The updated ``log.md`` text (always newline-terminated).
+        The updated body (always newline-terminated).
     """
     heading = f"## {date}"
     bullet = f"- {summary}"

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -686,6 +686,45 @@ def _scan_headings(lines: list[str]) -> list[tuple[int, int, str]]:
     return out
 
 
+def strip_frontmatter_block(text: str) -> str:
+    """Return *text* without its leading frontmatter block, body verbatim.
+
+    The counterpart of a ``write(body, frontmatter=...)``: a read-modify-write
+    that carries frontmatter across the rewrite must hand the writer the body
+    alone, or the serializer stacks a second block above the first (#1391).
+    ``NoteContent.content`` — and every other raw file text in this package —
+    includes the block, so it has to come off first.
+
+    Detection is delegated to ``python-frontmatter`` and so agrees with
+    :func:`parse_note` about *where* the block ends: the same handlers, the
+    same offset-zero anchoring (an identical block later in the body is body
+    text), and the same reading of an unterminated block as no frontmatter at
+    all. Unlike :func:`frontmatter.parse` the body is not stripped, so a first
+    line that is an indented code block keeps its indentation.
+
+    The newlines separating the block from the body are dropped — they are the
+    delimiter's, not the body's, and ``frontmatter.dumps`` re-inserts them on
+    the way back. Keeping them would add a blank line per rewrite.
+
+    Args:
+        text: Raw markdown file text (frontmatter included).
+
+    Returns:
+        The body. *text* unchanged when it opens with no frontmatter block.
+    """
+    candidate = text.lstrip()
+    handler = frontmatter.detect_format(candidate, frontmatter.handlers)
+    if handler is None:
+        return text
+    try:
+        _, body = handler.split(candidate)
+    except ValueError:
+        # Never closed — frontmatter.parse reads that as a file with no
+        # frontmatter, and so does the indexer that calls it.
+        return text
+    return body.lstrip("\n")
+
+
 def list_section_headings(text: str) -> list[str]:
     """Return the document's ATX heading texts in document order.
 

--- a/src/markdown_vault_mcp/types.py
+++ b/src/markdown_vault_mcp/types.py
@@ -263,7 +263,10 @@ class NoteContent:
         path: Relative path from the vault root (e.g. ``Journal/note.md``).
         title: Document title derived from the first H1 heading or filename.
         folder: Parent folder path (empty string for root-level documents).
-        content: Raw markdown body including frontmatter.
+        content: The note's raw file text, frontmatter block included.
+            A caller rewriting this through ``write(body, frontmatter=...)``
+            takes the block off first, or the writer stacks a second one
+            above it (#1391).
         frontmatter: Parsed YAML frontmatter as a dict.
         modified_at: Last-modified time as a Unix timestamp float.
         etag: Opaque hash of file content for optimistic concurrency checks.

--- a/tests/test_okf_convention.py
+++ b/tests/test_okf_convention.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
+import frontmatter as fm
 import pytest
 
 from markdown_vault_mcp._okf_convention import ConventionMaintainer
@@ -64,10 +65,18 @@ class _FakeDoc:
         self.existing: tuple[str, dict[str, Any]] | None = None
 
     def read(self, _path: str) -> Any:
+        """Model ``DocumentManager.read``: ``content`` is the *whole file*.
+
+        The frontmatter block is serialised back into ``content`` exactly as
+        the real read hands it back. A double that returned the body alone is
+        what let #1391 stay green: the maintainer fed the block back to a
+        ``write(frontmatter=...)``, which stacked a second one.
+        """
         if self.existing is None:
             return None
         body, metadata = self.existing
-        return type("N", (), {"content": body, "frontmatter": metadata})()
+        raw = fm.dumps(fm.Post(body, **metadata)) if metadata else body
+        return type("N", (), {"content": raw, "frontmatter": metadata})()
 
     def write(self, path: str, content: str, **kw: object) -> None:
         if self.raise_on_write:
@@ -155,10 +164,12 @@ class TestMaintainerFailureIsolation:
 class TestMaintainedLogFrontmatter:
     """The maintained ``log.md`` keeps satisfying the vault's index gate (#1174).
 
-    ``_append_log`` is a read-modify-write and ``read()`` returns the body
-    without frontmatter, so the log's frontmatter has to be carried across
-    the rewrite explicitly — the maintainer runs on *every* enforced write,
-    so getting this wrong strips it again after each save.
+    ``_append_log`` is a read-modify-write, so the log's frontmatter has to be
+    carried across the rewrite explicitly — the maintainer runs on *every*
+    enforced write, so getting this wrong strips it again after each save.
+    ``read()`` returns the whole file, block included, and ``write()`` puts
+    the ``frontmatter=`` mapping above the body it is given, so the block also
+    has to come *off* the text before the append (#1391).
     """
 
     def test_unconfigured_vault_writes_no_frontmatter(self) -> None:
@@ -174,6 +185,24 @@ class TestMaintainedLogFrontmatter:
             "title": "Change history",
             "type": "log",
         }
+        # ...and comes off the text, or write() serialises a second block
+        # above the one still in it (#1391).
+        assert "---" not in doc.writes[0][1]
+
+    def test_an_empty_block_is_dropped_on_an_unconfigured_vault(self) -> None:
+        """A block with no keys does not survive the rewrite, deliberately.
+
+        Taking the block off is unconditional; putting one back is the
+        policy's call, and with no required fields it returns ``None``. So a
+        hand-seeded ``---\n---`` goes away on the next append. It carried
+        nothing, and leaving it in the body is what stacks (#1391) — a block
+        with keys is still carried across, which is the case #1174 is about.
+        """
+        m, doc, _ = _maintainer()
+        doc.existing = ("---\n---\n# Log\n", {})
+        m.maintain("note.md", "write")
+        assert doc.write_kwargs[0]["frontmatter"] is None
+        assert "---" not in doc.writes[0][1]
 
     def test_required_field_is_seeded_on_a_fresh_log(self) -> None:
         m, doc, _ = _maintainer(
@@ -392,5 +421,55 @@ class TestUpkeepUnderRequiredFrontmatter:
             assert "wrote `guides/a.md`" in log.content
             assert "wrote `guides/b.md`" in log.content
             assert "guides/log.md" in {n.path for n in col.reader.list_documents()}
+        finally:
+            col.close()
+
+    def test_repeated_writes_keep_exactly_one_frontmatter_block(
+        self, tmp_path: Path
+    ) -> None:
+        """#1391: the read-modify-write stacked one block per write.
+
+        ``read()`` hands back the whole file, frontmatter included; the append
+        passed that straight to ``write(frontmatter=...)``, which serialises a
+        fresh block above whatever it is given. Three writes, three blocks.
+        """
+        root = tmp_path / "gated_vault_thrice"
+        (root / "guides").mkdir(parents=True)
+        (root / "index.md").write_text(_ROOT_INDEX, encoding="utf-8")
+        col = _build_vault(root, okf_write=True, required_frontmatter=["title"])
+        try:
+            for name in ("a", "b", "c"):
+                col.writer.write(
+                    f"guides/{name}.md", f"---\ntitle: {name}\n---\n# {name}\n"
+                )
+                wait_for_writer_drain(col)
+
+            text = (root / "guides" / "log.md").read_text(encoding="utf-8")
+            assert text.count("title: Log") == 1
+            assert text.count("- **Update**:") == 3
+        finally:
+            col.close()
+
+    def test_an_empty_seeded_block_is_replaced_not_stacked_above(
+        self, tmp_path: Path
+    ) -> None:
+        """#1391: an empty block carries no keys but is still a block.
+
+        A guard that asked "did the frontmatter parse to anything?" would read
+        ``---\\n---`` as no block at all and leave it in the body, so the
+        seeded ``title`` would land above it — the exact defect.
+        """
+        root = tmp_path / "gated_vault_empty_block"
+        (root / "guides").mkdir(parents=True)
+        (root / "index.md").write_text(_ROOT_INDEX, encoding="utf-8")
+        (root / "guides" / "log.md").write_text("---\n---\n# Log\n", encoding="utf-8")
+        col = _build_vault(root, okf_write=True, required_frontmatter=["title"])
+        try:
+            col.writer.write("guides/a.md", "---\ntitle: A\n---\n# A\n")
+            wait_for_writer_drain(col)
+
+            text = (root / "guides" / "log.md").read_text(encoding="utf-8")
+            assert text.count("---") == 2
+            assert text.startswith("---\ntitle: Log\n---\n\n# Log\n")
         finally:
             col.close()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -18,6 +18,7 @@ from markdown_vault_mcp.scanner import (
     normalize_heading,
     parse_note,
     scan_directory,
+    strip_frontmatter_block,
 )
 from markdown_vault_mcp.types import Chunk
 
@@ -1043,3 +1044,42 @@ class TestContentChars:
         (tmp_path / "n.md").write_text("---\ntitle: T\n---\n", encoding="utf-8")
 
         assert parse_note(tmp_path / "n.md", tmp_path).content_chars == 0
+
+
+class TestStripFrontmatterBlock:
+    """The read side of a ``write(body, frontmatter=...)`` round-trip (#1391)."""
+
+    def test_the_opening_block_comes_off_with_its_separator(self) -> None:
+        assert strip_frontmatter_block("---\ntitle: Log\n---\n\n# Log\n") == "# Log\n"
+
+    def test_a_file_with_no_block_is_returned_unchanged(self) -> None:
+        text = "# Log\n\n## 2026-09-08\n"
+        assert strip_frontmatter_block(text) == text
+
+    def test_an_empty_block_is_still_a_block(self) -> None:
+        # ``---\n---`` parses to empty metadata, so "carried no keys" does not
+        # distinguish it from "carried no block" — the delimiters do.
+        assert strip_frontmatter_block("---\n---\n# Log\n") == "# Log\n"
+
+    def test_an_unterminated_block_is_not_frontmatter(self) -> None:
+        # How ``frontmatter.parse`` reads it, and so how the indexer does.
+        text = "---\ntitle: Log\n# Log\n"
+        assert strip_frontmatter_block(text) == text
+
+    def test_only_the_block_that_opens_the_text_comes_off(self) -> None:
+        # An identical block further down is body — a log quoting its own
+        # frontmatter as a sample keeps it. Deciding otherwise needs a rule
+        # about body content, which this function does not have (#1403).
+        text = "---\ntitle: Log\n---\n\n---\ntitle: Log\n---\n\n# Log\n"
+        assert strip_frontmatter_block(text) == "---\ntitle: Log\n---\n\n# Log\n"
+
+    def test_the_body_is_not_normalised(self) -> None:
+        # ``frontmatter.parse`` strips the body at both ends, which silently
+        # de-indents a leading code block; this returns the raw remainder.
+        body = "    indented code\n\nprose\n\n\n"
+        assert strip_frontmatter_block(f"---\ntitle: T\n---\n\n{body}") == body
+
+    def test_blank_lines_before_the_block_do_not_hide_it(self) -> None:
+        # ``frontmatter.parse`` strips before detecting, so the indexer reads
+        # this as frontmatter; leaving the block in the body would stack it.
+        assert strip_frontmatter_block("\n\n---\ntitle: T\n---\n\n# T\n") == "# T\n"


### PR DESCRIPTION
## Closes / Refs

Closes #1391. Refs #1403 (the repair of files already stacked, deliberately not here).

Re-implementation from scratch after the earlier attempt was pulled and the issue reopened. Same destination, different route: this one fixes the read/write contract mismatch and stops.

## What & why

`DocumentManager.read` returns the whole file in `NoteContent.content`, block included (`managers/document.py:386` builds it from `_read_text_utf8`), while `write` puts a `frontmatter=` mapping *above* the body it is handed (`managers/document.py:663`). The OKF convention maintainer's `log.md` append fed the read text straight back, so on any vault whose log carries frontmatter — a `required_frontmatter` seeding `title`, or a hand-seeded block — every enforced write serialised one more identical block above the last. One live folder had accumulated eighteen.

`scanner.strip_frontmatter_block` takes the opening block off before the append; the frontmatter is still carried across as the mapping, which is what #1174 needs. The helper delegates detection to `python-frontmatter`, so it agrees with `parse_note` about where the block ends — same handlers, same offset-zero anchoring, an unterminated block read as no frontmatter at all — and returns the remainder **unnormalised**, unlike `frontmatter.parse`, which strips the body at both ends and would silently de-indent a leading code block. The separator newlines come off with the block because `frontmatter.dumps` re-inserts them; keeping them added a blank line per rewrite.

Only the block that *opens* the text comes off. An identical block further down is body text, because telling one stacked by the defect apart from one a log quotes on purpose needs a rule about body content this layer does not have.

**The class was swept.** `_append_log` is the only read-modify-write that carries frontmatter across a rewrite. The other three candidates are correct as they stand and are untouched: `okf_migrate.generate_index` reads only `existing.frontmatter` and writes a freshly built body (`managers/okf_migrate.py:195-207` — this confirms the issue's `[unverified]` note); `okf_migrate.seed_log` returns early when the log exists (`:244`); `okf_migrate.convert_links` writes the rewritten raw text back *without* `frontmatter=` (`:128`), which is why it never stacked. `DocumentManager.edit` goes through `_finalize_content_write` and never re-serialises a block.

**The unit-test double is part of the fix.** It returned a body-only `content`, which is what let the defect stay green through #1196. It now serialises the block back in as the real read does; with the source fix reverted, both it and the new real-vault test fail.

## What this PR deliberately does NOT do

- **Remove blocks already on disk.** A 4.1.0 or 4.2.0-rc.0 vault keeps what it has, in the body; the log stops growing. #1403.
- **Parse or inspect body text.** That is the rule #1403 needs and this fix does not invent.
- **Touch `generate_index`, `seed_log`, or `convert_links`** — verified correct above, so changing them would be churn.
- **Bump `INDEX_SEMANTICS_VERSION`.** No stored-row derivation changed: the helper is not on the indexing path, only on the write path. Per the once-per-release policy (#1365) the current value already covers this release in any case.
- **Move the release-notes watermark.** `notes-range-end: 60111e3f` stays: the squash SHA is not knowable here, and advancing it to a SHA that never lands on `main` would make the next notes refresh skip real research. The added paragraph is folded prose, not research output.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No commit carries `!`. Nothing on the operator surface changes; the public library interface only gains `scanner.strip_frontmatter_block` (`tests/public_import_surface.txt` is unchanged — the package root is what it guards).

## Docs impact

- [ ] `README.md` — no user-facing surface changed (no env var, tool, or flag)
- [x] `docs/` site pages — `docs/releases/4.2.md`, one paragraph. The defect shipped in v4.1.0 (`git tag --contains 65083123` → `v4.1.0`), so it is a real fix against this release's range start, not intra-range churn.
- [x] `docs/design/` — `docs/design/okf.md` said `DocumentManager.read` "returns the body without frontmatter". It does not; corrected, with the split now stated as the maintainer's own work.
- [x] Inline docstrings — `strip_frontmatter_block` (new), `_append_log`, `append_okf_log_entry`'s `text:` parameter, `NoteContent.content`.

## Self-review fa94472b..52a382fb

Charters: rules, diff, comments, history, conformance (no normative content — the log's `# Log` / `## YYYY-MM-DD` shape is unchanged), past-PRs (the pulled attempt's Codex findings). Coverage: full.

Four findings, all resolved in `52a382fb`:

- `src/markdown_vault_mcp/okf.py:919` — important/verified — docstring rot the diff introduced: `append_okf_log_entry`'s `text:` parameter said "The current `log.md` **file text**", but its only production caller now hands it the body. Exactly the misreading being fixed, one call away. Fix: the parameter and return are documented as the body, pointing at the helper for callers holding raw text.
- `src/markdown_vault_mcp/types.py:266` — important/verified — `NoteContent.content` read "Raw markdown body including frontmatter", the self-contradictory phrasing the defect grew from. Fix: "the note's raw file text, frontmatter block included", with the rewrite hazard named.
- `tests/test_okf_convention.py` — important/verified — an untested behaviour change: taking the block off is unconditional, but putting one back is the policy's call, so on a vault with no `required_frontmatter` a hand-seeded *empty* `---\n---` now disappears on the next append. It carried nothing and leaving it in the body is what stacks, so this is intended cleanup — now pinned by `test_an_empty_block_is_dropped_on_an_unconfigured_vault` rather than left to be discovered. A block **with** keys is still carried across (#1174's case, still pinned).
- `tests/test_scanner.py` — minor — an identity assertion (`is text`) over-specified "returned unchanged"; equality says what is meant.

Coverage: `_okf_convention.py` 100%, `types.py` 100%, `okf.py` 98% (misses are unrelated functions), and every added `scanner.py` line covered. Structural gate 100% over 189 changed lines, 0 violations. Full suite 4614 passed. `mkdocs build --strict` and Vale clean.

The pulled attempt's two surviving Codex findings both reproduce against a naive version of this helper and are pinned here: the empty block (`test_an_empty_block_is_still_a_block`, plus the real-vault `test_an_empty_seeded_block_is_replaced_not_stacked_above`) and body normalisation (`test_the_body_is_not_normalised`). Its earlier three belonged to the healing loop this revision does not have.

---
_Generated by [Claude Code](https://claude.ai/code)_
