### PR TITLE
fix(okf): a migration transform is mechanical through every entry point

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1496,7 +1496,11 @@ the spec itself says, dated and sourced, in
   bundle root seeds whole-vault history (#974). The
   tools are tagged ``{"okf", "write"}`` — hidden in read-only mode and
   under ``OKF_MODE=off`` — and gate on read-only only, not a future
-  ``OKF_WRITE`` flag (they are migrations, not enforcement). Bundle export
+  ``OKF_WRITE`` flag (they are migrations, not enforcement). Every write
+  a transform issues is entered under ``okf_write_suppressed`` **in the
+  manager**, not in the tool handler (#1401): being mechanical is a
+  property of the transform, so a library caller of ``vault.writer.okf_*``
+  gets the same unstamped rewrite the tool does. Bundle export
   ships as an overloaded download ref rather than a bespoke tool: the domain
   ``VaultTransferSink`` recognises an ``okf-bundle`` / ``okf-bundle:<folder>``
   ref on pvl-core's ``create_download_link`` and generates the archive at

--- a/docs/design/okf.md
+++ b/docs/design/okf.md
@@ -486,7 +486,11 @@ Tool tags following switches: #1412.
   `write` / `edit` on an OKF-active vault, skips a write whose target is
   itself a reserved file (`index.md` / `log.md`) so it never recurses, and is
   skipped for suppressed writes (`okf_verify`, the one-shot migrations) so an
-  attestation or mechanical rewrite does not churn the reserved files. The
+  attestation or mechanical rewrite does not churn the reserved files. A
+  transform suppresses each write it issues from inside `OkfMigrationManager`,
+  so the exemption is the transform's own and does not depend on which entry
+  point called it (#1401); it had been entered in the MCP tool handlers alone,
+  which left a library caller's bundle stamped by its own migration. The
   affected folder is the one directly containing the written note; the
   `index.md` refresh reuses the migration `generate_index`, draining the
   single-writer index first so a just-created note is listed. A brand-new

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -429,6 +429,20 @@ warning; the indexer records the file as a `parse_error` skip rather than an
 `internal_error` one, so `get_index_status.skipped_files` names the real
 cause. A well-formed JSON block still parses as it always did.
 
+**A migration transform stays mechanical for library callers too.** With
+`MARKDOWN_VAULT_MCP_OKF_WRITE` on, the one-shot transforms
+(`okf_convert_links`, `okf_generate_index`, `okf_seed_log`) are exempt from
+provenance stamping: a mechanical rewrite is not authorship. The exemption
+was entered in the MCP tool handlers only, so the same call through the
+Python API stamped `generated` into the files it rewrote. Because generated
+reserved files keep their existing keys, that stamp then survived every later
+regeneration
+([#1401](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1401)). Each
+transform now suppresses the stamp on every write it issues, so both entry
+points agree. Existing frontmatter, including a note's own `generated` and
+`verified`, is left alone. Stamps already written this way stay where they
+are; this release does not clean them up.
+
 **An enforced-write vault says why it refused a note.** With
 `MARKDOWN_VAULT_MCP_OKF_WRITE` on, the server stamps provenance into each
 note it writes, so a note whose frontmatter block cannot be parsed has

--- a/src/markdown_vault_mcp/_server_tools/writer.py
+++ b/src/markdown_vault_mcp/_server_tools/writer.py
@@ -880,12 +880,9 @@ def register(mcp: FastMCP) -> None:
             Dict with files_changed, links_converted, links_skipped, and
             notes_scanned.
         """
-        # Mechanical migration: suppress the enforced-write enricher so a link
-        # rewrite does not re-stamp provenance or clear human verification (#964).
-        with okf_write_suppressed():
-            result = await asyncio.to_thread(
-                vault.writer.okf_convert_links, folder=folder
-            )
+        # The suppression lives on the transform itself (#1401), so the
+        # library facade and this tool get the same mechanical write.
+        result = await asyncio.to_thread(vault.writer.okf_convert_links, folder=folder)
         return attach_remote_health(vault, asdict(result))
 
     @mcp.tool(
@@ -918,10 +915,7 @@ def register(mcp: FastMCP) -> None:
         Returns:
             Dict with path, entries (count), and frontmatter_preserved (bool).
         """
-        with okf_write_suppressed():
-            result = await asyncio.to_thread(
-                vault.writer.okf_generate_index, folder=folder
-            )
+        result = await asyncio.to_thread(vault.writer.okf_generate_index, folder=folder)
         return attach_remote_health(vault, asdict(result))
 
     @mcp.tool(
@@ -959,10 +953,7 @@ def register(mcp: FastMCP) -> None:
             Dict with path, commits (count), and dates (distinct-day count).
         """
         try:
-            with okf_write_suppressed():
-                result = await asyncio.to_thread(
-                    vault.writer.okf_seed_log, folder=folder
-                )
+            result = await asyncio.to_thread(vault.writer.okf_seed_log, folder=folder)
         except FileExistsError as exc:
             raise ToolError(str(exc)) from exc
         return attach_remote_health(vault, asdict(result))

--- a/src/markdown_vault_mcp/managers/okf_migrate.py
+++ b/src/markdown_vault_mcp/managers/okf_migrate.py
@@ -21,6 +21,14 @@ files they produce carry the frontmatter the vault's own index gate requires
 These are write tools gated on read-only mode only, not on a future
 ``OKF_WRITE`` flag (design §7): they are deliberate migrations, not ongoing
 enforcement.
+
+Every write they issue is entered under
+:func:`~markdown_vault_mcp._okf_write.okf_write_suppressed`, so on a vault
+that *does* run the enforced-write layer a mechanical rewrite neither stamps
+``generated`` nor clears ``verified``. That belongs here rather than in the
+MCP tool handlers, where it used to live: being mechanical is a property of
+the transform, and a library caller of ``vault.writer.okf_*`` gets the same
+rewrite the tool does (#1401).
 """
 
 from __future__ import annotations
@@ -28,6 +36,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from markdown_vault_mcp._okf_write import okf_write_suppressed
 from markdown_vault_mcp.okf import (
     OKF_LOG_TITLE,
     OKF_RESERVED_FILENAMES,
@@ -111,22 +120,26 @@ class OkfMigrationManager:
         converted = 0
         skipped = 0
         scanned = 0
-        for note in self._search_mgr.list(folder=folder, include_attachments=False):
-            scanned += 1
-            outlinks = self._link_mgr.get_outlinks(note.path)
-            if not any(link.link_type == "wikilink" for link in outlinks):
-                continue
-            note_content = self._doc_mgr.read(note.path)
-            if note_content is None:  # pragma: no cover - listed-then-deleted race
-                continue
-            new_content, n_conv, n_skip = convert_wikilinks_to_markdown(
-                note_content.content, outlinks
-            )
-            converted += n_conv
-            skipped += n_skip
-            if new_content != note_content.content:
-                self._doc_mgr.write(note.path, new_content, allow_overwrite=True)
-                files_changed += 1
+        # Every write a transform issues is mechanical: it must not re-stamp
+        # provenance or clear a human attestation, whichever entry point
+        # called it (#1401).
+        with okf_write_suppressed():
+            for note in self._search_mgr.list(folder=folder, include_attachments=False):
+                scanned += 1
+                outlinks = self._link_mgr.get_outlinks(note.path)
+                if not any(link.link_type == "wikilink" for link in outlinks):
+                    continue
+                note_content = self._doc_mgr.read(note.path)
+                if note_content is None:  # pragma: no cover - deleted mid-scan
+                    continue
+                new_content, n_conv, n_skip = convert_wikilinks_to_markdown(
+                    note_content.content, outlinks
+                )
+                converted += n_conv
+                skipped += n_skip
+                if new_content != note_content.content:
+                    self._doc_mgr.write(note.path, new_content, allow_overwrite=True)
+                    files_changed += 1
         return OkfConvertResult(
             files_changed=files_changed,
             links_converted=converted,
@@ -197,14 +210,15 @@ class OkfMigrationManager:
         preserved = bool(existing_fm)
         heading = folder.rsplit("/", 1)[-1] if folder else OKF_ROOT_INDEX_TITLE
         body = build_index_markdown(heading, entries)
-        self._doc_mgr.write(
-            index_path,
-            body,
-            frontmatter=self._reserved_frontmatter.build(
-                existing_fm if preserved else None, title=heading
-            ),
-            allow_overwrite=True,
-        )
+        with okf_write_suppressed():
+            self._doc_mgr.write(
+                index_path,
+                body,
+                frontmatter=self._reserved_frontmatter.build(
+                    existing_fm if preserved else None, title=heading
+                ),
+                allow_overwrite=True,
+            )
         return OkfIndexResult(
             path=index_path, entries=len(entries), frontmatter_preserved=preserved
         )
@@ -250,9 +264,10 @@ class OkfMigrationManager:
         # falls back to whole-vault history via path=None.
         history = self._git_query_mgr.get_history(path=folder or None, limit=limit)
         body, commits, dates = build_log_markdown(history)
-        self._doc_mgr.write(
-            log_path,
-            body,
-            frontmatter=self._reserved_frontmatter.build(None, title=OKF_LOG_TITLE),
-        )
+        with okf_write_suppressed():
+            self._doc_mgr.write(
+                log_path,
+                body,
+                frontmatter=self._reserved_frontmatter.build(None, title=OKF_LOG_TITLE),
+            )
         return OkfLogResult(path=log_path, commits=commits, dates=dates)

--- a/tests/test_okf_migrate.py
+++ b/tests/test_okf_migrate.py
@@ -46,6 +46,94 @@ def _outlink_targets(vault: Vault, path: str) -> set[str]:
     return {o.target_path for o in vault.graph.get_outlinks(path)}
 
 
+_ENFORCED_ROOT_INDEX = '---\nokf_version: "0.2"\n---\n# Bundle\n'
+
+
+@pytest.fixture
+def enforced_vault(source_dir: Path) -> Iterator[Vault]:
+    """A declared bundle with the enforced-write layer on (#1401)."""
+    (source_dir / "index.md").write_text(_ENFORCED_ROOT_INDEX, encoding="utf-8")
+    col = Vault(source_dir=source_dir, read_only=False, okf_mode="on", okf_write=True)
+    try:
+        col.index.build_index()
+        yield col
+    finally:
+        col.close()
+
+
+def _frontmatter_of(vault: Vault, path: str) -> dict[str, object]:
+    from markdown_vault_mcp.scanner import parse_frontmatter
+
+    raw = (vault.source_dir / path).read_text(encoding="utf-8")
+    return dict(parse_frontmatter(raw).metadata)
+
+
+class TestTransformsAreMechanicalThroughEveryEntryPoint:
+    """#1401: the suppression belongs to the transform, not to the tool layer.
+
+    The enforced-write layer stamps `generated` and clears `verified` on a
+    content write. A mechanical rewrite is exempt — `docs/design/okf.md` says
+    so without qualifying it by caller — but the suppression was entered in the
+    MCP tool handlers only, so a library caller got its bundle stamped.
+    """
+
+    def test_generated_index_is_not_stamped(self, enforced_vault: Vault) -> None:
+        _write(enforced_vault, "guides/note.md", "---\ntitle: N\n---\n# N\n")
+
+        enforced_vault.writer.okf_generate_index(folder="guides")
+        wait_for_writer_drain(enforced_vault)
+
+        assert "generated" not in _frontmatter_of(enforced_vault, "guides/index.md")
+
+    def test_seeded_log_is_not_stamped(self, enforced_vault: Vault) -> None:
+        enforced_vault.writer.okf_seed_log()
+        wait_for_writer_drain(enforced_vault)
+
+        assert "generated" not in _frontmatter_of(enforced_vault, "log.md")
+
+    def test_converted_links_keep_the_note_s_own_provenance(
+        self, enforced_vault: Vault
+    ) -> None:
+        # A link rewrite must not re-stamp the note or discard a human
+        # attestation: the bytes changed mechanically, not by an author.
+        _write(enforced_vault, "guides/target.md", "---\ntitle: T\n---\n# T\n")
+        (enforced_vault.source_dir / "guides" / "src.md").write_text(
+            "---\ntitle: S\ngenerated:\n  by: human:someone\n  at: '2020-01-01T00:00:00Z'\n"
+            "verified:\n  - by: human:someone\n    at: '2020-01-01T00:00:00Z'\n---\n"
+            "See [[target]].\n",
+            encoding="utf-8",
+        )
+        enforced_vault.index.reindex()
+
+        enforced_vault.writer.okf_convert_links(folder="guides")
+        wait_for_writer_drain(enforced_vault)
+
+        meta = _frontmatter_of(enforced_vault, "guides/src.md")
+        assert meta["generated"] == {
+            "by": "human:someone",
+            "at": "2020-01-01T00:00:00Z",
+        }
+        assert "verified" in meta
+
+    def test_a_transform_does_not_trigger_convention_maintenance(
+        self, enforced_vault: Vault
+    ) -> None:
+        # A mechanical rewrite must not make the folder log itself. This holds
+        # by routing rather than by suppression: `WriterFacet` calls the
+        # convention maintainer for ordinary writes only, and the transforms
+        # delegate straight to the migration manager. Pinned because the
+        # suppression this issue moves would otherwise be the only thing
+        # anyone could point at for it.
+        _write(enforced_vault, "guides/target.md", "---\ntitle: T\n---\n# T\n")
+        _write(enforced_vault, "guides/src.md", "---\ntitle: S\n---\nSee [[target]].\n")
+        (enforced_vault.source_dir / "guides" / "log.md").unlink(missing_ok=True)
+
+        enforced_vault.writer.okf_convert_links(folder="guides")
+        wait_for_writer_drain(enforced_vault)
+
+        assert not (enforced_vault.source_dir / "guides" / "log.md").exists()
+
+
 class TestConvertLinks:
     def test_graph_round_trips(self, vault: Vault) -> None:
         _write(vault, "guides/playbook.md", "# Playbook\nSteps.\n")

--- a/tests/test_okf_write.py
+++ b/tests/test_okf_write.py
@@ -603,8 +603,9 @@ class TestWriteToolThreadsActor:
     async def test_convert_links_migration_does_not_restamp(
         self, enforced_env: Path
     ) -> None:
-        # A migration transform is wrapped in okf_write_suppressed: converting a
-        # wikilink must not clear a note's human verification nor stamp it.
+        # A migration transform suppresses the enricher on every write it
+        # issues (#1401), so converting a wikilink must not clear a note's
+        # human verification nor stamp it — through this tool or the facade.
         (enforced_env / "guides" / "plain.md").write_text(
             "---\nverified:\n  - by: human:peter\n    at: 2026-01-01\n---\n"
             + _PLAIN_NOTE,


### PR DESCRIPTION
## Closes / Refs

Closes #1401. Refs #963 (the transforms), #964 (where the tool-layer suppression was introduced), #1174 (why generated reserved files keep existing keys, which is what made the stray stamp permanent), #1443 (the ordinary-write provenance policy this is independent of).

## What & why

`docs/design/okf.md` exempts the one-shot transforms from the enforced-write layer — *"a mechanical rewrite does not re-stamp provenance or discard a human attestation"* — and never qualifies that by caller. But `okf_write_suppressed()` was entered in the three MCP tool handlers, so the exemption was a property of **the tool layer**, not of the transform.

A library caller of `vault.writer.okf_generate_index` therefore got `generated: {by: markdown-vault-mcp/<version>, at: …}` written into the `index.md` its own migration produced. And because `ReservedFrontmatterPolicy.build` keeps existing keys (#1174), that stamp then survived every later regeneration: the bundle permanently claims the server authored its navigation.

**The suppression moves onto every write `OkfMigrationManager` issues.** Being mechanical is a property of the transform; the entry point is not part of the question. The issue left the placement open between the facade, the manager, and each write — the manager's writes are where it lands, because the facade is a thin delegate and a direct `OkfMigrationManager` caller deserves the same guarantee.

**The three tool-handler wrappers are deleted, not left in place.** A second copy of a rule drifts, and this issue is a picture of that drift. `okf_verify`'s own suppression is untouched: different purpose (it sets `verified` deliberately), different layer.

## The issue's `[unverified]` is now verified

It recorded the defect for `okf_generate_index` and suspected `okf_seed_log` and `okf_convert_links` had "the same shape". Both reproduced before the fix — the seeded `log.md` carried a `generated` block, and a link conversion re-stamped every note it rewrote — and both are covered by tests.

## Tests

Four, in `tests/test_okf_migrate.py` against a declared, `okf_write=True` vault driven through the **library facade** (the entry point that was wrong):

- `okf_generate_index` — the generated `index.md` carries no `generated`.
- `okf_seed_log` — the seeded `log.md` carries none either.
- `okf_convert_links` — a rewritten note keeps its own `generated` (a human's, from 2020) and its `verified` list: the transform must not overwrite provenance it did not create.
- A transform does not make the folder log itself.

Mutation-checked: replacing any one `with okf_write_suppressed():` fails exactly its own test.

That fourth test needs a note in review. I wrote it expecting suppression to be the reason — it passed before the fix, so I instrumented `ConventionMaintainer.maintain` and found it is **never called** for a transform: `WriterFacet` invokes the maintainer for ordinary `write`/`edit`/`append` only, and the transforms delegate straight to the manager. So the property holds by routing, not by suppression. The test stays, with a comment saying that, because nothing else pinned it and the suppression this PR moves would otherwise look like the reason.

## What this PR deliberately does NOT do

- Clean up `generated` blocks already written into reserved files by a library-path migration. The triage says not to migrate historical fields here; a regeneration overwrites the body but keeps the key (#1174), so removing them is its own decision.
- Change the ordinary-write provenance policy: #1443.
- Change what the transforms write, their frontmatter preservation, or the reserved-frontmatter policy.
- Touch `okf_verify`'s suppression, or the convention maintainer's own.

## On `INDEX_SEMANTICS_VERSION`

No bump. Stored rows derive from a note's bytes exactly as before; this only stops a key being added to bytes the server writes.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`. It caught two things in my own diff: I had truncated an unrelated `# pragma: no cover` comment to fit the new indentation (restored as `deleted mid-scan`, same meaning), and the module docstring still described the transforms without the suppression that now lives in them (extended).
- [x] No `!`. Library callers of `vault.writer.okf_*` see one fewer frontmatter key on files the transform writes — the documented behaviour they should already have had. No env var, config, tool schema or importable name changes meaning.

Gates, run locally on `dc7dcf80`: `pytest` full suite (4660 passed, 2 skipped), `ruff check`/`format --check`, `mypy src/ tests/`, `scripts/structural_gate.sh` (100%), Vale.

## Docs impact

- [ ] `README.md` (does not describe the transforms' stamping behaviour)
- [x] `docs/` site pages: `docs/releases/4.2.md` (paragraph, including that existing stray stamps are left alone; watermark not moved). `docs/guides/okf.md` already states the exemption without qualifying it by caller, which is exactly what the code now does.
- [x] `docs/design/`: `design.md`'s phase-4 entry and `okf.md`'s maintenance bullet both say where the suppression lives and why
- [x] Inline docstrings: `managers/okf_migrate.py`'s module docstring

---
_Generated by [Claude Code](https://claude.ai/code)_
