### PR TITLE
fix(okf): an enforced-write refusal says which note and why

### DIFF
--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -422,6 +422,17 @@ Tool tags following switches: #1412.
   `markdown-vault-mcp/<version>` as a tool actor. Existing `generated`
   values are overwritten (it describes the current bytes); `sources` are
   never touched.
+
+  A stamp is written *into* the note's frontmatter, so content whose block
+  no parser can read leaves nothing to stamp and the write is **refused**
+  (#1454). Writing it unstamped was the alternative and is worse: the layer's
+  whole claim is that every write it passes carries current provenance, and a
+  silent exception to that is the kind an operator finds months later. The
+  refusal is raised where the path is known (`_finalize_content_write`) as the
+  `ValueError` this layer uses for every other rejected write, so a caller is
+  told which note and why rather than being handed the parser's own exception.
+  With `OKF_WRITE` off there is no stamp to fail: the write lands, and the
+  indexer records the file as a `parse_error` skip (#1408).
 - **Verification invalidation** (`OKF_WRITE`): a content-changing `write`/`edit` to a note
   carrying `verified` clears the `verified` list — verification attests to
   bytes that no longer exist. Frontmatter-only edits that do not touch the

--- a/docs/guides/okf.md
+++ b/docs/guides/okf.md
@@ -104,6 +104,8 @@ With the layer on, and only while the vault is an active OKF bundle, every `writ
 
 The one-shot migration transforms above (`okf_convert_links`, `okf_generate_index`, `okf_seed_log`) are exempt: a mechanical rewrite does not re-stamp provenance or discard a human attestation.
 
+The stamp goes into the note's own frontmatter, so the layer refuses a write whose frontmatter cannot be parsed: there is nowhere to record the provenance it promises. The error names the note and the reason, and nothing is written. Fix the block and write again. With the layer off the write goes through, and the note is left out of the index until its frontmatter parses.
+
 ### Recording a human review
 
 Enabling the layer also exposes the [`okf_verify`](../tools/index.md#okf_verify) tool. Call it on a note you have reviewed and it appends a `{by: human:<subject>, at}` entry (`at` a UTC instant) to that note's `verified` list, which promotes the note's trust tier to `human-reviewed`. The verification write is exempt from the invalidation above, so attesting a note does not immediately clear the attestation you just added.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -429,6 +429,18 @@ warning; the indexer records the file as a `parse_error` skip rather than an
 `internal_error` one, so `get_index_status.skipped_files` names the real
 cause. A well-formed JSON block still parses as it always did.
 
+**An enforced-write vault says why it refused a note.** With
+`MARKDOWN_VAULT_MCP_OKF_WRITE` on, the server stamps provenance into each
+note it writes, so a note whose frontmatter block cannot be parsed has
+nowhere to carry the stamp and the write is refused. That much was already
+true; what reached the client was the raw complaint from the frontmatter
+library, naming no note and reading like a server fault
+([#1454](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1454)). It
+now reads as the refusal it is, naming the note, the reason, and the parse
+error behind it, in the same form as every other rejected write. Nothing is
+written either way. With the layer off, the write lands and the note simply
+stays out of the index until its frontmatter parses.
+
 **A byte-order mark no longer hides a file's frontmatter.** Every read of
 vault markdown strips a leading UTF-8 BOM, a contract from
 [#673](https://github.com/pvliesdonk/markdown-vault-mcp/issues/673). Three

--- a/src/markdown_vault_mcp/managers/document.py
+++ b/src/markdown_vault_mcp/managers/document.py
@@ -694,9 +694,25 @@ class DocumentManager:
             content: Full file content to persist.
             operation: The write operation reported to the enricher and the
                 write callback.
+
+        Raises:
+            ValueError: The enforced-write layer is on and *content* opens
+                with a frontmatter block it cannot parse.
         """
         if self._okf_write_enrich is not None:
-            content = self._okf_write_enrich(content, operation)
+            try:
+                content = self._okf_write_enrich(content, operation)
+            except yaml.YAMLError as exc:
+                # The stamp is written *into* the note's frontmatter, so a
+                # block the parser cannot read leaves the enforced-write layer
+                # nothing to stamp and the write is refused. The parser's own
+                # exception named no path and reached the client looking like a
+                # server fault, so it is restated as the refusal it is (#1454).
+                raise ValueError(
+                    f"Cannot {operation} {path}: its frontmatter block is not "
+                    f"parseable, so the OKF enforced-write layer cannot stamp "
+                    f"provenance on it — {exc}"
+                ) from exc
         atomic_write(abs_path, content)
         if self._mark_paths_dirty is not None:
             self._mark_paths_dirty([path])

--- a/src/markdown_vault_mcp/okf.py
+++ b/src/markdown_vault_mcp/okf.py
@@ -28,6 +28,10 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+# Both halves of the library are used here, deliberately: `fm` serialises the
+# write stamps (`fm.dumps` / `fm.Post`), while every *read* goes through
+# `parse_frontmatter`, the package's single parse entry point, so a block no
+# handler can read raises one error rather than the handler's own (#1408).
 import frontmatter as fm
 import yaml
 

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -451,6 +451,52 @@ class TestInvalidationMatrix:
         assert meta["generated"] == {"by": "process:enrich"}
 
 
+class TestUnparseableFrontmatterRefusal:
+    """#1454: the refusal is right; it has to say so in the caller's terms."""
+
+    MALFORMED_JSON = "{\n  not json,\n}\n# body\n"
+
+    def test_write_is_refused_with_the_path_and_the_reason(
+        self, enforced_vault: Vault
+    ) -> None:
+        # The stamp cannot be applied to a block that does not parse, so the
+        # write is refused — but it used to surface the parser's own exception,
+        # naming no path and reading like a server fault.
+        with pytest.raises(ValueError, match=r"bad\.md") as excinfo:
+            enforced_vault.writer.write("bad.md", self.MALFORMED_JSON)
+        assert "frontmatter" in str(excinfo.value)
+
+    def test_the_refused_write_leaves_no_file(self, enforced_vault: Vault) -> None:
+        with pytest.raises(ValueError):
+            enforced_vault.writer.write("bad.md", self.MALFORMED_JSON)
+        assert not (enforced_vault.source_dir / "bad.md").exists()
+
+    def test_malformed_yaml_is_refused_the_same_way(
+        self, enforced_vault: Vault
+    ) -> None:
+        # The dialect is not what the refusal is about (#1408).
+        with pytest.raises(ValueError, match=r"bad\.md"):
+            enforced_vault.writer.write("bad.md", "---\ntitle: [unclosed\n---\n# b\n")
+
+    def test_editing_an_already_malformed_note_names_the_operation(
+        self, enforced_vault: Vault
+    ) -> None:
+        # `edit` matches on raw text, so it reaches the stamp with a block that
+        # never parsed — the refusal has to read for that operation too.
+        (enforced_vault.source_dir / "bad.md").write_text(
+            self.MALFORMED_JSON, encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match=r"Cannot edit bad\.md"):
+            enforced_vault.writer.edit("bad.md", old_text="# body", new_text="# other")
+
+    def test_a_parseable_note_still_stamps(self, enforced_vault: Vault) -> None:
+        enforced_vault.writer.write("ok.md", '{\n"title": "T"\n}\n# T\n')
+        wait_for_writer_drain(enforced_vault)
+        assert _meta(enforced_vault, "ok.md")["generated"]["by"].startswith(
+            "markdown-vault-mcp/"
+        )
+
+
 class TestOffModeIdentity:
     def test_write_is_byte_identical_when_okf_write_off(self, tmp_path: Path) -> None:
         root = tmp_path / "vault"
@@ -573,6 +619,31 @@ class TestWriteToolThreadsActor:
         ).metadata
         assert meta["verified"] == [{"by": "human:peter", "at": _dt.date(2026, 1, 1)}]
         assert "generated" not in meta
+
+
+@pytest.mark.usefixtures("enforced_env")
+class TestUnparseableFrontmatterRefusalTool:
+    """The refusal as an MCP client reads it (#1454)."""
+
+    async def test_unparseable_frontmatter_is_refused_in_the_client_s_terms(
+        self, enforced_env: Path
+    ) -> None:
+        """The client is told what it did wrong, not what the parser hit.
+
+        The enricher's own exception reached the client as
+        ``Expecting property name enclosed in double quotes`` — no path, no
+        cause, and logged server-side as an unexpected tool failure (#1454).
+        """
+        async with Client(make_server()) as client:
+            await wait_for_mcp_writer_drain(client)
+            with pytest.raises(ToolError) as excinfo:
+                await client.call_tool(
+                    "write", {"path": "bad.md", "content": "{\n  not json,\n}\n# b\n"}
+                )
+        message = str(excinfo.value)
+        assert "bad.md" in message
+        assert "frontmatter" in message
+        assert not (enforced_env / "bad.md").exists()
 
 
 @pytest.mark.usefixtures("enforced_env")


### PR DESCRIPTION
## Closes / Refs

Closes #1454. Refs #1453 (which filed it, and whose review observation this carries), #1408 (the parse-error normalisation that made this path's failure legible), #1174.

## What & why

With `MARKDOWN_VAULT_MCP_OKF_WRITE` on, the enforced-write layer stamps `generated` provenance **into the note's own frontmatter**. A note whose block no parser can read leaves it nothing to stamp, so the write is refused. That was already the behaviour and it is the right one. The surface was not:

```
Error calling tool 'write': Expecting property name enclosed in double quotes: line 2 column 3 (char 4)
```

No note named, no cause, and server-side it logged as an unexpected tool failure. The caller cannot tell a rejected write from a server fault.

The refusal is now raised where the path is known — `DocumentManager._finalize_content_write`, around the enricher call — as the `ValueError` this layer already uses for every other rejected write. `[verified: probed through a live MCP client]` it reads:

```
Error calling tool 'write': Cannot write notes/bad.md: its frontmatter block is not
parseable, so the OKF enforced-write layer cannot stamp provenance on it —
Expecting property name enclosed in double quotes: line 2 column 3 (char 4)
```

**The alternative was writing the note unstamped, and it is worse.** The layer's whole claim is that every write it passes carries current provenance; a silent exception to that is the kind an operator finds months later, in a bundle that says it is enforced. Recorded in `docs/design/okf.md` §6 with that reasoning rather than as a bare fact.

**Unchanged:** with `OKF_WRITE` off there is no stamp to fail — the write lands and the indexer records a `parse_error` skip (#1408). Nothing is written in either the old or the new refusal; the enricher runs before `atomic_write`.

## Carried from #1453's review

`okf.py` imports both `frontmatter as fm` and `scanner.parse_frontmatter`, which the reviewer noted a future reader might stumble over. The import block now says why: `fm` serialises the write stamps (`fm.dumps` / `fm.Post`), every *read* goes through the single parse entry point. The review's other observation — that the `# type: ignore[misc]` rationale for subclassing `yaml.YAMLError` is accurate and well-documented — needed no change.

## Scope check I ran, and what it found

The issue left `[unverified]` what an MCP client sees. Probed, and it is above. I also probed the **log** side, where the issue's "cannot distinguish it from a server fault" claim came from: the traceback panel and `tool_call_failed error_type=ToolError` line are how this server logs *every* refusal — an existing `ValueError` ("Path traversal detected") logs the same shape. So the log side is uniform layer behaviour, not something this path does differently, and I have not touched it. The message is what changed.

## Tests

Six, each mutation-checked (reverting the guard fails all the defect tests; reverting just the `{operation}` interpolation fails only the edit one):

- `write` — refused with a `ValueError` naming the path and the reason.
- The refused write leaves no file on disk.
- Malformed **YAML** is refused identically: the dialect is not what the refusal is about.
- `edit` on an already-malformed note — reaches the stamp (it matches on raw text) and the message names that operation.
- Tool level — an MCP client gets a `ToolError` naming the note and the reason, and no file appears.
- A parseable note still stamps, including one with JSON frontmatter.

## What this PR deliberately does NOT do

- Change *whether* the write is refused. Only how the refusal reads.
- Touch the log shape for refusals: uniform across this server, as probed above. A PR that changes it should change it for all of them.
- Touch `append`: the enricher is a no-op for it (`operation not in ("write", "edit")`), so appending to a malformed note still succeeds unstamped. That asymmetry predates this issue and is not what #1454 reported.
- Migrate or repair notes already on disk with unparseable blocks.

## On `INDEX_SEMANTICS_VERSION`

No bump. No stored row's derivation changes: the refused write never reaches disk, and a note written with the layer off is skipped exactly as before.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No `!`. A refusal that already failed now fails with a clearer message and a different exception type on an error path; no env var, config, tool schema or importable name changes meaning.

Gates, run locally on `7cb94690`: `pytest` full suite (4656 passed, 2 skipped), `ruff check`/`format --check`, `mypy src/ tests/`, `scripts/structural_gate.sh` (100%), Vale.

## Review round 1 (Repowise health gate)

The gate flagged `tests/test_okf_write.py` (-0.4, "introduced low cohesion"). Part of that was mine and is fixed: I had dropped the tool-level refusal test into `TestWriteToolThreadsActor`, a class about *which actor string gets stamped*, because the fixture was convenient there. It now lives in its own `TestUnparseableFrontmatterRefusalTool` beside it, sharing the same `enforced_env` fixture; no test content changed.

The gate still flags the file, and the rest is not this diff. `test_okf_write.py` was already 786 lines and 13 classes covering everything from pure stamp builders to three `okf_verify` attribution modes, half on a library `Vault` fixture and half on an MCP one; any new class lowers its cohesion further. Splitting it is a move, not a fix, and doing it here would bury the change — so it is filed as **#1456** with the measurements, per `AGENTS.md`'s rule for decay noticed outside a change's scope. `Repowise / code health` is advisory: the repository's required checks are `Test (3.11/3.12/3.13)`, `Lint`, `Type Check`, `codecov/patch`, `CI Success` and `SPA source up-to-date`.

## Docs impact

- [ ] `README.md` (does not describe enforced-write failure modes)
- [x] `docs/` site pages: `docs/guides/okf.md` (what an operator sees and does about it), `docs/releases/4.2.md` (paragraph; watermark not moved)
- [x] `docs/design/`: `okf.md` §6 records the refusal, why unstamped-write was rejected, and where the error is raised
- [x] Inline docstrings: `_finalize_content_write` gains its `Raises:` entry; `okf.py`'s import block explains its two frontmatter entry points

---
_Generated by [Claude Code](https://claude.ai/code)_
