### PR TITLE
docs: prepare release notes for v4.2.0

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -122,6 +122,7 @@ dominators
 DOMPurify
 downloader
 downweight
+downweighted
 downweights
 embeddings_status
 errorname

--- a/docs/releases/1.x.md
+++ b/docs/releases/1.x.md
@@ -234,9 +234,9 @@ from the template flipped the license and replaced the command line, so the
 repository had to be reshaped before the automation could be trusted.
 
 The line closes with the search work that the 3.0 release then had to correct.
-v1.28.0 introduced four ranking knobs at once: a per-document cap on result
-slots, a length downweight, snippet truncation, and an adaptive chunker that
-descends heading levels when a chunk runs over budget
+v1.28.0 introduced four ranking controls at once. It capped result slots per
+document and downweighted long notes. It also truncated snippets and added an
+adaptive chunker that descends heading levels when a chunk runs over budget
 ([PR #433](https://github.com/pvliesdonk/markdown-vault-mcp/pull/433), closing
 [#432](https://github.com/pvliesdonk/markdown-vault-mcp/issues/432)). The
 adaptive chunker is what later caused several chunks of one document to crowd

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -257,7 +257,7 @@ backend is configured, the prompt recommends the single-call `summarize`
 tool first and offers itself as the fallback for scopes that don't fit in
 one call.
 
-### Precision search: frontmatter fields, ranking weights, consistent scoping
+### Precision search across frontmatter and folder scopes
 
 A curated vault keeps its highest-signal text in frontmatter (a display
 name, a hand-written summary) that search previously never saw, because it

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -18,8 +18,8 @@ needs a change; operators do not.
 
 This is the first release since [4.0](4.0.md). Its through-line is defaults:
 several places where the server knew enough to do the right thing but waited to
-be told. Alongside that sit two contributor features brought current, a size
-signal for planning, and a correctness pass on the OKF reserved files 4.0
+be told. It also brings two contributor features current. A size signal helps
+with planning, while a correctness pass covers the OKF reserved files 4.0
 introduced.
 
 ## Upgrade notes

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -1,25 +1,24 @@
 # 4.2
 
-<!-- notes-range-end: 60111e3fb38efdf54b78bc6fc1f5ca9acc2ff883 -->
+<!-- notes-range-end: 010ff42cfada2683b1b85515f07f7893aa95d20c -->
 
 <!-- RELEASE-SUMMARY v4.2.0 START -->
-This release is about trusting the git layer. On a git-backed vault, an
-agent can now undo an overwrite from the client: an overwriting `write`
-names the commit holding what it replaced, and `read` accepts a `revision`
-to get it back. Writes commit once per tool call instead of once per file,
-each commit is scoped so an operator's staged work is never swept in, and
-when the clone stops reaching its remote every write result says so instead
-of reporting quiet success. Six history bugs (wrong note, escaped path,
-rejected SHA, vanished history) are fixed. GitLab-hosted vaults gain the
-push-triggered reindex GitHub vaults already had, Voyage vaults get better
-search relevance with nothing to configure, and server instructions now
-arrive in full on Claude Code instead of losing their tail to a 2,048-unit
-cap. Seven link-extraction fixes reshape the link graph: broken-link counts
-drop, notes whose only links were embeds become orphans, and a duplicate-name
-`[[Note]]` resolves as Obsidian does. Nothing breaks: no env var, tool, or
-library import changes meaning. Two one-time costs on first start after
-upgrade: every vault rebuilds its text index once, and a Voyage vault
-re-embeds once.
+4.2 makes git-backed vaults safer to trust and draws a clearer boundary around
+OKF. An agent can undo an overwrite from the client: an overwriting `write`
+names the commit holding what it replaced, and `read` accepts a `revision` to
+get it back. Writes commit once per tool call instead of once per file, each
+commit is scoped so an operator's staged work is never swept in, and every
+write reports when the clone cannot reach its remote. The OKF stabilization
+makes audits and parsing resilient, keeps migration transforms mechanical,
+corrects navigation guidance, and documents the limits of current upkeep and
+export. A greenfield north star now separates portable author claims from
+server observations and operator authority; its seven-stage roadmap describes
+future work. GitLab-hosted vaults gain push-triggered reindexing,
+Voyage vaults get better search relevance, and server instructions arrive in
+full on Claude Code. Seven link-extraction fixes reshape the link graph.
+Nothing breaks: no env var, tool, or library import changes meaning. Two
+one-time costs on first start after upgrade: every vault rebuilds its text
+index once, and a Voyage vault re-embeds once.
 <!-- RELEASE-SUMMARY v4.2.0 END -->
 
 This is the first release since [4.1](4.1.md). Most of it happened in one
@@ -28,6 +27,34 @@ bulk call produced 2,596 commits, and a production deployment that wrote for
 hours into a clone that could no longer push. Around that sit a GitLab
 webhook and better search on Voyage vaults, plus a fix for server
 instructions that never fully arrived.
+
+## OKF stabilization and its next direction
+
+The work to stabilize OKF exposed a deeper design problem. The server had
+treated storage as authorship, a changed file as a verdict on verification, a
+reserved filename as permission to replace content, and search admission as a
+rule about what belongs in a bundle. Repeated review made individual mechanisms
+more consistent without making those responsibilities equivalent
+([#1433 review record](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1433#issuecomment-5598935941),
+[#1441](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1441)).
+
+The project has adopted a greenfield north star for future OKF work: people and
+agents should be able to exchange ordinary files while keeping author claims,
+server observations, and operator-granted maintenance authority distinct. A
+[seven-stage roadmap](https://github.com/pvliesdonk/markdown-vault-mcp/blob/010ff42cfada2683b1b85515f07f7893aa95d20c/docs/design/okf-roadmap.md)
+covers bundle inventory, preservation, evidence applicability, deliberate
+authoring and review, navigation and editorial history, provenance-aware
+retrieval, and faithful publication
+([#1425](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1425),
+[#1450](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1450)).
+
+Those capabilities have not shipped. The stages are independently shippable,
+with no promised release or date. Version 4.2 keeps the current OKF model and
+sets a narrower stabilization boundary: restore existing contracts, make
+parser and audit paths resilient, keep mechanical transforms mechanical, and
+state current operating limits accurately. The OKF fixes under Search and
+indexing are that stabilization work; later roadmap slices will change the
+underlying model.
 
 ## Undo an overwrite without leaving the client
 


### PR DESCRIPTION
## Closes / Refs

Refs #1425

## What & why

Refresh the v4.2.0 release notes through current `main`, covering the shipped OKF stabilization work and the decision to define a greenfield north-star design for a future roadmap. The page clearly separates what v4.2 ships from capabilities that remain planned.

## Release target and range

- Target: `v4.2.0` (not yet tagged), refreshing the canonical `docs/releases/4.2.md` page after `v4.2.0-rc.2`.
- Incremental research range: [`60111e3f...010ff42c`](https://github.com/pvliesdonk/markdown-vault-mcp/compare/60111e3fb38efdf54b78bc6fc1f5ca9acc2ff883...010ff42cfada2683b1b85515f07f7893aa95d20c), from the page's accepted watermark through current `main`.
- Candidate-to-target delta: [`v4.2.0-rc.2...010ff42c`](https://github.com/pvliesdonk/markdown-vault-mcp/compare/v4.2.0-rc.2...010ff42cfada2683b1b85515f07f7893aa95d20c).

## Narrative and evidence

Every factual claim in the page has an inline evidence link. The refresh adds the range's main design decision to the summary and narrative: the adopted greenfield OKF north star and seven-stage future roadmap, with the boundary that v4.2 stabilizes current behavior rather than implementing the redesign. Primary evidence is PRs [#1441](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1441) and [#1450](https://github.com/pvliesdonk/markdown-vault-mcp/pull/1450), plus tracking epic [#1425](https://github.com/pvliesdonk/markdown-vault-mcp/issues/1425).

The detailed shipped OKF corrections were already added to the page by their implementation PRs and remain evidence-linked there: maintained-log frontmatter, index-frontmatter diagnostics, BOM handling, malformed JSON-looking frontmatter, enforced-write error context, mechanical migration transforms, and accurate upkeep/export guidance. The watermark advances to `010ff42cfada2683b1b85515f07f7893aa95d20c`.

Release-preparation commits and routine Copier/OpenAI/Ruff dependency updates were researched and omitted because they add no installed-server story. No first-party dependency changed in the incremental range.

## Breaking-change classification

No breaking change is introduced by the incremental range. The operator surface and `tests/public_import_surface.txt` are unchanged. Tool names and parameters are unchanged; `okf_validate` gains the additive `index_frontmatter` finding. The conditionally generated OKF instruction is corrected to match existing upkeep behavior. The Python migration path is corrected to match its already-documented mechanical semantics. No commit marker disagrees with this classification.

The accepted page's v4.1-to-v4.2 upgrade classification remains intact. There is no new post-RC.2 index-semantics bump or cold-rebuild cost.

## Documentation review

No documentation-staleness candidate was found. `docs/guides/okf.md` and `docs/tools/index.md` cover the current behavior, while the north star and roadmap are explicitly internal future-direction documents.

The required full `vale docs/releases/` scan found three existing tricolon findings in older release pages after style-package sync. This branch makes minimal prose-only corrections in `1.x.md`, `4.0.md`, and `4.1.md`, and adds `downweighted` to the Base vocabulary. Vale and `uv run mkdocs build --strict` pass.

## Self-review 010ff42c..ce9a1018

Charters: rules, cumulative diff, adjacent commitments, history, conformance, and relevant past-PR evidence. Coverage: full release-notes and vocabulary diff; no executable or normative contract changes.

- `docs/releases/4.2.md:55` — important/verified — “the fixes under Search and indexing” could include unrelated link-graph work in the same section. Resolved in `ce9a1018` by narrowing the claim to the OKF fixes.

No other blocker or important finding survived refutation. The final prose distinguishes shipped stabilization from future design, preserves the accepted v4.1-to-v4.2 narrative, and keeps the older-page edits semantic no-ops required by the prose gate.

## What this PR deliberately does NOT do

- Claim that the north-star capabilities ship in v4.2; their implementation remains tracked by #1425.
- Set a future release date, final configuration names, schemas, database layout, or tool signatures; those decisions remain tracked by #1425.
- Make an outside-demand or prevalence claim for the redesign; its issues and PRs were owner-authored.
- Promise automatic repair of existing stacked log frontmatter or stray migration provenance stamps; follow-up behavior remains tracked by #1425.

## Local review

- [x] Ran a local code-review pass on the cumulative diff before `gh pr create`.
- [x] No commit carries `!`; the incremental range adds no break to an operator or public-library surface from the last stable release.

## Docs impact

- [ ] `README.md` — no README behavior changed.
- [x] `docs/` site pages — refreshed the v4.2 release page and fixed prose-gate findings in three older release pages.
- [ ] `docs/design/` — no design change is introduced by this release-notes PR; the cited design work is already recorded there.
- [ ] Inline docstrings — no public API changed.

---
_Generated by [Claude Code](https://claude.ai/code)_
