### PR TITLE
fix(okf): a BOM no longer hides frontmatter from the OKF and conventions readers

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2922,7 +2922,14 @@ file does not abort the scan.
 
 **UTF-8 BOM normalization (#673).** All vault-markdown reads strip a leading
 UTF-8 BOM via `utils.text.read_text_utf8` (path → str) and `decode_utf8`
-(bytes → str), both using the `utf-8-sig` codec. The scanner hashes the raw
+(bytes → str), both using the `utf-8-sig` codec. A probe that needs only a
+file's head passes `read_text_utf8(path, limit=...)` rather than opening its
+own handle: the OKF detector, the OKF audit and the conventions resolver each
+rolled their own capped `utf-8` read and so sat outside this contract, which
+left a BOM-prefixed declaration undetected, a conformant note audited as
+`missing_type`, and a convention file's raw YAML delivered as prose (#1407).
+The cap counts characters of text, so a stripped BOM does not spend one. The
+scanner hashes the raw
 on-disk bytes (BOM included) but decodes the text without the BOM, so a
 BOM-prefixed file's frontmatter parses and is indexed correctly. Writes are
 plain `utf-8` (no BOM), so the vault normalizes to no-BOM: a BOM-prefixed file

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -416,6 +416,21 @@ fields to each index it generates, which keeps the file in search. The
 audit reports those fields like any others. Leave them in place. Indexing
 is unchanged. The conformance ratio still counts notes only.
 
+**A byte-order mark no longer hides a file's frontmatter.** Every read of
+vault markdown strips a leading UTF-8 BOM, a contract from
+[#673](https://github.com/pvliesdonk/markdown-vault-mcp/issues/673). Three
+readers opened their own handle with plain `utf-8` and sat outside it
+([#1407](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1407)). A
+BOM in front of the opening `---` then hid the block from the parser
+underneath. The effects were spread out: a bundle whose root `index.md`
+declared `okf_version` behind a BOM stayed inactive, so no OKF annotations,
+no filters, and `okf_validate` reporting the vault as undeclared; a fully
+conformant note audited as `missing_type`, understating the conformance
+ratio; and a `_conventions.md` file handed the agent its raw YAML as though
+it were convention prose. All three now read through the same helper as the
+rest of the vault. A file without a BOM is unaffected, and a file that is
+not UTF-8 at all is still skipped.
+
 **A link with any URI scheme is external.** The external-link filter was an
 allowlist of four prefixes, so a `file:`, `ftp:`, `obsidian:` or `zotero:`
 destination was resolved against the source note's folder and reported as a
@@ -666,6 +681,16 @@ on your part:
   byte-identical when the same actor wrote it on the same day, now changes
   the stamp and, on a git-backed vault, produces a commit. Stamps already
   on disk stay bare dates until the note is next written.
+- **A vault whose root `index.md` starts with a byte-order mark becomes an
+  OKF bundle on upgrade**
+  ([#1407](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1407)).
+  Its declaration was invisible before, so results gain OKF annotations, the
+  OKF filters start matching, and reserved files and deprecated or stale
+  notes take their ranking downweights. Because `type`, `status` and
+  `stale_after` join the structured-filter set on an active bundle, that
+  vault also rebuilds its index once, on the existing
+  `indexed_frontmatter_fields` provenance check rather than a semantics
+  bump. Nothing on disk changes.
 - **`okf_validate` can report index files it used to pass.** A vault with
   `MARKDOWN_VAULT_MCP_REQUIRED_FIELDS` set sees each `index.md` the server
   wrote those fields into under the new `index_frontmatter` finding

--- a/src/markdown_vault_mcp/conventions.py
+++ b/src/markdown_vault_mcp/conventions.py
@@ -29,6 +29,7 @@ from markdown_vault_mcp.utils import (
     resolve_inside,
 )
 from markdown_vault_mcp.utils.fs import iter_markdown_files
+from markdown_vault_mcp.utils.text import read_text_utf8
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -197,8 +198,7 @@ class ConventionsResolver:
         rel = f"{folder}/{self._filename}" if folder else self._filename
         file_path = self._source_dir / rel
         try:
-            with file_path.open(encoding="utf-8") as fh:
-                raw = fh.read(_MAX_READ_CHARS)
+            raw = read_text_utf8(file_path, limit=_MAX_READ_CHARS)
         except FileNotFoundError:
             return None
         except (OSError, UnicodeDecodeError):

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -31,6 +31,8 @@ from typing import TYPE_CHECKING, Any
 import frontmatter as fm
 import yaml
 
+from markdown_vault_mcp.utils.text import read_text_utf8
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
@@ -183,8 +185,7 @@ class OkfDetector:
         """
         file_path = self._source_dir / _ROOT_INDEX
         try:
-            with file_path.open(encoding="utf-8") as fh:
-                raw = fh.read(_MAX_READ_CHARS)
+            raw = read_text_utf8(file_path, limit=_MAX_READ_CHARS)
         except FileNotFoundError:
             return None
         except (OSError, UnicodeDecodeError):
@@ -580,8 +581,7 @@ def _index_frontmatter_conforms(rel: str, raw: str, metadata: dict[str, Any]) ->
 def _read_capped(file_path: Path, rel: str) -> str | None:
     """Read up to :data:`_MAX_READ_CHARS` of *file_path*, ``None`` on error."""
     try:
-        with file_path.open(encoding="utf-8") as fh:
-            return fh.read(_MAX_READ_CHARS)
+        return read_text_utf8(file_path, limit=_MAX_READ_CHARS)
     except (OSError, UnicodeDecodeError):
         logger.debug("okf_audit_read_failed path=%s", rel, exc_info=True)
         return None

--- a/src/markdown_vault_mcp/utils/text.py
+++ b/src/markdown_vault_mcp/utils/text.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def read_text_utf8(path: Path) -> str:
+def read_text_utf8(path: Path, *, limit: int | None = None) -> str:
     """Read a text file as UTF-8, stripping a leading BOM if present (#673).
 
     Uses ``utf-8-sig``: a leading UTF-8 BOM (``\\ufeff``) is stripped, and a
@@ -25,13 +25,23 @@ def read_text_utf8(path: Path) -> str:
     non-UTF-8 file still raises ``UnicodeDecodeError``, exactly as ``utf-8``
     would.
 
+    *limit* bounds the read for a probe that needs only a file's head (the
+    OKF detector and audit, the conventions resolver). It belongs here rather
+    than in each probe because rolling a capped read by hand is how those
+    three came to pick plain ``utf-8`` and fall out of this contract (#1407).
+    The cap counts characters of text, so a stripped BOM does not spend one.
+
     Args:
         path: File to read.
+        limit: Maximum characters to read; ``None`` reads the whole file.
 
     Returns:
         The file's text with any leading UTF-8 BOM removed.
     """
-    return path.read_text(encoding="utf-8-sig")
+    if limit is None:
+        return path.read_text(encoding="utf-8-sig")
+    with path.open(encoding="utf-8-sig") as fh:
+        return fh.read(limit)
 
 
 def decode_utf8(data: bytes) -> str:

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -73,6 +73,15 @@ class TestForPath:
         entries = resolver.for_path("3-Resources")
         assert entries[1].content == "Resource rules."
 
+    def test_frontmatter_behind_a_bom_is_stripped(self, tmp_path: Path) -> None:
+        # A BOM hid the block from _strip_frontmatter, so the raw YAML was
+        # delivered to the agent as convention prose (#1407).
+        (tmp_path / "_conventions.md").write_bytes(
+            b"\xef\xbb\xbf---\ntitle: C\n---\nUse sentence case."
+        )
+        resolver = ConventionsResolver(tmp_path, "_conventions.md")
+        assert resolver.for_path("note.md")[0].content == "Use sentence case."
+
     def test_invalid_frontmatter_falls_back_to_raw(self, tmp_path: Path) -> None:
         raw = "---\n: bad: [yaml\n---\nBody text."
         (tmp_path / "_conventions.md").write_text(raw, encoding="utf-8")

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -47,6 +47,16 @@ class TestOkfDetector:
         assert state.active is True
         assert state.declared_version == "0.2"
 
+    def test_declaration_behind_a_bom_is_detected(self, tmp_path: Path) -> None:
+        # A BOM before the opening delimiter used to hide the declaration, so
+        # a declared bundle stayed inactive (#1407).
+        (tmp_path / "index.md").write_bytes(
+            b'\xef\xbb\xbf---\nokf_version: "0.2"\n---\n# Bundle\n'
+        )
+        state = OkfDetector(tmp_path, mode="auto").state()
+        assert state.declared_version == "0.2"
+        assert state.active is True
+
     def test_mode_off_ignores_marker(self, tmp_path: Path) -> None:
         _write_root_index(tmp_path, '---\nokf_version: "0.2"\n---\n')
         state = OkfDetector(tmp_path, mode="off").state()
@@ -691,6 +701,20 @@ class TestOkfAudit:
         assert report.conformant_notes == 1
         assert report.root_index_missing is True
 
+    def test_note_behind_a_bom_is_audited_on_its_frontmatter(
+        self, tmp_path: Path
+    ) -> None:
+        # The audit's own read used to keep the BOM, so a conformant note
+        # audited as missing_type and the ratio understated the bundle (#1407).
+        from markdown_vault_mcp.okf import audit_bundle
+
+        (tmp_path / "good.md").write_bytes(
+            b"\xef\xbb\xbf---\ntype: Playbook\n---\n# Good\n"
+        )
+        report = audit_bundle(tmp_path)
+        assert report.conformant_notes == 1
+        assert report.missing_type.count == 0
+
     def test_unreadable_file_skipped(self, tmp_path: Path) -> None:
         from markdown_vault_mcp.okf import audit_bundle
 
@@ -822,6 +846,16 @@ class TestIndexFrontmatterAudit:
         )
         report = audit_bundle(tmp_path, exclude_patterns=["junk/**"])
         assert report.index_frontmatter.count == 0
+
+    def test_root_index_finding_behind_a_bom(self, tmp_path: Path) -> None:
+        # The rule reads presence and keys from one string, so it starts
+        # seeing a BOM-prefixed index as soon as the reader does (#1407).
+        from markdown_vault_mcp.okf import audit_bundle
+
+        (tmp_path / "index.md").write_bytes(
+            b'\xef\xbb\xbf---\nokf_version: "0.2"\ntitle: Bundle\n---\n# Bundle\n'
+        )
+        assert audit_bundle(tmp_path).index_frontmatter.examples == ("index.md",)
 
     def test_log_frontmatter_is_not_an_index_finding(self, tmp_path: Path) -> None:
         from markdown_vault_mcp.okf import audit_bundle

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
 from markdown_vault_mcp.utils.text import (
     CHAR_SUBS,
     build_position_map,
     find_closest_match,
     normalize_text,
+    read_text_utf8,
 )
 
 # ---------------------------------------------------------------------------
@@ -241,3 +249,35 @@ class TestUtf8BomHelpers:
 
         with pytest.raises(UnicodeDecodeError):
             decode_utf8(b"\xff\xfe\x80")
+
+
+# ---------------------------------------------------------------------------
+# read_text_utf8 (#673, #1407)
+# ---------------------------------------------------------------------------
+
+
+class TestReadTextUtf8:
+    def test_strips_a_leading_bom(self, tmp_path: Path) -> None:
+        p = tmp_path / "note.md"
+        p.write_bytes(b"\xef\xbb\xbf---\ntitle: T\n---\n# Body\n")
+        assert read_text_utf8(p).startswith("---")
+
+    def test_limit_caps_the_read(self, tmp_path: Path) -> None:
+        p = tmp_path / "note.md"
+        p.write_text("abcdef", encoding="utf-8")
+        assert read_text_utf8(p, limit=3) == "abc"
+
+    def test_limit_counts_characters_past_a_stripped_bom(self, tmp_path: Path) -> None:
+        # The BOM is not one of the characters the cap spends: a capped read
+        # returns the same prefix whether or not the file carries one (#1407).
+        plain = tmp_path / "plain.md"
+        plain.write_bytes(b"abcdef")
+        bom = tmp_path / "bom.md"
+        bom.write_bytes(b"\xef\xbb\xbfabcdef")
+        assert read_text_utf8(bom, limit=3) == read_text_utf8(plain, limit=3) == "abc"
+
+    def test_non_utf8_still_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.md"
+        p.write_bytes(b"\xff\xfe\x00broken")
+        with pytest.raises(UnicodeDecodeError):
+            read_text_utf8(p)


### PR DESCRIPTION
## Closes / Refs

Closes #1407. Refs #673 (the BOM contract these three readers sat outside), #1396 (its BOM acceptance case becomes testable here and is now pinned), #1408 (the other reader defect surfaced from #1396, still open and untouched).

## What & why

Every vault-markdown read strips a leading UTF-8 BOM through `utils.text.read_text_utf8` / `decode_utf8` (#673, and `docs/design/design.md` says so in as many words). Three readers opened their own handle with plain `utf-8` and so chose the codec independently of that contract:

| Reader | What a BOM did |
|---|---|
| `OkfDetector._probe_declared_version` | A root `index.md` declaring `okf_version` read as undeclared: no OKF annotations, no filters, `okf_validate` reporting the vault as off. |
| `okf._read_capped` (the audit) | A fully conformant note audited as `missing_type`, understating the conformance ratio. |
| `ConventionsResolver._load` | `_strip_frontmatter` could not find the block, so the agent got the file's raw YAML as convention prose. |

All three are *capped* reads, which is why they were bespoke: the contract's primitive reads a whole file, and these are probes that must bound I/O on a pathological one. So the cap is what cost them the codec, and the fix puts the cap in the primitive — `read_text_utf8(path, limit=...)` — rather than patching `encoding=` at three call sites. The next capped reader gets the contract for free; a second copy of the codec choice cannot drift.

`limit` counts characters of text, so a stripped BOM does not spend one: a capped read returns the same prefix whether or not the file carries a BOM. Pinned by `test_limit_counts_characters_past_a_stripped_bom`.

Each reader keeps its own error handling exactly as it was (`FileNotFoundError` → `None`, `(OSError, UnicodeDecodeError)` → logged debug and skipped); `utf-8-sig` raises `UnicodeDecodeError` on a non-UTF-8 file exactly as `utf-8` did.

**The issue's `[unverified]` sweep is settled.** `grep` for a bare `encoding="utf-8"` read across `src/` returns only these three for vault markdown. Everything else is either a write (writes stay plain `utf-8` — that is what normalizes the vault to no-BOM), internal state JSON (`tracker.py`, `vector_index.py`, `managers/embeddings.py`), packaged assets (`_server_apps.py`), or already correct (`scanner.py` hashes raw bytes and decodes through `decode_utf8`). `_server_prompts.py` reads built-in prompts with a hand-rolled `utf-8-sig` and a comment saying why: it holds an `importlib.resources` traversable, not a `Path`. Left alone.

## Tests

Four reproductions, one per effect, each mutation-checked by putting `utf-8` back in the primitive:

- `test_declaration_behind_a_bom_is_detected` — declared version and `active`.
- `test_note_behind_a_bom_is_audited_on_its_frontmatter` — conformant, not `missing_type`.
- `test_frontmatter_behind_a_bom_is_stripped` — the convention entry is the body, not the YAML.
- `test_root_index_finding_behind_a_bom` — **closes #1396's deferred case**: that PR could not pin BOM behaviour because the reader was blind. Presence and keys are read from one string there, so the rule starts seeing a BOM-prefixed index the moment the reader does, with no change to the rule.

Plus `TestReadTextUtf8` on the primitive: BOM stripped, cap honoured, cap unaffected by a BOM, non-UTF-8 still raises.

## On `INDEX_SEMANTICS_VERSION`

**No bump, deliberately.** No stored row's derivation from a note's bytes changes: the scanner already decoded through `decode_utf8`, and the detector, audit and conventions resolver produce no rows.

There *is* a knock-on, and the existing machinery already covers it: on a vault whose declaration was hidden, detection now reports active, so `type` / `status` / `stale_after` join the effective indexed fields (`VaultSettings.effective_indexed_frontmatter_fields`). That set is recorded build provenance, so `_chunking_meta_matches` rejects the warm restart and the vault rebuilds once on the `indexed_frontmatter_fields` key (#927) — its own cause, named in the log. Documented in the release-notes Upgrading bullet.

## What this PR deliberately does NOT do

- Fix the audit aborting on malformed JSON frontmatter: #1408.
- Touch `_server_prompts.py`'s traversable read (correct as it stands, and not a vault read).
- Unify the two `_MAX_READ_CHARS = 65536` constants: pre-existing, deliberately mirrored, and not a defect.
- Strip BOMs from files on disk: the vault still normalizes to no-BOM on the next rewrite, as #673 decided.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No `!`. `read_text_utf8` gains a keyword-only parameter with a default: existing callers and any downstream consumer are unaffected. No env var, config, tool or import changes meaning.

Gates, run locally on `abbcc624`: `pytest` full suite, `ruff check`/`format --check`, `mypy src/ tests/`, `scripts/structural_gate.sh` (100%), Vale.

## Review round 1 (@claude, 2026-09-12) — approve, with minor observations

Taken along in `abbcc624`: the `read_text_utf8` docstring mixed the parameter's rationale with a full recap of the bug, so the recap is now one clause and the cap's semantics stand on their own. The other two observations (each reader's `except` surface preserved exactly, docs updated on both pages) were confirmations, not changes.

Two bot notes, both checked rather than assumed:

- **repowise flagged 10 callers of the changed signature.** `limit` is keyword-only with a default, and every call site outside this PR passes a single positional argument (`_server_prompts.py`, `git/conflict.py`, `okf_bundle.py`, and seven in `managers/document.py` through its module-local alias). None can be affected.
- **Codecov reports `-0.02%`, one more miss and one more partial, while the patch itself is 100%.** Neither is in this diff: the misses in `utils/text.py` are the pre-existing fallback paths in `build_position_map` / `find_closest_match`, untouched here. `codecov/project` and `codecov/patch` both pass.

## Docs impact

- [ ] `README.md` (does not describe read encodings)
- [x] `docs/` site pages: `docs/releases/4.2.md` — a paragraph on the three effects, and an Upgrading bullet for the vault that becomes an OKF bundle on restart (watermark not moved)
- [x] `docs/design/`: the `#673` BOM-normalization section now states the capped-read rule and names what went wrong without it
- [x] Inline docstrings: `read_text_utf8`

---
_Generated by [Claude Code](https://claude.ai/code)_
