### PR TITLE
fix(okf): a malformed JSON-looking block is a finding, not an aborted audit

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -2913,6 +2913,21 @@ def parse_note(path: Path, source_dir: Path) -> ParsedNote: ...
 **Frontmatter parsing**: use `python-frontmatter` library. Schema-agnostic.
 Documents without frontmatter get an empty dict and proceed normally.
 
+**One parse entry point, one parse error (#1408).** Every call into
+`frontmatter.loads` in this package goes through `scanner.parse_frontmatter`.
+The library picks a handler by the block's opening delimiter and lets that
+handler's own error escape — YAML raises `yaml.YAMLError`, the JSON handler
+`json.JSONDecodeError`, a TOML handler (registered whenever `toml` is
+importable in the consumer's environment) `toml.TomlDecodeError` — and every
+guard in the package named only the first, so a `{`-delimited block that was
+not valid JSON aborted the whole OKF audit and escaped
+`DocumentManager.read`. `parse_frontmatter` re-raises the non-YAML failures
+as `MalformedFrontmatterError`, **a subclass of `yaml.YAMLError`**: the
+failure is the same one in any dialect, and the nine existing guards (and any
+downstream consumer's) keep working without a per-site change. A block that
+parses in any supported dialect is unaffected; syntax conformance is not a
+rule this package enforces.
+
 **Exclude patterns**: glob patterns (such as `[".obsidian/**", "_templates/**"]`)
 matched against relative paths from `source_dir` using `pathlib.Path.match()`.
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -416,6 +416,19 @@ fields to each index it generates, which keeps the file in search. The
 audit reports those fields like any others. Leave them in place. Indexing
 is unchanged. The conformance ratio still counts notes only.
 
+**A note that opens with a brace no longer takes down the audit.** The
+frontmatter library picks its parser from the block's opening delimiter, so a
+file starting with `{` is read as JSON. When that JSON was malformed, the
+error it raised was not the one every caller guarded against, and it escaped
+([#1408](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1408)):
+`okf_validate` returned no report at all for the whole vault, naming no path,
+and `read` on such a file raised instead of returning nothing. Both now treat
+it as what it is. The audit lists the file under `unparseable_frontmatter`
+and reports the rest of the bundle; `read` returns nothing and logs a
+warning; the indexer records the file as a `parse_error` skip rather than an
+`internal_error` one, so `get_index_status.skipped_files` names the real
+cause. A well-formed JSON block still parses as it always did.
+
 **A byte-order mark no longer hides a file's frontmatter.** Every read of
 vault markdown strips a leading UTF-8 BOM, a contract from
 [#673](https://github.com/pvliesdonk/markdown-vault-mcp/issues/673). Three

--- a/src/markdown_vault_mcp/_server_prompts.py
+++ b/src/markdown_vault_mcp/_server_prompts.py
@@ -19,10 +19,10 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-import frontmatter
 from fastmcp import FastMCP
 
 from ._icons import _TOOL_ICONS
+from .scanner import parse_frontmatter
 from .utils.text import read_text_utf8
 
 _BUILTIN_PROMPTS_DIR = importlib.resources.files("markdown_vault_mcp").joinpath(
@@ -173,7 +173,7 @@ def _load_user_prompt_defs(prompts_folder: str | None) -> dict[str, dict[str, An
     for md_file in sorted(folder.glob("*.md")):
         name = md_file.stem
         try:
-            post = frontmatter.loads(read_text_utf8(md_file))
+            post = parse_frontmatter(read_text_utf8(md_file))
         except Exception:
             logger.warning(
                 "Failed to parse user prompt file %r — skipping",
@@ -283,7 +283,7 @@ def _load_builtin_prompt(name: str) -> dict[str, Any] | None:
         logger.warning("Built-in prompt file %s.md not found — skipping", name)
         return None
     try:
-        post = frontmatter.loads(text)
+        post = parse_frontmatter(text)
     except Exception:
         logger.warning(
             "Failed to parse built-in prompt file %s.md — skipping",

--- a/src/markdown_vault_mcp/conventions.py
+++ b/src/markdown_vault_mcp/conventions.py
@@ -20,9 +20,9 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import frontmatter as fm
 import yaml
 
+from markdown_vault_mcp.scanner import parse_frontmatter
 from markdown_vault_mcp.utils import (
     is_note,
     is_path_excluded,
@@ -224,7 +224,7 @@ class ConventionsResolver:
             block fails to parse.
         """
         try:
-            return fm.loads(raw).content.strip()
+            return parse_frontmatter(raw).content.strip()
         except yaml.YAMLError:
             logger.debug("conventions_frontmatter_invalid path=%s", rel, exc_info=True)
             return raw.strip()

--- a/src/markdown_vault_mcp/git/conflict.py
+++ b/src/markdown_vault_mcp/git/conflict.py
@@ -23,6 +23,7 @@ from markdown_vault_mcp.git.types import (
     PULL_REASON_CONFLICT_RESOLUTION_FAILED,
     PullResult,
 )
+from markdown_vault_mcp.scanner import parse_frontmatter
 from markdown_vault_mcp.utils.text import read_text_utf8
 
 if TYPE_CHECKING:
@@ -397,7 +398,7 @@ def write_conflict_files(
 
         # --- Write conflict file (MCP version) ---
         try:
-            post = frontmatter.loads(mcp_content)
+            post = parse_frontmatter(mcp_content)
         except Exception:
             # If frontmatter parsing fails, treat as plain content.
             logger.warning(
@@ -427,7 +428,7 @@ def write_conflict_files(
                 # whole pull.
                 content = read_text_utf8(original_abs)
                 try:
-                    orig_post = frontmatter.loads(content)
+                    orig_post = parse_frontmatter(content)
                 except Exception:
                     logger.warning(
                         "Git pull: failed to parse frontmatter for original file %s; treating as plain content",

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 import frontmatter as fm
 import yaml
 
+from markdown_vault_mcp.scanner import parse_frontmatter
 from markdown_vault_mcp.utils.text import read_text_utf8
 
 if TYPE_CHECKING:
@@ -192,7 +193,7 @@ class OkfDetector:
             logger.debug("okf_probe_read_failed path=%s", _ROOT_INDEX, exc_info=True)
             return None
         try:
-            metadata = fm.loads(raw).metadata
+            metadata = parse_frontmatter(raw).metadata
         except yaml.YAMLError:
             logger.debug(
                 "okf_probe_frontmatter_invalid path=%s", _ROOT_INDEX, exc_info=True
@@ -612,7 +613,7 @@ def _evaluate_note(
 def _audit_file(rel: str, raw: str, acc: _AuditCounters) -> None:
     """Classify one markdown file and update the audit counters."""
     try:
-        post = fm.loads(raw)
+        post = parse_frontmatter(raw)
         metadata: dict[str, Any] = dict(post.metadata)
         body = post.content
         parse_ok = True
@@ -1039,7 +1040,7 @@ def apply_okf_write_stamp(text: str, *, actor: str, now: _dt.datetime) -> str:
         is identical (the same actor and instant, no ``verified``) — so a
         repeated stamp keeps the note's exact bytes and YAML formatting.
     """
-    post = fm.loads(text)
+    post = parse_frontmatter(text)
     meta: dict[str, Any] = dict(post.metadata)
     new_meta: dict[str, Any] = dict(meta)
     new_meta["generated"] = {"by": actor, "at": okf_timestamp(now)}
@@ -1066,7 +1067,7 @@ def append_okf_verification(text: str, *, subject: str, now: _dt.datetime) -> st
     Returns:
         The note text with the appended verification.
     """
-    post = fm.loads(text)
+    post = parse_frontmatter(text)
     meta: dict[str, Any] = dict(post.metadata)
     verified = list(verified_entries(meta))
     verified.append({"by": f"{_HUMAN_ACTOR_PREFIX}{subject}", "at": okf_timestamp(now)})

--- a/src/markdown_vault_mcp/scanner.py
+++ b/src/markdown_vault_mcp/scanner.py
@@ -686,6 +686,57 @@ def _scan_headings(lines: list[str]) -> list[tuple[int, int, str]]:
     return out
 
 
+# PyYAML ships no stubs and no `py.typed`, so `yaml.YAMLError` types as `Any`
+# and strict mypy rejects subclassing it. The base is the point of the class
+# (see below), so the alternative is adding `types-PyYAML` and re-typing every
+# yaml call site in the package — a wider change than this fix.
+class MalformedFrontmatterError(yaml.YAMLError):  # type: ignore[misc]
+    """A leading frontmatter block no parser could read (#1408).
+
+    ``python-frontmatter`` picks a handler by the block's opening delimiter
+    and lets that handler's own error escape: YAML raises ``yaml.YAMLError``,
+    the JSON handler raises ``json.JSONDecodeError``, and a TOML handler —
+    registered whenever ``toml`` is importable in the consumer's
+    environment — raises ``toml.TomlDecodeError``. Only the first was ever
+    guarded, so a ``{``-delimited block that is not valid JSON aborted the
+    whole OKF audit and escaped ``DocumentManager.read``.
+
+    Subclassing ``yaml.YAMLError`` is what keeps that from needing a guard
+    change per call site: every guard in this package, and any downstream
+    consumer's, already names it, and the failure it describes — *this block
+    did not parse* — is the same one whatever dialect the block was written
+    in. Raised by :func:`parse_frontmatter`; the original error is the
+    ``__cause__``.
+    """
+
+
+def parse_frontmatter(text: str) -> frontmatter.Post:
+    """Parse *text* as markdown-with-frontmatter, one error for one failure.
+
+    The package's single entry point to ``frontmatter.loads``, so no caller
+    has to know which handler will run or which error it raises (#1408). A
+    YAML failure propagates as the ``yaml.YAMLError`` it already was; every
+    other handler's failure — all of them ``ValueError`` subclasses — is
+    re-raised as :class:`MalformedFrontmatterError`, which is one.
+
+    Args:
+        text: Raw markdown text, frontmatter block included.
+
+    Returns:
+        The parsed post (metadata plus body). Text with no frontmatter
+        yields empty metadata, exactly as ``frontmatter.loads`` does.
+
+    Raises:
+        MalformedFrontmatterError: The block is present but unreadable.
+    """
+    try:
+        return frontmatter.loads(text)
+    except ValueError as exc:
+        # yaml.YAMLError is not a ValueError, so it is never caught here and
+        # reaches the caller unchanged.
+        raise MalformedFrontmatterError(str(exc)) from exc
+
+
 def strip_frontmatter_block(text: str) -> str:
     """Return *text* without its leading frontmatter block, body verbatim.
 
@@ -737,7 +788,7 @@ def list_section_headings(text: str) -> list[str]:
     Returns:
         Heading strings as written (whitespace not normalised), in order.
     """
-    body = frontmatter.loads(text).content
+    body = parse_frontmatter(text).content
     return [h for _, _, h in _scan_headings(body.splitlines(keepends=True))]
 
 
@@ -764,7 +815,7 @@ def extract_section(text: str, heading: str) -> str | None:
     norm_query = normalize_heading(heading)
     if not norm_query:
         return None
-    body = frontmatter.loads(text).content
+    body = parse_frontmatter(text).content
     lines = body.splitlines(keepends=True)
     headings = _scan_headings(lines)
     for i, (idx, level, htext) in enumerate(headings):
@@ -1553,7 +1604,7 @@ def parse_note(
     text = decode_utf8(raw_bytes)
 
     # python-frontmatter strips the YAML block and returns the body separately.
-    post = frontmatter.loads(text)
+    post = parse_frontmatter(text)
     metadata: dict[str, Any] = dict(post.metadata)
     body: str = post.content
 

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -89,6 +89,14 @@ class TestForPath:
         entries = resolver.for_path("")
         assert entries[0].content == raw.strip()
 
+    def test_malformed_json_frontmatter_falls_back_to_raw(self, tmp_path: Path) -> None:
+        # Same fallback as malformed YAML: the JSON handler's error is the
+        # block failing to parse, not a reason to lose the entry (#1408).
+        raw = "{\n  not json,\n}\nBody text."
+        (tmp_path / "_conventions.md").write_text(raw, encoding="utf-8")
+        resolver = ConventionsResolver(tmp_path, "_conventions.md")
+        assert resolver.for_path("")[0].content == raw.strip()
+
     def test_backslashes_and_slashes_normalized(self, vault_dir: Path) -> None:
         resolver = ConventionsResolver(vault_dir, "_conventions.md")
         entries = resolver.for_path("\\3-Resources\\CRA.md")

--- a/tests/test_managers_document.py
+++ b/tests/test_managers_document.py
@@ -174,6 +174,25 @@ class TestRead:
             for record in caplog.records
         ), f"expected a degrade-to-None warning for {path!r}; got {caplog.records!r}"
 
+    def test_read_degrades_to_none_on_malformed_json_frontmatter(
+        self,
+        doc_mgr: DocumentManager,
+        doc_vault: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A `{` block the JSON handler rejects degrades like malformed YAML.
+
+        The guard names ``yaml.YAMLError``, but ``python-frontmatter`` picks
+        its handler by the opening delimiter, so this file raised
+        ``json.JSONDecodeError`` straight through ``read`` (#1408).
+        """
+        (doc_vault / "badjson.md").write_text(
+            "{\n  not json,\n}\n# body\n", encoding="utf-8"
+        )
+        with caplog.at_level(logging.WARNING):
+            assert doc_mgr.read("badjson.md") is None
+        self._assert_degrade_warning(caplog, "badjson.md")
+
     def test_read_degrades_to_none_if_content_read_fails(
         self,
         doc_mgr: DocumentManager,

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -47,6 +47,14 @@ class TestOkfDetector:
         assert state.active is True
         assert state.declared_version == "0.2"
 
+    def test_malformed_json_root_index_reports_undeclared(self, tmp_path: Path) -> None:
+        # The probe guards yaml.YAMLError only, so a `{` block the JSON
+        # handler rejects escaped it and broke detection outright (#1408).
+        (tmp_path / "index.md").write_text("{\n  not json,\n}\n# Bundle\n")
+        state = OkfDetector(tmp_path, mode="auto").state()
+        assert state.declared_version is None
+        assert state.active is False
+
     def test_declaration_behind_a_bom_is_detected(self, tmp_path: Path) -> None:
         # A BOM before the opening delimiter used to hide the declaration, so
         # a declared bundle stayed inactive (#1407).
@@ -714,6 +722,32 @@ class TestOkfAudit:
         report = audit_bundle(tmp_path)
         assert report.conformant_notes == 1
         assert report.missing_type.count == 0
+
+    def test_malformed_json_block_is_a_finding_not_a_crash(
+        self, tmp_path: Path
+    ) -> None:
+        # python-frontmatter picks its handler by the opening delimiter, so a
+        # `{` block raises JSONDecodeError where YAML raises YAMLError. That
+        # escaped the audit and failed the whole tool call, naming no path
+        # (#1408). One bad note must not take down the bundle's report.
+        from markdown_vault_mcp.okf import audit_bundle
+
+        (tmp_path / "good.md").write_text("---\ntype: Note\n---\n# G\n")
+        (tmp_path / "bad.md").write_text("{\n  not json,\n}\n# body\n")
+        report = audit_bundle(tmp_path)
+        assert report.unparseable_frontmatter.examples == ("bad.md",)
+        # The rest of the bundle is still audited: both files were examined,
+        # and the readable one was not swept up in the failure.
+        assert report.total_notes == 2
+        assert report.missing_type.count == 0
+
+    def test_well_formed_json_frontmatter_still_parses(self, tmp_path: Path) -> None:
+        # The guard normalises the JSON handler's *failures*; a block it reads
+        # is as valid here as a YAML one (#1408).
+        from markdown_vault_mcp.okf import audit_bundle
+
+        (tmp_path / "note.md").write_text('{\n"type": "Note"\n}\n# N\n')
+        assert audit_bundle(tmp_path).conformant_notes == 1
 
     def test_unreadable_file_skipped(self, tmp_path: Path) -> None:
         from markdown_vault_mcp.okf import audit_bundle

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -965,6 +966,25 @@ class TestParseNoteCategorized:
         assert outcome.skip.category == "missing_frontmatter"
         assert outcome.content_hash == compute_file_hash(note)
 
+    def test_malformed_json_block_is_a_parse_error(self, tmp_path: Path) -> None:
+        """A ``{``-delimited block the JSON handler rejects is a parse error.
+
+        ``python-frontmatter`` picks its handler by the opening delimiter, so
+        this raises ``json.JSONDecodeError`` where a broken YAML block raises
+        ``yaml.YAMLError`` — it used to fall through to the generic branch and
+        be recorded as ``internal_error`` (#1408).
+        """
+        from markdown_vault_mcp.scanner import (
+            CategorizedSkip,
+            parse_note_categorized,
+        )
+
+        note = tmp_path / "bad.md"
+        note.write_text("{\n  not json,\n}\n# body\n", encoding="utf-8")
+        outcome = parse_note_categorized(note, tmp_path, None, rel_path="bad.md")
+        assert isinstance(outcome, CategorizedSkip)
+        assert outcome.skip.category == "parse_error"
+
     def test_exception_categories_have_no_hash(self, tmp_path: Path) -> None:
         """Exception skips carry no hash — parsing never produced a note."""
         from markdown_vault_mcp.scanner import (
@@ -978,6 +998,39 @@ class TestParseNoteCategorized:
         assert isinstance(outcome, CategorizedSkip)
         assert outcome.skip.category == "encoding_error"
         assert outcome.content_hash is None
+
+
+class TestParseFrontmatter:
+    """#1408: one exception for a block no handler could read."""
+
+    def test_malformed_json_raises_the_normalised_error(self) -> None:
+        import yaml
+
+        from markdown_vault_mcp.scanner import (
+            MalformedFrontmatterError,
+            parse_frontmatter,
+        )
+
+        with pytest.raises(MalformedFrontmatterError) as excinfo:
+            parse_frontmatter("{\n  not json,\n}\n# body\n")
+        # A subclass of the error every existing guard already names, so the
+        # guards keep working and a consumer's `except yaml.YAMLError` does too.
+        assert isinstance(excinfo.value, yaml.YAMLError)
+        assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
+
+    def test_malformed_yaml_still_raises_the_yaml_error_itself(self) -> None:
+        import yaml
+
+        from markdown_vault_mcp.scanner import parse_frontmatter
+
+        with pytest.raises(yaml.YAMLError):
+            parse_frontmatter("---\ntitle: [unclosed\n---\n# body\n")
+
+    def test_well_formed_json_frontmatter_parses(self) -> None:
+        from markdown_vault_mcp.scanner import parse_frontmatter
+
+        post = parse_frontmatter('{\n"title": "T"\n}\n# body\n')
+        assert post.metadata == {"title": "T"}
 
 
 class TestContentChars:


### PR DESCRIPTION
## Closes / Refs

Closes #1408. Refs #1454 (filed from this work), #1396 and #1407 (the two reader defects surfaced alongside it, both merged), #802 (the `parse_error` / `internal_error` split this restores for a second dialect).

## What & why

`python-frontmatter` picks a handler from the block's opening delimiter and lets that handler's own error escape. YAML raises `yaml.YAMLError`; the JSON handler raises `json.JSONDecodeError`; a TOML handler, registered whenever `toml` is importable in the consumer's environment, raises `toml.TomlDecodeError`. **Every guard in this package named only the first.**

So a file opening with `{` and holding invalid JSON raised straight through `_audit_file`, through `audit_bundle`, and out of `okf_validate`: one note took down the report for the entire vault, naming no path. The same shape escaped `DocumentManager.read`, left `read(section=...)` raising instead of its user-facing `ValueError`, broke the OKF detection probe, lost the conventions resolver's raw-text fallback, and made the indexer record the file as `internal_error` rather than the `parse_error` skip #802 introduced.

**The fix is one parse entry point, not nine wider guards.** `scanner.parse_frontmatter` is now the package's only call into `frontmatter.loads`, and re-raises every non-YAML handler failure as `MalformedFrontmatterError`. A YAML failure still propagates as the `yaml.YAMLError` it already was.

`MalformedFrontmatterError` **subclasses `yaml.YAMLError`**, and that is the load-bearing choice: the failure it describes — *this block did not parse* — is the same one in any dialect, so the nine existing guards, and any downstream consumer's `except yaml.YAMLError`, keep working with no per-site change. The alternative shapes were worse:

- **Widening nine guards to `ValueError`** would have broadened `try` blocks that hold more than the parse — `document.py:372` wraps `parse_note` *and* a second read, `git_query.py:378` wraps two section calls — so a `ValueError` from anything else in them would start being swallowed as "malformed frontmatter".
- **A shared exception tuple** still lets a tenth call site type `except yaml.YAMLError` and be wrong. With the wrapper, a thirteenth parse site cannot be.

Adding `ValueError` as a second base was considered and rejected: it buys nothing today (the one guard phrased that way, `embeddings.py:1118`, already lists both) and would let a future `except ValueError` catch frontmatter failures by accident.

## Verified end to end, not only in unit tests

On a scratch vault, a note whose body is `{\n  not json,\n}\n# body\n`:

- `write` succeeds and the file lands on disk; `process_dirty_paths` logs `skipping bad.md (malformed frontmatter)`; `read` returns `None` and logs `could not parse file`. Before, the same file's read raised.
- With `OKF_WRITE` on, writing that body is still rejected — the provenance stamp cannot be applied to a block it cannot parse. That was already true; only the exception's type changed (`JSONDecodeError` → `MalformedFrontmatterError`). Filed as #1454 rather than widened into here: the refusal is right, its surface is not.

## Tests

Eight, each mutation-checked by narrowing the wrapper's `except ValueError` (all six defect tests fail; the two well-formed-JSON regression guards stay green):

- `audit_bundle` — the bad note is `unparseable_frontmatter` with its path, and the rest of the bundle is still reported.
- `DocumentManager.read` — `None` plus the documented degrade warning naming the path.
- `parse_note_categorized` — `parse_error`, not `internal_error`.
- `ConventionsResolver` — falls back to raw text, exactly as for malformed YAML.
- `OkfDetector` — reports undeclared instead of crashing detection outright.
- `parse_frontmatter` — raises `MalformedFrontmatterError`, which *is* a `yaml.YAMLError`, chaining `__cause__` to the original `JSONDecodeError`; a malformed YAML block still raises the YAML error itself.
- Well-formed JSON frontmatter still parses, in the wrapper and through the audit.

## What this PR deliberately does NOT do

- Touch the nine guards. The wrapper is what makes them correct; changing them too would be the same fix twice.
- Touch `_server_prompts.py` / `git/conflict.py`'s `except Exception` guards: already tolerant. They use the wrapper for consistency, and their behaviour is unchanged.
- Touch `strip_frontmatter_block` / `split_frontmatter_block`: they call `handler.split`, not `loads`, and already catch the `ValueError` it raises.
- Enforce a syntax dialect. A block that parses in any handler the library ships is as valid here as it was before.
- Add `types-PyYAML`. The `# type: ignore[misc]` on the class carries its reason: PyYAML ships no stubs, so `yaml.YAMLError` is `Any` and strict mypy rejects subclassing it; the base is the point of the class, and typing every `yaml` call site in the package is a wider change than this fix.

## On `INDEX_SEMANTICS_VERSION`

No bump. No stored row's derivation from a note's bytes changes: a file that was skipped as `internal_error` and is now skipped as `parse_error` produces the same tombstone either way, and every file that parsed before parses identically.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`. It caught one real design risk in my own first shape — sites that used to catch the JSON error *as a* `ValueError` would stop catching it — so I traced every `except ValueError` in the package and confirmed none wraps a frontmatter parse (`_transfer_sink.py:273` is an attachment read, the two in `_server_prompts.py` guard signature building).
- [x] No `!`. A new name in `scanner` is additive, the package root's import surface is unchanged, and `MalformedFrontmatterError` is a subclass of the error consumers already catch.

Gates, run locally on `dd852e62`: `pytest` full suite (4650 passed, 2 skipped), `ruff check`/`format --check`, `mypy src/ tests/`, `scripts/structural_gate.sh` (100%), Vale, plus `tests/test_config_import_floor.py` for the four modules that gained a `scanner` import.

## Review round 1 (Repowise health gate)

The gate failed on `tests/test_okf.py` (-0.5, "introduced duplicated assertion block"), and it was right: my two new audit tests asserted a near-identical pair, `conformant_notes == 1` plus an `unparseable_frontmatter` count, so neither name matched what it actually checked. Each now asserts its own claim — the crash test checks that *both* files were examined and the readable one was not swept up (`total_notes == 2`, `missing_type.count == 0`), the regression test checks only that a readable JSON block counts as conformant. Re-mutation-checked after the reshape: both still fail when the wrapper's `except ValueError` is narrowed.

## Docs impact

- [ ] `README.md` (does not describe parse-failure handling)
- [x] `docs/` site pages: `docs/releases/4.2.md` — one paragraph covering the audit, `read` and the skip category (watermark not moved)
- [x] `docs/design/`: the `scanner.py` section now states the single-entry-point rule, why the error subclasses `yaml.YAMLError`, and that syntax conformance is not enforced
- [x] Inline docstrings: `MalformedFrontmatterError`, `parse_frontmatter`

---
_Generated by [Claude Code](https://claude.ai/code)_
